### PR TITLE
fix(get endtoken line and column) handler "\n" in end token

### DIFF
--- a/common/yak/antlr4yak/yakast/misc.go
+++ b/common/yak/antlr4yak/yakast/misc.go
@@ -2,6 +2,8 @@ package yakast
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
@@ -134,12 +136,26 @@ func (y *YakCompiler) _setCurrentStartPosition(t antlr.Token) *Position {
 
 func (y *YakCompiler) _setCurrentEndPosition(t antlr.Token) *Position {
 	origin := y.currentEndPosition
+	line, column := GetEndPosition(t)
 	y.currentEndPosition = &Position{
-		LineNumber:   t.GetLine(),
-		ColumnNumber: t.GetColumn() + len(t.GetText()),
+		LineNumber:   line,
+		ColumnNumber: column,
 	}
 	if y.currentEndPosition.ColumnNumber > 0 {
 		y.currentEndPosition.ColumnNumber--
 	}
 	return origin
+}
+
+func GetEndPosition(t antlr.Token) (int, int) {
+	var line, column int
+	str := strings.Split(t.GetText(), "\n")
+	if len(str) > 1 {
+		line = t.GetLine() + len(str) - 1
+		column = len(str[len(str)-1])
+	} else {
+		line = t.GetLine()
+		column = t.GetColumn()
+	}
+	return line, column
 }

--- a/common/yak/ssa/range.go
+++ b/common/yak/ssa/range.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakast"
 )
 
 type canStartStopToken interface {
@@ -16,12 +17,13 @@ func (b *builder) SetRange(token canStartStopToken) func() {
 	pos := b.currtenPos
 	// fmt.Printf("debug %v\n", b.GetText())
 	source := strings.Split(token.GetText(), "\n")[0]
+	endline, endcolumn := yakast.GetEndPosition(token.GetStop())
 	b.currtenPos = &Position{
 		SourceCode:  source,
 		StartLine:   token.GetStart().GetLine(),
 		StartColumn: token.GetStart().GetColumn(),
-		EndLine:     token.GetStop().GetLine(),
-		EndColumn:   token.GetStop().GetColumn(),
+		EndLine:     endline,
+		EndColumn:   endcolumn,
 	}
 
 	return func() {


### PR DESCRIPTION
修了一个获取指令范围时候没考虑换行的问题

![image](https://github.com/yaklang/yaklang/assets/52876328/f1c2009e-33bd-4d15-863d-547eff682a7b)
