### PR TITLE
fix installing yaklang on windows failure

### DIFF
--- a/common/yak/cmd/yak.go
+++ b/common/yak/cmd/yak.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/jinzhu/gorm"
@@ -129,7 +130,7 @@ var installSubCommand = cli.Command{
 	Usage: "安装 Yak/Install Yak  (Add to ENV PATH)",
 	Action: func(c *cli.Context) error {
 		file, err := exec.LookPath(os.Args[0])
-		if err != nil {
+		if err != nil && !errors.Is(err, exec.ErrDot) {
 			return utils.Errorf("fetch current binary yak path failed: %s", err)
 		}
 


### PR DESCRIPTION
go1.19 给exec包加了点安全机制 https://pkg.go.dev/os/exec#hdr-Executables_in_the_current_directory
这导致了原有的安装脚本无法执行，报错 “cannot run executable found relative to current directory”
加了个err检查，由于yak获取这个路径并不是用来执行文件的，所以go1.19这个修改要防的安全问题在这个场景下并不存在