### PR TITLE
pref(mitm): hookcolor db

### DIFF
--- a/common/utils/retry.go
+++ b/common/utils/retry.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"time"
+)
+
+func Retry(times int, f func() error) error {
+	var err error
+	for i := 0; i < times; i++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+func RetryWithExpBackOff(f func() error) error {
+	return RetryWithExpBackOffEx(5, 300, f)
+}
+
+func RetryWithExpBackOffEx(times int, begin int, f func() error) error {
+	var err error
+	for i := 0; i < times; i++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(time.Duration(begin*(1<<i)) * time.Millisecond)
+	}
+	return err
+}

--- a/common/yakgrpc/grpc_mitm_replacers.go
+++ b/common/yakgrpc/grpc_mitm_replacers.go
@@ -183,7 +183,6 @@ func (m *mitmReplacer) GetHijackingRules() []*ypb.MITMContentReplacer {
 
 func stringForSettingColor(db *gorm.DB, s string, extraTag []string, flow *yakit.HTTPFlow) {
 	flow.AddTag(extraTag...)
-
 	log.Debugf("set color[%v] for %v", s, flow.Url)
 	switch strings.ToLower(s) {
 	case "red":
@@ -205,11 +204,20 @@ func stringForSettingColor(db *gorm.DB, s string, extraTag []string, flow *yakit
 	default:
 		flow.Red()
 	}
-	for i := 0; i < 3; i++ {
-		err := yakit.UpdateHTTPFlowTags(db, flow)
-		if err != nil {
-			log.Errorf("update flow tags failed: %v", err)
+
+	lock, ok := db.Get("lock")
+	if ok {
+		lock, ok := lock.(*sync.Mutex)
+		if ok {
+			lock.Lock()
+			defer lock.Unlock()
 		}
+	}
+
+	if err := utils.Retry(3, func() error {
+		return yakit.UpdateHTTPFlowTags(db, flow)
+	}); err != nil {
+		log.Errorf("update http flow tags failed: %v", err)
 	}
 }
 

--- a/common/yakgrpc/grpc_mitm_replacers.go
+++ b/common/yakgrpc/grpc_mitm_replacers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/dlclark/regexp2"
 	"github.com/jinzhu/gorm"
-	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/go-funk"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
@@ -214,14 +213,9 @@ func stringForSettingColor(db *gorm.DB, s string, extraTag []string, flow *yakit
 	}
 }
 
-func (m *mitmReplacer) hookColor(request, response []byte, req *http.Request, flow *yakit.HTTPFlow) {
-	tx := consts.GetGormProjectDatabase().Begin()
+func (m *mitmReplacer) hookColor(tx *gorm.DB, request, response []byte, req *http.Request, flow *yakit.HTTPFlow) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("colorize failed: %v", strconv.Quote(string(request)))
-			tx.Rollback()
-		}
-		if err := tx.Commit().Error; err != nil {
 			log.Errorf("colorize failed: %v", strconv.Quote(string(request)))
 		}
 	}()

--- a/common/yakgrpc/yakit/extracted_data.go
+++ b/common/yakgrpc/yakit/extracted_data.go
@@ -79,7 +79,7 @@ func QueryExtractedData(db *gorm.DB, req *ypb.QueryMITMRuleExtractedDataRequest)
 	return paging, ret, nil
 }
 
-func SaveExtractedDataFromHTTPFlow(db *gorm.DB, flowHash string, ruleName string, data string, regexpStr ...string) error {
+func ExtractedDataFromHTTPFlow(flowHash string, ruleName string, data string, regexpStr ...string) *ExtractedData {
 	var r string
 	if len(regexpStr) > 0 {
 		r = strings.Join(regexpStr, ", ")
@@ -91,7 +91,7 @@ func SaveExtractedDataFromHTTPFlow(db *gorm.DB, flowHash string, ruleName string
 		RuleVerbose: ruleName,
 		Data:        data,
 	}
-	return CreateOrUpdateExtractedData(db, -1, extractData)
+	return extractData
 }
 
 func BatchExtractedData(db *gorm.DB, ctx context.Context) chan *ExtractedData {


### PR DESCRIPTION
- 写入流量和染色尽可能合并成一个事务（染色超时则降级到独立事务）
- 写数据库的重试改为指数退避
- 分离染色的逻辑和存储过程