### PR TITLE
feat&fix:

### DIFF
--- a/common/yak/httptpl/nuclei_tag.go
+++ b/common/yak/httptpl/nuclei_tag.go
@@ -4,31 +4,32 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/yaklang/yaklang/common/fuzztagx/parser"
-	"github.com/yaklang/yaklang/common/log"
 )
 
 type NucleiTag struct {
 	parser.BaseTag
-	GetVar     func(s string) (string, bool)
-	ExecDSL    func(s string) (string, error)
+	Variables  map[string]any
 	Payload    map[string][]string
 	AttackMode string
 }
 
 func (n *NucleiTag) Exec(ctx context.Context, raw *parser.FuzzResult, yield func(result *parser.FuzzResult), params map[string]*parser.TagMethod) error {
-	// 变量渲染
-	if n.GetVar != nil {
-		if v, ok := n.GetVar(string(raw.GetData())); ok {
-			yield(parser.NewFuzzResultWithData(v))
-			return nil
-		} else {
-			yield(parser.NewFuzzResultWithData("{{" + string(raw.GetData()) + "}}"))
-			return nil
-		}
-	}
 	s := string(raw.GetData())
+
+	// Variables 直接读取
+	if v, ok := n.Variables[s]; ok {
+		yield(parser.NewFuzzResultWithData(v))
+		return nil
+	}
+	// 沙箱执行
+	res, err := NewNucleiDSLYakSandbox().Execute(s, n.Variables)
+	if err == nil && res != nil {
+		yield(parser.NewFuzzResultWithData(res))
+		return nil
+	}
 	// payload 直接渲染
 	if v, ok := n.Payload[s]; ok {
 		if n.AttackMode == "pitchfork" || n.AttackMode == "sync" {
@@ -39,22 +40,13 @@ func (n *NucleiTag) Exec(ctx context.Context, raw *parser.FuzzResult, yield func
 		}
 		return nil
 	}
-	// 沙箱执行
-	if n.ExecDSL != nil {
-		res, err := n.ExecDSL(s)
-		if err != nil {
-			yield(parser.NewFuzzResultWithData("{{" + string(raw.GetData()) + "}}"))
-			return nil
-		}
-		yield(parser.NewFuzzResultWithData(res))
-		return nil
-	}
+
 	yield(parser.NewFuzzResultWithData("{{" + string(raw.GetData()) + "}}"))
 	return nil
 }
 
-// RenderNucleiTagWithVar 渲染变量 （只渲染变量不执行）
-func RenderNucleiTagWithVar(raw string, vars map[string]any) (result string, err error) {
+// QuickFuzzNucleiTag 渲染变量 （只渲染变量不执行）
+func QuickFuzzNucleiTag(raw string, vars map[string]any) (result string, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", err)
@@ -62,43 +54,13 @@ func RenderNucleiTagWithVar(raw string, vars map[string]any) (result string, err
 	}()
 	nodes, err := parser.Parse(raw,
 		parser.NewTagDefine("nucleiTag", "{{", "}}", &NucleiTag{
-			GetVar: func(s string) (string, bool) {
-				if v, ok := vars[s]; ok {
-					return toString(v), true
-				}
-				return "", false
-			},
+			Variables: vars,
 		}),
 	)
 	gener := parser.NewGenerator(nil, nodes, map[string]*parser.TagMethod{})
 	gener.Next()
 	res := gener.Result()
 	return string(res.GetData()), nil
-}
-
-// ExecNucleiTag 执行包含tag的字符串
-func ExecNucleiTag(raw string, vars map[string]any) (result string, err error) {
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("%v", err)
-		}
-	}()
-	res, err := execNucleiTag(raw, nil, func(s string) (string, error) {
-		v, ok := vars[s]
-		if !ok {
-			return "", errors.New("not found var:" + s)
-		}
-		switch ret := v.(type) {
-		case func() string:
-			return ret(), nil
-		default:
-			return toString(v), nil
-		}
-	}, "")
-	if len(res) == 0 {
-		return "", errors.New("generate error")
-	}
-	return string(res[0]), err
 }
 
 // FuzzNucleiTag 使用payload对包含tag的字符串进行fuzz
