### PR TITLE
fix(routewrapper): replace %s with %v in error message

### DIFF
--- a/common/utils/netutil/routewrapper/routewrapper_test/command_test.go
+++ b/common/utils/netutil/routewrapper/routewrapper_test/command_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+package routewrapper_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/utils/netutil/routewrapper"
+)
+
+func TestCommandSpec_Run_Windows(t *testing.T) {
+	cmdSpec := routewrapper.CommandSpec{
+		Name: "cmd",
+		Args: []string{"/C", "echo", "hello"},
+	}
+
+	stdout, stderr, err := cmdSpec.Run()
+
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %v", err)
+	}
+
+	if len(stderr) > 0 {
+		t.Fatalf("Expected no stderr, but got: %s", string(stderr))
+	}
+
+	expectedOutput := "hello\r\n"
+	if !bytes.Equal(stdout, []byte(expectedOutput)) {
+		t.Fatalf("Expected stdout to be %q, but got %q", expectedOutput, string(stdout))
+	}
+}

--- a/common/utils/netutil/routewrapper/routewrapper_windows.go
+++ b/common/utils/netutil/routewrapper/routewrapper_windows.go
@@ -631,7 +631,7 @@ func NewWindowsRouteWrapper(routeCommand string) (*WindowsRouteWrapper, error) {
 		pif := &ifs[i]
 		_, ok := interfaces[pif.Index]
 		if ok {
-			return nil, fmt.Errorf("More than one Interfaces with the same index exists: %s", pif.Index)
+			return nil, fmt.Errorf("More than one Interfaces with the same index exists: %v", pif.Index)
 		}
 		interfaces[pif.Index] = pif
 		_, ok = interfacesByName[pif.Name]


### PR DESCRIPTION
In routewrapper_windows.go, at 634:91, It prints int as %s which will cause error