### PR TITLE
fix: unable to get tool call details by calltoolid

### DIFF
--- a/common/ai/aid/aireact/invoke_toolcall.go
+++ b/common/ai/aid/aireact/invoke_toolcall.go
@@ -12,6 +12,15 @@ import (
 
 // handleRequireTool handles tool requirement action using aicommon.ToolCaller
 func (r *ReAct) handleRequireTool(toolName string) (*aitool.ToolResult, bool, error) {
+	r.config.Emitter = r.config.Emitter.PushEventProcesser(func(event *schema.AiOutputEvent) *schema.AiOutputEvent {
+		if event.TaskIndex == "" {
+			event.TaskIndex = r.currentTask.Id
+		}
+		return event
+	})
+	defer func() {
+		r.config.Emitter = r.config.Emitter.PopEventProcesser()
+	}()
 	// Find the required tool
 	tool, err := r.config.aiToolManager.GetToolByName(toolName)
 	if err != nil {


### PR DESCRIPTION
- Fix Emitter's PushEventProcesser bug caused by shallow copy of eventProcesserStack pointer that modified original emitter's stack when pushing handlers, now performs deep copy of eventProcesserStack
- Fix ToolCaller bug where modifying emitter in onStart was ineffective (this bug worked in combination with the previous bug, making it hard to detect)
- Add AIReact event persistence to database
- Fix AIReact tool call history retrieval failure