### PR TITLE
feat(ts2ssa, ssa): cyclic re-exports, import=require, global bindings; fix ReplaceValue; add Program export-forward table

### DIFF
--- a/common/yak/ssa/declare_export.go
+++ b/common/yak/ssa/declare_export.go
@@ -25,3 +25,41 @@ func (p *Program) SetExportValue(name string, v Value) {
 	}
 	p.ExportValue[name] = v
 }
+
+func (p *Program) SetReExportInfo(reexportName, from, exportName string, isNameSpaceExport, isWildCardExport bool) {
+	if p.ReExportTable == nil {
+		p.ReExportTable = make(map[string]*ReExportInfo)
+	}
+	p.ReExportTable[reexportName] = &ReExportInfo{
+		FilePath:          from,
+		ExportName:        exportName,
+		IsNameSpaceExport: isNameSpaceExport,
+		IsWildCardExport:  isWildCardExport,
+	}
+}
+
+func (p *Program) SetWildCardReExportInfo(from string) {
+	if p.ReExportTable == nil {
+		p.ReExportTable = make(map[string]*ReExportInfo)
+	}
+	p.ReExportTable["*"] = &ReExportInfo{
+		FilePath:          from,
+		ExportName:        "*",
+		IsNameSpaceExport: false,
+		IsWildCardExport:  true,
+	}
+}
+
+func (p *Program) GetReExportInfo(reexportName string) *ReExportInfo {
+	if info, ok := p.ReExportTable[reexportName]; ok {
+		return info
+	}
+	return nil
+}
+
+func (p *Program) GetWildCardReExportInfo() *ReExportInfo {
+	if info, ok := p.ReExportTable["*"]; ok {
+		return info
+	}
+	return nil
+}

--- a/common/yak/ssa/declare_import.go
+++ b/common/yak/ssa/declare_import.go
@@ -64,6 +64,11 @@ func (p *Program) TryReadImportDeclare(name string) (Type, bool) {
 				if ok && ret != nil {
 					break
 				}
+				lib.GlobalVariablesBlueprint.Build()
+				if _, ok = lib.GetGlobalVariable(name); ok {
+					ret = lib.GlobalVariablesBlueprint
+					return true
+				}
 			}
 
 		}

