### PR TITLE
添加对照显示源码和opcode的功能，实现类似code的map功能

### DIFF
--- a/common/yak/antlr4yak/yakast/listener_test.go
+++ b/common/yak/antlr4yak/yakast/listener_test.go
@@ -1,0 +1,123 @@
+package yakast_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
+	"github.com/yaklang/yaklang/common/yak/antlr4nasl/visitors"
+	yak "github.com/yaklang/yaklang/common/yak/antlr4yak/parser"
+)
+
+func testYakParserWalKing(i string) {
+	// include
+	file, err := os.CreateTemp("", "test*.yak")
+	if err != nil {
+		panic(err)
+	}
+	file.WriteString(i)
+	defer os.Remove(file.Name())
+
+	inputStream, _ := antlr.NewFileStream(file.Name())
+	lex := yak.NewYaklangLexer(inputStream)
+
+	// for _, t := range lex.GetAllTokens() {
+	// fmt.Println(t.GetText())
+	// }
+
+	tokenStream := antlr.NewCommonTokenStream(lex, antlr.TokenDefaultChannel)
+
+	p := yak.NewYaklangParser(tokenStream)
+	p.BuildParseTrees = true
+	tree := p.Program()
+	listener := visitors.NewParseTreeListener()
+	listener.SetEnter(func(ctx antlr.ParserRuleContext) {})
+	listener.SetExit(func(ctx antlr.ParserRuleContext) {
+		fmt.Printf("rule->%d, text->[%s]\n", ctx.GetRuleIndex(), ctx.GetText())
+	})
+	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
+
+}
+
+func TestYakParserASTWalking(t *testing.T) {
+	t.Run("simple func", func(t *testing.T) {
+		expr := `
+		func sum(a) {
+			result = 0
+			for i = range a {
+				result = result +  i
+			}
+			return result
+		}
+		
+		a=sum(2)
+		dump(a)
+		assert a == 3
+			`
+		testYakParserWalKing(expr)
+	})
+
+}
+
+func testYakLexerWalKing(i string) {
+	// include
+	file, err := os.CreateTemp("", "test*.yak")
+	if err != nil {
+		panic(err)
+	}
+	file.WriteString(i)
+	defer os.Remove(file.Name())
+
+	inputStream, _ := antlr.NewFileStream(file.Name())
+	lex := yak.NewYaklangLexer(inputStream)
+
+	for _, t := range lex.GetAllTokens() {
+		fmt.Printf("token->[%s], type->%d\n", t.GetText(), t.GetTokenType())
+	}
+}
+
+func TestYakTokenWalking(t *testing.T) {
+	t.Run("simple func", func(t *testing.T) {
+		expr := `
+		func sum(a) {
+			result = 0
+			for i = range a {
+				result = result +  i
+			}
+			return result
+		}
+		
+		a=sum(2)
+		dump(a)
+		assert a == 3
+			`
+		testYakLexerWalKing(expr)
+	})
+
+	t.Run("non sense txt", func(t *testing.T) {
+		expr := `
+
+		1
+		11
+		asdfa
+		asdf
+		asdf
+		asd
+		f;123;123  
+			a=12
+		123
+		sadfas
+		
+		
+		sd
+		fa
+		sdf
+		asd
+		expression(123) 
+		a+1=123
+			`
+		testYakLexerWalKing(expr)
+	})
+
+}

--- a/common/yak/antlr4yak/yakast/visitor.go
+++ b/common/yak/antlr4yak/yakast/visitor.go
@@ -3,6 +3,7 @@ package yakast
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/yaklang/yaklang/common/go-funk"
 	"github.com/yaklang/yaklang/common/log"
 	yak "github.com/yaklang/yaklang/common/yak/antlr4yak/parser"
