### PR TITLE
fix: fix space engine API path joining bug and rename APIHost field t…

### DIFF
--- a/common/utils/spacengine/base/base.go
+++ b/common/utils/spacengine/base/base.go
@@ -2,8 +2,8 @@ package base
 
 import (
 	"net/http"
+	"net/url"
 
-	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
 	"github.com/yaklang/yaklang/common/utils/lowhttp/poc"
 )
@@ -15,7 +15,7 @@ type BaseSpaceEngineConfig struct {
 }
 type BaseSpaceEngineClient struct {
 	Key     string
-	APIHost string
+	BaseUrl string
 }
 
 type SpaceEngineResponse struct {
@@ -29,12 +29,12 @@ type SpaceEngineResponse struct {
 func NewBaseSpaceEngineClient(key string, host string) *BaseSpaceEngineClient {
 	return &BaseSpaceEngineClient{
 		Key:     key,
-		APIHost: lowhttp.FixURLScheme(host),
+		BaseUrl: lowhttp.FixURLScheme(host),
 	}
 }
 
 func (c *BaseSpaceEngineClient) Do(method, path string, opts ...poc.PocConfigOption) (*SpaceEngineResponse, error) {
-	urlStr, err := utils.UrlJoin(c.APIHost, path)
+	urlStr, err := url.JoinPath(c.BaseUrl, path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…o BaseUrl

- Replace utils.UrlJoin with standard url.JoinPath for proper path joining
- Rename APIHost field to BaseUrl for better clarity and consistency
- Remove unused utils import and add net/url import