### PR TITLE
fix(syntaxflow):all statement should wrap in statement opcode

### DIFF
--- a/common/syntaxflow/sfvm/frame.go
+++ b/common/syntaxflow/sfvm/frame.go
@@ -317,49 +317,6 @@ func (s *SFFrame) exec(input ValueOperator) (ret error) {
 			if err := s.IterEnd(); err != nil {
 				return err
 			}
-		case OpFileFilterJsonPath:
-			s.debugSubLog(">> pop file name: %v", i.UnaryStr)
-			name := i.UnaryStr
-			if name == "" {
-				return utils.Errorf("file filter failed: file name is empty")
-			}
-			paramList := i.Values
-			paramMap := i.FileFilterMethodItem
-			res, err := input.FileFilter(name, "jsonpath", paramMap, paramList)
-			if err != nil {
-				return utils.Errorf("file filter failed: %v", err)
-			}
-			s.stack.Push(res)
-		case OpFileFilterXpath:
-			s.debugSubLog(">> pop file name: %v", i.UnaryStr)
-			name := i.UnaryStr
-			if name == "" {
-				return utils.Errorf("file filter failed: file name is empty")
-			}
-			paramList := i.Values
-			paramMap := i.FileFilterMethodItem
-			res, err := input.FileFilter(name, "xpath", paramMap, paramList)
-			if err != nil {
-				return utils.Errorf("file filter failed: %v", err)
-			}
-			s.stack.Push(res)
-			_ = paramList
-			_ = paramMap
-		case OpFileFilterReg:
-			s.debugSubLog(">> pop file name: %v", i.UnaryStr)
-			name := i.UnaryStr
-			if name == "" {
-				return utils.Errorf("file filter failed: file name is empty")
-			}
-			paramList := i.Values
-			paramMap := i.FileFilterMethodItem
-			res, err := input.FileFilter(name, "regexp", paramMap, paramList)
-			if err != nil {
-				return utils.Errorf("file filter failed: %v", err)
-			}
-			s.stack.Push(res)
-			// _ = paramList
-			// _ = paramMap
 		default:
 			if err := s.execStatement(i); err != nil {
 				if errors.Is(err, CriticalError) {
@@ -1244,7 +1201,11 @@ func (s *SFFrame) execStatement(i *SFI) error {
 		s.debugSubLog("<< push: %v", ret)
 		s.stack.Push(ret)
 	case OpFileFilterJsonPath:
-		// TODO: 调用FileFilter接口并实现具体功能
+		s.debugSubLog(">> pop")
+		value := s.stack.Pop()
+		if value == nil {
+			return utils.Wrap(CriticalError, "native call failed: stack top is empty")
+		}
 		s.debugSubLog(">> pop file name: %v", i.UnaryStr)
 		name := i.UnaryStr
 		if name == "" {
@@ -1252,10 +1213,17 @@ func (s *SFFrame) execStatement(i *SFI) error {
 		}
 		paramList := i.Values
 		paramMap := i.FileFilterMethodItem
-		_ = paramList
-		_ = paramMap
+		res, err := value.FileFilter(name, "jsonpath", paramMap, paramList)
+		if err != nil {
+			return utils.Errorf("file filter failed: %v", err)
+		}
+		s.stack.Push(res)
 	case OpFileFilterXpath:
-		// TODO: 调用FileFilter接口并实现具体功能
+		s.debugSubLog(">> pop")
+		value := s.stack.Pop()
+		if value == nil {
+			return utils.Wrap(CriticalError, "native call failed: stack top is empty")
+		}
 		s.debugSubLog(">> pop file name: %v", i.UnaryStr)
 		name := i.UnaryStr
 		if name == "" {
@@ -1263,10 +1231,19 @@ func (s *SFFrame) execStatement(i *SFI) error {
 		}
 		paramList := i.Values
 		paramMap := i.FileFilterMethodItem
+		res, err := value.FileFilter(name, "xpath", paramMap, paramList)
+		if err != nil {
+			return utils.Errorf("file filter failed: %v", err)
+		}
+		s.stack.Push(res)
 		_ = paramList
 		_ = paramMap
 	case OpFileFilterReg:
-		// TODO: 调用FileFilter接口并实现具体功能
+		s.debugSubLog(">> pop")
+		value := s.stack.Pop()
+		if value == nil {
+			return utils.Wrap(CriticalError, "native call failed: stack top is empty")
+		}
 		s.debugSubLog(">> pop file name: %v", i.UnaryStr)
 		name := i.UnaryStr
 		if name == "" {
@@ -1274,8 +1251,13 @@ func (s *SFFrame) execStatement(i *SFI) error {
 		}
 		paramList := i.Values
 		paramMap := i.FileFilterMethodItem
-		_ = paramList
-		_ = paramMap
+		res, err := value.FileFilter(name, "regexp", paramMap, paramList)
+		if err != nil {
+			return utils.Errorf("file filter failed: %v", err)
+		}
+		s.stack.Push(res)
+		// _ = paramList
+		// _ = paramMap
 	default:
 		msg := fmt.Sprintf("unhandled default case, undefined opcode %v", i.String())
 		return utils.Wrap(CriticalError, msg)

--- a/common/syntaxflow/sfvm/visitor.go
+++ b/common/syntaxflow/sfvm/visitor.go
@@ -61,19 +61,16 @@ func (y *SyntaxFlowVisitor) VisitStatement(raw sf.IStatementContext) {
 		return
 	}
 
+	statement := y.EmitEnterStatement()
 	switch i := raw.(type) {
 	case *sf.FilterContext:
-		statement := y.EmitEnterStatement()
 		y.VisitFilterStatement(i.FilterStatement())
-		y.EmitExitStatement(statement)
 	case *sf.CheckContext:
 		y.VisitCheckStatement(i.CheckStatement())
 	case *sf.DescriptionContext:
 		y.VisitDescriptionStatement(i.DescriptionStatement())
 	case *sf.AlertContext:
-		statement := y.EmitEnterStatement()
 		y.VisitAlertStatement(i.AlertStatement())
-		y.EmitExitStatement(statement)
 	case *sf.EmptyContext:
 		return
 	case *sf.FileFilterContentContext:
@@ -84,6 +81,7 @@ func (y *SyntaxFlowVisitor) VisitStatement(raw sf.IStatementContext) {
 	default:
 		log.Debugf("syntaxflow met statement: %v", strings.TrimSpace(i.GetText()))
 	}
+	y.EmitExitStatement(statement)
 	return
 }
 

--- a/common/yak/ssaapi/sf_value.go
+++ b/common/yak/ssaapi/sf_value.go
@@ -203,6 +203,6 @@ func (v *Value) AppendPredecessor(operator sfvm.ValueOperator, opts ...sfvm.Anal
 	})
 }
 
-func (v *Value) FileFilter(string, string, map[string]string, []string) (sfvm.ValueOperator, error) {
-	return nil, utils.Error("ssa.Value is not supported file filter")
+func (v *Value) FileFilter(path string, match string, rule map[string]string, rule2 []string) (sfvm.ValueOperator, error) {
+	return v.ParentProgram.FileFilter(path, match, rule, rule2)
 }

--- a/common/yak/ssaapi/sf_values.go
+++ b/common/yak/ssaapi/sf_values.go
@@ -200,6 +200,23 @@ func (value Values) AppendPredecessor(operator sfvm.ValueOperator, opts ...sfvm.
 	return nil
 }
 
-func (value Values) FileFilter(string, string, map[string]string, []string) (sfvm.ValueOperator, error) {
-	return nil, utils.Error("ssa.Values is not supported file filter")
+// func (value Values) FileFilter(string, string, map[string]string, []string) (sfvm.ValueOperator, error) {
+func (vs Values) FileFilter(path string, match string, rule map[string]string, rule2 []string) (sfvm.ValueOperator, error) {
+	var res []sfvm.ValueOperator
+	var errs error
+	for _, value := range vs {
+		filtered, err := value.FileFilter(path, match, rule, rule2)
+		if err != nil {
+			errs = utils.JoinErrors(errs, err)
+			// return nil, err
+			continue
+		}
+		if filtered != nil {
+			res = append(res, filtered)
+		}
+	}
+	if errs != nil {
+		return nil, errs
+	}
+	return sfvm.NewValues(res), nil
 }


### PR DESCRIPTION
所有语句都保存在Statement的Opcode中，出现错误将会被跳过而非停止整个规则。
影响一下三种语句：
* description语句将不会出现错误，
* check语句的快速失败模式包裹了criticalError，
* fileFilter也应该跳过而非停止。

