### PR TITLE
Fix/lowhttp/redirect

### DIFF
--- a/common/coreplugin/base-yak-plugin/CSRF 表单保护与 CORS 配置不当检测.yak
+++ b/common/coreplugin/base-yak-plugin/CSRF 表单保护与 CORS 配置不当检测.yak
@@ -78,7 +78,7 @@ corsLog = func(result){
 }
 
 csrf_Detect =  func(url,req,rsp,body,ishttps){
-    lowHttpRsp,_,err = poc.HTTPEx(req, [poc.deleteHeader("Cookie"),poc.https(ishttps)]...)
+    lowHttpRsp,_,err = poc.HTTPEx(req, poc.deleteHeader("Cookie"), poc.https(ishttps))
     checkErr(err)
     rspWithoutCookie = lowHttpRsp.RedirectRawPackets[0].Response
 
@@ -88,8 +88,6 @@ csrf_Detect =  func(url,req,rsp,body,ishttps){
     checkErr(err)
     pforms = xpath.Find(phtml,"//form")
     forms = xpath.Find(html,"//form")
-
-
 
     dforms = []
     for pform in pforms{

--- a/common/mutate/http_pool.go
+++ b/common/mutate/http_pool.go
@@ -92,6 +92,8 @@ type httpPoolConfig struct {
 
 	// withPayloads 是否查询 payloads
 	WithPayloads bool
+
+	Session string // for cookie jar
 }
 
 // WithPoolOpt_DNSNoCache is not effective
@@ -500,6 +502,12 @@ func _httpPool_withPayloads(b bool) HttpPoolConfigOption {
 	}
 }
 
+func _httpPool_withSession(session string) HttpPoolConfigOption {
+	return func(config *httpPoolConfig) {
+		config.Session = session
+	}
+}
+
 type HttpPoolConfigOption func(config *httpPoolConfig)
 
 type HttpResult struct {
@@ -748,6 +756,7 @@ func _httpPool(i interface{}, opts ...HttpPoolConfigOption) (chan *HttpResult, e
 							lowhttp.WithETCHosts(config.EtcHosts),
 							lowhttp.WithGmTLS(config.IsGmTLS),
 							lowhttp.WithConnPool(config.WithConnPool),
+							lowhttp.WithSession(config.Session),
 						}
 
 						if config.OverrideEnableSystemProxyEnv {
@@ -1044,4 +1053,5 @@ var (
 	WithConnPool                           = _httpPool_withConnPool
 	WithPoolOpt_ExternSwitch               = _httpPool_ExternSwitch
 	WithPoolOpt_WithPayloads               = _httpPool_withPayloads
+	WithPoolOpt_Session                    = _httpPool_withSession
 )

--- a/common/utils/http_request_builder.go
+++ b/common/utils/http_request_builder.go
@@ -448,7 +448,9 @@ func readHTTPRequestFromBufioReader(reader *bufio.Reader, fixContentLength bool,
 		host = hostInHeader
 	}
 	req.Host = host
-
+	if req.URL.Host == "" {
+		req.URL.Host = hostInHeader
+	}
 	bodyRawBuf := new(bytes.Buffer)
 	if fixContentLength {
 		// by reader

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -60,7 +60,6 @@ func HTTP(opts ...LowhttpOpt) (*LowhttpResponse, error) {
 		redirectTimes      = option.RedirectTimes
 		redirectHandler    = option.RedirectHandler
 		jsRedirect         = option.JsRedirect
-		session            = option.Session
 		redirectRawPackets []*RedirectFlow
 		response           *LowhttpResponse
 		err                error
@@ -99,9 +98,8 @@ func HTTP(opts ...LowhttpOpt) (*LowhttpResponse, error) {
 
 			targetUrl := MergeUrlFromHTTPRequest(r, target, forceHttps)
 
-			cookiejar := GetCookiejar(session)
 			// should not extract response cookie
-			r, err = UrlToRequestPacketEx(method, targetUrl, r, forceHttps, statusCode, cookiejar)
+			r, err = UrlToRequestPacketEx(method, targetUrl, r, forceHttps, statusCode)
 			if err != nil {
 				log.Errorf("met error in redirect: %v", err)
 				response.RawPacket = lastPacket.Response // 保留原始报文

--- a/common/utils/lowhttp/url_to_request.go
+++ b/common/utils/lowhttp/url_to_request.go
@@ -100,9 +100,13 @@ func UrlToRequestPacketEx(method string, targetURL string, originRequest []byte,
 		if originReqIns == nil {
 			return nil, utils.Error("parse bytes to http request error, empty request")
 		}
-		if https {
-			// fix https externally
-			originReqIns.URL.Scheme = "https"
+		if originReqIns.URL != nil {
+			if https {
+				// fix https externally
+				originReqIns.URL.Scheme = "https"
+			} else if originReqIns.URL.Scheme == "" {
+				originReqIns.URL.Scheme = "http"
+			}
 		}
 		if method == "" {
 			method = originReqIns.Method

--- a/common/utils/lowhttp/url_to_request.go
+++ b/common/utils/lowhttp/url_to_request.go
@@ -101,6 +101,9 @@ func UrlToRequestPacketEx(method string, targetURL string, originRequest []byte,
 	raw = NewRequestPacketFromMethod(method, targetURL, originRequest, originReqIns, https, cookies...)
 	if is302Or303 {
 		raw = ReplaceHTTPPacketBodyFast(raw, nil)
+		raw = DeleteHTTPPacketHeader(raw, "Content-Length")
+		raw = DeleteHTTPPacketHeader(raw, "Transfer-Encoding")
+		raw = DeleteHTTPPacketHeader(raw, "Content-Type")
 	}
 	if originReqIns != nil && originReqIns.URL != nil {
 		raw = ReplaceHTTPPacketHeader(raw, "Referer", originReqIns.URL.String())

--- a/common/utils/lowhttp/url_to_request_test.go
+++ b/common/utils/lowhttp/url_to_request_test.go
@@ -95,11 +95,27 @@ func TestUrlToRequestPacketEx(t *testing.T) {
 		result, err := UrlToRequestPacketEx(http.MethodGet, "https://example.com/asd", nil, true, -1, nil)
 		require.NoError(t, err)
 
-		wantResult := string(FixHTTPRequest([]byte(`GET /asd HTTP/1.1
+		wantResult := `GET /asd HTTP/1.1
 Host: example.com
 
-`)))
-		CheckRequest(t, result, string(wantResult))
+`
+		CheckRequest(t, result, wantResult)
+	})
+	t.Run("referer", func(t *testing.T) {
+		result, err := UrlToRequestPacketEx("", "https://example.com/qwe", []byte(`POST /asd HTTP/1.1
+Host: example.com
+AAA: BBB
+Cookie: test=12;
+
+aaa`), false, 302, nil)
+		require.NoError(t, err)
+
+		wantResult := `GET /qwe HTTP/1.1
+Host: example.com
+AAA: BBB
+Referer: http://example.com/asd
+		`
+		CheckRequest(t, result, wantResult)
 	})
 	t.Run("302", func(t *testing.T) {
 		result, err := UrlToRequestPacketEx("", "https://example.com/qwe", []byte(`POST /asd HTTP/1.1

--- a/common/utils/lowhttp/url_to_request_test.go
+++ b/common/utils/lowhttp/url_to_request_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 )
 
-func CheckResponse(t *testing.T, raw []byte, wantReq string) {
+func CheckRequest(t *testing.T, raw []byte, wantReq string) {
 	t.Helper()
 
 	raw = FixHTTPRequest(raw)
@@ -87,10 +87,20 @@ Host: example.com
 AAA: BBB
 Referer: https://example.com/qwe
 `
-	CheckResponse(t, result, wantResult)
+	CheckRequest(t, result, wantResult)
 }
 
 func TestUrlToRequestPacketEx(t *testing.T) {
+	t.Run("nil origin request", func(t *testing.T) {
+		result, err := UrlToRequestPacketEx(http.MethodGet, "https://example.com/asd", nil, true, -1, nil)
+		require.NoError(t, err)
+
+		wantResult := string(FixHTTPRequest([]byte(`GET /asd HTTP/1.1
+Host: example.com
+
+`)))
+		CheckRequest(t, result, string(wantResult))
+	})
 	t.Run("302", func(t *testing.T) {
 		result, err := UrlToRequestPacketEx("", "https://example.com/qwe", []byte(`POST /asd HTTP/1.1
 Host: example.com
@@ -105,7 +115,7 @@ Host: example.com
 AAA: BBB
 Referer: https://example.com/asd
 `
-		CheckResponse(t, result, wantResult)
+		CheckRequest(t, result, wantResult)
 	})
 	t.Run("307", func(t *testing.T) {
 		result, err := UrlToRequestPacketEx("", "https://example.com/qwe", []byte(`POST /asd HTTP/1.1
@@ -122,7 +132,7 @@ AAA: BBB
 Referer: https://example.com/asd
 
 aaa`
-		CheckResponse(t, result, wantResult)
+		CheckRequest(t, result, wantResult)
 	})
 
 	t.Run("jar", func(t *testing.T) {
@@ -155,7 +165,7 @@ Referer: https://example.com/asd
 
 ab
 `
-		CheckResponse(t, result, wantResult)
+		CheckRequest(t, result, wantResult)
 	})
 }
 

--- a/common/utils/lowhttp/url_to_request_test.go
+++ b/common/utils/lowhttp/url_to_request_test.go
@@ -3,7 +3,6 @@ package lowhttp
 import (
 	"bytes"
 	"net/http"
-	"net/http/cookiejar"
 	"sort"
 	"strings"
 	"testing"
@@ -11,7 +10,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yaklang/yaklang/common/utils"
 )
 
 func CheckRequest(t *testing.T, raw []byte, wantReq string) {
@@ -92,7 +90,7 @@ Referer: https://example.com/qwe
 
 func TestUrlToRequestPacketEx(t *testing.T) {
 	t.Run("nil origin request", func(t *testing.T) {
-		result, err := UrlToRequestPacketEx(http.MethodGet, "https://example.com/asd", nil, true, -1, nil)
+		result, err := UrlToRequestPacketEx(http.MethodGet, "https://example.com/asd", nil, true, -1)
 		require.NoError(t, err)
 
 		wantResult := `GET /asd HTTP/1.1
@@ -148,39 +146,6 @@ AAA: BBB
 Referer: https://example.com/asd
 
 aaa`
-		CheckRequest(t, result, wantResult)
-	})
-
-	t.Run("jar", func(t *testing.T) {
-		jar, err := cookiejar.New(nil)
-		require.NoError(t, err)
-
-		urlIns := utils.ParseStringToUrl("https://example.com")
-		jar.SetCookies(urlIns, []*http.Cookie{
-			{
-				Name:  "test",
-				Value: "12",
-			},
-		})
-
-		result, err := UrlToRequestPacketEx(http.MethodPost, "https://example.com/qwe", []byte(`POST /asd HTTP/1.1
-Host: example.com
-AAA: BBB
-Content-Length: 4
-
-ab
-`), true, 307, jar)
-		require.NoError(t, err)
-
-		wantResult := `POST /qwe HTTP/1.1
-Host: example.com
-Cookie: test=12
-AAA: BBB
-Content-Length: 4
-Referer: https://example.com/asd
-
-ab
-`
 		CheckRequest(t, result, wantResult)
 	})
 }

--- a/common/utils/lowhttp/url_to_request_test.go
+++ b/common/utils/lowhttp/url_to_request_test.go
@@ -2,10 +2,16 @@ package lowhttp
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/cookiejar"
+	"sort"
+	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
 )
 
 func CheckResponse(t *testing.T, raw []byte, wantReq string) {
@@ -15,89 +21,142 @@ func CheckResponse(t *testing.T, raw []byte, wantReq string) {
 	wantRaw := FixHTTPRequest([]byte(wantReq))
 
 	reqIns, err := ParseBytesToHttpRequest(raw)
-	if err != nil {
-		t.Fatalf("parse request error: %v\n%s", err, string(raw))
-	}
+	require.NoError(t, err, "parse request error")
 	wantReqIns, err := ParseBytesToHttpRequest(wantRaw)
-	if err != nil {
-		t.Fatalf("parse want request error: %v\n%s", err, string(wantRaw))
-	}
+	require.NoError(t, err, "parse want request error")
 
 	// compare method
 	if reqIns.Method != wantReqIns.Method {
-		t.Errorf("method Error: got:\n%s\nwant:\n%s\n", reqIns.Method, wantReqIns.Method)
+		require.Equal(t, wantReqIns.Method, reqIns.Method, "method")
 	}
 	// compare url
 	if reqIns.URL.String() != wantReqIns.URL.String() {
-		t.Errorf("url Error: got:\n%s\nwant:\n%s\n", reqIns.URL.String(), wantReqIns.URL.String())
+		require.Equal(t, wantReqIns.URL.String(), reqIns.URL.String(), "url")
 	}
 	// compare header
 	if len(reqIns.Header) != len(wantReqIns.Header) {
-		t.Errorf("header len Error: got:\n%d\nwant:\n%d\n", len(reqIns.Header), len(wantReqIns.Header))
-	}
-	for k, v := range reqIns.Header {
-		if v[0] != wantReqIns.Header[k][0] {
-			t.Errorf("header Error: got:\n%s\nwant:\n%s\n", v[0], wantReqIns.Header[k][0])
+		require.Len(t, reqIns.Header, len(wantReqIns.Header), "header len")
+	} else {
+		for k, v := range reqIns.Header {
+			require.Greater(t, len(v), 0, "header %s is empty", k)
+			require.Greater(t, len(wantReqIns.Header[k]), 0, "want header %s is empty", k)
+
+			header, wantHeader := v[0], wantReqIns.Header[k][0]
+			if k == "Cookie" {
+				// sort header and wantHeader
+				headers := lo.FilterMap(strings.Split(header, ";"), func(item string, index int) (string, bool) {
+					trimed := strings.TrimSpace(item)
+					return trimed, trimed != ""
+				})
+				wantHeaders := lo.FilterMap(strings.Split(wantHeader, ";"), func(item string, index int) (string, bool) {
+					trimed := strings.TrimSpace(item)
+					return trimed, trimed != ""
+				})
+				sort.Strings(headers)
+				sort.Strings(wantHeaders)
+				header = strings.Join(headers, "; ")
+				wantHeader = strings.Join(wantHeaders, "; ")
+			}
+			require.Equalf(t, wantHeader, header, "Header %s", k)
 		}
 	}
 
 	// compare body
+	if reqIns.Body == nil && wantReqIns.Body != nil {
+		t.Fatal("raw body is nil")
+	}
+	if reqIns.Body != nil && wantReqIns.Body == nil {
+		t.Fatal("new body is nil")
+	}
 	if reqIns.Body != nil && wantReqIns.Body != nil {
 		var buf1, buf2 bytes.Buffer
 		_, _ = buf1.ReadFrom(reqIns.Body)
 		_, _ = buf2.ReadFrom(wantReqIns.Body)
-		if buf1.String() != buf2.String() {
-			t.Errorf("body Error: got:\n%s\nwant:\n%s\n", buf1.String(), buf2.String())
-		}
+		require.Equal(t, buf2.String(), buf1.String(), "body")
 	}
 }
 
 func TestUrlToGetRequestPacket(t *testing.T) {
-	result := UrlToGetRequestPacket("https://baidu.com/asd", []byte(`GET / HTTP/1.1
-Host: baidu.com
-Cookie: test=12;`), false)
+	// keep header
+	result := UrlToGetRequestPacket("https://example.com/asd", []byte(`GET /qwe HTTP/1.1
+Host: example.com
+AAA: BBB
+Cookie: test=12;`), true)
 	wantResult := `GET /asd HTTP/1.1
-Host: baidu.com
-User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
-Cookie: test=12
+Host: example.com
+AAA: BBB
+Referer: https://example.com/qwe
 `
 	CheckResponse(t, result, wantResult)
 }
 
-func TestUrlToGetRequestPacket302(t *testing.T) {
-	resp := []byte(`HTTP/1.1 302
-	Set-Cookie: test2=34;`)
-	respcookies := ExtractCookieJarFromHTTPResponse(resp)
-	result := UrlToGetRequestPacketWithResponse("https://baidu.com/qwe", []byte(`POST /asd HTTP/1.1
-Host: baidu.com
-Cookie: test=12;`), resp, false, respcookies...)
-	wantResult := `GET /qwe HTTP/1.1
-Host: baidu.com
-User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:68.0) Gecko/20100101 Firefox/68.0
-Cookie: test=12
-`
-	CheckResponse(t, result, wantResult)
-}
-
-func TestUrlToGetRequestPacket307(t *testing.T) {
-	resp := []byte(`HTTP/1.1 307` + "\r\n" + `Set-Cookie: test2=34;` + "\r\n\r\n")
-	respcookies := ExtractCookieJarFromHTTPResponse(resp)
-	result := UrlToGetRequestPacketWithResponse("https://baidu.com/qwe", []byte(`POST /asd HTTP/1.1
-Host: baidu.com
+func TestUrlToRequestPacketEx(t *testing.T) {
+	t.Run("302", func(t *testing.T) {
+		result, err := UrlToRequestPacketEx("", "https://example.com/qwe", []byte(`POST /asd HTTP/1.1
+Host: example.com
+AAA: BBB
 Cookie: test=12;
+
+aaa`), true, 302, nil)
+		require.NoError(t, err)
+
+		wantResult := `GET /qwe HTTP/1.1
+Host: example.com
+AAA: BBB
+Referer: https://example.com/asd
+`
+		CheckResponse(t, result, wantResult)
+	})
+	t.Run("307", func(t *testing.T) {
+		result, err := UrlToRequestPacketEx("", "https://example.com/qwe", []byte(`POST /asd HTTP/1.1
+Host: example.com
+AAA: BBB
+Cookie: test=12;
+
+aaa`), true, 307, nil)
+		require.NoError(t, err)
+
+		wantResult := `POST /qwe HTTP/1.1
+Host: example.com
+AAA: BBB
+Referer: https://example.com/asd
+
+aaa`
+		CheckResponse(t, result, wantResult)
+	})
+
+	t.Run("jar", func(t *testing.T) {
+		jar, err := cookiejar.New(nil)
+		require.NoError(t, err)
+
+		urlIns := utils.ParseStringToUrl("https://example.com")
+		jar.SetCookies(urlIns, []*http.Cookie{
+			{
+				Name:  "test",
+				Value: "12",
+			},
+		})
+
+		result, err := UrlToRequestPacketEx(http.MethodPost, "https://example.com/qwe", []byte(`POST /asd HTTP/1.1
+Host: example.com
+AAA: BBB
 Content-Length: 4
 
 ab
-`), resp, false, respcookies...)
+`), true, 307, jar)
+		require.NoError(t, err)
 
-	wantResult := `POST /qwe HTTP/1.1
-Host: baidu.com
-Cookie: test=12; test2=34
+		wantResult := `POST /qwe HTTP/1.1
+Host: example.com
+Cookie: test=12
+AAA: BBB
 Content-Length: 4
+Referer: https://example.com/asd
 
 ab
 `
-	CheckResponse(t, result, wantResult)
+		CheckResponse(t, result, wantResult)
+	})
 }
 
 func TestUrlToHTTPRequest(t *testing.T) {
@@ -159,18 +218,18 @@ func TestUrlToHTTPRequest(t *testing.T) {
 
 func TestFixURL(t *testing.T) {
 	t.Run("no scheme 80 port", func(t *testing.T) {
-		require.Equal(t, "http://baidu.com", FixURLScheme("baidu.com:80"))
+		require.Equal(t, "http://example.com", FixURLScheme("example.com:80"))
 	})
 	t.Run("no scheme 443 port", func(t *testing.T) {
-		require.Equal(t, "https://baidu.com", FixURLScheme("baidu.com:443"))
+		require.Equal(t, "https://example.com", FixURLScheme("example.com:443"))
 	})
 	t.Run("no scheme not normal port", func(t *testing.T) {
-		require.Equal(t, "http://baidu.com:11111", FixURLScheme("baidu.com:11111"))
+		require.Equal(t, "http://example.com:11111", FixURLScheme("example.com:11111"))
 	})
 	t.Run("normal http", func(t *testing.T) {
-		require.Equal(t, "http://baidu.com:80", FixURLScheme("http://baidu.com:80"))
+		require.Equal(t, "http://example.com:80", FixURLScheme("http://example.com:80"))
 	})
 	t.Run("normal https", func(t *testing.T) {
-		require.Equal(t, "http://baidu.com:8443", FixURLScheme("http://baidu.com:8443"))
+		require.Equal(t, "http://example.com:8443", FixURLScheme("http://example.com:8443"))
 	})
 }

--- a/common/yak/httptpl/yaktpl_exec_test.go
+++ b/common/yak/httptpl/yaktpl_exec_test.go
@@ -4,6 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/yaklang/yaklang/common/facades"
@@ -12,11 +18,6 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
 	"github.com/yaklang/yaklang/common/utils/lowhttp/poc"
-	"net/http"
-	"net/url"
-	"strings"
-	"testing"
-	"time"
 )
 
 func TestMockTest_SmokingTest(t *testing.T) {
@@ -1405,6 +1406,7 @@ requests:
 		}
 	}
 }
+
 func TestRenderPackage(t *testing.T) {
 	server, port := utils.DebugMockHTTPWithTimeout(10000*time.Second, []byte(`HTTP/1.1 200 OK
 TestDebug: 111
@@ -1518,6 +1520,7 @@ User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 
 	}
 }
+
 func TestMockTest_OOB(t *testing.T) {
 	dnsserver := facades.MockDNSServer(context.Background(), "aaa.asdgiqwfkbas.com", 8901, func(record string, domain string) string {
 		return "1.1.1.1"
@@ -1594,6 +1597,7 @@ http:
 		t.Error("test oob error")
 	}
 }
+
 func TestMockTest_Body(t *testing.T) {
 	server, port := utils.DebugMockHTTPWithTimeout(10000*time.Second, []byte(`HTTP/1.1 200 OK
 TestDebug: 111
@@ -1674,6 +1678,7 @@ http:
 		}
 	}
 }
+
 func TestMockTest_StopAtFirstMatch(t *testing.T) {
 	server, port := utils.DebugMockHTTPWithTimeout(10000*time.Second, []byte(`HTTP/1.1 200 OK
 TestDebug: 111
@@ -1772,14 +1777,15 @@ func TestMockTest_interactsh(t *testing.T) {
 	interactshProtocol := make(map[string]string)
 	interactshRequest := make(map[string][][]byte)
 
-	dnsServer := facades.MockDNSServer(context.Background(), rootDomain, 8902, func(record string, domain string) string {
+	port := utils.GetRandomAvailableUDPPort()
+	dnsServer := facades.MockDNSServer(context.Background(), rootDomain, port, func(record string, domain string) string {
 		if strings.Contains(domain, token) {
 			interactshProtocol[token] = "dns"
 		}
 		return "127.0.0.1"
 	})
 
-	_, httpServerPort := utils.DebugMockHTTPEx(func(req []byte) []byte {
+	httpServerHost, httpServerPort := utils.DebugMockHTTPEx(func(req []byte) []byte {
 		reqStr := string(req)
 		if strings.Contains(reqStr, token) {
 			interactshProtocol[token] = "http"
@@ -1854,6 +1860,7 @@ http:
 	config := NewConfig(WithOOBRequireCallback(func(f ...float64) (string, string, error) {
 		return fmt.Sprintf("%s:%d", tokenDomain, httpServerPort), token, nil
 	}), WithOOBRequireCheckingTrigger(func(s string, runtimeID string, f ...float64) (string, []byte) {
+		log.Infof("interactsh protocol:%v\n", interactshProtocol[s])
 		if interactshProtocol[s] == "http" {
 			for _, request := range interactshRequest[s] {
 				if strings.Contains(string(request), sendToken) {
@@ -1865,77 +1872,11 @@ http:
 		ok = false
 		return "", []byte("")
 	}))
+	log.Infof("vul http server:%s:%d\n", server, port)
+	log.Infof("interactsh http server:%s:%d\n", httpServerHost, httpServerPort)
+	log.Infof("interactsh dns server:%s\n", dnsServer)
 	tmpIns.ExecWithUrl("http://www.baidu.com", config, lowhttp.WithHost(server), lowhttp.WithPort(port))
 	if !ok {
 		t.Error("test oob error")
 	}
 }
-
-//
-//func TestMockTest_OOBAAAA(t *testing.T) {
-//
-//	server, port := utils.DebugMockHTTPHandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-//		writer.Write([]byte("ok"))
-//		u := request.URL.Query().Get("consumerUri")
-//		urlIns, err := url.Parse(u)
-//		if err != nil {
-//			t.Fatal(err)
-//			return
-//		}
-//		//netx.LookupFirst(urlIns.Host, netx.WithTimeout(time.Second), netx.WithDNSDisableSystemResolver(true))
-//		poc.DoGET(urlIns.String())
-//	})
-//	tmp := `id: CVE-2017-9506
-//
-//info:
-//  name: Atlassian Jira IconURIServlet - Cross-Site Scripting/Server-Side Request Forgery
-//  author: pdteam
-//  severity: medium
-//  description: The Atlassian Jira IconUriServlet of the OAuth Plugin from version 1.3.0 before version 1.9.12 and from version 2.0.0 before version 2.0.4 contains a cross-site scripting vulnerability which allows remote attackers to access the content of internal network resources and/or perform an attack via Server Side Request Forgery.
-//  remediation: |
-//    Apply the latest security patches provided by Atlassian to mitigate these vulnerabilities.
-//  reference:
-//    - http://dontpanic.42.nl/2017/12/there-is-proxy-in-your-atlassian.html
-//    - https://ecosystem.atlassian.net/browse/OAUTH-344
-//    - https://medium.com/bugbountywriteup/piercing-the-veil-server-side-request-forgery-to-niprnet-access-171018bca2c3
-//    - https://nvd.nist.gov/vuln/detail/CVE-2017-9506
-//  classification:
-//    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
-//    cvss-score: 6.1
-//    cve-id: CVE-2017-9506
-//    cwe-id: CWE-918
-//    epss-score: 0.00575
-//    epss-percentile: 0.75469
-//    cpe: cpe:2.3:a:atlassian:oauth:1.3.0:*:*:*:*:*:*:*
-//  metadata:
-//    max-request: 1
-//    vendor: atlassian
-//    product: oauth
-//    shodan-query: http.component:"Atlassian Jira"
-//  tags: cve,cve2017,atlassian,jira,ssrf,oast
-//
-//http:
-//  - raw:
-//      - |
-//        GET /plugins/servlet/oauth/users/icon-uri?consumerUri=http://{{interactsh-url}} HTTP/1.1
-//        Host: {{Hostname}}
-//        Origin: {{BaseURL}}
-//
-//    matchers:
-//      - type: word
-//        part: interactsh_protocol # Confirms the HTTP Interaction
-//        words:
-//          - "http"
-//
-//# digest: 4a0a0047304502203f149b24ebd177d43629ee418d28fc0878939ccdd4283537cbaced55a753b59f0221008b8e75e9de7c7ddd6fd2ffe85e574fc9b523f0980011ed7a71df7e6d8475ec4a:922c64590222798bb761d5b6d8e72950`
-//	tmpIns, err := CreateYakTemplateFromNucleiTemplateRaw(tmp)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	ok := false
-//	config := NewConfig()
-//	tmpIns.ExecWithUrl("http://www.baidu.com", config, lowhttp.WithHost(server), lowhttp.WithPort(port))
-//	if !ok {
-//		t.Error("test oob error")
-//	}
-//}

--- a/common/yakgrpc/grpc_fuzzer.go
+++ b/common/yakgrpc/grpc_fuzzer.go
@@ -40,7 +40,10 @@ import (
 	"github.com/saintfish/chardet"
 )
 
-var _FuzzerTaskSwitchMap = new(sync.Map)
+var (
+	_FuzzerTaskSwitchMap = new(sync.Map)
+	fuzzerSession        = "__FUZZER_SESSION__"
+)
 
 func Chardet(raw []byte) string {
 	res, err := chardet.NewTextDetector().DetectBest(raw)
@@ -743,6 +746,7 @@ func (s *Server) HTTPFuzzer(req *ypb.FuzzerRequest, stream ypb.Yak_HTTPFuzzerSer
 			mutate.WithPoolOpt_MutateWithMethods(req.GetMutateMethods()),
 			mutate.WithPoolOpt_RuntimeId(runtimeID),
 			mutate.WithPoolOpt_WithPayloads(true),
+			mutate.WithPoolOpt_Session(fuzzerSession),
 		}
 
 		fuzzMode := req.GetFuzzTagMode() // ""/"close"/"standard"/"legacy"

--- a/common/yakgrpc/grpc_http_request_builder_scripts.yak
+++ b/common/yakgrpc/grpc_http_request_builder_scripts.yak
@@ -59,7 +59,7 @@ for req in reqs {
                     u = str.ExtractURLFromHTTPRequestRaw(req.RawHTTPRequest, req.IsHttps )~
                     caller.MirrorHTTPFlowExSync(!isSmoking,req.IsHttps, u.String(), "", "", "") // port scan not need req and rsp
                 default:
-                    rspIns, _ := poc.HTTPEx(req.RawHTTPRequest, poc.https(req.IsHttps))~
+                    rspIns, _ := poc.HTTPEx(req.RawHTTPRequest, poc.https(req.IsHttps), poc.session("__GRPC_TEST__"))~
                     rsp = rspIns.RawPacket
                     firstRsp = rspIns.RedirectRawPackets[0].Response
                     firstReq = rspIns.RedirectRawPackets[0].Request


### PR DESCRIPTION
1. 修改了一个默认的错误，即lowhttp在重定向时会强制带上响应时的Set-Cookie
2. 重构了UrlToRequest与NewRequestPacketFromMethod的逻辑
3. 为GRPC测试与fuzzer添加默认的session
4. 重定向时会保留请求头，并带上Referer，302重定向时遵循比较常见的做法，即将请求方法改为GET，将某些请求头与请求体删除