### PR TITLE
[Fix] ssa parameter length

### DIFF
--- a/common/yak/ssa/call.go
+++ b/common/yak/ssa/call.go
@@ -130,9 +130,12 @@ func (c *Call) handleCalleeFunction() {
 				variable = builder.CreateVariable(se.Name)
 			}
 
+			// TODO: handle side effect in loop scope, will replace value in scope and create new phi
 			sideEffect := builder.EmitSideEffect(se.Name, c, se.Modify)
-			builder.AssignVariable(variable, sideEffect)
-			sideEffect.SetVerboseName(se.VerboseName)
+			if sideEffect != nil {
+				builder.AssignVariable(variable, sideEffect)
+				sideEffect.SetVerboseName(se.VerboseName)
+			}
 		}
 		recoverBuilder()
 	}

--- a/common/yak/ssa/return.go
+++ b/common/yak/ssa/return.go
@@ -92,6 +92,7 @@ func (f *Function) Finish() {
 		handlerReturnType(f.Return),
 		f.hasEllipsis,
 	)
+	funType.ParameterLen = f.ParamLength
 	funType.ParameterValue = f.Param
 	funType.SetFreeValue(f.FreeValues)
 	funType.SetSideEffect(f.SideEffects)

--- a/common/yak/ssa/ssa.go
+++ b/common/yak/ssa/ssa.go
@@ -152,9 +152,10 @@ type Function struct {
 	Package *Package
 
 	// just function parameter and all return instruction
-	Param    []*Parameter
-	paramMap map[Value]int // for get parameter index
-	Return   []*Return
+	Param       []*Parameter
+	paramMap    map[Value]int // for get parameter index
+	ParamLength int
+	Return      []*Return
 
 	// BasicBlock list
 	Blocks []*BasicBlock

--- a/common/yak/ssa/ssautil/phi.go
+++ b/common/yak/ssa/ssautil/phi.go
@@ -88,6 +88,8 @@ func (s *ScopedVersionedTable[T]) Spin(
 	header, latch ScopedVersionedTableIF[T],
 	handler SpinHandle[T],
 ) {
+	s.spin = false
+	s.createEmptyPhi = nil
 	s.incomingPhi.ForEach(func(name string, ver VersionedIF[T]) bool {
 		last := latch.ReadValue(name)
 		origin := header.ReadValue(name)

--- a/common/yak/ssa/type.go
+++ b/common/yak/ssa/type.go
@@ -53,10 +53,10 @@ func typeCompareEx(t1, t2 Type, depth int) bool {
 			break
 		}
 		t1f, _ := ToFunctionType(t1)
-		if len(t1f.Parameter) != len(t2f.Parameter) {
+		if t1f.ParameterLen != t2f.ParameterLen {
 			return false
 		}
-		for i := 0; i < len(t1f.Parameter); i++ {
+		for i := 0; i < t1f.ParameterLen; i++ {
 			if !typeCompareEx(t1f.Parameter[i], t2f.Parameter[i], depth) {
 				return false
 			}
@@ -793,6 +793,7 @@ type FunctionType struct {
 	pkgPath        string
 	ReturnType     Type
 	Parameter      Types
+	ParameterLen   int
 	ParameterValue []*Parameter
 	FreeValue      []*Parameter
 	SideEffects    []*FunctionSideEffect
@@ -833,10 +834,11 @@ func CalculateType(ts []Type) Type {
 
 func NewFunctionType(name string, Parameter []Type, ReturnType Type, IsVariadic bool) *FunctionType {
 	f := &FunctionType{
-		Name:       name,
-		Parameter:  Parameter,
-		IsVariadic: IsVariadic,
-		ReturnType: ReturnType,
+		Name:         name,
+		Parameter:    Parameter,
+		ParameterLen: len(Parameter),
+		IsVariadic:   IsVariadic,
+		ReturnType:   ReturnType,
 	}
 	return f
 }
@@ -869,10 +871,15 @@ func (s *FunctionType) RawString() string {
 		str += "..."
 	}
 
+	paras := make([]string, 0, s.ParameterLen)
+	for i := 0; i < s.ParameterLen; i++ {
+		paras = append(paras, s.Parameter[i].String())
+	}
+
 	return fmt.Sprintf(
 		"(%s %s) -> %s",
 		strings.Join(
-			lo.Map(s.Parameter, func(t Type, _ int) string { return t.String() }),
+			paras,
 			",",
 		),
 		str,

--- a/common/yak/ssa/use.go
+++ b/common/yak/ssa/use.go
@@ -146,6 +146,8 @@ func (c *Call) GetValues() Values {
 func (c *Call) ReplaceValue(v Value, to Value) {
 	if c.Method == v {
 		c.Method = to
+		c.handleCalleeFunction()
+		c.handlerReturnType()
 	} else if index := slices.Index(c.Args, v); index > -1 {
 		c.Args[index] = to
 	} else if index := slices.Index(c.binding, v); index > -1 {

--- a/common/yak/ssa4analyze/type_check.go
+++ b/common/yak/ssa4analyze/type_check.go
@@ -2,6 +2,7 @@ package ssa4analyze
 
 import (
 	"github.com/samber/lo"
+	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/yak/ssa"
 	"golang.org/x/exp/slices"
 )
@@ -169,11 +170,15 @@ func (t *TypeCheck) TypeCheckCall(c *ssa.Call) {
 			lengthError = gotParaLen != wantParaLen
 		}
 		if lengthError {
-			c.NewError(
-				ssa.Error, TypeCheckTAG,
-				NotEnoughArgument(funName, gotPara.String(), funcTyp.GetParamString()),
-			)
-			return
+			if gotParaLen != funcTyp.ParameterLen {
+				c.NewError(
+					ssa.Error, TypeCheckTAG,
+					NotEnoughArgument(funName, gotPara.String(), funcTyp.GetParamString()),
+				)
+				return
+			}
+			log.Errorf("TypeCheckCall: %s, %s", c.Method.GetVerboseName(),
+				"gotParaLen == funcTyp.ParameterLen but no enough argument")
 		}
 		checkParamType := func(i int) {
 			if !ssa.TypeCompare(gotPara[i], funcTyp.Parameter[i]) {
@@ -188,7 +193,7 @@ func (t *TypeCheck) TypeCheckCall(c *ssa.Call) {
 			}
 		}
 
-		for i := 0; i < wantParaLen; i++ {
+		for i := 0; i < gotParaLen; i++ {
 			if i == wantParaLen-1 && funcTyp.IsVariadic {
 				break // ignore
 			}

--- a/common/yak/static_analyzer/test/basic_error_test.go
+++ b/common/yak/static_analyzer/test/basic_error_test.go
@@ -81,7 +81,7 @@ func TestFunctionCallParameterLength(t *testing.T) {
 		a = ["a", "b"]
 		codec.DecodeBase64(a...)
 		`, []string{
-			ssa4analyze.NotEnoughArgument("codec.DecodeBase64", "[]string", "string"),
+			ssa4analyze.ArgumentTypeError(1, "[]string", "string", "codec.DecodeBase64"),
 		})
 	})
 }

--- a/common/yak/yak2ssa/builder_ast.go
+++ b/common/yak/yak2ssa/builder_ast.go
@@ -1332,6 +1332,7 @@ func (b *astbuilder) buildAnonymousFunctionDecl(stmt *yak.AnonymousFunctionDeclC
 	// save Current function builder marked FunctionType
 	MarkedFunctionType := b.GetMarkedFunction()
 	handleFunctionType := func(fun *ssa.Function) {
+		fun.ParamLength = len(fun.Param)
 		// in this function, builder is sub-function builder
 		if MarkedFunctionType == nil {
 			return

--- a/common/yak/yak2ssa/test/real_yak_test.go
+++ b/common/yak/yak2ssa/test/real_yak_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssatest"
+)
+
+func Test_RealYak_Function(t *testing.T) {
+	t.Run("object", func(t *testing.T) {
+		ssatest.CheckNoError(t, `
+lock := sync.NewLock()
+
+x.Foreach([1,2], func(e){
+	lock.Lock()
+	println(e)
+	lock.Unlock()
+})
+		`)
+	})
+
+	t.Run("function parameter but in loop", func(t *testing.T) {
+		ssatest.CheckNoError(t, `
+lock := sync.NewLock()
+f = (i)=>{
+    lock.Lock()
+    println(i)
+    lock.Unlock()
+}
+f(1)
+for true {
+    f(1)
+}
+`)
+	})
+}


### PR DESCRIPTION
- 在SSA处理OOP的时候将会将成员访问设置到参数，并转换为额外的参数传入，以达到在函数调用时进行成员变量的获取的效果。但是这样的处理将会导致函数出现多余的参数，因此需要保留原本函数定义中的预期参数个数。

- 在循环中，函数的PHI替换将会导致函数调用语句定义改变，因此需要在Call指令的Method被替换时进行修正。