### PR TITLE
feat(cve): add AICompleteFields, Export, Import functions

### DIFF
--- a/common/cve/cvequeryops/cve_ai.go
+++ b/common/cve/cvequeryops/cve_ai.go
@@ -1,0 +1,411 @@
+package cvequeryops
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/jinzhu/gorm"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/cve/cveresources"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
+
+	// import aiforge to register liteforge callback
+	_ "github.com/yaklang/yaklang/common/aiforge"
+)
+
+// CVEAICompleteConfig holds configuration for CVE AI completion
+type CVEAICompleteConfig struct {
+	Concurrent int   // Number of concurrent workers
+	TestLimit  int   // Limit number of CVEs to process (0 = no limit)
+	aiOpts     []any // AI options to pass to LiteForge
+}
+
+// CVEAICompleteOption is a function type for configuring CVE AI completion
+type CVEAICompleteOption func(*CVEAICompleteConfig)
+
+// WithCVEAIConcurrent sets the number of concurrent workers for AI completion
+func WithCVEAIConcurrent(n int) CVEAICompleteOption {
+	return func(c *CVEAICompleteConfig) {
+		if n > 0 {
+			c.Concurrent = n
+		}
+	}
+}
+
+// WithCVETestLimit sets the maximum number of CVEs to process (for testing)
+func WithCVETestLimit(n int) CVEAICompleteOption {
+	return func(c *CVEAICompleteConfig) {
+		if n > 0 {
+			c.TestLimit = n
+		}
+	}
+}
+
+// cveTranslationTask represents a single CVE translation task
+type cveTranslationTask struct {
+	cve    *cveresources.CVE
+	prompt string
+	index  int
+	total  int
+}
+
+// cveTranslationResult represents the result of a translation task
+type cveTranslationResult struct {
+	cve     *cveresources.CVE
+	success bool
+	err     error
+}
+
+// CVEAICompleteFields uses AI to complete missing CVE fields like translations
+// Usage:
+//   - cve.AICompleteFields() - use default settings
+//   - cve.AICompleteFields(ai.type("openai")) - specify AI type
+//   - cve.AICompleteFields(cve.aiConcurrent(10)) - use 10 concurrent workers
+//   - cve.AICompleteFields(cve.testLimit(5)) - only process 5 CVEs for testing
+//   - cve.AICompleteFields(cve.aiConcurrent(10), cve.testLimit(5), ai.type("openai"))
+func CVEAICompleteFields(opts ...any) error {
+	// Parse options
+	config := &CVEAICompleteConfig{
+		Concurrent: 5, // Default: parallel processing with 5 concurrent workers
+		TestLimit:  0, // Default: no limit
+	}
+
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case CVEAICompleteOption:
+			v(config)
+		default:
+			// Pass other options (like ai.type, ai.model) to LiteForge
+			config.aiOpts = append(config.aiOpts, opt)
+		}
+	}
+
+	db := consts.GetGormCVEDatabase()
+	if db == nil {
+		return utils.Errorf("cannot get CVE database")
+	}
+
+	// Count total CVEs to process
+	var totalCount int
+	if err := db.Model(&cveresources.CVE{}).Count(&totalCount).Error; err != nil {
+		return utils.Errorf("count CVE entries failed: %v", err)
+	}
+	log.Infof("found %d CVE entries in database", totalCount)
+
+	if totalCount == 0 {
+		return utils.Errorf("no CVE entries found in database, please run cve.Download() and cve.LoadCVE() first")
+	}
+
+	// Collect CVEs that need translation
+	var cvesToProcess []*cveresources.CVE
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	skippedCount := 0
+	for cve := range cveresources.YieldCVEs(db, ctx) {
+		// Skip if already has Chinese translations
+		if cve.TitleZh != "" && cve.DescriptionMainZh != "" {
+			skippedCount++
+			continue
+		}
+		cvesToProcess = append(cvesToProcess, cve)
+
+		// Check test limit
+		if config.TestLimit > 0 && len(cvesToProcess) >= config.TestLimit {
+			log.Infof("test limit reached: %d CVEs", config.TestLimit)
+			break
+		}
+	}
+
+	needProcess := len(cvesToProcess)
+	log.Infof("need to process %d CVEs, skipped %d (already translated)", needProcess, skippedCount)
+
+	if needProcess == 0 {
+		log.Infof("no CVEs need translation")
+		return nil
+	}
+
+	// Adjust concurrent workers
+	concurrent := config.Concurrent
+	if concurrent > needProcess {
+		concurrent = needProcess
+	}
+	log.Infof("using %d concurrent workers", concurrent)
+
+	// Create task and result channels
+	taskChan := make(chan *cveTranslationTask, needProcess)
+	resultChan := make(chan *cveTranslationResult, needProcess)
+
+	// Start workers
+	var wg sync.WaitGroup
+	for i := 0; i < concurrent; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for task := range taskChan {
+				result := processCVETranslation(ctx, db, task, config.aiOpts)
+				resultChan <- result
+			}
+		}(i)
+	}
+
+	// Send tasks
+	go func() {
+		for i, cve := range cvesToProcess {
+			prompt := generateCVETranslationPrompt(cve)
+			taskChan <- &cveTranslationTask{
+				cve:    cve,
+				prompt: prompt,
+				index:  i + 1,
+				total:  needProcess,
+			}
+		}
+		close(taskChan)
+	}()
+
+	// Wait for all workers to finish and close result channel
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	// Collect results
+	successCount := 0
+	errorCount := 0
+	for result := range resultChan {
+		if result.success {
+			successCount++
+		} else {
+			errorCount++
+		}
+	}
+
+	log.Infof("AI completion finished: %d total, %d success, %d skipped, %d errors",
+		needProcess, successCount, skippedCount, errorCount)
+	return nil
+}
+
+// processCVETranslation processes a single CVE translation task
+func processCVETranslation(ctx context.Context, db *gorm.DB, task *cveTranslationTask, aiOpts []any) *cveTranslationResult {
+	cve := task.cve
+	log.Infof("processing %s (%d/%d): %s/%s", cve.CVE, task.index, task.total, cve.Vendor, cve.Product)
+
+	result, err := invokeCVETranslationLiteForge(ctx, task.prompt, aiOpts...)
+	if err != nil {
+		log.Warnf("LiteForge failed for %s: %v", cve.CVE, err)
+		return &cveTranslationResult{cve: cve, success: false, err: err}
+	}
+
+	// Extract fields from result
+	if result != nil {
+		if titleZh := result.GetString("title_zh"); titleZh != "" {
+			cve.TitleZh = titleZh
+		}
+		if descZh := result.GetString("description_zh"); descZh != "" {
+			cve.DescriptionMainZh = descZh
+		}
+		if solution := result.GetString("solution"); solution != "" && cve.Solution == "" {
+			cve.Solution = solution
+		}
+	}
+
+	// Validate that we got at least a title translation
+	if cve.TitleZh == "" {
+		log.Warnf("failed to extract Chinese title for %s", cve.CVE)
+		return &cveTranslationResult{cve: cve, success: false, err: utils.Errorf("no title_zh extracted")}
+	}
+
+	// Save updated CVE to database using Table to bypass BeforeSave hook
+	if err := db.Table("cves").Where("cve = ?", cve.CVE).Updates(map[string]interface{}{
+		"title_zh":            cve.TitleZh,
+		"description_main_zh": cve.DescriptionMainZh,
+		"solution":            cve.Solution,
+	}).Error; err != nil {
+		log.Warnf("save %s failed: %v", cve.CVE, err)
+		return &cveTranslationResult{cve: cve, success: false, err: err}
+	}
+
+	// Print translation result for user to verify quality
+	log.Infof("%s completed:", cve.CVE)
+	log.Infof("  [%s]: %s", cve.TitleZh, truncateString(cve.DescriptionMainZh, 100))
+	if cve.Solution != "" {
+		log.Infof("  [Solution]: %s", truncateString(cve.Solution, 100))
+	}
+
+	return &cveTranslationResult{cve: cve, success: true}
+}
+
+// invokeCVETranslationLiteForge calls AI using LiteForge with structured output schema
+func invokeCVETranslationLiteForge(ctx context.Context, prompt string, opts ...any) (*aicommon.ForgeResult, error) {
+	// Build LiteForge options with output schema
+	var liteforgeOpts []any
+
+	// Set context
+	liteforgeOpts = append(liteforgeOpts, aicommon.WithContext(ctx))
+
+	// Set output schema using aicommon.WithLiteForgeOutputSchemaFromAIToolOptions
+	liteforgeOpts = append(liteforgeOpts, aicommon.WithLiteForgeOutputSchemaFromAIToolOptions(
+		aitool.WithStringParam("title_zh",
+			aitool.WithParam_Description("A concise Chinese title for this CVE vulnerability"),
+			aitool.WithParam_Required(true),
+		),
+		aitool.WithStringParam("description_zh",
+			aitool.WithParam_Description("Chinese translation of the CVE description"),
+			aitool.WithParam_Required(true),
+		),
+		aitool.WithStringParam("solution",
+			aitool.WithParam_Description("Brief solution or mitigation for this vulnerability in Chinese"),
+		),
+	))
+
+	// Add user-provided options (like ai.type, ai.model, etc.)
+	liteforgeOpts = append(liteforgeOpts, opts...)
+
+	// Execute LiteForge
+	result, err := aicommon.InvokeLiteForge(prompt, liteforgeOpts...)
+	if err != nil {
+		return nil, utils.Errorf("invoke liteforge failed: %v", err)
+	}
+
+	return result, nil
+}
+
+// generateCVETranslationPrompt generates a prompt for AI to translate CVE fields
+func generateCVETranslationPrompt(cve *cveresources.CVE) string {
+	var prompt strings.Builder
+
+	prompt.WriteString("You are a security expert and translator. ")
+	prompt.WriteString("Please translate the following CVE vulnerability information to Chinese. ")
+	prompt.WriteString("Also provide a brief solution or mitigation for this vulnerability.\n\n")
+
+	prompt.WriteString(fmt.Sprintf("CVE ID: %s\n", cve.CVE))
+	if cve.CWE != "" {
+		prompt.WriteString(fmt.Sprintf("CWE: %s\n", cve.CWE))
+	}
+	prompt.WriteString(fmt.Sprintf("Description: %s\n", cve.DescriptionMain))
+	if cve.Severity != "" {
+		prompt.WriteString(fmt.Sprintf("Severity: %s\n", cve.Severity))
+	}
+	if cve.Vendor != "" {
+		prompt.WriteString(fmt.Sprintf("Vendor: %s\n", cve.Vendor))
+	}
+	if cve.Product != "" {
+		prompt.WriteString(fmt.Sprintf("Product: %s\n", cve.Product))
+	}
+	if cve.BaseCVSSv2Score > 0 {
+		prompt.WriteString(fmt.Sprintf("CVSS Score: %.1f\n", cve.BaseCVSSv2Score))
+	}
+
+	prompt.WriteString("\nPlease provide:\n")
+	prompt.WriteString("1. title_zh: A concise Chinese title for this vulnerability (e.g., 'Apache Log4j 远程代码执行漏洞')\n")
+	prompt.WriteString("2. description_zh: Chinese translation of the description\n")
+	prompt.WriteString("3. solution: Brief solution or mitigation in Chinese\n")
+
+	return prompt.String()
+}
+
+// truncateString truncates a string to the specified length
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// ExportCVE exports all CVE entries to a JSONL file
+// Each line is a JSON object representing a CVE entry
+func ExportCVE(filename string) error {
+	db := consts.GetGormCVEDatabase()
+	if db == nil {
+		return utils.Errorf("cannot get CVE database")
+	}
+
+	fp, err := os.Create(filename)
+	if err != nil {
+		return utils.Errorf("create file failed: %v", err)
+	}
+	defer fp.Close()
+
+	ctx := context.Background()
+	count := 0
+
+	for cve := range cveresources.YieldCVEs(db, ctx) {
+		data, err := json.Marshal(cve)
+		if err != nil {
+			log.Errorf("marshal %s failed: %v", cve.CVE, err)
+			continue
+		}
+		fp.Write(data)
+		fp.Write([]byte{'\n'})
+		count++
+	}
+
+	log.Infof("exported %d CVE entries to %s", count, filename)
+	return nil
+}
+
+// ImportCVE imports CVE entries from a JSONL file
+// Each line should be a JSON object representing a CVE entry
+func ImportCVE(filename string) error {
+	db := consts.GetGormCVEDatabase()
+	if db == nil {
+		return utils.Errorf("cannot get CVE database")
+	}
+
+	// Auto migrate CVE table
+	if err := db.AutoMigrate(&cveresources.CVE{}).Error; err != nil {
+		return utils.Errorf("auto migrate CVE table failed: %v", err)
+	}
+
+	fp, err := os.Open(filename)
+	if err != nil {
+		return utils.Errorf("open file failed: %v", err)
+	}
+	defer fp.Close()
+
+	scanner := bufio.NewReader(fp)
+	count := 0
+	errorCount := 0
+
+	for {
+		line, err := utils.BufioReadLine(scanner)
+		if err != nil {
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			return utils.Errorf("read line failed: %v", err)
+		}
+
+		if len(line) == 0 {
+			continue
+		}
+
+		var cve cveresources.CVE
+		if err := json.Unmarshal(line, &cve); err != nil {
+			log.Errorf("unmarshal CVE failed: %v", err)
+			errorCount++
+			continue
+		}
+
+		// Save to database
+		if err := db.Save(&cve).Error; err != nil {
+			log.Errorf("save %s failed: %v", cve.CVE, err)
+			errorCount++
+			continue
+		}
+		count++
+	}
+
+	log.Infof("imported %d CVE entries from %s, %d errors", count, filename, errorCount)
+	return nil
+}

