### PR TITLE
fix(poc): modify the default poc http timeout

### DIFF
--- a/common/utils/lowhttp/poc/poc.go
+++ b/common/utils/lowhttp/poc/poc.go
@@ -28,7 +28,7 @@ import (
 var (
 	defaultWaitTime    = time.Duration(100) * time.Millisecond
 	defaultMaxWaitTime = time.Duration(2000) * time.Millisecond
-	defaultTimeout     = time.Duration(1500) * time.Millisecond
+	defaultTimeout     = time.Duration(15000) * time.Millisecond
 )
 
 type PocConfig struct {


### PR DESCRIPTION
文档介绍 poc 请求默认超时时间为 15 秒
+ https://yaklang.io/docs/api/poc/#timeout
+ https://yaklang.io/docs/api/poc/#connecttimeout

实测为 1.5秒
![image](https://github.com/yaklang/yaklang/assets/39155974/b8bed9b0-da21-4b10-8ee1-90ac2fd3dd83)

代码写的是 1500毫秒
```go
defaultTimeout     = time.Duration(1500) * time.Millisecond
```

修改后正常
![image](https://github.com/yaklang/yaklang/assets/39155974/5fe592e0-0650-4a6c-ba07-1db35fe83a0e)

实际使用场景 1.5 秒太容易超时了，然后使用者如果 `resp, _, _ = poc.xx`，忽略异常的话会很无感， 直接请求什么反应都没有