### PR TITLE
fix: prevent ResponseRaw and RequestRaw from being nil in webfuzzer s…

### DIFF
--- a/common/yakgrpc/grpc_fuzzer_sequence.go
+++ b/common/yakgrpc/grpc_fuzzer_sequence.go
@@ -237,11 +237,24 @@ func (s *Server) execFlow(senderMutex *sync.Mutex, flowMax int64, wg *sync.WaitG
 				log.Errorf("json unmarshal FuzzerRequest failed: %s", err)
 				return
 			}
+
+			copiedRsp := ypb.FuzzerResponse{}
+			raw, err = json.Marshal(response)
+			if err != nil {
+				log.Errorf("json marshal ypb.FuzzerRequest failed: %s", err)
+				return
+			}
+			err = json.Unmarshal(raw, &copiedRsp)
+			if err != nil {
+				log.Errorf("json unmarshal FuzzerRequest failed: %s", err)
+				return
+			}
+
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				swg.Add()
-				flow := NewFuzzerSequenceFlow(&copiedReq).FromFuzzerResponse(response)
+				flow := NewFuzzerSequenceFlow(&copiedReq).FromFuzzerResponse(&copiedRsp)
 				flow.next = f.next.next
 				err := s.execFlow(senderMutex, flowMax, wg, flow, stream)
 				swg.Done()


### PR DESCRIPTION
…equence during high-volume packet sending

- Add deep copy mechanism for FuzzerResponse to avoid data race conditions
- Use JSON marshal/unmarshal approach to create independent response copy
- Ensures ResponseRaw and RequestRaw fields remain intact during concurrent operations