### PR TITLE
Fixup [ssa4analyze] check key type in getField method

### DIFF
--- a/common/yak/ssa/type.go
+++ b/common/yak/ssa/type.go
@@ -463,10 +463,12 @@ func (s *ObjectType) AddField(key Value, field Type) {
 }
 
 // return (field-type, key-type)
-func (s *ObjectType) GetField(key Value) (Type, Type) {
+func (s *ObjectType) GetField(key Value) Type {
 	switch s.Kind {
 	case Slice, Map:
-		return s.FieldType, s.KeyTyp
+		if key.GetType() == s.KeyTyp {
+			return s.FieldType
+		}
 	case Struct:
 		getField := func(o *ObjectType) Type {
 			if index := slices.IndexFunc(o.Key, func(v Value) bool { return v.String() == key.String() }); index != -1 {
@@ -476,15 +478,15 @@ func (s *ObjectType) GetField(key Value) (Type, Type) {
 			}
 		}
 		if t := getField(s); t != nil {
-			return t, key.GetType()
+			return t
 		}
 		for _, obj := range s.AnonymousField {
 			if t := getField(obj); t != nil {
-				return t, key.GetType()
+				return t
 			}
 		}
 	}
-	return nil, nil
+	return nil
 }
 
 // ===================== Finish simply

--- a/common/yak/ssa4analyze/type_inference.go
+++ b/common/yak/ssa4analyze/type_inference.go
@@ -222,7 +222,7 @@ func (t *TypeInference) TypeInferenceField(f *ssa.Field) {
 		switch t.GetTypeKind() {
 		case ssa.ObjectTypeKind:
 			interfaceTyp := f.Obj.GetType().(*ssa.ObjectType)
-			fTyp, _ := interfaceTyp.GetField(f.Key)
+			fTyp := interfaceTyp.GetField(f.Key)
 			if !utils.IsNil(fTyp) {
 				f.SetType(fTyp)
 				return

--- a/common/yak/yak2ssa/ssa_error_test.go
+++ b/common/yak/yak2ssa/ssa_error_test.go
@@ -389,6 +389,7 @@ func TestMemberCall(t *testing.T) {
 			`,
 			errs: []string{
 				ssa4analyze.ValueUndefined("UndefineKey"),
+				ssa4analyze.InvalidField("map[string]number", "$UndefineKey"),
 			},
 		})
 	})
@@ -468,6 +469,19 @@ func TestSliceCall(t *testing.T) {
 				c = b[0]
 			}
 			`,
+		})
+	})
+
+	t.Run("slice type check", func(t *testing.T) {
+		CheckTestCase(t, TestCase{
+			code: `
+			a = make([]int, 0)
+			b = a[0]
+			b = a.bb
+			`,
+			errs: []string{
+				ssa4analyze.InvalidField("[]number", "bb"),
+			},
 		})
 	})
 }


### PR DESCRIPTION
- [x] 对于Slice和Map类型，需要对Key的类型进行检查。之前缺失检查导致出现错误的类型推导。
- [x] 修正并增加对应测试。