@@ -174,6 +175,9 @@ func (y *YakCompiler) Init(lexer *yak.YaklangLexer, parser *yak.YaklangParser) {
 }
 func (y *YakCompiler) ShowOpcodes() {
 	yakvm.ShowOpcodes(y.codes)
+}
+func (y *YakCompiler) ShowOpcodesWithSource(src string) {
+	yakvm.ShowOpcodesWithSouce(src, y.codes)
 }
 func (y *YakCompiler) CompileSourceCodeWithPath(code string, fPath *string) bool {
 	y.sourceCodeFilePathPointer = fPath

--- a/common/yak/antlr4yak/yakast/visitor_test.go
+++ b/common/yak/antlr4yak/yakast/visitor_test.go
@@ -1,9 +1,10 @@
 package yakast
 
 import (
+	"testing"
+
 	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
 	yak "github.com/yaklang/yaklang/common/yak/antlr4yak/parser"
-	"testing"
 )
 
 func testYakParsing(i string) {
@@ -51,4 +52,66 @@ func TestYakAST_Cond(t *testing.T) {
 	testYakParsing(`
 
 `)
+}
+
+func testYakParsingWithSource(i string) {
+	inputStream := antlr.NewInputStream(i)
+	lex := yak.NewYaklangLexer(inputStream)
+
+	// for _, t := range lex.GetAllTokens() {
+	// 	println(t.GetText())
+	// }
+
+	tokenStream := antlr.NewCommonTokenStream(lex, antlr.TokenDefaultChannel)
+
+	p := yak.NewYaklangParser(tokenStream)
+	vt := NewYakCompiler()
+	vt.AntlrTokenStream = tokenStream
+	vt.VisitProgram(p.Program().(*yak.ProgramContext))
+	println(vt.GetFormattedCode())
+	vt.ShowOpcodesWithSource(i)
+}
+
+func TestSimpleYakAST(t *testing.T) {
+	t.Run("simple func", func(t *testing.T) {
+		expr := `
+		func sum(a) {
+			result = 0
+			for i = range a {
+				result = result +  i
+			}
+			return result
+		}
+		
+		a=sum(2)
+		dump(a)
+		assert a == 3
+			`
+		testYakParsingWithSource(expr)
+	})
+
+	t.Run("nonsense txt", func(t *testing.T) {
+		expr := `
+		
+		1
+		11
+		asdfa
+		asdf
+		asdf
+		asd
+		f;123;123  
+			a=12
+		123
+		sadfas
+		
+		
+		sd
+		fa
+		sdf
+		asd
+		expression(123) 
+		a+1=123
+			`
+		testYakParsingWithSource(expr)
+	})
 }

--- a/common/yak/antlr4yak/yakvm/vm_exec.go
+++ b/common/yak/antlr4yak/yakvm/vm_exec.go
@@ -210,6 +210,26 @@ func ShowOpcodes(c []*Code) {
 	}
 }
 
+func ShowOpcodesWithSouce(src string, c []*Code) {
+	lines := strings.Split(src, "\n")
+	cur := -1
+	for i, code := range c {
+		if cur < 0 || code.StartLineNumber != cur {
+			cur = code.StartLineNumber
+			fmt.Printf("%s\n", lines[cur-1])
+		}
+
+		fmt.Printf("%-13s %4d:%v\n", code.RangeVerbose(), i, code.String())
+
+		if code.Opcode == OpPush {
+			v, ok := code.Op1.Value.(*Function)
+			if ok {
+				ShowOpcodesWithSouce(src, v.codes)
+			}
+		}
+	}
+}
+
 func OpcodesString(c []*Code) string {
 	var buf strings.Builder
 	for i, code := range c {


### PR DESCRIPTION
实现yak源码与opcode的对照查看功能，具体效果见测试用例。
显示的格式如下
```
                func sum(a) {
2:2->8:2         0:OP:pushleftr  1
2:2->8:2         1:OP:push       function params[1] codes[32]
                func sum(a) {
2:14->8:2        0:OP:new-scope  3
                        result = 0
3:12->3:12       1:OP:push       0
3:12->3:12       2:OP:list       1
3:3->3:8         3:OP:pushleftr  3
3:3->3:8         4:OP:list       1
3:3->3:12        5:OP:assign
```
方便查看vm的代码生成