### PR TITLE
fix/vm/closure_assign  check if func.scope == nil?

### DIFF
--- a/common/yak/antlr4yak/executor_test.go
+++ b/common/yak/antlr4yak/executor_test.go
@@ -3089,6 +3089,24 @@ assert d.$e == 23
 	_formattest(code)
 }
 
+func TestNewExecutor_ClosureAssignFix(t *testing.T) {
+	code := `
+f = () => 1
+{
+	a = 2
+	f = () => a
+}
+
+{
+	f2 = f
+	assert f() == 2
+	assert f2() == 2
+}
+`
+	_marshallerTest(code)
+	_formattest(code)
+}
+
 // 测试 assert/字符串索引、拼接/结构体、和map调用成员
 func TestNewExecutor_MemberCall(t *testing.T) {
 	u := &user{

--- a/common/yak/antlr4yak/yakvm/vm_exec.go
+++ b/common/yak/antlr4yak/yakvm/vm_exec.go
@@ -407,8 +407,10 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 			if v, ok := rightVal.([]*Value); ok && len(v) > 0 {
 				rightVal = v[0].Value
 			}
-			if _, ok := rightVal.(*Function); ok {
-				rightVal.(*Function).scope = v.CurrentScope()
+			if rv, ok := rightVal.(*Function); ok {
+				if rv.scope == nil {
+					rv.scope = v.CurrentScope()
+				}
 				if val, ok := leftVal.([]*Value); ok && len(val) > 0 {
 					lv, err := val[0].ConvertToLeftValue()
 					if err == nil {


### PR DESCRIPTION
* set function scope when this scope not set  (when build function).
* don't set function scope in other time (such as assign variable from a function variable)