### PR TITLE
fix(ssaapi):recover cross process should not clear the visited map

### DIFF
--- a/common/yak/ssaapi/exclusive_z_bottom_use.go
+++ b/common/yak/ssaapi/exclusive_z_bottom_use.go
@@ -49,7 +49,7 @@ func (v *Value) visitUserFallback(actx *AnalyzeContext, opt ...OperationOption) 
 			return v.visitedDefs(actx, opt...)
 		}
 		vals = append(vals, obj.getBottomUses(actx, opt...)...)
-		actx.PopObject()
+		actx.popObject()
 	}
 	if len(vals) <= 0 {
 		return Values{v}
@@ -254,7 +254,7 @@ func (v *Value) getBottomUses(actx *AnalyzeContext, opt ...OperationOption) Valu
 			if newVals := returnReceiver.AppendDependOn(returnReceiver).AppendDependOn(v).getBottomUses(actx); len(newVals) > 0 {
 				vals = append(vals, newVals...)
 			}
-			actx.PopObject()
+			actx.popObject()
 		}
 		if len(vals) > 0 {
 			return vals

--- a/common/yak/ssaapi/exclusive_z_top_defs.go
+++ b/common/yak/ssaapi/exclusive_z_top_defs.go
@@ -91,13 +91,13 @@ func (i *Value) getTopDefs(actx *AnalyzeContext, opt ...OperationOption) Values 
 		return Values{}
 	}
 	{
-		obj, key, member := actx.GetCurrentObject()
+		obj, key, member := actx.getCurrentObject()
 		_ = obj
 		_ = key
 		_ = member
 		if obj != nil && i.IsObject() && i != obj {
 			if m := i.GetMember(key); m != nil && !ValueCompare(m, member) {
-				actx.PopObject()
+				actx.popObject()
 				return m.getTopDefs(actx, opt...)
 			}
 		}
@@ -429,7 +429,7 @@ func (i *Value) getTopDefs(actx *AnalyzeContext, opt ...OperationOption) Values 
 				continue
 			}
 			values = append(values, value.getTopDefs(actx, opt...)...)
-			actx.PopObject()
+			actx.popObject()
 		}
 		return values
 	}

--- a/common/yak/ssaapi/test/syntaxflow/syntaxflow_cross_process_test.go
+++ b/common/yak/ssaapi/test/syntaxflow/syntaxflow_cross_process_test.go
@@ -1,0 +1,29 @@
+package syntaxflow
+
+import (
+	"github.com/yaklang/yaklang/common/yak/ssaapi/test/ssatest"
+	"testing"
+)
+
+func TestMultiDataFlow_CrossProcess(t *testing.T) {
+	t.Run("test multi data flow cross process simple", func(t *testing.T) {
+		code := `
+		f= (param) => {
+			return param	
+		}
+		d = f(1) + f(2)
+     `
+		ssatest.CheckSyntaxFlow(t, code, `d #-> * as $target`, map[string][]string{"target": {"1", "2"}})
+	})
+
+	t.Run("test multi data flow cross process with call as object", func(t *testing.T) {
+		code := `
+		f= () => {
+			return {"b":1, "c":2}	
+		}
+		a=f()
+		d = a.b + a.c
+     `
+		ssatest.CheckSyntaxFlow(t, code, `d #-> * as $target`, map[string][]string{"target": {"1", "2", "Undefined-a.b(valid)", "Undefined-a.c(valid)"}})
+	})
+}

--- a/common/yak/ssaapi/test/syntaxflow/top_user_recursive_test.go
+++ b/common/yak/ssaapi/test/syntaxflow/top_user_recursive_test.go
@@ -154,7 +154,7 @@ func TestCrossProcessAndReverseProcess(t *testing.T) {
 		f2(tmp)
 		`, `
 		a1?{opcode: param} #-> * as $target`, map[string][]string{
-			"target": {"11"},
+			"target": {"11", "Parameter-a2"},
 		})
 	})
 }


### PR DESCRIPTION
- recover cross process should not clear the visited map

- the hash of from which is call should include `object context`