### PR TITLE
ci: rebalance essential ssa suites and improve failure summary

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -273,11 +273,11 @@ jobs:
         env:
           GOCACHE: ${{ env.GOCACHE }}
           GOMODCACHE: ${{ env.GOMODCACHE }}
+          COMPILE_WORKERS: "2"
+          GO_TEST_P: "1"
         run: |
           export TEST_BIN_DIR="${{ runner.temp }}/test_binaries"
           export TEST_CONFIG="${{ runner.temp }}/prepare_yakgrpc_test_config.json"
-          export COMPILE_WORKERS=2
-          export GO_TEST_P=1
           ./scripts/ci/test-compile.sh
 
       - name: Package shared suite
@@ -346,11 +346,11 @@ jobs:
         env:
           GOCACHE: ${{ env.GOCACHE }}
           GOMODCACHE: ${{ env.GOMODCACHE }}
+          COMPILE_WORKERS: "1"
+          GO_TEST_P: "1"
         run: |
           export TEST_BIN_DIR="${{ runner.temp }}/test_binaries"
           export TEST_CONFIG="${{ runner.temp }}/prepare_coreplugin_test_config.json"
-          export COMPILE_WORKERS=1
-          export GO_TEST_P=1
           ./scripts/ci/test-compile.sh
 
       - name: Package shared suite
@@ -401,16 +401,6 @@ jobs:
                 {"package": ".common/crep/...", "timeout": "5m"}
               ]
 
-          - name: "Test SFWeb / Integration SyntaxFlow / SFDB / SFVM / SFReport"
-            sync_rule: "1"
-            test_configs: |
-              [
-                {"package": "./common/sfweb/...", "timeout": "4m"},
-                {"package": "./common/syntaxflow/tests", "timeout": "20s"},
-                {"package": "./common/syntaxflow/sfdb/...", "timeout": "20s"},
-                {"package": "./common/syntaxflow/sfvm/...", "timeout": "20s"},
-                {"package": "./common/yak/ssaapi/sfreport/...", "timeout": "1m"}
-              ]
           - name: "Test Utils Infra / Parser / Net in 2min USE gRPC"
             test_configs: |
               [
@@ -480,46 +470,59 @@ jobs:
                 {"package": "./common/yak/ssaapi/ssaconfig", "timeout": "20s"}
               ]
 
-          - name: "Test SSA Frontend Java / JS(TS|ES)"
+          - name: "Test SSA Frontend Java / JS(TS|ES) / Yak / Python / Golang / C"
+            compile_workers: "3"
+            go_test_p: "1"
             test_configs: |
               [
-                {"package": "./common/yak/java/...", "timeout": "5m"},
-                {"package": "./common/yak/ssaapi/test/java/...", "timeout": "3m"},
+                {"package": "./common/yak/java/...", "timeout": "8m"},
+                {"package": "./common/yak/ssaapi/test/java/...", "timeout": "4m"},
                 {"package": "./common/yak/typescript/...", "timeout": "2m"},
-                {"package": "./common/yak/ssaapi/test/javascript/...", "timeout": "1m"}
-              ]
-
-          - name: "Test SSA Frontend Yak / PHP / Python / Golang / C / SSAAPI Other"
-            test_configs: |
-              [
+                {"package": "./common/yak/ssaapi/test/javascript/...", "timeout": "1m"},
                 {"package": "./common/yak/yak2ssa/test/...", "timeout": "20s"},
                 {"package": "./common/yak/ssaapi/test/yak/...", "timeout": "1m"},
                 {"package": "./common/yak/antlr4yak/lsp/...", "timeout": "20s"},
-                {"package": "./common/yak/php/...", "timeout": "5m"},
-                {"package": "./common/yak/ssaapi/test/php/...", "timeout": "2m"},
-                {"package": "./common/yak/python/...", "timeout": "2m"},
-                {"package": "./common/yak/ssaapi/test/python/...", "timeout": "1m"},
+                {"package": "./common/yak/python/...", "timeout": "4m"},
+                {"package": "./common/yak/ssaapi/test/python/...", "timeout": "2m"},
                 {"package": "./common/yak/go2ssa/...", "timeout": "3m"},
-                {"package": "./common/yak/antlr4go/...", "timeout": "30s"},
-                {"package": "./common/yak/ssaapi/test/golang/...", "timeout": "2m"},
+                {"package": "./common/yak/antlr4go/...", "timeout": "2m"},
+                {"package": "./common/yak/ssaapi/test/golang/...", "timeout": "3m"},
                 {"package": "./common/yak/c2ssa/...", "timeout": "30s"},
                 {"package": "./common/yak/antlr4c/...", "timeout": "30s"},
-                {"package": "./common/yak/ssaapi/test/c/...", "timeout": "2m"},
-                {"package": "./common/yak/ssaapi/test/...", "timeout": "2m", "exclude_packages": ["./common/yak/ssaapi/test/yak/...", "./common/yak/ssaapi/test/java/...", "./common/yak/ssaapi/test/javascript/...", "./common/yak/ssaapi/test/php/...", "./common/yak/ssaapi/test/python/...", "./common/yak/ssaapi/test/golang/...", "./common/yak/ssaapi/test/c/...", "./common/yak/ssaapi/test/syntaxflow/...", "./common/yak/ssaapi/test/ssatest/..."]}
+                {"package": "./common/yak/ssaapi/test/c/...", "timeout": "2m"}
               ]
 
