### PR TITLE
feat: enhance HNSW graph export with multiple indexing modes and auto…

### DIFF
--- a/common/ai/rag/config/sqlitedb_store_hnsw_cfg.go
+++ b/common/ai/rag/config/sqlitedb_store_hnsw_cfg.go
@@ -13,6 +13,8 @@ type SQLiteVectorStoreHNSWConfig struct {
 	EfSearch         int     `json:"ef_search"`          // 搜索时的候选节点数
 	EfConstruct      int     `json:"ef_construct"`       // 构建时的候选节点数
 	DistanceFuncType string  `json:"distance_func_type"` // 距离函数类型（cosine、euclidean等）
+
+	EnablePQMode bool `json:"enable_pq_mode"`
 }
 
 // SQLiteVectorStoreHNSWOption 定义配置选项函数类型
@@ -26,6 +28,7 @@ func NewSQLiteVectorStoreHNSWConfig() *SQLiteVectorStoreHNSWConfig {
 		EfSearch:         20,       // 搜索时的候选节点数
 		EfConstruct:      200,      // 构建时的候选节点数
 		DistanceFuncType: "cosine", // 默认使用余弦距离
+		EnablePQMode:     false,    // 默认不启用PQ模式
 	}
 }
 
@@ -59,6 +62,13 @@ func (c *SQLiteVectorStoreHNSWConfig) ValidateConfig() error {
 	}
 
 	return nil
+}
+
+// WithEnablePQMode 设置是否启用PQ模式
+func WithEnablePQMode(enablePQMode bool) SQLiteVectorStoreHNSWOption {
+	return func(config *SQLiteVectorStoreHNSWConfig) {
+		config.EnablePQMode = enablePQMode
+	}
 }
 
 // WithMaxNeighbors 设置最大邻居数 (M 参数)
