### PR TITLE
fix rule schema missing when Load rule that needs recompile for updated OpCodes

### DIFF
--- a/common/syntaxflow/sfvm/sfi.go
+++ b/common/syntaxflow/sfvm/sfi.go
@@ -23,7 +23,7 @@ func ToOpCodes(code string) (*OpCodes, bool) {
 		return nil, false
 	}
 	// check version
-	if opcodes.Version != "dev" && opcodes.Version != consts.GetYakVersion() {
+	if consts.GetYakVersion() != "dev" && opcodes.Version != "dev" && opcodes.Version != consts.GetYakVersion() {
 		return nil, false
 	}
 

--- a/common/syntaxflow/sfvm/vm.go
+++ b/common/syntaxflow/sfvm/vm.go
@@ -86,7 +86,12 @@ func (s *SyntaxFlowVirtualMachine) Load(rule *schema.SyntaxFlowRule) (*SFFrame, 
 		if err != nil {
 			return nil, false, utils.Errorf("SyntaxFlow compile error: %v", err)
 		}
-		return frame, true, nil
+		// compile only with rule.Content will lose original rule schema info
+		// so set it back here
+		newFrame := newSfFrameEx(s.vars, rule.Content, frame.Codes, rule, s.config)
+		newFrame.config = s.config
+		newFrame.vm = s
+		return newFrame, true, nil
 	}
 }
 


### PR DESCRIPTION
fix rule schema missing when Load rule that needs recompile for updated OpCodes