-          - name: "Test StaticAnalyze / Builtin SyntaxFlow Rule / SSA / SSA-API / SF Scan"
+          - name: "Test SSA / SSAAPI Core / SyntaxFlow / StaticAnalyze / SFDB / SFVM"
+            sync_rule: "1"
+            compile_workers: "3"
+            go_test_p: "1"
             test_configs: |
               [
-                {"package": "./common/yak/static_analyzer/test/...", "timeout": "20s"},
-                {"package": "./common/syntaxflow/sfbuildin/...", "timeout": "5m"},
-                {"package": "./common/yak/ssaapi/test/syntaxflow/...", "timeout": "1m"},
-                {"package": "./common/syntaxflow/sfanalysis/...", "timeout": "20s"},
                 {"package": "./common/yak/ssa/...", "timeout": "20s"},
                 {"package": "./common/yak/ssaapi", "timeout": "1m"},
                 {"package": "./common/yak/ssaapi/ssareducer", "timeout": "1m"},
                 {"package": "./common/yak/ssaapi/test/ssatest/...", "timeout": "1m"},
+                {"package": "./common/yak/ssaapi/test/...", "timeout": "2m", "exclude_packages": ["./common/yak/ssaapi/test/yak/...", "./common/yak/ssaapi/test/java/...", "./common/yak/ssaapi/test/javascript/...", "./common/yak/ssaapi/test/php/...", "./common/yak/ssaapi/test/python/...", "./common/yak/ssaapi/test/golang/...", "./common/yak/ssaapi/test/c/...", "./common/yak/ssaapi/test/syntaxflow/...", "./common/yak/ssaapi/test/ssatest/..."]},
+                {"package": "./common/syntaxflow/tests", "timeout": "20s"},
+                {"package": "./common/syntaxflow/sfdb/...", "timeout": "20s"},
+                {"package": "./common/syntaxflow/sfvm/...", "timeout": "20s"},
+                {"package": "./common/syntaxflow/sfbuildin/...", "timeout": "5m"},
+                {"package": "./common/yak/ssaapi/test/syntaxflow/...", "timeout": "1m"},
+                {"package": "./common/syntaxflow/sfanalysis/...", "timeout": "20s"},
+                {"package": "./common/yak/static_analyzer/test/...", "timeout": "20s"},
                 {"package": "./common/yak/syntaxflow_scan/...", "timeout": "1m"}
+              ]
+
+          - name: "Test SSA PHP / SSAAPI PHP / SFWeb / SFReport"
+            sync_rule: "1"
+            compile_workers: "3"
+            go_test_p: "1"
+            test_configs: |
+              [
+                {"package": "./common/yak/php/...", "timeout": "5m"},
+                {"package": "./common/yak/ssaapi/test/php/...", "timeout": "3m"},
+                {"package": "./common/sfweb/...", "timeout": "4m"},
+                {"package": "./common/yak/ssaapi/sfreport/...", "timeout": "1m"}
               ]
 
           - name: "Test AI Aid / React"
@@ -605,11 +608,11 @@ jobs:
         env:
           GOCACHE: ${{ env.GOCACHE }}
           GOMODCACHE: ${{ env.GOMODCACHE }}
