### PR TITLE
修复mitm下 h2 不生效，修复 gmtls 和 h2 同时勾选下的 ErrUnexpectedEOF

### DIFF
--- a/common/minimartian/proxy.go
+++ b/common/minimartian/proxy.go
@@ -83,6 +83,8 @@ type Proxy struct {
 	lowhttpConfig []lowhttp.LowhttpOpt
 
 	maxContentLength int
+
+	h2Cache sync.Map
 }
 
 func (p *Proxy) saveCache(r *http.Request, ctx *Context) {

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -443,6 +443,9 @@ func HTTPWithoutRedirect(opts ...LowhttpOpt) (*LowhttpResponse, error) {
 	// 需要用于标识连接 https gmTLS
 	// configTLS
 	var dialopts []netx.DialXOption
+
+	dialopts = append(dialopts, netx.DialX_WithTLSNextProto(nextProto...))
+
 	if https {
 		if gmTLS {
 			dialopts = append(dialopts, netx.DialX_WithGMTLSConfig(&gmtls.Config{


### PR DESCRIPTION
使用 sync map 缓存是否支持 h2 的站点可能有待商榷