@@ -108,48 +70,13 @@ func FuzzNucleiTag(raw string, vars map[string]any, payload map[string][]string,
 			err = fmt.Errorf("%v", err)
 		}
 	}()
-	return execNucleiTag(raw, payload, func(s string) (string, error) {
-		v, ok := vars[s]
-		if !ok {
-			return "", errors.New("not found var:" + s)
-		}
-		return toString(v), nil
-	}, mode)
-}
-
-func execNucleiTag(raw string, payloads map[string][]string, getVar func(s string) (string, error), mode string) ([][]byte, error) {
 	nodes, err := parser.Parse(raw,
 		parser.NewTagDefine("nucleiTag", "{{", "}}", &NucleiTag{
+			Payload:    payload,
 			AttackMode: mode,
-			Payload:    payloads,
-			ExecDSL: func(s string) (string, error) {
-				res1, err := getVar(s)
-				if err == nil {
-					return res1, nil
-				}
-				var getVarError error
-				res, err := NewNucleiDSLYakSandbox().ExecuteWithOnGetVar(s, func(name string) (any, bool) {
-					if getVar == nil {
-						return nil, false
-					}
-					res, err := getVar(name)
-					if err != nil {
-						getVarError = err
-						log.Error(err)
-						return nil, false
-					}
-					return res, true
-				})
-				if getVarError != nil {
-					return "", getVarError
-				}
-				return toString(res), err
-			},
+			Variables:  vars,
 		}),
 	)
-	if err != nil {
-		return nil, err
-	}
 	res := [][]byte{}
 	gener := parser.NewGenerator(nil, nodes, map[string]*parser.TagMethod{})
 	for gener.Next() {
@@ -157,4 +84,38 @@ func execNucleiTag(raw string, payloads map[string][]string, getVar func(s strin
 		res = append(res, result.GetData())
 	}
 	return res, nil
+}
+
+// ExecNucleiDSL 执行包含tag的字符串
+func ExecNucleiDSL(raw string, vars map[string]any) (result any, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("%v", err)
+		}
+	}()
+	res, err := execNucleiDSL(raw, func(s string) (any, error) {
+		v, ok := vars[s]
+		if !ok {
+			return "", errors.New("not found var:" + s)
+		}
+		return v, nil
+	})
+	return res, err
+}
+
+func execNucleiDSL(raw string, getVar func(s string) (any, error)) (any, error) {
+	raw = strings.TrimPrefix(raw, "{{")
+	raw = strings.TrimSuffix(raw, "}}")
+
+	res, err := NewNucleiDSLYakSandbox().ExecuteWithOnGetVar(raw, func(name string) (any, bool) {
+		if getVar == nil {
+			return nil, false
+		}
+		res, err := getVar(name)
+		if err != nil {
+			return nil, false
+		}
+		return res, true
+	})
+	return res, err
 }