+          COMPILE_WORKERS: ${{ matrix.compile_workers || '' }}
+          GO_TEST_P: ${{ matrix.go_test_p || '' }}
         run: |
           export TEST_BIN_DIR="${{ runner.temp }}/test_binaries"
           export TEST_CONFIG="${{ runner.temp }}/test_config.json"
-          export COMPILE_WORKERS=2
-          export GO_TEST_P=1
           ./scripts/ci/test-compile.sh
 
       - name: ${{ matrix.name }}

--- a/scripts/ci/test-compile.sh
+++ b/scripts/ci/test-compile.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # 可覆写：编译 worker 数、go test -p、输出目录、测试配置
 DEFAULT_CPUS=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu || echo 2)
 COMPILE_WORKERS=${COMPILE_WORKERS:-${JOBS:-$DEFAULT_CPUS}}
-GO_TEST_P=${GO_TEST_P:-1}
+GO_TEST_P="${GO_TEST_P:-}"
 TEST_BIN_DIR="${TEST_BIN_DIR:-./test_binaries}"
 TEST_CONFIG="${TEST_CONFIG:-}"  # 测试配置文件（JSON格式），必须提供
 RESET_TEST_BIN_DIR="${RESET_TEST_BIN_DIR:-1}"  # 0=保留已有产物并增量编译
@@ -26,7 +26,11 @@ fi
 
 echo "=== Compile Tests from Config ==="
 echo "COMPILE_WORKERS=$COMPILE_WORKERS"
-echo "GO_TEST_P=$GO_TEST_P"
+if [[ -n "$GO_TEST_P" ]]; then
+  echo "GO_TEST_P=$GO_TEST_P"
+else
+  echo "GO_TEST_P=<go default>"
+fi
 echo "BIN_DIR=$TEST_BIN_DIR"
 echo "CONFIG=$TEST_CONFIG"
 echo "RESET_TEST_BIN_DIR=$RESET_TEST_BIN_DIR"
