### PR TITLE
Add 'flow control' option to Fuzztagx; skip flow control tags during …

### DIFF
--- a/common/fuzztagx/fuzztag.go
+++ b/common/fuzztagx/fuzztag.go
@@ -109,6 +109,9 @@ func (f *FuzzTag) Exec(ctx context.Context, raw *parser.FuzzResult, yield func(r
 	if fun.IsDyn || isDynFunRes {
 		f.Labels = append(f.Labels, "dyn")
 	}
+	if fun.IsFlowControl {
+		f.Labels = append(f.Labels, "flowcontrol")
+	}
 	return runFun(fun, params)
 }
 
@@ -231,6 +234,9 @@ func (f *SimpleFuzzTag) Exec(ctx context.Context, raw *parser.FuzzResult, yield 
 		yield(parser.NewFuzzResultWithData(fmt.Sprintf("{{%s}}", escaper.Escape(rawData))))
 		return nil
 	}
+	if f.IsFlowControl() {
+		labels = append(labels, "flowcontrol")
+	}
 	set := utils.NewSet(labels)
 	f.Labels = set.List()
 	commonFuzztag.Labels = f.Labels
@@ -319,6 +325,9 @@ func getResultVerbose(f *parser.FuzzResult, visitedMap map[*parser.FuzzResult]st
 		}
 	} else if f.Verbose == "" {
 		f.Verbose = utils.InterfaceToString(f.Data)
+	}
+	if f.Verbose == "" {
+		return verboses
 	}
 	return append([]string{f.Verbose}, verboses...)
 }

--- a/common/fuzztagx/parser/tag.go
+++ b/common/fuzztagx/parser/tag.go
@@ -3,9 +3,10 @@ package parser
 import (
 	"context"
 	"fmt"
-	"github.com/yaklang/yaklang/common/utils"
 	"reflect"
 	"sync"
+
+	"github.com/yaklang/yaklang/common/utils"
 )
 
 type FuzzResult struct {
@@ -60,13 +61,14 @@ func (f *FuzzResult) GetVerbose() []string {
 }
 
 type TagMethod struct {
-	Name        string
-	IsDyn       bool
-	Fun         func(string) ([]*FuzzResult, error)
-	YieldFun    func(ctx context.Context, params string, yield func(*FuzzResult)) error
-	Expand      map[string]any
-	Alias       []string
-	Description string
+	Name          string
+	IsDyn         bool
+	IsFlowControl bool
+	Fun           func(string) ([]*FuzzResult, error)
+	YieldFun      func(ctx context.Context, params string, yield func(*FuzzResult)) error
+	Expand        map[string]any
+	Alias         []string
+	Description   string
 }
 type Node interface {
 	IsNode()
@@ -80,6 +82,9 @@ func (s StringNode) IsNode() {
 func (s StringNode) String() string {
 	return string(s)
 }
+func (s StringNode) IsFlowControl() bool {
+	return false
+}
 
 type TagNode interface {
 	IsNode()
@@ -90,13 +95,19 @@ type TagNode interface {
 	String() string
 	GetData() []Node
 	GetLabels() []string
+	IsFlowControl() bool
 }
 
 type BaseTag struct {
 	Data   []Node
 	Labels []string
 	// initOnce 用来对子结构体的初始化
-	initOnce sync.Once
+	isFlowControl bool
+	initOnce      sync.Once
+}
+
+func (b *BaseTag) IsFlowControl() bool {
+	return b.isFlowControl
 }
 
 func (*BaseTag) IsNode() {

--- a/common/fuzztagx/reader_test.go
+++ b/common/fuzztagx/reader_test.go
@@ -2,14 +2,15 @@ package fuzztagx
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
-	"github.com/yaklang/yaklang/common/fuzztagx/parser"
-	"github.com/yaklang/yaklang/common/utils"
 	"io"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yaklang/yaklang/common/fuzztagx/parser"
+	"github.com/yaklang/yaklang/common/utils"
 )
 
 func TestReader(t *testing.T) {

--- a/common/mutate/fuzztag.go
+++ b/common/mutate/fuzztag.go
@@ -51,6 +51,7 @@ type FuzzTagDescription struct {
 	HandlerAndYieldString func(s string, yield func(s string)) error
 	ErrorInfoHandler      func(string) ([]string, error)
 	IsDyn                 bool
+	IsFlowControl         bool
 	IsDynFun              func(name, params string) bool
 	Alias                 []string
 	Description           string
@@ -80,22 +81,24 @@ func AddFuzzTagDescriptionToMap(methodMap map[string]*parser.TagMethod, f *FuzzT
 	}
 	if f.HandlerAndYield != nil {
 		methodMap[name] = &parser.TagMethod{
-			Name:        name,
-			IsDyn:       f.IsDyn,
-			Expand:      expand,
-			Alias:       alias,
-			Description: f.Description,
+			Name:          name,
+			IsDyn:         f.IsDyn,
+			IsFlowControl: f.IsFlowControl,
+			Expand:        expand,
+			Alias:         alias,
+			Description:   f.Description,
 			YieldFun: func(ctx context.Context, s string, recv func(*parser.FuzzResult)) error {
 				return f.HandlerAndYield(ctx, s, recv)
 			},
 		}
 	} else {
 		methodMap[name] = &parser.TagMethod{
-			Name:        name,
-			IsDyn:       f.IsDyn,
-			Expand:      expand,
-			Alias:       alias,
-			Description: f.Description,
+			Name:          name,
+			IsDyn:         f.IsDyn,
+			IsFlowControl: f.IsFlowControl,
+			Expand:        expand,
+			Alias:         alias,
+			Description:   f.Description,
 			Fun: func(s string) (result []*parser.FuzzResult, err error) {
 				defer func() {
 					if r := recover(); r != nil {
@@ -652,7 +655,8 @@ func init() {
 	})
 
 	AddFuzzTagToGlobal(&FuzzTagDescription{
-		TagName: "repeat",
+		TagName:       "repeat",
+		IsFlowControl: true,
 		HandlerAndYield: func(ctx context.Context, s string, yield func(res *parser.FuzzResult)) error {
 			i := atoi(s)
 			if i == 0 {

--- a/common/mutate/fuzztag_test.go
+++ b/common/mutate/fuzztag_test.go
@@ -426,3 +426,17 @@ func TestTimestampFuzzTag(t *testing.T) {
 	now := time.Now().UnixMicro()
 	require.True(t, got >= now-1000 && got <= now+1000)
 }
+
+func TestFlowControlTag(t *testing.T) {
+	results, err := FuzzTagExec(`{{int(1-2)}}{{int(3-5)}}{{repeat(2)}}`, Fuzz_WithResultHandler(func(s string, i []string) bool {
+		return true
+	}), Fuzz_SyncTag(true))
+	require.NoError(t, err)
+	require.Len(t, results, 6)
+
+	results, err = FuzzTagExec(`{{int(1-2)}}{{int(3-5)}}{{repeat(4)}}`, Fuzz_WithResultHandler(func(s string, i []string) bool {
+		return true
+	}), Fuzz_SyncTag(true))
+	require.NoError(t, err)
+	require.Len(t, results, 12)
+}


### PR DESCRIPTION
…sync rendering. Fix incorrect request count when 'repeat' tag and sync rendering are both enabled.