### PR TITLE
fix(mitm-socks5): socks5 auth not work

### DIFF
--- a/common/minimartian/s5.go
+++ b/common/minimartian/s5.go
@@ -3,16 +3,17 @@ package minimartian
 import (
 	"context"
 	"encoding/binary"
-	"github.com/yaklang/yaklang/common/cybertunnel/ctxio"
-	"github.com/yaklang/yaklang/common/log"
-	"github.com/yaklang/yaklang/common/netx"
-	"github.com/yaklang/yaklang/common/utils"
 	"io"
 	"net"
 	"os"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/yaklang/yaklang/common/cybertunnel/ctxio"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/netx"
+	"github.com/yaklang/yaklang/common/utils"
 )
 
 type S5Config struct {
@@ -103,19 +104,7 @@ func (c *S5Config) handshakeHandler(conn net.Conn) error {
 	}
 
 	finishedAuth := len(methods) > 0
-	needpassword := false
-
-	for _, method := range methods {
-		switch method {
-		case authNone:
-			needpassword = false
-			break
-		case authWithUsernameAndPass:
-			needpassword = true
-		default:
-			continue
-		}
-	}
+	needpassword := c.ProxyPassword != "" || c.ProxyUsername != ""
 
 	if !finishedAuth {
 		conn.Write([]byte{socks5Version, authNoAcceptable})


### PR DESCRIPTION
漏洞成因在于：是否需要认证完全决定于客户端握手时的method，这意味着客户端可以决定是否需要认证（即是否携带密码），这实际上是不合理的，应该以yakit是否设置了认证为准