@@ -176,8 +180,12 @@ compile_one() {
   fi
 
   # 构建编译参数
-  local compile_args=("-p=$GO_TEST_P" "-c" "-o" "$bin")
+  local compile_args=("-c" "-o" "$bin")
   local enable_race_for_pkg=0
+
+  if [[ -n "$GO_TEST_P" ]]; then
+    compile_args=("-p=$GO_TEST_P" "${compile_args[@]}")
+  fi
   
   # 检查该包是否需要启用race检测
   if should_enable_race "$pkg"; then

--- a/scripts/ci/test-run.sh
+++ b/scripts/ci/test-run.sh
@@ -29,7 +29,7 @@ build_package_map() {
     pkg_file="${bin}.package"
     if [[ ! -f "$pkg_file" ]]; then
       echo "WARNING: Skipping binary because package metadata is missing: $(basename "$bin").package"
-      ((skipped_entries++))
+      ((++skipped_entries))
       continue
     fi
     pkg_path="$(cat "$pkg_file")"
@@ -243,6 +243,10 @@ run_test() {
       echo "✅ Completed in ${final_mins}m${final_secs}s"
     else
       echo "❌ Failed after ${final_mins}m${final_secs}s (exit code: $code)"
+      {
+        echo "FAIL: $name (exit=$code, attempt=$((attempt + 1))/$((max_retries + 1)))"
+        echo "FAIL_ELAPSED: ${final_mins}m${final_secs}s"
+      } >> "$log"
     fi
     
     exec 3>&-  # 关闭文件描述符
@@ -258,11 +262,11 @@ run_test() {
       # 如果还有重试机会，显示详细日志摘要
       if [[ $attempt -lt $max_retries ]]; then
         echo "失败日志摘要："
-        grep -E "(FAIL|--- FAIL|panic:|test timed out|TLS handshake error)" "$log" | head -20 | sed 's/^/  /'
+        grep -aE "(FAIL|--- FAIL|panic:|test timed out|TLS handshake error)" "$log" | head -20 | sed 's/^/  /'
       fi
     fi
     
-    ((attempt++))
+    ((++attempt))
   done
   
   if [[ $success -eq 0 ]]; then
@@ -359,7 +363,7 @@ if [[ -n "$TEST_CONFIG" && -f "$TEST_CONFIG" ]]; then
     done
     
     if [[ $is_processed -eq 0 ]]; then
-      ((uncovered_count++))
+      ((++uncovered_count))
       uncovered_tests+=("${ALL_TEST_PKGS[$i]}")
     fi
   done
@@ -394,6 +398,102 @@ echo ""
 echo "=== Test Summary ==="
 echo "Total tests: ${#ALL_TEST_BINS[@]}"
 
+extract_failed_test_names() {
+  local log="$1"
+  grep -aE '^--- FAIL: ' "$log" | sed -E 's/^--- FAIL: ([^ ]+).*/\1/' | sort -u | paste -sd ', ' - || true
+}
+
+extract_failure_reason() {
+  local log="$1"
+  local reason=""
+
+  reason=$(grep -am1 -E 'test timed out|panic:|Error:[[:space:]]|should have|first record does not look like a TLS handshake|connection reset by peer|context deadline exceeded|testing:|flag provided but not defined|invalid value|Usage of ' "$log" || true)
+  if [[ -z "$reason" ]]; then
+    reason=$(grep -am1 -E '^--- FAIL: ' "$log" || true)
+  fi
+  if [[ -z "$reason" ]]; then
+    reason=$(grep -am1 -E '^FAIL: ' "$log" || true)
+  fi
+  if [[ -z "$reason" ]]; then
+    reason=$(grep -am1 -v -E '^(Command:|Test:|Config:|Retry:|----|[[:space:]]*$)' "$log" || true)
+  fi
+
+  printf '%s\n' "$reason" | sed -E 's/^[[:space:]]+//'
+}
+
+extract_failure_elapsed() {
+  local log="$1"
+  grep -am1 '^FAIL_ELAPSED: ' "$log" | sed -E 's/^FAIL_ELAPSED: //' || true
+}
+
+extract_timeout_running_tests() {
+  local log="$1"
+  awk '
+    /running tests:/ { capture=1; next }
+    capture {
+      line=$0
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      if (line == "") {
+        next
+      }
+      if (line ~ /^goroutine / || line ~ /^created by / || line ~ /^\//) {
+        exit
+      }
+      print line
+    }
+  ' "$log" | head -20
+}
+
+extract_failed_case_details() {
+  local log="$1"
+  awk '
+    function trim(s) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+      return s
+    }
+    {
+      lines[NR] = $0
+    }
+    /^--- FAIL: / {
+      name = $3
+      sub(/\(.*/, "", name)
+      if (!(name in seen)) {
+        seen[name] = 1
+        order[++count] = name
+      }
+    }
+    END {
+      for (i = 1; i <= count; i++) {
+        name = order[i]
+        reason = ""
+        fail_line = 0
+
+        for (j = 1; j <= NR; j++) {
+          if (lines[j] ~ ("^--- FAIL: " name "([[:space:]]|$)")) {
+            fail_line = j
+            break
+          }
+        }
+
+        if (fail_line > 0) {
+          start = fail_line - 20
+          if (start < 1) {
+            start = 1
+          }
+          for (j = fail_line - 1; j >= start; j--) {
+            if (lines[j] ~ /panic:|Error:[[:space:]]*|Received unexpected error|should have|not greater than|testing:|flag provided but not defined|invalid value|context deadline exceeded|first record does not look like a TLS handshake|connection reset by peer/) {
+              reason = trim(lines[j])
+              break
+            }
+          }
+        }
+
+        print name "|" reason
+      }
+    }
+  ' "$log"
+}
+
 if [[ $rc -eq 0 ]]; then
   echo "Result: ALL PASSED"
 else
@@ -402,8 +502,46 @@ else
   echo "Failed tests:"
   # 列出所有包含失败标记的日志
   while IFS= read -r log; do
-    if grep -q "^FAIL:" "$log" || grep -q "^--- FAIL:" "$log" || grep -q "^FAIL$" "$log"; then
-      echo "  - $(basename "$log" .run.log)"
+    if grep -aEq "^FAIL:|^--- FAIL:|^FAIL$|test timed out|^panic:" "$log"; then
+      test_name="$(basename "$log" .run.log)"
+      failed_cases="$(extract_failed_test_names "$log")"
+      failure_reason="$(extract_failure_reason "$log")"
+      failure_elapsed="$(extract_failure_elapsed "$log")"
+
+      if grep -aEq 'test timed out' "$log"; then
+        echo "  - ${test_name}"
+        [[ -n "$failure_reason" ]] && echo "    reason: ${failure_reason}"
+        [[ -n "$failure_elapsed" ]] && echo "    elapsed: ${failure_elapsed}"
+        printed_running_tests=0
+        while IFS= read -r running_test; do
+          [[ -z "$running_test" ]] && continue
+          if [[ $printed_running_tests -ne 1 ]]; then
+            echo "    running tests:"
+            printed_running_tests=1
+          fi
+          echo "      ${running_test}"
+        done < <(extract_timeout_running_tests "$log")
+        printed_running_tests=0
+        continue
+      fi
+
+      emitted_case_details=0
+      while IFS='|' read -r failed_case case_reason; do
+        [[ -z "$failed_case" ]] && continue
+        emitted_case_details=1
+        echo "  - ${test_name} :: ${failed_case}"
+        [[ -n "$case_reason" ]] && echo "    reason: ${case_reason}"
+      done < <(extract_failed_case_details "$log")
+
+      if [[ $emitted_case_details -eq 1 ]]; then
+        [[ -n "$failure_elapsed" ]] && echo "    elapsed: ${failure_elapsed}"
+        continue
+      fi
+
+      echo "  - ${test_name}"
+      [[ -n "$failed_cases" ]] && echo "    failed cases: ${failed_cases}"
+      [[ -n "$failure_reason" ]] && echo "    reason: ${failure_reason}"
+      [[ -n "$failure_elapsed" ]] && echo "    elapsed: ${failure_elapsed}"
     fi
   done < <(find "$TEST_LOG_DIR" -maxdepth 1 -type f -name "test_*.run.log" | sort)
 fi


### PR DESCRIPTION
## 概要
- 重新平衡 essential 中 SSA 相关测试分组，尽量压低最长路径
- 让 `scripts/ci/test-compile.sh` 支持由 workflow 传入编译并发和 `go test -p`
- 改进 `scripts/ci/test-run.sh` 的失败汇总，让 timeout 和直接退出类失败都能报出具体测试、原因和耗时

## 主要修改
- 将 SSA 相关 job 调整为三组：
  - `Test SSA Frontend Java / JS(TS|ES) / Yak / Python / Golang / C`
  - `Test SSA / SSAAPI Core / SyntaxFlow / StaticAnalyze / SFDB / SFVM`
  - `Test SSA PHP / SSAAPI PHP / SFWeb / SFReport`
- 编译阶段不再把 `COMPILE_WORKERS=2`、`GO_TEST_P=1` 写死，而是允许按矩阵配置传入
- 改进 `scripts/ci/test-run.sh` 的错误收集：
  - 对 `exit=2` 这类直接退出失败，把标准化的 `FAIL` 和 `elapsed` 元信息回写进 `.run.log`
  - 对 timeout 场景，汇总时额外显示耗时和 timeout 发生时正在运行的测试
  - 对普通断言失败，按 failed case 展开，而不是只给一行合并后的 `failed cases:`

## 错误收集
### 普通错误收集
验证 job：
- https://github.com/yaklang/yaklang/actions/runs/24234188597/job/70753324770

现在的 summary 会先给出具体 test binary，然后把 failed case 一条一条展开，并给每条失败对应的原因。例如：

```text
=== Test Summary ===
Total tests: 38
Result: SOME FAILED

Failed tests:
  - test_common_yak_ssaapi_test_java
    reason: testing: -parallel can only be given a positive integer
    elapsed: 0m1s
  - test_common_yak_ssaapi_test_javascript_cwe-094-template-object-injection :: TestTemplateObjectInjection_BodyProfileDirectRender
    reason: Error:
"0" is not greater than or equal to "1"
  - test_common_yak_ssaapi_test_javascript_cwe-094-template-object-injection :: TestTemplateObjectInjection_BodyDirectRender
    reason: Error:
"0" is not greater than or equal to "1"
```

### 超时错误收集
验证 job：
- https://github.com/yaklang/yaklang/actions/runs/24234188597/job/70753324759

现在的 summary 会给出具体 test binary、timeout 原因、耗时，以及 timeout 发生时正在运行的测试。例如：

```text
Failed tests:
  - test_common_yak_php_tests
    reason: panic: test timed out after 1s
    elapsed: 0m1s
    running tests:
      TestCondition (0s)
```

## 验证
- 注入失败的验证分支：`test-1/verify-summary/ci-essential-test-ssaapi-test-shrink-time`
- summary 格式验证 run：https://github.com/yaklang/yaklang/actions/runs/24234188597
- 当前正式分支 run：https://github.com/yaklang/yaklang/actions/runs/24236446343