--- a/common/cve/cvequeryops/cve_ai_test.go
+++ b/common/cve/cvequeryops/cve_ai_test.go
@@ -1,0 +1,318 @@
+package cvequeryops
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/cve/cveresources"
+)
+
+func TestCVEAICompleteConfig(t *testing.T) {
+	t.Run("default config", func(t *testing.T) {
+		config := &CVEAICompleteConfig{
+			Concurrent: 5,
+			TestLimit:  0,
+		}
+		assert.Equal(t, 5, config.Concurrent)
+		assert.Equal(t, 0, config.TestLimit)
+	})
+
+	t.Run("WithCVEAIConcurrent", func(t *testing.T) {
+		config := &CVEAICompleteConfig{Concurrent: 5}
+		opt := WithCVEAIConcurrent(10)
+		opt(config)
+		assert.Equal(t, 10, config.Concurrent)
+	})
+
+	t.Run("WithCVEAIConcurrent zero ignored", func(t *testing.T) {
+		config := &CVEAICompleteConfig{Concurrent: 5}
+		opt := WithCVEAIConcurrent(0)
+		opt(config)
+		assert.Equal(t, 5, config.Concurrent) // should not change
+	})
+
+	t.Run("WithCVEAIConcurrent negative ignored", func(t *testing.T) {
+		config := &CVEAICompleteConfig{Concurrent: 5}
+		opt := WithCVEAIConcurrent(-1)
+		opt(config)
+		assert.Equal(t, 5, config.Concurrent) // should not change
+	})
+
+	t.Run("WithCVETestLimit", func(t *testing.T) {
+		config := &CVEAICompleteConfig{TestLimit: 0}
+		opt := WithCVETestLimit(100)
+		opt(config)
+		assert.Equal(t, 100, config.TestLimit)
+	})
+
+	t.Run("WithCVETestLimit zero ignored", func(t *testing.T) {
+		config := &CVEAICompleteConfig{TestLimit: 10}
+		opt := WithCVETestLimit(0)
+		opt(config)
+		assert.Equal(t, 10, config.TestLimit) // should not change
+	})
+}
+
+func TestGenerateCVETranslationPrompt(t *testing.T) {
+	t.Run("basic CVE", func(t *testing.T) {
+		cve := &cveresources.CVE{
+			CVE:             "CVE-2021-44228",
+			CWE:             "CWE-502",
+			DescriptionMain: "Apache Log4j2 allows remote code execution.",
+			Severity:        "CRITICAL",
+			Vendor:          "apache",
+			Product:         "log4j",
+			BaseCVSSv2Score: 10.0,
+		}
+
+		prompt := generateCVETranslationPrompt(cve)
+
+		assert.Contains(t, prompt, "CVE-2021-44228")
+		assert.Contains(t, prompt, "CWE-502")
+		assert.Contains(t, prompt, "Apache Log4j2")
+		assert.Contains(t, prompt, "CRITICAL")
+		assert.Contains(t, prompt, "apache")
+		assert.Contains(t, prompt, "log4j")
+		assert.Contains(t, prompt, "10.0")
+		assert.Contains(t, prompt, "title_zh")
+		assert.Contains(t, prompt, "description_zh")
+		assert.Contains(t, prompt, "solution")
+	})
+
+	t.Run("minimal CVE", func(t *testing.T) {
+		cve := &cveresources.CVE{
+			CVE:             "CVE-2020-1234",
+			DescriptionMain: "A vulnerability exists.",
+		}
+
+		prompt := generateCVETranslationPrompt(cve)
+
+		assert.Contains(t, prompt, "CVE-2020-1234")
+		assert.Contains(t, prompt, "A vulnerability exists.")
+		// Should not contain empty fields
+		assert.NotContains(t, prompt, "CWE: \n")
+	})
+}
+
+func TestTruncateString(t *testing.T) {
+	t.Run("short string unchanged", func(t *testing.T) {
+		result := truncateString("hello", 10)
+		assert.Equal(t, "hello", result)
+	})
+
+	t.Run("exact length unchanged", func(t *testing.T) {
+		result := truncateString("hello", 5)
+		assert.Equal(t, "hello", result)
+	})
+
+	t.Run("long string truncated", func(t *testing.T) {
+		result := truncateString("hello world", 5)
+		assert.Equal(t, "hello...", result)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		result := truncateString("", 10)
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestCVEExportImport(t *testing.T) {
+	// Create temp directory for test files
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test_cve.jsonl")
+
+	t.Run("export and import roundtrip", func(t *testing.T) {
+		db := consts.GetGormCVEDatabase()
+		if db == nil {
+			t.Skip("CVE database not available")
+		}
+
+		// Check if there are any CVEs in the database
+		var count int
+		db.Model(&cveresources.CVE{}).Count(&count)
+		if count == 0 {
+			t.Skip("No CVE entries in database")
+		}
+
+		// Export
+		err := ExportCVE(testFile)
+		require.NoError(t, err)
+
+		// Verify file exists and has content
+		info, err := os.Stat(testFile)
+		require.NoError(t, err)
+		assert.True(t, info.Size() > 0, "exported file should have content")
+	})
+
+	t.Run("import from file", func(t *testing.T) {
+		db := consts.GetGormCVEDatabase()
+		if db == nil {
+			t.Skip("CVE database not available")
+		}
+
+		// Create a test JSONL file with mock data
+		mockFile := filepath.Join(tempDir, "mock_cve.jsonl")
+		mockCVE := &cveresources.CVE{
+			CVE:               "CVE-TEST-0001",
+			DescriptionMain:   "Test vulnerability",
+			TitleZh:           "测试漏洞",
+			DescriptionMainZh: "这是一个测试漏洞",
+			Severity:          "HIGH",
+		}
+
+		f, err := os.Create(mockFile)
+		require.NoError(t, err)
+
+		data, err := json.Marshal(mockCVE)
+		require.NoError(t, err)
+		f.Write(data)
+		f.Write([]byte{'\n'})
+		f.Close()
+
+		// Import
+		err = ImportCVE(mockFile)
+		require.NoError(t, err)
+
+		// Verify imported data
+		var imported cveresources.CVE
+		err = db.Where("cve = ?", "CVE-TEST-0001").First(&imported).Error
+		if err == nil {
+			assert.Equal(t, "Test vulnerability", imported.DescriptionMain)
+			assert.Equal(t, "测试漏洞", imported.TitleZh)
+
+			// Cleanup
+			db.Where("cve = ?", "CVE-TEST-0001").Delete(&cveresources.CVE{})
+		}
+	})
+
+	t.Run("import empty file", func(t *testing.T) {
+		db := consts.GetGormCVEDatabase()
+		if db == nil {
+			t.Skip("CVE database not available")
+		}
+
+		emptyFile := filepath.Join(tempDir, "empty.jsonl")
+		f, err := os.Create(emptyFile)
+		require.NoError(t, err)
+		f.Close()
+
+		err = ImportCVE(emptyFile)
+		require.NoError(t, err)
+	})
+
+	t.Run("import nonexistent file", func(t *testing.T) {
+		err := ImportCVE(filepath.Join(tempDir, "nonexistent.jsonl"))
+		require.Error(t, err)
+	})
+
+	t.Run("export to invalid path", func(t *testing.T) {
+		err := ExportCVE("/nonexistent/path/file.jsonl")
+		require.Error(t, err)
+	})
+}
+
+func TestCVEAICompleteFields_NoDB(t *testing.T) {
+	// This test verifies behavior when database is not available
+	// The actual AI completion requires a real AI service
+
+	t.Run("parse options correctly", func(t *testing.T) {
+		// Test that options are parsed correctly without actually running AI
+		config := &CVEAICompleteConfig{
+			Concurrent: 5,
+			TestLimit:  0,
+		}
+
+		// Apply options
+		opts := []any{
+			WithCVEAIConcurrent(10),
+			WithCVETestLimit(3),
+			"some_ai_option", // Should be passed to aiOpts
+		}
+
+		for _, opt := range opts {
+			switch v := opt.(type) {
+			case CVEAICompleteOption:
+				v(config)
+			default:
+				config.aiOpts = append(config.aiOpts, opt)
+			}
+		}
+
+		assert.Equal(t, 10, config.Concurrent)
+		assert.Equal(t, 3, config.TestLimit)
+		assert.Len(t, config.aiOpts, 1)
+		assert.Equal(t, "some_ai_option", config.aiOpts[0])
+	})
+}
+
+func TestCVETranslationTask(t *testing.T) {
+	t.Run("task struct", func(t *testing.T) {
+		cve := &cveresources.CVE{CVE: "CVE-2021-44228"}
+		task := &cveTranslationTask{
+			cve:    cve,
+			prompt: "test prompt",
+			index:  1,
+			total:  10,
+		}
+
+		assert.Equal(t, "CVE-2021-44228", task.cve.CVE)
+		assert.Equal(t, "test prompt", task.prompt)
+		assert.Equal(t, 1, task.index)
+		assert.Equal(t, 10, task.total)
+	})
+
+	t.Run("result struct success", func(t *testing.T) {
+		cve := &cveresources.CVE{CVE: "CVE-2021-44228"}
+		result := &cveTranslationResult{
+			cve:     cve,
+			success: true,
+			err:     nil,
+		}
+
+		assert.True(t, result.success)
+		assert.Nil(t, result.err)
+	})
+
+	t.Run("result struct failure", func(t *testing.T) {
+		cve := &cveresources.CVE{CVE: "CVE-2021-44228"}
+		result := &cveTranslationResult{
+			cve:     cve,
+			success: false,
+			err:     context.DeadlineExceeded,
+		}
+
+		assert.False(t, result.success)
+		assert.Error(t, result.err)
+	})
+}
+
+// TestCVEAICompleteFields_Integration is an integration test that requires a real AI service
+// Run with: go test -v -run TestCVEAICompleteFields_Integration -tags=integration
+func TestCVEAICompleteFields_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := consts.GetGormCVEDatabase()
+	if db == nil {
+		t.Skip("CVE database not available")
+	}
+
+	var count int
+	db.Model(&cveresources.CVE{}).Count(&count)
+	if count == 0 {
+		t.Skip("No CVE entries in database")
+	}
+
+	// Only process 1 CVE for testing
+	err := CVEAICompleteFields(WithCVETestLimit(1))
+	if err != nil {
+		t.Logf("AI completion error (may be expected if no AI configured): %v", err)
+	}
+}

--- a/common/cve/export.go
+++ b/common/cve/export.go
@@ -88,6 +88,13 @@ var CVEExports = map[string]interface{}{
 	"GetCVE":        getCVE,
 	"NewStatistics": NewStatistics,
 
+	// AI completion and import/export
+	"AICompleteFields": cvequeryops.CVEAICompleteFields,
+	"Export":           cvequeryops.ExportCVE,
+	"Import":           cvequeryops.ImportCVE,
+	"aiConcurrent":     cvequeryops.WithCVEAIConcurrent,
+	"testLimit":        cvequeryops.WithCVETestLimit,
+
 	//"LoadCNNVD":    cveAction.LoadCNNVD,
 	"cwe":        cvequeryops.CWE,
 	"cve":        cvequeryops.CVE,

--- a/scripts/ci-works/rag/cve.yak
+++ b/scripts/ci-works/rag/cve.yak
@@ -1,0 +1,92 @@
+// CVE Database AI Completion Script
+// Usage:
+//   go run common/yak/cmd/yak.go scripts/ci-works/rag/cve.yak --output cve_output.jsonl --ai-limit 5
+//   go run common/yak/cmd/yak.go scripts/ci-works/rag/cve.yak --output cve_output.jsonl --ai-type openai --ai-key YOUR_API_KEY
+//   go run common/yak/cmd/yak.go scripts/ci-works/rag/cve.yak --input cve_data.jsonl --output cve_output.jsonl
+
+loglevel("info")
+
+// Parse CLI arguments
+inputFile = cli.String("input", cli.setHelp("Input JSONL file path, if exists will import first"))
+outputFile = cli.String("output", cli.setHelp("Output JSONL file path for export"), cli.setRequired(true))
+aiLimit = cli.Int("ai-limit", cli.setHelp("Limit number of CVEs to process with AI (for testing)"), cli.setDefault(0))
+aiConcurrent = cli.Int("ai-concurrent", cli.setHelp("Number of concurrent AI workers"), cli.setDefault(5))
+aiType = cli.String("ai-type", cli.setHelp("AI provider type, e.g., openai, chatglm, moonshot"))
+aiKey = cli.String("ai-key", cli.setHelp("AI API key"))
+aiModel = cli.String("ai-model", cli.setHelp("AI model name"))
+aiDomain = cli.String("ai-domain", cli.setHelp("AI API domain (for custom endpoints)"))
+aiProxy = cli.String("ai-proxy", cli.setHelp("Proxy for AI requests"))
+skipAI = cli.Bool("skip-ai", cli.setHelp("Skip AI completion step"))
+
+cli.check()
+
+log.Info("=== CVE Database AI Completion Script ===")
+log.Info("Input file: %s", inputFile)
+log.Info("Output file: %s", outputFile)
+log.Info("AI limit: %d", aiLimit)
+log.Info("AI concurrent: %d", aiConcurrent)
+log.Info("AI type: %s", aiType)
+log.Info("AI model: %s", aiModel)
+log.Info("Skip AI: %v", skipAI)
+
+// Step 1: Import if input file exists
+if inputFile != "" && file.IsExisted(inputFile) {
+    log.Info("Importing from: %s", inputFile)
+    err = cve.Import(inputFile)
+    if err != nil {
+        log.Error("Import failed: %v", err)
+        die(err)
+    }
+    log.Info("Import completed")
+} else if inputFile != "" {
+    log.Warn("Input file does not exist: %s", inputFile)
+}
+
+// Step 2: AI Complete Fields (if not skipped)
+if !skipAI {
+    log.Info("Running AI completion...")
+    aiOpts = []
+    aiOpts = append(aiOpts, cve.aiConcurrent(aiConcurrent))
+
+    if aiLimit > 0 {
+        log.Info("AI limit: %d CVEs", aiLimit)
+        aiOpts = append(aiOpts, cve.testLimit(aiLimit))
+    }
+
+    // Add AI configuration options
+    if aiType != "" {
+        aiOpts = append(aiOpts, ai.type(aiType))
+    }
+    if aiKey != "" {
+        aiOpts = append(aiOpts, ai.apiKey(aiKey))
+    }
+    if aiModel != "" {
+        aiOpts = append(aiOpts, ai.model(aiModel))
+    }
+    if aiDomain != "" {
+        aiOpts = append(aiOpts, ai.domain(aiDomain))
+    }
+    if aiProxy != "" {
+        aiOpts = append(aiOpts, ai.proxy(aiProxy))
+    }
+
+    err = cve.AICompleteFields(aiOpts...)
+    if err != nil {
+        log.Error("AI completion failed: %v", err)
+        die(err)
+    }
+    log.Info("AI completion finished")
+} else {
+    log.Info("AI completion skipped")
+}
+
+// Step 3: Export to output file
+log.Info("Exporting to: %s", outputFile)
+err = cve.Export(outputFile)
+if err != nil {
+    log.Error("Export failed: %v", err)
+    die(err)
+}
+log.Info("Export completed")
+
+log.Info("=== Script completed ===")


### PR DESCRIPTION
为CVE模块添加AI补全和导入导出功能，与CWE模块保持一致的API风格。

## 新增功能

- `cve.AICompleteFields()` - AI补全TitleZh、DescriptionMainZh、Solution字段
- `cve.Export()` - 导出CVE到JSONL文件
- `cve.Import()` - 从JSONL导入CVE
- `cve.aiConcurrent()` / `cve.testLimit()` - 配置选项

## 使用示例

```yak
// AI补全
cve.AICompleteFields(cve.testLimit(5), ai.type("openai"), ai.apiKey("sk-xxx"))

// 导出导入
cve.Export("cve.jsonl")
cve.Import("cve.jsonl")
```

## 新增文件

- `common/cve/cvequeryops/cve_ai.go` - 核心实现
- `common/cve/cvequeryops/cve_ai_test.go` - 单元测试
- `scripts/ci-works/rag/cve.yak` - 使用示例脚本

## 修改文件

- `common/cve/export.go` - 添加导出项