--- a/common/yak/httptpl/nuclei_tag_test.go
+++ b/common/yak/httptpl/nuclei_tag_test.go
@@ -1,8 +1,9 @@
 package httptpl
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNucleiTag_RandStr(t *testing.T) {
@@ -12,15 +13,11 @@ func TestNucleiTag_RandStr(t *testing.T) {
 }
 
 func TestNucleiTag(t *testing.T) {
-	res, err := ExecNucleiTag(`http://{{HostName}}:80/aaa`, map[string]any{
-		"HostName": "baidu.com",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res != "http://baidu.com:80/aaa" {
-		t.Fatal(errors.New("ExecNucleiTag error"))
-	}
+	// res, err := QuickFuzzNucleiTag(`http://{{HostName}}:80/aaa`, map[string]any{
+	// 	"HostName": "baidu.com",
+	// })
+	// require.NoError(t, err)
+	// require.Equal(t, "http://baidu.com:80/aaa", res)
 	// 集束炸弹
 	fuzzRes, err := FuzzNucleiTag("{{account}}:{{username}}-{{password}}", map[string]any{
 		"account": "account",
@@ -28,14 +25,10 @@ func TestNucleiTag(t *testing.T) {
 		"username": {"admin", "root"},
 		"password": {"123456", "000000"},
 	}, "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []string{"account:admin-123456", "account:root-123456", "account:admin-000000", "account:root-000000"}
 	for i, r := range fuzzRes {
-		if string(r) != expect[i] {
-			t.Fatal("FuzzNucleiTag error")
-		}
+		require.Equal(t, expect[i], string(r))
 	}
 	// 草叉模式
 	fuzzRes, err = FuzzNucleiTag("{{account}}:{{username}}-{{password}}", map[string]any{
@@ -44,13 +37,9 @@ func TestNucleiTag(t *testing.T) {
 		"username": {"admin", "root"},
 		"password": {"123456", "000000"},
 	}, "pitchfork")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []string{"account:admin-123456", "account:root-000000"}
 	for i, r := range fuzzRes {
-		if string(r) != expect[i] {
-			t.Fatal("FuzzNucleiTag error")
-		}
+		require.Equal(t, expect[i], string(r))
 	}
 }

--- a/common/yak/httptpl/yaktpl_matcher.go
+++ b/common/yak/httptpl/yaktpl_matcher.go
@@ -155,8 +155,8 @@ func (y *YakMatcher) ExecuteWithConfig(config *Config, rsp *RespForMatch, vars m
 func (y *YakMatcher) executeRaw(name string, config *Config, rsp []byte, duration float64, vars map[string]any, sufs ...string) (bool, error) {
 	isExpr := false
 
-	var interactsh_protocol = utils.InterfaceToString(vars["interactsh_protocol"])
-	var interactsh_request = utils.InterfaceToString(vars["interactsh_request"])
+	interactsh_protocol := utils.InterfaceToString(vars["interactsh_protocol"])
+	interactsh_request := utils.InterfaceToString(vars["interactsh_request"])
 
 	getMaterial := func() string {
 		if isExpr {
@@ -309,9 +309,9 @@ func (y *YakMatcher) executeRaw(name string, config *Config, rsp []byte, duratio
 				return strings.Contains(s, sub)
 			} else {
 				if strings.Contains(sub, "{{") && strings.Contains(sub, "}}") {
-					results, err := ExecNucleiTag(sub, vars)
+					result, err := ExecNucleiDSL(sub, vars)
 					if err == nil {
-						return strings.Contains(s, results)
+						return strings.Contains(s, toString(result))
 					}
 				}
 			}

--- a/common/yak/httptpl/yaktpl_payloads.go
+++ b/common/yak/httptpl/yaktpl_payloads.go
@@ -1,9 +1,10 @@
 package httptpl
 
 import (
+	"reflect"
+
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
-	"reflect"
 )
 
 type YakPayloads struct {
@@ -16,16 +17,27 @@ type YakPayload struct {
 }
 
 func (y *YakPayloads) GetData() map[string][]string {
+	if y == nil {
+		return map[string][]string{}
+	}
 	res := map[string][]string{}
 	for k, v := range y.raw {
 		res[k] = v.Data
 	}
 	return res
 }
+
 func (y *YakPayloads) GetRawPayloads() map[string]*YakPayload {
+	if y == nil {
+		return map[string]*YakPayload{}
+	}
 	return y.raw
 }
+
 func (y *YakPayloads) GetRawMap() map[string]any {
+	if y == nil {
+		return map[string]any{}
+	}
 	res := map[string]any{}
 	for k, payload := range y.raw {
 		if payload.FromFile != "" {
@@ -36,7 +48,11 @@ func (y *YakPayloads) GetRawMap() map[string]any {
 	}
 	return res
 }
+
 func (y *YakPayloads) AddPayloads(data map[string]any) error {
+	if y == nil {
+		return nil
+	}
 	for k, v := range data {
 		if reflect.TypeOf(v).Kind() == reflect.Slice {
 			y.raw[k] = &YakPayload{
@@ -57,6 +73,7 @@ func (y *YakPayloads) AddPayloads(data map[string]any) error {
 	}
 	return nil
 }
+
 func LoadPayloads(data map[string]any) map[string][]string {
 	res := map[string][]string{}
 	for k, v := range data {

--- a/common/yak/httptpl/yaktpl_tcp.go
+++ b/common/yak/httptpl/yaktpl_tcp.go
@@ -1,8 +1,9 @@
 package httptpl
 
 import (
-	"github.com/yaklang/yaklang/common/log"
 	"strings"
+
+	"github.com/yaklang/yaklang/common/log"
 )
 
 type TCPRequestBulk struct {
@@ -27,17 +28,16 @@ type YakTcpInput struct {
 	Type string
 }
 
-type YakTcpHosts struct {
-}
+type YakTcpHosts struct{}
 
 func (y *YakTcpInput) BuildPayload(vars map[string]any) {
-	var data = y.Data
+	data := y.Data
 	if strings.Contains(y.Data, `{{`) && strings.Contains(y.Data, "}}") {
-		dataRaw, err := ExecNucleiTag(y.Data, vars)
+		result, err := ExecNucleiDSL(y.Data, vars)
 		if err != nil {
 			log.Warnf(`YakTcpInput.Execute.ExecuteNucleiTags failed: %s`, err)
 		} else {
-			data = dataRaw
+			data = toString(result)
 		}
 	}
 	_ = data

--- a/common/yak/httptpl/yaktpl_tcp_exec.go
+++ b/common/yak/httptpl/yaktpl_tcp_exec.go
@@ -2,11 +2,12 @@ package httptpl
 
 import (
 	"fmt"
-	"github.com/yaklang/yaklang/common/netx"
 	"net"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/yaklang/yaklang/common/netx"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/yaklang/yaklang/common/cybertunnel/ctxio"
@@ -134,7 +135,7 @@ func (y *YakNetworkBulkConfig) handleConn(
 		vars["raw"] = availableResponse[0]
 	}
 
-	var haveResponse = len(availableResponse) > 0
+	haveResponse := len(availableResponse) > 0
 	for _, response := range availableResponse {
 		if y.Matcher != nil {
 			matched, err := y.Matcher.ExecuteRawWithConfig(config, response.RawPacket, vars)
@@ -162,7 +163,7 @@ func (y *YakNetworkBulkConfig) Execute(
 
 	var err error
 	for _, host := range y.Hosts {
-		host, err = RenderNucleiTagWithVar(host, utils.InterfaceToMapInterface(params))
+		host, err = QuickFuzzNucleiTag(host, utils.InterfaceToMapInterface(params))
 		if err != nil {
 			log.Error("YakNetworkBulkConfig render host error " + err.Error())
 			continue

--- a/common/yak/httptpl/yaktpl_variables_test.go
+++ b/common/yak/httptpl/yaktpl_variables_test.go
@@ -1,8 +1,9 @@
 package httptpl
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestYakVariables_ToMap check circular reference
@@ -12,6 +13,6 @@ func TestYakVariables_ToMap(t *testing.T) {
 	vars.SetAsNucleiTags("a", "{{b}}")
 	vars.SetAsNucleiTags("b", "{{a}}")
 	res := vars.ToMap() // toMap occurs error
-	assert.Equal(t, res["test"], "{{test}}")
+	assert.Equal(t, "{{test}}", res["test"])
 	assert.Equal(t, res["a"], res["b"]) // var a and b value should be "{{a}}" or "{{b}}"
 }

--- a/common/yak/httptpl/yaml_utils.go
+++ b/common/yak/httptpl/yaml_utils.go
@@ -1,0 +1,143 @@
+package httptpl
+
+import (
+	"strconv"
+
+	"github.com/samber/lo"
+	"github.com/yaklang/yaklang/common/utils"
+	"gopkg.in/yaml.v3"
+)
+
+func nodeGetRaw(node *yaml.Node, key string) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.DocumentNode {
+		node = node.Content[0]
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func nodeGetFirstRaw(node *yaml.Node, keys ...string) *yaml.Node {
+	for _, key := range keys {
+		if ret := nodeGetRaw(node, key); ret != nil {
+			return ret
+		}
+	}
+	return nil
+}
+
+func sequenceNodeForEach(node *yaml.Node, fn func(value *yaml.Node) error) error {
+	if node == nil {
+		return utils.Error("node is nil")
+	}
+	if node.Kind != yaml.SequenceNode {
+		return utils.Error("node is not node")
+	}
+	for _, i := range node.Content {
+		if err := fn(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mappingNodeForEach(node *yaml.Node, fn func(key string, subNode *yaml.Node) error) error {
+	if node == nil {
+		return utils.Error("node is nil")
+	}
+	if node.Kind != yaml.MappingNode {
+		return utils.Error("node is not node")
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		if err := fn(node.Content[i].Value, node.Content[i+1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nodeGetString(node *yaml.Node, key string) string {
+	innerNode := nodeGetRaw(node, key)
+	if innerNode == nil {
+		return ""
+	}
+	return innerNode.Value
+}
+
+func nodeGetBool(node *yaml.Node, key string) bool {
+	value := nodeGetString(node, key)
+	b, _ := strconv.ParseBool(value)
+	return b
+}
+
+func nodeGetInt64(node *yaml.Node, key string) int64 {
+	value := nodeGetString(node, key)
+	i, _ := strconv.ParseInt(value, 10, 64)
+	return i
+}
+
+func nodeGetFloat64(node *yaml.Node, key string) float64 {
+	value := nodeGetString(node, key)
+	i, _ := strconv.ParseFloat(value, 64)
+	return i
+}
+
+func nodeGetStringSlice(node *yaml.Node, key string) []string {
+	innerNode := nodeGetRaw(node, key)
+	if innerNode == nil {
+		return nil
+	}
+	contents := lo.Map(innerNode.Content, func(item *yaml.Node, index int) string {
+		return item.Value
+	})
+	return contents
+}
+
+func nodeToStringSlice(node *yaml.Node) []string {
+	if node == nil {
+		return nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var ret []string
+	for _, i := range node.Content {
+		ret = append(ret, i.Value)
+	}
+	return ret
+}
+
+func nodeToInt64(node *yaml.Node) int64 {
+	if node == nil {
+		return 0
+	}
+	i, _ := strconv.ParseInt(node.Value, 10, 64)
+	return i
+}
+
+func nodeToBool(node *yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	b, _ := strconv.ParseBool(node.Value)
+	return b
+}
+
+func nodeGetStringSliceFallback(node *yaml.Node, keys ...string) []string {
+	subNode := nodeGetFirstRaw(node, keys...)
+	if subNode == nil {
+		return nil
+	}
+	groups := nodeToStringSlice(subNode)
+	if len(groups) == 0 {
+		// fallback to string
+		groups = append(groups, subNode.Value)
+	}
+	return groups
+}

--- a/common/yak/httptpl/yaml_utils_test.go
+++ b/common/yak/httptpl/yaml_utils_test.go
@@ -1,0 +1,172 @@
+package httptpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestYamlNodeUtils(t *testing.T) {
+	testYaml := `id: CVE-2023-24278
+
+info:
+  testInt: 123
+  testFloat: 123.456
+  name: Squidex <7.4.0 - Cross-Site Scripting
+  author: r3Y3r53
+  severity: medium
+  description: |
+    Squidex before 7.4.0 contains a cross-site scripting vulnerability via the squid.svg endpoint. An attacker can possibly obtain sensitive information, modify data, and/or execute unauthorized administrative operations in the context of the affected site.
+  reference:
+    - https://census-labs.com/news/2023/03/16/reflected-xss-vulnerabilities-in-squidex-squidsvg-endpoint/
+    - https://www.openwall.com/lists/oss-security/2023/03/16/1
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-24278
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+    cvss-score: 6.1
+    cve-id: CVE-2023-24278
+    cwe-id: CWE-79
+  metadata:
+    shodan-query: http.favicon.hash:1099097618
+    verified: "true"
+  tags: cve,cve2023,xss,squidex,cms,unauth
+
+variables:
+  a1: "{{rand_int(1000,9000)}}"
+  a2: "{{rand_int(1000,9000)}}"
+  a3: "{{rand_int(1000,9000)}}{{a1}}"
+  a4: "{{rand_int(1000,9000)}}{{a2}}------{{a1+a2}}=={{a1}}+{{a2}}  {{to_number(a1)*to_number(a2)}}=={{a1}}*{{a2}}"
+  a5: "{{randstr}}"
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/squid.svg?title=Not%20Found&text=This%20is%20not%20the%20page%20you%20are%20looking%20for!&background=%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E%3Cimg%20src=%22&small"
+      - "{{BaseURL}}/squi{{a4}}d.svg?title=Not%20Found&text=This%20is%20not%20the%20page%20you%20are%20looking%20for!&background=%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E%3Cimg%20src=%22&small"
+      - "{{BaseURL}}/squi{{md5(a4)}}d.svg?title=Not%20Found&text=This%20is%20not%20the%20page%20you%20are%20looking%20for!&background=%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E%3Cimg%20src=%22&small"
+      - "{{BaseURL}}/squi{{md5(a4)}}{{a1}}d.svg?title=Not%20Found&text=This%20is%20not%20the%20page%20you%20are%20looking%20for!&background=%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E%3Cimg%20src=%22&small"
+    headers:
+      Authorization: "{{a1+a3}} {{a2}} {{BaseURL}}"
+      Test-Payload: "{{name}} {{a6}}"
+
+    payloads:
+      name:
+        - "admin123"
+        - "aaa123"
+      a6:
+        - "321nimda"
+        - 321aaa
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "<script>alert(document.domain)</script>"
+          - "looking for!"
+          - "{{md5(a4)}}"
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - "image/svg+xml"
+
+      - type: status
+        status:
+          - 200
+
+# Enhanced by md on 2023/04/14`
+	root := &yaml.Node{}
+	err := yaml.Unmarshal([]byte(testYaml), root)
+	require.NoError(t, err)
+	t.Run("nodeGetRaw", func(t *testing.T) {
+		node := nodeGetRaw(root, "id")
+		require.NotNil(t, node)
+		require.Equal(t, "CVE-2023-24278", node.Value)
+	})
+	t.Run("nodeGetFirstRaw", func(t *testing.T) {
+		infoNode := nodeGetRaw(root, "info")
+		require.NotNil(t, infoNode)
+		testNode := nodeGetFirstRaw(infoNode, "name", "author")
+		require.NotNil(t, testNode)
+		require.Equal(t, "Squidex <7.4.0 - Cross-Site Scripting", testNode.Value)
+	})
+	t.Run("nodeGetString", func(t *testing.T) {
+		str := nodeGetString(root, "id")
+		require.Equal(t, "CVE-2023-24278", str)
+	})
+	t.Run("nodeGetBool", func(t *testing.T) {
+		infoNode := nodeGetRaw(root, "info")
+		metaNode := nodeGetRaw(infoNode, "metadata")
+		verifiedNode := nodeGetBool(metaNode, "verified")
+		require.True(t, verifiedNode)
+	})
+	t.Run("nodeGetInt64", func(t *testing.T) {
+		infoNode := nodeGetRaw(root, "info")
+		testNode := nodeGetRaw(infoNode, "testInt")
+		require.NotNil(t, testNode)
+		require.Equal(t, int64(123), nodeGetInt64(infoNode, "testInt"))
+	})
+	t.Run("nodeGetFloat64", func(t *testing.T) {
+		infoNode := nodeGetRaw(root, "info")
+		testNode := nodeGetRaw(infoNode, "testFloat")
+		require.NotNil(t, testNode)
+		require.Equal(t, 123.456, nodeGetFloat64(infoNode, "testFloat"))
+	})
+	wantReferences := []string{
+		"https://census-labs.com/news/2023/03/16/reflected-xss-vulnerabilities-in-squidex-squidsvg-endpoint/",
+		"https://www.openwall.com/lists/oss-security/2023/03/16/1",
+		"https://nvd.nist.gov/vuln/detail/CVE-2023-24278",
+	}
+	t.Run("nodeGetStringSlice", func(t *testing.T) {
+		infoNode := nodeGetRaw(root, "info")
+		references := nodeGetStringSlice(infoNode, "reference")
+		require.NotNil(t, references)
+		require.Equal(t, wantReferences, references)
+	})
+	t.Run("sequenceNodeForEach", func(t *testing.T) {
+		infoNode := nodeGetRaw(root, "info")
+		i := 0
+		sequenceNodeForEach(nodeGetRaw(infoNode, "reference"), func(value *yaml.Node) error {
+			require.Equal(t, wantReferences[i], value.Value)
+			i++
+			return nil
+		})
+	})
+	t.Run("mappingNodeForEach", func(t *testing.T) {
+		wantVariables := []struct {
+			Key, Value string
+		}{
+			{
+				Key:   "a1",
+				Value: "{{rand_int(1000,9000)}}",
+			},
+			{
+				Key:   "a2",
+				Value: "{{rand_int(1000,9000)}}",
+			},
+			{
+				Key:   "a3",
+				Value: "{{rand_int(1000,9000)}}{{a1}}",
+			},
+			{
+				Key:   "a4",
+				Value: "{{rand_int(1000,9000)}}{{a2}}------{{a1+a2}}=={{a1}}+{{a2}}  {{to_number(a1)*to_number(a2)}}=={{a1}}*{{a2}}",
+			},
+			{
+				Key:   "a5",
+				Value: "{{randstr}}",
+			},
+		}
+		i := 0
+		mappingNodeForEach(nodeGetRaw(root, "variables"), func(key string, node *yaml.Node) error {
+			require.Equal(t, wantVariables[i].Key, key)
+			require.Equal(t, wantVariables[i].Value, node.Value)
+
+			i++
+			return nil
+		})
+	})
+}

--- a/common/yakgrpc/grpc_fuzzer_yaml_test.go
+++ b/common/yakgrpc/grpc_fuzzer_yaml_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/yaklang/yaklang/common/utils/lowhttp"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
 
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/httptpl"
@@ -76,6 +77,7 @@ func CompareNucleiYaml(yaml1, yaml2 string) error {
 	}
 	return nil
 }
+
 func TestGRPCMUSTPASS_HTTPFuzzer_CompareNucleiYamlFunc(t *testing.T) {
 	testCases := []struct {
 		content string
@@ -292,7 +294,8 @@ func TestGRPCMUSTPASS_HTTPFuzzer_CompareNucleiYamlFunc(t *testing.T) {
           - 'contains(body_1, "FUEL CMS")'
         condition: and`,
 			err: "sign main params not equal",
-		}}
+		},
+	}
 	for _, testCase := range testCases {
 		err := CompareNucleiYaml(testCase.content, testCase.expect)
 		if err != nil {
@@ -306,6 +309,7 @@ func TestGRPCMUSTPASS_HTTPFuzzer_CompareNucleiYamlFunc(t *testing.T) {
 		}
 	}
 }
+
 func TestGRPCMUSTPASS_HTTPFuzzer_CheckSignParam(t *testing.T) {
 	template := `http:
 - raw:
@@ -318,10 +322,9 @@ func TestGRPCMUSTPASS_HTTPFuzzer_CheckSignParam(t *testing.T) {
 
     {"key": "value"}
 `
-	//对 method, paths, headers, body、raw、matcher、extractor、payloads 签名检查
+	// 对 method, paths, headers, body、raw、matcher、extractor、payloads 签名检查
 	testCase := []func(req *httptpl.YakRequestBulkConfig){
 		func(req *httptpl.YakRequestBulkConfig) {
-
 		},
 		func(req *httptpl.YakRequestBulkConfig) {
 			req.Method = "GET"
@@ -806,6 +809,7 @@ func TestGRPCMUSTPASS_HTTPFuzzer_WebFuzzerSequenceConvertYaml(t *testing.T) {
 		})
 	}
 }
+
 func TestGRPCMUSTPASS_HTTPFuzzer_ExtractWithId(t *testing.T) {
 	tests := []struct{ raw, expect string }{
 		{
@@ -887,8 +891,8 @@ http:
 			assert.Equal(t, test.expect, extractedTitle)
 		})
 	}
-
 }
+
 func TestGRPCMUSTPASS_HTTPFuzzer_MatchWithId(t *testing.T) {
 	tests := []struct {
 		raw    string
@@ -1095,7 +1099,6 @@ http:
 			assert.Equal(t, 2, sendN)
 		})
 	}
-
 }
 
 func TestMatcherId(t *testing.T) {
@@ -1195,7 +1198,6 @@ Host: www.example.com
 		},
 		TemplateType: "path",
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Refactor the logic for rendering variables and Payload
- Fix Payload was not rendered during request sequence rendering
- Refactor CreateYakTemplateFromNucleiTemplateRaw to ensure the order of maps and slices
- Fix the bug where a specified variable type during template generation was treated as nuclei DSL
- Fix: values return from nuclei DSL lost their types
- Fix an unexpected cache when variable values are the same, e.g.  rand_int(100) return same value