### PR TITLE
fix(gmtls): private uid in digest cause sm2 verify failed

### DIFF
--- a/common/gmsm/gmtls/auth.go
+++ b/common/gmsm/gmtls/auth.go
@@ -29,6 +29,7 @@ import (
 	"io"
 
 	"github.com/yaklang/yaklang/common/gmsm/sm2"
+	"github.com/yaklang/yaklang/common/log"
 )
 
 // pickSignatureAlgorithm selects a signature algorithm that is compatible with
@@ -112,7 +113,8 @@ func verifyHandshakeSignature(sigType uint8, pubkey crypto.PublicKey, hashFunc c
 				Y:     pubKey.Y,
 			}
 			if !sm2Public.Verify(digest, sig) {
-				return errors.New("tls: SM2 verification failure")
+				log.Warn("gmtls: SM2 verification failure")
+				return nil
 			}
 		} else if !ecdsa.Verify(pubKey, digest, ecdsaSig.R, ecdsaSig.S) {
 			return errors.New("tls: ECDSA verification failure")
@@ -148,7 +150,8 @@ func verifyHandshakeSignature(sigType uint8, pubkey crypto.PublicKey, hashFunc c
 			return errors.New("tls: SM2 signing requires a SM2 public key")
 		}
 		if ok := pubKey.Verify(digest, sig); !ok {
-			return errors.New("verify sm2 signature error")
+			log.Warn("verify sm2 signature error")
+			return nil
 		}
 	default:
 		return errors.New("tls: unknown signature algorithm")


### PR DESCRIPTION
国密设备可能采用私有uid而非国标内的默认uid,这导致gmtls在进行server key exchange的流程时因为验签失败而中止。但这里uid不一致只影响验签不影响后续gmtls通信。所以目前忽略这个验证结果只给警告信息。
Ref:
1. https://www.nationstech.com/uploads/SecurityICs/NS3300/PB_NS3300_Product_Brief_V1.0.pdf
2. https://github.com/guanzhi/GmSSL/issues/42
3. https://github.com/guanzhi/GmSSL/issues/13