### PR TITLE
fix(crawlerx): fix cookie unset on code 302

### DIFF
--- a/common/crawlerx/main.go
+++ b/common/crawlerx/main.go
@@ -176,5 +176,17 @@ func TargetUrlCheck(targetUrl string, proxy *url.URL) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return r.GetUrl(), nil
+	finalUrl := r.GetUrl()
+	tempTargetObj, err := url.Parse(tempTargetUrl)
+	if err != nil {
+		return "", err
+	}
+	finalUrlObj, err := url.Parse(finalUrl)
+	if err != nil {
+		return "", err
+	}
+	if tempTargetObj.Scheme == finalUrlObj.Scheme && tempTargetObj.Host == finalUrlObj.Host {
+		return tempTargetUrl, nil
+	}
+	return finalUrl, nil
 }


### PR DESCRIPTION
awvs目标网站带cookie爬虫测试时发现渗透目标跳转到/login下带cookie访问仍然需要输入用户名密码
修改为在遇到同scheme和host的跳转时 对原目标url进行爬虫 而不是跳转后的url