### PR TITLE
ci: cache 优化

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -3,6 +3,7 @@ name: Essential Tests
 on:
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened, closed]
     paths:
       - 'common/**'
       - '.github/workflows/essential-tests.yml'


### PR DESCRIPTION
不同分支的 actions cache 是独立的，但是新签出的分支能继承原先的分支的 cache。
让ci在pr closed的时候也运行，确保：分支rebase后能过ci，main分支有cache给其他分支继承。