### PR TITLE
vulinbox agent websocket protocol

### DIFF
--- a/common/utils/lowhttp/vulinbox_agent.go
+++ b/common/utils/lowhttp/vulinbox_agent.go
@@ -68,7 +68,7 @@ User-Agent: FeedbackStreamer/1.0
 	var start = false
 	client, err := NewWebsocketClient(wsPacket, WithWebsocketFromServerHandler(func(bytes []byte) {
 		if !start {
-			if utils.ExtractMapValueString(bytes, "type") == "ping" {
+			if utils.ExtractMapValueString(bytes, "action") == "ping" {
 				start = true
 			}
 		}
@@ -97,7 +97,7 @@ User-Agent: FeedbackStreamer/1.0
 				case <-ctx.Done():
 					return
 				default:
-					client.WriteText([]byte(`{"type":"ping"}`))
+					client.WriteText([]byte(`{"action":"ping"}`))
 					time.Sleep(time.Second)
 				}
 			}

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -204,6 +204,14 @@ func Jsonify(i interface{}) []byte {
 	return raw
 }
 
+func MustUnmarshalJson[T any](raw []byte) *T {
+	var ret T
+	if err := json.Unmarshal(raw, &ret); err != nil {
+		return nil
+	}
+	return &ret
+}
+
 func NewDefaultHTTPClientWithProxy(proxy string) *http.Client {
 	client := NewDefaultHTTPClient()
 	if proxy == "" {

--- a/common/vulinbox/route.go
+++ b/common/vulinbox/route.go
@@ -15,7 +15,7 @@ var routeHtml []byte
 
 func (s *VulinServer) init() {
 	if s.agentFeedbackChan == nil {
-		s.agentFeedbackChan = make(chan []byte, 10000)
+		s.agentFeedbackChan = make(chan any, 10000)
 	}
 
 	router := s.router
@@ -30,7 +30,7 @@ func (s *VulinServer) init() {
 		}
 		if len(reqRaw) > 0 {
 			select {
-			case s.agentFeedbackChan <- reqRaw:
+			case s.agentFeedbackChan <- newDataBackAction("http-request", string(reqRaw)):
 				//log.Infof("agentFeedbackHandler: %s", string(reqRaw))
 			default:
 				log.Errorf("agentFeedbackHandler is full, drop request: %s", string(reqRaw))
@@ -60,7 +60,7 @@ func (s *VulinServer) init() {
 			}
 			if len(reqRaw) > 0 {
 				select {
-				case s.agentFeedbackChan <- reqRaw:
+				case s.agentFeedbackChan <- newDataBackAction("http-request", string(reqRaw)):
 					log.Infof("agentFeedbackHandler: %s", string(reqRaw))
 				default:
 					log.Errorf("agentFeedbackHandler is full, drop request: %s", string(reqRaw))

--- a/common/vulinbox/service_wsagent.go
+++ b/common/vulinbox/service_wsagent.go
@@ -13,12 +13,103 @@ import (
 
 func (r *VulinServer) registerWSAgent() {
 	router := r.router
-	var agentFeedbackHandler = r.agentFeedbackChan
+	var wsAgentWrite = r.agentFeedbackChan
 	// wsAgent
 	var upgrader = websocket.Upgrader{}
 	router.HandleFunc("/_/ws", func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", `text/html`)
-		unsafeTemplateRender(writer, request, `
+		unsafeTemplateRender(writer, request, wspage, map[string]any{
+			"host": request.Host,
+		})
+	})
+	var wsAgentMux = new(sync.Mutex)
+
+	router.HandleFunc("/_/ws/agent", func(writer http.ResponseWriter, request *http.Request) {
+		/*
+			GET /_/ws/agent HTTP/1.1
+			Host: 127.0.0.1:8787
+			Connection: Upgrade
+			Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
+			Sec-WebSocket-Key: kpFli2X1YeW53YainWGFzA==
+			Sec-WebSocket-Protocol: pbbp2
+			Sec-WebSocket-Version: 13
+			Upgrade: websocket
+			User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+		*/
+
+		if !wsAgentMux.TryLock() {
+			writer.Write([]byte(`agent is connected by other user`))
+			writer.WriteHeader(502)
+			return
+		} else {
+			log.Info("start to enter ws agent lock")
+		}
+
+		defer wsAgentMux.Unlock()
+		defer func() {
+			if err := recover(); err != nil {
+				spew.Dump(err)
+				utils.PrintCurrentGoroutineRuntimeStack()
+			}
+		}()
+
+		log.Infof("start to upgrade to ws agent: %s", request.RemoteAddr)
+		responseHeader := make(http.Header)
+		conn, err := upgrader.Upgrade(writer, request, responseHeader)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		defer func() {
+			conn.Close()
+		}()
+
+		var wr sync.Mutex
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			defer cancel()
+			for {
+				_, m, err := conn.ReadMessage()
+				if err != nil {
+					return
+				}
+				go MessageMux(m, func(ack *AckAction) {
+					wsAgentWrite <- ack
+				})
+			}
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case feedback := <-wsAgentWrite:
+				wr.Lock()
+				err := conn.WriteJSON(feedback)
+				wr.Unlock()
+				if err != nil {
+					log.Debugf("ws conn from: %v closed", conn.LocalAddr())
+					cancel()
+					return
+				}
+			case <-time.After(time.Second):
+				log.Debugf("ws conn start to send: %v ping", conn.LocalAddr())
+				wr.Lock()
+				err := conn.WriteJSON(newPingAction())
+				wr.Unlock()
+				if err != nil {
+					log.Debugf("ws conn from: %v closed", conn.LocalAddr())
+					cancel()
+					return
+				}
+				continue
+			}
+		}
+	})
+}
+
+const wspage = `
 <!doctype html>
 <html>
 <head>
@@ -64,96 +155,4 @@ User-Agent: FeedbackStreamer/1.0
 </html>
 
 
-`, map[string]any{
-			"host": request.Host,
-		})
-	})
-	var wsAgentMux = new(sync.Mutex)
-
-	router.HandleFunc("/_/ws/agent", func(writer http.ResponseWriter, request *http.Request) {
-		/*
-			GET /_/ws/agent HTTP/1.1
-			Host: 127.0.0.1:8787
-			Connection: Upgrade
-			Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
-			Sec-WebSocket-Key: kpFli2X1YeW53YainWGFzA==
-			Sec-WebSocket-Protocol: pbbp2
-			Sec-WebSocket-Version: 13
-			Upgrade: websocket
-			User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
-		*/
-
-		if !wsAgentMux.TryLock() {
-			writer.Write([]byte(`agent is connected by other user`))
-			writer.WriteHeader(502)
-			return
-		} else {
-			log.Info("start to enter ws agent lock")
-		}
-
-		defer wsAgentMux.Unlock()
-		defer func() {
-			if err := recover(); err != nil {
-				spew.Dump(err)
-				utils.PrintCurrentGoroutineRuntimeStack()
-			}
-		}()
-
-		log.Infof("start to upgrade to ws agent: %s", request.RemoteAddr)
-		responseHeader := make(http.Header)
-		conn, err := upgrader.Upgrade(writer, request, responseHeader)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-		defer func() {
-			conn.Close()
-		}()
-		var wr sync.Mutex
-		ctx, cancel := context.WithCancel(context.Background())
-		go func() {
-			defer cancel()
-			for {
-				conn.SetReadDeadline(time.Now().Add(time.Second * 3))
-				_, m, err := conn.ReadMessage()
-				if err != nil {
-					return
-				}
-				if utils.ExtractMapValueString(m, "type") != "ping" {
-					log.Debugf("recv from client: %v", string(m))
-				} else {
-					log.Debugf("recv from client ping: %v", string(m))
-				}
-			}
-		}()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case bytes := <-agentFeedbackHandler:
-				wr.Lock()
-				err := conn.WriteJSON(map[string]any{
-					"type":    "request",
-					"request": string(bytes),
-				})
-				wr.Unlock()
-				if err != nil {
-					log.Debugf("ws conn from: %v closed", conn.LocalAddr())
-					cancel()
-					return
-				}
-			case <-time.After(time.Second):
-				log.Debugf("ws conn start to send: %v ping", conn.LocalAddr())
-				wr.Lock()
-				err := conn.WriteJSON(map[string]any{"type": "ping"})
-				wr.Unlock()
-				if err != nil {
-					log.Debugf("ws conn from: %v closed", conn.LocalAddr())
-					cancel()
-					return
-				}
-				continue
-			}
-		}
-	})
-}
+`

--- a/common/vulinbox/vul_server.go
+++ b/common/vulinbox/vul_server.go
@@ -19,7 +19,7 @@ type VulinServer struct {
 	database *dbm
 	router   *mux.Router
 
-	agentFeedbackChan chan []byte
+	agentFeedbackChan chan any
 	safeMode          bool
 }
 

--- a/common/vulinbox/wsagent_proto.go
+++ b/common/vulinbox/wsagent_proto.go
@@ -62,7 +62,7 @@ func newUDPAction(content []byte, target netip.AddrPort) *UDPAction {
 type AckAction struct {
 	AgentProtocol
 	Status string `json:"status"`
-	Data   any
+	Data   any    `json:"data"`
 }
 
 func newAckAction(id uint32, status string, data any) *AckAction {

--- a/common/vulinbox/wsagent_proto.go
+++ b/common/vulinbox/wsagent_proto.go
@@ -1,0 +1,142 @@
+package vulinbox
+
+import (
+	"encoding/base64"
+	"github.com/yaklang/yaklang/common/utils"
+	"math/rand"
+	"net"
+	"net/netip"
+	"time"
+)
+
+const (
+	ActionUDP       = "udp"
+	ActionAck       = "ack"
+	ActionDataback  = "databack"
+	ActionSubscribe = "subscribe"
+	ActionPing      = "ping"
+)
+
+type AgentProtocol struct {
+	ActionId uint32 `json:"id"`
+	Action   string `json:"action"`
+}
+
+func newAgentProtocol(action string) AgentProtocol {
+	return AgentProtocol{
+		ActionId: rand.Uint32(),
+		Action:   action,
+	}
+}
+
+type DatabackAction struct {
+	AgentProtocol
+	Type string `json:"type"`
+	Data any    `json:"data"`
+}
+
+func newDataBackAction(tp string, data any) *DatabackAction {
+	return &DatabackAction{
+		AgentProtocol: newAgentProtocol(ActionDataback),
+		Type:          tp,
+		Data:          data,
+	}
+}
+
+type UDPAction struct {
+	AgentProtocol
+	// base64 encoded content
+	Content     string         `json:"content"`
+	Target      netip.AddrPort `json:"target"`
+	WaitTimeout time.Duration  `json:"wait_timeout"`
+}
+
+func newUDPAction(content []byte, target netip.AddrPort) *UDPAction {
+	return &UDPAction{
+		AgentProtocol: newAgentProtocol(ActionUDP),
+		Content:       base64.StdEncoding.EncodeToString(content),
+		Target:        target,
+	}
+}
+
+type AckAction struct {
+	AgentProtocol
+	Status string `json:"status"`
+	Data   any
+}
+
+func newAckAction(id uint32, status string, data any) *AckAction {
+	return &AckAction{
+		AgentProtocol: AgentProtocol{
+			ActionId: id,
+			Action:   ActionAck,
+		},
+		Status: status,
+		Data:   data,
+	}
+}
+
+type PingAction struct {
+	AgentProtocol
+}
+
+func newPingAction() *PingAction {
+	return &PingAction{
+		AgentProtocol: newAgentProtocol(ActionPing),
+	}
+}
+
+type SubscribeAction struct {
+	AgentProtocol
+	Subscribe []string `json:"subscribe"`
+}
+
+func MessageMux(data []byte, ack func(ack *AckAction)) {
+	ap := utils.MustUnmarshalJson[AgentProtocol](data)
+	var err error
+	var rec any
+	switch ap.Action {
+	case ActionUDP:
+		rec, err = handleUDP(utils.MustUnmarshalJson[UDPAction](data))
+	}
+	if err != nil {
+		ack(newAckAction(ap.ActionId, "error", err))
+		return
+	}
+	ack(newAckAction(ap.ActionId, "ok", rec))
+}
+
+func handleUDP(udp *UDPAction) ([]byte, error) {
+	if udp == nil {
+		return nil, nil
+	}
+	conn, err := net.DialUDP("udp", nil, net.UDPAddrFromAddrPort(udp.Target))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	bytes, err := base64.StdEncoding.DecodeString(udp.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = conn.Write(bytes); err != nil {
+		return nil, err
+	}
+
+	if udp.WaitTimeout == 0 {
+		return nil, nil
+	}
+
+	if err := conn.SetDeadline(time.Now().Add(udp.WaitTimeout)); err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 1024)
+	_, _, err = conn.ReadFromUDP(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,6 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
-	moul.io/http2curl v1.0.0
 	rsc.io/qr v0.2.0
 )
 
@@ -210,7 +209,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shoenig/go-m1cpu v0.1.5 // indirect
-	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/tebeka/strftime v0.1.3 // indirect
 	github.com/temoto/robotstxt v1.1.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -324,7 +324,6 @@ github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
@@ -546,9 +545,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsRvKfwY81a8=
-github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
-github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -902,7 +898,5 @@ modernc.org/libc v1.22.2 h1:4U7v51GyhlWqQmwCHj28Rdq2Yzwk55ovjFrdPjs8Hb0=
 modernc.org/mathutil v1.5.0 h1:rV0Ko/6SfM+8G+yKiyI830l3Wuz1zRutdslNoQ0kfiQ=
 modernc.org/memory v1.5.0 h1:N+/8c5rE6EqugZwHii4IFsaJ7MUhoWX07J5tC/iI5Ds=
 modernc.org/sqlite v1.20.3 h1:SqGJMMxjj1PHusLxdYxeQSodg7Jxn9WWkaAQjKrntZs=
-moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=
-moul.io/http2curl v1.0.0/go.mod h1:f6cULg+e4Md/oW1cYmwW4IWQOVl2lGbmCNGOHvzX2kE=
 rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
 rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=


### PR DESCRIPTION
给 vulinbox agent websocket 规定了协议格式，主要分为两种
- ACTION-ACK格式
- 订阅格式

ACTION-ACK 格式用于命令 vulinbox 发送一些数据包，ACK 用于确认成功或者回传err
订阅格式即订阅，比如 vulinbox 收到的所有 http 包
