### PR TITLE
fix(crawler):fix send on closed channel panic

### DIFF
--- a/common/crawler/core.go
+++ b/common/crawler/core.go
@@ -849,6 +849,12 @@ func (c *Crawler) preReq(r *Req) bool {
 
 func (c *Crawler) submit(r *Req) {
 	c.reqWaitGroup.Add(1)
+	defer func() {
+		if err := recover(); err != nil {
+			// channel 已关闭，回滚 WaitGroup 计数
+			c.reqWaitGroup.Done()
+		}
+	}()
 	select {
 	case c.reqChan <- r:
 	}


### PR DESCRIPTION

[36m[INFO][0m 2026-01-12 11:06:20 [js:106] Found param from XMLHttpRequest with API EndPoint: 

panic: send on closed channel

goroutine 8138 [running]:
github.com/yaklang/yaklang/common/crawler.(*Crawler).submit(...)
	/Users/runner/work/yaklang/yaklang/common/crawler/core.go:853
github.com/yaklang/yaklang/common/crawler.(*Crawler).handleReqResult.func1(0xe0?, {0x141239705b0?, 
0x3?, 0x1400fdcfba0?})
	/Users/runner/work/yaklang/yaklang/common/crawler/core.go:566 +0xd0
github.com/yaklang/yaklang/common/crawler.(*Crawler).handleReqResult.func5.1(0x70?, {0x141239705b0?, 0xd0?, 0x14002b6af68?})
	/Users/runner/work/yaklang/yaklang/common/crawler/core.go:679 +0x28
github.com/yaklang/yaklang/common/crawler.HandleJSGetNewRequest.func2(0x14178671b40)
	/Users/runner/work/yaklang/yaklang/common/crawler/js.go:43 +0x384
github.com/yaklang/yaklang/common/crawler.handleJS.func2(0x1417992ea90)
	/Users/runner/work/yaklang/yaklang/common/crawler/js.go:107 +0xd4
github.com/yaklang/yaklang/common/yak/ssaapi.Values.ForEach(...)
	/Users/runner/work/yaklang/yaklang/common/yak/ssaapi/values.go:1224
github.com/yaklang/yaklang/common/crawler.handleJS({0x1400c5e2000, 0x1911f7}, 0x1400fdcfec8)
	/Users/runner/work/yaklang/yaklang/common/crawler/js.go:66 +0x114
github.com/yaklang/yaklang/common/crawler.HandleJSGetNewRequest(0x0?, {0x14005b06140?, 0xa3?, 0x140?}, {0x1400c5e2000?, 0x1911f7?}, {0x140046ee790?, 0x1?, 0x1?})
	/Users/runner/work/yaklang/yaklang/common/crawler/js.go:54 +0x84
github.com/yaklang/yaklang/common/crawler.(*Crawler).handleReqResult.func5()
	/Users/runner/work/yaklang/yaklang/common/crawler/core.go:678 +0xcc
github.com/yaklang/yaklang/common/utils.CallWithTimeout.func1()
	/Users/runner/work/yaklang/yaklang/common/utils/utils.go:428 +0x2c
created by github.com/yaklang/yaklang/common/utils.CallWithTimeout in goroutine 6531
	/Users/runner/work/yaklang/yaklang/common/utils/utils.go:427 +0xac