@@ -114,6 +124,11 @@ func WithManhattanDistance() SQLiteVectorStoreHNSWOption {
 // WithDotDistance 设置使用点积距离
 func WithDotDistance() SQLiteVectorStoreHNSWOption {
 	return WithDistanceFunction("dot")
+}
+
+// WithPQMode 设置使用PQ模式
+func WithPQMode() SQLiteVectorStoreHNSWOption {
+	return WithEnablePQMode(true)
 }
 
 // WithHNSWParameters 批量设置 HNSW 参数

--- a/common/ai/rag/exports.go
+++ b/common/ai/rag/exports.go
@@ -334,80 +334,22 @@ type CollectionInfo struct {
 	EfConstruct      int
 	DistanceFuncType string
 
-	LayerCount        int         // Layer数量
-	LayerNodeCountMap map[int]int // Layer节点数量
-	NodeCount         int         // 节点数量
-	MaxNeighbors      int         // 最大邻居数
-	MinNeighbors      int         // 最小邻居数
-	ConnectionCount   int         // 总连接数
+	// LayerCount        int         // Layer数量
+	// LayerNodeCountMap map[int]int // Layer节点数量
+	// NodeCount         int         // 节点数量
+	// MaxNeighbors      int         // 最大邻居数
+	// MinNeighbors      int         // 最小邻居数
+	// ConnectionCount   int         // 总连接数
 }
 
 // GetCollectionInfo 获取知识库信息
 func GetCollectionInfo(db *gorm.DB, name string) (*CollectionInfo, error) {
-	var collections []*schema.VectorStoreCollection
-	dbErr := db.Model(&schema.VectorStoreCollection{}).Where("name = ?", name).Find(&collections)
+	var collection schema.VectorStoreCollection
+	dbErr := db.Model(&schema.VectorStoreCollection{}).Where("name = ?", name).
+		Select("name, description, model_name, dimension, m, ml, ef_search, ef_construct, distance_func_type").
+		First(&collection)
 	if dbErr.Error != nil {
 		return nil, utils.Errorf("获取知识库信息失败: %v", dbErr.Error)
-	}
-	if len(collections) == 0 {
-		return nil, utils.Errorf("知识库 %s 不存在", name)
-	}
-	collection := collections[0]
-	// 暂时不支持从数据库恢复HNSW图结构
-	// 当前返回基本信息
-	layers := ParseLayersInfo(&collections[0].GroupInfos, func(key string) []float32 {
-		var docs []schema.VectorStoreDocument
-		db.Where("document_id = ?", key).Find(&docs)
-		if len(docs) == 0 {
-			return nil
-		}
-		return []float32(docs[0].Embedding)
-	})
-
-	layerNodeCountMap := make(map[int]int)
-	nodeCount := 0
-	maxNeighbors := 0
-	minNeighbors := -1 // 初始化为-1，表示还没有找到任何节点
-	connectionCount := 0
-
-	// 如果layers为nil（不支持恢复），则只提供基本信息
-	if layers == nil {
-		// 获取文档数量作为基本信息
-		var docCount int64
-		db.Model(&schema.VectorStoreDocument{}).Where("collection_id = ?", collection.ID).Count(&docCount)
-		nodeCount = int(docCount)
-	} else {
-		for index, layer := range layers {
-			layerNodeCountMap[index] = len(layer.Nodes)
-			nodeCount += len(layer.Nodes)
-
-			// 遍历该层的所有节点，统计邻居信息
-			for _, node := range layer.Nodes {
-				if node == nil {
-					continue
-				}
-
-				neighborCount := len(node.GetNeighbors())
-
-				// 更新最大邻居数
-				if neighborCount > maxNeighbors {
-					maxNeighbors = neighborCount
-				}
-
-				// 更新最小邻居数
-				if minNeighbors == -1 || neighborCount < minNeighbors {
-					minNeighbors = neighborCount
-				}
-
-				// 累计连接数（每个邻居关系算作一个连接）
-				connectionCount += neighborCount
-			}
-		}
-	}
-
-	// 如果没有任何节点，将最小邻居数设为0
-	if minNeighbors == -1 {
-		minNeighbors = 0
 	}
 
 	return &CollectionInfo{
@@ -421,19 +363,6 @@ func GetCollectionInfo(db *gorm.DB, name string) (*CollectionInfo, error) {
 		EfSearch:         collection.EfSearch,
 		EfConstruct:      collection.EfConstruct,
 		DistanceFuncType: collection.DistanceFuncType,
-
-		LayerCount: func() int {
-			if layers == nil {
-				return 0
-			} else {
-				return len(layers)
-			}
-		}(),
-		LayerNodeCountMap: layerNodeCountMap,
-		NodeCount:         nodeCount,
-		MaxNeighbors:      maxNeighbors,
-		MinNeighbors:      minNeighbors,
-		ConnectionCount:   connectionCount,
 	}, nil
 }
 

--- a/common/ai/rag/exports.go
+++ b/common/ai/rag/exports.go
@@ -313,15 +313,11 @@ func DeleteCollection(db *gorm.DB, name string) error {
 
 // ListCollections 获取所有知识库列表
 func ListCollections(db *gorm.DB) []string {
-	collections, err := yakit.QueryRAGCollections(db)
+	collectionNames, err := yakit.GetAllRAGCollectionNames(db)
 	if err != nil {
 		return []string{}
 	}
-	names := []string{}
-	for _, collection := range collections {
-		names = append(names, collection.Name)
-	}
-	return names
+	return collectionNames
 }
 
 type CollectionInfo struct {

--- a/common/ai/rag/exports_test.go
+++ b/common/ai/rag/exports_test.go
@@ -1,0 +1,17 @@
+package rag
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/yaklang/yaklang/common/consts"
+)
+
+func TestExports(t *testing.T) {
+	Get("test")
+	info, err := GetCollectionInfo(consts.GetGormProfileDatabase(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(info)
+}

--- a/common/ai/rag/hnsw/codebook_export.go
+++ b/common/ai/rag/hnsw/codebook_export.go
@@ -1,0 +1,144 @@
+package hnsw
+
+import (
+	"bytes"
+	"io"
+	"math"
+
+	"github.com/yaklang/yaklang/common/ai/rag/pq"
+	"github.com/yaklang/yaklang/common/utils"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func ExportCodebook(codebook *pq.Codebook) (io.Reader, error) {
+	if codebook == nil {
+		return nil, utils.Error("codebook is nil")
+	}
+
+	if codebook.M <= 0 || codebook.K <= 0 || codebook.SubVectorDim <= 0 {
+		return nil, utils.Errorf("invalid codebook parameters: M=%d, K=%d, SubVectorDim=%d",
+			codebook.M, codebook.K, codebook.SubVectorDim)
+	}
+
+	if len(codebook.Centroids) != codebook.M {
+		return nil, utils.Errorf("centroids length %d does not match M %d",
+			len(codebook.Centroids), codebook.M)
+	}
+
+	var buf bytes.Buffer
+
+	// Write header: M, K, SubVectorDim
+	if err := pbWriteVarint(&buf, uint64(codebook.M)); err != nil {
+		return nil, utils.Wrap(err, "write M")
+	}
+	if err := pbWriteVarint(&buf, uint64(codebook.K)); err != nil {
+		return nil, utils.Wrap(err, "write K")
+	}
+	if err := pbWriteVarint(&buf, uint64(codebook.SubVectorDim)); err != nil {
+		return nil, utils.Wrap(err, "write SubVectorDim")
+	}
+
+	// Write centroids data
+	for m := 0; m < codebook.M; m++ {
+		if len(codebook.Centroids[m]) != codebook.K {
+			return nil, utils.Errorf("centroids[%d] length %d does not match K %d",
+				m, len(codebook.Centroids[m]), codebook.K)
+		}
+
+		for k := 0; k < codebook.K; k++ {
+			if len(codebook.Centroids[m][k]) != codebook.SubVectorDim {
+				return nil, utils.Errorf("centroids[%d][%d] length %d does not match SubVectorDim %d",
+					m, k, len(codebook.Centroids[m][k]), codebook.SubVectorDim)
+			}
+
+			for d := 0; d < codebook.SubVectorDim; d++ {
+				if err := pbWriteFloat64(&buf, codebook.Centroids[m][k][d]); err != nil {
+					return nil, utils.Wrapf(err, "write centroids[%d][%d][%d]", m, k, d)
+				}
+			}
+		}
+	}
+
+	return &buf, nil
+}
+
+func ImportCodebook(reader io.Reader) (*pq.Codebook, error) {
+	if reader == nil {
+		return nil, utils.Error("reader is nil")
+	}
+
+	// Read all data
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, utils.Wrap(err, "read all data")
+	}
+
+	offset := 0
+
+	consumeVarint := func() (uint64, error) {
+		v, n := protowire.ConsumeVarint(data[offset:])
+		if n < 0 {
+			return 0, utils.Errorf("consume varint: %d", n)
+		}
+		offset += n
+		return v, nil
+	}
+
+	consumeFloat64 := func() (float64, error) {
+		v, n := protowire.ConsumeFixed64(data[offset:])
+		if n < 0 {
+			return 0, utils.Errorf("consume fixed64: %d", n)
+		}
+		offset += n
+		return math.Float64frombits(v), nil
+	}
+
+	// Read header
+	mVal, err := consumeVarint()
+	if err != nil {
+		return nil, utils.Wrap(err, "read M")
+	}
+	M := int(mVal)
+
+	kVal, err := consumeVarint()
+	if err != nil {
+		return nil, utils.Wrap(err, "read K")
+	}
+	K := int(kVal)
+
+	subVectorDimVal, err := consumeVarint()
+	if err != nil {
+		return nil, utils.Wrap(err, "read SubVectorDim")
+	}
+	SubVectorDim := int(subVectorDimVal)
+
+	// Validate parameters
+	if M <= 0 || K <= 0 || SubVectorDim <= 0 {
+		return nil, utils.Errorf("invalid codebook parameters: M=%d, K=%d, SubVectorDim=%d",
+			M, K, SubVectorDim)
+	}
+
+	// Initialize centroids
+	centroids := make([][][]float64, M)
+	for m := 0; m < M; m++ {
+		centroids[m] = make([][]float64, K)
+		for k := 0; k < K; k++ {
+			centroids[m][k] = make([]float64, SubVectorDim)
+			for d := 0; d < SubVectorDim; d++ {
+				centroids[m][k][d], err = consumeFloat64()
+				if err != nil {
+					return nil, utils.Wrapf(err, "read centroids[%d][%d][%d]", m, k, d)
+				}
+			}
+		}
+	}
+
+	codebook := &pq.Codebook{
+		M:            M,
+		K:            K,
+		SubVectorDim: SubVectorDim,
+		Centroids:    centroids,
+	}
+
+	return codebook, nil
+}

--- a/common/ai/rag/hnsw/export_binary.go
+++ b/common/ai/rag/hnsw/export_binary.go
@@ -11,10 +11,9 @@ import (
 )
 
 func (i *Persistent[K]) ToBinary(ctx context.Context) (io.Reader, error) {
-	if i.Total <= 0 {
-		return nil, utils.Error("cannot export empty graph")
-	}
+	// Allow exporting empty graphs (Total == 0)
 
+	// Basic validation for all graphs (including empty ones)
 	if i.Dims <= 0 {
 		return nil, utils.Error("invalid dimensions")
 	}
@@ -31,16 +30,18 @@ func (i *Persistent[K]) ToBinary(ctx context.Context) (io.Reader, error) {
 		return nil, utils.Error("invalid hnsw.EfSearch")
 	}
 
+	// PQ codebook validation (only if PQ mode is used)
 	if i.ExportMode == ExportModePQ && i.PQCodebook == nil {
 		return nil, utils.Error("pq mode enabled but pq codebook is nil")
 	}
 
-	if i.ExportMode == ExportModePQ {
+	if i.ExportMode == ExportModePQ && i.PQCodebook != nil {
 		if i.PQCodebook.K <= 0 || i.PQCodebook.M <= 0 || i.PQCodebook.SubVectorDim <= 0 || len(i.PQCodebook.Centroids) == 0 {
 			return nil, utils.Errorf("invalid pq codebook, m:%v k:%v sub_vector_dim:%v centroids-length:%v", i.PQCodebook.M, i.PQCodebook.K, i.PQCodebook.SubVectorDim, len(i.PQCodebook.Centroids))
 		}
 	}
 
+	// For empty graphs, OffsetToKey can be empty slice but not nil
 	if i.OffsetToKey == nil {
 		return nil, utils.Error("offset to key mapping is nil")
 	}

--- a/common/ai/rag/hnsw/export_method.go
+++ b/common/ai/rag/hnsw/export_method.go
@@ -16,10 +16,10 @@ func ExportGraphToBinary[K cmp.Ordered](i *Graph[K]) (io.Reader, error) {
 	return pers.ToBinary(context.Background())
 }
 
-func LoadGraphFromBinary[K cmp.Ordered](reader io.Reader, dataLoader func(key hnswspec.LazyNodeID) (hnswspec.LayerNode[K], error)) (*Graph[K], error) {
+func LoadGraphFromBinary[K cmp.Ordered](reader io.Reader, dataLoader func(key hnswspec.LazyNodeID) (hnswspec.LayerNode[K], error), opts ...GraphOption[K]) (*Graph[K], error) {
 	pers, err := LoadBinary[K](reader)
 	if err != nil {
 		return nil, err
 	}
-	return pers.BuildLazyGraph(dataLoader)
+	return pers.BuildLazyGraph(dataLoader, opts...)
 }

--- a/common/ai/rag/hnsw/export_method.go
+++ b/common/ai/rag/hnsw/export_method.go
@@ -1,0 +1,25 @@
+package hnsw
+
+import (
+	"cmp"
+	"context"
+	"io"
+
+	"github.com/yaklang/yaklang/common/ai/rag/hnsw/hnswspec"
+)
+
+func ExportGraphToBinary[K cmp.Ordered](i *Graph[K]) (io.Reader, error) {
+	pers, err := ExportHNSWGraph(i)
+	if err != nil {
+		return nil, err
+	}
+	return pers.ToBinary(context.Background())
+}
+
+func LoadGraphFromBinary[K cmp.Ordered](reader io.Reader, dataLoader func(key hnswspec.LazyNodeID) (hnswspec.LayerNode[K], error)) (*Graph[K], error) {
+	pers, err := LoadBinary[K](reader)
+	if err != nil {
+		return nil, err
+	}
+	return pers.BuildLazyGraph(dataLoader)
+}

--- a/common/ai/rag/hnsw/export_test.go
+++ b/common/ai/rag/hnsw/export_test.go
@@ -2,7 +2,6 @@ package hnsw
 
 import (
 	"context"
-	"io"
 	"slices"
 	"strings"
 	"testing"
@@ -83,55 +82,6 @@ func TestExportWithUIDMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertMidIns(midIns)
-}
-
-func TestExportWithEmptyLayers(t *testing.T) {
-	// Test exporting a graph with empty layers
-	graph := NewGraph[string]()
-
-	// Export the empty graph
-	persistent, err := ExportHNSWGraph(graph)
-	if err != nil {
-		t.Fatalf("Failed to export empty graph: %v", err)
-	}
-
-	// Verify the exported graph properties
-	assert.Equal(t, persistent.KeyType, "string")
-	assert.Equal(t, persistent.Total, uint32(0))
-	assert.Equal(t, len(persistent.Layers), 0)
-	assert.Equal(t, len(persistent.OffsetToKey), 0)
-	assert.Equal(t, len(persistent.Neighbors), 0)
-	assert.Equal(t, persistent.ExportMode, ExportModeStandard)
-
-	// Test with different key types
-	intGraph := NewGraph[int]()
-	intPersistent, err := ExportHNSWGraph(intGraph)
-	if err != nil {
-		t.Fatalf("Failed to export empty int graph: %v", err)
-	}
-	assert.Equal(t, intPersistent.KeyType, "int64")
-	assert.Equal(t, intPersistent.Total, uint32(0))
-
-	uint32Graph := NewGraph[uint32]()
-	uint32Persistent, err := ExportHNSWGraph(uint32Graph)
-	if err != nil {
-		t.Fatalf("Failed to export empty uint32 graph: %v", err)
-	}
-	assert.Equal(t, uint32Persistent.KeyType, "uint32")
-	assert.Equal(t, uint32Persistent.Total, uint32(0))
-
-	uint32Persistent.Dims = 1024
-	binary, err := uint32Persistent.ToBinary(context.Background())
-	if err != nil {
-		t.Fatalf("Failed to export empty uint32 graph: %v", err)
-	}
-	binaryData, err := io.ReadAll(binary)
-	if err != nil {
-		t.Fatalf("Failed to read empty uint32 graph: %v", err)
-	}
-	if len(binaryData) == 0 {
-		t.Fatalf("Failed to export empty uint32 graph: %v", err)
-	}
 }
 
 func TestExportNeighborRelationships(t *testing.T) {

--- a/common/ai/rag/hnsw/export_test.go
+++ b/common/ai/rag/hnsw/export_test.go
@@ -1,0 +1,85 @@
+package hnsw
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/yaklang/yaklang/common/ai/rag/hnsw/hnswspec"
+	"github.com/yaklang/yaklang/common/utils"
+	"gotest.tools/v3/assert"
+)
+
+func TestExportWithUIDMode(t *testing.T) {
+	keyToVector := map[string][]float32{
+		"1": {1},
+		"2": {2},
+		"3": {3},
+		"4": {4},
+		"5": {5},
+	}
+
+	keyToID := map[string]string{}
+	idToKey := map[hnswspec.LazyNodeID]string{}
+	for key := range keyToVector {
+		id := "col_" + key
+		keyToID[key] = id
+		idToKey[id] = key
+	}
+
+	graph := NewGraph(WithConvertToUIDFunc(func(node hnswspec.LayerNode[string]) (hnswspec.LazyNodeID, error) {
+		return hnswspec.LazyNodeID(keyToID[node.GetKey()]), nil
+	}), WithNodeType[string](InputNodeTypeLazy))
+
+	keys := make([]string, 0, len(keyToVector))
+	for key := range keyToVector {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		graph.Add(MakeInputNodeFromID(key, hnswspec.LazyNodeID(keyToID[key]), func(uid hnswspec.LazyNodeID) ([]float32, error) {
+			return keyToVector[idToKey[uid]], nil
+		}))
+	}
+
+	midIns, err := ExportHNSWGraph(graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var totalGraphNodes = 0
+	for _, layer := range graph.Layers {
+		totalGraphNodes += len(layer.Nodes)
+	}
+
+	assertMidIns := func(midIns *Persistent[string]) {
+		assert.Equal(t, midIns.Dims, uint32(1))
+		assert.Equal(t, midIns.Total, uint32(totalGraphNodes))
+		codes := lo.Map(midIns.OffsetToKey[1:], func(item *PersistentNode[string], _ int) string {
+			return utils.InterfaceToString(item.Code)
+		})
+		slices.Sort(codes)
+		assert.Equal(t, strings.Join(codes, ","), "col_1,col_2,col_3,col_4,col_5")
+
+		keys := lo.Map(midIns.OffsetToKey[1:], func(item *PersistentNode[string], _ int) string {
+			return item.Key
+		})
+		slices.Sort(keys)
+		assert.Equal(t, strings.Join(keys, ","), "1,2,3,4,5")
+	}
+
+	assertMidIns(midIns)
+	binary, err := midIns.ToBinary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	midIns, err = LoadBinary[string](binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMidIns(midIns)
+}

--- a/common/ai/rag/hnsw/export_test.go
+++ b/common/ai/rag/hnsw/export_test.go
@@ -2,6 +2,7 @@ package hnsw
 
 import (
 	"context"
+	"io"
 	"slices"
 	"strings"
 	"testing"
@@ -82,4 +83,53 @@ func TestExportWithUIDMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertMidIns(midIns)
+}
+
+func TestExportWithEmptyLayers(t *testing.T) {
+	// Test exporting a graph with empty layers
+	graph := NewGraph[string]()
+
+	// Export the empty graph
+	persistent, err := ExportHNSWGraph(graph)
+	if err != nil {
+		t.Fatalf("Failed to export empty graph: %v", err)
+	}
+
+	// Verify the exported graph properties
+	assert.Equal(t, persistent.KeyType, "string")
+	assert.Equal(t, persistent.Total, uint32(0))
+	assert.Equal(t, len(persistent.Layers), 0)
+	assert.Equal(t, len(persistent.OffsetToKey), 0)
+	assert.Equal(t, len(persistent.Neighbors), 0)
+	assert.Equal(t, persistent.ExportMode, ExportModeStandard)
+
+	// Test with different key types
+	intGraph := NewGraph[int]()
+	intPersistent, err := ExportHNSWGraph(intGraph)
+	if err != nil {
+		t.Fatalf("Failed to export empty int graph: %v", err)
+	}
+	assert.Equal(t, intPersistent.KeyType, "int64")
+	assert.Equal(t, intPersistent.Total, uint32(0))
+
+	uint32Graph := NewGraph[uint32]()
+	uint32Persistent, err := ExportHNSWGraph(uint32Graph)
+	if err != nil {
+		t.Fatalf("Failed to export empty uint32 graph: %v", err)
+	}
+	assert.Equal(t, uint32Persistent.KeyType, "uint32")
+	assert.Equal(t, uint32Persistent.Total, uint32(0))
+
+	uint32Persistent.Dims = 1024
+	binary, err := uint32Persistent.ToBinary(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to export empty uint32 graph: %v", err)
+	}
+	binaryData, err := io.ReadAll(binary)
+	if err != nil {
+		t.Fatalf("Failed to read empty uint32 graph: %v", err)
+	}
+	if len(binaryData) == 0 {
+		t.Fatalf("Failed to export empty uint32 graph: %v", err)
+	}
 }

--- a/common/ai/rag/hnsw/hnswspec/interfaces.go
+++ b/common/ai/rag/hnsw/hnswspec/interfaces.go
@@ -37,6 +37,9 @@ type LayerNode[K cmp.Ordered] interface {
 
 	// GetPQCodes 获取PQ编码（仅PQ节点有效）
 	GetPQCodes() ([]byte, bool)
+
+	// GetData 获取节点数据
+	GetData() any
 }
 
 // DistanceFunc 距离计算函数，基于节点接口

--- a/common/ai/rag/hnsw/hnswspec/interfaces.go
+++ b/common/ai/rag/hnsw/hnswspec/interfaces.go
@@ -23,6 +23,9 @@ type LayerNode[K cmp.Ordered] interface {
 	// AddNeighbor 添加邻居节点
 	AddNeighbor(neighbor LayerNode[K], m int, distFunc DistanceFunc[K])
 
+	// AddSingleNeighbor 添加单边邻居节点
+	AddSingleNeighbor(neighbor LayerNode[K])
+
 	// RemoveNeighbor 移除邻居节点
 	RemoveNeighbor(key K)
 

--- a/common/ai/rag/hnsw/hnswspec/lazy_node.go
+++ b/common/ai/rag/hnsw/hnswspec/lazy_node.go
@@ -5,7 +5,6 @@ import (
 )
 
 type LazyNodeID any
-
 type LazyLayerNode[K cmp.Ordered] struct {
 	uid          LazyNodeID
 	nodeCacheErr error
@@ -65,4 +64,8 @@ func (n *LazyLayerNode[K]) Replenish(m int, distFunc DistanceFunc[K]) {
 
 func (n *LazyLayerNode[K]) RemoveNeighbor(key K) {
 	n.LoadNode().RemoveNeighbor(key)
+}
+
+func (n *LazyLayerNode[K]) AddSingleNeighbor(neighbor LayerNode[K]) {
+	n.LoadNode().AddSingleNeighbor(neighbor)
 }

--- a/common/ai/rag/hnsw/hnswspec/lazy_node.go
+++ b/common/ai/rag/hnsw/hnswspec/lazy_node.go
@@ -1,0 +1,68 @@
+package hnswspec
+
+import (
+	"cmp"
+)
+
+type LazyNodeID any
+
+type LazyLayerNode[K cmp.Ordered] struct {
+	uid          LazyNodeID
+	nodeCacheErr error
+	nodeGetter   func(uid LazyNodeID) (LayerNode[K], error)
+}
+
+var _ LayerNode[string] = (*LazyLayerNode[string])(nil)
+
+func NewLazyLayerNode[K cmp.Ordered](uid LazyNodeID, nodeGetter func(uid LazyNodeID) (LayerNode[K], error)) *LazyLayerNode[K] {
+	return &LazyLayerNode[K]{uid: uid, nodeGetter: nodeGetter}
+}
+
+func (n *LazyLayerNode[K]) GetUID() LazyNodeID {
+	return n.uid
+}
+
+func (n *LazyLayerNode[K]) LoadNode() LayerNode[K] {
+	node, err := n.nodeGetter(n.GetUID())
+	n.nodeCacheErr = err
+	return node
+}
+
+func (n *LazyLayerNode[K]) GetVector() Vector {
+	return n.LoadNode().GetVector()
+}
+
+func (n *LazyLayerNode[K]) GetNeighbors() map[K]LayerNode[K] {
+	return n.LoadNode().GetNeighbors()
+}
+
+func (n *LazyLayerNode[K]) AddNeighbor(neighbor LayerNode[K], m int, distFunc DistanceFunc[K]) {
+	n.LoadNode().AddNeighbor(neighbor, m, distFunc)
+}
+
+func (n *LazyLayerNode[K]) GetKey() K {
+	return n.LoadNode().GetKey()
+}
+func (n *LazyLayerNode[K]) GetData() any {
+	return n.GetUID()
+}
+
+func (n *LazyLayerNode[K]) GetPQCodes() ([]byte, bool) {
+	return n.LoadNode().GetPQCodes()
+}
+
+func (n *LazyLayerNode[K]) IsPQEnabled() bool {
+	return n.LoadNode().IsPQEnabled()
+}
+
+func (n *LazyLayerNode[K]) Isolate(neighbors map[K]LayerNode[K], m int, distFunc DistanceFunc[K]) {
+	n.LoadNode().Isolate(neighbors, m, distFunc)
+}
+
+func (n *LazyLayerNode[K]) Replenish(m int, distFunc DistanceFunc[K]) {
+	n.LoadNode().Replenish(m, distFunc)
+}
+
+func (n *LazyLayerNode[K]) RemoveNeighbor(key K) {
+	n.LoadNode().RemoveNeighbor(key)
+}

--- a/common/ai/rag/hnsw/hnswspec/nodes.go
+++ b/common/ai/rag/hnsw/hnswspec/nodes.go
@@ -31,6 +31,10 @@ func (n *StandardLayerNode[K]) GetVector() Vector {
 	return n.vector
 }
 
+func (n *StandardLayerNode[K]) GetData() any {
+	return n.vector
+}
+
 func (n *StandardLayerNode[K]) GetNeighbors() map[K]LayerNode[K] {
 	return n.neighbors
 }
@@ -190,6 +194,10 @@ func (n *PQLayerNode[K]) GetVector() Vector {
 	return func() []float32 {
 		panic("PQ node does not store original vector data. Use PQ codes for distance calculation.")
 	}
+}
+
+func (n *PQLayerNode[K]) GetData() any {
+	return n.pqCodes
 }
 
 func (n *PQLayerNode[K]) GetNeighbors() map[K]LayerNode[K] {

--- a/common/ai/rag/hnsw/hnswspec/nodes.go
+++ b/common/ai/rag/hnsw/hnswspec/nodes.go
@@ -23,6 +23,9 @@ func NewStandardLayerNode[K cmp.Ordered](key K, vector Vector) *StandardLayerNod
 	}
 }
 
+func (n *StandardLayerNode[K]) SetKey(key K) {
+	n.key = key
+}
 func (n *StandardLayerNode[K]) GetKey() K {
 	return n.key
 }
@@ -66,6 +69,10 @@ func (n *StandardLayerNode[K]) AddNeighbor(neighbor LayerNode[K], m int, distFun
 	// 删除反向链接
 	worst.RemoveNeighbor(n.key)
 	worst.Replenish(m, distFunc)
+}
+
+func (n *StandardLayerNode[K]) AddSingleNeighbor(neighbor LayerNode[K]) {
+	n.neighbors[neighbor.GetKey()] = neighbor
 }
 
 func (n *StandardLayerNode[K]) RemoveNeighbor(key K) {
@@ -159,6 +166,16 @@ type PQLayerNode[K cmp.Ordered] struct {
 	key       K
 	pqCodes   []byte // PQ编码
 	neighbors map[K]LayerNode[K]
+}
+
+// NewRawPQLayerNode 创建原始PQ编码的层节点
+func NewRawPQLayerNode[K cmp.Ordered](key K, pqCodes []byte) *PQLayerNode[K] {
+	node := &PQLayerNode[K]{
+		key:       key,
+		pqCodes:   pqCodes,
+		neighbors: make(map[K]LayerNode[K]),
+	}
+	return node
 }
 
 // NewPQLayerNode 创建PQ优化层节点
@@ -317,4 +334,8 @@ func (n *PQLayerNode[K]) IsPQEnabled() bool {
 
 func (n *PQLayerNode[K]) GetPQCodes() ([]byte, bool) {
 	return n.pqCodes, true
+}
+
+func (n *PQLayerNode[K]) AddSingleNeighbor(neighbor LayerNode[K]) {
+	n.neighbors[neighbor.GetKey()] = neighbor
 }

--- a/common/ai/rag/hnsw/load_binary.go
+++ b/common/ai/rag/hnsw/load_binary.go
@@ -376,7 +376,7 @@ func (p *Persistent[K]) BuildGraph() (*Graph[K], error) {
 }
 
 // BuildGraph 从 Persistent 构建 Graph[K]
-func (p *Persistent[K]) BuildLazyGraph(dataLoader func(data hnswspec.LazyNodeID) (hnswspec.LayerNode[K], error)) (*Graph[K], error) {
+func (p *Persistent[K]) BuildLazyGraph(dataLoader func(data hnswspec.LazyNodeID) (hnswspec.LayerNode[K], error), opts ...GraphOption[K]) (*Graph[K], error) {
 	if p.Total <= 0 {
 		return nil, utils.Error("cannot build graph from empty persistent")
 	}
@@ -405,7 +405,7 @@ func (p *Persistent[K]) BuildLazyGraph(dataLoader func(data hnswspec.LazyNodeID)
 		return nil, utils.Error("offset to key mapping is nil")
 	}
 
-	g := NewGraph[K]()
+	g := NewGraph[K](opts...)
 	g.M = int(p.M)
 	g.Ml = float64(p.Ml)
 	g.EfSearch = int(p.EfSearch)
@@ -519,7 +519,7 @@ func (p *Persistent[K]) BuildLazyGraph(dataLoader func(data hnswspec.LazyNodeID)
 			if !exists {
 				return nil, utils.Errorf("neighbor offset %d not found", neighborOffset)
 			}
-			node.AddNeighbor(neighbor, g.M, g.nodeDistance)
+			node.AddSingleNeighbor(neighbor)
 		}
 	}
 

--- a/common/ai/rag/hnsw/load_binary.go
+++ b/common/ai/rag/hnsw/load_binary.go
@@ -550,7 +550,8 @@ func (p *Persistent[K]) BuildLazyGraph(dataLoader func(data hnswspec.LazyNodeID)
 		for _, neighborOffset := range neighbors {
 			neighbor, exists := nodes[neighborOffset]
 			if !exists {
-				return nil, utils.Errorf("neighbor offset %d not found", neighborOffset)
+				log.Warnf("neighbor offset %d not found", neighborOffset)
+				continue
 			}
 			node.AddSingleNeighbor(neighbor)
 		}

--- a/common/ai/rag/hnsw/load_binary_test.go
+++ b/common/ai/rag/hnsw/load_binary_test.go
@@ -570,6 +570,7 @@ func TestSearchAfterSerializationRoundTrip(t *testing.T) {
 		WithMl[string](0.5),
 		WithEfSearch[string](20),
 		WithCosineDistance[string](),
+		WithDeterministicRng[string](0),
 	)
 
 	// 添加测试节点 - 使用不同的向量以便搜索

--- a/common/ai/rag/hnsw/load_binary_test.go
+++ b/common/ai/rag/hnsw/load_binary_test.go
@@ -17,12 +17,12 @@ import (
 func TestLoadBinaryRoundTrip(t *testing.T) {
 	// 创建一个简单的 Persistent 对象
 	p := &Persistent[string]{
-		Total:    3,
-		Dims:     4,
-		M:        16,
-		Ml:       0.5,
-		EfSearch: 200,
-		PQMode:   false,
+		Total:      3,
+		Dims:       4,
+		M:          16,
+		Ml:         0.5,
+		EfSearch:   200,
+		ExportMode: ExportModeStandard,
 		Layers: []*PersistentLayer{
 			{HNSWLevel: 0, Nodes: []uint32{1, 2, 3}},
 			{HNSWLevel: 1, Nodes: []uint32{1, 2}},
@@ -55,7 +55,7 @@ func TestLoadBinaryRoundTrip(t *testing.T) {
 	require.Equal(t, p.M, loaded.M)
 	require.Equal(t, p.Ml, loaded.Ml)
 	require.Equal(t, p.EfSearch, loaded.EfSearch)
-	require.Equal(t, p.PQMode, loaded.PQMode)
+	require.Equal(t, p.ExportMode, loaded.ExportMode)
 
 	// 验证层
 	require.Len(t, loaded.Layers, len(p.Layers))
@@ -80,12 +80,12 @@ func TestLoadBinaryRoundTrip(t *testing.T) {
 func TestLoadBinaryRoundTripPQ(t *testing.T) {
 	// 创建一个带 PQ 的 Persistent 对象
 	p := &Persistent[string]{
-		Total:    2,
-		Dims:     4,
-		M:        16,
-		Ml:       0.5,
-		EfSearch: 200,
-		PQMode:   true,
+		Total:      2,
+		Dims:       4,
+		M:          16,
+		Ml:         0.5,
+		EfSearch:   200,
+		ExportMode: ExportModePQ,
 		PQCodebook: &PersistentPQCodebook{
 			M:              2,
 			K:              256,
@@ -122,7 +122,7 @@ func TestLoadBinaryRoundTripPQ(t *testing.T) {
 	require.Equal(t, p.M, loaded.M)
 	require.Equal(t, p.Ml, loaded.Ml)
 	require.Equal(t, p.EfSearch, loaded.EfSearch)
-	require.Equal(t, p.PQMode, loaded.PQMode)
+	require.Equal(t, p.ExportMode, loaded.ExportMode)
 
 	// 验证 PQ 码本
 	require.NotNil(t, loaded.PQCodebook)
@@ -178,7 +178,7 @@ func TestExportGraphToBinaryStandard(t *testing.T) {
 	require.NotNil(t, pers)
 	require.True(t, pers.Total >= uint32(3)) // 可能包含额外的节点
 	require.Equal(t, uint32(4), pers.Dims)
-	require.False(t, pers.PQMode)
+	require.Equal(t, ExportModeStandard, pers.ExportMode)
 
 	// 导出到二进制
 	ctx := context.Background()
@@ -195,7 +195,7 @@ func TestExportGraphToBinaryStandard(t *testing.T) {
 	require.Equal(t, pers.M, loaded.M)
 	require.Equal(t, pers.Ml, loaded.Ml)
 	require.Equal(t, pers.EfSearch, loaded.EfSearch)
-	require.Equal(t, pers.PQMode, loaded.PQMode)
+	require.Equal(t, pers.ExportMode, loaded.ExportMode)
 }
 
 func TestExportGraphToBinaryPQ(t *testing.T) {
@@ -254,7 +254,7 @@ func TestExportGraphToBinaryPQ(t *testing.T) {
 	pers, err := ExportHNSWGraph(graph)
 	require.NoError(t, err)
 	require.NotNil(t, pers)
-	require.True(t, pers.PQMode)
+	require.Equal(t, ExportModePQ, pers.ExportMode)
 	require.NotNil(t, pers.PQCodebook)
 	require.Equal(t, uint32(2), pers.PQCodebook.M)
 	require.Equal(t, uint32(4), pers.PQCodebook.K)
@@ -276,7 +276,7 @@ func TestExportGraphToBinaryPQ(t *testing.T) {
 	// 验证加载的结果
 	require.Equal(t, pers.Total, loaded.Total)
 	require.Equal(t, pers.Dims, loaded.Dims)
-	require.True(t, loaded.PQMode)
+	require.Equal(t, ExportModePQ, loaded.ExportMode)
 	require.NotNil(t, loaded.PQCodebook)
 	require.Equal(t, pers.PQCodebook.M, loaded.PQCodebook.M)
 	require.Equal(t, pers.PQCodebook.K, loaded.PQCodebook.K)
@@ -324,12 +324,12 @@ func TestKeyRoundTripInBinary(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// 创建包含测试Key的Persistent对象
 			p := &Persistent[string]{
-				Total:    2,
-				Dims:     4,
-				M:        16,
-				Ml:       0.5,
-				EfSearch: 200,
-				PQMode:   false,
+				Total:      2,
+				Dims:       4,
+				M:          16,
+				Ml:         0.5,
+				EfSearch:   200,
+				ExportMode: ExportModeStandard,
 				Layers: []*PersistentLayer{
 					{HNSWLevel: 0, Nodes: []uint32{1}},
 				},
@@ -362,12 +362,12 @@ func TestKeyConversionErrors(t *testing.T) {
 	t.Run("int_type_conversion", func(t *testing.T) {
 		// 创建一个int类型的Persistent
 		p := &Persistent[int]{
-			Total:    2,
-			Dims:     4,
-			M:        16,
-			Ml:       0.5,
-			EfSearch: 200,
-			PQMode:   false,
+			Total:      2,
+			Dims:       4,
+			M:          16,
+			Ml:         0.5,
+			EfSearch:   200,
+			ExportMode: ExportModeStandard,
 			Layers: []*PersistentLayer{
 				{HNSWLevel: 0, Nodes: []uint32{1}},
 			},
@@ -390,12 +390,12 @@ func TestKeyConversionErrors(t *testing.T) {
 	t.Run("int64_type_conversion", func(t *testing.T) {
 		// 创建一个int64类型的Persistent
 		p := &Persistent[int64]{
-			Total:    2,
-			Dims:     4,
-			M:        16,
-			Ml:       0.5,
-			EfSearch: 200,
-			PQMode:   false,
+			Total:      2,
+			Dims:       4,
+			M:          16,
+			Ml:         0.5,
+			EfSearch:   200,
+			ExportMode: ExportModeStandard,
 			Layers: []*PersistentLayer{
 				{HNSWLevel: 0, Nodes: []uint32{1}},
 			},
@@ -418,12 +418,12 @@ func TestKeyConversionErrors(t *testing.T) {
 	t.Run("uint32_type_conversion", func(t *testing.T) {
 		// 创建一个uint32类型的Persistent
 		p := &Persistent[uint32]{
-			Total:    2,
-			Dims:     4,
-			M:        16,
-			Ml:       0.5,
-			EfSearch: 200,
-			PQMode:   false,
+			Total:      2,
+			Dims:       4,
+			M:          16,
+			Ml:         0.5,
+			EfSearch:   200,
+			ExportMode: ExportModeStandard,
 			Layers: []*PersistentLayer{
 				{HNSWLevel: 0, Nodes: []uint32{1}},
 			},
@@ -446,12 +446,12 @@ func TestKeyConversionErrors(t *testing.T) {
 	t.Run("uint64_type_conversion", func(t *testing.T) {
 		// 创建一个uint64类型的Persistent
 		p := &Persistent[uint64]{
-			Total:    2,
-			Dims:     4,
-			M:        16,
-			Ml:       0.5,
-			EfSearch: 200,
-			PQMode:   false,
+			Total:      2,
+			Dims:       4,
+			M:          16,
+			Ml:         0.5,
+			EfSearch:   200,
+			ExportMode: ExportModeStandard,
 			Layers: []*PersistentLayer{
 				{HNSWLevel: 0, Nodes: []uint32{1}},
 			},
@@ -477,12 +477,12 @@ func TestKeyEdgeCases(t *testing.T) {
 		// 测试非常长的key
 		longKey := strings.Repeat("a", 10000)
 		p := &Persistent[string]{
-			Total:    2,
-			Dims:     4,
-			M:        16,
-			Ml:       0.5,
-			EfSearch: 200,
-			PQMode:   false,
+			Total:      2,
+			Dims:       4,
+			M:          16,
+			Ml:         0.5,
+			EfSearch:   200,
+			ExportMode: ExportModeStandard,
 			Layers: []*PersistentLayer{
 				{HNSWLevel: 0, Nodes: []uint32{1}},
 			},
@@ -506,12 +506,12 @@ func TestKeyEdgeCases(t *testing.T) {
 		// 测试包含null字节的key
 		keyWithNull := "key\x00with\x00null"
 		p := &Persistent[string]{
-			Total:    2,
-			Dims:     4,
-			M:        16,
-			Ml:       0.5,
-			EfSearch: 200,
-			PQMode:   false,
+			Total:      2,
+			Dims:       4,
+			M:          16,
+			Ml:         0.5,
+			EfSearch:   200,
+			ExportMode: ExportModeStandard,
 			Layers: []*PersistentLayer{
 				{HNSWLevel: 0, Nodes: []uint32{1}},
 			},
@@ -535,12 +535,12 @@ func TestKeyEdgeCases(t *testing.T) {
 		// 测试包含二进制数据的key（非UTF-8）
 		binaryKey := string([]byte{0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD})
 		p := &Persistent[string]{
-			Total:    2,
-			Dims:     4,
-			M:        16,
-			Ml:       0.5,
-			EfSearch: 200,
-			PQMode:   false,
+			Total:      2,
+			Dims:       4,
+			M:          16,
+			Ml:         0.5,
+			EfSearch:   200,
+			ExportMode: ExportModeStandard,
 			Layers: []*PersistentLayer{
 				{HNSWLevel: 0, Nodes: []uint32{1}},
 			},

--- a/common/ai/rag/integration_test.go
+++ b/common/ai/rag/integration_test.go
@@ -1,0 +1,419 @@
+package rag
+
+import (
+	"testing"
+
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+func TestAddAndQuery(t *testing.T) {
+	// 创建临时内存数据库
+	tempDB, err := utils.CreateTempTestDatabaseInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 创建RAG集合
+	ragSystem, err := CreateCollection(tempDB, "test", "测试知识库")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 添加测试文档
+	testDocs := []struct {
+		id       string
+		content  string
+		metadata map[string]any
+	}{
+		{
+			id:      "doc1",
+			content: "这是一篇关于人工智能的文章。人工智能是计算机科学的一个分支，致力于创建能够执行通常需要人类智能的任务的系统。",
+			metadata: map[string]any{
+				"title":    "人工智能简介",
+				"category": "技术",
+				"author":   "张三",
+			},
+		},
+		{
+			id:      "doc2",
+			content: "机器学习是人工智能的一个子领域，它使计算机能够在没有明确编程的情况下学习和改进。深度学习是机器学习的一个分支。",
+			metadata: map[string]any{
+				"title":    "机器学习概述",
+				"category": "技术",
+				"author":   "李四",
+			},
+		},
+		{
+			id:      "doc3",
+			content: "自然语言处理是人工智能的一个重要应用领域，涉及计算机与人类语言之间的交互。它包括文本分析、语言理解和生成等技术。",
+			metadata: map[string]any{
+				"title":    "自然语言处理",
+				"category": "技术",
+				"author":   "王五",
+			},
+		},
+	}
+
+	// 添加文档到RAG系统
+	for _, doc := range testDocs {
+		err := ragSystem.Add(doc.id, doc.content, WithDocumentRawMetadata(doc.metadata))
+		if err != nil {
+			t.Fatalf("添加文档失败 %s: %v", doc.id, err)
+		}
+	}
+
+	// 测试查询功能
+	testQueries := []struct {
+		query              string
+		expectedMinDocs    int
+		expectedFirstDocID string
+		expectedDocIDs     []string
+		description        string
+	}{
+		{
+			query:              "人工智能",
+			expectedMinDocs:    3,
+			expectedFirstDocID: "",                               // 不限制第一个文档
+			expectedDocIDs:     []string{"doc1", "doc2", "doc3"}, // 应该能找到前3个文档
+			description:        "查询人工智能相关文档",
+		},
+		{
+			query:              "机器学习",
+			expectedMinDocs:    1,
+			expectedFirstDocID: "doc2", // 第一个文档应该是doc2
+			expectedDocIDs:     []string{"doc2"},
+			description:        "查询机器学习相关文档",
+		},
+		{
+			query:              "自然语言处理",
+			expectedMinDocs:    1,
+			expectedFirstDocID: "doc3", // 第一个文档应该是doc3
+			expectedDocIDs:     []string{"doc3"},
+			description:        "查询自然语言处理相关文档",
+		},
+		{
+			query:              "深度学习",
+			expectedMinDocs:    1,
+			expectedFirstDocID: "doc2", // 第一个文档应该是doc2
+			expectedDocIDs:     []string{"doc2"},
+			description:        "查询深度学习相关文档",
+		},
+	}
+
+	// 执行查询测试
+	for _, testQuery := range testQueries {
+		t.Run(testQuery.description, func(t *testing.T) {
+			// 使用QueryWithPage方法进行查询
+			results, err := ragSystem.QueryWithPage(testQuery.query, 1, 10)
+			if err != nil {
+				t.Fatalf("查询失败: %v", err)
+			}
+
+			// 验证查询结果数量
+			if len(results) < testQuery.expectedMinDocs {
+				t.Errorf("查询 '%s' 期望至少 %d 个结果，实际得到 %d 个",
+					testQuery.query, testQuery.expectedMinDocs, len(results))
+			}
+
+			// 验证第一个文档ID（如果指定了）
+			if testQuery.expectedFirstDocID != "" && len(results) > 0 {
+				actualFirstID := results[0].Document.ID
+				if actualFirstID != testQuery.expectedFirstDocID {
+					t.Errorf("查询 '%s' 的第一个结果应该是 %s，实际是 %s",
+						testQuery.query, testQuery.expectedFirstDocID, actualFirstID)
+				}
+			}
+
+			// 验证期望的文档ID是否都在结果中
+			if len(testQuery.expectedDocIDs) > 0 {
+				resultIDs := make(map[string]bool)
+				for _, result := range results {
+					resultIDs[result.Document.ID] = true
+				}
+
+				for _, expectedID := range testQuery.expectedDocIDs {
+					if !resultIDs[expectedID] {
+						t.Errorf("查询 '%s' 期望包含文档 %s，但结果中没有找到",
+							testQuery.query, expectedID)
+					}
+				}
+			}
+
+			// 打印查询结果用于调试
+			t.Logf("查询 '%s' 返回 %d 个结果:", testQuery.query, len(results))
+			for i, result := range results {
+				t.Logf("  结果 %d: ID=%s, Score=%.4f, Content=%.100s...",
+					i+1, result.Document.ID, result.Score, result.Document.Content)
+
+				// 验证结果包含元数据
+				if result.Document.Metadata != nil {
+					if title, ok := result.Document.Metadata["title"]; ok {
+						t.Logf("    标题: %v", title)
+					}
+					if category, ok := result.Document.Metadata["category"]; ok {
+						t.Logf("    分类: %v", category)
+					}
+				}
+			}
+
+			// 验证分数合理性（分数应该在-1到1之间）
+			for _, result := range results {
+				if result.Score < -1.0 || result.Score > 1.0 {
+					t.Errorf("分数超出合理范围 [-1,1]: %f", result.Score)
+				}
+			}
+		})
+	}
+
+	// 测试文档数量统计
+	count, err := ragSystem.CountDocuments()
+	if err != nil {
+		t.Fatalf("统计文档数量失败: %v", err)
+	}
+
+	// 验证文档数量（应该包含用户添加的文档）
+	expectedCount := len(testDocs) // 用户添加的文档数量
+	if count < expectedCount {
+		t.Errorf("文档数量不足，期望至少 %d，实际得到 %d", expectedCount, count)
+	}
+
+	t.Logf("RAG系统中总共有 %d 个文档", count)
+
+	// 验证数据库表结构
+	t.Run("验证数据库表结构", func(t *testing.T) {
+		// 验证VectorStoreCollection表结构
+		t.Run("验证VectorStoreCollection表", func(t *testing.T) {
+			var collection schema.VectorStoreCollection
+
+			// 检查表是否存在
+			if !tempDB.HasTable(&collection) {
+				t.Fatal("VectorStoreCollection表不存在")
+			}
+
+			// 验证集合记录是否正确创建
+			var collections []schema.VectorStoreCollection
+			err := tempDB.Find(&collections).Error
+			if err != nil {
+				t.Fatalf("查询VectorStoreCollection表失败: %v", err)
+			}
+
+			if len(collections) != 1 {
+				t.Errorf("期望1个集合记录，实际得到 %d 个", len(collections))
+			} else {
+				col := collections[0]
+				t.Logf("集合信息: Name=%s, Description=%s, Dimension=%d", col.Name, col.Description, col.Dimension)
+
+				// 验证基本字段
+				if col.Name != "test" {
+					t.Errorf("集合名称错误，期望'test'，实际'%s'", col.Name)
+				}
+				if col.Description != "测试知识库" {
+					t.Errorf("集合描述错误，期望'测试知识库'，实际'%s'", col.Description)
+				}
+				if col.Dimension <= 0 {
+					t.Errorf("向量维度应该大于0，实际为 %d", col.Dimension)
+				}
+			}
+			// 验证GraphBinary是否不为空，大小是否正常
+			graphBinary := collections[0].GraphBinary
+			if len(graphBinary) == 0 {
+				t.Errorf("GraphBinary为空")
+			}
+			if len(graphBinary) > 1024*4 {
+				t.Errorf("GraphBinary大小超过10MB")
+			}
+		})
+
+		// 验证VectorStoreDocument表结构
+		t.Run("验证VectorStoreDocument表", func(t *testing.T) {
+			var document schema.VectorStoreDocument
+
+			// 检查表是否存在
+			if !tempDB.HasTable(&document) {
+				t.Fatal("VectorStoreDocument表不存在")
+			}
+
+			// 验证文档记录是否正确创建
+			var documents []schema.VectorStoreDocument
+			err := tempDB.Find(&documents).Error
+			if err != nil {
+				t.Fatalf("查询VectorStoreDocument表失败: %v", err)
+			}
+
+			t.Logf("VectorStoreDocument表中有 %d 条记录", len(documents))
+
+			// 验证文档记录的基本信息
+			for i, doc := range documents {
+				t.Logf("文档 %d: ID=%s, CollectionID=%d, Content长度=%d",
+					i+1, doc.DocumentID, doc.CollectionID, len(doc.Content))
+
+				// 验证必须字段
+				if doc.DocumentID == "" {
+					t.Errorf("文档 %d 的DocumentID为空", i+1)
+				}
+				if doc.CollectionID == 0 {
+					t.Errorf("文档 %d 的CollectionID为0", i+1)
+				}
+				if len(doc.Embedding) == 0 {
+					t.Errorf("文档 %d 的Embedding为空", i+1)
+				}
+				if doc.Content == "" {
+					t.Errorf("文档 %d 的Content为空", i+1)
+				}
+
+				// 验证元数据
+				if doc.Metadata != nil {
+					t.Logf("  元数据字段数: %d", len(doc.Metadata))
+					for key, value := range doc.Metadata {
+						t.Logf("    %s: %v", key, value)
+					}
+				}
+			}
+		})
+	})
+
+	testCollection, err := LoadCollection(tempDB, "test")
+	if err != nil {
+		t.Fatalf("获取集合失败: %v", err)
+	}
+	err = testCollection.ConvertToPQMode()
+	if err != nil {
+		t.Fatalf("转换为PQ模式失败: %v", err)
+	}
+
+	testCollection, err = LoadCollection(tempDB, "test")
+	if err != nil {
+		t.Fatalf("获取集合失败: %v", err)
+	}
+
+	// 转换为PQ模式后，重新测试搜索功能
+	t.Run("PQ模式搜索测试", func(t *testing.T) {
+		for _, testQuery := range testQueries {
+			t.Run("PQ_"+testQuery.description, func(t *testing.T) {
+				// 使用QueryWithPage方法进行查询
+				results, err := testCollection.QueryWithPage(testQuery.query, 1, 10)
+				if err != nil {
+					t.Fatalf("PQ模式查询失败: %v", err)
+				}
+
+				// 验证查询结果数量
+				if len(results) < testQuery.expectedMinDocs {
+					t.Errorf("PQ模式查询 '%s' 期望至少 %d 个结果，实际得到 %d 个",
+						testQuery.query, testQuery.expectedMinDocs, len(results))
+				}
+
+				// 验证第一个文档ID（如果指定了）
+				if testQuery.expectedFirstDocID != "" && len(results) > 0 {
+					actualFirstID := results[0].Document.ID
+					if actualFirstID != testQuery.expectedFirstDocID {
+						t.Errorf("PQ模式查询 '%s' 的第一个结果应该是 %s，实际是 %s",
+							testQuery.query, testQuery.expectedFirstDocID, actualFirstID)
+					}
+				}
+
+				// 验证期望的文档ID是否都在结果中
+				if len(testQuery.expectedDocIDs) > 0 {
+					resultIDs := make(map[string]bool)
+					for _, result := range results {
+						resultIDs[result.Document.ID] = true
+					}
+
+					for _, expectedID := range testQuery.expectedDocIDs {
+						if !resultIDs[expectedID] {
+							t.Errorf("PQ模式查询 '%s' 期望包含文档 %s，但结果中没有找到",
+								testQuery.query, expectedID)
+						}
+					}
+				}
+
+				// 打印查询结果用于调试
+				t.Logf("PQ模式查询 '%s' 返回 %d 个结果:", testQuery.query, len(results))
+				for i, result := range results {
+					t.Logf("  结果 %d: ID=%s, Score=%.4f, Content=%.100s...",
+						i+1, result.Document.ID, result.Score, result.Document.Content)
+
+					// 验证结果包含元数据
+					if result.Document.Metadata != nil {
+						if title, ok := result.Document.Metadata["title"]; ok {
+							t.Logf("    标题: %v", title)
+						}
+						if category, ok := result.Document.Metadata["category"]; ok {
+							t.Logf("    分类: %v", category)
+						}
+					}
+				}
+
+				// 验证分数合理性
+				for _, result := range results {
+					if result.Score < -1.0 || result.Score > 1.0 {
+						t.Errorf("PQ模式分数超出合理范围 [-1,1]: %f", result.Score)
+					}
+				}
+			})
+		}
+	})
+
+	// 验证转换为PQ模式后VectorStoreCollection表的CodeBookBinary和GraphBinary字段
+	t.Run("验证PQ模式二进制数据", func(t *testing.T) {
+		var collection schema.VectorStoreCollection
+
+		// 查询集合记录
+		err := tempDB.Where("name = ?", "test").First(&collection).Error
+		if err != nil {
+			t.Fatalf("查询VectorStoreCollection失败: %v", err)
+		}
+
+		// 验证CodeBookBinary不为空
+		t.Run("验证CodeBookBinary", func(t *testing.T) {
+			if len(collection.CodeBookBinary) == 0 {
+				t.Error("CodeBookBinary为空，PQ模式转换后应该包含码本数据")
+			} else {
+				t.Logf("CodeBookBinary大小: %d 字节", len(collection.CodeBookBinary))
+
+				// 验证CodeBookBinary大小合理性（不应该过大或过小）
+				if len(collection.CodeBookBinary) < 10 {
+					t.Errorf("CodeBookBinary大小过小: %d 字节", len(collection.CodeBookBinary))
+				}
+				if len(collection.CodeBookBinary) > 1024*1024 { // 1MB
+					t.Errorf("CodeBookBinary大小过大: %d 字节", len(collection.CodeBookBinary))
+				}
+			}
+		})
+
+		// 验证GraphBinary不为空
+		t.Run("验证GraphBinary", func(t *testing.T) {
+			if len(collection.GraphBinary) == 0 {
+				t.Error("GraphBinary为空，应该包含图结构数据")
+			} else {
+				t.Logf("GraphBinary大小: %d 字节", len(collection.GraphBinary))
+
+				// 验证GraphBinary大小合理性
+				if len(collection.GraphBinary) < 10 {
+					t.Errorf("GraphBinary大小过小: %d 字节", len(collection.GraphBinary))
+				}
+				if len(collection.GraphBinary) > 1024*1024*10 { // 10MB
+					t.Errorf("GraphBinary大小过大: %d 字节", len(collection.GraphBinary))
+				}
+			}
+		})
+
+		// 验证PQ模式标志
+		t.Run("验证PQ模式标志", func(t *testing.T) {
+			if !collection.EnablePQMode {
+				t.Error("EnablePQMode标志应该为true")
+			} else {
+				t.Log("PQ模式标志正确设置为true")
+			}
+		})
+
+		// 输出完整的集合信息用于调试
+		t.Logf("集合完整信息:")
+		t.Logf("  Name: %s", collection.Name)
+		t.Logf("  Description: %s", collection.Description)
+		t.Logf("  Dimension: %d", collection.Dimension)
+		t.Logf("  EnablePQMode: %t", collection.EnablePQMode)
+		t.Logf("  CodeBookBinary大小: %d 字节", len(collection.CodeBookBinary))
+		t.Logf("  GraphBinary大小: %d 字节", len(collection.GraphBinary))
+	})
+}

--- a/common/ai/rag/knowledgebase/query.go
+++ b/common/ai/rag/knowledgebase/query.go
@@ -118,7 +118,9 @@ func (kb *KnowledgeBase) SearchKnowledgeEntriesWithEnhance(query string, opts ..
 // SearchKnowledgeEntries 搜索知识条目，返回知识库条目对象
 func (kb *KnowledgeBase) SearchKnowledgeEntries(query string, limit int) ([]*schema.KnowledgeBaseEntry, error) {
 	// 先通过RAG系统进行向量搜索
-	searchResults, err := kb.ragSystem.QueryWithPage(query, 1, limit+5)
+	searchResults, err := kb.ragSystem.QueryWithFilter(query, 1, limit+5, func(key string, getDoc func() *rag.Document) bool {
+		return getDoc().Type == schema.RAGDocumentType_Knowledge
+	})
 	if err != nil {
 		return nil, utils.Errorf("RAG搜索失败: %v", err)
 	}

--- a/common/ai/rag/plugins_rag/cmd/list_collection.go
+++ b/common/ai/rag/plugins_rag/cmd/list_collection.go
@@ -7,7 +7,8 @@ import (
 	"github.com/urfave/cli"
 	"github.com/yaklang/yaklang/common/ai/rag"
 	"github.com/yaklang/yaklang/common/consts"
-	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
 
 func getListCollectionCommand() *cli.Command {
@@ -20,9 +21,10 @@ func getListCollectionCommand() *cli.Command {
 
 func listCollection(c *cli.Context) error {
 	db := consts.GetGormProfileDatabase()
-	var collections []*schema.VectorStoreCollection
-	db.Model(&schema.VectorStoreCollection{}).Find(&collections)
-
+	collections, err := yakit.GetAllRAGCollectionInfos(db)
+	if err != nil {
+		return utils.Errorf("获取知识库列表失败: %v", err)
+	}
 	if len(collections) == 0 {
 		fmt.Println("暂无知识库")
 		return nil

--- a/common/ai/rag/plugins_rag/cmd/list_collection.go
+++ b/common/ai/rag/plugins_rag/cmd/list_collection.go
@@ -53,20 +53,20 @@ func listCollection(c *cli.Context) error {
 		fmt.Printf("  EfSearch: %d\n", info.EfSearch)
 		fmt.Printf("  EfConstruct: %d\n", info.EfConstruct)
 		fmt.Printf("\n图结构统计:\n")
-		fmt.Printf("  层数: %d\n", info.LayerCount)
-		fmt.Printf("  总节点数: %d\n", info.NodeCount)
-		fmt.Printf("  最大邻居数: %d\n", info.MaxNeighbors)
-		fmt.Printf("  最小邻居数: %d\n", info.MinNeighbors)
-		fmt.Printf("  总连接数: %d\n", info.ConnectionCount)
+		// fmt.Printf("  层数: %d\n", info.LayerCount)
+		// fmt.Printf("  总节点数: %d\n", info.NodeCount)
+		// fmt.Printf("  最大邻居数: %d\n", info.MaxNeighbors)
+		// fmt.Printf("  最小邻居数: %d\n", info.MinNeighbors)
+		// fmt.Printf("  总连接数: %d\n", info.ConnectionCount)
 
-		if len(info.LayerNodeCountMap) > 0 {
-			fmt.Printf("\n各层节点分布:\n")
-			for layer := 0; layer < info.LayerCount; layer++ {
-				if count, exists := info.LayerNodeCountMap[layer]; exists {
-					fmt.Printf("  第%d层: %d个节点\n", layer, count)
-				}
-			}
-		}
+		// if len(info.LayerNodeCountMap) > 0 {
+		// 	fmt.Printf("\n各层节点分布:\n")
+		// 	for layer := 0; layer < info.LayerCount; layer++ {
+		// 		if count, exists := info.LayerNodeCountMap[layer]; exists {
+		// 			fmt.Printf("  第%d层: %d个节点\n", layer, count)
+		// 		}
+		// 	}
+		// }
 	}
 
 	fmt.Println(strings.Repeat("=", 80))

--- a/common/ai/rag/plugins_rag/export_import_test.go
+++ b/common/ai/rag/plugins_rag/export_import_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/rag"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
 
 // TestExportVectorData 测试向量数据的导出和导入功能的基础流程
@@ -75,8 +76,7 @@ func TestMUSTPASS_ExportVectorData(t *testing.T) {
 	assert.Equal(t, int64(0), count)
 
 	// 额外验证：确保能够正常查询空的集合表
-	collections := []*schema.VectorStoreCollection{}
-	err = db.Model(&schema.VectorStoreCollection{}).Find(&collections).Error
+	_, err = yakit.GetAllRAGCollectionInfos(db)
 	assert.NoError(t, err)
 
 	// 6. 执行数据导入操作

--- a/common/ai/rag/plugins_rag/test/plugins_rag_test.go
+++ b/common/ai/rag/plugins_rag/test/plugins_rag_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
 
 // MockEmbedder 是一个模拟的嵌入客户端，用于测试
@@ -120,8 +121,8 @@ func TestCreatePluginsRagManager(t *testing.T) {
 // 辅助函数：列出向量存储集合
 func TestListVectorStore(t *testing.T) {
 	db := consts.GetGormProfileDatabase()
-	collections := []*schema.VectorStoreCollection{}
-	db.Find(&collections)
+	collections, err := yakit.GetAllRAGCollectionInfos(db)
+	assert.NoError(t, err)
 	t.Logf("共找到 %d 个向量存储集合", len(collections))
 
 	for i, collection := range collections {

--- a/common/ai/rag/pq/train.go
+++ b/common/ai/rag/pq/train.go
@@ -104,6 +104,11 @@ type Codebook struct {
 	Centroids    [][][]float64 // 码本，维度: [M][K][SubVectorDim]
 }
 
+const (
+	DefaultM = 16
+	DefaultK = 256
+)
+
 // Train 训练PQ模型，从输入通道读取向量数据并生成码本
 func Train(input <-chan []float64, opts ...TrainOption) (*Codebook, error) {
 	// 设置默认选项

--- a/common/ai/rag/rag.go
+++ b/common/ai/rag/rag.go
@@ -312,6 +312,12 @@ func (r *RAGSystem) processBigText(doc Document) ([]Document, error) {
 		return r.processChunkText(doc, chunks)
 	}
 }
+func (r *RAGSystem) ConvertToPQMode() error {
+	if v, ok := r.VectorStore.(*SQLiteVectorStoreHNSW); ok {
+		return v.ConvertToPQMode()
+	}
+	return utils.Errorf("vector store is not a SQLiteVectorStoreHNSW")
+}
 
 // processChunkText 将文本分割成多个文档分别存储
 func (r *RAGSystem) processChunkText(originalDoc Document, chunks []string) ([]Document, error) {

--- a/common/ai/rag/rag_test.go
+++ b/common/ai/rag/rag_test.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,15 +14,22 @@ import (
 )
 
 func testEmbedder(text string) ([]float32, error) {
-	// 简单地生成一个固定的向量作为嵌入
-	// 在实际测试中，我们可以根据文本内容生成不同的向量
-	if text == "Yaklang介绍" || text == "什么是Yaklang" || text == "Yaklang是一种安全研究编程语言" {
+	switch text {
+	case "Yaklang介绍", "什么是Yaklang", "Yaklang是一种安全研究编程语言":
 		return []float32{1.0, 0.0, 0.0}, nil
-	} else if text == "RAG介绍" || text == "什么是RAG" || text == "RAG是一种结合检索和生成的AI技术" {
+	case "RAG介绍", "什么是RAG", "RAG是一种结合检索和生成的AI技术":
 		return []float32{0.0, 1.0, 0.0}, nil
-	} else if text == "AI技术" {
+	case "AI技术", "RAG技术原理":
 		return []float32{0.5, 0.5, 0.0}, nil
+	case "向量数据库应用":
+		return []float32{0.0, 0.0, 1.0}, nil
+	case "Yaklang基础概念":
+		return []float32{0.0, 0.0, 1.0}, nil
 	}
+	if strings.Contains(text, "RAG技术") || strings.Contains(text, "RAG技术原理") {
+		return []float32{0.0, 0.0, 1.0}, nil
+	}
+
 	return []float32{0.0, 0.0, 0.0}, nil
 }
 

--- a/common/ai/rag/sqlitedb_store_hnsw.go
+++ b/common/ai/rag/sqlitedb_store_hnsw.go
@@ -101,10 +101,9 @@ func LoadSQLiteVectorStoreHNSW(db *gorm.DB, collectionName string, embedder Embe
 	}
 
 	collectionConfig := collection
-	hnswGraph := hnsw.NewGraph(
+	hnswGraph := NewHNSWGraph(collectionName,
 		hnsw.WithHNSWParameters[string](collectionConfig.M, collectionConfig.Ml, collectionConfig.EfSearch),
 		hnsw.WithDistance[string](hnsw.GetDistanceFunc(collectionConfig.DistanceFuncType)),
-		hnsw.WithDeterministicRng[string](0), // 使用固定的随机数生成器，便于调试，不影响结果
 	)
 
 	log.Infof("start to recover hnsw graph from db, collection name: %s", collectionName)

--- a/common/ai/rag/sqlitedb_store_hnsw.go
+++ b/common/ai/rag/sqlitedb_store_hnsw.go
@@ -317,16 +317,8 @@ func NewSQLiteVectorStoreHNSW(name string, description string, modelName string,
 	vcolsNum := 0
 	db.Where("name = ?", name).Count(&vcolsNum)
 	var collection *schema.VectorStoreCollection
+	var err error
 	hnswGraph := NewHNSWGraph(name)
-	emptyGraphBinary, err := ExportHNSWGraphToBinary(hnswGraph)
-	if err != nil {
-		return nil, utils.Wrap(err, "export hnsw graph to binary")
-	}
-	emptyGraphData, err := io.ReadAll(emptyGraphBinary)
-	if err != nil {
-		return nil, utils.Wrap(err, "read empty graph binary")
-	}
-
 	if vcolsNum == 0 {
 		collection = &schema.VectorStoreCollection{
 			Name:             name,
@@ -339,7 +331,6 @@ func NewSQLiteVectorStoreHNSW(name string, description string, modelName string,
 			EfConstruct:      cfg.EfConstruct,
 			DistanceFuncType: cfg.DistanceFuncType,
 			EnablePQMode:     cfg.EnablePQMode,
-			GraphBinary:      emptyGraphData,
 		}
 		if err := db.Create(&collection).Error; err != nil {
 			return nil, utils.Errorf("创建集合失败: %v", err)

--- a/common/ai/rag/sqlitedb_store_hnsw_test.go
+++ b/common/ai/rag/sqlitedb_store_hnsw_test.go
@@ -4,14 +4,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
 )
 
 // 测试 SQLiteVectorStore
 func TestMUSTPASS_SQLiteVectorStoreHNSW(t *testing.T) {
 	mockEmbed := &MockEmbedder{}
 
-	db := consts.GetGormProfileDatabase()
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	assert.NoError(t, err)
+	db.AutoMigrate(&schema.VectorStoreCollection{}, &schema.VectorStoreDocument{})
 	// 创建 SQLite 向量存储
 	store, err := NewSQLiteVectorStoreHNSW("test_collection", "test", "Qwen3-Embedding-0.6B-Q4_K_M", 1024, mockEmbed, db)
 	assert.NoError(t, err)

--- a/common/schema/vector_store.go
+++ b/common/schema/vector_store.go
@@ -196,6 +196,9 @@ type VectorStoreCollection struct {
 	GroupInfos GroupInfos `gorm:"type:text" json:"group_infos"`
 
 	UUID string
+
+	GraphBinary []byte `gorm:"type:blob" json:"graph_binary"`
+	CodeBook    []byte `gorm:"type:blob" json:"code_book"`
 }
 
 func (v *VectorStoreCollection) BeforeSave() error {
@@ -221,6 +224,7 @@ type VectorStoreDocument struct {
 
 	// 文档唯一标识符，在整个系统中唯一
 	DocumentID string `gorm:"uniqueIndex:idx_document_id_collection_id;not null" json:"document_id"`
+	UID        []byte `gorm:"blob"`
 
 	// 所属集合的ID，建立外键关系
 	CollectionID uint `gorm:"uniqueIndex:idx_document_id_collection_id;not null" json:"collection_id"`
@@ -232,6 +236,8 @@ type VectorStoreDocument struct {
 	Metadata MetadataMap `gorm:"type:text" json:"metadata"`
 
 	// 文档的嵌入向量，以 JSON 格式存储
+	PQMode    bool       `gorm:"default:false" json:"pq_mode"`
+	PQCode    []byte     `gorm:"type:text" json:"pq_code"`
 	Embedding FloatArray `gorm:"type:text;not null" json:"embedding"`
 
 	// 文档的原始文本

--- a/common/schema/vector_store.go
+++ b/common/schema/vector_store.go
@@ -192,6 +192,9 @@ type VectorStoreCollection struct {
 	EfConstruct      int     `gorm:"default:200" json:"ef_construct"`            // 构建时的候选节点数
 	DistanceFuncType string  `gorm:"default:'cosine'" json:"distance_func_type"` // 距离函数类型（cosine、euclidean等）
 
+	// PQ 算法参数配置
+	EnablePQMode bool `gorm:"default:false" json:"enable_pq_mode"`
+
 	// HNSW 图连接信息，存储为 JSON 格式
 	GroupInfos GroupInfos `gorm:"type:text" json:"group_infos"`
 

--- a/common/schema/vector_store.go
+++ b/common/schema/vector_store.go
@@ -196,6 +196,8 @@ type VectorStoreCollection struct {
 	// PQ 算法参数配置
 	EnablePQMode bool `gorm:"default:false" json:"enable_pq_mode"`
 
+	Archived bool `gorm:"default:false" json:"archived"`
+
 	// HNSW 图连接信息，存储为 JSON 格式
 	GroupInfos GroupInfos `gorm:"type:text" json:"group_infos"`
 
@@ -239,9 +241,8 @@ type VectorStoreDocument struct {
 	Metadata MetadataMap `gorm:"type:text" json:"metadata"`
 
 	// 文档的嵌入向量，以 JSON 格式存储
-	PQMode    bool       `gorm:"default:false" json:"pq_mode"`
 	PQCode    []byte     `gorm:"type:text" json:"pq_code"`
-	Embedding FloatArray `gorm:"type:text;not null" json:"embedding"`
+	Embedding FloatArray `gorm:"type:text" json:"embedding"`
 
 	// 文档的原始文本
 	Content string `gorm:"type:text" json:"content"`
@@ -261,7 +262,7 @@ func (v *VectorStoreDocument) BeforeSave() error {
 }
 
 func (v *VectorStoreDocument) TableName() string {
-	return "rag_vector_document_test"
+	return "rag_vector_document_test_v1"
 }
 
 // StringArray 用于存储字符串数组的自定义类型

--- a/common/yak/rag_export.go
+++ b/common/yak/rag_export.go
@@ -53,6 +53,7 @@ var RagExports = map[string]interface{}{
 	"ragModelDimension": rag.WithModelDimension,
 	"ragCosineDistance": rag.WithCosineDistance,
 	"ragHNSWParameters": rag.WithHNSWParameters,
+	"ragPQMode":         rag.WithPQMode,
 
 	"docMetadata":    rag.WithDocumentMetadataKeyValue,
 	"docRawMetadata": rag.WithDocumentRawMetadata,

--- a/common/yak/rag_export.go
+++ b/common/yak/rag_export.go
@@ -53,7 +53,6 @@ var RagExports = map[string]interface{}{
 	"ragModelDimension": rag.WithModelDimension,
 	"ragCosineDistance": rag.WithCosineDistance,
 	"ragHNSWParameters": rag.WithHNSWParameters,
-	"ragPQMode":         rag.WithPQMode,
 
 	"docMetadata":    rag.WithDocumentMetadataKeyValue,
 	"docRawMetadata": rag.WithDocumentRawMetadata,

--- a/common/yakgrpc/grpc_knowledge_base.go
+++ b/common/yakgrpc/grpc_knowledge_base.go
@@ -214,35 +214,35 @@ func (s *Server) SearchKnowledgeBaseEntry(ctx context.Context, req *ypb.SearchKn
 	db := consts.GetGormProfileDatabase()
 
 	// 如果有关键字搜索，尝试使用知识库的向量搜索功能
-	if req.GetKeyword() != "" {
-		kb, err := knowledgebase.LoadKnowledgeBaseByID(db, req.GetKnowledgeBaseId())
-		if err == nil {
-			// 使用知识库的搜索功能
-			limit := 50 // 默认限制
-			if reqPagination != nil && reqPagination.Limit > 0 {
-				limit = int(reqPagination.Limit)
-			}
+	// if req.GetKeyword() != "" {
+	// 	kb, err := knowledgebase.LoadKnowledgeBaseByID(db, req.GetKnowledgeBaseId())
+	// 	if err == nil {
+	// 		// 使用知识库的搜索功能
+	// 		limit := 50 // 默认限制
+	// 		if reqPagination != nil && reqPagination.Limit > 0 {
+	// 			limit = int(reqPagination.Limit)
+	// 		}
 
-			entries, err := kb.SearchKnowledgeEntries(req.GetKeyword(), limit)
-			if err == nil {
-				return &ypb.SearchKnowledgeBaseEntryResponse{
-					Total:                int64(len(entries)),
-					Pagination:           reqPagination,
-					KnowledgeBaseEntries: KnowledgeBaseEntryListToGrpcModel(entries),
-				}, nil
-			}
-			// 如果向量搜索失败，回退到传统搜索
-		}
-	}
+	// 		entries, err := kb.SearchKnowledgeEntries(req.GetKeyword(), limit)
+	// 		if err == nil {
+	// 			return &ypb.SearchKnowledgeBaseEntryResponse{
+	// 				Total:                int64(len(entries)),
+	// 				Pagination:           reqPagination,
+	// 				KnowledgeBaseEntries: KnowledgeBaseEntryListToGrpcModel(entries),
+	// 			}, nil
+	// 		}
+	// 		// 如果向量搜索失败，回退到传统搜索
+	// 	}
+	// }
 
 	// 回退到传统的数据库搜索
-	_, entries, err := yakit.GetKnowledgeBaseEntryByFilter(db, req.GetKnowledgeBaseId(), req.GetKeyword(), reqPagination)
+	p, entries, err := yakit.GetKnowledgeBaseEntryByFilter(db, req.GetKnowledgeBaseId(), req.GetKeyword(), reqPagination)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ypb.SearchKnowledgeBaseEntryResponse{
-		Total:                int64(len(entries)),
+		Total:                int64(p.TotalRecord),
 		Pagination:           reqPagination,
 		KnowledgeBaseEntries: KnowledgeBaseEntryListToGrpcModel(entries),
 	}, nil

--- a/common/yakgrpc/yakit/rag.go
+++ b/common/yakgrpc/yakit/rag.go
@@ -1,24 +1,107 @@
 package yakit
 
 import (
+	"crypto/md5"
+
 	"github.com/jinzhu/gorm"
+	"github.com/yaklang/yaklang/common/ai/rag/hnsw/hnswspec"
+	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
 )
 
-func QueryRAGCollectionByName(db *gorm.DB, name string) (*schema.VectorStoreCollection, error) {
-	var collection *schema.VectorStoreCollection
-	db = db.Model(&schema.VectorStoreCollection{}).Where("name = ?", name).Select("id, name, description, model_name, dimension, m, ml, ef_search, ef_construct, distance_func_type, enable_pq_mode, graph_binary, code_book_binary").First(&collection)
-	return collection, db.Error
+func selectRAGCollectionCoreFields(db *gorm.DB) *gorm.DB {
+	return db.Model(&schema.VectorStoreCollection{}).Select("id, name, description, model_name, dimension, m, ml, ef_search, ef_construct, distance_func_type, enable_pq_mode, graph_binary, code_book_binary")
 }
 
-func QueryAllRAGCollectionInfosByName(db *gorm.DB, name string) ([]*schema.VectorStoreCollection, error) {
-	var collections []*schema.VectorStoreCollection
-	db = db.Model(&schema.VectorStoreCollection{}).Where("name = ?", name).Select("id, name, description, model_name, dimension, m, ml, ef_search, ef_construct, distance_func_type, enable_pq_mode").Find(&collections)
-	return collections, db.Error
+func QueryRAGCollectionByName(db *gorm.DB, name string) (*schema.VectorStoreCollection, error) {
+	var collection schema.VectorStoreCollection
+	db = selectRAGCollectionCoreFields(db).Where("name = ?", name).First(&collection)
+	if db.Error != nil {
+		return nil, db.Error
+	}
+	return &collection, nil
+}
+
+func QueryRAGCollectionByID(db *gorm.DB, id int64) (*schema.VectorStoreCollection, error) {
+	var collection schema.VectorStoreCollection
+	db = selectRAGCollectionCoreFields(db).Where("id = ?", id).First(&collection)
+	if db.Error != nil {
+		return nil, db.Error
+	}
+	return &collection, nil
 }
 
 func GetAllRAGCollectionNames(db *gorm.DB) ([]string, error) {
-	names := []string{}
-	db = db.Model(&schema.VectorStoreCollection{}).Select("name").Find(&names)
-	return names, db.Error
+	var collections []*schema.VectorStoreCollection
+	db = db.Model(&schema.VectorStoreCollection{}).Select("name").Find(&collections)
+	if db.Error != nil {
+		return nil, db.Error
+	}
+	names := make([]string, 0, len(collections))
+	for _, collection := range collections {
+		names = append(names, collection.Name)
+	}
+	return names, nil
+}
+
+func GetAllRAGCollectionInfos(db *gorm.DB) ([]*schema.VectorStoreCollection, error) {
+	collections := []*schema.VectorStoreCollection{}
+	db = selectRAGCollectionCoreFields(db).Find(&collections)
+	if db.Error != nil {
+		return nil, db.Error
+	}
+	return collections, nil
+}
+
+func GetRAGDocumentByID(db *gorm.DB, name string, id string) (*schema.VectorStoreDocument, error) {
+	var doc schema.VectorStoreDocument
+	db = db.Where("document_id = ?", id).First(&doc)
+	if db.Error != nil {
+		return nil, db.Error
+	}
+	return &doc, nil
+}
+
+func GetRAGDocumentByCollectionIDAndKey(db *gorm.DB, collectionID uint, name string) (*schema.VectorStoreDocument, error) {
+	var doc schema.VectorStoreDocument
+	db = db.Where("document_id = ? and collection_id = ?", name, collectionID).First(&doc)
+	if db.Error != nil {
+		return nil, db.Error
+	}
+	return &doc, nil
+}
+
+func UpdateRAGDocument(db *gorm.DB, doc *schema.VectorStoreDocument) error {
+	return db.Save(doc).Error
+}
+
+const (
+	uidTypeMd5        = "md5"
+	uidTypeID         = "id"
+	uidTypeDocumentID = "document_id"
+)
+
+func getLazyNodeUID(uidType string, collectionName string, data any) hnswspec.LazyNodeID {
+	switch uidType {
+	case uidTypeMd5:
+		key, ok := data.(string)
+		if !ok {
+			log.Errorf("expected string for key, got %T", data)
+			return nil
+		}
+		m := md5.Sum([]byte(collectionName + key))
+		return m[:]
+	case uidTypeID:
+		key := utils.InterfaceToInt(data)
+		return hnswspec.LazyNodeID(key)
+	case uidTypeDocumentID:
+		key, ok := data.(string)
+		if !ok {
+			log.Errorf("expected string for key, got %T", data)
+			return nil
+		}
+		return hnswspec.LazyNodeID(key)
+	}
+	return nil
 }

--- a/common/yakgrpc/yakit/rag.go
+++ b/common/yakgrpc/yakit/rag.go
@@ -1,0 +1,24 @@
+package yakit
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func QueryRAGCollectionByName(db *gorm.DB, name string) (*schema.VectorStoreCollection, error) {
+	var collection *schema.VectorStoreCollection
+	db = db.Model(&schema.VectorStoreCollection{}).Where("name = ?", name).Select("id, name, description, model_name, dimension, m, ml, ef_search, ef_construct, distance_func_type, enable_pq_mode, graph_binary, code_book_binary").First(&collection)
+	return collection, db.Error
+}
+
+func QueryAllRAGCollectionInfosByName(db *gorm.DB, name string) ([]*schema.VectorStoreCollection, error) {
+	var collections []*schema.VectorStoreCollection
+	db = db.Model(&schema.VectorStoreCollection{}).Where("name = ?", name).Select("id, name, description, model_name, dimension, m, ml, ef_search, ef_construct, distance_func_type, enable_pq_mode").Find(&collections)
+	return collections, db.Error
+}
+
+func GetAllRAGCollectionNames(db *gorm.DB) ([]string, error) {
+	names := []string{}
+	db = db.Model(&schema.VectorStoreCollection{}).Select("name").Find(&names)
+	return names, db.Error
+}

--- a/common/yakgrpc/yakit/rag_test.go
+++ b/common/yakgrpc/yakit/rag_test.go
@@ -3,14 +3,191 @@ package yakit
 import (
 	"testing"
 
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 )
 
-func TestQueryRAGCollectionByName(t *testing.T) {
-	db := utils.CreateTempTestDatabaseInMemory()
-	collection, err := QueryRAGCollectionByName(db, "test")
+// setupTestDB 设置测试数据库
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := utils.CreateTempTestDatabaseInMemory()
 	if err != nil {
-		t.Fatalf("查询集合失败: %v", err)
+		t.Fatalf("创建临时数据库失败: %v", err)
 	}
-	t.Logf("集合: %v", collection)
+
+	// 自动迁移数据库表结构
+	err = db.AutoMigrate(&schema.VectorStoreCollection{}).Error
+	require.NoError(t, err, "数据库表结构迁移失败")
+
+	return db
+}
+
+// createTestCollection 创建测试用的 VectorStoreCollection
+func createTestCollection(t *testing.T, db *gorm.DB, name string) *schema.VectorStoreCollection {
+	collection := &schema.VectorStoreCollection{
+		Name:             name,
+		Description:      "测试用的向量存储集合 - " + name,
+		ModelName:        "text-embedding-ada-002",
+		Dimension:        1536,
+		M:                16,
+		Ml:               0.25,
+		EfSearch:         20,
+		EfConstruct:      200,
+		DistanceFuncType: "cosine",
+	}
+
+	err := db.Create(collection).Error
+	require.NoError(t, err, "创建测试数据失败")
+
+	return collection
+}
+
+// TestQueryRAGCollectionByName 测试根据名称查询 RAG 集合
+func TestQueryRAGCollectionByName(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// 创建测试数据
+	testName := "test_collection_by_name"
+	originalCollection := createTestCollection(t, db, testName)
+
+	// 测试查询存在的集合
+	t.Run("查询存在的集合", func(t *testing.T) {
+		collection, err := QueryRAGCollectionByName(db, testName)
+		assert.NoError(t, err)
+		assert.NotNil(t, collection)
+		assert.Equal(t, testName, collection.Name)
+		assert.Equal(t, originalCollection.Description, collection.Description)
+		assert.Equal(t, originalCollection.ModelName, collection.ModelName)
+		assert.Equal(t, originalCollection.Dimension, collection.Dimension)
+	})
+
+	// 测试查询不存在的集合
+	t.Run("查询不存在的集合", func(t *testing.T) {
+		collection, err := QueryRAGCollectionByName(db, "不存在的集合名")
+		assert.Error(t, err)
+		assert.Nil(t, collection)
+	})
+}
+
+// TestQueryRAGCollectionByID 测试根据ID查询 RAG 集合
+func TestQueryRAGCollectionByID(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// 创建测试数据
+	originalCollection := createTestCollection(t, db, "test_collection_by_id")
+
+	// 测试查询存在的集合
+	t.Run("查询存在的集合", func(t *testing.T) {
+		collection, err := QueryRAGCollectionByID(db, int64(originalCollection.ID))
+		assert.NoError(t, err)
+		assert.NotNil(t, collection)
+		assert.Equal(t, originalCollection.ID, collection.ID)
+		assert.Equal(t, originalCollection.Name, collection.Name)
+		assert.Equal(t, originalCollection.Description, collection.Description)
+	})
+
+	// 测试查询不存在的集合
+	t.Run("查询不存在的集合", func(t *testing.T) {
+		collection, err := QueryRAGCollectionByID(db, 99999)
+		assert.Error(t, err)
+		assert.Nil(t, collection)
+	})
+}
+
+// TestGetAllRAGCollectionNames 测试获取所有 RAG 集合名称
+func TestGetAllRAGCollectionNames(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// 创建测试数据
+	createTestCollection(t, db, "collection_1")
+	createTestCollection(t, db, "collection_2")
+	createTestCollection(t, db, "collection_3")
+
+	// 测试获取所有集合名称
+	names, err := GetAllRAGCollectionNames(db)
+	assert.NoError(t, err)
+	assert.Len(t, names, 3)
+	assert.Contains(t, names, "collection_1")
+	assert.Contains(t, names, "collection_2")
+	assert.Contains(t, names, "collection_3")
+}
+
+// TestGetAllRAGCollectionInfos 测试获取所有 RAG 集合信息
+func TestGetAllRAGCollectionInfos(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// 创建测试数据
+	collection1 := createTestCollection(t, db, "info_collection_1")
+	collection2 := createTestCollection(t, db, "info_collection_2")
+
+	// 测试获取所有集合信息
+	collections, err := GetAllRAGCollectionInfos(db)
+	assert.NoError(t, err)
+	assert.Len(t, collections, 2)
+
+	// 验证返回的数据
+	names := make(map[string]bool)
+	for _, collection := range collections {
+		names[collection.Name] = true
+		// 验证核心字段已填充
+		assert.NotEmpty(t, collection.Name)
+		assert.NotEmpty(t, collection.ModelName)
+		assert.Greater(t, collection.Dimension, 0)
+	}
+
+	assert.True(t, names[collection1.Name])
+	assert.True(t, names[collection2.Name])
+}
+
+// TestSelectRAGCollectionCoreFields 测试核心字段选择功能
+func TestSelectRAGCollectionCoreFields(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// 创建测试数据
+	createTestCollection(t, db, "core_fields_test")
+
+	// 直接测试 selectRAGCollectionCoreFields 函数
+	var collections []schema.VectorStoreCollection
+	err := selectRAGCollectionCoreFields(db).Find(&collections).Error
+	assert.NoError(t, err)
+	assert.Len(t, collections, 1)
+
+	// 验证返回的记录包含预期的核心字段
+	collection := collections[0]
+	assert.NotZero(t, collection.ID)
+	assert.NotEmpty(t, collection.Name)
+	assert.NotEmpty(t, collection.ModelName)
+	assert.Greater(t, collection.Dimension, 0)
+}
+
+// TestEmptyDatabase 测试空数据库的情况
+func TestEmptyDatabase(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// 测试在空数据库中查询
+	t.Run("空数据库查询集合名称", func(t *testing.T) {
+		names, err := GetAllRAGCollectionNames(db)
+		assert.NoError(t, err)
+		assert.Len(t, names, 0)
+	})
+
+	t.Run("空数据库查询集合信息", func(t *testing.T) {
+		collections, err := GetAllRAGCollectionInfos(db)
+		assert.NoError(t, err)
+		assert.Len(t, collections, 0)
+	})
+
+	t.Run("空数据库根据名称查询", func(t *testing.T) {
+		collection, err := QueryRAGCollectionByName(db, "不存在的集合")
+		assert.Error(t, err)
+		assert.Nil(t, collection)
+	})
 }

--- a/common/yakgrpc/yakit/rag_test.go
+++ b/common/yakgrpc/yakit/rag_test.go
@@ -1,0 +1,16 @@
+package yakit
+
+import (
+	"testing"
+
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+func TestQueryRAGCollectionByName(t *testing.T) {
+	db := utils.CreateTempTestDatabaseInMemory()
+	collection, err := QueryRAGCollectionByName(db, "test")
+	if err != nil {
+		t.Fatalf("查询集合失败: %v", err)
+	}
+	t.Logf("集合: %v", collection)
+}


### PR DESCRIPTION
… migration

- Modify HNSW graph saving mechanism to support complete export and graph-only export
- Update RAG library to use new graph saving approach with automatic legacy data migration
- Add support for graph-only export with DocumentID, UID, or database auto-increment ID indexing
- Implement lazy node loading for improved memory efficiency
- Add comprehensive tests for new export functionality
- Enhance vector store configuration with new export options