### PR TITLE
impr large httpflow

### DIFF
--- a/common/domainextractor/extractdomain_test.go
+++ b/common/domainextractor/extractdomain_test.go
@@ -57,6 +57,11 @@ sec-ch-ua-platform: "macOS"
 	}
 }
 
+func TestHaveDomainDOS(t *testing.T) {
+	var result, rootDomain = scan(string(strings.Repeat("a", 1000*1000) + " baidu.com "))
+	spew.Dump(result, rootDomain)
+}
+
 func testExtractDomain(code string, i ...string) {
 	if len(i) <= 0 {
 		panic("no expected")

--- a/common/yakgrpc/grpc_httpflow_test.go
+++ b/common/yakgrpc/grpc_httpflow_test.go
@@ -95,4 +95,7 @@ Host: www.example.com
 		t.Fatal("should be cached")
 	}
 	_ = response
+	if len(response.GetResponse()) < 1000*800 {
+		t.Fatal("response is missed")
+	}
 }

--- a/common/yakgrpc/grpc_httpflow_test.go
+++ b/common/yakgrpc/grpc_httpflow_test.go
@@ -1,0 +1,41 @@
+package yakgrpc
+
+import (
+	"context"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+	"testing"
+)
+
+func TestGRPCMUSTPASS_QueryHTTPFlow_Oversize(t *testing.T) {
+	var client, err = NewLocalClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := client.QueryHTTPFlows(context.Background(), &ypb.QueryHTTPFlowRequest{
+		Pagination: &ypb.Paging{
+			Page:    1,
+			Limit:   100,
+			OrderBy: "body_length",
+			Order:   "desc",
+		},
+		Full: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range resp.GetData() {
+		if r.BodyLength > 1000*1000 {
+			if len(r.Response) != 0 {
+				t.Fatal("response should be empty")
+			}
+		} else if r.BodyLength < 100*1000 {
+			if len(r.Response) == 0 {
+				spew.Dump(r.Response)
+				println(string(r.Response))
+				t.Fatal("response should not be empty")
+			}
+		}
+	}
+}

--- a/common/yakgrpc/grpc_mitm.go
+++ b/common/yakgrpc/grpc_mitm.go
@@ -921,7 +921,7 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 			websocketHashCache.Store(wshash, true)
 
 			flow, err := yakit.CreateHTTPFlowFromHTTPWithBodySaved(
-				s.GetProjectDatabase(), isTls, req, rsp, "mitm", urlStr, httpctx.GetRemoteAddr(req), true, true,
+				isTls, req, rsp, "mitm", urlStr, httpctx.GetRemoteAddr(req),
 			)
 			if err != nil {
 				log.Errorf("httpflow failed: %s", err)
@@ -1234,7 +1234,7 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 					// 保存到数据库
 					log.Debugf("start to create httpflow from mitm[%v %v]", originReqIns.Method, truncate(originReqIns.URL.String()))
 					var startCreateFlow = time.Now()
-					flow, err := yakit.CreateHTTPFlowFromHTTPWithNoRspSaved(s.GetProjectDatabase(), isHttps, originReqIns, "mitm", originReqIns.URL.String(), remoteAddr, true, true)
+					flow, err := yakit.CreateHTTPFlowFromHTTPWithNoRspSaved(isHttps, originReqIns, "mitm", originReqIns.URL.String(), remoteAddr)
 					if err != nil {
 						log.Errorf("save http flow[%v %v] from mitm failed: %s", originReqIns.Method, originReqIns.URL.String(), err)
 						return nil
@@ -1356,10 +1356,10 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 		var startCreateFlow = time.Now()
 		var flow *yakit.HTTPFlow
 		if httpctx.GetContextBoolInfoFromRequest(req, httpctx.RESPONSE_CONTEXT_NOLOG) {
-			flow, err = yakit.CreateHTTPFlowFromHTTPWithNoRspSaved(s.GetProjectDatabase(), isHttps, req, "mitm", reqUrl, remoteAddr, true, true)
+			flow, err = yakit.CreateHTTPFlowFromHTTPWithNoRspSaved(isHttps, req, "mitm", reqUrl, remoteAddr)
 			flow.StatusCode = 200 //先设置成200
 		} else {
-			flow, err = yakit.CreateHTTPFlowFromHTTPWithBodySaved(s.GetProjectDatabase(), isHttps, req, rsp, "mitm", reqUrl, remoteAddr, true, !responseOverSize)
+			flow, err = yakit.CreateHTTPFlowFromHTTPWithBodySaved(isHttps, req, rsp, "mitm", reqUrl, remoteAddr) // , !responseOverSize)
 		}
 		if err != nil {
 			log.Errorf("save http flow[%v %v] from mitm failed: %s", req.Method, reqUrl, err)


### PR DESCRIPTION
优化 HTTPFlow 查询的行为
1. 在大 Response / Request 的时候，不查询 Body
2. 新增 database 之外的字段用来标记大数据包
3. 保持了对 `full` 的兼容性