### PR TITLE
Rookie/feat/ai focus/http fuzz/fuzztag

### DIFF
--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_body.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_body.go
@@ -17,7 +17,7 @@ var fuzzBodyAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption
 		[]aitool.ToolOption{
 			aitool.WithStringParam("body_type", aitool.WithParam_Description("Type of body fuzzing: 'raw' (replace entire body), 'post_params' (fuzz form parameters), 'json_params' (fuzz JSON fields)"), aitool.WithParam_Required(true)),
 			aitool.WithStringParam("param_name", aitool.WithParam_Description("Parameter name to fuzz (required for post_params and json_params types)")),
-			aitool.WithStringArrayParam("param_values", aitool.WithParam_Description("Values to test"), aitool.WithParam_Required(true)),
+			aitool.WithStringArrayParam("param_values", aitool.WithParam_Description("Values to test. Supports arbitrary fuzztag; see the FUZZTAG_REFERENCE and AVAILABLE_PAYLOAD_GROUPS context blocks for the current full tag manual and payload dictionary groups. For brute-force or dictionary-style testing, prefer concise fuzztag rules over long handwritten lists."), aitool.WithParam_Required(true)),
 			aitool.WithStringParam("reason", aitool.WithParam_Description("请用中文说明为什么要测试这些 Body 值、怀疑的漏洞类型以及安全测试边界。")),
 		},
 		[]*reactloops.LoopStreamField{

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_cookie.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_cookie.go
@@ -16,7 +16,7 @@ var fuzzCookieAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 		"Fuzz HTTP cookies. Use this to test session manipulation, cookie injection, or authentication bypass attacks.",
 		[]aitool.ToolOption{
 			aitool.WithStringParam("cookie_name", aitool.WithParam_Description("The cookie name to fuzz. If empty and raw_mode is true, will replace entire Cookie header")),
-			aitool.WithStringArrayParam("cookie_values", aitool.WithParam_Description("Values to test for the cookie"), aitool.WithParam_Required(true)),
+			aitool.WithStringArrayParam("cookie_values", aitool.WithParam_Description("Values to test for the cookie. Supports arbitrary fuzztag; see the FUZZTAG_REFERENCE and AVAILABLE_PAYLOAD_GROUPS context blocks for the current full tag manual and payload dictionary groups. For brute-force or dictionary-style testing, prefer concise fuzztag rules over long handwritten lists."), aitool.WithParam_Required(true)),
 			aitool.WithBoolParam("raw_mode", aitool.WithParam_Description("If true, replace entire Cookie header with the provided values")),
 			aitool.WithStringParam("reason", aitool.WithParam_Description("请用中文说明为什么要测试这些 Cookie 值、怀疑的漏洞类型以及安全测试边界。")),
 		},

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_get_params.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_get_params.go
@@ -16,7 +16,7 @@ var fuzzGetParamsAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopO
 		"Fuzz GET query parameters. Use this to test SQL injection, XSS, or other parameter-based attacks on URL query string.",
 		[]aitool.ToolOption{
 			aitool.WithStringParam("param_name", aitool.WithParam_Description("The GET parameter name to fuzz. If empty, will add new parameters"), aitool.WithParam_Required(true)),
-			aitool.WithStringArrayParam("param_values", aitool.WithParam_Description("Values to test for the parameter, e.g., [\"' OR '1'='1\", '<script>alert(1)</script>', '{{7*7}}']"), aitool.WithParam_Required(true)),
+			aitool.WithStringArrayParam("param_values", aitool.WithParam_Description("Values to test for the parameter. Supports arbitrary fuzztag; see the FUZZTAG_REFERENCE and AVAILABLE_PAYLOAD_GROUPS context blocks for the current full tag manual and payload dictionary groups. For brute-force or dictionary-style testing, prefer concise fuzztag rules over long handwritten lists."), aitool.WithParam_Required(true)),
 			aitool.WithBoolParam("raw_mode", aitool.WithParam_Description("If true, replace the entire query string with the provided values")),
 			aitool.WithStringParam("reason", aitool.WithParam_Description("请用中文说明为什么要测试这些参数值、怀疑的漏洞类型以及安全测试边界。")),
 		},

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_header.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_header.go
@@ -15,7 +15,7 @@ var fuzzHeaderAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 		"Fuzz HTTP request headers. Use this to test header injection, authentication bypass, or header-based attacks.",
 		[]aitool.ToolOption{
 			aitool.WithStringParam("header_name", aitool.WithParam_Description("The header name to fuzz, e.g., 'X-Forwarded-For', 'Authorization', 'User-Agent'"), aitool.WithParam_Required(true)),
-			aitool.WithStringArrayParam("header_values", aitool.WithParam_Description("Values to test for the header"), aitool.WithParam_Required(true)),
+			aitool.WithStringArrayParam("header_values", aitool.WithParam_Description("Values to test for the header. Supports arbitrary fuzztag; see the FUZZTAG_REFERENCE and AVAILABLE_PAYLOAD_GROUPS context blocks for the current full tag manual and payload dictionary groups. When batch generation is needed, prefer concise fuzztag rules over long handwritten lists."), aitool.WithParam_Required(true)),
 			aitool.WithStringParam("reason", aitool.WithParam_Description("请用中文说明为什么要测试这个请求头、怀疑的漏洞类型以及安全测试边界。")),
 		},
 		[]*reactloops.LoopStreamField{

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_path.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_fuzz_path.go
@@ -15,7 +15,7 @@ var fuzzPathAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption
 		"fuzz_path",
 		"Fuzz the HTTP request path. Use this to test path traversal, different endpoints, or path-based attacks.",
 		[]aitool.ToolOption{
-			aitool.WithStringArrayParam("paths", aitool.WithParam_Description("Paths to test, e.g., ['/admin', '/api/v2', '../etc/passwd', '/backup']"), aitool.WithParam_Required(true)),
+			aitool.WithStringArrayParam("paths", aitool.WithParam_Description("Paths to test, e.g., ['/admin', '/api/v2', '../etc/passwd', '/backup']. Supports arbitrary fuzztag; see the FUZZTAG_REFERENCE and AVAILABLE_PAYLOAD_GROUPS context blocks for the current full tag manual and payload dictionary groups. When path enumeration is needed, prefer concise fuzztag rules over long handwritten lists."), aitool.WithParam_Required(true)),
 			aitool.WithBoolParam("append_mode", aitool.WithParam_Description("If true, append paths to existing path instead of replacing. Default is false (replace mode)")),
 			aitool.WithStringParam("reason", aitool.WithParam_Description("请用中文说明为什么要测试这些路径、怀疑的漏洞类型以及安全测试边界。")),
 		},

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/finalize.go
@@ -58,13 +58,7 @@ func generateLoopHTTPFuzzFinalizeSummary(loop *reactloops.ReActLoop, reason any)
 		out.WriteString("\n\n")
 	}
 
-	if diffResult := strings.TrimSpace(loop.Get("diff_result_compressed")); diffResult == "" {
-		if diffResult = strings.TrimSpace(loop.Get("diff_result")); diffResult != "" {
-			out.WriteString("## 当前发现\n\n")
-			out.WriteString(utils.ShrinkTextBlock(diffResult, 2000))
-			out.WriteString("\n\n")
-		}
-	} else {
+	if diffResult := firstNonEmptyString(loop.Get("diff_result_compressed"), loop.Get("diff_result_analysis"), loop.Get("diff_result")); diffResult != "" {
 		out.WriteString("## 当前发现\n\n")
 		out.WriteString(utils.ShrinkTextBlock(diffResult, 2000))
 		out.WriteString("\n\n")

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/finalize_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/finalize_test.go
@@ -132,6 +132,25 @@ func TestLoopHTTPFuzztestFinalize_DeliversFallbackSummary(t *testing.T) {
 	}
 }
 
+func TestGenerateLoopHTTPFuzzFinalizeSummary_PrefersCompressedResultOverAnalysis(t *testing.T) {
+	invoker := newFuzzFinalizeTestInvoker(t)
+	loop := newFuzzFinalizeTestLoop(t, invoker)
+
+	loop.Set("original_request", "GET /health HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	loop.Set("original_request_summary", "URL: http://example.com/health BODY: [(0) bytes]")
+	loop.Set("current_request_summary", "URL: http://example.com/health BODY: [(0) bytes]")
+	loop.Set("diff_result_analysis", "analysis-only result")
+	loop.Set("diff_result_compressed", "compressed result")
+
+	finalContent := generateLoopHTTPFuzzFinalizeSummary(loop, "done")
+	if !strings.Contains(finalContent, "compressed result") {
+		t.Fatalf("expected finalize summary to include compressed result, got: %s", finalContent)
+	}
+	if strings.Contains(finalContent, "analysis-only result") {
+		t.Fatalf("expected finalize summary to prefer compressed result over analysis result, got: %s", finalContent)
+	}
+}
+
 func TestLoopHTTPFuzztestFinalize_SkipsWhenAlreadyDirectlyAnswered(t *testing.T) {
 	invoker := newFuzzFinalizeTestInvoker(t)
 	loop := newFuzzFinalizeTestLoop(t, invoker)

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
@@ -13,7 +13,6 @@ import (
 	"github.com/yaklang/yaklang/common/mutate"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
-	"github.com/yaklang/yaklang/common/utils/yakgit/yakdiff"
 )
 
 const (
@@ -54,12 +53,25 @@ type loopHTTPFuzzResponseLengthGroup struct {
 	BaselineLabel string
 }
 
+type loopHTTPFuzzProcessedResult struct {
+	RequestRaw      string
+	ResponseRaw     string
+	RequestSummary  string
+	ResponseSummary string
+	RequestDiff     string
+	ResponseDigest  string
+	HiddenIndex     string
+	StatusCode      int
+	BodyLength      int
+	DurationMs      int64
+	Payloads        []string
+	Sample          loopHTTPFuzzInterestingSample
+}
+
 type loopHTTPFuzzAggregateStats struct {
 	TotalRequests        int
 	FailedRequests       int
 	SavedHTTPFlowCount   int
-	DetailedResultsShown int
-	OmittedDetails       int
 	SuccessfulResponses  int
 	TotalDurationMs      int64
 	MinDurationMs        int64
@@ -81,24 +93,6 @@ func newLoopHTTPFuzzAggregateStats() *loopHTTPFuzzAggregateStats {
 		StatusCounts:         make(map[int]int),
 		ResponseLengthGroups: make(map[int]*loopHTTPFuzzResponseLengthGroup),
 	}
-}
-
-func (s *loopHTTPFuzzAggregateStats) allowDetailedResult() bool {
-	return s != nil && s.DetailedResultsShown < loopHTTPFuzzDetailedResultLimit
-}
-
-func (s *loopHTTPFuzzAggregateStats) markDetailedResultWritten() {
-	if s == nil {
-		return
-	}
-	s.DetailedResultsShown++
-}
-
-func (s *loopHTTPFuzzAggregateStats) markDetailedResultOmitted() {
-	if s == nil {
-		return
-	}
-	s.OmittedDetails++
 }
 
 func (s *loopHTTPFuzzAggregateStats) observeError() {
@@ -179,75 +173,20 @@ func (s *loopHTTPFuzzAggregateStats) observeResponseLengthGroup(sample loopHTTPF
 	}
 }
 
-func scoreLoopHTTPFuzzInterestingSample(statusCode int, durationMs int64, bodyLength int, baselineBodyLength int, responseRaw string) int {
-	score := 0
-	switch {
-	case statusCode >= 500:
-		score += 90
-	case statusCode >= 400:
-		score += 45
-	case statusCode >= 300:
-		score += 20
-	}
-
-	if baselineBodyLength >= 0 {
-		delta := abs(bodyLength - baselineBodyLength)
-		if baselineBodyLength == 0 {
-			if delta > 0 {
-				score += 35
-			}
-		} else if delta > baselineBodyLength/2 {
-			score += 35
-		} else if delta > baselineBodyLength/4 {
-			score += 18
-		}
-	}
-
-	switch {
-	case durationMs >= 3000:
-		score += 40
-	case durationMs >= 1000:
-		score += 20
-	case durationMs >= 500:
-		score += 10
-	}
-
-	responseLower := strings.ToLower(responseRaw)
-	for _, keyword := range []string{
-		"sql", "syntax error", "exception", "stack trace", "traceback",
-		"unauthorized", "forbidden", "access denied", "permission denied",
-		"welcome", "login success", "token", "debug",
-	} {
-		if strings.Contains(responseLower, keyword) {
-			score += 25
-			break
-		}
-	}
-
-	return score
-}
-
-func writeLoopHTTPFuzzDetailTruncationNotice(diffSummary, analysisSummary *strings.Builder, omitted int) {
-	if omitted <= 0 {
-		return
-	}
-	msg := fmt.Sprintf("\n--- Detailed Results Truncated ---\nDetailed request/response logs were limited to the first %d results. The remaining %d results are summarized in the aggregate report below because all HTTP flows have already been saved to the database.\n", loopHTTPFuzzDetailedResultLimit, omitted)
-	diffSummary.WriteString(msg)
-	analysisSummary.WriteString(msg)
-}
-
 func buildLoopHTTPFuzzAggregateReport(actionName string, stats *loopHTTPFuzzAggregateStats) string {
 	if stats == nil {
 		return ""
 	}
+	includeLengthAnalysis := stats.shouldUseResponseLengthAnalysis()
+	truncatedDetails := max(stats.TotalRequests-loopHTTPFuzzDetailedResultLimit, 0)
 
 	var out strings.Builder
 	out.WriteString(fmt.Sprintf("=== Aggregate Summary for %s ===\n", actionName))
 	out.WriteString(fmt.Sprintf("Total Requests: %d\n", stats.TotalRequests))
 	out.WriteString(fmt.Sprintf("Failed Requests: %d\n", stats.FailedRequests))
 	out.WriteString(fmt.Sprintf("Saved HTTPFlows: %d\n", stats.SavedHTTPFlowCount))
-	if stats.OmittedDetails > 0 {
-		out.WriteString(fmt.Sprintf("Detailed Results Shown: %d (omitted %d additional detailed entries; full traffic remains stored in HTTPFlow)\n", stats.DetailedResultsShown, stats.OmittedDetails))
+	if truncatedDetails > 0 {
+		out.WriteString(fmt.Sprintf("Frontend Detail Omitted: %d results (detail output is limited to the first %d results; full traffic remains stored in HTTPFlow)\n", truncatedDetails, loopHTTPFuzzDetailedResultLimit))
 	}
 
 	if len(stats.StatusCounts) > 0 {
@@ -274,14 +213,14 @@ func buildLoopHTTPFuzzAggregateReport(actionName string, stats *loopHTTPFuzzAggr
 		out.WriteString(fmt.Sprintf("Response Body Stats: avg=%d bytes min=%d bytes max=%d bytes\n", avgBodyLength, stats.MinBodyLength, stats.MaxBodyLength))
 	}
 
-	if len(stats.ResponseLengthGroups) > 0 {
+	if includeLengthAnalysis && len(stats.ResponseLengthGroups) > 0 {
 		out.WriteString("Response Length Groups:\n")
-		for _, group := range buildLoopHTTPFuzzResponseLengthGroups(stats) {
+		for _, group := range stats.sortedResponseLengthGroups() {
 			out.WriteString(fmt.Sprintf("- %d bytes: %d responses", group.BodyLength, group.Count))
 			if group.IsBaseline {
 				out.WriteString(" [baseline]")
 			}
-			if statusPreview := buildLoopHTTPFuzzStatusPreviewFromCounts(group.StatusCounts, 4); statusPreview != "" {
+			if statusPreview := formatLoopHTTPFuzzTopStatusCounts(group.StatusCounts, 4); statusPreview != "" {
 				out.WriteString(fmt.Sprintf(" (statuses: %s)", statusPreview))
 			}
 			out.WriteByte('\n')
@@ -357,19 +296,12 @@ func buildLoopHTTPFuzzVerificationOverview(actionName string, stats *loopHTTPFuz
 	return strings.TrimSpace(out.String())
 }
 
-func formatLoopHTTPFuzzStatusCode(statusCode int) string {
-	if statusCode <= 0 {
-		return "(no status code)"
-	}
-	return fmt.Sprintf("%d", statusCode)
-}
-
-func buildLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats) []*loopHTTPFuzzResponseLengthGroup {
-	if stats == nil || len(stats.ResponseLengthGroups) == 0 {
+func (s *loopHTTPFuzzAggregateStats) sortedResponseLengthGroups() []*loopHTTPFuzzResponseLengthGroup {
+	if s == nil || len(s.ResponseLengthGroups) == 0 {
 		return nil
 	}
-	groups := make([]*loopHTTPFuzzResponseLengthGroup, 0, len(stats.ResponseLengthGroups))
-	for _, group := range stats.ResponseLengthGroups {
+	groups := make([]*loopHTTPFuzzResponseLengthGroup, 0, len(s.ResponseLengthGroups))
+	for _, group := range s.ResponseLengthGroups {
 		if group != nil {
 			groups = append(groups, group)
 		}
@@ -383,11 +315,33 @@ func buildLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats) []
 	return groups
 }
 
-func finalizeLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats) {
-	if stats == nil || len(stats.ResponseLengthGroups) == 0 {
+func (s *loopHTTPFuzzAggregateStats) shouldUseResponseLengthAnalysis() bool {
+	if s == nil || len(s.ResponseLengthGroups) < 2 {
+		return false
+	}
+	groups := s.sortedResponseLengthGroups()
+	if len(groups) < 2 {
+		return false
+	}
+
+	dominantCount := groups[0].Count
+	switch {
+	case s.TotalRequests > loopHTTPFuzzDetailedResultLimit:
+		return true
+	case s.SuccessfulResponses >= 15:
+		return true
+	case dominantCount >= 10:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *loopHTTPFuzzAggregateStats) finalizeResponseLengthGroups() {
+	if s == nil || len(s.ResponseLengthGroups) == 0 {
 		return
 	}
-	groups := buildLoopHTTPFuzzResponseLengthGroups(stats)
+	groups := s.sortedResponseLengthGroups()
 	if len(groups) == 0 {
 		return
 	}
@@ -400,7 +354,7 @@ func finalizeLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats)
 			baselineGroup = group
 			continue
 		}
-		if group.Count == baselineGroup.Count && group.BodyLength == stats.BaselineBodyLength {
+		if group.Count == baselineGroup.Count && group.BodyLength == s.BaselineBodyLength {
 			baselineGroup = group
 		}
 	}
@@ -416,7 +370,7 @@ func finalizeLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats)
 		group.BaselineLabel = ""
 		if group.IsBaseline {
 			group.BaselineLabel = fmt.Sprintf("Baseline group selected by dominant body length: %d bytes (%d responses).", group.BodyLength, group.Count)
-			stats.BaselineBodyLength = group.BodyLength
+			s.BaselineBodyLength = group.BodyLength
 			group.Sample.ResponseDiff = "  (baseline representative response)"
 			continue
 		}
@@ -424,76 +378,18 @@ func finalizeLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats)
 	}
 }
 
-func buildLoopHTTPFuzzResponseDiffFromBaseline(baselineResponseRaw, sampleResponseRaw string) string {
-	baselineResponseRaw = strings.TrimSpace(baselineResponseRaw)
-	sampleResponseRaw = strings.TrimSpace(sampleResponseRaw)
-	if baselineResponseRaw == "" || sampleResponseRaw == "" {
-		return ""
-	}
-	if baselineResponseRaw == sampleResponseRaw {
-		return "  (same as baseline representative response)"
-	}
-
-	_, baselineBody := lowhttp.SplitHTTPPacketFast([]byte(baselineResponseRaw))
-	_, sampleBody := lowhttp.SplitHTTPPacketFast([]byte(sampleResponseRaw))
-	left := string(baselineBody)
-	right := string(sampleBody)
-	if strings.TrimSpace(left) == "" && strings.TrimSpace(right) == "" {
-		left = baselineResponseRaw
-		right = sampleResponseRaw
-	}
-
-	diffText, err := yakdiff.DiffToString(left, right)
-	if err == nil && strings.TrimSpace(diffText) != "" {
-		return strings.TrimSpace(diffText)
-	}
-	return compareRequests(left, right)
-}
-
-func buildLoopHTTPFuzzStatusPreviewFromCounts(counts map[int]int, maxItems int) string {
-	if len(counts) == 0 || maxItems <= 0 {
-		return ""
-	}
-	statuses := make([]int, 0, len(counts))
-	for statusCode := range counts {
-		statuses = append(statuses, statusCode)
-	}
-	sort.SliceStable(statuses, func(i, j int) bool {
-		if counts[statuses[i]] == counts[statuses[j]] {
-			return statuses[i] < statuses[j]
-		}
-		return counts[statuses[i]] > counts[statuses[j]]
-	})
-	if len(statuses) > maxItems {
-		statuses = statuses[:maxItems]
-	}
-	parts := make([]string, 0, len(statuses))
-	for _, statusCode := range statuses {
-		parts = append(parts, fmt.Sprintf("%s=%d", formatLoopHTTPFuzzStatusCode(statusCode), counts[statusCode]))
-	}
-	return strings.Join(parts, ", ")
-}
-
 type loopHTTPFuzzProgressReporter struct {
 	loop       *reactloops.ReActLoop
 	taskID     string
 	actionName string
-	lastEmitAt time.Time
+	throttle   func(func())
 }
 
-func newLoopHTTPFuzzProgressReporter(loop *reactloops.ReActLoop, taskID, actionName string) *loopHTTPFuzzProgressReporter {
-	return &loopHTTPFuzzProgressReporter{
-		loop:       loop,
-		taskID:     taskID,
-		actionName: actionName,
-	}
-}
-
-func (r *loopHTTPFuzzProgressReporter) allowDetailedFrontendEvent(resultIndex int) bool {
+func (r *loopHTTPFuzzProgressReporter) allowEmitDetailHttpFlow(resultIndex int) bool {
 	return r != nil && resultIndex > 0 && resultIndex <= loopHTTPFuzzFrontendDetailLimit
 }
 
-func (r *loopHTTPFuzzProgressReporter) maybeEmit(stats *loopHTTPFuzzAggregateStats, lastStatusCode int, force bool) {
+func (r *loopHTTPFuzzProgressReporter) emitProgress(stats *loopHTTPFuzzAggregateStats, lastStatusCode int, force bool) {
 	if r == nil || r.loop == nil || strings.TrimSpace(r.taskID) == "" || stats == nil {
 		return
 	}
@@ -501,17 +397,18 @@ func (r *loopHTTPFuzzProgressReporter) maybeEmit(stats *loopHTTPFuzzAggregateSta
 		return
 	}
 
-	now := time.Now()
-	if !force && !r.lastEmitAt.IsZero() && now.Sub(r.lastEmitAt) < loopHTTPFuzzProgressEmitInterval {
-		return
-	}
-
 	snapshot := buildLoopHTTPFuzzProgressSnapshot(r.actionName, stats, lastStatusCode, force)
 	if strings.TrimSpace(snapshot) == "" {
 		return
 	}
-	emitFuzzStage(r.loop, r.taskID, snapshot)
-	r.lastEmitAt = now
+	emit := func() {
+		emitFuzzStage(r.loop, r.taskID, snapshot)
+	}
+	if force || r.throttle == nil {
+		emit()
+		return
+	}
+	r.throttle(emit)
 }
 
 func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzAggregateStats, lastStatusCode int, finished bool) string {
@@ -538,11 +435,13 @@ func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzAgg
 	if stats.SuccessfulResponses > 0 {
 		out.WriteString(fmt.Sprintf("，平均响应 %d ms", stats.TotalDurationMs/int64(stats.SuccessfulResponses)))
 	}
-	if statusPreview := buildLoopHTTPFuzzStatusPreview(stats, 3); statusPreview != "" {
+	if statusPreview := formatLoopHTTPFuzzTopStatusCounts(stats.StatusCounts, 3); statusPreview != "" {
 		out.WriteString(fmt.Sprintf("，状态分布 %s", statusPreview))
 	}
-	if lengthPreview := buildLoopHTTPFuzzResponseLengthPreview(stats, 3); lengthPreview != "" {
-		out.WriteString(fmt.Sprintf("，长度分布 %s", lengthPreview))
+	if stats.shouldUseResponseLengthAnalysis() {
+		if lengthPreview := stats.responseLengthPreview(3); lengthPreview != "" {
+			out.WriteString(fmt.Sprintf("，长度分布 %s", lengthPreview))
+		}
 	}
 	if len(stats.InterestingSamples) > 0 {
 		out.WriteString(fmt.Sprintf("，可疑样本 %d 个", len(stats.InterestingSamples)))
@@ -551,18 +450,11 @@ func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzAgg
 	return out.String()
 }
 
-func buildLoopHTTPFuzzStatusPreview(stats *loopHTTPFuzzAggregateStats, maxItems int) string {
-	if stats == nil || maxItems <= 0 {
+func (s *loopHTTPFuzzAggregateStats) responseLengthPreview(maxItems int) string {
+	if s == nil || len(s.ResponseLengthGroups) == 0 || maxItems <= 0 {
 		return ""
 	}
-	return buildLoopHTTPFuzzStatusPreviewFromCounts(stats.StatusCounts, maxItems)
-}
-
-func buildLoopHTTPFuzzResponseLengthPreview(stats *loopHTTPFuzzAggregateStats, maxItems int) string {
-	if stats == nil || len(stats.ResponseLengthGroups) == 0 || maxItems <= 0 {
-		return ""
-	}
-	groups := buildLoopHTTPFuzzResponseLengthGroups(stats)
+	groups := s.sortedResponseLengthGroups()
 	if len(groups) > maxItems {
 		groups = groups[:maxItems]
 	}
@@ -571,6 +463,123 @@ func buildLoopHTTPFuzzResponseLengthPreview(stats *loopHTTPFuzzAggregateStats, m
 		parts = append(parts, fmt.Sprintf("%dB=%d", group.BodyLength, group.Count))
 	}
 	return strings.Join(parts, ", ")
+}
+
+func appendLoopHTTPFuzzErrorResult(diffSummary, analysisSummary *strings.Builder, resultIndex int, resultErr error) {
+	if diffSummary == nil || analysisSummary == nil || resultErr == nil {
+		return
+	}
+	errMsg := fmt.Sprintf("\n--- Result %d ---\nError: %v\n", resultIndex, resultErr)
+	diffSummary.WriteString(errMsg)
+	analysisSummary.WriteString(errMsg)
+}
+
+func buildLoopHTTPFuzzProcessedResult(resultIndex int, result *mutate.HttpResult, originalRequest string, baselineBodyLength int) loopHTTPFuzzProcessedResult {
+	requestRaw := string(result.RequestRaw)
+	responseRaw := string(result.ResponseRaw)
+	requestURL, requestSummary := buildHTTPRequestStreamSummary(requestRaw, result.Request.TLS != nil)
+	responseSummary := buildHTTPResponseStreamSummary(responseRaw, requestURL)
+	requestDiff := compareRequests(originalRequest, requestRaw)
+	responseDigest := summarizeResponse(responseRaw)
+	statusCode := getStatusFromResponse(responseRaw)
+	_, responseBody := lowhttp.SplitHTTPPacketFast([]byte(responseRaw))
+	bodyLength := len(responseBody)
+	hiddenIndex := ""
+	if result.LowhttpResponse != nil {
+		hiddenIndex = strings.TrimSpace(result.LowhttpResponse.HiddenIndex)
+	}
+	score := scoreLoopHTTPFuzzInterestingSample(statusCode, result.DurationMs, bodyLength, baselineBodyLength, responseRaw)
+
+	return loopHTTPFuzzProcessedResult{
+		RequestRaw:      requestRaw,
+		ResponseRaw:     responseRaw,
+		RequestSummary:  requestSummary,
+		ResponseSummary: responseSummary,
+		RequestDiff:     requestDiff,
+		ResponseDigest:  responseDigest,
+		HiddenIndex:     hiddenIndex,
+		StatusCode:      statusCode,
+		BodyLength:      bodyLength,
+		DurationMs:      result.DurationMs,
+		Payloads:        append([]string(nil), result.Payloads...),
+		Sample: loopHTTPFuzzInterestingSample{
+			Index:           resultIndex,
+			Score:           score,
+			StatusCode:      statusCode,
+			DurationMs:      result.DurationMs,
+			BodyLength:      bodyLength,
+			HiddenIndex:     hiddenIndex,
+			Payloads:        append([]string(nil), result.Payloads...),
+			RequestSummary:  requestSummary,
+			ResponseSummary: responseSummary,
+			RequestDiff:     requestDiff,
+			ResponseDigest:  responseDigest,
+			ResponseRaw:     responseRaw,
+		},
+	}
+}
+
+func syncLoopHTTPFuzzLastResultState(loop *reactloops.ReActLoop, processed loopHTTPFuzzProcessedResult, runtimeID string, progressReporter *loopHTTPFuzzProgressReporter, resultIndex int) {
+	if loop == nil {
+		return
+	}
+	loop.Set("last_request", processed.RequestRaw)
+	loop.Set("last_request_summary", processed.RequestSummary)
+	loop.Set("last_response", processed.ResponseRaw)
+	loop.Set("last_response_summary", processed.ResponseSummary)
+	if strings.TrimSpace(processed.HiddenIndex) != "" {
+		loop.Set("last_httpflow_hidden_index", processed.HiddenIndex)
+	}
+
+	if progressReporter == nil || !progressReporter.allowEmitDetailHttpFlow(resultIndex) || strings.TrimSpace(progressReporter.taskID) == "" {
+		return
+	}
+	emitPacketSummary(loop, progressReporter.taskID, progressReporter.actionName, resultIndex, "request", processed.RequestSummary)
+	emitPacketSummary(loop, progressReporter.taskID, progressReporter.actionName, resultIndex, "response", processed.ResponseSummary)
+	if runtimeID != "" && strings.TrimSpace(processed.HiddenIndex) != "" {
+		loop.GetEmitter().EmitYakitHTTPFlow(runtimeID, processed.HiddenIndex)
+	}
+}
+
+func appendLoopHTTPFuzzDetailedResult(diffSummary, analysisSummary *strings.Builder, resultIndex int, processed loopHTTPFuzzProcessedResult) {
+	if diffSummary == nil || analysisSummary == nil {
+		return
+	}
+	diffSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultIndex))
+	analysisSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultIndex))
+	diffSummary.WriteString(fmt.Sprintf("Payload: %v\n", processed.Payloads))
+	analysisSummary.WriteString(fmt.Sprintf("Payload: %v\n", processed.Payloads))
+	diffSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", processed.DurationMs))
+	analysisSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", processed.DurationMs))
+	diffSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(processed.StatusCode)))
+	analysisSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(processed.StatusCode)))
+	diffSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", processed.RequestSummary))
+	analysisSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", processed.RequestSummary))
+	diffSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", processed.ResponseSummary))
+	analysisSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", processed.ResponseSummary))
+	if processed.HiddenIndex != "" {
+		diffSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", processed.HiddenIndex))
+		analysisSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", processed.HiddenIndex))
+	}
+	diffSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", processed.RequestDiff))
+	analysisSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", processed.RequestDiff))
+	diffSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", processed.ResponseDigest))
+	analysisSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", processed.ResponseDigest))
+	diffSummary.WriteString("Request Packet:\n")
+	diffSummary.WriteString(processed.RequestRaw)
+	diffSummary.WriteString("\nResponse Packet:\n")
+	diffSummary.WriteString(processed.ResponseRaw)
+	diffSummary.WriteRune('\n')
+}
+
+func shouldUpdateLoopHTTPFuzzRepresentative(processed loopHTTPFuzzProcessedResult, bestRepresentativeScore int, representativeHiddenIndex string, representativeRequest string) bool {
+	if representativeRequest == "" {
+		return true
+	}
+	if processed.Sample.Score > bestRepresentativeScore {
+		return true
+	}
+	return processed.Sample.Score == bestRepresentativeScore && representativeHiddenIndex == "" && processed.HiddenIndex != ""
 }
 
 func newLoopFuzzRequest(taskCtx context.Context, runtime aicommon.AIInvokeRuntime, rawPacket []byte, isHTTPS bool) (*mutate.FuzzHTTPRequest, error) {
@@ -784,7 +793,12 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	}
 
 	emitFuzzStage(loop, streamTaskID, fmt.Sprintf("开始执行 %s，HTTPFlow 会落库并保留完整请求/响应。", actionName))
-	progressReporter := newLoopHTTPFuzzProgressReporter(loop, streamTaskID, actionName)
+	progressReporter := &loopHTTPFuzzProgressReporter{
+		loop:       loop,
+		taskID:     streamTaskID,
+		actionName: actionName,
+		throttle:   utils.NewThrottle(loopHTTPFuzzProgressEmitInterval.Seconds()),
+	}
 
 	// Execute the fuzz request
 	execOpts := []mutate.HttpPoolConfigOption{
@@ -808,7 +822,6 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 
 	originalRequest := getCurrentRequestRaw(loop)
 	stats := newLoopHTTPFuzzAggregateStats()
-	resultCount := 0
 	representativeRequest := ""
 	representativeResponse := ""
 	representativeHiddenIndex := ""
@@ -817,119 +830,42 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	bestRepresentativeScore := -1
 
 	for result := range resultCh {
-		resultCount++
+		detailedWritten := stats.TotalRequests <= loopHTTPFuzzDetailedResultLimit
 		if result.Error != nil {
 			stats.observeError()
-			if stats.allowDetailedResult() {
-				errMsg := fmt.Sprintf("\n--- Result %d ---\nError: %v\n", resultCount, result.Error)
-				diffSummary.WriteString(errMsg)
-				analysisSummary.WriteString(errMsg)
-				stats.markDetailedResultWritten()
-			} else {
-				stats.markDetailedResultOmitted()
+			if detailedWritten {
+				appendLoopHTTPFuzzErrorResult(&diffSummary, &analysisSummary, stats.TotalRequests, result.Error)
 			}
-			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 第 %d 个测试请求执行失败：%v", actionName, resultCount, result.Error))
-			progressReporter.maybeEmit(stats, 0, false)
+			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 第 %d 个测试请求执行失败：%v", actionName, stats.TotalRequests, result.Error))
+			progressReporter.emitProgress(stats, 0, false)
 			continue
 		}
 
-		// Get request and response
-		requestRaw := string(result.RequestRaw)
-		responseRaw := string(result.ResponseRaw)
-		requestURL, requestStreamSummary := buildHTTPRequestStreamSummary(requestRaw, isHttps)
-		responseStreamSummary := buildHTTPResponseStreamSummary(responseRaw, requestURL)
-		collectedPayloads = append(collectedPayloads, result.Payloads...)
+		processed := buildLoopHTTPFuzzProcessedResult(stats.TotalRequests, result, originalRequest, stats.BaselineBodyLength)
+		collectedPayloads = append(collectedPayloads, processed.Payloads...)
+		syncLoopHTTPFuzzLastResultState(loop, processed, runtimeID, progressReporter, stats.TotalRequests)
 
-		if progressReporter.allowDetailedFrontendEvent(resultCount) && streamTaskID != "" {
-			emitPacketSummary(loop, streamTaskID, actionName, resultCount, "request", requestStreamSummary)
-			emitPacketSummary(loop, streamTaskID, actionName, resultCount, "response", responseStreamSummary)
+		stats.observeSuccess(processed.StatusCode, processed.DurationMs, processed.BodyLength, processed.HiddenIndex != "")
+		stats.considerInterestingSample(processed.Sample)
+		stats.observeResponseLengthGroup(processed.Sample)
+
+		if shouldUpdateLoopHTTPFuzzRepresentative(processed, bestRepresentativeScore, representativeHiddenIndex, representativeRequest) {
+			bestRepresentativeScore = processed.Sample.Score
+			representativeRequest = processed.RequestRaw
+			representativeResponse = processed.ResponseRaw
+			representativeHiddenIndex = processed.HiddenIndex
+			representativeStatusCode = processed.StatusCode
 		}
 
-		hiddenIndex := ""
-		if result.LowhttpResponse != nil {
-			hiddenIndex = strings.TrimSpace(result.LowhttpResponse.HiddenIndex)
-			if hiddenIndex != "" {
-				loop.Set("last_httpflow_hidden_index", hiddenIndex)
-				if progressReporter.allowDetailedFrontendEvent(resultCount) && runtimeID != "" {
-					loop.GetEmitter().EmitYakitHTTPFlow(runtimeID, hiddenIndex)
-				}
-			}
+		if detailedWritten {
+			appendLoopHTTPFuzzDetailedResult(&diffSummary, &analysisSummary, stats.TotalRequests, processed)
 		}
 
-		// Compare request differences
-		requestDiff := compareRequests(originalRequest, requestRaw)
-		responseSummary := summarizeResponse(responseRaw)
-		statusCode := getStatusFromResponse(responseRaw)
-		_, responseBody := lowhttp.SplitHTTPPacketFast([]byte(responseRaw))
-		bodyLength := len(responseBody)
-		loop.Set("last_request", requestRaw)
-		loop.Set("last_request_summary", requestStreamSummary)
-		loop.Set("last_response", responseRaw)
-		loop.Set("last_response_summary", responseStreamSummary)
-
-		stats.observeSuccess(statusCode, result.DurationMs, bodyLength, hiddenIndex != "")
-		sampleScore := scoreLoopHTTPFuzzInterestingSample(statusCode, result.DurationMs, bodyLength, stats.BaselineBodyLength, responseRaw)
-		sample := loopHTTPFuzzInterestingSample{
-			Index:           resultCount,
-			Score:           sampleScore,
-			StatusCode:      statusCode,
-			DurationMs:      result.DurationMs,
-			BodyLength:      bodyLength,
-			HiddenIndex:     hiddenIndex,
-			Payloads:        append([]string(nil), result.Payloads...),
-			RequestSummary:  requestStreamSummary,
-			ResponseSummary: responseStreamSummary,
-			RequestDiff:     requestDiff,
-			ResponseDigest:  responseSummary,
-			ResponseRaw:     responseRaw,
-		}
-		stats.considerInterestingSample(sample)
-		stats.observeResponseLengthGroup(sample)
-
-		if representativeRequest == "" || sampleScore > bestRepresentativeScore || (sampleScore == bestRepresentativeScore && representativeHiddenIndex == "" && hiddenIndex != "") {
-			bestRepresentativeScore = sampleScore
-			representativeRequest = requestRaw
-			representativeResponse = responseRaw
-			representativeHiddenIndex = hiddenIndex
-			representativeStatusCode = statusCode
-		}
-
-		if stats.allowDetailedResult() {
-			diffSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultCount))
-			analysisSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultCount))
-			diffSummary.WriteString(fmt.Sprintf("Payload: %v\n", result.Payloads))
-			analysisSummary.WriteString(fmt.Sprintf("Payload: %v\n", result.Payloads))
-			diffSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", result.DurationMs))
-			analysisSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", result.DurationMs))
-			diffSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(statusCode)))
-			analysisSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(statusCode)))
-			diffSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", requestStreamSummary))
-			analysisSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", requestStreamSummary))
-			diffSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", responseStreamSummary))
-			analysisSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", responseStreamSummary))
-			if hiddenIndex != "" {
-				diffSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", hiddenIndex))
-				analysisSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", hiddenIndex))
-			}
-			diffSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", requestDiff))
-			analysisSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", requestDiff))
-			diffSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", responseSummary))
-			analysisSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", responseSummary))
-			diffSummary.WriteString("Request Packet:\n")
-			diffSummary.WriteString(requestRaw)
-			diffSummary.WriteString("\nResponse Packet:\n")
-			diffSummary.WriteString(responseRaw)
-			diffSummary.WriteRune('\n')
-			stats.markDetailedResultWritten()
-		} else {
-			stats.markDetailedResultOmitted()
-		}
-
-		progressReporter.maybeEmit(stats, statusCode, false)
+		progressReporter.emitProgress(stats, processed.StatusCode, false)
 	}
 
-	finalizeLoopHTTPFuzzResponseLengthGroups(stats)
-	progressReporter.maybeEmit(stats, representativeStatusCode, true)
+	stats.finalizeResponseLengthGroups()
+	progressReporter.emitProgress(stats, representativeStatusCode, true)
 
 	if representativeRequest != "" || representativeResponse != "" {
 		loop.Set("representative_request", representativeRequest)
@@ -937,7 +873,7 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		loop.Set("representative_httpflow_hidden_index", representativeHiddenIndex)
 	}
 
-	if resultCount == 0 {
+	if stats.TotalRequests == 0 {
 		diffSummary.WriteString("\n(no results returned by the fuzz execution)\n")
 		analysisSummary.WriteString("\n(no results returned by the fuzz execution)\n")
 	}
@@ -945,9 +881,7 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		diffSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", stats.SavedHTTPFlowCount))
 		analysisSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", stats.SavedHTTPFlowCount))
 	}
-	if stats.OmittedDetails > 0 {
-		writeLoopHTTPFuzzDetailTruncationNotice(&diffSummary, &analysisSummary, stats.OmittedDetails)
-	}
+
 	aggregateReport := buildLoopHTTPFuzzAggregateReport(actionName, stats)
 	if aggregateReport != "" {
 		diffSummary.WriteString("\n\n")
@@ -989,9 +923,9 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		loop.Set("verification_result", verificationText)
 	}
 
-	actionResultSummary := fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。代表性响应状态：%s", resultCount, stats.SavedHTTPFlowCount, formatLoopHTTPFuzzStatusCode(representativeStatusCode))
+	actionResultSummary := fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。代表性响应状态：%s", stats.TotalRequests, stats.SavedHTTPFlowCount, formatLoopHTTPFuzzStatusCode(representativeStatusCode))
 	if representativeStatusCode == 0 {
-		actionResultSummary = fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。", resultCount, stats.SavedHTTPFlowCount)
+		actionResultSummary = fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。", stats.TotalRequests, stats.SavedHTTPFlowCount)
 	}
 	verificationSummary := buildLoopHTTPFuzzVerificationSummary(verifyResult)
 	actionRecord := recordLoopHTTPFuzzAction(loop, actionName, paramSummary, actionResultSummary, verificationSummary, representativeHiddenIndex, collectedPayloads)
@@ -1207,41 +1141,6 @@ func compareRequests(original, modified string) string {
 		return "  (no changes)"
 	}
 	return diff.String()
-}
-
-// summarizeResponse creates a summary of the HTTP response
-func summarizeResponse(response string) string {
-	if response == "" {
-		return "  (empty response)"
-	}
-
-	_, body := lowhttp.SplitHTTPPacketFast([]byte(response))
-	statusCode := getStatusFromResponse(response)
-
-	var summary strings.Builder
-	summary.WriteString(fmt.Sprintf("  Status Code: %s\n", formatLoopHTTPFuzzStatusCode(statusCode)))
-
-	// Get content length
-	contentLength := len(body)
-	summary.WriteString(fmt.Sprintf("  Content-Length: %d bytes\n", contentLength))
-
-	// Show first part of body if not too long
-	if contentLength > 0 {
-		bodyPreview := string(body)
-		if len(bodyPreview) > 200 {
-			bodyPreview = bodyPreview[:200] + "..."
-		}
-		bodyPreview = strings.ReplaceAll(bodyPreview, "\n", " ")
-		summary.WriteString(fmt.Sprintf("  Body Preview: %s\n", bodyPreview))
-	}
-
-	return summary.String()
-}
-
-// getStatusFromResponse extracts status code from response
-func getStatusFromResponse(response string) int {
-	statusCode := lowhttp.ExtractStatusCodeFromResponse([]byte(response))
-	return statusCode
 }
 
 func max(a, b int) int {

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
@@ -68,7 +68,23 @@ type loopHTTPFuzzProcessedResult struct {
 	Sample          loopHTTPFuzzInterestingSample
 }
 
-type loopHTTPFuzzAggregateStats struct {
+// loopHTTPFuzzDetailRecord 表示少量结果场景下需要保留的一条详细记录。
+// Error 非空时表示该条执行失败；否则使用 Processed 渲染完整请求/响应详情。
+type loopHTTPFuzzDetailRecord struct {
+	Index     int
+	Error     string
+	Processed loopHTTPFuzzProcessedResult
+}
+
+// loopHTTPFuzzReportData 只保存渲染报告所需的结构化数据。
+// 为了控制内存与最终输出体积，详细记录只保留限制内的前几条。
+type loopHTTPFuzzReportData struct {
+	DetailRecords []loopHTTPFuzzDetailRecord
+}
+
+// loopHTTPFuzzOverviewStats 保存固定 overview 需要的聚合统计，
+// 以及大样本场景下的分组样本和可疑样本摘要。
+type loopHTTPFuzzOverviewStats struct {
 	TotalRequests        int
 	FailedRequests       int
 	SavedHTTPFlowCount   int
@@ -85,8 +101,8 @@ type loopHTTPFuzzAggregateStats struct {
 	InterestingSamples   []loopHTTPFuzzInterestingSample
 }
 
-func newLoopHTTPFuzzAggregateStats() *loopHTTPFuzzAggregateStats {
-	return &loopHTTPFuzzAggregateStats{
+func newLoopHTTPFuzzOverviewStats() *loopHTTPFuzzOverviewStats {
+	return &loopHTTPFuzzOverviewStats{
 		MinDurationMs:        -1,
 		MinBodyLength:        -1,
 		BaselineBodyLength:   -1,
@@ -95,7 +111,8 @@ func newLoopHTTPFuzzAggregateStats() *loopHTTPFuzzAggregateStats {
 	}
 }
 
-func (s *loopHTTPFuzzAggregateStats) observeError() {
+// observeError 只维护总量和失败数，不负责保留详细失败文本。
+func (s *loopHTTPFuzzOverviewStats) observeError() {
 	if s == nil {
 		return
 	}
@@ -103,7 +120,8 @@ func (s *loopHTTPFuzzAggregateStats) observeError() {
 	s.FailedRequests++
 }
 
-func (s *loopHTTPFuzzAggregateStats) observeSuccess(statusCode int, durationMs int64, bodyLength int, saved bool) {
+// observeSuccess 更新固定 overview 所需的统计信息。
+func (s *loopHTTPFuzzOverviewStats) observeSuccess(statusCode int, durationMs int64, bodyLength int, saved bool) {
 	if s == nil {
 		return
 	}
@@ -132,7 +150,8 @@ func (s *loopHTTPFuzzAggregateStats) observeSuccess(statusCode int, durationMs i
 	}
 }
 
-func (s *loopHTTPFuzzAggregateStats) considerInterestingSample(sample loopHTTPFuzzInterestingSample) {
+// considerInterestingSample 保留 topN 可疑样本，供大数据量分析段渲染。
+func (s *loopHTTPFuzzOverviewStats) considerInterestingSample(sample loopHTTPFuzzInterestingSample) {
 	if s == nil {
 		return
 	}
@@ -151,7 +170,8 @@ func (s *loopHTTPFuzzAggregateStats) considerInterestingSample(sample loopHTTPFu
 	}
 }
 
-func (s *loopHTTPFuzzAggregateStats) observeResponseLengthGroup(sample loopHTTPFuzzInterestingSample) {
+// observeResponseLengthGroup 维护响应长度分组及其代表样本。
+func (s *loopHTTPFuzzOverviewStats) observeResponseLengthGroup(sample loopHTTPFuzzInterestingSample) {
 	if s == nil {
 		return
 	}
@@ -173,21 +193,45 @@ func (s *loopHTTPFuzzAggregateStats) observeResponseLengthGroup(sample loopHTTPF
 	}
 }
 
-func buildLoopHTTPFuzzAggregateReport(actionName string, stats *loopHTTPFuzzAggregateStats) string {
+func newLoopHTTPFuzzReportData() *loopHTTPFuzzReportData {
+	return &loopHTTPFuzzReportData{}
+}
+
+// observeError 只在详细结果上限内记录失败详情，避免大批量错误撑爆报告。
+func (r *loopHTTPFuzzReportData) observeError(index int, resultErr error) {
+	if r == nil || resultErr == nil || index <= 0 || index > loopHTTPFuzzDetailedResultLimit {
+		return
+	}
+	r.DetailRecords = append(r.DetailRecords, loopHTTPFuzzDetailRecord{
+		Index: index,
+		Error: resultErr.Error(),
+	})
+}
+
+// observeDetailedResult 只在详细结果上限内保留完整请求/响应详情。
+func (r *loopHTTPFuzzReportData) observeDetailedResult(resultIndex int, processed loopHTTPFuzzProcessedResult) {
+	if r == nil || resultIndex <= 0 || resultIndex > loopHTTPFuzzDetailedResultLimit {
+		return
+	}
+	processed.Sample.Index = resultIndex
+	r.DetailRecords = append(r.DetailRecords, loopHTTPFuzzDetailRecord{
+		Index:     resultIndex,
+		Processed: processed,
+	})
+}
+
+// buildLoopHTTPFuzzOverviewReport 负责渲染固定概况段。
+// 这部分内容不会参与压缩，避免每次压缩都重复处理稳定的概况信息。
+func buildLoopHTTPFuzzOverviewReport(actionName string, stats *loopHTTPFuzzOverviewStats) string {
 	if stats == nil {
 		return ""
 	}
-	includeLengthAnalysis := stats.shouldUseResponseLengthAnalysis()
-	truncatedDetails := max(stats.TotalRequests-loopHTTPFuzzDetailedResultLimit, 0)
 
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf("=== Aggregate Summary for %s ===\n", actionName))
+	out.WriteString(fmt.Sprintf("=== Fuzz Overview for %s ===\n", actionName))
 	out.WriteString(fmt.Sprintf("Total Requests: %d\n", stats.TotalRequests))
 	out.WriteString(fmt.Sprintf("Failed Requests: %d\n", stats.FailedRequests))
 	out.WriteString(fmt.Sprintf("Saved HTTPFlows: %d\n", stats.SavedHTTPFlowCount))
-	if truncatedDetails > 0 {
-		out.WriteString(fmt.Sprintf("Frontend Detail Omitted: %d results (detail output is limited to the first %d results; full traffic remains stored in HTTPFlow)\n", truncatedDetails, loopHTTPFuzzDetailedResultLimit))
-	}
 
 	if len(stats.StatusCounts) > 0 {
 		out.WriteString("Status Distribution:\n")
@@ -213,7 +257,25 @@ func buildLoopHTTPFuzzAggregateReport(actionName string, stats *loopHTTPFuzzAggr
 		out.WriteString(fmt.Sprintf("Response Body Stats: avg=%d bytes min=%d bytes max=%d bytes\n", avgBodyLength, stats.MinBodyLength, stats.MaxBodyLength))
 	}
 
-	if includeLengthAnalysis && len(stats.ResponseLengthGroups) > 0 {
+	if lengthPreview := stats.responseLengthPreview(6); lengthPreview != "" {
+		out.WriteString(fmt.Sprintf("Response Length Overview: %s\n", lengthPreview))
+	}
+
+	return strings.TrimSpace(out.String())
+}
+
+// buildLoopHTTPFuzzLargeRunAnalysisReport 负责渲染大样本场景的分析段：
+// 主要包含长度分组代表样本，以及 topN 可疑样本摘要。
+func buildLoopHTTPFuzzLargeRunAnalysisReport(stats *loopHTTPFuzzOverviewStats) string {
+	if stats == nil {
+		return ""
+	}
+
+	var out strings.Builder
+	out.WriteString("=== Large-Run Analysis ===\n")
+	wroteContent := false
+	if stats.shouldUseResponseLengthAnalysis() && len(stats.ResponseLengthGroups) > 0 {
+		wroteContent = true
 		out.WriteString("Response Length Groups:\n")
 		for _, group := range stats.sortedResponseLengthGroups() {
 			out.WriteString(fmt.Sprintf("- %d bytes: %d responses", group.BodyLength, group.Count))
@@ -247,6 +309,10 @@ func buildLoopHTTPFuzzAggregateReport(actionName string, stats *loopHTTPFuzzAggr
 	}
 
 	if len(stats.InterestingSamples) > 0 {
+		if wroteContent {
+			out.WriteByte('\n')
+		}
+		wroteContent = true
 		out.WriteString("Interesting Samples:\n")
 		for idx, sample := range stats.InterestingSamples {
 			out.WriteString(fmt.Sprintf("%d. score=%d status=%s duration=%d ms body=%d bytes\n", idx+1, sample.Score, formatLoopHTTPFuzzStatusCode(sample.StatusCode), sample.DurationMs, sample.BodyLength))
@@ -275,28 +341,97 @@ func buildLoopHTTPFuzzAggregateReport(actionName string, stats *loopHTTPFuzzAggr
 		}
 	}
 
+	if !wroteContent {
+		return ""
+	}
 	return strings.TrimSpace(out.String())
 }
 
-func buildLoopHTTPFuzzVerificationOverview(actionName string, stats *loopHTTPFuzzAggregateStats, representativeHiddenIndex string) string {
-	aggregateReport := strings.TrimSpace(buildLoopHTTPFuzzAggregateReport(actionName, stats))
-	if aggregateReport == "" && strings.TrimSpace(representativeHiddenIndex) == "" {
+// buildLoopHTTPFuzzDetailedPacketReport 负责渲染小样本场景的详细包结果。
+// 这里只读取循环中预先裁剪过的 detail records，不再额外扩容。
+func buildLoopHTTPFuzzDetailedPacketReport(reportData *loopHTTPFuzzReportData) string {
+	if reportData == nil || len(reportData.DetailRecords) == 0 {
 		return ""
 	}
 
 	var out strings.Builder
-	out.WriteString("=== Fuzz Overview For Next-Step Analysis ===\n")
-	if aggregateReport != "" {
-		out.WriteString(aggregateReport)
-		out.WriteByte('\n')
-	}
-	if strings.TrimSpace(representativeHiddenIndex) != "" {
-		out.WriteString(fmt.Sprintf("Representative HTTPFlow: %s\n", representativeHiddenIndex))
+	out.WriteString("=== Detailed Packet Results ===\n")
+	for _, detail := range reportData.DetailRecords {
+		if strings.TrimSpace(detail.Error) != "" {
+			out.WriteString(fmt.Sprintf("\n--- Result %d ---\n", detail.Index))
+			out.WriteString(fmt.Sprintf("Error: %s\n", detail.Error))
+			continue
+		}
+		appendLoopHTTPFuzzRenderedDetailedResult(&out, detail.Index, detail.Processed)
 	}
 	return strings.TrimSpace(out.String())
 }
 
-func (s *loopHTTPFuzzAggregateStats) sortedResponseLengthGroups() []*loopHTTPFuzzResponseLengthGroup {
+// appendLoopHTTPFuzzRenderedDetailedResult 负责把一条结构化结果渲染成详细包文本。
+func appendLoopHTTPFuzzRenderedDetailedResult(out *strings.Builder, resultIndex int, processed loopHTTPFuzzProcessedResult) {
+	if out == nil {
+		return
+	}
+	out.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultIndex))
+	out.WriteString(fmt.Sprintf("Payload: %v\n", processed.Payloads))
+	out.WriteString(fmt.Sprintf("Duration: %d ms\n", processed.DurationMs))
+	out.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(processed.StatusCode)))
+	out.WriteString(fmt.Sprintf("Request Summary: %s\n", processed.RequestSummary))
+	out.WriteString(fmt.Sprintf("Response Summary: %s\n", processed.ResponseSummary))
+	if processed.HiddenIndex != "" {
+		out.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", processed.HiddenIndex))
+	}
+	out.WriteString(fmt.Sprintf("Request Changes:\n%s\n", processed.RequestDiff))
+	out.WriteString(fmt.Sprintf("Response Summary:\n%s\n", processed.ResponseDigest))
+	out.WriteString("Request Packet:\n")
+	out.WriteString(processed.RequestRaw)
+	out.WriteString("\nResponse Packet:\n")
+	out.WriteString(processed.ResponseRaw)
+	out.WriteRune('\n')
+}
+
+// buildLoopHTTPFuzzAnalysisSection 根据本轮结果规模选择渲染详细包段或大样本分析段。
+func buildLoopHTTPFuzzAnalysisSection(stats *loopHTTPFuzzOverviewStats, reportData *loopHTTPFuzzReportData) string {
+	if stats == nil {
+		return ""
+	}
+	if stats.TotalRequests == 0 {
+		return "=== Detailed Packet Results ===\n(no results returned by the fuzz execution)"
+	}
+	if stats.TotalRequests <= loopHTTPFuzzDetailedResultLimit {
+		return buildLoopHTTPFuzzDetailedPacketReport(reportData)
+	}
+	return buildLoopHTTPFuzzLargeRunAnalysisReport(stats)
+}
+
+// joinLoopHTTPFuzzReportSections 把多个非空段落按空行拼接成最终文档。
+func joinLoopHTTPFuzzReportSections(sections ...string) string {
+	parts := make([]string, 0, len(sections))
+	for _, section := range sections {
+		if trimmed := strings.TrimSpace(section); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// buildLoopHTTPFuzzVerificationPayload 在最终反馈文档基础上补齐代表性 HTTPFlow，
+// 供 VerifyUserSatisfaction 使用，避免验证输入缺少定位样本。
+func buildLoopHTTPFuzzVerificationPayload(feedbackResult, representativeHiddenIndex string) string {
+	payload := strings.TrimSpace(feedbackResult)
+	if payload == "" {
+		if strings.TrimSpace(representativeHiddenIndex) == "" {
+			return ""
+		}
+		return fmt.Sprintf("Representative HTTPFlow: %s", strings.TrimSpace(representativeHiddenIndex))
+	}
+	if strings.TrimSpace(representativeHiddenIndex) != "" && !strings.Contains(payload, representativeHiddenIndex) {
+		payload += fmt.Sprintf("\n\nRepresentative HTTPFlow: %s", strings.TrimSpace(representativeHiddenIndex))
+	}
+	return payload
+}
+
+func (s *loopHTTPFuzzOverviewStats) sortedResponseLengthGroups() []*loopHTTPFuzzResponseLengthGroup {
 	if s == nil || len(s.ResponseLengthGroups) == 0 {
 		return nil
 	}
@@ -315,7 +450,7 @@ func (s *loopHTTPFuzzAggregateStats) sortedResponseLengthGroups() []*loopHTTPFuz
 	return groups
 }
 
-func (s *loopHTTPFuzzAggregateStats) shouldUseResponseLengthAnalysis() bool {
+func (s *loopHTTPFuzzOverviewStats) shouldUseResponseLengthAnalysis() bool {
 	if s == nil || len(s.ResponseLengthGroups) < 2 {
 		return false
 	}
@@ -337,7 +472,7 @@ func (s *loopHTTPFuzzAggregateStats) shouldUseResponseLengthAnalysis() bool {
 	}
 }
 
-func (s *loopHTTPFuzzAggregateStats) finalizeResponseLengthGroups() {
+func (s *loopHTTPFuzzOverviewStats) finalizeResponseLengthGroups() {
 	if s == nil || len(s.ResponseLengthGroups) == 0 {
 		return
 	}
@@ -378,18 +513,18 @@ func (s *loopHTTPFuzzAggregateStats) finalizeResponseLengthGroups() {
 	}
 }
 
-type loopHTTPFuzzProgressReporter struct {
+type loopHTTPFuzzThrottleEmitter struct {
 	loop       *reactloops.ReActLoop
 	taskID     string
 	actionName string
 	throttle   func(func())
 }
 
-func (r *loopHTTPFuzzProgressReporter) allowEmitDetailHttpFlow(resultIndex int) bool {
+func (r *loopHTTPFuzzThrottleEmitter) allowEmitDetailHttpFlow(resultIndex int) bool {
 	return r != nil && resultIndex > 0 && resultIndex <= loopHTTPFuzzFrontendDetailLimit
 }
 
-func (r *loopHTTPFuzzProgressReporter) emitProgress(stats *loopHTTPFuzzAggregateStats, lastStatusCode int, force bool) {
+func (r *loopHTTPFuzzThrottleEmitter) emitProgress(stats *loopHTTPFuzzOverviewStats, lastStatusCode int, force bool) {
 	if r == nil || r.loop == nil || strings.TrimSpace(r.taskID) == "" || stats == nil {
 		return
 	}
@@ -411,7 +546,7 @@ func (r *loopHTTPFuzzProgressReporter) emitProgress(stats *loopHTTPFuzzAggregate
 	r.throttle(emit)
 }
 
-func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzAggregateStats, lastStatusCode int, finished bool) string {
+func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzOverviewStats, lastStatusCode int, finished bool) string {
 	if stats == nil || stats.TotalRequests <= 0 {
 		return ""
 	}
@@ -450,7 +585,7 @@ func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzAgg
 	return out.String()
 }
 
-func (s *loopHTTPFuzzAggregateStats) responseLengthPreview(maxItems int) string {
+func (s *loopHTTPFuzzOverviewStats) responseLengthPreview(maxItems int) string {
 	if s == nil || len(s.ResponseLengthGroups) == 0 || maxItems <= 0 {
 		return ""
 	}
@@ -463,15 +598,6 @@ func (s *loopHTTPFuzzAggregateStats) responseLengthPreview(maxItems int) string 
 		parts = append(parts, fmt.Sprintf("%dB=%d", group.BodyLength, group.Count))
 	}
 	return strings.Join(parts, ", ")
-}
-
-func appendLoopHTTPFuzzErrorResult(diffSummary, analysisSummary *strings.Builder, resultIndex int, resultErr error) {
-	if diffSummary == nil || analysisSummary == nil || resultErr == nil {
-		return
-	}
-	errMsg := fmt.Sprintf("\n--- Result %d ---\nError: %v\n", resultIndex, resultErr)
-	diffSummary.WriteString(errMsg)
-	analysisSummary.WriteString(errMsg)
 }
 
 func buildLoopHTTPFuzzProcessedResult(resultIndex int, result *mutate.HttpResult, originalRequest string, baselineBodyLength int) loopHTTPFuzzProcessedResult {
@@ -519,7 +645,7 @@ func buildLoopHTTPFuzzProcessedResult(resultIndex int, result *mutate.HttpResult
 	}
 }
 
-func syncLoopHTTPFuzzLastResultState(loop *reactloops.ReActLoop, processed loopHTTPFuzzProcessedResult, runtimeID string, progressReporter *loopHTTPFuzzProgressReporter, resultIndex int) {
+func syncLoopHTTPFuzzLastResultState(loop *reactloops.ReActLoop, processed loopHTTPFuzzProcessedResult, runtimeID string, progressReporter *loopHTTPFuzzThrottleEmitter, resultIndex int) {
 	if loop == nil {
 		return
 	}
@@ -539,37 +665,6 @@ func syncLoopHTTPFuzzLastResultState(loop *reactloops.ReActLoop, processed loopH
 	if runtimeID != "" && strings.TrimSpace(processed.HiddenIndex) != "" {
 		loop.GetEmitter().EmitYakitHTTPFlow(runtimeID, processed.HiddenIndex)
 	}
-}
-
-func appendLoopHTTPFuzzDetailedResult(diffSummary, analysisSummary *strings.Builder, resultIndex int, processed loopHTTPFuzzProcessedResult) {
-	if diffSummary == nil || analysisSummary == nil {
-		return
-	}
-	diffSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultIndex))
-	analysisSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultIndex))
-	diffSummary.WriteString(fmt.Sprintf("Payload: %v\n", processed.Payloads))
-	analysisSummary.WriteString(fmt.Sprintf("Payload: %v\n", processed.Payloads))
-	diffSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", processed.DurationMs))
-	analysisSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", processed.DurationMs))
-	diffSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(processed.StatusCode)))
-	analysisSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(processed.StatusCode)))
-	diffSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", processed.RequestSummary))
-	analysisSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", processed.RequestSummary))
-	diffSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", processed.ResponseSummary))
-	analysisSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", processed.ResponseSummary))
-	if processed.HiddenIndex != "" {
-		diffSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", processed.HiddenIndex))
-		analysisSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", processed.HiddenIndex))
-	}
-	diffSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", processed.RequestDiff))
-	analysisSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", processed.RequestDiff))
-	diffSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", processed.ResponseDigest))
-	analysisSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", processed.ResponseDigest))
-	diffSummary.WriteString("Request Packet:\n")
-	diffSummary.WriteString(processed.RequestRaw)
-	diffSummary.WriteString("\nResponse Packet:\n")
-	diffSummary.WriteString(processed.ResponseRaw)
-	diffSummary.WriteRune('\n')
 }
 
 func shouldUpdateLoopHTTPFuzzRepresentative(processed loopHTTPFuzzProcessedResult, bestRepresentativeScore int, representativeHiddenIndex string, representativeRequest string) bool {
@@ -751,7 +846,7 @@ func getLoopTaskContext(loop *reactloops.ReActLoop) context.Context {
 	return task.GetContext()
 }
 
-// getFuzzRequest retrieves the FuzzHTTPRequest from loop context
+// getFuzzRequest 从循环上下文里读取当前生效的 FuzzHTTPRequest。
 func getFuzzRequest(loop *reactloops.ReActLoop) (*mutate.FuzzHTTPRequest, error) {
 	fuzzReqAny := loop.GetVariable("fuzz_request")
 	if fuzzReqAny == nil {
@@ -764,8 +859,11 @@ func getFuzzRequest(loop *reactloops.ReActLoop) (*mutate.FuzzHTTPRequest, error)
 	return fuzzReq, nil
 }
 
-// executeFuzzAndCompare executes the fuzz request, keeps the full request/response archive,
-// emits compact user-visible summaries, and asks AI whether fuzzing should continue.
+// executeFuzzAndCompare 是 HTTP fuzz 循环的核心执行入口。
+// 它的职责分三步：
+// 1. 执行 fuzz，并在循环中只收集结构化统计与受限详细记录。
+// 2. 结束后根据数据规模渲染 overview + analysis 文档。
+// 3. 在需要时只压缩 analysis 段，再把最终反馈送去满意度验证。
 func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTTPRequestIf, actionName string, paramSummary string) (string, *aicommon.VerifySatisfactionResult, error) {
 	isHttpsStr := loop.Get("is_https")
 	isHttps := isHttpsStr == "true"
@@ -792,15 +890,16 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		taskCtx = context.Background()
 	}
 
+	// 进度事件仍然边执行边发，但正文报告改成最后统一渲染。
 	emitFuzzStage(loop, streamTaskID, fmt.Sprintf("开始执行 %s，HTTPFlow 会落库并保留完整请求/响应。", actionName))
-	progressReporter := &loopHTTPFuzzProgressReporter{
+	progressEmitter := &loopHTTPFuzzThrottleEmitter{
 		loop:       loop,
 		taskID:     streamTaskID,
 		actionName: actionName,
 		throttle:   utils.NewThrottle(loopHTTPFuzzProgressEmitInterval.Seconds()),
 	}
 
-	// Execute the fuzz request
+	// 真实执行阶段只保留结构化数据，不在循环里直接拼接长文本报告。
 	execOpts := []mutate.HttpPoolConfigOption{
 		mutate.WithPoolOpt_Https(isHttps),
 		mutate.WithPoolOpt_RuntimeId(runtimeID),
@@ -815,13 +914,9 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		return "", nil, utils.Errorf("failed to execute fuzz request: %v", err)
 	}
 
-	var diffSummary strings.Builder
-	diffSummary.WriteString(fmt.Sprintf("=== Fuzz Results for %s ===\n", actionName))
-	var analysisSummary strings.Builder
-	analysisSummary.WriteString(fmt.Sprintf("=== 漏洞测试分析：%s ===\n", actionName))
-
 	originalRequest := getCurrentRequestRaw(loop)
-	stats := newLoopHTTPFuzzAggregateStats()
+	overview := newLoopHTTPFuzzOverviewStats()
+	reportData := newLoopHTTPFuzzReportData()
 	representativeRequest := ""
 	representativeResponse := ""
 	representativeHiddenIndex := ""
@@ -830,24 +925,23 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	bestRepresentativeScore := -1
 
 	for result := range resultCh {
-		detailedWritten := stats.TotalRequests <= loopHTTPFuzzDetailedResultLimit
+		// 结果编号按 1 开始，便于报告、前端事件和样本索引统一。
+		resultIndex := overview.TotalRequests + 1
 		if result.Error != nil {
-			stats.observeError()
-			if detailedWritten {
-				appendLoopHTTPFuzzErrorResult(&diffSummary, &analysisSummary, stats.TotalRequests, result.Error)
-			}
-			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 第 %d 个测试请求执行失败：%v", actionName, stats.TotalRequests, result.Error))
-			progressReporter.emitProgress(stats, 0, false)
+			overview.observeError()
+			reportData.observeError(resultIndex, result.Error)
+			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 第 %d 个测试请求执行失败：%v", actionName, resultIndex, result.Error))
+			progressEmitter.emitProgress(overview, 0, false)
 			continue
 		}
 
-		processed := buildLoopHTTPFuzzProcessedResult(stats.TotalRequests, result, originalRequest, stats.BaselineBodyLength)
+		processed := buildLoopHTTPFuzzProcessedResult(resultIndex, result, originalRequest, overview.BaselineBodyLength)
 		collectedPayloads = append(collectedPayloads, processed.Payloads...)
-		syncLoopHTTPFuzzLastResultState(loop, processed, runtimeID, progressReporter, stats.TotalRequests)
+		syncLoopHTTPFuzzLastResultState(loop, processed, runtimeID, progressEmitter, resultIndex)
 
-		stats.observeSuccess(processed.StatusCode, processed.DurationMs, processed.BodyLength, processed.HiddenIndex != "")
-		stats.considerInterestingSample(processed.Sample)
-		stats.observeResponseLengthGroup(processed.Sample)
+		overview.observeSuccess(processed.StatusCode, processed.DurationMs, processed.BodyLength, processed.HiddenIndex != "")
+		overview.considerInterestingSample(processed.Sample)
+		overview.observeResponseLengthGroup(processed.Sample)
 
 		if shouldUpdateLoopHTTPFuzzRepresentative(processed, bestRepresentativeScore, representativeHiddenIndex, representativeRequest) {
 			bestRepresentativeScore = processed.Sample.Score
@@ -857,15 +951,13 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 			representativeStatusCode = processed.StatusCode
 		}
 
-		if detailedWritten {
-			appendLoopHTTPFuzzDetailedResult(&diffSummary, &analysisSummary, stats.TotalRequests, processed)
-		}
+		reportData.observeDetailedResult(resultIndex, processed)
 
-		progressReporter.emitProgress(stats, processed.StatusCode, false)
+		progressEmitter.emitProgress(overview, processed.StatusCode, false)
 	}
 
-	stats.finalizeResponseLengthGroups()
-	progressReporter.emitProgress(stats, representativeStatusCode, true)
+	overview.finalizeResponseLengthGroups()
+	progressEmitter.emitProgress(overview, representativeStatusCode, true)
 
 	if representativeRequest != "" || representativeResponse != "" {
 		loop.Set("representative_request", representativeRequest)
@@ -873,48 +965,31 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		loop.Set("representative_httpflow_hidden_index", representativeHiddenIndex)
 	}
 
-	if stats.TotalRequests == 0 {
-		diffSummary.WriteString("\n(no results returned by the fuzz execution)\n")
-		analysisSummary.WriteString("\n(no results returned by the fuzz execution)\n")
-	}
-	if stats.SavedHTTPFlowCount > 0 {
-		diffSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", stats.SavedHTTPFlowCount))
-		analysisSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", stats.SavedHTTPFlowCount))
-	}
+	overviewReport := buildLoopHTTPFuzzOverviewReport(actionName, overview)
+	analysisSection := buildLoopHTTPFuzzAnalysisSection(overview, reportData)
 
-	aggregateReport := buildLoopHTTPFuzzAggregateReport(actionName, stats)
-	if aggregateReport != "" {
-		diffSummary.WriteString("\n\n")
-		diffSummary.WriteString(aggregateReport)
-		diffSummary.WriteRune('\n')
-		analysisSummary.WriteString("\n\n")
-		analysisSummary.WriteString(aggregateReport)
-		analysisSummary.WriteRune('\n')
-	}
+	loop.Set("diff_result_compressed", "")
 
-	fullDiffResult := diffSummary.String()
-	analysisResult := analysisSummary.String()
-	loop.Set("diff_result_full", fullDiffResult)
-	loop.Set("diff_result_compressed", analysisResult)
-	verificationOverview := buildLoopHTTPFuzzVerificationOverview(actionName, stats, representativeHiddenIndex)
-
-	feedbackResult := analysisResult
-	compressedResult := ""
-	if len(fullDiffResult) > loopHTTPFuzzCompressionThreshold && invoker != nil {
+	if len(strings.TrimSpace(analysisSection)) > loopHTTPFuzzCompressionThreshold && invoker != nil {
 		emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 结果超过 40KB，开始生成压缩报告并检查所有数据包。", actionName))
 		compressionTarget := buildFuzzCompressionTarget(loop, actionName)
-		compressed, compressErr := invoker.CompressLongTextWithDestination(taskCtx, fullDiffResult, compressionTarget, loopHTTPFuzzCompressionTarget)
+		compressed, compressErr := invoker.CompressLongTextWithDestination(taskCtx, analysisSection, compressionTarget, loopHTTPFuzzCompressionTarget)
 		if compressErr != nil {
 			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 压缩报告失败，回退到原始测试结果。", actionName))
 		} else {
-			compressedResult = compressed
-			feedbackResult = buildCompressedFeedbackReport(verificationOverview, compressed, representativeRequest, representativeResponse, representativeHiddenIndex)
-			loop.Set("diff_result_compressed", feedbackResult)
+			analysisSection = buildCompressedAnalysisSection(compressed, representativeRequest, representativeResponse, representativeHiddenIndex)
+			loop.Set("diff_result_compressed", analysisSection)
 			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 压缩报告完成，准备验证是否达到安全测试目标。", actionName))
 		}
 	}
 
-	verifyResult, verificationText, err := verifyFuzzCompletion(loop, taskCtx, streamTaskID, actionName, verificationOverview, feedbackResult, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex)
+	fullReport := joinLoopHTTPFuzzReportSections(overviewReport, analysisSection)
+	loop.Set("diff_result_full", fullReport)
+	loop.Set("diff_result_analysis", fullReport)
+	feedbackResult := fullReport
+
+	verificationPayload := buildLoopHTTPFuzzVerificationPayload(feedbackResult, representativeHiddenIndex)
+	verifyResult, verificationText, err := verifyFuzzCompletion(loop, taskCtx, streamTaskID, actionName, verificationPayload, representativeHiddenIndex)
 	if err != nil {
 		return "", nil, err
 	}
@@ -923,9 +998,9 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		loop.Set("verification_result", verificationText)
 	}
 
-	actionResultSummary := fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。代表性响应状态：%s", stats.TotalRequests, stats.SavedHTTPFlowCount, formatLoopHTTPFuzzStatusCode(representativeStatusCode))
+	actionResultSummary := fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。代表性响应状态：%s", overview.TotalRequests, overview.SavedHTTPFlowCount, formatLoopHTTPFuzzStatusCode(representativeStatusCode))
 	if representativeStatusCode == 0 {
-		actionResultSummary = fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。", stats.TotalRequests, stats.SavedHTTPFlowCount)
+		actionResultSummary = fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。", overview.TotalRequests, overview.SavedHTTPFlowCount)
 	}
 	verificationSummary := buildLoopHTTPFuzzVerificationSummary(verifyResult)
 	actionRecord := recordLoopHTTPFuzzAction(loop, actionName, paramSummary, actionResultSummary, verificationSummary, representativeHiddenIndex, collectedPayloads)
@@ -938,6 +1013,7 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	return feedbackResult, verifyResult, nil
 }
 
+// buildFuzzCompressionTarget 只描述“可压缩分析段”的压缩目标，不包含固定 overview。
 func buildFuzzCompressionTarget(loop *reactloops.ReActLoop, actionName string) string {
 	task := loop.GetCurrentTask()
 	userInput := ""
@@ -947,16 +1023,14 @@ func buildFuzzCompressionTarget(loop *reactloops.ReActLoop, actionName string) s
 	if userInput == "" {
 		userInput = "HTTP 安全模糊测试"
 	}
-	return fmt.Sprintf("用户正在执行 HTTP 安全模糊测试，当前步骤是 %s。你的核心目标是分析漏洞，而不是复述数据包。请覆盖所有请求/响应对，重点归纳疑似漏洞类型、触发依据、差异模式、可复现代表性数据包、以及下一步验证动作。原始目标：%s", actionName, userInput)
+	return fmt.Sprintf("用户正在执行 HTTP 安全模糊测试，当前步骤是 %s。你将收到的是可压缩分析段，不包含固定概况。你的核心目标是分析漏洞，而不是复述数据包。请覆盖所有请求/响应对，重点归纳疑似漏洞类型、触发依据、差异模式、可复现代表性数据包、以及下一步验证动作。原始目标：%s", actionName, userInput)
 }
 
-func buildCompressedFeedbackReport(overview, compressed, representativeRequest, representativeResponse, representativeHiddenIndex string) string {
+// buildCompressedAnalysisSection 只渲染压缩后的分析段。
+// 固定 overview 会在外层通过 joinLoopHTTPFuzzReportSections 单独拼接。
+func buildCompressedAnalysisSection(compressed, representativeRequest, representativeResponse, representativeHiddenIndex string) string {
 	var out strings.Builder
-	if strings.TrimSpace(overview) != "" {
-		out.WriteString(strings.TrimSpace(overview))
-		out.WriteString("\n\n")
-	}
-	out.WriteString("=== Compressed Fuzz Report ===\n")
+	out.WriteString("=== Compressed Fuzz Analysis ===\n")
 	out.WriteString(compressed)
 	if representativeRequest != "" || representativeResponse != "" {
 		out.WriteString("\n\n=== Representative Packet For Follow-Up Testing ===\n")
@@ -976,22 +1050,15 @@ func buildCompressedFeedbackReport(overview, compressed, representativeRequest, 
 	return out.String()
 }
 
-func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, streamTaskID, actionName, verificationOverview, feedbackResult, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex string) (*aicommon.VerifySatisfactionResult, string, error) {
+func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, streamTaskID, actionName, verificationPayload, representativeHiddenIndex string) (*aicommon.VerifySatisfactionResult, string, error) {
 	invoker := loop.GetInvoker()
 	task := loop.GetCurrentTask()
 	if invoker == nil || task == nil {
 		return nil, "", nil
 	}
 
-	payload := feedbackResult
-	if compressedResult != "" {
-		payload = buildCompressedFeedbackReport(verificationOverview, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex)
-	} else if strings.TrimSpace(verificationOverview) != "" && !strings.Contains(feedbackResult, verificationOverview) {
-		payload = verificationOverview + "\n\n" + feedbackResult
-	}
-
 	emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 测试结果已准备完成，开始验证是否达到当前安全测试目标。", actionName))
-	verifyResult, err := invoker.VerifyUserSatisfaction(taskCtx, task.GetUserInput(), true, payload)
+	verifyResult, err := invoker.VerifyUserSatisfaction(taskCtx, task.GetUserInput(), true, verificationPayload)
 	if err != nil {
 		return nil, "", utils.Wrap(err, "verify fuzz completion")
 	}
@@ -1109,7 +1176,7 @@ func buildLoopHTTPFuzzVerificationSummary(verifyResult *aicommon.VerifySatisfact
 	return fmt.Sprintf("%s；%s", state, strings.TrimSpace(verifyResult.Reasoning))
 }
 
-// compareRequests compares two HTTP requests and returns the differences
+// compareRequests 用于对比两个 HTTP 请求，返回逐行差异。
 func compareRequests(original, modified string) string {
 	originalLines := strings.Split(strings.TrimSpace(original), "\n")
 	modifiedLines := strings.Split(strings.TrimSpace(modified), "\n")

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yaklang/yaklang/common/mutate"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/utils/yakgit/yakdiff"
 )
 
 const (
@@ -37,7 +38,7 @@ type loopHTTPFuzzInterestingSample struct {
 	RequestSummary  string
 	ResponseSummary string
 	RequestDiff     string
-	ResponseDigest  string
+	ResponsePreview string
 	ResponseRaw     string
 	ResponseDiff    string
 }
@@ -59,7 +60,7 @@ type loopHTTPFuzzProcessedResult struct {
 	RequestSummary  string
 	ResponseSummary string
 	RequestDiff     string
-	ResponseDigest  string
+	ResponsePreview string
 	HiddenIndex     string
 	StatusCode      int
 	BodyLength      int
@@ -222,13 +223,19 @@ func (r *loopHTTPFuzzReportData) observeDetailedResult(resultIndex int, processe
 
 // buildLoopHTTPFuzzOverviewReport 负责渲染固定概况段。
 // 这部分内容不会参与压缩，避免每次压缩都重复处理稳定的概况信息。
-func buildLoopHTTPFuzzOverviewReport(actionName string, stats *loopHTTPFuzzOverviewStats) string {
+// 除了固定统计外，这里也补充本轮 fuzz 的关键参数，方便直接看出“测了谁、怎么测的”。
+func buildLoopHTTPFuzzOverviewReport(actionName string, paramSummary string, stats *loopHTTPFuzzOverviewStats) string {
 	if stats == nil {
 		return ""
 	}
 
 	var out strings.Builder
 	out.WriteString(fmt.Sprintf("=== Fuzz Overview for %s ===\n", actionName))
+	if strings.TrimSpace(paramSummary) != "" {
+		out.WriteString("Fuzz Parameters:\n")
+		out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(strings.TrimSpace(paramSummary), 600), "- "))
+		out.WriteByte('\n')
+	}
 	out.WriteString(fmt.Sprintf("Total Requests: %d\n", stats.TotalRequests))
 	out.WriteString(fmt.Sprintf("Failed Requests: %d\n", stats.FailedRequests))
 	out.WriteString(fmt.Sprintf("Saved HTTPFlows: %d\n", stats.SavedHTTPFlowCount))
@@ -274,7 +281,7 @@ func buildLoopHTTPFuzzLargeRunAnalysisReport(stats *loopHTTPFuzzOverviewStats) s
 	var out strings.Builder
 	out.WriteString("=== Large-Run Analysis ===\n")
 	wroteContent := false
-	if stats.shouldUseResponseLengthAnalysis() && len(stats.ResponseLengthGroups) > 0 {
+	if len(stats.ResponseLengthGroups) > 0 {
 		wroteContent = true
 		out.WriteString("Response Length Groups:\n")
 		for _, group := range stats.sortedResponseLengthGroups() {
@@ -299,8 +306,17 @@ func buildLoopHTTPFuzzLargeRunAnalysisReport(stats *loopHTTPFuzzOverviewStats) s
 				if group.IsBaseline && strings.TrimSpace(group.BaselineLabel) != "" {
 					out.WriteString(fmt.Sprintf("  %s\n", group.BaselineLabel))
 				}
+				if group.IsBaseline && strings.TrimSpace(group.Sample.ResponseRaw) != "" {
+					out.WriteString("  Baseline Response Packet:\n")
+					out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(group.Sample.ResponseRaw, 600), "    "))
+					out.WriteByte('\n')
+				}
 				if strings.TrimSpace(group.Sample.ResponseDiff) != "" {
-					out.WriteString("  Sample Diff From Baseline:\n")
+					if group.IsBaseline {
+						out.WriteString("  Baseline Representative Response:\n")
+					} else {
+						out.WriteString("  Sample Diff From Baseline:\n")
+					}
 					out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(group.Sample.ResponseDiff, 400), "    "))
 					out.WriteByte('\n')
 				}
@@ -333,9 +349,9 @@ func buildLoopHTTPFuzzLargeRunAnalysisReport(stats *loopHTTPFuzzOverviewStats) s
 				out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(sample.RequestDiff, 240), "     "))
 				out.WriteByte('\n')
 			}
-			if sample.ResponseDigest != "" {
+			if sample.ResponsePreview != "" {
 				out.WriteString("   Response Digest:\n")
-				out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(sample.ResponseDigest, 240), "     "))
+				out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(sample.ResponsePreview, 240), "     "))
 				out.WriteByte('\n')
 			}
 		}
@@ -382,7 +398,7 @@ func appendLoopHTTPFuzzRenderedDetailedResult(out *strings.Builder, resultIndex 
 		out.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", processed.HiddenIndex))
 	}
 	out.WriteString(fmt.Sprintf("Request Changes:\n%s\n", processed.RequestDiff))
-	out.WriteString(fmt.Sprintf("Response Summary:\n%s\n", processed.ResponseDigest))
+	out.WriteString(fmt.Sprintf("Response Summary:\n%s\n", processed.ResponsePreview))
 	out.WriteString("Request Packet:\n")
 	out.WriteString(processed.RequestRaw)
 	out.WriteString("\nResponse Packet:\n")
@@ -506,7 +522,7 @@ func (s *loopHTTPFuzzOverviewStats) finalizeResponseLengthGroups() {
 		if group.IsBaseline {
 			group.BaselineLabel = fmt.Sprintf("Baseline group selected by dominant body length: %d bytes (%d responses).", group.BodyLength, group.Count)
 			s.BaselineBodyLength = group.BodyLength
-			group.Sample.ResponseDiff = "  (baseline representative response)"
+			group.Sample.ResponseDiff = "  (representative baseline response)"
 			continue
 		}
 		group.Sample.ResponseDiff = buildLoopHTTPFuzzResponseDiffFromBaseline(baselineGroup.Sample.ResponseRaw, group.Sample.ResponseRaw)
@@ -573,10 +589,8 @@ func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzOve
 	if statusPreview := formatLoopHTTPFuzzTopStatusCounts(stats.StatusCounts, 3); statusPreview != "" {
 		out.WriteString(fmt.Sprintf("，状态分布 %s", statusPreview))
 	}
-	if stats.shouldUseResponseLengthAnalysis() {
-		if lengthPreview := stats.responseLengthPreview(3); lengthPreview != "" {
-			out.WriteString(fmt.Sprintf("，长度分布 %s", lengthPreview))
-		}
+	if lengthPreview := stats.responseLengthPreview(3); lengthPreview != "" {
+		out.WriteString(fmt.Sprintf("，长度分布 %s", lengthPreview))
 	}
 	if len(stats.InterestingSamples) > 0 {
 		out.WriteString(fmt.Sprintf("，可疑样本 %d 个", len(stats.InterestingSamples)))
@@ -606,7 +620,7 @@ func buildLoopHTTPFuzzProcessedResult(resultIndex int, result *mutate.HttpResult
 	requestURL, requestSummary := buildHTTPRequestStreamSummary(requestRaw, result.Request.TLS != nil)
 	responseSummary := buildHTTPResponseStreamSummary(responseRaw, requestURL)
 	requestDiff := compareRequests(originalRequest, requestRaw)
-	responseDigest := summarizeResponse(responseRaw)
+	responsePreview := summarizeResponse(responseRaw)
 	statusCode := getStatusFromResponse(responseRaw)
 	_, responseBody := lowhttp.SplitHTTPPacketFast([]byte(responseRaw))
 	bodyLength := len(responseBody)
@@ -622,7 +636,7 @@ func buildLoopHTTPFuzzProcessedResult(resultIndex int, result *mutate.HttpResult
 		RequestSummary:  requestSummary,
 		ResponseSummary: responseSummary,
 		RequestDiff:     requestDiff,
-		ResponseDigest:  responseDigest,
+		ResponsePreview: responsePreview,
 		HiddenIndex:     hiddenIndex,
 		StatusCode:      statusCode,
 		BodyLength:      bodyLength,
@@ -639,7 +653,7 @@ func buildLoopHTTPFuzzProcessedResult(resultIndex int, result *mutate.HttpResult
 			RequestSummary:  requestSummary,
 			ResponseSummary: responseSummary,
 			RequestDiff:     requestDiff,
-			ResponseDigest:  responseDigest,
+			ResponsePreview: responsePreview,
 			ResponseRaw:     responseRaw,
 		},
 	}
@@ -965,7 +979,7 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		loop.Set("representative_httpflow_hidden_index", representativeHiddenIndex)
 	}
 
-	overviewReport := buildLoopHTTPFuzzOverviewReport(actionName, overview)
+	overviewReport := buildLoopHTTPFuzzOverviewReport(actionName, paramSummary, overview)
 	analysisSection := buildLoopHTTPFuzzAnalysisSection(overview, reportData)
 
 	loop.Set("diff_result_compressed", "")
@@ -1178,36 +1192,15 @@ func buildLoopHTTPFuzzVerificationSummary(verifyResult *aicommon.VerifySatisfact
 
 // compareRequests 用于对比两个 HTTP 请求，返回逐行差异。
 func compareRequests(original, modified string) string {
-	originalLines := strings.Split(strings.TrimSpace(original), "\n")
-	modifiedLines := strings.Split(strings.TrimSpace(modified), "\n")
-
-	var diff strings.Builder
-	maxLines := max(len(originalLines), len(modifiedLines))
-
-	for i := 0; i < maxLines; i++ {
-		origLine := ""
-		modLine := ""
-		if i < len(originalLines) {
-			origLine = strings.TrimSpace(originalLines[i])
-		}
-		if i < len(modifiedLines) {
-			modLine = strings.TrimSpace(modifiedLines[i])
-		}
-
-		if origLine != modLine {
-			if origLine != "" {
-				diff.WriteString(fmt.Sprintf("  - %s\n", origLine))
-			}
-			if modLine != "" {
-				diff.WriteString(fmt.Sprintf("  + %s\n", modLine))
-			}
-		}
+	diffText, err := yakdiff.Diff(original, modified)
+	if err != nil {
+		return fmt.Sprintf("  (diff failed: %v)", err)
 	}
-
-	if diff.Len() == 0 {
+	diffText = strings.TrimSpace(diffText)
+	if diffText == "" {
 		return "  (no changes)"
 	}
-	return diff.String()
+	return diffText
 }
 
 func max(a, b int) int {

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
@@ -4,21 +4,574 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/mutate"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/utils/yakgit/yakdiff"
 )
 
 const (
 	loopHTTPFuzzCompressionThreshold = 40 * 1024
 	loopHTTPFuzzCompressionTarget    = 20 * 1024
 	loopHTTPFuzzTimelinePreviewSize  = 8 * 1024
+	loopHTTPFuzzDetailedResultLimit  = 12
+	loopHTTPFuzzFrontendDetailLimit  = 6
+	loopHTTPFuzzInterestingTopN      = 6
+	loopHTTPFuzzProgressEmitInterval = 2 * time.Second
 	modifiedPacketContentField       = "modified_packet_content"
 )
+
+type loopHTTPFuzzInterestingSample struct {
+	Index           int
+	Score           int
+	StatusCode      int
+	DurationMs      int64
+	BodyLength      int
+	HiddenIndex     string
+	Payloads        []string
+	RequestSummary  string
+	ResponseSummary string
+	RequestDiff     string
+	ResponseDigest  string
+	ResponseRaw     string
+	ResponseDiff    string
+}
+
+type loopHTTPFuzzResponseLengthGroup struct {
+	BodyLength    int
+	Count         int
+	StatusCounts  map[int]int
+	Sample        loopHTTPFuzzInterestingSample
+	HasSample     bool
+	BestScore     int
+	IsBaseline    bool
+	BaselineLabel string
+}
+
+type loopHTTPFuzzAggregateStats struct {
+	TotalRequests        int
+	FailedRequests       int
+	SavedHTTPFlowCount   int
+	DetailedResultsShown int
+	OmittedDetails       int
+	SuccessfulResponses  int
+	TotalDurationMs      int64
+	MinDurationMs        int64
+	MaxDurationMs        int64
+	TotalBodyLength      int64
+	MinBodyLength        int
+	MaxBodyLength        int
+	BaselineBodyLength   int
+	StatusCounts         map[int]int
+	ResponseLengthGroups map[int]*loopHTTPFuzzResponseLengthGroup
+	InterestingSamples   []loopHTTPFuzzInterestingSample
+}
+
+func newLoopHTTPFuzzAggregateStats() *loopHTTPFuzzAggregateStats {
+	return &loopHTTPFuzzAggregateStats{
+		MinDurationMs:        -1,
+		MinBodyLength:        -1,
+		BaselineBodyLength:   -1,
+		StatusCounts:         make(map[int]int),
+		ResponseLengthGroups: make(map[int]*loopHTTPFuzzResponseLengthGroup),
+	}
+}
+
+func (s *loopHTTPFuzzAggregateStats) allowDetailedResult() bool {
+	return s != nil && s.DetailedResultsShown < loopHTTPFuzzDetailedResultLimit
+}
+
+func (s *loopHTTPFuzzAggregateStats) markDetailedResultWritten() {
+	if s == nil {
+		return
+	}
+	s.DetailedResultsShown++
+}
+
+func (s *loopHTTPFuzzAggregateStats) markDetailedResultOmitted() {
+	if s == nil {
+		return
+	}
+	s.OmittedDetails++
+}
+
+func (s *loopHTTPFuzzAggregateStats) observeError() {
+	if s == nil {
+		return
+	}
+	s.TotalRequests++
+	s.FailedRequests++
+}
+
+func (s *loopHTTPFuzzAggregateStats) observeSuccess(statusCode int, durationMs int64, bodyLength int, saved bool) {
+	if s == nil {
+		return
+	}
+	s.TotalRequests++
+	s.SuccessfulResponses++
+	if saved {
+		s.SavedHTTPFlowCount++
+	}
+	s.StatusCounts[statusCode]++
+	s.TotalDurationMs += durationMs
+	if s.MinDurationMs < 0 || durationMs < s.MinDurationMs {
+		s.MinDurationMs = durationMs
+	}
+	if durationMs > s.MaxDurationMs {
+		s.MaxDurationMs = durationMs
+	}
+	s.TotalBodyLength += int64(bodyLength)
+	if s.MinBodyLength < 0 || bodyLength < s.MinBodyLength {
+		s.MinBodyLength = bodyLength
+	}
+	if bodyLength > s.MaxBodyLength {
+		s.MaxBodyLength = bodyLength
+	}
+	if s.BaselineBodyLength < 0 {
+		s.BaselineBodyLength = bodyLength
+	}
+}
+
+func (s *loopHTTPFuzzAggregateStats) considerInterestingSample(sample loopHTTPFuzzInterestingSample) {
+	if s == nil {
+		return
+	}
+	if sample.Score <= 0 {
+		return
+	}
+	s.InterestingSamples = append(s.InterestingSamples, sample)
+	sort.SliceStable(s.InterestingSamples, func(i, j int) bool {
+		if s.InterestingSamples[i].Score == s.InterestingSamples[j].Score {
+			return s.InterestingSamples[i].Index < s.InterestingSamples[j].Index
+		}
+		return s.InterestingSamples[i].Score > s.InterestingSamples[j].Score
+	})
+	if len(s.InterestingSamples) > loopHTTPFuzzInterestingTopN {
+		s.InterestingSamples = s.InterestingSamples[:loopHTTPFuzzInterestingTopN]
+	}
+}
+
+func (s *loopHTTPFuzzAggregateStats) observeResponseLengthGroup(sample loopHTTPFuzzInterestingSample) {
+	if s == nil {
+		return
+	}
+	group, ok := s.ResponseLengthGroups[sample.BodyLength]
+	if !ok {
+		group = &loopHTTPFuzzResponseLengthGroup{
+			BodyLength:   sample.BodyLength,
+			StatusCounts: make(map[int]int),
+			BestScore:    -1,
+		}
+		s.ResponseLengthGroups[sample.BodyLength] = group
+	}
+	group.Count++
+	group.StatusCounts[sample.StatusCode]++
+	if !group.HasSample || sample.Score > group.BestScore || (sample.Score == group.BestScore && group.Sample.HiddenIndex == "" && sample.HiddenIndex != "") {
+		group.Sample = sample
+		group.HasSample = true
+		group.BestScore = sample.Score
+	}
+}
+
+func scoreLoopHTTPFuzzInterestingSample(statusCode int, durationMs int64, bodyLength int, baselineBodyLength int, responseRaw string) int {
+	score := 0
+	switch {
+	case statusCode >= 500:
+		score += 90
+	case statusCode >= 400:
+		score += 45
+	case statusCode >= 300:
+		score += 20
+	}
+
+	if baselineBodyLength >= 0 {
+		delta := abs(bodyLength - baselineBodyLength)
+		if baselineBodyLength == 0 {
+			if delta > 0 {
+				score += 35
+			}
+		} else if delta > baselineBodyLength/2 {
+			score += 35
+		} else if delta > baselineBodyLength/4 {
+			score += 18
+		}
+	}
+
+	switch {
+	case durationMs >= 3000:
+		score += 40
+	case durationMs >= 1000:
+		score += 20
+	case durationMs >= 500:
+		score += 10
+	}
+
+	responseLower := strings.ToLower(responseRaw)
+	for _, keyword := range []string{
+		"sql", "syntax error", "exception", "stack trace", "traceback",
+		"unauthorized", "forbidden", "access denied", "permission denied",
+		"welcome", "login success", "token", "debug",
+	} {
+		if strings.Contains(responseLower, keyword) {
+			score += 25
+			break
+		}
+	}
+
+	return score
+}
+
+func writeLoopHTTPFuzzDetailTruncationNotice(diffSummary, analysisSummary *strings.Builder, omitted int) {
+	if omitted <= 0 {
+		return
+	}
+	msg := fmt.Sprintf("\n--- Detailed Results Truncated ---\nDetailed request/response logs were limited to the first %d results. The remaining %d results are summarized in the aggregate report below because all HTTP flows have already been saved to the database.\n", loopHTTPFuzzDetailedResultLimit, omitted)
+	diffSummary.WriteString(msg)
+	analysisSummary.WriteString(msg)
+}
+
+func buildLoopHTTPFuzzAggregateReport(actionName string, stats *loopHTTPFuzzAggregateStats) string {
+	if stats == nil {
+		return ""
+	}
+
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("=== Aggregate Summary for %s ===\n", actionName))
+	out.WriteString(fmt.Sprintf("Total Requests: %d\n", stats.TotalRequests))
+	out.WriteString(fmt.Sprintf("Failed Requests: %d\n", stats.FailedRequests))
+	out.WriteString(fmt.Sprintf("Saved HTTPFlows: %d\n", stats.SavedHTTPFlowCount))
+	if stats.OmittedDetails > 0 {
+		out.WriteString(fmt.Sprintf("Detailed Results Shown: %d (omitted %d additional detailed entries; full traffic remains stored in HTTPFlow)\n", stats.DetailedResultsShown, stats.OmittedDetails))
+	}
+
+	if len(stats.StatusCounts) > 0 {
+		out.WriteString("Status Distribution:\n")
+		statuses := make([]int, 0, len(stats.StatusCounts))
+		for statusCode := range stats.StatusCounts {
+			statuses = append(statuses, statusCode)
+		}
+		sort.SliceStable(statuses, func(i, j int) bool {
+			if stats.StatusCounts[statuses[i]] == stats.StatusCounts[statuses[j]] {
+				return statuses[i] < statuses[j]
+			}
+			return stats.StatusCounts[statuses[i]] > stats.StatusCounts[statuses[j]]
+		})
+		for _, statusCode := range statuses {
+			out.WriteString(fmt.Sprintf("- %s: %d\n", formatLoopHTTPFuzzStatusCode(statusCode), stats.StatusCounts[statusCode]))
+		}
+	}
+
+	if stats.SuccessfulResponses > 0 {
+		avgDuration := stats.TotalDurationMs / int64(stats.SuccessfulResponses)
+		avgBodyLength := stats.TotalBodyLength / int64(stats.SuccessfulResponses)
+		out.WriteString(fmt.Sprintf("Duration Stats: avg=%d ms min=%d ms max=%d ms\n", avgDuration, stats.MinDurationMs, stats.MaxDurationMs))
+		out.WriteString(fmt.Sprintf("Response Body Stats: avg=%d bytes min=%d bytes max=%d bytes\n", avgBodyLength, stats.MinBodyLength, stats.MaxBodyLength))
+	}
+
+	if len(stats.ResponseLengthGroups) > 0 {
+		out.WriteString("Response Length Groups:\n")
+		for _, group := range buildLoopHTTPFuzzResponseLengthGroups(stats) {
+			out.WriteString(fmt.Sprintf("- %d bytes: %d responses", group.BodyLength, group.Count))
+			if group.IsBaseline {
+				out.WriteString(" [baseline]")
+			}
+			if statusPreview := buildLoopHTTPFuzzStatusPreviewFromCounts(group.StatusCounts, 4); statusPreview != "" {
+				out.WriteString(fmt.Sprintf(" (statuses: %s)", statusPreview))
+			}
+			out.WriteByte('\n')
+			if group.HasSample {
+				if group.Sample.HiddenIndex != "" {
+					out.WriteString(fmt.Sprintf("  Sample HTTPFlow: %s\n", group.Sample.HiddenIndex))
+				}
+				if len(group.Sample.Payloads) > 0 {
+					out.WriteString(fmt.Sprintf("  Sample Payloads: %s\n", shrinkLoopHTTPFuzzList(group.Sample.Payloads, 4, 200)))
+				}
+				if group.Sample.RequestSummary != "" {
+					out.WriteString(fmt.Sprintf("  Sample Request Summary: %s\n", group.Sample.RequestSummary))
+				}
+				if group.IsBaseline && strings.TrimSpace(group.BaselineLabel) != "" {
+					out.WriteString(fmt.Sprintf("  %s\n", group.BaselineLabel))
+				}
+				if strings.TrimSpace(group.Sample.ResponseDiff) != "" {
+					out.WriteString("  Sample Diff From Baseline:\n")
+					out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(group.Sample.ResponseDiff, 400), "    "))
+					out.WriteByte('\n')
+				}
+			}
+		}
+	}
+
+	if len(stats.InterestingSamples) > 0 {
+		out.WriteString("Interesting Samples:\n")
+		for idx, sample := range stats.InterestingSamples {
+			out.WriteString(fmt.Sprintf("%d. score=%d status=%s duration=%d ms body=%d bytes\n", idx+1, sample.Score, formatLoopHTTPFuzzStatusCode(sample.StatusCode), sample.DurationMs, sample.BodyLength))
+			if sample.HiddenIndex != "" {
+				out.WriteString(fmt.Sprintf("   HTTPFlow: %s\n", sample.HiddenIndex))
+			}
+			if len(sample.Payloads) > 0 {
+				out.WriteString(fmt.Sprintf("   Payloads: %s\n", shrinkLoopHTTPFuzzList(sample.Payloads, 4, 200)))
+			}
+			if sample.RequestSummary != "" {
+				out.WriteString(fmt.Sprintf("   Request Summary: %s\n", sample.RequestSummary))
+			}
+			if sample.ResponseSummary != "" {
+				out.WriteString(fmt.Sprintf("   Response Summary: %s\n", sample.ResponseSummary))
+			}
+			if sample.RequestDiff != "" {
+				out.WriteString("   Request Changes:\n")
+				out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(sample.RequestDiff, 240), "     "))
+				out.WriteByte('\n')
+			}
+			if sample.ResponseDigest != "" {
+				out.WriteString("   Response Digest:\n")
+				out.WriteString(utils.PrefixLines(utils.ShrinkTextBlock(sample.ResponseDigest, 240), "     "))
+				out.WriteByte('\n')
+			}
+		}
+	}
+
+	return strings.TrimSpace(out.String())
+}
+
+func buildLoopHTTPFuzzVerificationOverview(actionName string, stats *loopHTTPFuzzAggregateStats, representativeHiddenIndex string) string {
+	aggregateReport := strings.TrimSpace(buildLoopHTTPFuzzAggregateReport(actionName, stats))
+	if aggregateReport == "" && strings.TrimSpace(representativeHiddenIndex) == "" {
+		return ""
+	}
+
+	var out strings.Builder
+	out.WriteString("=== Fuzz Overview For Next-Step Analysis ===\n")
+	if aggregateReport != "" {
+		out.WriteString(aggregateReport)
+		out.WriteByte('\n')
+	}
+	if strings.TrimSpace(representativeHiddenIndex) != "" {
+		out.WriteString(fmt.Sprintf("Representative HTTPFlow: %s\n", representativeHiddenIndex))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func formatLoopHTTPFuzzStatusCode(statusCode int) string {
+	if statusCode <= 0 {
+		return "(no status code)"
+	}
+	return fmt.Sprintf("%d", statusCode)
+}
+
+func buildLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats) []*loopHTTPFuzzResponseLengthGroup {
+	if stats == nil || len(stats.ResponseLengthGroups) == 0 {
+		return nil
+	}
+	groups := make([]*loopHTTPFuzzResponseLengthGroup, 0, len(stats.ResponseLengthGroups))
+	for _, group := range stats.ResponseLengthGroups {
+		if group != nil {
+			groups = append(groups, group)
+		}
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].Count == groups[j].Count {
+			return groups[i].BodyLength < groups[j].BodyLength
+		}
+		return groups[i].Count > groups[j].Count
+	})
+	return groups
+}
+
+func finalizeLoopHTTPFuzzResponseLengthGroups(stats *loopHTTPFuzzAggregateStats) {
+	if stats == nil || len(stats.ResponseLengthGroups) == 0 {
+		return
+	}
+	groups := buildLoopHTTPFuzzResponseLengthGroups(stats)
+	if len(groups) == 0 {
+		return
+	}
+	baselineGroup := groups[0]
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+		if group.Count > baselineGroup.Count {
+			baselineGroup = group
+			continue
+		}
+		if group.Count == baselineGroup.Count && group.BodyLength == stats.BaselineBodyLength {
+			baselineGroup = group
+		}
+	}
+	if baselineGroup == nil {
+		return
+	}
+
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+		group.IsBaseline = group.BodyLength == baselineGroup.BodyLength
+		group.BaselineLabel = ""
+		if group.IsBaseline {
+			group.BaselineLabel = fmt.Sprintf("Baseline group selected by dominant body length: %d bytes (%d responses).", group.BodyLength, group.Count)
+			stats.BaselineBodyLength = group.BodyLength
+			group.Sample.ResponseDiff = "  (baseline representative response)"
+			continue
+		}
+		group.Sample.ResponseDiff = buildLoopHTTPFuzzResponseDiffFromBaseline(baselineGroup.Sample.ResponseRaw, group.Sample.ResponseRaw)
+	}
+}
+
+func buildLoopHTTPFuzzResponseDiffFromBaseline(baselineResponseRaw, sampleResponseRaw string) string {
+	baselineResponseRaw = strings.TrimSpace(baselineResponseRaw)
+	sampleResponseRaw = strings.TrimSpace(sampleResponseRaw)
+	if baselineResponseRaw == "" || sampleResponseRaw == "" {
+		return ""
+	}
+	if baselineResponseRaw == sampleResponseRaw {
+		return "  (same as baseline representative response)"
+	}
+
+	_, baselineBody := lowhttp.SplitHTTPPacketFast([]byte(baselineResponseRaw))
+	_, sampleBody := lowhttp.SplitHTTPPacketFast([]byte(sampleResponseRaw))
+	left := string(baselineBody)
+	right := string(sampleBody)
+	if strings.TrimSpace(left) == "" && strings.TrimSpace(right) == "" {
+		left = baselineResponseRaw
+		right = sampleResponseRaw
+	}
+
+	diffText, err := yakdiff.DiffToString(left, right)
+	if err == nil && strings.TrimSpace(diffText) != "" {
+		return strings.TrimSpace(diffText)
+	}
+	return compareRequests(left, right)
+}
+
+func buildLoopHTTPFuzzStatusPreviewFromCounts(counts map[int]int, maxItems int) string {
+	if len(counts) == 0 || maxItems <= 0 {
+		return ""
+	}
+	statuses := make([]int, 0, len(counts))
+	for statusCode := range counts {
+		statuses = append(statuses, statusCode)
+	}
+	sort.SliceStable(statuses, func(i, j int) bool {
+		if counts[statuses[i]] == counts[statuses[j]] {
+			return statuses[i] < statuses[j]
+		}
+		return counts[statuses[i]] > counts[statuses[j]]
+	})
+	if len(statuses) > maxItems {
+		statuses = statuses[:maxItems]
+	}
+	parts := make([]string, 0, len(statuses))
+	for _, statusCode := range statuses {
+		parts = append(parts, fmt.Sprintf("%s=%d", formatLoopHTTPFuzzStatusCode(statusCode), counts[statusCode]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+type loopHTTPFuzzProgressReporter struct {
+	loop       *reactloops.ReActLoop
+	taskID     string
+	actionName string
+	lastEmitAt time.Time
+}
+
+func newLoopHTTPFuzzProgressReporter(loop *reactloops.ReActLoop, taskID, actionName string) *loopHTTPFuzzProgressReporter {
+	return &loopHTTPFuzzProgressReporter{
+		loop:       loop,
+		taskID:     taskID,
+		actionName: actionName,
+	}
+}
+
+func (r *loopHTTPFuzzProgressReporter) allowDetailedFrontendEvent(resultIndex int) bool {
+	return r != nil && resultIndex > 0 && resultIndex <= loopHTTPFuzzFrontendDetailLimit
+}
+
+func (r *loopHTTPFuzzProgressReporter) maybeEmit(stats *loopHTTPFuzzAggregateStats, lastStatusCode int, force bool) {
+	if r == nil || r.loop == nil || strings.TrimSpace(r.taskID) == "" || stats == nil {
+		return
+	}
+	if !force && stats.TotalRequests <= loopHTTPFuzzFrontendDetailLimit {
+		return
+	}
+
+	now := time.Now()
+	if !force && !r.lastEmitAt.IsZero() && now.Sub(r.lastEmitAt) < loopHTTPFuzzProgressEmitInterval {
+		return
+	}
+
+	snapshot := buildLoopHTTPFuzzProgressSnapshot(r.actionName, stats, lastStatusCode, force)
+	if strings.TrimSpace(snapshot) == "" {
+		return
+	}
+	emitFuzzStage(r.loop, r.taskID, snapshot)
+	r.lastEmitAt = now
+}
+
+func buildLoopHTTPFuzzProgressSnapshot(actionName string, stats *loopHTTPFuzzAggregateStats, lastStatusCode int, finished bool) string {
+	if stats == nil || stats.TotalRequests <= 0 {
+		return ""
+	}
+
+	stateLabel := "执行进度"
+	if finished {
+		stateLabel = "执行完成"
+	}
+
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("%s：%s 已处理 %d 个请求", stateLabel, actionName, stats.TotalRequests))
+	if stats.SuccessfulResponses > 0 || stats.FailedRequests > 0 {
+		out.WriteString(fmt.Sprintf("，成功 %d，失败 %d", stats.SuccessfulResponses, stats.FailedRequests))
+	}
+	if stats.SavedHTTPFlowCount > 0 {
+		out.WriteString(fmt.Sprintf("，已落库 %d 条 HTTPFlow", stats.SavedHTTPFlowCount))
+	}
+	if lastStatusCode > 0 {
+		out.WriteString(fmt.Sprintf("，最近状态 %s", formatLoopHTTPFuzzStatusCode(lastStatusCode)))
+	}
+	if stats.SuccessfulResponses > 0 {
+		out.WriteString(fmt.Sprintf("，平均响应 %d ms", stats.TotalDurationMs/int64(stats.SuccessfulResponses)))
+	}
+	if statusPreview := buildLoopHTTPFuzzStatusPreview(stats, 3); statusPreview != "" {
+		out.WriteString(fmt.Sprintf("，状态分布 %s", statusPreview))
+	}
+	if lengthPreview := buildLoopHTTPFuzzResponseLengthPreview(stats, 3); lengthPreview != "" {
+		out.WriteString(fmt.Sprintf("，长度分布 %s", lengthPreview))
+	}
+	if len(stats.InterestingSamples) > 0 {
+		out.WriteString(fmt.Sprintf("，可疑样本 %d 个", len(stats.InterestingSamples)))
+	}
+	out.WriteString("。")
+	return out.String()
+}
+
+func buildLoopHTTPFuzzStatusPreview(stats *loopHTTPFuzzAggregateStats, maxItems int) string {
+	if stats == nil || maxItems <= 0 {
+		return ""
+	}
+	return buildLoopHTTPFuzzStatusPreviewFromCounts(stats.StatusCounts, maxItems)
+}
+
+func buildLoopHTTPFuzzResponseLengthPreview(stats *loopHTTPFuzzAggregateStats, maxItems int) string {
+	if stats == nil || len(stats.ResponseLengthGroups) == 0 || maxItems <= 0 {
+		return ""
+	}
+	groups := buildLoopHTTPFuzzResponseLengthGroups(stats)
+	if len(groups) > maxItems {
+		groups = groups[:maxItems]
+	}
+	parts := make([]string, 0, len(groups))
+	for _, group := range groups {
+		parts = append(parts, fmt.Sprintf("%dB=%d", group.BodyLength, group.Count))
+	}
+	return strings.Join(parts, ", ")
+}
 
 func newLoopFuzzRequest(taskCtx context.Context, runtime aicommon.AIInvokeRuntime, rawPacket []byte, isHTTPS bool) (*mutate.FuzzHTTPRequest, error) {
 	opts := []mutate.BuildFuzzHTTPRequestOption{
@@ -231,6 +784,7 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	}
 
 	emitFuzzStage(loop, streamTaskID, fmt.Sprintf("开始执行 %s，HTTPFlow 会落库并保留完整请求/响应。", actionName))
+	progressReporter := newLoopHTTPFuzzProgressReporter(loop, streamTaskID, actionName)
 
 	// Execute the fuzz request
 	execOpts := []mutate.HttpPoolConfigOption{
@@ -253,21 +807,29 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	analysisSummary.WriteString(fmt.Sprintf("=== 漏洞测试分析：%s ===\n", actionName))
 
 	originalRequest := getCurrentRequestRaw(loop)
+	stats := newLoopHTTPFuzzAggregateStats()
 	resultCount := 0
-	savedFlowCount := 0
 	representativeRequest := ""
 	representativeResponse := ""
 	representativeHiddenIndex := ""
 	collectedPayloads := make([]string, 0)
-	representativeStatus := ""
+	representativeStatusCode := 0
+	bestRepresentativeScore := -1
 
 	for result := range resultCh {
 		resultCount++
 		if result.Error != nil {
-			errMsg := fmt.Sprintf("\n--- Result %d ---\nError: %v\n", resultCount, result.Error)
-			diffSummary.WriteString(errMsg)
-			analysisSummary.WriteString(errMsg)
+			stats.observeError()
+			if stats.allowDetailedResult() {
+				errMsg := fmt.Sprintf("\n--- Result %d ---\nError: %v\n", resultCount, result.Error)
+				diffSummary.WriteString(errMsg)
+				analysisSummary.WriteString(errMsg)
+				stats.markDetailedResultWritten()
+			} else {
+				stats.markDetailedResultOmitted()
+			}
 			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 第 %d 个测试请求执行失败：%v", actionName, resultCount, result.Error))
+			progressReporter.maybeEmit(stats, 0, false)
 			continue
 		}
 
@@ -278,7 +840,7 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		responseStreamSummary := buildHTTPResponseStreamSummary(responseRaw, requestURL)
 		collectedPayloads = append(collectedPayloads, result.Payloads...)
 
-		if streamTaskID != "" {
+		if progressReporter.allowDetailedFrontendEvent(resultCount) && streamTaskID != "" {
 			emitPacketSummary(loop, streamTaskID, actionName, resultCount, "request", requestStreamSummary)
 			emitPacketSummary(loop, streamTaskID, actionName, resultCount, "response", responseStreamSummary)
 		}
@@ -287,9 +849,8 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		if result.LowhttpResponse != nil {
 			hiddenIndex = strings.TrimSpace(result.LowhttpResponse.HiddenIndex)
 			if hiddenIndex != "" {
-				savedFlowCount++
 				loop.Set("last_httpflow_hidden_index", hiddenIndex)
-				if runtimeID != "" {
+				if progressReporter.allowDetailedFrontendEvent(resultCount) && runtimeID != "" {
 					loop.GetEmitter().EmitYakitHTTPFlow(runtimeID, hiddenIndex)
 				}
 			}
@@ -298,61 +859,110 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		// Compare request differences
 		requestDiff := compareRequests(originalRequest, requestRaw)
 		responseSummary := summarizeResponse(responseRaw)
+		statusCode := getStatusFromResponse(responseRaw)
+		_, responseBody := lowhttp.SplitHTTPPacketFast([]byte(responseRaw))
+		bodyLength := len(responseBody)
 		loop.Set("last_request", requestRaw)
 		loop.Set("last_request_summary", requestStreamSummary)
 		loop.Set("last_response", responseRaw)
 		loop.Set("last_response_summary", responseStreamSummary)
 
-		if representativeRequest == "" {
+		stats.observeSuccess(statusCode, result.DurationMs, bodyLength, hiddenIndex != "")
+		sampleScore := scoreLoopHTTPFuzzInterestingSample(statusCode, result.DurationMs, bodyLength, stats.BaselineBodyLength, responseRaw)
+		sample := loopHTTPFuzzInterestingSample{
+			Index:           resultCount,
+			Score:           sampleScore,
+			StatusCode:      statusCode,
+			DurationMs:      result.DurationMs,
+			BodyLength:      bodyLength,
+			HiddenIndex:     hiddenIndex,
+			Payloads:        append([]string(nil), result.Payloads...),
+			RequestSummary:  requestStreamSummary,
+			ResponseSummary: responseStreamSummary,
+			RequestDiff:     requestDiff,
+			ResponseDigest:  responseSummary,
+			ResponseRaw:     responseRaw,
+		}
+		stats.considerInterestingSample(sample)
+		stats.observeResponseLengthGroup(sample)
+
+		if representativeRequest == "" || sampleScore > bestRepresentativeScore || (sampleScore == bestRepresentativeScore && representativeHiddenIndex == "" && hiddenIndex != "") {
+			bestRepresentativeScore = sampleScore
 			representativeRequest = requestRaw
 			representativeResponse = responseRaw
 			representativeHiddenIndex = hiddenIndex
-			representativeStatus = getStatusFromResponse(responseRaw)
-			loop.Set("representative_request", representativeRequest)
-			loop.Set("representative_response", representativeResponse)
-			loop.Set("representative_httpflow_hidden_index", representativeHiddenIndex)
+			representativeStatusCode = statusCode
 		}
 
-		diffSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultCount))
-		analysisSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultCount))
-		diffSummary.WriteString(fmt.Sprintf("Payload: %v\n", result.Payloads))
-		analysisSummary.WriteString(fmt.Sprintf("Payload: %v\n", result.Payloads))
-		diffSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", result.DurationMs))
-		analysisSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", result.DurationMs))
-		diffSummary.WriteString(fmt.Sprintf("Status: %s\n", getStatusFromResponse(responseRaw)))
-		analysisSummary.WriteString(fmt.Sprintf("Status: %s\n", getStatusFromResponse(responseRaw)))
-		diffSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", requestStreamSummary))
-		analysisSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", requestStreamSummary))
-		diffSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", responseStreamSummary))
-		analysisSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", responseStreamSummary))
-		if hiddenIndex != "" {
-			diffSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", hiddenIndex))
-			analysisSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", hiddenIndex))
+		if stats.allowDetailedResult() {
+			diffSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultCount))
+			analysisSummary.WriteString(fmt.Sprintf("\n--- Result %d ---\n", resultCount))
+			diffSummary.WriteString(fmt.Sprintf("Payload: %v\n", result.Payloads))
+			analysisSummary.WriteString(fmt.Sprintf("Payload: %v\n", result.Payloads))
+			diffSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", result.DurationMs))
+			analysisSummary.WriteString(fmt.Sprintf("Duration: %d ms\n", result.DurationMs))
+			diffSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(statusCode)))
+			analysisSummary.WriteString(fmt.Sprintf("Status: %s\n", formatLoopHTTPFuzzStatusCode(statusCode)))
+			diffSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", requestStreamSummary))
+			analysisSummary.WriteString(fmt.Sprintf("Request Summary: %s\n", requestStreamSummary))
+			diffSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", responseStreamSummary))
+			analysisSummary.WriteString(fmt.Sprintf("Response Summary: %s\n", responseStreamSummary))
+			if hiddenIndex != "" {
+				diffSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", hiddenIndex))
+				analysisSummary.WriteString(fmt.Sprintf("Saved HTTPFlow: %s\n", hiddenIndex))
+			}
+			diffSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", requestDiff))
+			analysisSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", requestDiff))
+			diffSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", responseSummary))
+			analysisSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", responseSummary))
+			diffSummary.WriteString("Request Packet:\n")
+			diffSummary.WriteString(requestRaw)
+			diffSummary.WriteString("\nResponse Packet:\n")
+			diffSummary.WriteString(responseRaw)
+			diffSummary.WriteRune('\n')
+			stats.markDetailedResultWritten()
+		} else {
+			stats.markDetailedResultOmitted()
 		}
-		diffSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", requestDiff))
-		analysisSummary.WriteString(fmt.Sprintf("Request Changes:\n%s\n", requestDiff))
-		diffSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", responseSummary))
-		analysisSummary.WriteString(fmt.Sprintf("Response Summary:\n%s\n", responseSummary))
-		diffSummary.WriteString("Request Packet:\n")
-		diffSummary.WriteString(requestRaw)
-		diffSummary.WriteString("\nResponse Packet:\n")
-		diffSummary.WriteString(responseRaw)
-		diffSummary.WriteRune('\n')
+
+		progressReporter.maybeEmit(stats, statusCode, false)
+	}
+
+	finalizeLoopHTTPFuzzResponseLengthGroups(stats)
+	progressReporter.maybeEmit(stats, representativeStatusCode, true)
+
+	if representativeRequest != "" || representativeResponse != "" {
+		loop.Set("representative_request", representativeRequest)
+		loop.Set("representative_response", representativeResponse)
+		loop.Set("representative_httpflow_hidden_index", representativeHiddenIndex)
 	}
 
 	if resultCount == 0 {
 		diffSummary.WriteString("\n(no results returned by the fuzz execution)\n")
 		analysisSummary.WriteString("\n(no results returned by the fuzz execution)\n")
 	}
-	if savedFlowCount > 0 {
-		diffSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", savedFlowCount))
-		analysisSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", savedFlowCount))
+	if stats.SavedHTTPFlowCount > 0 {
+		diffSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", stats.SavedHTTPFlowCount))
+		analysisSummary.WriteString(fmt.Sprintf("\nSaved %d HTTP flow records to database and linked them to the current AI runtime/task event context.\n", stats.SavedHTTPFlowCount))
+	}
+	if stats.OmittedDetails > 0 {
+		writeLoopHTTPFuzzDetailTruncationNotice(&diffSummary, &analysisSummary, stats.OmittedDetails)
+	}
+	aggregateReport := buildLoopHTTPFuzzAggregateReport(actionName, stats)
+	if aggregateReport != "" {
+		diffSummary.WriteString("\n\n")
+		diffSummary.WriteString(aggregateReport)
+		diffSummary.WriteRune('\n')
+		analysisSummary.WriteString("\n\n")
+		analysisSummary.WriteString(aggregateReport)
+		analysisSummary.WriteRune('\n')
 	}
 
 	fullDiffResult := diffSummary.String()
 	analysisResult := analysisSummary.String()
 	loop.Set("diff_result_full", fullDiffResult)
 	loop.Set("diff_result_compressed", analysisResult)
+	verificationOverview := buildLoopHTTPFuzzVerificationOverview(actionName, stats, representativeHiddenIndex)
 
 	feedbackResult := analysisResult
 	compressedResult := ""
@@ -364,13 +974,13 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 压缩报告失败，回退到原始测试结果。", actionName))
 		} else {
 			compressedResult = compressed
-			feedbackResult = buildCompressedFeedbackReport(compressed, representativeRequest, representativeResponse, representativeHiddenIndex)
-			loop.Set("diff_result_compressed", compressed)
+			feedbackResult = buildCompressedFeedbackReport(verificationOverview, compressed, representativeRequest, representativeResponse, representativeHiddenIndex)
+			loop.Set("diff_result_compressed", feedbackResult)
 			emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 压缩报告完成，准备验证是否达到安全测试目标。", actionName))
 		}
 	}
 
-	verifyResult, verificationText, err := verifyFuzzCompletion(loop, taskCtx, streamTaskID, actionName, feedbackResult, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex)
+	verifyResult, verificationText, err := verifyFuzzCompletion(loop, taskCtx, streamTaskID, actionName, verificationOverview, feedbackResult, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex)
 	if err != nil {
 		return "", nil, err
 	}
@@ -379,9 +989,9 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 		loop.Set("verification_result", verificationText)
 	}
 
-	actionResultSummary := fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。代表性响应状态：%s", resultCount, savedFlowCount, strings.TrimSpace(representativeStatus))
-	if strings.TrimSpace(representativeStatus) == "" {
-		actionResultSummary = fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。", resultCount, savedFlowCount)
+	actionResultSummary := fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。代表性响应状态：%s", resultCount, stats.SavedHTTPFlowCount, formatLoopHTTPFuzzStatusCode(representativeStatusCode))
+	if representativeStatusCode == 0 {
+		actionResultSummary = fmt.Sprintf("共执行 %d 次测试，保存 %d 条 HTTPFlow。", resultCount, stats.SavedHTTPFlowCount)
 	}
 	verificationSummary := buildLoopHTTPFuzzVerificationSummary(verifyResult)
 	actionRecord := recordLoopHTTPFuzzAction(loop, actionName, paramSummary, actionResultSummary, verificationSummary, representativeHiddenIndex, collectedPayloads)
@@ -406,8 +1016,12 @@ func buildFuzzCompressionTarget(loop *reactloops.ReActLoop, actionName string) s
 	return fmt.Sprintf("用户正在执行 HTTP 安全模糊测试，当前步骤是 %s。你的核心目标是分析漏洞，而不是复述数据包。请覆盖所有请求/响应对，重点归纳疑似漏洞类型、触发依据、差异模式、可复现代表性数据包、以及下一步验证动作。原始目标：%s", actionName, userInput)
 }
 
-func buildCompressedFeedbackReport(compressed, representativeRequest, representativeResponse, representativeHiddenIndex string) string {
+func buildCompressedFeedbackReport(overview, compressed, representativeRequest, representativeResponse, representativeHiddenIndex string) string {
 	var out strings.Builder
+	if strings.TrimSpace(overview) != "" {
+		out.WriteString(strings.TrimSpace(overview))
+		out.WriteString("\n\n")
+	}
 	out.WriteString("=== Compressed Fuzz Report ===\n")
 	out.WriteString(compressed)
 	if representativeRequest != "" || representativeResponse != "" {
@@ -428,7 +1042,7 @@ func buildCompressedFeedbackReport(compressed, representativeRequest, representa
 	return out.String()
 }
 
-func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, streamTaskID, actionName, feedbackResult, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex string) (*aicommon.VerifySatisfactionResult, string, error) {
+func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, streamTaskID, actionName, verificationOverview, feedbackResult, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex string) (*aicommon.VerifySatisfactionResult, string, error) {
 	invoker := loop.GetInvoker()
 	task := loop.GetCurrentTask()
 	if invoker == nil || task == nil {
@@ -437,7 +1051,9 @@ func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, s
 
 	payload := feedbackResult
 	if compressedResult != "" {
-		payload = buildCompressedFeedbackReport(compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex)
+		payload = buildCompressedFeedbackReport(verificationOverview, compressedResult, representativeRequest, representativeResponse, representativeHiddenIndex)
+	} else if strings.TrimSpace(verificationOverview) != "" && !strings.Contains(feedbackResult, verificationOverview) {
+		payload = verificationOverview + "\n\n" + feedbackResult
 	}
 
 	emitFuzzStage(loop, streamTaskID, fmt.Sprintf("%s 测试结果已准备完成，开始验证是否达到当前安全测试目标。", actionName))
@@ -488,12 +1104,12 @@ func buildHTTPRequestStreamSummary(requestRaw string, isHTTPS bool) (string, str
 }
 
 func buildHTTPResponseStreamSummary(responseRaw, requestURL string) string {
-	status := strings.TrimSpace(getStatusFromResponse(responseRaw))
+	status := getStatusFromResponse(responseRaw)
 	_, body := lowhttp.SplitHTTPPacketFast([]byte(responseRaw))
-	if status == "" {
+	if status == 0 {
 		return fmt.Sprintf("URL: %s BODY: [(%d) bytes]", requestURL, len(body))
 	}
-	return fmt.Sprintf("URL: %s STATUS: %s BODY: [(%d) bytes]", requestURL, status, len(body))
+	return fmt.Sprintf("URL: %s STATUS: %d BODY: [(%d) bytes]", requestURL, status, len(body))
 }
 
 func extractRequestURL(requestRaw string, isHTTPS bool) string {
@@ -599,10 +1215,11 @@ func summarizeResponse(response string) string {
 		return "  (empty response)"
 	}
 
-	statusLine, body := lowhttp.SplitHTTPPacketFast([]byte(response))
+	_, body := lowhttp.SplitHTTPPacketFast([]byte(response))
+	statusCode := getStatusFromResponse(response)
 
 	var summary strings.Builder
-	summary.WriteString(fmt.Sprintf("  Status: %s\n", statusLine))
+	summary.WriteString(fmt.Sprintf("  Status Code: %s\n", formatLoopHTTPFuzzStatusCode(statusCode)))
 
 	// Get content length
 	contentLength := len(body)
@@ -622,9 +1239,9 @@ func summarizeResponse(response string) string {
 }
 
 // getStatusFromResponse extracts status code from response
-func getStatusFromResponse(response string) string {
-	statusLine, _ := lowhttp.SplitHTTPPacketFast([]byte(response))
-	return statusLine
+func getStatusFromResponse(response string) int {
+	statusCode := lowhttp.ExtractStatusCodeFromResponse([]byte(response))
+	return statusCode
 }
 
 func max(a, b int) int {
@@ -632,4 +1249,11 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
 }

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
@@ -8,10 +8,6 @@ import (
 
 func TestBuildLoopHTTPFuzzAggregateReport_SummarizesLargeRuns(t *testing.T) {
 	stats := newLoopHTTPFuzzAggregateStats()
-	stats.observeSuccess(200, 120, 24, true)
-	stats.observeSuccess(401, 1450, 0, true)
-	stats.markDetailedResultWritten()
-	stats.markDetailedResultOmitted()
 	baselineSample := loopHTTPFuzzInterestingSample{
 		Index:          1,
 		Score:          5,
@@ -23,7 +19,6 @@ func TestBuildLoopHTTPFuzzAggregateReport_SummarizesLargeRuns(t *testing.T) {
 		ResponseRaw:    "HTTP/1.1 200 OK\r\nContent-Length: 24\r\n\r\nhello user",
 		ResponseDigest: "  Status Code: 200\n  Content-Length: 24 bytes\n",
 	}
-	stats.observeResponseLengthGroup(baselineSample)
 	sample := loopHTTPFuzzInterestingSample{
 		Index:           2,
 		Score:           70,
@@ -38,21 +33,29 @@ func TestBuildLoopHTTPFuzzAggregateReport_SummarizesLargeRuns(t *testing.T) {
 		ResponseDigest:  "  Status Code: 401\n  Content-Length: 0 bytes\n",
 		ResponseRaw:     "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
 	}
+
+	for i := 0; i < 9; i++ {
+		stats.observeSuccess(200, 120, 24, true)
+		stats.observeResponseLengthGroup(baselineSample)
+	}
+	for i := 0; i < 4; i++ {
+		stats.observeSuccess(401, 1450, 0, true)
+		stats.observeResponseLengthGroup(sample)
+	}
 	stats.considerInterestingSample(sample)
-	stats.observeResponseLengthGroup(sample)
-	finalizeLoopHTTPFuzzResponseLengthGroups(stats)
+	stats.finalizeResponseLengthGroups()
 
 	report := buildLoopHTTPFuzzAggregateReport("fuzz_body", stats)
 	require.Contains(t, report, "=== Aggregate Summary for fuzz_body ===")
-	require.Contains(t, report, "Total Requests: 2")
-	require.Contains(t, report, "Saved HTTPFlows: 2")
-	require.Contains(t, report, "Detailed Results Shown: 1 (omitted 1 additional detailed entries; full traffic remains stored in HTTPFlow)")
+	require.Contains(t, report, "Total Requests: 13")
+	require.Contains(t, report, "Saved HTTPFlows: 13")
+	require.Contains(t, report, "Frontend Detail Omitted: 1 results (detail output is limited to the first 12 results; full traffic remains stored in HTTPFlow)")
 	require.Contains(t, report, "Status Distribution:")
-	require.Contains(t, report, "401: 1")
+	require.Contains(t, report, "401: 4")
 	require.Contains(t, report, "Response Length Groups:")
-	require.Contains(t, report, "- 24 bytes: 1 responses [baseline] (statuses: 200=1)")
-	require.Contains(t, report, "Baseline group selected by dominant body length: 24 bytes (1 responses).")
-	require.Contains(t, report, "- 0 bytes: 1 responses (statuses: 401=1)")
+	require.Contains(t, report, "- 24 bytes: 9 responses [baseline] (statuses: 200=9)")
+	require.Contains(t, report, "Baseline group selected by dominant body length: 24 bytes (9 responses).")
+	require.Contains(t, report, "- 0 bytes: 4 responses (statuses: 401=4)")
 	require.Contains(t, report, "Sample HTTPFlow: flow-2")
 	require.Contains(t, report, "Sample Diff From Baseline:")
 	require.Contains(t, report, "Interesting Samples:")
@@ -79,6 +82,8 @@ func TestBuildLoopHTTPFuzzProgressSnapshot_SummarizesCurrentProgress(t *testing.
 	stats := newLoopHTTPFuzzAggregateStats()
 	stats.observeSuccess(200, 120, 24, true)
 	stats.observeSuccess(401, 1450, 0, true)
+	stats.observeSuccess(401, 1200, 0, true)
+	stats.observeSuccess(401, 1300, 0, true)
 	stats.observeError()
 	sample := loopHTTPFuzzInterestingSample{
 		Index:      2,
@@ -96,12 +101,12 @@ func TestBuildLoopHTTPFuzzProgressSnapshot_SummarizesCurrentProgress(t *testing.
 	stats.observeResponseLengthGroup(sample)
 
 	snapshot := buildLoopHTTPFuzzProgressSnapshot("fuzz_body", stats, 401, false)
-	require.Contains(t, snapshot, "执行进度：fuzz_body 已处理 3 个请求")
-	require.Contains(t, snapshot, "成功 2，失败 1")
-	require.Contains(t, snapshot, "已落库 2 条 HTTPFlow")
+	require.Contains(t, snapshot, "执行进度：fuzz_body 已处理 5 个请求")
+	require.Contains(t, snapshot, "成功 4，失败 1")
+	require.Contains(t, snapshot, "已落库 4 条 HTTPFlow")
 	require.Contains(t, snapshot, "最近状态 401")
-	require.Contains(t, snapshot, "状态分布 200=1, 401=1")
-	require.Contains(t, snapshot, "长度分布 0B=1, 24B=1")
+	require.Contains(t, snapshot, "状态分布 401=3, 200=1")
+	require.NotContains(t, snapshot, "长度分布")
 	require.Contains(t, snapshot, "可疑样本 1 个")
 }
 
@@ -129,11 +134,25 @@ func TestFinalizeLoopHTTPFuzzResponseLengthGroups_UsesDominantLengthAsBaseline(t
 		ResponseRaw: "HTTP/1.1 401 Unauthorized\r\nContent-Length: 5\r\n\r\nadmin",
 	})
 
-	finalizeLoopHTTPFuzzResponseLengthGroups(stats)
+	stats.finalizeResponseLengthGroups()
 
 	require.Equal(t, 10, stats.BaselineBodyLength)
 	require.True(t, stats.ResponseLengthGroups[10].IsBaseline)
 	require.Contains(t, stats.ResponseLengthGroups[10].Sample.ResponseDiff, "baseline representative response")
 	require.False(t, stats.ResponseLengthGroups[5].IsBaseline)
 	require.NotEmpty(t, stats.ResponseLengthGroups[5].Sample.ResponseDiff)
+}
+
+func TestBuildLoopHTTPFuzzAggregateReport_SkipsLengthAnalysisForSmallRuns(t *testing.T) {
+	stats := newLoopHTTPFuzzAggregateStats()
+	stats.observeSuccess(200, 100, 12, true)
+	stats.observeSuccess(200, 110, 18, true)
+	stats.observeSuccess(200, 120, 27, true)
+	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{BodyLength: 12, StatusCode: 200, ResponseRaw: "HTTP/1.1 200 OK\r\n\r\na"})
+	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{BodyLength: 18, StatusCode: 200, ResponseRaw: "HTTP/1.1 200 OK\r\n\r\nbb"})
+	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{BodyLength: 27, StatusCode: 200, ResponseRaw: "HTTP/1.1 200 OK\r\n\r\nccc"})
+	stats.finalizeResponseLengthGroups()
+
+	report := buildLoopHTTPFuzzAggregateReport("fuzz_get_params", stats)
+	require.NotContains(t, report, "Response Length Groups:")
 }

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
@@ -1,13 +1,15 @@
 package loop_http_fuzztest
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildLoopHTTPFuzzAggregateReport_SummarizesLargeRuns(t *testing.T) {
-	stats := newLoopHTTPFuzzAggregateStats()
+func TestBuildLoopHTTPFuzzOverviewReport_SummarizesLargeRuns(t *testing.T) {
+	stats := newLoopHTTPFuzzOverviewStats()
 	baselineSample := loopHTTPFuzzInterestingSample{
 		Index:          1,
 		Score:          5,
@@ -45,41 +47,40 @@ func TestBuildLoopHTTPFuzzAggregateReport_SummarizesLargeRuns(t *testing.T) {
 	stats.considerInterestingSample(sample)
 	stats.finalizeResponseLengthGroups()
 
-	report := buildLoopHTTPFuzzAggregateReport("fuzz_body", stats)
-	require.Contains(t, report, "=== Aggregate Summary for fuzz_body ===")
+	report := buildLoopHTTPFuzzOverviewReport("fuzz_body", stats)
+	require.Contains(t, report, "=== Fuzz Overview for fuzz_body ===")
 	require.Contains(t, report, "Total Requests: 13")
 	require.Contains(t, report, "Saved HTTPFlows: 13")
-	require.Contains(t, report, "Frontend Detail Omitted: 1 results (detail output is limited to the first 12 results; full traffic remains stored in HTTPFlow)")
 	require.Contains(t, report, "Status Distribution:")
 	require.Contains(t, report, "401: 4")
-	require.Contains(t, report, "Response Length Groups:")
-	require.Contains(t, report, "- 24 bytes: 9 responses [baseline] (statuses: 200=9)")
-	require.Contains(t, report, "Baseline group selected by dominant body length: 24 bytes (9 responses).")
-	require.Contains(t, report, "- 0 bytes: 4 responses (statuses: 401=4)")
-	require.Contains(t, report, "Sample HTTPFlow: flow-2")
-	require.Contains(t, report, "Sample Diff From Baseline:")
-	require.Contains(t, report, "Interesting Samples:")
-	require.Contains(t, report, "HTTPFlow: flow-2")
-	require.Contains(t, report, "{{payload(pass_top25)}}")
+	require.Contains(t, report, "Response Length Overview: 24B=9, 0B=4")
 }
 
-func TestBuildCompressedFeedbackReport_PrependsOverview(t *testing.T) {
-	report := buildCompressedFeedbackReport(
-		"=== Fuzz Overview For Next-Step Analysis ===\nTotal Requests: 120\nRepresentative HTTPFlow: flow-9",
+func TestBuildCompressedAnalysisSection_RendersRepresentativePacket(t *testing.T) {
+	report := buildCompressedAnalysisSection(
 		"compressed body",
 		"GET /login HTTP/1.1\r\nHost: example.test\r\n\r\n",
 		"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
 		"flow-9",
 	)
 
-	require.Contains(t, report, "=== Fuzz Overview For Next-Step Analysis ===")
-	require.Contains(t, report, "Total Requests: 120")
-	require.Contains(t, report, "=== Compressed Fuzz Report ===")
+	require.Contains(t, report, "=== Compressed Fuzz Analysis ===")
+	require.Contains(t, report, "compressed body")
 	require.Contains(t, report, "Representative Packet For Follow-Up Testing")
 }
 
+func TestBuildLoopHTTPFuzzVerificationPayload_DoesNotDuplicateAggregateOverview(t *testing.T) {
+	payload := buildLoopHTTPFuzzVerificationPayload(
+		"=== Fuzz Overview for fuzz_body ===\nTotal Requests: 12\nSaved HTTPFlows: 12",
+		"flow-9",
+	)
+
+	require.Equal(t, 1, strings.Count(payload, "=== Fuzz Overview for fuzz_body ==="))
+	require.Contains(t, payload, "Representative HTTPFlow: flow-9")
+}
+
 func TestBuildLoopHTTPFuzzProgressSnapshot_SummarizesCurrentProgress(t *testing.T) {
-	stats := newLoopHTTPFuzzAggregateStats()
+	stats := newLoopHTTPFuzzOverviewStats()
 	stats.observeSuccess(200, 120, 24, true)
 	stats.observeSuccess(401, 1450, 0, true)
 	stats.observeSuccess(401, 1200, 0, true)
@@ -111,7 +112,7 @@ func TestBuildLoopHTTPFuzzProgressSnapshot_SummarizesCurrentProgress(t *testing.
 }
 
 func TestFinalizeLoopHTTPFuzzResponseLengthGroups_UsesDominantLengthAsBaseline(t *testing.T) {
-	stats := newLoopHTTPFuzzAggregateStats()
+	stats := newLoopHTTPFuzzOverviewStats()
 	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{
 		Index:       1,
 		Score:       5,
@@ -143,8 +144,8 @@ func TestFinalizeLoopHTTPFuzzResponseLengthGroups_UsesDominantLengthAsBaseline(t
 	require.NotEmpty(t, stats.ResponseLengthGroups[5].Sample.ResponseDiff)
 }
 
-func TestBuildLoopHTTPFuzzAggregateReport_SkipsLengthAnalysisForSmallRuns(t *testing.T) {
-	stats := newLoopHTTPFuzzAggregateStats()
+func TestBuildLoopHTTPFuzzOverviewReport_SkipsLengthAnalysisForSmallRuns(t *testing.T) {
+	stats := newLoopHTTPFuzzOverviewStats()
 	stats.observeSuccess(200, 100, 12, true)
 	stats.observeSuccess(200, 110, 18, true)
 	stats.observeSuccess(200, 120, 27, true)
@@ -153,6 +154,87 @@ func TestBuildLoopHTTPFuzzAggregateReport_SkipsLengthAnalysisForSmallRuns(t *tes
 	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{BodyLength: 27, StatusCode: 200, ResponseRaw: "HTTP/1.1 200 OK\r\n\r\nccc"})
 	stats.finalizeResponseLengthGroups()
 
-	report := buildLoopHTTPFuzzAggregateReport("fuzz_get_params", stats)
-	require.NotContains(t, report, "Response Length Groups:")
+	report := buildLoopHTTPFuzzOverviewReport("fuzz_get_params", stats)
+	require.Contains(t, report, "Response Length Overview: 12B=1, 18B=1, 27B=1")
+}
+
+func TestBuildLoopHTTPFuzzLargeRunAnalysisReport_RendersGroupsAndInterestingSamples(t *testing.T) {
+	stats := newLoopHTTPFuzzOverviewStats()
+	baselineSample := loopHTTPFuzzInterestingSample{
+		Index:          1,
+		Score:          5,
+		StatusCode:     200,
+		DurationMs:     120,
+		BodyLength:     24,
+		HiddenIndex:    "flow-1",
+		RequestSummary: "URL: https://example.test/login BODY: [(32) bytes]",
+		ResponseRaw:    "HTTP/1.1 200 OK\r\nContent-Length: 24\r\n\r\nhello user",
+		ResponseDigest: "  Status Code: 200\n  Content-Length: 24 bytes\n",
+	}
+	sample := loopHTTPFuzzInterestingSample{
+		Index:           2,
+		Score:           70,
+		StatusCode:      401,
+		DurationMs:      1450,
+		BodyLength:      0,
+		HiddenIndex:     "flow-2",
+		Payloads:        []string{"{{payload(pass_top25)}}"},
+		RequestSummary:  "URL: https://example.test/login BODY: [(32) bytes]",
+		ResponseSummary: "URL: https://example.test/login STATUS: 401 BODY: [(0) bytes]",
+		RequestDiff:     "  + password={{payload(pass_top25)}}",
+		ResponseDigest:  "  Status Code: 401\n  Content-Length: 0 bytes\n",
+		ResponseRaw:     "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
+	}
+
+	for i := 0; i < 9; i++ {
+		stats.observeSuccess(200, 120, 24, true)
+		stats.observeResponseLengthGroup(baselineSample)
+	}
+	for i := 0; i < 4; i++ {
+		stats.observeSuccess(401, 1450, 0, true)
+		stats.observeResponseLengthGroup(sample)
+	}
+	stats.considerInterestingSample(sample)
+	stats.finalizeResponseLengthGroups()
+
+	report := buildLoopHTTPFuzzLargeRunAnalysisReport(stats)
+	require.Contains(t, report, "=== Large-Run Analysis ===")
+	require.Contains(t, report, "Response Length Groups:")
+	require.Contains(t, report, "- 24 bytes: 9 responses [baseline] (statuses: 200=9)")
+	require.Contains(t, report, "Baseline group selected by dominant body length: 24 bytes (9 responses).")
+	require.Contains(t, report, "- 0 bytes: 4 responses (statuses: 401=4)")
+	require.Contains(t, report, "Sample HTTPFlow: flow-2")
+	require.Contains(t, report, "Sample Diff From Baseline:")
+	require.Contains(t, report, "Interesting Samples:")
+	require.Contains(t, report, "HTTPFlow: flow-2")
+	require.Contains(t, report, "{{payload(pass_top25)}}")
+}
+
+func TestBuildLoopHTTPFuzzDetailedPacketReport_RendersStoredResults(t *testing.T) {
+	reportData := newLoopHTTPFuzzReportData()
+	reportData.observeError(1, errors.New("network timeout"))
+	reportData.observeDetailedResult(2, loopHTTPFuzzProcessedResult{
+		RequestRaw:      "GET /debug?id=1 HTTP/1.1\r\nHost: example.test\r\n\r\n",
+		ResponseRaw:     "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+		RequestSummary:  "URL: https://example.test/debug?id=1 BODY: [(0) bytes]",
+		ResponseSummary: "URL: https://example.test/debug?id=1 STATUS: 200 BODY: [(2) bytes]",
+		RequestDiff:     "  + id=1",
+		ResponseDigest:  "  Status Code: 200\n  Content-Length: 2 bytes\n",
+		HiddenIndex:     "flow-2",
+		StatusCode:      200,
+		DurationMs:      180,
+		Payloads:        []string{"1"},
+		Sample: loopHTTPFuzzInterestingSample{
+			Index: 2,
+		},
+	})
+
+	report := buildLoopHTTPFuzzDetailedPacketReport(reportData)
+	require.Contains(t, report, "=== Detailed Packet Results ===")
+	require.Contains(t, report, "--- Result 1 ---")
+	require.Contains(t, report, "Error:")
+	require.Contains(t, report, "--- Result 2 ---")
+	require.Contains(t, report, "Saved HTTPFlow: flow-2")
+	require.Contains(t, report, "Request Packet:")
+	require.Contains(t, report, "Response Packet:")
 }

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
@@ -19,7 +19,6 @@ func TestBuildLoopHTTPFuzzOverviewReport_SummarizesLargeRuns(t *testing.T) {
 		HiddenIndex:    "flow-1",
 		RequestSummary: "URL: https://example.test/login BODY: [(32) bytes]",
 		ResponseRaw:    "HTTP/1.1 200 OK\r\nContent-Length: 24\r\n\r\nhello user",
-		ResponseDigest: "  Status Code: 200\n  Content-Length: 24 bytes\n",
 	}
 	sample := loopHTTPFuzzInterestingSample{
 		Index:           2,
@@ -32,7 +31,6 @@ func TestBuildLoopHTTPFuzzOverviewReport_SummarizesLargeRuns(t *testing.T) {
 		RequestSummary:  "URL: https://example.test/login BODY: [(32) bytes]",
 		ResponseSummary: "URL: https://example.test/login STATUS: 401 BODY: [(0) bytes]",
 		RequestDiff:     "  + password={{payload(pass_top25)}}",
-		ResponseDigest:  "  Status Code: 401\n  Content-Length: 0 bytes\n",
 		ResponseRaw:     "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
 	}
 
@@ -47,8 +45,10 @@ func TestBuildLoopHTTPFuzzOverviewReport_SummarizesLargeRuns(t *testing.T) {
 	stats.considerInterestingSample(sample)
 	stats.finalizeResponseLengthGroups()
 
-	report := buildLoopHTTPFuzzOverviewReport("fuzz_body", stats)
+	report := buildLoopHTTPFuzzOverviewReport("fuzz_body", "body_type=json_params; param_name=username; param_values=[admin {{7*7}}]", stats)
 	require.Contains(t, report, "=== Fuzz Overview for fuzz_body ===")
+	require.Contains(t, report, "Fuzz Parameters:")
+	require.Contains(t, report, "param_name=username")
 	require.Contains(t, report, "Total Requests: 13")
 	require.Contains(t, report, "Saved HTTPFlows: 13")
 	require.Contains(t, report, "Status Distribution:")
@@ -107,7 +107,6 @@ func TestBuildLoopHTTPFuzzProgressSnapshot_SummarizesCurrentProgress(t *testing.
 	require.Contains(t, snapshot, "已落库 4 条 HTTPFlow")
 	require.Contains(t, snapshot, "最近状态 401")
 	require.Contains(t, snapshot, "状态分布 401=3, 200=1")
-	require.NotContains(t, snapshot, "长度分布")
 	require.Contains(t, snapshot, "可疑样本 1 个")
 }
 
@@ -139,7 +138,7 @@ func TestFinalizeLoopHTTPFuzzResponseLengthGroups_UsesDominantLengthAsBaseline(t
 
 	require.Equal(t, 10, stats.BaselineBodyLength)
 	require.True(t, stats.ResponseLengthGroups[10].IsBaseline)
-	require.Contains(t, stats.ResponseLengthGroups[10].Sample.ResponseDiff, "baseline representative response")
+	require.Contains(t, stats.ResponseLengthGroups[10].Sample.ResponseDiff, "representative baseline response")
 	require.False(t, stats.ResponseLengthGroups[5].IsBaseline)
 	require.NotEmpty(t, stats.ResponseLengthGroups[5].Sample.ResponseDiff)
 }
@@ -154,8 +153,9 @@ func TestBuildLoopHTTPFuzzOverviewReport_SkipsLengthAnalysisForSmallRuns(t *test
 	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{BodyLength: 27, StatusCode: 200, ResponseRaw: "HTTP/1.1 200 OK\r\n\r\nccc"})
 	stats.finalizeResponseLengthGroups()
 
-	report := buildLoopHTTPFuzzOverviewReport("fuzz_get_params", stats)
+	report := buildLoopHTTPFuzzOverviewReport("fuzz_get_params", "param_name=id; param_values=[1 2 3]", stats)
 	require.Contains(t, report, "Response Length Overview: 12B=1, 18B=1, 27B=1")
+	require.Contains(t, report, "param_name=id")
 }
 
 func TestBuildLoopHTTPFuzzLargeRunAnalysisReport_RendersGroupsAndInterestingSamples(t *testing.T) {
@@ -169,7 +169,6 @@ func TestBuildLoopHTTPFuzzLargeRunAnalysisReport_RendersGroupsAndInterestingSamp
 		HiddenIndex:    "flow-1",
 		RequestSummary: "URL: https://example.test/login BODY: [(32) bytes]",
 		ResponseRaw:    "HTTP/1.1 200 OK\r\nContent-Length: 24\r\n\r\nhello user",
-		ResponseDigest: "  Status Code: 200\n  Content-Length: 24 bytes\n",
 	}
 	sample := loopHTTPFuzzInterestingSample{
 		Index:           2,
@@ -182,7 +181,6 @@ func TestBuildLoopHTTPFuzzLargeRunAnalysisReport_RendersGroupsAndInterestingSamp
 		RequestSummary:  "URL: https://example.test/login BODY: [(32) bytes]",
 		ResponseSummary: "URL: https://example.test/login STATUS: 401 BODY: [(0) bytes]",
 		RequestDiff:     "  + password={{payload(pass_top25)}}",
-		ResponseDigest:  "  Status Code: 401\n  Content-Length: 0 bytes\n",
 		ResponseRaw:     "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
 	}
 
@@ -219,7 +217,6 @@ func TestBuildLoopHTTPFuzzDetailedPacketReport_RendersStoredResults(t *testing.T
 		RequestSummary:  "URL: https://example.test/debug?id=1 BODY: [(0) bytes]",
 		ResponseSummary: "URL: https://example.test/debug?id=1 STATUS: 200 BODY: [(2) bytes]",
 		RequestDiff:     "  + id=1",
-		ResponseDigest:  "  Status Code: 200\n  Content-Length: 2 bytes\n",
 		HiddenIndex:     "flow-2",
 		StatusCode:      200,
 		DurationMs:      180,

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils_test.go
@@ -1,0 +1,139 @@
+package loop_http_fuzztest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildLoopHTTPFuzzAggregateReport_SummarizesLargeRuns(t *testing.T) {
+	stats := newLoopHTTPFuzzAggregateStats()
+	stats.observeSuccess(200, 120, 24, true)
+	stats.observeSuccess(401, 1450, 0, true)
+	stats.markDetailedResultWritten()
+	stats.markDetailedResultOmitted()
+	baselineSample := loopHTTPFuzzInterestingSample{
+		Index:          1,
+		Score:          5,
+		StatusCode:     200,
+		DurationMs:     120,
+		BodyLength:     24,
+		HiddenIndex:    "flow-1",
+		RequestSummary: "URL: https://example.test/login BODY: [(32) bytes]",
+		ResponseRaw:    "HTTP/1.1 200 OK\r\nContent-Length: 24\r\n\r\nhello user",
+		ResponseDigest: "  Status Code: 200\n  Content-Length: 24 bytes\n",
+	}
+	stats.observeResponseLengthGroup(baselineSample)
+	sample := loopHTTPFuzzInterestingSample{
+		Index:           2,
+		Score:           70,
+		StatusCode:      401,
+		DurationMs:      1450,
+		BodyLength:      0,
+		HiddenIndex:     "flow-2",
+		Payloads:        []string{"{{payload(pass_top25)}}"},
+		RequestSummary:  "URL: https://example.test/login BODY: [(32) bytes]",
+		ResponseSummary: "URL: https://example.test/login STATUS: 401 BODY: [(0) bytes]",
+		RequestDiff:     "  + password={{payload(pass_top25)}}",
+		ResponseDigest:  "  Status Code: 401\n  Content-Length: 0 bytes\n",
+		ResponseRaw:     "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
+	}
+	stats.considerInterestingSample(sample)
+	stats.observeResponseLengthGroup(sample)
+	finalizeLoopHTTPFuzzResponseLengthGroups(stats)
+
+	report := buildLoopHTTPFuzzAggregateReport("fuzz_body", stats)
+	require.Contains(t, report, "=== Aggregate Summary for fuzz_body ===")
+	require.Contains(t, report, "Total Requests: 2")
+	require.Contains(t, report, "Saved HTTPFlows: 2")
+	require.Contains(t, report, "Detailed Results Shown: 1 (omitted 1 additional detailed entries; full traffic remains stored in HTTPFlow)")
+	require.Contains(t, report, "Status Distribution:")
+	require.Contains(t, report, "401: 1")
+	require.Contains(t, report, "Response Length Groups:")
+	require.Contains(t, report, "- 24 bytes: 1 responses [baseline] (statuses: 200=1)")
+	require.Contains(t, report, "Baseline group selected by dominant body length: 24 bytes (1 responses).")
+	require.Contains(t, report, "- 0 bytes: 1 responses (statuses: 401=1)")
+	require.Contains(t, report, "Sample HTTPFlow: flow-2")
+	require.Contains(t, report, "Sample Diff From Baseline:")
+	require.Contains(t, report, "Interesting Samples:")
+	require.Contains(t, report, "HTTPFlow: flow-2")
+	require.Contains(t, report, "{{payload(pass_top25)}}")
+}
+
+func TestBuildCompressedFeedbackReport_PrependsOverview(t *testing.T) {
+	report := buildCompressedFeedbackReport(
+		"=== Fuzz Overview For Next-Step Analysis ===\nTotal Requests: 120\nRepresentative HTTPFlow: flow-9",
+		"compressed body",
+		"GET /login HTTP/1.1\r\nHost: example.test\r\n\r\n",
+		"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n",
+		"flow-9",
+	)
+
+	require.Contains(t, report, "=== Fuzz Overview For Next-Step Analysis ===")
+	require.Contains(t, report, "Total Requests: 120")
+	require.Contains(t, report, "=== Compressed Fuzz Report ===")
+	require.Contains(t, report, "Representative Packet For Follow-Up Testing")
+}
+
+func TestBuildLoopHTTPFuzzProgressSnapshot_SummarizesCurrentProgress(t *testing.T) {
+	stats := newLoopHTTPFuzzAggregateStats()
+	stats.observeSuccess(200, 120, 24, true)
+	stats.observeSuccess(401, 1450, 0, true)
+	stats.observeError()
+	sample := loopHTTPFuzzInterestingSample{
+		Index:      2,
+		Score:      70,
+		StatusCode: 401,
+		BodyLength: 0,
+	}
+	stats.considerInterestingSample(sample)
+	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{
+		Index:      1,
+		Score:      5,
+		StatusCode: 200,
+		BodyLength: 24,
+	})
+	stats.observeResponseLengthGroup(sample)
+
+	snapshot := buildLoopHTTPFuzzProgressSnapshot("fuzz_body", stats, 401, false)
+	require.Contains(t, snapshot, "执行进度：fuzz_body 已处理 3 个请求")
+	require.Contains(t, snapshot, "成功 2，失败 1")
+	require.Contains(t, snapshot, "已落库 2 条 HTTPFlow")
+	require.Contains(t, snapshot, "最近状态 401")
+	require.Contains(t, snapshot, "状态分布 200=1, 401=1")
+	require.Contains(t, snapshot, "长度分布 0B=1, 24B=1")
+	require.Contains(t, snapshot, "可疑样本 1 个")
+}
+
+func TestFinalizeLoopHTTPFuzzResponseLengthGroups_UsesDominantLengthAsBaseline(t *testing.T) {
+	stats := newLoopHTTPFuzzAggregateStats()
+	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{
+		Index:       1,
+		Score:       5,
+		StatusCode:  200,
+		BodyLength:  10,
+		ResponseRaw: "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n0123456789",
+	})
+	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{
+		Index:       2,
+		Score:       6,
+		StatusCode:  200,
+		BodyLength:  10,
+		ResponseRaw: "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n0123456789",
+	})
+	stats.observeResponseLengthGroup(loopHTTPFuzzInterestingSample{
+		Index:       3,
+		Score:       20,
+		StatusCode:  401,
+		BodyLength:  5,
+		ResponseRaw: "HTTP/1.1 401 Unauthorized\r\nContent-Length: 5\r\n\r\nadmin",
+	})
+
+	finalizeLoopHTTPFuzzResponseLengthGroups(stats)
+
+	require.Equal(t, 10, stats.BaselineBodyLength)
+	require.True(t, stats.ResponseLengthGroups[10].IsBaseline)
+	require.Contains(t, stats.ResponseLengthGroups[10].Sample.ResponseDiff, "baseline representative response")
+	require.False(t, stats.ResponseLengthGroups[5].IsBaseline)
+	require.NotEmpty(t, stats.ResponseLengthGroups[5].Sample.ResponseDiff)
+}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzztag_context.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzztag_context.go
@@ -1,0 +1,91 @@
+package loop_http_fuzztest
+
+import (
+	_ "embed"
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/jinzhu/gorm"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+const (
+	loopHTTPFuzzFuzztagReferenceKey       = "fuzztag_reference"
+	loopHTTPFuzzPayloadGroupsReferenceKey = "payload_groups_reference"
+)
+
+var (
+	loopHTTPFuzzFuzztagReferenceOnce sync.Once
+	loopHTTPFuzzFuzztagReferenceText string
+)
+
+func bootstrapLoopHTTPFuzzFuzztagContext(loopStateSetter interface{ Set(string, any) }, db *gorm.DB) {
+	if loopStateSetter == nil {
+		return
+	}
+	loopStateSetter.Set(loopHTTPFuzzFuzztagReferenceKey, getLoopHTTPFuzzFuzztagReference())
+	loopStateSetter.Set(loopHTTPFuzzPayloadGroupsReferenceKey, buildLoopHTTPFuzzPayloadGroupsReference(db))
+}
+
+func getLoopHTTPFuzzFuzztagReference() string {
+	loopHTTPFuzzFuzztagReferenceOnce.Do(func() {
+		loopHTTPFuzzFuzztagReferenceText = loadLoopHTTPFuzzFuzztagReference()
+	})
+	return loopHTTPFuzzFuzztagReferenceText
+}
+
+//go:embed prompts/fuzztag.md
+var fuzztagReferenceData []byte
+
+func loadLoopHTTPFuzzFuzztagReference() string {
+	content := strings.TrimSpace(html.UnescapeString(string(fuzztagReferenceData)))
+	if content == "" {
+		return ""
+	}
+	var out strings.Builder
+	out.WriteString("This is the current built-in fuzztag reference. You may use any relevant fuzztag listed here, not only a small subset of examples.\n")
+	out.WriteString("When you need batch generation for path/query/header/body/cookie/auth values, prefer writing a compact fuzztag rule instead of manually expanding all values.\n\n")
+	out.WriteString(content)
+	return out.String()
+}
+
+func buildLoopHTTPFuzzPayloadGroupsReference(db *gorm.DB) string {
+	var out strings.Builder
+	out.WriteString("Payload dictionary tags are available in these forms:\n")
+	out.WriteString("- {{payload(group)}}: line-based expansion with deduplication\n")
+	out.WriteString("- {{payload:nodup(group)}}: line-based expansion without deduplication\n")
+	out.WriteString("- {{payload:full(group)}}: return the full block without splitting lines\n")
+
+	if db == nil {
+		out.WriteString("\nCurrent database payload groups are unavailable because DB is not configured.")
+		return out.String()
+	}
+
+	groups, err := yakit.GetAllPayloadGroupName(db)
+	if err != nil {
+		log.Warnf("failed to query payload group names: %v", err)
+		out.WriteString("\nCurrent database payload groups are unavailable because the query failed.")
+		return out.String()
+	}
+
+	sort.Strings(groups)
+	if len(groups) == 0 {
+		out.WriteString("\nCurrent database payload groups: (none)")
+		return out.String()
+	}
+
+	out.WriteString(fmt.Sprintf("\nCurrent database payload groups (%d):\n", len(groups)))
+	for _, group := range groups {
+		if strings.TrimSpace(group) == "" {
+			continue
+		}
+		out.WriteString("- ")
+		out.WriteString(group)
+		out.WriteByte('\n')
+	}
+	return strings.TrimSpace(out.String())
+}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzztag_context_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzztag_context_test.go
@@ -14,7 +14,7 @@ import (
 func TestGetLoopHTTPFuzzFuzztagReference_LoadsSourceDocument(t *testing.T) {
 	ref := getLoopHTTPFuzzFuzztagReference()
 	require.NotEmpty(t, ref)
-	require.Contains(t, ref, "common/mutate/fuzztag.md")
+	require.Contains(t, ref, "This is the current built-in fuzztag reference.")
 	require.Contains(t, ref, "## fuzztag 可用标签一览")
 	require.Contains(t, ref, "`fuzz:password`")
 	require.Contains(t, ref, "{{payload(pass_top25)}}")

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzztag_context_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzztag_context_test.go
@@ -1,0 +1,54 @@
+package loop_http_fuzztest
+
+import (
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+func TestGetLoopHTTPFuzzFuzztagReference_LoadsSourceDocument(t *testing.T) {
+	ref := getLoopHTTPFuzzFuzztagReference()
+	require.NotEmpty(t, ref)
+	require.Contains(t, ref, "common/mutate/fuzztag.md")
+	require.Contains(t, ref, "## fuzztag 可用标签一览")
+	require.Contains(t, ref, "`fuzz:password`")
+	require.Contains(t, ref, "{{payload(pass_top25)}}")
+}
+
+func TestBuildLoopHTTPFuzzPayloadGroupsReference_UsesCurrentDBGroups(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, db.AutoMigrate(&schema.Payload{}).Error)
+	require.NoError(t, yakit.SavePayloadGroup(db, "pass_top25", []string{"admin", "root"}))
+	require.NoError(t, yakit.SavePayloadGroup(db, "usernames_default", []string{"admin", "guest"}))
+
+	ref := buildLoopHTTPFuzzPayloadGroupsReference(db)
+	require.Contains(t, ref, "{{payload(group)}}")
+	require.Contains(t, ref, "{{payload:nodup(group)}}")
+	require.Contains(t, ref, "{{payload:full(group)}}")
+	require.Contains(t, ref, "pass_top25")
+	require.Contains(t, ref, "usernames_default")
+	require.Contains(t, ref, "Current database payload groups (2):")
+}
+
+func TestLoopHTTPFuzzReactiveData_RendersFuzztagAndPayloadGroupContext(t *testing.T) {
+	rendered, err := utils.RenderTemplate(reactiveData, map[string]any{
+		"Nonce":                  "n123",
+		"OriginalRequest":        "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+		"FuzztagReference":       "Source: common/mutate/fuzztag.md\n{{fuzz:password}}\n{{payload(pass_top25)}}",
+		"PayloadGroupsReference": "Current database payload groups (1):\n- pass_top25",
+	})
+	require.NoError(t, err)
+	require.Contains(t, rendered, "<|FUZZTAG_REFERENCE_n123|>")
+	require.Contains(t, rendered, "{{fuzz:password}}")
+	require.Contains(t, rendered, "{{payload(pass_top25)}}")
+	require.Contains(t, rendered, "<|AVAILABLE_PAYLOAD_GROUPS_n123|>")
+	require.Contains(t, rendered, "pass_top25")
+}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
@@ -65,6 +65,8 @@ func init() {
 					securityKnowledge := loop.Get("security_knowledge")
 					recentActionsSummary := buildLoopHTTPFuzzRecentActionsPrompt(loop)
 					testedPayloadSummary := buildLoopHTTPFuzzTestedPayloadPrompt(loop)
+					fuzztagReference := loop.Get(loopHTTPFuzzFuzztagReferenceKey)
+					payloadGroupsReference := loop.Get(loopHTTPFuzzPayloadGroupsReferenceKey)
 
 					renderMap := map[string]any{
 						"OriginalRequest":           originalRequest,
@@ -82,6 +84,8 @@ func init() {
 						"SecurityKnowledge":         securityKnowledge,
 						"RecentActionsSummary":      recentActionsSummary,
 						"TestedPayloadSummary":      testedPayloadSummary,
+						"FuzztagReference":          fuzztagReference,
+						"PayloadGroupsReference":    payloadGroupsReference,
 						"Nonce":                     nonce,
 						"FeedbackMessages":          feedbacker.String(),
 					}
@@ -125,9 +129,9 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 	return func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
 		emitter := r.GetConfig().GetEmitter()
 		config := r.GetConfig()
-		_ = config
 
 		invoker := loop.GetInvoker()
+		bootstrapLoopHTTPFuzzFuzztagContext(loop, config.GetDB())
 
 		// TBD: 检查是否已经有 fuzz_request 了（可能是用户之前的交互设置的），如果有就直接继续
 		haveReq := loop.Get("fuzz_request") // Just to ensure the key exists in the loop state

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompt_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompt_test.go
@@ -14,6 +14,10 @@ func TestLoopHTTPFuzztestPersistentInstruction_CoversDirectAnswerAndPacketRepair
 		"User-Agent",
 		"FINAL_ANSWER AITAG",
 		"answer_payload 与 FINAL_ANSWER 互斥",
+		"fuzztag 使用规则",
+		"{{fuzz:password}}",
+		"{{payload(pass_top25)}}",
+		"不要手写几十上百个 payload",
 	}
 
 	for _, needle := range checks {
@@ -32,11 +36,29 @@ func TestLoopHTTPFuzztestOutputExample_CoversStructuredDirectAnswerFewShot(t *te
 		"信息泄漏线索",
 		"<|FINAL_ANSWER_{{ .Nonce }}|>",
 		"| 观察项 | 当前结论 | 对后续测试的价值 |",
+		"{{fuzz:password(admin)}}",
+		"{{fuzz:username(admin)}}",
+		"这里优先使用 fuzztag 表达批量生成规则",
 	}
 
 	for _, needle := range checks {
 		if !strings.Contains(outputExample, needle) {
 			t.Fatalf("expected output example to contain %q", needle)
+		}
+	}
+}
+
+func TestLoopHTTPFuzztestReactiveData_CoversFuzztagReferenceBlocks(t *testing.T) {
+	checks := []string{
+		"FUZZTAG_REFERENCE",
+		"AVAILABLE_PAYLOAD_GROUPS",
+		"fuzztag 手册",
+		"`payload(...)` 系列 fuzztag",
+	}
+
+	for _, needle := range checks {
+		if !strings.Contains(reactiveData, needle) {
+			t.Fatalf("expected reactive data to contain %q", needle)
 		}
 	}
 }

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/fuzztag.md
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/fuzztag.md
@@ -1,0 +1,74 @@
+## fuzztag 可用标签一览
+
+|标签名|标签别名|标签描述|
+|:-------|:-------|:-------|
+|`array`|`list`|设置一个数组，使用 `&#124;` 分割，例如：`{{array(1&#124;2&#124;3)}}`，结果为：[1,2,3]，|
+|`base64dec`|`base64decode, base64d, b64d`|进行 base64 解码，{{base64dec(YWJj)}} => abc|
+|`base64enc`|`base64encode, base64e, base64, b64`|进行 base64 编码，{{base64enc(abc)}} => YWJj|
+|`base64tohex`|`b642h, base642hex`|把 Base64 字符串转换为 HEX 编码，{{base64tohex(YWJj)}} => 616263|
+|`bmp`|  |生成一个 bmp 文件头，例如 {{bmp}}|
+|`char`|`c, ch`|生成一个字符，例如：`{{char(a-z)}}`, 结果为 [a b c ... x y z]|
+|`codec`|  |调用 Yakit Codec 插件|
+|`codec:line`|  |调用 Yakit Codec 插件，把结果解析成行|
+|`date`|  |生成一个时间，格式为YYYY-MM-dd，如果指定了格式，将按照指定的格式生成时间|
+|`datetime`|`time`|生成一个时间，格式为YYYY-MM-dd HH:mm:ss，如果指定了格式，将按照指定的格式生成时间|
+|`doubleurldec`|`doubleurldecode, durldec, durldecode`|双重URL解码，{{doubleurldec(%2561%2562%2563)}} => abc|
+|`doubleurlenc`|`doubleurlencode, durlenc, durl`|双重URL编码，{{doubleurlenc(abc)}} => %2561%2562%2563|
+|`file`|  |读取文件内容，可以支持多个文件，用竖线分割，`{{file(/tmp/1.txt)}}` 或 `{{file(/tmp/1.txt&#124;/tmp/test.txt)}}`|
+|`file:dir`|`filedir`|解析文件夹，把文件夹中文件的内容读取出来，读取成数组返回，定义为 `{{file:dir(/tmp/test)}}` 或 `{{file:dir(/tmp/test&#124;/tmp/1)}}`|
+|`file:line`|`fileline, file:lines`|解析文件名（可以用 `&#124;` 分割），把文件中的内容按行反回成数组，定义为 `{{file:line(/tmp/test.txt)}}` 或 `{{file:line(/tmp/test.txt&#124;/tmp/1.txt)}}`|
+|`fuzz:password`|`fuzz:pass`|根据所输入的操作随机生成可能的密码（默认为 root/admin 生成）|
+|`fuzz:username`|`fuzz:user`|根据所输入的操作随机生成可能的用户名（默认为 root/admin 生成）|
+|`gif`|  |生成 gif 文件头|
+|`headerauth`|  ||
+|`hexdec`|`hexd, hexdec, hexdecode`|HEX 解码，{{hexdec(616263)}} => abc|
+|`hexenc`|`hex, hexencode`|HEX 编码，{{hexenc(abc)}} => 616263|
+|`hextobase64`|`h2b64, hex2base64`|把 HEX 字符串转换为 base64 编码，{{hextobase64(616263)}} => YWJj|
+|`htmldec`|`htmldecode, htmlunescape`|HTML 解码，{{htmldec(&#97;&#98;&#99;)}} => abc|
+|`htmlenc`|`htmlencode, html, htmle, htmlescape`|HTML 实体编码，{{htmlenc(abc)}} => &#97;&#98;&#99;|
+|`htmlhexenc`|`htmlhex, htmlhexencode, htmlhexescape`|HTML 十六进制实体编码，{{htmlhexenc(abc)}} => &#x61;&#x62;&#x63;|
+|`ico`|  |生成一个 ico 文件头，例如 `{{ico}}`|
+|`int`|`port, ports, integer, i, p`|生成一个整数以及范围，例如 {{int(1,2,3,4,5)}} 生成 1,2,3,4,5 中的一个整数，也可以使用 {{int(1-5)}} 生成 1-5 的整数，也可以使用 `{{int(1-5&#124;4)}}` 生成 1-5 的整数，但是每个整数都是 4 位数，例如 0001, 0002, 0003, 0004, 0005|
+|`jpg`|`jpeg`|生成 jpeg / jpg 文件头|
+|`lower`|  |把传入的内容都设置成小写 {{lower(Abc)}} => abc|
+|`md5`|  |进行 md5 编码，{{md5(abc)}} => 900150983cd24fb0d6963f7d28e17f72|
+|`network`|`host, hosts, cidr, ip, net`|生成一个网络地址，例如 `{{network(192.168.1.1/24)}}` 对应 cidr 192.168.1.1/24 所有地址，可以逗号分隔，例如 `{{network(8.8.8.8,192.168.1.1/25,example.com)}}`|
+|`null`|`nullbyte`|生成一个空字节，如果指定了数量，将生成指定数量的空字节 {{null(5)}} 表示生成 5 个空字节|
+|`padding:null`|`nullpadding, np`|使用 \x00 来填充补偿字符串长度不足的问题，{{nullpadding(abc&#124;5)}} 表示将 abc 填充到长度为 5 的字符串（\x00\x00abc），{{nullpadding(abc&#124;-5)}} 表示将 abc 填充到长度为 5 的字符串，并且在右边填充 (abc\x00\x00)|
+|`padding:zero`|`zeropadding, zp`|使用0来填充补偿字符串长度不足的问题，{{zeropadding(abc&#124;5)}} 表示将 abc 填充到长度为 5 的字符串（00abc），{{zeropadding(abc&#124;-5)}} 表示将 abc 填充到长度为 5 的字符串，并且在右边填充 (abc00)|
+|`payload`|`x`|从数据库加载 Payload，默认按行展开并去重，`{{payload(pass_top25)}}`|
+|`payload:full`|  |从数据库加载 Payload，整块返回且不拆行、不去重，`{{payload:full(pass_top25)}}`|
+|`payload:nodup`|  |从数据库加载 Payload，按行展开且不去重，`{{payload:nodup(pass_top25)}}`|
+|`png`|  |生成 PNG 文件头|
+|`punctuation`|`punc`|生成所有标点符号|
+|`quote`|  |strconv.Quote 转化|
+|`randint`|`ri, rand:int, randi`|随机生成整数，定义为 {{randint(10)}} 生成0-10中任意一个随机数，{{randint(1,50)}} 生成 1-50 任意一个随机数，{{randint(1,50,10)}} 生成 1-50 任意一个随机数，重复 10 次|
+|`randomupper`|`random:upper, random:lower`|随机大小写，{{randomupper(abc)}} => aBc|
+|`randstr`|`rand:str, rs, rands`|随机生成个字符串，定义为 {{randstr(10)}} 生成长度为 10 的随机字符串，{{randstr(1,30)}} 生成长度为 1-30 为随机字符串，{{randstr(1,30,10)}} 生成 10 个随机字符串，长度为 1-30|
+|`rangechar`|`range:char, range`|按顺序生成一个 range 字符集，例如 `{{rangechar(20,7e)}}` 生成 0x20 - 0x7e 的字符集|
+|`regen`|`re`|使用正则生成所有可能的字符|
+|`repeat`|  |重复一个字符串，例如：`{{repeat(abc&#124;3)}}`，结果为：abcabcabc|
+|`repeat:range`|  |重复一个字符串，并把重复步骤全都输出出来，例如：`{{repeat(abc&#124;3)}}`，结果为：['' abc abcabc abcabcabc]|
+|`repeatstr`|`repeat:str`|重复字符串，`{{repeatstr(abc&#124;3)}}` => abcabcabc|
+|`sha1`|  |进行 sha1 编码，{{sha1(abc)}} => a9993e364706816aba3e25717850c26c9cd0d89d|
+|`sha224`|  ||
+|`sha256`|  |进行 sha256 编码，{{sha256(abc)}} => ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad|
+|`sha384`|  ||
+|`sha512`|  |进行 sha512 编码，{{sha512(abc)}} => ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f|
+|`sm3`|  |计算 sm3 哈希值，{{sm3(abc)}} => 66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a3f0b8ddb27d8a7eb3|
+|`tiff`|  |生成一个 tiff 文件头，例如 `{{tiff}}`|
+|`timestamp`|  |生成一个时间戳，默认单位为秒，可指定单位：s, ms, ns: {{timestamp(s)}}|
+|`trim`|  |去除字符串两边的空格，一般配合其他 tag 使用，如：{{trim({{x(dict)}})}}|
+|`unquote`|  |把内容进行 strconv.Unquote 转化|
+|`upper`|  |把传入的内容变成大写 {{upper(abc)}} => ABC|
+|`urldec`|`urldecode, urld`|URL 强制解码，{{urldec(%61%62%63)}} => abc|
+|`urlenc`|`urlencode, url`|URL 强制编码，{{urlenc(abc)}} => %61%62%63|
+|`urlescape`|`urlesc`|url 编码(只编码特殊字符)，{{urlescape(abc=)}} => abc%3d|
+|`uuid`|  |生成一个随机的uuid，如果指定了数量，将生成指定数量的uuid|
+|`yso:bodyexec`|  |尽力使用 class body exec 的方式生成多个链|
+|`yso:dnslog`|  ||
+|`yso:exec`|  ||
+|`yso:find_gadget_by_bomb`|  ||
+|`yso:find_gadget_by_dns`|  ||
+|`yso:headerecho`|  |尽力使用 header echo 生成多个链|
+|`yso:urldns`|  ||

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/persistent_instruction.txt
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/persistent_instruction.txt
@@ -54,6 +54,16 @@
 - IDOR/参数遍历：连续数字 ID、UUID、订单号、用户名、租户编号、文件编号、资源路径枚举。
 - 信息泄漏：备份文件、调试端点、错误栈、版本信息、目录索引、越权读取返回中的敏感字段。
 
+### fuzztag 使用规则
+
+1. 当前 fuzz 接口支持 fuzztag。`param_values`、`header_values`、`cookie_values`、`paths` 等字符串值里可以直接写 `{{ "{{...}}" }}` 标签，由底层展开成大量测试数据。
+2. 每轮决策前，优先参考上下文中的 `FUZZTAG_REFERENCE` 和 `AVAILABLE_PAYLOAD_GROUPS` 区块。前者说明当前可用的完整 fuzztag 手册，后者说明当前数据库里有哪些 payload group 可以被 `payload(...)` 系列标签直接引用。
+3. 你的职责是决定“生成策略”，不是把所有爆破 payload 或所有批量枚举值全部展开写出来。需要大批量生成时，优先写 fuzztag 规则。
+4. 当目标是密码爆破、用户名枚举、对象编号遍历、常见弱口令尝试、批量字典测试、头部批量构造、编码组合或认证材料批量变形时，优先使用 fuzztag，不要手写几十上百个 payload。
+5. 你可以使用 `FUZZTAG_REFERENCE` 中任何合适的标签，不只限于少数示例。比如 `{{ "{{fuzz:password}}" }}`、`{{ "{{fuzz:username}}" }}`、`{{ "{{payload(pass_top25)}}" }}`、`{{ "{{int(1000-1010)}}" }}` 只是常见写法，不是能力边界。
+6. 如果只是少量高价值探测，例如 3 到 6 个布尔型 SQL 注入或上下文明确的 XSS payload，可以直接写具体值；不要为了很小的测试强行改成 fuzztag。
+7. 使用 fuzztag 时，reason 里要明确说明这是“批量枚举/爆破/字典型验证”，并说明为什么选择该标签或 payload group，而不是手写列表。
+
 ### generate_and_send_packet 的 AITAG 规则
 
 当使用 generate_and_send_packet 时，必须输出完整原始 HTTP 数据包，并使用以下格式：

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/reactive_data.txt
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/reactive_data.txt
@@ -30,6 +30,22 @@
 {{ .OriginalRequest }}
 <|ORIGINAL_REQUEST_END_{{ .Nonce }}|>
 
+{{ if .FuzztagReference }}
+### Fuzztag Reference
+下面是当前可直接使用的 fuzztag 手册。规划下一步时，凡是需要批量生成 header、query、body、cookie、path、认证材料或字典型值时，优先参考这里，而不是手写展开后的长列表。
+<|FUZZTAG_REFERENCE_{{ .Nonce }}|>
+{{ .FuzztagReference }}
+<|FUZZTAG_REFERENCE_END_{{ .Nonce }}|>
+{{ end }}
+
+{{ if .PayloadGroupsReference }}
+### Available Payload Groups
+下面是当前数据库中可直接被 `payload(...)` 系列 fuzztag 引用的 group 名单。
+<|AVAILABLE_PAYLOAD_GROUPS_{{ .Nonce }}|>
+{{ .PayloadGroupsReference }}
+<|AVAILABLE_PAYLOAD_GROUPS_END_{{ .Nonce }}|>
+{{ end }}
+
 {{ if .SecurityKnowledge }}
 ### Security Knowledge Base Results
 <|SECURITY_KNOWLEDGE_{{ .Nonce }}|>
@@ -96,4 +112,3 @@ Based on the above context and security knowledge, decide your next vulnerabilit
 4. What attack surface remains untested?
 5. Which payloads have already been tested for this action, and how will you avoid repeating them unless you need confirmation?
 6. How can the next step validate the suspected vulnerability safely without destructive behavior?
-

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/reflection_output_example.txt
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/reflection_output_example.txt
@@ -48,7 +48,28 @@
 }
 ```
 
-### 示例 5：测试 Cookie 会话操控
+### 示例 5：使用 fuzztag 做登录口密码爆破
+```json
+{
+  "@action": "fuzz_body",
+  "body_type": "post_params",
+  "param_name": "password",
+  "param_values": ["{{ "{{fuzz:password(admin)}}" }}", "{{ "{{payload(pass_top25)}}" }}"],
+  "reason": "这是登录接口，password 字段适合做弱口令和字典型爆破验证。这里优先使用 fuzztag 表达批量生成规则，而不是手写大量密码列表。整个测试保持只读，不包含任何破坏性 payload。"
+}
+```
+
+### 示例 6：使用 fuzztag 做用户名枚举或对象遍历
+```json
+{
+  "@action": "fuzz_get_params",
+  "param_name": "username",
+  "param_values": ["{{ "{{fuzz:username(admin)}}" }}"],
+  "reason": "当前接口疑似登录或找回密码场景，username 参数适合做批量用户名枚举。这里让底层通过 fuzztag 自动展开常见用户名，而不是手写长列表。"
+}
+```
+
+### 示例 7：测试 Cookie 会话操控
 ```json
 {
   "@action": "fuzz_cookie",
@@ -59,7 +80,7 @@
 }
 ```
 
-### 示例 6：测试 HTTP 方法差异
+### 示例 8：测试 HTTP 方法差异
 ```json
 {
   "@action": "fuzz_method",
@@ -68,7 +89,7 @@
 }
 ```
 
-### 示例 7：修改当前数据包并要求人工审核
+### 示例 9：修改当前数据包并要求人工审核
 ```json
 {
   "@action": "modify_http_request",
@@ -86,7 +107,7 @@ Cookie: session=guest
 
 <|GEN_MODIFIED_PACKET_END_{{ .Nonce }}|>
 
-### 示例 8：测试过程中的简短问答
+### 示例 10：测试过程中的简短问答
 ```json
 {
   "@action": "directly_answer",
@@ -94,7 +115,7 @@ Cookie: session=guest
 }
 ```
 
-### 示例 9：使用 FINAL_ANSWER 输出更复杂的阶段结论
+### 示例 11：使用 FINAL_ANSWER 输出更复杂的阶段结论
 ```json
 {
   "@action": "directly_answer"
@@ -129,7 +150,7 @@ Cookie: session=guest
 3. 观察是否能通过调试信息、模板报错或搜索结果差异挖到信息泄漏。
 <|FINAL_ANSWER_END_{{ .Nonce }}|>
 
-### 示例 10：使用 FINAL_ANSWER 输出 IDOR/信息泄漏方向
+### 示例 12：使用 FINAL_ANSWER 输出 IDOR/信息泄漏方向
 ```json
 {
   "@action": "directly_answer"
@@ -157,7 +178,7 @@ Cookie: session=guest
 3. 再看详情接口、导出接口、文件下载接口是否复用了同一对象访问控制缺陷。
 <|FINAL_ANSWER_END_{{ .Nonce }}|>
 
-### 示例 11：直接生成完整原始数据包并发送
+### 示例 13：直接生成完整原始数据包并发送
 ```json
 {
   "@action": "generate_and_send_packet",
@@ -176,7 +197,7 @@ Cookie: session=guest
 username=admin%27%20or%20%271%27=%271&password=test
 <|GEN_PACKET_END_{{ .Nonce }}|>
 
-### 示例 12：完全新建原始数据包做模板注入探测
+### 示例 14：完全新建原始数据包做模板注入探测
 ```json
 {
   "@action": "generate_and_send_packet",

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/request_state.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/request_state.go
@@ -283,6 +283,7 @@ func resetLoopHTTPFuzzExecutionState(loop *reactloops.ReActLoop) {
 	loop.Set("representative_httpflow_hidden_index", "")
 	loop.Set("diff_result", "")
 	loop.Set("diff_result_full", "")
+	loop.Set("diff_result_analysis", "")
 	loop.Set("diff_result_compressed", "")
 	loop.Set("verification_result", "")
 }

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/result_analysis.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/result_analysis.go
@@ -1,0 +1,147 @@
+package loop_http_fuzztest
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/utils/yakgit/yakdiff"
+)
+
+func scoreLoopHTTPFuzzInterestingSample(statusCode int, durationMs int64, bodyLength int, baselineBodyLength int, responseRaw string) int {
+	score := 0
+	switch {
+	case statusCode >= 500:
+		score += 90
+	case statusCode >= 400:
+		score += 45
+	case statusCode >= 300:
+		score += 20
+	}
+
+	if baselineBodyLength >= 0 {
+		delta := abs(bodyLength - baselineBodyLength)
+		if baselineBodyLength == 0 {
+			if delta > 0 {
+				score += 35
+			}
+		} else if delta > baselineBodyLength/2 {
+			score += 35
+		} else if delta > baselineBodyLength/4 {
+			score += 18
+		}
+	}
+
+	switch {
+	case durationMs >= 3000:
+		score += 40
+	case durationMs >= 1000:
+		score += 20
+	case durationMs >= 500:
+		score += 10
+	}
+
+	responseLower := strings.ToLower(responseRaw)
+	for _, keyword := range []string{
+		"sql", "syntax error", "exception", "stack trace", "traceback",
+		"unauthorized", "forbidden", "access denied", "permission denied",
+		"welcome", "login success", "token", "debug",
+	} {
+		if strings.Contains(responseLower, keyword) {
+			score += 25
+			break
+		}
+	}
+
+	return score
+}
+
+func formatLoopHTTPFuzzStatusCode(statusCode int) string {
+	if statusCode <= 0 {
+		return "(no status code)"
+	}
+	return fmt.Sprintf("%d", statusCode)
+}
+
+func buildLoopHTTPFuzzResponseDiffFromBaseline(baselineResponseRaw, sampleResponseRaw string) string {
+	baselineResponseRaw = strings.TrimSpace(baselineResponseRaw)
+	sampleResponseRaw = strings.TrimSpace(sampleResponseRaw)
+	if baselineResponseRaw == "" || sampleResponseRaw == "" {
+		return ""
+	}
+	if baselineResponseRaw == sampleResponseRaw {
+		return "  (same as baseline representative response)"
+	}
+
+	_, baselineBody := lowhttp.SplitHTTPPacketFast([]byte(baselineResponseRaw))
+	_, sampleBody := lowhttp.SplitHTTPPacketFast([]byte(sampleResponseRaw))
+	left := string(baselineBody)
+	right := string(sampleBody)
+	if strings.TrimSpace(left) == "" && strings.TrimSpace(right) == "" {
+		left = baselineResponseRaw
+		right = sampleResponseRaw
+	}
+
+	diffText, err := yakdiff.DiffToString(left, right)
+	if err == nil && strings.TrimSpace(diffText) != "" {
+		return strings.TrimSpace(diffText)
+	}
+	return compareRequests(left, right)
+}
+
+func formatLoopHTTPFuzzTopStatusCounts(counts map[int]int, maxItems int) string {
+	if len(counts) == 0 || maxItems <= 0 {
+		return ""
+	}
+	statuses := make([]int, 0, len(counts))
+	for statusCode := range counts {
+		statuses = append(statuses, statusCode)
+	}
+	sort.SliceStable(statuses, func(i, j int) bool {
+		if counts[statuses[i]] == counts[statuses[j]] {
+			return statuses[i] < statuses[j]
+		}
+		return counts[statuses[i]] > counts[statuses[j]]
+	})
+	if len(statuses) > maxItems {
+		statuses = statuses[:maxItems]
+	}
+	parts := make([]string, 0, len(statuses))
+	for _, statusCode := range statuses {
+		parts = append(parts, fmt.Sprintf("%s=%d", formatLoopHTTPFuzzStatusCode(statusCode), counts[statusCode]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// summarizeResponse creates a summary of the HTTP response
+func summarizeResponse(response string) string {
+	if response == "" {
+		return "  (empty response)"
+	}
+
+	_, body := lowhttp.SplitHTTPPacketFast([]byte(response))
+	statusCode := getStatusFromResponse(response)
+
+	var summary strings.Builder
+	summary.WriteString(fmt.Sprintf("  Status Code: %s\n", formatLoopHTTPFuzzStatusCode(statusCode)))
+
+	contentLength := len(body)
+	summary.WriteString(fmt.Sprintf("  Content-Length: %d bytes\n", contentLength))
+
+	if contentLength > 0 {
+		bodyPreview := string(body)
+		if len(bodyPreview) > 200 {
+			bodyPreview = bodyPreview[:200] + "..."
+		}
+		bodyPreview = strings.ReplaceAll(bodyPreview, "\n", " ")
+		summary.WriteString(fmt.Sprintf("  Body Preview: %s\n", bodyPreview))
+	}
+
+	return summary.String()
+}
+
+// getStatusFromResponse extracts status code from response
+func getStatusFromResponse(response string) int {
+	return lowhttp.ExtractStatusCodeFromResponse([]byte(response))
+}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/result_analysis.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/result_analysis.go
@@ -2,6 +2,7 @@ package loop_http_fuzztest
 
 import (
 	"fmt"
+	"github.com/yaklang/yaklang/common/utils"
 	"sort"
 	"strings"
 
@@ -130,10 +131,7 @@ func summarizeResponse(response string) string {
 	summary.WriteString(fmt.Sprintf("  Content-Length: %d bytes\n", contentLength))
 
 	if contentLength > 0 {
-		bodyPreview := string(body)
-		if len(bodyPreview) > 200 {
-			bodyPreview = bodyPreview[:200] + "..."
-		}
+		bodyPreview := utils.ShrinkString(string(body), 200)
 		bodyPreview = strings.ReplaceAll(bodyPreview, "\n", " ")
 		summary.WriteString(fmt.Sprintf("  Body Preview: %s\n", bodyPreview))
 	}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/session_state.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/session_state.go
@@ -60,13 +60,16 @@ func captureLoopHTTPFuzzSessionContext(loop *reactloops.ReActLoop, source string
 		return nil
 	}
 
-	analysisSummary := strings.TrimSpace(loop.Get("diff_result_compressed"))
+	analysisSummary := strings.TrimSpace(loop.Get("diff_result_analysis"))
+	if analysisSummary == "" {
+		analysisSummary = strings.TrimSpace(loop.Get("diff_result_compressed"))
+	}
 	if analysisSummary == "" {
 		analysisSummary = strings.TrimSpace(loop.Get("diff_result"))
 	}
 
 	ctx := &loopHTTPFuzzSessionContext{
-		Version:                   3,
+		Version:                   4,
 		OriginalRequest:           originalRequest,
 		OriginalRequestSummary:    strings.TrimSpace(loop.Get("original_request_summary")),
 		CurrentRequest:            strings.TrimSpace(loop.Get("current_request")),
@@ -208,7 +211,8 @@ func applyLoopHTTPFuzzSessionContext(loop *reactloops.ReActLoop, runtime aicommo
 	loop.Set("representative_response", ctx.RepresentativeResponse)
 	loop.Set("representative_httpflow_hidden_index", ctx.RepresentativeHiddenIndex)
 	loop.Set("diff_result", ctx.AnalysisSummary)
-	loop.Set("diff_result_compressed", ctx.AnalysisSummary)
+	loop.Set("diff_result_analysis", ctx.AnalysisSummary)
+	loop.Set("diff_result_compressed", "")
 	loop.Set("verification_result", ctx.VerificationResult)
 	setLoopHTTPFuzzRecentActions(loop, ctx.RecentActions)
 	setLoopHTTPFuzzTestedPayloads(loop, ctx.TestedPayloadsByAction)


### PR DESCRIPTION
###   主要改动

  1. 重写 fuzz 结果的组织方式
     不再在执行循环里持续拼接多份文本 summary，而是改为先收集结构化统计数据与受限样本，最后统一渲染报告。
     这样避免了循环内重复造报告、重复维护多份 summary、以及不同报告段之间内容交叉污染的问题。
  2. 报告拆分为三层职责
     最终报告按以下逻辑生成：

  - 固定概况 overview
    包含 fuzz 目标的关键概况，如请求总量、状态码分布、耗时统计、响应体长度分布概况，以及本轮关键 fuzz 参数。
  - 大样本分析段 analysis
    当结果量较大时，输出响应长度分组代表样本、可疑样本、baseline 对比等分析内容。
  - 小样本详细结果段 details
    当结果量较小时，直接展示限制内的详细数据包结果，便于人工排查。

  3. 用 stats 承接核心分析数据
     弱语义的 diffSummary / analysisSummary 不再作为主数据载体，核心信息收敛到结构化 stats 中存储。
     报告只是 stats 的最终展示层，而不是执行过程中的主状态。这样后续更容易继续扩展、压缩或切换展示形式。
  4. 详细结果存储做上限控制
     详细数据包只保留限制内的前几条，避免一次 fuzz 把内存、上下文和最终报告体积全部撑爆。
     当前阶段先处理“执行后即展示”的链路，不额外实现从数据库回放再重建详细报告。
  5. 压缩边界调整
     压缩只作用于可压缩的分析段，不再包含固定 overview。
     固定概况保持原样输出，避免压缩后把最基础、最稳定、最需要直读的信息也丢进去一起摘要。
  6. baseline 展示补全
     baseline 分组除了差异占位信息外，补充展示其代表性原始响应内容，避免分析节里只有“这是 baseline”但看不到 baseline 本体的问题。
  7. 收敛无意义 summary 输出
     报告中减少语义模糊、信息密度低的 request/response summary 打印，优先保留真正有分析价值的内容，例如：

  - fuzz 参数
  - payload
  - request diff
  - response preview / digest
  - baseline diff
  - 原始 request/response packet

  8. 清理遗留代码与注释补全
     清理无用函数和过度拆分的结构，合并可以合并的数据结构。
     同时补齐这一段循环和报告逻辑的中文注释，降低后续维护成本。
  9. 复用已有 diff 工具
     局部自实现的请求对比逻辑改为复用已有 yakdiff 工具，减少重复实现和维护成本。

  结果

  这次调整后，loop_http_fuzztest 的输出逻辑会更清晰：

  - 执行阶段负责收集结构化结果
  - 渲染阶段负责按规模选择 overview / analysis / details
  - 压缩阶段只处理真正需要压缩的分析内容
  - baseline、代表样本、可疑样本和小样本详情的边界更明确

  整体上，报告更像“面向安全分析的结果文档”，而不是“循环过程中不断拼出来的临时日志”。