### PR TITLE
fix(crawlerx): fix subdomain scan range not work in some cases

### DIFF
--- a/common/crawlerx/check.go
+++ b/common/crawlerx/check.go
@@ -169,9 +169,16 @@ func generalMainDomainRange(targetUrl string) []string {
 func generalSubDomainRange(targetUrl string) []string {
 	url, _ := u.Parse(targetUrl)
 	ranges := make([]string, 0)
-	ranges = append(ranges, url.Scheme+"://"+url.Host+url.Path)
+	var path string
+	if strings.HasSuffix(url.Path, "/") {
+		path = url.Path
+	} else {
+		tempPaths := strings.Split(url.Path, "/")
+		path = strings.Join(tempPaths[0:len(tempPaths)-1], "/")
+	}
+	ranges = append(ranges, url.Scheme+"://"+url.Host+path)
 	if !strings.HasPrefix(url.Host, "www.") {
-		ranges = append(ranges, url.Scheme+"://www."+url.Host+url.Path)
+		ranges = append(ranges, url.Scheme+"://www."+url.Host+path)
 	}
 	return ranges
 }

--- a/common/crawlerx/check.go
+++ b/common/crawlerx/check.go
@@ -174,7 +174,7 @@ func generalSubDomainRange(targetUrl string) []string {
 		path = url.Path
 	} else {
 		tempPaths := strings.Split(url.Path, "/")
-		path = strings.Join(tempPaths[0:len(tempPaths)-1], "/")
+		path = strings.Join(tempPaths[0:len(tempPaths)-1], "/") + "/"
 	}
 	ranges = append(ranges, url.Scheme+"://"+url.Host+path)
 	if !strings.HasPrefix(url.Host, "www.") {

--- a/common/crawlerx/check_test.go
+++ b/common/crawlerx/check_test.go
@@ -75,3 +75,22 @@ func TestUrlQuery(t *testing.T) {
 	}
 	test.Equal("id=3&value=4&test=5&data=xxx", strings.Join(queryItem, "&"))
 }
+
+func TestGeneralSubDomainRange(t *testing.T) {
+	type args struct {
+		targetUrl string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"case1", args{targetUrl: "https://www.test.com/abc/def/"}, []string{"https://www.test.com/abc/def/"}},
+		{"case2", args{targetUrl: "https://www.test.com/abc/def"}, []string{"https://www.test.com/abc/"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, generalSubDomainRange(tt.args.targetUrl), "generalSubDomainRange(%v)", tt.args.targetUrl)
+		})
+	}
+}


### PR DESCRIPTION
修复当目标url不以"/"结尾时，子域名扫描范围判断错误的bug