### PR TITLE
fix[ssa] fixup extern type map 

### DIFF
--- a/common/yak/ssa/extern_instance.go
+++ b/common/yak/ssa/extern_instance.go
@@ -106,13 +106,6 @@ func (f *FunctionBuilder) CoverReflectFunctionType(itype reflect.Type, level int
 	for i := 0; i < itype.NumOut(); i++ {
 		returns = append(returns, f.handlerType(itype.Out(i), level))
 	}
-	if isVariadic {
-		if t, ok := params[len(params)-1].(*ObjectType); ok {
-			t.VariadicPara = true
-		} else {
-			// error
-		}
-	}
 	return NewFunctionType(itype.String(), params, returns, isVariadic)
 }
 

--- a/common/yak/ssa/type.go
+++ b/common/yak/ssa/type.go
@@ -313,8 +313,8 @@ type ObjectType struct {
 
 	AnonymousField []*ObjectType
 
-	Combination  bool // function multiple return will combined to struct
-	VariadicPara bool // function last variadic parameter will become slice
+	Combination bool // function multiple return will combined to struct
+	// VariadicPara bool // function last variadic parameter will become slice
 
 	method map[string]*FunctionType
 
@@ -386,9 +386,6 @@ func (itype ObjectType) String() string {
 			),
 			", ",
 		)
-	}
-	if itype.VariadicPara {
-		return "..." + itype.FieldType.String()
 	}
 	if itype.Name != "" {
 		return itype.Name
@@ -579,6 +576,26 @@ func (s *FunctionType) RawString() string {
 		str,
 		s.ReturnType,
 	)
+}
+
+func (s *FunctionType) GetParamString() string {
+	ret := ""
+	for index, t := range s.Parameter {
+		if index == len(s.Parameter)-1 {
+			if s.IsVariadic {
+				if obj, ok := ToObjectType(t); ok && obj.Kind == Slice {
+					// last
+					ret += "..." + obj.FieldType.String()
+				}
+			} else {
+				ret += t.String()
+
+			}
+		} else {
+			ret += t.String() + ", "
+		}
+	}
+	return ret
 }
 
 func (s *FunctionType) GetTypeKind() TypeKind {

--- a/common/yak/ssa4analyze/type_check.go
+++ b/common/yak/ssa4analyze/type_check.go
@@ -106,7 +106,7 @@ func (t *TypeCheck) TypeCheckCall(c *ssa.Call) {
 		}
 		c.NewError(
 			ssa.Error, TypeCheckTAG,
-			NotEnoughArgument(str, gotPara.String(), funcTyp.Parameter.String()),
+			NotEnoughArgument(str, gotPara.String(), funcTyp.GetParamString()),
 		)
 	}()
 

--- a/common/yak/yak2ssa/ssa_error_test.go
+++ b/common/yak/yak2ssa/ssa_error_test.go
@@ -792,6 +792,22 @@ func TestExternInstance(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("test bytes", func(t *testing.T) {
+		CheckTestCase(t, TestCase{
+			code: `
+			fun1("1")
+			fun("1")
+			`,
+			errs: []string{
+				ssa4analyze.NotEnoughArgument("fun", "string", "bytes, boolean"),
+			},
+			ExternValue: map[string]any{
+				"fun":  func([]byte, bool) {},
+				"fun1": func(...byte) {},
+			},
+		})
+	})
 }
 
 func TestErrorHandler(t *testing.T) {


### PR DESCRIPTION
所有外部数据都保存在Map中，所有引用都是指针, 当类型在某处被修改时，导致同类型的其他使用位置都会出现错误。
* 将Variadic从ObjectType中删除，外部类型只在创建时修改，解决互相修改的问题。
* 该Variadic保存到FunctionType中，并在FunctionType手动处理参数的打印。
