### PR TITLE
fix(mitm): isHTTPS always false when using HTTP Proxy

### DIFF
--- a/common/crep/mitm_hijack_handler.go
+++ b/common/crep/mitm_hijack_handler.go
@@ -282,7 +282,7 @@ func (m *MITMServer) hijackResponseHandler(rsp *http.Response) error {
 		reqRawBytes := httpctx.GetRequestBytes(requestOrigin)
 		if reqRawBytes != nil {
 			var start = time.Now()
-			m.httpFlowMirror(requestOrigin.TLS != nil, requestOrigin, rsp, start.Unix())
+			m.httpFlowMirror(httpctx.GetRequestHTTPS(requestOrigin), requestOrigin, rsp, start.Unix())
 			var end = time.Now()
 			cost := end.Sub(start)
 			if cost.Milliseconds() > 600 {


### PR DESCRIPTION
起初只是从 history 发送到 web fuzzer 的时候没有勾上 https 的简单问题
定位下来发现塞到数据库的 http_flow 就有问题
测试发现，mitm 使用 HTTP 代理时，存进数据库一定不是 https，socks5 我用不了，ws 不会有这个问题
isHTTPS 是根据是否有 requestOrigin.TLS 判断的，而 requestOrigin.TLS 是根据 conn 的类型判断的，但是在上述情况下这个 conn 永远都不是 *tls.Conn 
看上去这个 conn 是那个 http proxy 代理本身的 conn
先检查个 schema 补救一下