### PR TITLE
fix http flow color filter

### DIFF
--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -752,7 +752,7 @@ func FilterHTTPFlow(db *gorm.DB, params *ypb.QueryHTTPFlowRequest) *gorm.DB {
 	}
 
 	if len(params.GetColor()) > 0 {
-		db = bizhelper.FuzzSearchWithStringArrayOrAf(db, []string{"tags"}, params.GetColor(), false)
+		db = bizhelper.FuzzSearchWithStringArrayOrEx(db, []string{"tags"}, params.GetColor(), false)
 	}
 
 	// 搜索 Content-Type


### PR DESCRIPTION
FuzzSearchWithStringArrayOrAf函数只对搜索项左模糊匹配，导致形如`YAKIT_COLOR_GREEN|SQL注入测试点`的tags匹配失败
![image](https://github.com/user-attachments/assets/f73b10d9-00cd-49c6-9b29-598a2c31b576)
