### PR TITLE
fix(ssa):fix error hash for source code

### DIFF
--- a/common/utils/memedit/editor.go
+++ b/common/utils/memedit/editor.go
@@ -49,6 +49,10 @@ func (ve *MemEditor) SetUrl(url string) {
 	ve.fileUrl = url
 }
 
+func (ve *MemEditor) GetIrSourceHash(programName string) string {
+	return codec.Md5(strings.Join([]string{programName, ve.GetFilename()}, "/"))
+}
+
 func (ve *MemEditor) GetFormatedUrl() string {
 	u := ve.fileUrl
 	if strings.HasPrefix(u, "file://") {

--- a/common/utils/memedit/editor.go
+++ b/common/utils/memedit/editor.go
@@ -41,6 +41,17 @@ func NewMemEditor(sourceCode string) *MemEditor {
 	return editor
 }
 
+func NewMemEditorWithFileUrl(sourceCode string, fileUrl string) *MemEditor {
+	editor := &MemEditor{
+		safeSourceCode:     NewSafeString(sourceCode),
+		lineLensMap:        make(map[int]int),
+		lineStartOffsetMap: make(map[int]int),
+		fileUrl:            fileUrl,
+	}
+	editor.recalculateLineMappings()
+	return editor
+}
+
 func (ve *MemEditor) CodeLength() int {
 	return ve.safeSourceCode.Len()
 }
@@ -49,8 +60,9 @@ func (ve *MemEditor) SetUrl(url string) {
 	ve.fileUrl = url
 }
 
+// GetIrSourceHash 使用程序名称、路径和源代码计算哈希值
 func (ve *MemEditor) GetIrSourceHash(programName string) string {
-	return codec.Md5(strings.Join([]string{programName, ve.GetFilename()}, "/"))
+	return codec.Md5(programName + ve.GetFilename() + ve.GetSourceCode())
 }
 
 func (ve *MemEditor) GetFormatedUrl() string {

--- a/common/yak/java/java2ssa/builder_prehandler.go
+++ b/common/yak/java/java2ssa/builder_prehandler.go
@@ -76,7 +76,10 @@ func (s *SSABuilder) PreHandlerProject(fileSystem fi.FileSystem, fb *ssa.Functio
 			folders = append(folders,
 				strings.Split(dirname, string(fileSystem.GetSeparators()))...,
 			)
-			prog.ExtraFile[path] = ssadb.SaveFile(filename, string(raw), folders)
+			content := string(raw)
+			editor := memedit.NewMemEditor(content)
+			editor.SetUrl(path)
+			prog.ExtraFile[path] = ssadb.SaveFile(filename, content, editor.GetIrSourceHash(prog.GetProgramName()), folders)
 		}
 	}
 	switch strings.ToLower(fileSystem.Ext(path)) {

--- a/common/yak/java/java2ssa/builder_prehandler.go
+++ b/common/yak/java/java2ssa/builder_prehandler.go
@@ -54,8 +54,7 @@ func (s *SSABuilder) PreHandlerProject(fileSystem fi.FileSystem, fb *ssa.Functio
 			log.Warnf("read pom.xml error: %v", err)
 			return nil
 		}
-		editor := memedit.NewMemEditor(string(raw))
-		editor.SetUrl(path)
+		editor := memedit.NewMemEditorWithFileUrl(string(raw), path)
 		fb.SetEditor(editor)
 		vfs := filesys.NewVirtualFs()
 		vfs.AddFile(filename, string(raw))

--- a/common/yak/java/template2java/tempate2java.go
+++ b/common/yak/java/template2java/tempate2java.go
@@ -67,12 +67,12 @@ func ConvertTemplateToJava(typ JavaTemplateType, content, filePath string) (tl.T
 	var err error
 	switch typ {
 	case JSP:
-		visitor, err = NewTemplateVisitor(memedit.NewMemEditor(content), tl.TEMPLATE_JAVA_JSP)
+		visitor, err = NewTemplateVisitor(memedit.NewMemEditorWithFileUrl(content, filePath), tl.TEMPLATE_JAVA_JSP)
 		if err != nil {
 			return nil, err
 		}
 	case Freemarker:
-		visitor, err = NewTemplateVisitor(memedit.NewMemEditor(content), tl.TEMPLATE_JAVA_FREEMARKER)
+		visitor, err = NewTemplateVisitor(memedit.NewMemEditorWithFileUrl(content, filePath), tl.TEMPLATE_JAVA_FREEMARKER)
 		if err != nil {
 			return nil, err
 		}

--- a/common/yak/ssa/database_code.go
+++ b/common/yak/ssa/database_code.go
@@ -5,7 +5,6 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/memedit"
 	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
-	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 )
 
 // Instruction2IrCode : marshal instruction to ir code, used in cache, to save to database
@@ -37,11 +36,12 @@ func (c *Cache) IrCodeToInstruction(inst Instruction, ir *ssadb.IrCode) Instruct
 }
 
 func fitRange(c *ssadb.IrCode, rangeIns memedit.RangeIf) {
-	if rangeIns == nil || utils.IsNil(rangeIns) {
+	if rangeIns == nil || utils.IsNil(rangeIns) || utils.IsNil(rangeIns.GetEditor()) {
 		log.Warnf("(BUG or in DEBUG MODE) Range not found for %s", c.Name)
 		return
 	}
-	c.SourceCodeHash = codec.Sha256(rangeIns.GetEditor().GetSourceCode())
+	editor := rangeIns.GetEditor()
+	c.SourceCodeHash = editor.GetIrSourceHash(c.ProgramName)
 	// start, end := rangeIns.GetOffsetRange()
 	c.SourceCodeStartOffset = int64(rangeIns.GetStartOffset())
 	c.SourceCodeEndOffset = int64(rangeIns.GetEndOffset())

--- a/common/yak/ssa/database_offset.go
+++ b/common/yak/ssa/database_offset.go
@@ -24,8 +24,7 @@ func SaveValueOffset(inst Instruction) {
 		log.Errorf("%v: CreateOffset: rng or editor is nil", inst.GetVerboseName())
 		return
 	}
-	irOffset := ssadb.CreateOffset(rng)
-
+	irOffset := ssadb.CreateOffset(rng, inst.GetProgram().GetApplication().GetProgramName())
 	// program name \ file name \ offset
 	irOffset.ProgramName = inst.GetProgram().GetProgramName()
 	// value id
@@ -41,7 +40,7 @@ func SaveVariableOffset(v *Variable, variableName string) {
 		if utils.IsNil(rng) || utils.IsNil(rng.GetEditor()) {
 			return
 		}
-		irOffset := ssadb.CreateOffset(rng)
+		irOffset := ssadb.CreateOffset(rng, v.GetProgram().GetApplication().GetProgramName())
 		// program name \ file name \ offset
 		irOffset.ProgramName = v.GetProgram().GetProgramName()
 		// variable name

--- a/common/yak/ssa/ssadb/offset.go
+++ b/common/yak/ssa/ssadb/offset.go
@@ -20,9 +20,9 @@ type IrOffset struct {
 	ValueID int64 `json:"value_id"` // this id will set
 }
 
-func CreateOffset(rng memedit.RangeIf) *IrOffset {
+func CreateOffset(rng memedit.RangeIf, projectName string) *IrOffset {
 	ret := &IrOffset{}
-	ret.FileHash = rng.GetEditor().GetPureSourceHash()
+	ret.FileHash = rng.GetEditor().GetIrSourceHash(projectName)
 	ret.StartOffset = int64(rng.GetStartOffset())
 	ret.EndOffset = int64(rng.GetEndOffset())
 	ret.VariableName = ""
@@ -43,9 +43,10 @@ func GetOffsetByVariable(name string, valueID int64) []*IrOffset {
 	return ir
 }
 
-func GetValueBeforeEndOffset(DB *gorm.DB, rng memedit.RangeIf) (int64, error) {
+func GetValueBeforeEndOffset(DB *gorm.DB, rng memedit.RangeIf, programName string) (int64, error) {
 	// get the last ir code before the end offset, and the source code hash must be the same
-	db := DB.Model(&IrOffset{}).Where("end_offset <= ? and  file_hash = ?", rng.GetEndOffset(), rng.GetEditor().GetPureSourceHash())
+	hash := rng.GetEditor().GetIrSourceHash(programName)
+	db := DB.Model(&IrOffset{}).Where("end_offset <= ? and  file_hash = ?", rng.GetEndOffset(), hash)
 	var ir IrOffset
 	if err := db.Order("end_offset desc").First(&ir).Error; err != nil {
 		return -1, err

--- a/common/yak/ssa/ssadb/source.go
+++ b/common/yak/ssa/ssadb/source.go
@@ -45,8 +45,8 @@ func GetIrSourceByPathAndName(path, name string) (*IrSource, error) {
 	return &source, nil
 }
 
-func GetEditorByFileName(name string) (*memedit.MemEditor, error) {
-	dir, name := pathSplit(name)
+func GetEditorByFileName(fileName string) (*memedit.MemEditor, error) {
+	dir, name := pathSplit(fileName)
 	source, err := GetIrSourceByPathAndName(dir, name)
 	if err != nil {
 		return nil, err
@@ -56,6 +56,8 @@ func GetEditorByFileName(name string) (*memedit.MemEditor, error) {
 		code = s
 	}
 	ret := memedit.NewMemEditor(code)
+	_, filePath := splitProjectPath(fileName)
+	ret.SetUrl(filePath)
 	return ret, nil
 }
 

--- a/common/yak/ssa/ssadb/source.go
+++ b/common/yak/ssa/ssadb/source.go
@@ -1,6 +1,7 @@
 package ssadb
 
 import (
+	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 	"path"
 	"strconv"
 	"strings"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/memedit"
-	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 )
 
 var irSourceCache = utils.NewTTLCache[*memedit.MemEditor]()
@@ -59,7 +59,7 @@ func GetEditorByFileName(name string) (*memedit.MemEditor, error) {
 	return ret, nil
 }
 
-func SaveFile(filename, content string, folderPath []string) string {
+func SaveFile(filename, content string, hash string, folderPath []string) string {
 	start := time.Now()
 	defer func() {
 		atomic.AddUint64(&_SSASourceCodeCost, uint64(time.Now().Sub(start).Nanoseconds()))
@@ -69,7 +69,6 @@ func SaveFile(filename, content string, folderPath []string) string {
 		return ""
 	}
 	programName := folderPath[0]
-	hash := codec.Sha256(content)
 	irSource := &IrSource{
 		ProgramName:    programName,
 		SourceCodeHash: hash,
@@ -79,7 +78,7 @@ func SaveFile(filename, content string, folderPath []string) string {
 		IsBigFile:      false,
 	}
 	irSource.save()
-	return hash
+	return irSource.SourceCodeHash
 }
 
 func SaveFolder(folderName string, folderPaths []string) error {

--- a/common/yak/ssa/ssadb/source_filesys.go
+++ b/common/yak/ssa/ssadb/source_filesys.go
@@ -16,6 +16,8 @@ type irSourceFS struct {
 	virtual map[string]*filesys.VirtualFS // echo program -> virtual fs
 }
 
+var IrSourceFsSeparators = '/'
+
 var _ filesys_interface.ReadOnlyFileSystem = (*irSourceFS)(nil)
 var _ filesys_interface.FileSystem = (*irSourceFS)(nil)
 
@@ -142,7 +144,11 @@ func (fs *irSourceFS) getProgram(path string) (string, bool) {
 	return dir[1], len(dir) == 2
 }
 
-func (f *irSourceFS) GetSeparators() rune         { return '/' }
+func GetIrSourceFsSeparators() rune {
+	return IrSourceFsSeparators
+}
+
+func (f *irSourceFS) GetSeparators() rune         { return IrSourceFsSeparators }
 func (f *irSourceFS) Join(paths ...string) string { return path.Join(paths...) }
 func (f *irSourceFS) IsAbs(name string) bool {
 	return len(name) > 0 && name[0] == byte(f.GetSeparators())

--- a/common/yak/ssa/ssadb/source_filesys.go
+++ b/common/yak/ssa/ssadb/source_filesys.go
@@ -100,6 +100,18 @@ func pathSplit(p string) (string, string) {
 	return dir, name
 }
 
+// splitProjectPath传入全路径，会以路径分隔符分割，分割后的第一个元素为项目名，后面的元素为文件路径
+func splitProjectPath(p string) (projectPath string, fileName string) {
+	paths := strings.Split(p, string(IrSourceFsSeparators))
+	paths = utils.StringArrayFilterEmpty(paths)
+	if len(paths) == 1 {
+		return paths[0], ""
+	} else if len(paths) > 1 {
+		return paths[0], strings.Join(paths[1:], string(IrSourceFsSeparators))
+	}
+	return "", ""
+}
+
 func (f *irSourceFS) ExtraInfo(path string) map[string]any {
 	m := make(map[string]any)
 	programName, isProgram := f.getProgram(path)

--- a/common/yak/ssaapi/ssa_compile_init.go
+++ b/common/yak/ssaapi/ssa_compile_init.go
@@ -11,7 +11,6 @@ import (
 	"github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
 	"github.com/yaklang/yaklang/common/utils/memedit"
 	"github.com/yaklang/yaklang/common/yak/ssa"
-	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 )
 
 func (c *config) init(filesystem filesys_interface.FileSystem) (*ssa.Program, *ssa.FunctionBuilder, error) {
@@ -92,7 +91,8 @@ func (c *config) init(filesystem filesys_interface.FileSystem) (*ssa.Program, *s
 
 		if ret := fb.GetEditor(); ret != nil {
 			cache := application.Cache
-			progName, hash := application.GetProgramName(), codec.Sha256(ret.GetSourceCode())
+			progName := application.GetProgramName()
+			hash := ret.GetIrSourceHash(programName)
 			if cache.IsExistedSourceCodeHash(progName, hash) {
 				c.DatabaseProgramCacheHitter(fb)
 			}

--- a/common/yak/ssaapi/ssa_compile_init.go
+++ b/common/yak/ssaapi/ssa_compile_init.go
@@ -2,6 +2,7 @@ package ssaapi
 
 import (
 	"fmt"
+	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
 	"strings"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
 	"github.com/yaklang/yaklang/common/utils/memedit"
 	"github.com/yaklang/yaklang/common/yak/ssa"
-	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
 	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 )
 
@@ -48,7 +48,9 @@ func (c *config) init(filesystem filesys_interface.FileSystem) (*ssa.Program, *s
 		if src == nil {
 			return fmt.Errorf("origin source code (MemEditor) is nil")
 		}
-		src.SetUrl(filePath)
+		if src.GetFilename() == "" {
+			src.SetUrl(filePath)
+		}
 		// backup old editor (source code)
 		originEditor := fb.GetEditor()
 		// TODO: check prog.FileList avoid duplicate file save to sourceDB,

--- a/common/yak/ssaapi/ssa_compile_init.go
+++ b/common/yak/ssaapi/ssa_compile_init.go
@@ -48,6 +48,7 @@ func (c *config) init(filesystem filesys_interface.FileSystem) (*ssa.Program, *s
 		if src == nil {
 			return fmt.Errorf("origin source code (MemEditor) is nil")
 		}
+		src.SetUrl(filePath)
 		// backup old editor (source code)
 		originEditor := fb.GetEditor()
 		// TODO: check prog.FileList avoid duplicate file save to sourceDB,
@@ -60,8 +61,7 @@ func (c *config) init(filesystem filesys_interface.FileSystem) (*ssa.Program, *s
 				folders = append(folders,
 					strings.Split(folderName, string(filesystem.GetSeparators()))...,
 				)
-				src.ResetSourceCodeHash()
-				ssadb.SaveFile(fileName, src.GetSourceCode(), folders)
+				ssadb.SaveFile(fileName, src.GetSourceCode(), src.GetIrSourceHash(programName), folders)
 			}
 		}
 		// include source code will change the context of the origin editor

--- a/common/yak/ssaapi/test/yak/compile_db_test.go
+++ b/common/yak/ssaapi/test/yak/compile_db_test.go
@@ -3,6 +3,7 @@ package ssaapi
 import (
 	"context"
 	"fmt"
+	"github.com/yaklang/yaklang/common/utils/memedit"
 	"os"
 	"strconv"
 	"testing"
@@ -145,8 +146,11 @@ c("d")
 	} else {
 		t.Logf("IRCODE Fetch: %v", count)
 	}
-	if includeFile.Len() != 2 {
-		t.Fatal("have 2 source code hash")
+	// 创建依赖的ircode为第一个sourcecode hash
+	// 解析文件为第二个
+	// 解析include的文件为第三个
+	if includeFile.Len() != 3 {
+		t.Fatal("have not 3 source code hash")
 	}
 }
 
@@ -168,7 +172,7 @@ c("d")
 
 	haveIncluded := false
 	includeFile := omap.NewOrderedMap(make(map[string]any))
-	includeHash := codec.Sha256(includeCode)
+	includeHash := memedit.NewMemEditorWithFileUrl(includeCode, filename).GetIrSourceHash(progName)
 	for result := range ssadb.YieldIrCodesProgramName(ssadb.GetDB(), context.Background(), progName) {
 		if result.IsEmptySourceCodeHash() {
 			log.Warn("source code hash is empty")
@@ -182,8 +186,8 @@ c("d")
 			haveIncluded = true
 		}
 	}
-	if includeFile.Len() != 2 {
-		t.Fatal("have 2 source code hash")
+	if includeFile.Len() != 3 {
+		t.Fatal("have not 3 source code hash")
 	}
 	if !haveIncluded {
 		t.Fatal("not included")
@@ -216,8 +220,8 @@ dump(a(3))
 		}
 		m.Set(result.SourceCodeHash, struct{}{})
 	}
-	if m.Len() != 1 {
-		t.Fatal("source code hash is not unique")
+	if m.Len() != 2 {
+		t.Fatal("have not 2 source code hash")
 	}
 	if count <= 0 {
 		t.Fatal("no result in ir code database")

--- a/common/yakgrpc/language_server.go
+++ b/common/yakgrpc/language_server.go
@@ -82,11 +82,11 @@ func languageServerAnalyzeFromDatabase(req *ypb.YaklangLanguageSuggestionRequest
 	ret.Word = SSARange.GetText()
 
 	// value
-	valueID, err := ssadb.GetValueBeforeEndOffset(ssadb.GetDB(), SSARange)
+	valueID, err := ssadb.GetValueBeforeEndOffset(ssadb.GetDB(), SSARange, programName)
 	if err != nil {
 		return ret, err
 	}
-	if value, err := ssa.NewLazyInstruction(valueID); err != nil {
+	if value, err := ssa.NewLazyInstruction(valueID); err != nil && !utils.IsNil(value) {
 		return ret, err
 	} else {
 		ret.Value = ret.Program.NewValue(value)


### PR DESCRIPTION
ircode只使用文件内容作为hash，会导致不同项目相同文件内容文件hash一样。进而导致ircode的位置会乱掉。
- 使用项目名+路径+文件内容作为hash