### PR TITLE
fix problem of yak engine parse args 

### DIFF
--- a/common/utils/cli/cli.go
+++ b/common/utils/cli/cli.go
@@ -79,6 +79,7 @@ func init() {
 
 		// 设置默认的命令行程序名称
 		DefaultCliApp.appName = strings.TrimSuffix(filename, fileSuffix)
+		DefaultCliApp.args = OsArgs[1:]
 	}
 
 	CliExportFuncNames = lo.Keys(CliExports)

--- a/common/yakgrpc/grpc_execYak.go
+++ b/common/yakgrpc/grpc_execYak.go
@@ -214,6 +214,7 @@ func (s *Server) execRequest(req *ypb.ExecRequest, moduleName string, ctx contex
 	cmd.Stderr = io.MultiWriter(writer, &stderrBuffer, os.Stderr)
 
 	start := time.Now()
+	println(cmd.String())
 	err = cmd.Run()
 	history := &yakit.ExecHistory{
 		Script:        code,

--- a/common/yakgrpc/grpc_execYak.go
+++ b/common/yakgrpc/grpc_execYak.go
@@ -214,7 +214,6 @@ func (s *Server) execRequest(req *ypb.ExecRequest, moduleName string, ctx contex
 	cmd.Stderr = io.MultiWriter(writer, &stderrBuffer, os.Stderr)
 
 	start := time.Now()
-	println(cmd.String())
 	err = cmd.Run()
 	history := &yakit.ExecHistory{
 		Script:        code,


### PR DESCRIPTION
fix problem of yak engine parse args is not work when use script such as yak example.yak --name xxx