--- a/common/yak/ssa/program.go
+++ b/common/yak/ssa/program.go
@@ -125,6 +125,7 @@ func (prog *Program) createSubProgram(name string, kind ssadb.ProgramKind, path 
 	subProg.ExternLib = prog.ExternLib
 	subProg.ExportType = make(map[string]Type)
 	subProg.ExportValue = make(map[string]Value)
+	subProg.ReExportTable = make(map[string]*ReExportInfo)
 
 	// up-down stream and application
 	prog.AddUpStream(subProg)

--- a/common/yak/ssa/ssa.go
+++ b/common/yak/ssa/ssa.go
@@ -215,6 +215,14 @@ const (
 	SideEffectOut
 )
 
+// ReExportInfo stores re-export information
+type ReExportInfo struct {
+	FilePath          string // source file path
+	ExportName        string // exported name
+	IsNameSpaceExport bool
+	IsWildCardExport  bool
+}
+
 // both instruction and value
 type Program struct {
 	// project
@@ -270,6 +278,7 @@ type Program struct {
 	BlueprintStack *utils.Stack[*Blueprint]
 	ExportValue    map[string]Value
 	ExportType     map[string]Type
+	ReExportTable  map[string]*ReExportInfo // re-export name/type --from--> filepath
 
 	// GlobalVariablesBlueprint is a virtual Blueprint that wraps global variables,
 	// enabling them to be lazily built through the LazyBuilder mechanism

--- a/common/yak/ssa/use.go
+++ b/common/yak/ssa/use.go
@@ -20,6 +20,9 @@ func ReplaceValue(v Value, to Value, skip func(Instruction) bool) {
 			log.Errorf("=============================\n"+"replace value panic: %v", r)
 		}
 	}()
+	if v.getAnValue() == to.getAnValue() {
+		return
+	}
 
 	for _, variable := range v.GetAllVariables() {
 		// TODO: handler variable replace value

--- a/common/yak/typescript/ts2ssa/auxiliary.go
+++ b/common/yak/typescript/ts2ssa/auxiliary.go
@@ -2,10 +2,10 @@ package ts2ssa
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/ssa"
 	"github.com/yaklang/yaklang/common/yak/ssa/ssalog"
 	"github.com/yaklang/yaklang/common/yak/typescript/frontend/ast"
@@ -57,6 +57,8 @@ var comparisonBinOpTbl = map[ast.Kind]ssa.BinaryOpcode{
 	ast.KindExclamationEqualsToken:       ssa.OpNotEq,
 	ast.KindExclamationEqualsEqualsToken: ssa.OpNotEq,
 }
+
+const EXPORT_EQUAL_VALUE = "EXPORT_EQUAL_VALUE"
 
 // VisitLeftValueExpression 只接收左值
 func (b *builder) VisitLeftValueExpression(node *ast.Expression) *ssa.Variable {
@@ -157,24 +159,26 @@ func (b *builder) getImportCandidates(importPath, baseDir string) []string {
 	candidates := []string{}
 	extensions := []string{".ts", ".tsx", ".js", ".jsx", ".d.ts"}
 
+	fs := b.GetProgram().Loader.GetFilesysFileSystem()
+
 	// 如果导入路径已经有扩展名，直接使用
 	if hasValidExtension(importPath) {
-		if !filepath.IsAbs(importPath) {
-			candidates = append(candidates, filepath.Join(baseDir, importPath))
+		if !fs.IsAbs(importPath) {
+			candidates = append(candidates, fs.Join(baseDir, importPath))
 		} else {
 
 		}
 
 	} else {
 		// 尝试添加各种扩展名
-		if !filepath.IsAbs(importPath) {
+		if !fs.IsAbs(importPath) {
 			for _, ext := range extensions {
-				candidates = append(candidates, filepath.Join(baseDir, importPath+ext))
+				candidates = append(candidates, fs.Join(baseDir, importPath+ext))
 			}
 
 			// 尝试index文件
 			for _, ext := range extensions {
-				candidates = append(candidates, filepath.Join(baseDir, importPath, "index"+ext))
+				candidates = append(candidates, fs.Join(baseDir, importPath, "index"+ext))
 			}
 		} else {
 
@@ -267,6 +271,63 @@ func (b *builder) getDeclarationNameText(name *ast.DeclarationName) string {
 	return ""
 }
 
+// getEntityNameText 获取实体名称的文本
+// 用于处理 EntityName（Identifier 或 QualifiedName，如 A.B.C）
+func (b *builder) getEntityNameText(entityName *ast.ModuleReference) string {
+	if entityName == nil {
+		return ""
+	}
+
+	switch entityName.Kind {
+	case ast.KindIdentifier:
+		// 简单标识符: import A = B
+		return entityName.AsIdentifier().Text
+
+	case ast.KindQualifiedName:
+		// 限定名: import A = B.C.D
+		// QualifiedName 是递归结构: Left.Right
+		return b.getQualifiedNameText(entityName.AsQualifiedName())
+
+	default:
+		return ""
+	}
+}
+
+// getQualifiedNameText 递归获取限定名的完整文本
+// 例如: A.B.C 会被递归处理为 "A.B.C"
+func (b *builder) getQualifiedNameText(qualifiedName *ast.QualifiedName) string {
+	if qualifiedName == nil {
+		return ""
+	}
+
+	// QualifiedName 结构: Left.Right
+	// Left 可以是 Identifier 或另一个 QualifiedName
+	// Right 总是 Identifier
+
+	var leftText string
+	if qualifiedName.Left != nil {
+		switch qualifiedName.Left.Kind {
+		case ast.KindIdentifier:
+			leftText = qualifiedName.Left.AsIdentifier().Text
+		case ast.KindQualifiedName:
+			leftText = b.getQualifiedNameText(qualifiedName.Left.AsQualifiedName())
+		}
+	}
+
+	var rightText string
+	if qualifiedName.Right != nil {
+		rightText = qualifiedName.Right.AsIdentifier().Text
+	}
+
+	if leftText != "" && rightText != "" {
+		return leftText + "." + rightText
+	} else if leftText != "" {
+		return leftText
+	} else {
+		return rightText
+	}
+}
+
 // createExternalModuleLibrary 为外部模块创建占位符Library
 func (b *builder) createExternalModuleLibrary(modulePath string) {
 	prog := b.GetProgram()
@@ -280,8 +341,8 @@ func (b *builder) createExternalModuleLibrary(modulePath string) {
 	}
 }
 
-// assignImportedValue 分配导入的值
-func (b *builder) assignImportedValue(localName, exportName, modulePath string, isExternal bool) {
+// ImportExternLibValue 分配导入的值
+func (b *builder) ImportExternLibValue(localName, exportName, modulePath string, isExternal bool) {
 	if localName == "" {
 		return
 	}
@@ -289,73 +350,175 @@ func (b *builder) assignImportedValue(localName, exportName, modulePath string, 
 	var value ssa.Value
 
 	if isExternal {
-		// 外部模块：创建占位符
-		value = b.createExternalImportPlaceholder(modulePath, exportName)
+		return
 	} else {
 		// 本地模块：尝试获取实际值
 		value = b.getModuleExportValue(modulePath, exportName)
 	}
 	_ = value
+}
 
-	// 创建变量并赋值
-	if value != nil && !b.PreHandler() {
-		variable := b.CreateJSVariable(localName)
-		b.AssignVariable(variable, value)
-		log.Infof("Import binding: %s -> %s from %s (external: %t)", localName, exportName, modulePath, isExternal)
+func (b *builder) addImport(resolvedPath, originalName, localName string) {
+	if b.importTbl == nil {
+		b.importTbl = make(map[string]map[string]string)
 	}
+
+	if _, ok := b.importTbl[resolvedPath]; !ok {
+		b.importTbl[resolvedPath] = make(map[string]string)
+	}
+
+	b.importTbl[resolvedPath][originalName] = localName
 }
 
 // bindNamespaceImport 绑定命名空间导入
 func (b *builder) bindNamespaceImport(localName, modulePath string, isExternal bool) {
-	if localName == "" {
+	if localName == "" || !b.PreHandler() {
 		return
 	}
 
 	var value ssa.Value
 
 	if isExternal {
-		// 外部模块：创建命名空间占位符
-		value = b.createNamespaceImportPlaceholder(modulePath)
+		return
 	} else {
 		// 本地模块：创建包含所有导出的容器
-		value = b.createLocalNamespaceObject(modulePath)
+		value = b.createLocalNamespaceObject(modulePath, localName)
 	}
-
-	// 创建变量并赋值
-	variable := b.CreateJSVariable(localName)
-	b.AssignVariable(variable, value)
+	_ = value
 
 	log.Infof("Namespace import binding: %s -> * from %s (external: %t)", localName, modulePath, isExternal)
 }
 
 // createLocalNamespaceObject 为本地模块创建命名空间对象
-func (b *builder) createLocalNamespaceObject(modulePath string) ssa.Value {
+func (b *builder) createLocalNamespaceObject(modulePath string, localName string) ssa.Value {
 	prog := b.GetProgram()
 	if prog == nil {
-		return b.EmitUndefined("namespace_prog_not_found")
-	}
-
-	// 尝试获取模块Program
-	moduleProgram, exists := prog.GetLibrary(modulePath)
-	if !exists {
-		return b.EmitUndefined(fmt.Sprintf("namespace_module_%s_not_found", modulePath))
+		return nil
 	}
 
 	// 创建命名空间容器
-	namespaceObj := b.EmitEmptyContainer()
-
-	// 从模块的ExportValue中添加所有导出
-	if moduleProgram.ExportValue != nil {
-		for exportName, exportValue := range moduleProgram.ExportValue {
-			member := b.CreateMemberCallVariable(namespaceObj, b.EmitConstInst(exportName))
-			b.AssignVariable(member, exportValue)
+	namespaceObj := b.CreateBlueprint(localName)
+	namespaceObj.AddLazyBuilder(func() {
+		// 尝试获取模块Program
+		moduleProgram, exists := prog.GetLibrary(modulePath)
+		if !exists {
+			return
 		}
-		log.Infof("Created local namespace object for module: %s with %d exports", modulePath, len(moduleProgram.ExportValue))
-	}
+		cnt := 0
+		// 从模块的ExportValue中添加所有导出
+		if moduleProgram.ExportValue != nil {
+			for exportName, exportValue := range moduleProgram.ExportValue {
+				namespaceObj.RegisterStaticMember(exportName, exportValue)
+				cnt++
+			}
+		}
+		container := moduleProgram.GlobalVariablesBlueprint.Container()
+		if container != nil {
+			for i, m := range container.GetAllMember() {
+				namespaceObj.RegisterStaticMember(i.String(), m)
+				cnt++
+			}
+		}
+		log.Infof("Created local namespace object for module: %s with %d exports", modulePath, cnt)
+	})
+	namespaceObj.Build()
 
-	return namespaceObj
+	return namespaceObj.Container()
 }
 
-func ShouldVisit(isPreHandle, isExport bool) bool {
-	return isExport == isPreHandle
+// resolveExportValueAndType 递归解析导出值和类型，处理重导出链
+// 返回值: (value ssa.Value, type ssa.Type)
+func (b *builder) resolveExportValueAndType(prog *ssa.Program, lib *ssa.Program, exportName string) (ssa.Value, ssa.Type) {
+	return b.resolveExportValueAndTypeRecursive(prog, lib, exportName, make(map[string]bool))
+}
+
+// resolveExportValueAndTypeRecursive 递归解析导出值和类型的内部实现
+// visited 用于防止循环引用
+func (b *builder) resolveExportValueAndTypeRecursive(prog *ssa.Program, lib *ssa.Program, exportName string, visited map[string]bool) (ssa.Value, ssa.Type) {
+	if lib == nil {
+		return nil, nil
+	}
+
+	// 生成唯一的库+导出名标识，用于防止循环引用
+	visitKey := lib.GetProgramName() + ":" + exportName
+	if visited[visitKey] {
+		return nil, nil
+	}
+	visited[visitKey] = true
+
+	// 首先尝试直接获取导出值和类型
+	externValue := lib.GetExportValue(exportName)
+	externalType, typeOk := lib.GetExportType(exportName)
+
+	// 如果找到了值或类型，直接返回
+	if !utils.IsNil(externValue) || typeOk {
+		return externValue, externalType
+	}
+
+	// 如果没有找到，检查是否有重导出信息
+	info := lib.GetReExportInfo(exportName)
+	wildCardInfo := lib.GetWildCardReExportInfo()
+	if info == nil {
+		if wildCardInfo != nil {
+			info = wildCardInfo
+		} else {
+			return nil, nil
+		}
+	}
+
+	// 获取重导出的源库
+	realLib, found := prog.GetLibrary(info.FilePath)
+	if !found {
+		return nil, nil
+	}
+
+	// 处理命名空间导出 (export * as ns from './mod')
+	if info.IsNameSpaceExport {
+		variable := b.CreateVariable(exportName)
+		value := b.createLocalNamespaceObject(info.FilePath, exportName)
+		b.AssignVariable(variable, value)
+		return value, nil
+	}
+
+	// 处理通配符导出 (export * from './mod')
+	if info.IsWildCardExport {
+		// 通配符导出，需要递归查找
+		// 因为源库也可能使用了重导出（包括通配符重导出）
+		return b.resolveExportValueAndTypeRecursive(prog, realLib, exportName, visited)
+	}
+
+	// 处理普通重导出，递归查找
+	// 如果有指定的导出名，使用指定的名称，否则使用原名称
+	targetName := exportName
+	if info.ExportName != "" {
+		targetName = info.ExportName
+	}
+
+	return b.resolveExportValueAndTypeRecursive(prog, realLib, targetName, visited)
+}
+
+// IsTopLevelNodeInAST 判断某个节点是否为 AST 的顶层语句
+// 顶层语句是直接位于 SourceFile.Statements 中的语句节点
+func (b *builder) IsTopLevelNodeInAST(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	// 方法1：检查父节点是否为 SourceFile
+	// 在某些情况下，语句节点的 Parent 直接指向 SourceFile
+	if node.Parent != nil && ast.IsSourceFile(node.Parent) {
+		return true
+	}
+
+	// 方法2：检查当前 sourceFile 的 Statements 列表中是否包含此节点
+	// 这是更可靠的方法，因为有些节点的 Parent 可能不是直接指向 SourceFile
+	if b.sourceFile != nil && b.sourceFile.Statements != nil {
+		for _, stmt := range b.sourceFile.Statements.Nodes {
+			if stmt == node {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/common/yak/typescript/ts2ssa/builder.go
+++ b/common/yak/typescript/ts2ssa/builder.go
@@ -47,10 +47,15 @@ type builder struct {
 
 	currentImportModule               string
 	unresolvedCurrentImportModulePath string
-	namedValueExports                 map[string]string // exportedName -> realName (exportedName may not be the same as realName in case of export alias)
-	namedTypeExports                  map[string]string
-	cjsExport                         string                       // export equal + require syntax only support one export per ts file
-	reExports                         map[string]map[string]string // re-exported name -> (path -> exportName)
+	exportNameMap                     map[string]string // exportedName -> realName (exportedName may not be the same as realName in case of export alias)
+	namedValueExports                 map[string]ssa.Value
+	namedTypeExports                  map[string]ssa.Type
+
+	hasExportEquals     bool
+	hasWildCardReExport bool
+
+	reExports map[string]map[string]string // re-exported name -> (path -> exportName)
+	importTbl map[string]map[string]string // libName -> (importItemName -> aliasName)
 
 }
 
@@ -104,9 +109,10 @@ func (*SSABuilder) BuildFromAST(raw ssa.FrontAST, b *ssa.FunctionBuilder) error 
 		sourceFile:        jsAST,
 		useStrict:         false,
 		contextLabelStack: make([]string, 0),
-		namedValueExports: make(map[string]string),
-		namedTypeExports:  make(map[string]string),
+		namedValueExports: make(map[string]ssa.Value),
+		namedTypeExports:  make(map[string]ssa.Type),
 		reExports:         make(map[string]map[string]string),
+		importTbl:         make(map[string]map[string]string),
 	}
 	build.VisitSourceFile(jsAST)
 	return nil

--- a/common/yak/typescript/ts2ssa/error_message.go
+++ b/common/yak/typescript/ts2ssa/error_message.go
@@ -32,6 +32,10 @@ func UnexpectedRightValueForObjectPropertyAccess() string {
 	return "unexpected right value for object property access"
 }
 
+func UnexpectedLeftValueForObjectPropertyAccess() string {
+	return "unexpected left value for object property access"
+}
+
 func NoOperandFoundForPrefixUnaryExp() string {
 	return "missing operand for prefix unary expression"
 }

--- a/common/yak/typescript/ts2ssa/tests/ast2ssa_test.go
+++ b/common/yak/typescript/ts2ssa/tests/ast2ssa_test.go
@@ -1869,13 +1869,24 @@ func TestClass(t *testing.T) {
 				A.a = par;
 			}
 		}
+		println(A.a)
 		println(A.getA());
 		A.setA(1);
 		println(A.getA());
 		`, []string{
-			"Function-A.getA()",
-			"Function-A.getA()",
+			"0",
+			"Function-A.getA() binding[A] member[0]",
+			"Function-A.getA() binding[A] member[side-effect(Parameter-par, A.a)]",
 		}, t)
+	})
+
+	t.Run("static method call", func(t *testing.T) {
+		ssatest.CheckPrintlnValue(`
+class Calc {
+	static add(a: number) { return a; }
+}
+println(Calc.add(1))
+`, []string{"Function-Calc.add(1)"}, t)
 	})
 
 	t.Run("simple class with constructor and method", func(t *testing.T) {

--- a/common/yak/typescript/ts2ssa/tests/import_test.go
+++ b/common/yak/typescript/ts2ssa/tests/import_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/yaklang/yaklang/common/utils/filesys"
 	"github.com/yaklang/yaklang/common/yak/ssaapi"
 	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssareducer"
 	"github.com/yaklang/yaklang/common/yak/ssaapi/test/ssatest"
 )
+
+// TODO 已知问题 当一个value通过CrateMemberCallVariable后被赋值到成员变量 后续这个value的ReplaceValue无法生效
+// TODO 已知问题 当一个BluePrint触发LazyBuild时使用一个UndefinedValue 后续这个Value被Replace在蓝图中注册的StaticMember不生效(TestNamedImportWithGlobalVar)
 
 func TestBasicImport(t *testing.T) {
 	vf := filesys.NewVirtualFs()
@@ -34,7 +38,37 @@ go0p()
 	ssatest.CheckSyntaxFlowWithFS(t, vf, `
 		console.log(* #-> as $result)
 	`, map[string][]string{
-		"result": {"Undefined-PI", "FreeValue-getValue", "42", "\"Hello World\""},
+		"result": {"Undefined-PI", "42", "\"Hello World\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS),
+	)
+}
+
+func TestBasicImportReverse(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/main.ts", `
+import { getValue, message } from './utils';
+
+console.log(getValue());
+console.log(message);
+console.log(PI);
+function go0p(){
+console.log(getValue())
+}
+go0p()
+`)
+	vf.AddFile("src/utils.ts", `
+export function getValue(): number {
+	return 42;
+}
+
+export const message = "Hello World";
+const PI = 3.14
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $result)
+	`, map[string][]string{
+		"result": {"Undefined-PI", "42", "\"Hello World\""},
 	}, false, ssaapi.WithLanguage(ssaconfig.TS),
 	)
 }
@@ -62,18 +96,18 @@ export default function calculate(): number {
 
 func TestNamespaceImport(t *testing.T) {
 	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/index.ts", `
+import * as Constants from './constants';
+
+console.log(Constants.PI);
+console.log(Constants.getVersion());
+`)
 	vf.AddFile("src/constants.ts", `
 export const PI = 3.14;
 export const E = 2.71;
 export function getVersion(): string {
 	return "1.0.0";
 }
-`)
-	vf.AddFile("src/index.ts", `
-import * as Constants from './constants';
-
-console.log(Constants.PI);
-console.log(Constants.getVersion());
 `)
 
 	ssatest.CheckSyntaxFlowWithFS(t, vf, `
@@ -111,7 +145,7 @@ console.log(helper());
 		console.log(* #-> as $outputs)
 	`, map[string][]string{
 		"outputs": {"20", "10", "\"2.0\"", "\"helper\""},
-	}, false, ssaapi.WithLanguage(ssaconfig.TS),
+	}, true, ssaapi.WithLanguage(ssaconfig.TS),
 	)
 }
 
@@ -356,7 +390,6 @@ export enum Status {
 	}, false, ssaapi.WithLanguage(ssaconfig.TS))
 }
 
-// TODO: Fix environment lost in lazy build lazy build not contain full variable table context
 func TestImportEnumRecursive(t *testing.T) {
 	vf := filesys.NewVirtualFs()
 	vf.AddFile("src/main.ts", `
@@ -391,4 +424,540 @@ export const enum Palette {
 	`, map[string][]string{
 		"enumValues": {"\"red\"", "2"},
 	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestImportEnumRecursiveReverse(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/enums/palette.ts", `
+export const enum Palette {
+ SlotA = "red"
+}
+`)
+	vf.AddFile("src/enums/colors.ts", `
+import { Palette } from './palette';
+
+export enum Color {
+ Red = Palette.SlotA,   // 二层递归来源
+ Green = "green",
+ Blue = "blue",
+}
+
+export enum Status {
+ Pending = 1,
+ Approved = 2,
+ Rejected = 3
+}
+`)
+	vf.AddFile("src/main.ts", `
+import { Color, Status } from './enums/colors';
+
+console.log(Color.Red);
+console.log(Status.Approved);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $enumValues)
+	`, map[string][]string{
+		"enumValues": {"\"red\"", "2"},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestNamedImportWithGlobalVar(t *testing.T) {
+	t.Skip("TODO 已知问题 当一个BluePrint触发LazyBuild时使用一个UndefinedValue 后续这个Value被Replace在蓝图中注册的StaticMember不生效")
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/enums/colors.ts", `
+import { PI } from './const';
+
+export enum Color {
+ Red = PI,   // 二层递归来源
+ Green = "green",
+ Blue = "blue",
+}
+`)
+	vf.AddFile("src/main.ts", `
+import { Color} from './enums/colors';
+
+console.log(Color.Red);
+`)
+
+	vf.AddFile("src/enums/const.ts", `
+export const PI = 3.14
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $enumValues)
+	`, map[string][]string{
+		"enumValues": {"3.14"},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestNameSpaceImportWithGlobalVar(t *testing.T) {
+	t.Skip("TODO 已知问题 当一个value通过CrateMemberCallVariable后被赋值到成员变量 后续这个value的ReplaceValue无法生效")
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/enums/colors.ts", `
+import * as C from './const';
+
+export enum Color {
+ Red = C.PI,   // 二层递归来源
+ Green = "green",
+ Blue = "blue",
+}
+`)
+	vf.AddFile("src/main.ts", `
+import { Color } from './enums/colors';
+
+console.log(Color.Red);
+`)
+	vf.AddFile("src/enums/const.ts", `
+export const PI = 3.14
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $enumValues)
+	`, map[string][]string{
+		"enumValues": {"3.14"},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestDefaultImportWithGlobalVar(t *testing.T) {
+	t.Skip("TODO 已知问题 当一个value通过CrateMemberCallVariable后被赋值到成员变量 后续这个value的ReplaceValue无法生效")
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/enums/colors.ts", `
+import GG from './const';
+
+export enum Color {
+ Red = GG,   // 二层递归来源
+ Green = "green",
+ Blue = "blue",
+}
+`)
+	vf.AddFile("src/enums/const.ts", `
+const PI = 3.14
+export default PI;
+`)
+	vf.AddFile("src/main.ts", `
+import {Color} from './enums/colors';
+
+console.log(Color.Red);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $enumValues)
+	`, map[string][]string{
+		"enumValues": {"3.14"},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS), ssaapi.WithASTOrder(ssareducer.Order))
+}
+
+func TestRenamedImportWithGlobalVar(t *testing.T) {
+	t.Skip("TODO 已知问题 当一个BluePrint触发LazyBuild时使用一个UndefinedValue 后续这个Value被Replace在蓝图中注册的StaticMember不生效")
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/main.ts", `
+import { Color} from './enums/colors';
+
+console.log(Color.Red);
+`)
+	vf.AddFile("src/enums/colors.ts", `
+import { PI as MyPI } from './const';
+
+export enum Color {
+ Red = MyPI,   // 二层递归来源
+ Green = "green",
+ Blue = "blue",
+}
+`)
+	vf.AddFile("src/enums/const.ts", `
+export const PI = 3.14
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $enumValues)
+	`, map[string][]string{
+		"enumValues": {"3.14"},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestReExportNamed(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/lib.ts", `
+export const value = 7;
+export function twice(n: number) { return n; }
+`)
+	vf.AddFile("src/index.ts", `
+export { value as answer, twice as double } from './lib';
+`)
+	vf.AddFile("src/main.ts", `
+import { answer, double } from './index';
+
+console.log(answer);
+console.log(double(5));
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $out)
+	`, map[string][]string{
+		"out": {"7", "5"},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestReExportDefaultAsNamed(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/lib.ts", `
+export default class Calc {
+	static add(a: number) { return a+1; }
+}
+export const version = "3.0";
+`)
+	vf.AddFile("src/index.ts", `
+export { default as Calc, version } from './lib';
+`)
+	vf.AddFile("src/main.ts", `
+import { Calc, version } from './index';
+
+console.log(Calc.add(2));
+console.log(version);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $out)
+	`, map[string][]string{
+		"out": {"1", "2", "\"3.0\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestReExportDefaultAsNamedReverseOrder(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/main.ts", `
+import { Calc, version } from './index';
+
+console.log(Calc.add(2));
+console.log(version);
+`)
+	vf.AddFile("src/lib.ts", `
+export default class Calc {
+	static add(a: number) { return a+1; }
+}
+export const version = "3.0";
+`)
+	vf.AddFile("src/index.ts", `
+export { default as Calc, version } from './lib';
+`)
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $out)
+	`, map[string][]string{
+		"out": {"1", "2", "\"3.0\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestTypeOnlyReExport(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/types.ts", `
+export interface User { id: number; name: string; }
+`)
+	vf.AddFile("src/index.ts", `
+export type { User } from './types';
+`)
+	vf.AddFile("src/main.ts", `
+import type { User } from './index';
+
+const u: User = { id: 1, name: "Alice" };
+console.log(u.name);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $name)
+	`, map[string][]string{
+		"name": {"\"Alice\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestExportEqualsAndImportEquals(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/math.ts", `
+function sum(a: number, b: number) { return a + b + 1; }
+export = sum;
+`)
+	vf.AddFile("src/main.ts", `
+// TS ImportEquals 语法
+import sum = require('./math');
+console.log(sum(2, 3));
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $out)
+	`, map[string][]string{
+		"out": {"2", "3", "1"},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+// sanity check
+func TestCircularImportBasic(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/a.ts", `
+import { bVal } from './b';
+export const aVal = "A" + (bVal || "");
+`)
+	vf.AddFile("src/b.ts", `
+import { aVal } from './a';
+export const bVal = "B" + (aVal ? "" : "");
+`)
+	vf.AddFile("src/main.ts", `
+import { aVal } from './a';
+import { bVal } from './b';
+console.log(aVal);
+console.log(bVal);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $vals)
+	`, map[string][]string{
+		"vals": {"\"A\"", "\"B\""},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestExportStarVsDefault(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/lib.ts", `
+export default function f() { return "D"; }
+export const X = "X";
+`)
+	vf.AddFile("src/index.ts", `
+// 星号只转发命名导出，不含 default
+export * from './lib';
+// 想拿到 default，必须显式取别名
+export { default as DF } from './lib';
+`)
+	vf.AddFile("src/main.ts", `
+import { X, DF } from './index';
+console.log(X);
+console.log(DF());
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $vals)
+	`, map[string][]string{
+		"vals": {"\"X\"", "\"D\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+func TestExportStarVsDefaultForDebug(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/index.ts", `
+// 星号只转发命名导出，不含 default
+export * from './lib';
+`)
+	vf.AddFile("src/lib.ts", `
+export const X = "X";
+`)
+	vf.AddFile("src/main.ts", `
+import { X } from './index';
+console.log(X);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $vals)
+	`, map[string][]string{
+		"vals": {"\"X\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+// TestDeepReExportChain 测试深层递归重导出链
+// 验证递归函数能正确处理多层重导出 (A -> B -> C -> D)
+func TestDeepReExportChain(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/d.ts", `
+export const deepValue = 42;
+export function deepFunc() { return "deep"; }
+`)
+	vf.AddFile("src/c.ts", `
+// C 从 D 重导出
+export { deepValue as cValue, deepFunc as cFunc } from './d';
+`)
+	vf.AddFile("src/b.ts", `
+// B 从 C 重导出
+export { cValue as bValue, cFunc as bFunc } from './c';
+`)
+	vf.AddFile("src/a.ts", `
+// A 从 B 重导出
+export { bValue as aValue, bFunc as aFunc } from './b';
+`)
+	vf.AddFile("src/main.ts", `
+import { aValue, aFunc } from './a';
+
+console.log(aValue);
+console.log(aFunc());
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $results)
+	`, map[string][]string{
+		"results": {"42", "\"deep\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+// TestReExportWithWildcard 测试通配符重导出的递归处理
+func TestReExportWithWildcard(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/main.ts", `
+import { alpha, beta, extra } from './top';
+
+console.log(alpha);
+console.log(beta);
+console.log(extra);
+`)
+	vf.AddFile("src/base.ts", `
+export const alpha = "alpha";
+export const beta = "beta";
+export const gamma = "gamma";
+`)
+	vf.AddFile("src/middle.ts", `
+// 通配符重导出所有命名导出
+export * from './base';
+export const extra = "extra";
+`)
+	vf.AddFile("src/top.ts", `
+// 再次通配符重导出
+export * from './middle';
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $values)
+	`, map[string][]string{
+		"values": {"\"alpha\"", "\"beta\"", "\"extra\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+// TestReExportNamespaceExport 测试命名空间重导出
+func TestReExportNamespaceExport(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/utils.ts", `
+export const PI = 3.14;
+export const E = 2.71;
+export function calculate() { return 100; }
+`)
+	vf.AddFile("src/index.ts", `
+// 命名空间重导出: export * as ns from 'module'
+export * as Utils from './utils';
+`)
+	vf.AddFile("src/main.ts", `
+import { Utils } from './index';
+
+console.log(Utils.PI);
+console.log(Utils.E);
+console.log(Utils.calculate());
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $values)
+	`, map[string][]string{
+		"values": {"3.14", "2.71", "100"},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+// TestMixedReExportChain 测试混合类型的重导出链
+// 包含命名重导出、通配符重导出和重命名
+func TestMixedReExportChain(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/core.ts", `
+export const coreValue = 999;
+export default function coreFunc() { return "core"; }
+export class CoreClass {
+	static method() { return "method"; }
+}
+`)
+	vf.AddFile("src/layer1.ts", `
+// 混合：命名导出、默认导出重命名、通配符
+export * from './core';
+export { default as defaultCore } from './core';
+`)
+	vf.AddFile("src/layer2.ts", `
+// 继续重导出，并添加新的导出
+export { coreValue as finalValue, CoreClass, defaultCore } from './layer1';
+export const layer2Value = "layer2";
+`)
+	vf.AddFile("src/main.ts", `
+import { finalValue, CoreClass, defaultCore, layer2Value } from './layer2';
+
+console.log(CoreClass.method());
+console.log(finalValue);
+console.log(defaultCore());
+console.log(layer2Value);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $all)
+	`, map[string][]string{
+		"all": {"999", "\"method\"", "\"core\"", "\"layer2\""},
+	}, true, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+// TestWildcardReExportRecursive 测试通配符重导出的递归场景
+// A 使用 B 的通配符重导出，B 又使用了 C 的通配符重导出
+func TestWildcardReExportRecursive(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/c.ts", `
+export const valueC1 = "c1";
+export const valueC2 = "c2";
+export function funcC() { return "funcC"; }
+`)
+	vf.AddFile("src/b.ts", `
+// B 通过通配符从 C 重导出
+export * from './c';
+export const valueB = "b";
+`)
+	vf.AddFile("src/a.ts", `
+// A 通过通配符从 B 重导出（B 本身也是通过通配符从 C 重导出）
+export * from './b';
+export const valueA = "a";
+`)
+	vf.AddFile("src/main.ts", `
+import { valueC1, valueC2, funcC, valueB, valueA } from './a';
+
+console.log(valueC1);
+console.log(valueC2);
+console.log(funcC());
+console.log(valueB);
+console.log(valueA);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $values)
+	`, map[string][]string{
+		"values": {"\"c1\"", "\"c2\"", "\"funcC\"", "\"b\"", "\"a\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
+}
+
+// TestWildcardWithNamedReExportRecursive 测试通配符和命名重导出混合的递归场景
+func TestWildcardWithNamedReExportRecursive(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("src/base.ts", `
+export const x = 1;
+export const y = 2;
+export const z = 3;
+`)
+	vf.AddFile("src/middle.ts", `
+// 通配符重导出 base 的所有内容
+export * from './base';
+// 同时添加新的命名导出
+export const middle = "m";
+`)
+	vf.AddFile("src/top.ts", `
+// 命名重导出 middle 中的部分内容（这些内容来自 base 的通配符重导出）
+export { x as topX, middle as topMiddle } from './middle';
+// 通配符重导出 middle 的所有内容
+export * from './middle';
+`)
+	vf.AddFile("src/main.ts", `
+import { topX, topMiddle, y, z } from './top';
+
+console.log(topX);
+console.log(y);
+console.log(z);
+console.log(topMiddle);
+`)
+
+	ssatest.CheckSyntaxFlowWithFS(t, vf, `
+		console.log(* #-> as $all)
+	`, map[string][]string{
+		"all": {"1", "2", "3", "\"m\""},
+	}, false, ssaapi.WithLanguage(ssaconfig.TS))
 }


### PR DESCRIPTION
feat(ts2ssa, ssa): cyclic re-exports, import=require, global bindings; fix ReplaceValue; add Program export-forward table

- Implement cycle-safe handling of re-exports (`export * from`, chained re-exports).
- Support TypeScript `import x = require('...')` semantics in the ts2ssa pipeline.
- Make global variables participate correctly in import/export binding resolution.
- Fix SSA ReplaceValue bug causing incorrect substitutions in transformed graphs.
- Add `Program.ReExportTable` to record/export re-export forwarding for lookups.