### PR TITLE
ci: improve essential test failure summaries

### DIFF
--- a/common/yakgrpc/grpc_syntaxflow_scan_test.go
+++ b/common/yakgrpc/grpc_syntaxflow_scan_test.go
@@ -3,6 +3,7 @@ package yakgrpc_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -41,6 +42,12 @@ type GRPCBasicScanTestConfig struct {
 	UseDuplexConnection   bool               // 是否使用双工连接
 	Language              ssaconfig.Language // 编译语言
 	ProgramFileSystem     map[string]string  // 程序文件系统（如果为空则使用默认）
+}
+
+type grpcBasicScanNotificationResult struct {
+	matchTaskID bool
+	matchRisk   bool
+	err         error
 }
 
 // checkGRPCBasicScanTest 统一的基础扫描测试检查函数
@@ -86,11 +93,17 @@ func checkGRPCBasicScanTest(t *testing.T, client ypb.YakClient, config GRPCBasic
 
 	// 设置双工连接（如果需要）
 	var notify ypb.Yak_DuplexConnectionClient
+	var notifyDone chan grpcBasicScanNotificationResult
+	var notifyCancel context.CancelFunc
 	var notifyErr error
 	if config.UseDuplexConnection {
 		log.Infof("[checkGRPCBasicScanTest] Step 2: Setting up duplex connection")
-		notify, notifyErr = client.DuplexConnection(ctx)
+		notifyCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		notifyCancel = cancel
+		defer notifyCancel()
+		notify, notifyErr = client.DuplexConnection(notifyCtx)
 		require.NoError(t, notifyErr, "[checkGRPCBasicScanTest] Failed to create duplex connection")
+		notifyDone = make(chan grpcBasicScanNotificationResult, 1)
 	}
 
 	// 启动扫描
@@ -108,6 +121,11 @@ func checkGRPCBasicScanTest(t *testing.T, client ypb.YakClient, config GRPCBasic
 	if config.UseDuplexConnection && notify != nil {
 		log.Infof("[checkGRPCBasicScanTest] Step 4: Setting up notification handler")
 		go func() {
+			result := grpcBasicScanNotificationResult{}
+			defer func() {
+				notifyDone <- result
+			}()
+
 			for {
 				res, err := notify.Recv()
 				if err != nil {
@@ -116,27 +134,42 @@ func checkGRPCBasicScanTest(t *testing.T, client ypb.YakClient, config GRPCBasic
 						return
 					}
 					log.Errorf("[checkGRPCBasicScanTest] Notification recv error: %v", err)
+					result.err = fmt.Errorf("[checkGRPCBasicScanTest] notification recv error: %w", err)
 					return
 				}
 				log.Infof("[checkGRPCBasicScanTest] Received notification: MessageType=%v", res.MessageType)
 				if res.MessageType == ssadb.ServerPushType_SyntaxflowResult {
 					var tmp map[string]string
 					err = json.Unmarshal(res.GetData(), &tmp)
-					require.NoError(t, err, "[checkGRPCBasicScanTest] Failed to unmarshal notification data")
+					if err != nil {
+						result.err = fmt.Errorf("[checkGRPCBasicScanTest] failed to unmarshal notification data: %w", err)
+						return
+					}
 					log.Infof("[checkGRPCBasicScanTest] Notification taskid: %#v", tmp)
 					if tmp["task_id"] == taskID {
-						matchTaskID = true
+						result.matchTaskID = true
 						log.Infof("[checkGRPCBasicScanTest] Task ID matched in notification")
-						res, err := client.QuerySyntaxFlowResult(ctx, &ypb.QuerySyntaxFlowResultRequest{
+						resultResp, err := client.QuerySyntaxFlowResult(context.Background(), &ypb.QuerySyntaxFlowResultRequest{
 							Filter: &ypb.SyntaxFlowResultFilter{
 								TaskIDs: []string{taskID},
 							},
 						})
-						require.NoError(t, err, "[checkGRPCBasicScanTest] Failed to query syntax flow result")
+						if err != nil {
+							result.err = fmt.Errorf("[checkGRPCBasicScanTest] failed to query syntax flow result: %w", err)
+							return
+						}
 						if config.ExpectedResultCount > 0 {
-							require.Greater(t, len(res.Results), 0, "[checkGRPCBasicScanTest] Should have at least one result")
-							if config.ExpectedResultKind != "" {
-								require.Equal(t, res.Results[0].Kind, config.ExpectedResultKind, "[checkGRPCBasicScanTest] Result kind mismatch")
+							if len(resultResp.Results) == 0 {
+								result.err = fmt.Errorf("[checkGRPCBasicScanTest] should have at least one result for task %s", taskID)
+								return
+							}
+							if config.ExpectedResultKind != "" && resultResp.Results[0].Kind != config.ExpectedResultKind {
+								result.err = fmt.Errorf(
+									"[checkGRPCBasicScanTest] result kind mismatch: got %q want %q",
+									resultResp.Results[0].Kind,
+									config.ExpectedResultKind,
+								)
+								return
 							}
 						}
 					}
@@ -144,12 +177,19 @@ func checkGRPCBasicScanTest(t *testing.T, client ypb.YakClient, config GRPCBasic
 				if res.MessageType == schema.ServerPushType_SSARisk {
 					var tmp map[string]string
 					err = json.Unmarshal(res.GetData(), &tmp)
-					require.NoError(t, err, "[checkGRPCBasicScanTest] Failed to unmarshal risk notification data")
+					if err != nil {
+						result.err = fmt.Errorf("[checkGRPCBasicScanTest] failed to unmarshal risk notification data: %w", err)
+						return
+					}
 					log.Infof("[checkGRPCBasicScanTest] Risk notification taskid: %#v", tmp)
 					if tmp["task_id"] == taskID {
-						matchRisk = true
+						result.matchRisk = true
 						log.Infof("[checkGRPCBasicScanTest] Risk matched in notification")
 					}
+				}
+
+				if (!config.ExpectedMatchTaskID || result.matchTaskID) && (!config.ExpectedMatchRisk || result.matchRisk) {
+					return
 				}
 			}
 		}()
@@ -181,6 +221,13 @@ func checkGRPCBasicScanTest(t *testing.T, client ypb.YakClient, config GRPCBasic
 	}
 	if config.ExpectedFinishStatus != "" {
 		require.Equal(t, config.ExpectedFinishStatus, finishStatus, "[checkGRPCBasicScanTest] Finish status mismatch")
+	}
+	if config.UseDuplexConnection && notifyDone != nil {
+		log.Infof("[checkGRPCBasicScanTest] Step 6: Waiting for notification handler")
+		notifyResult := <-notifyDone
+		require.NoError(t, notifyResult.err)
+		matchTaskID = notifyResult.matchTaskID
+		matchRisk = notifyResult.matchRisk
 	}
 	if config.ExpectedMatchTaskID {
 		require.True(t, matchTaskID, "[checkGRPCBasicScanTest] Should match task ID in notification")

--- a/scripts/ci/test-run.sh
+++ b/scripts/ci/test-run.sh
@@ -403,27 +403,176 @@ extract_failed_test_names() {
   grep -aE '^--- FAIL: ' "$log" | sed -E 's/^--- FAIL: ([^ ]+).*/\1/' | sort -u | paste -sd ', ' - || true
 }
 
+sanitize_summary_line() {
+  local line="$1"
+  printf '%s\n' "$line" \
+    | sed -E 's/\x1B\[[0-9;]*[[:alpha:]]//g; s/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+truncate_summary_line() {
+  local line="$1"
+  local max_len="${2:-240}"
+
+  if [[ ${#line} -le $max_len ]]; then
+    printf '%s\n' "$line"
+    return 0
+  fi
+
+  printf '%s...\n' "${line:0:max_len-3}"
+}
+
+reason_is_low_signal() {
+  local reason="$1"
+
+  if [[ -z "$reason" ]]; then
+    return 0
+  fi
+
+  if [[ "$reason" =~ ^FAIL:\  || "$reason" =~ ^---\ FAIL: ]]; then
+    return 0
+  fi
+
+  if [[ "$reason" == *"RequestQuotedJson:"* || "$reason" == *"ResponseQuotedJson:"* || "$reason" == *"&{Model:"* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+extract_panic_reason() {
+  local log="$1"
+  grep -aom1 -E 'panic:.*|fatal error:.*' "$log" | sed -E 's/.*(panic:.*|fatal error:.*)/\1/' || true
+}
+
+extract_panic_test_name() {
+  local log="$1"
+  grep -aom1 -E 'panic: .* after [^ ]+ has completed' "$log" | sed -E 's/.* after ([^ ]+) has completed/\1/' || true
+}
+
+extract_panic_location() {
+  local log="$1"
+  awk '
+    /panic:|fatal error:/ { capture=1; next }
+    capture {
+      line=$0
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      if (line == "") {
+        next
+      }
+      if (line ~ /\/testing\/testing\.go:/ || line ~ /github\.com\/stretchr\/testify\//) {
+        next
+      }
+      if (line ~ /\.go:[0-9]+/) {
+        print line
+        exit
+      }
+      if (line ~ /^created by /) {
+        exit
+      }
+    }
+  ' "$log" || true
+}
+
 extract_failure_reason() {
   local log="$1"
   local reason=""
 
-  reason=$(grep -am1 -E 'test timed out|panic:|Error:[[:space:]]|should have|first record does not look like a TLS handshake|connection reset by peer|context deadline exceeded|testing:|flag provided but not defined|invalid value|Usage of ' "$log" || true)
+  reason=$(extract_panic_reason "$log")
   if [[ -z "$reason" ]]; then
-    reason=$(grep -am1 -E '^--- FAIL: ' "$log" || true)
+    reason=$(grep -aE 'test timed out|Error:[[:space:]].*|should have.*|first record does not look like a TLS handshake.*|connection reset by peer.*|context deadline exceeded.*|testing:.*|flag provided but not defined.*|invalid value.*|Usage of .*' "$log" | tail -n 1 || true)
   fi
   if [[ -z "$reason" ]]; then
-    reason=$(grep -am1 -E '^FAIL: ' "$log" || true)
+    reason=$(grep -aE '^--- FAIL: .*' "$log" | tail -n 1 || true)
   fi
   if [[ -z "$reason" ]]; then
-    reason=$(grep -am1 -v -E '^(Command:|Test:|Config:|Retry:|----|[[:space:]]*$)' "$log" || true)
+    reason=$(grep -aE '^FAIL: .*' "$log" | tail -n 1 || true)
+  fi
+  if [[ -z "$reason" ]]; then
+    reason=$(grep -aE '^[[:space:]]*[[:alnum:]_.-]+_test\.go:[0-9]+: .*' "$log" | tail -n 1 || true)
+  fi
+  if [[ -z "$reason" ]]; then
+    reason=$(grep -aE '^> .+' "$log" | tail -n 1 || true)
+  fi
+  if [[ -z "$reason" ]]; then
+    reason=$(awk '
+      function trim(s) {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+        return s
+      }
+      {
+        lines[NR] = $0
+      }
+      END {
+        for (i = NR; i >= 1; i--) {
+          line = lines[i]
+          gsub(/\x1B\[[0-9;]*[[:alpha:]]/, "", line)
+          line = trim(line)
+          if (line == "" || line ~ /^(Command:|Test:|Config:|Retry:|----|PASS$|FAIL$|FAIL: |FAIL_ELAPSED:|完整日志:|测试失败，已尝试|失败日志摘要：|重试测试|[[:space:]]*$)/) {
+            continue
+          }
+          print line
+          exit
+        }
+      }
+    ' "$log" || true)
   fi
 
-  printf '%s\n' "$reason" | sed -E 's/^[[:space:]]+//'
+  reason="$(sanitize_summary_line "$reason")"
+  truncate_summary_line "$reason" 240
+}
+
+extract_failure_context() {
+  local log="$1"
+  awk '
+    function trim(s) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+      return s
+    }
+    function ignored(s) {
+      return s == "" ||
+        s ~ /^(Command:|Test:|Config:|Retry:|----|PASS$|FAIL$|FAIL: |FAIL_ELAPSED:|完整日志:|测试失败，已尝试|失败日志摘要：|重试测试|preparing for end iteration|cumulative_summary:|@action: object|Result: SOME FAILED|Failed tests:|=== Test Summary ===|Total tests:|Verifying test coverage\.\.\.|All tests are covered by config rules|<<+|-{5,}|━━━━━━━━|⏱|✅|❌)/
+    }
+    {
+      lines[NR] = $0
+      if ($0 ~ /^FAIL$/ || $0 ~ /^FAIL: /) {
+        fail_line = NR
+      }
+    }
+    END {
+      if (fail_line == 0) {
+        fail_line = NR + 1
+      }
+      start = fail_line - 20
+      if (start < 1) {
+        start = 1
+      }
+      count = 0
+      for (i = start; i < fail_line; i++) {
+        line = lines[i]
+        gsub(/\x1B\[[0-9;]*[[:alpha:]]/, "", line)
+        line = trim(line)
+        if (ignored(line)) {
+          continue
+        }
+        if (line ~ /^--- PASS:/ || line ~ /^PASS: /) {
+          continue
+        }
+        candidates[++count] = line
+      }
+      begin = count - 2
+      if (begin < 1) {
+        begin = 1
+      }
+      for (i = begin; i <= count; i++) {
+        print candidates[i]
+      }
+    }
+  ' "$log" || true
 }
 
 extract_failure_elapsed() {
   local log="$1"
-  grep -am1 '^FAIL_ELAPSED: ' "$log" | sed -E 's/^FAIL_ELAPSED: //' || true
+  grep -aom1 -E '^FAIL_ELAPSED: .*' "$log" | sed -E 's/^FAIL_ELAPSED: //' || true
 }
 
 extract_timeout_running_tests() {
@@ -502,11 +651,27 @@ else
   echo "Failed tests:"
   # 列出所有包含失败标记的日志
   while IFS= read -r log; do
-    if grep -aEq "^FAIL:|^--- FAIL:|^FAIL$|test timed out|^panic:" "$log"; then
+    if grep -aEq "^FAIL:|^--- FAIL:|^FAIL$|test timed out|panic:|fatal error:" "$log"; then
       test_name="$(basename "$log" .run.log)"
       failed_cases="$(extract_failed_test_names "$log")"
       failure_reason="$(extract_failure_reason "$log")"
+      failure_context="$(extract_failure_context "$log")"
       failure_elapsed="$(extract_failure_elapsed "$log")"
+      panic_reason="$(extract_panic_reason "$log")"
+
+      if [[ -n "$panic_reason" ]]; then
+        panic_case="$(extract_panic_test_name "$log")"
+        panic_location="$(extract_panic_location "$log")"
+        if [[ -n "$panic_case" ]]; then
+          echo "  - ${test_name} :: ${panic_case}"
+        else
+          echo "  - ${test_name}"
+        fi
+        echo "    reason: ${panic_reason}"
+        [[ -n "$panic_location" ]] && echo "    location: ${panic_location}"
+        [[ -n "$failure_elapsed" ]] && echo "    elapsed: ${failure_elapsed}"
+        continue
+      fi
 
       if grep -aEq 'test timed out' "$log"; then
         echo "  - ${test_name}"
@@ -540,7 +705,21 @@ else
 
       echo "  - ${test_name}"
       [[ -n "$failed_cases" ]] && echo "    failed cases: ${failed_cases}"
-      [[ -n "$failure_reason" ]] && echo "    reason: ${failure_reason}"
+      if ! reason_is_low_signal "$failure_reason"; then
+        echo "    reason: ${failure_reason}"
+      fi
+      printed_context=0
+      while IFS= read -r context_line; do
+        [[ -z "$context_line" ]] && continue
+        context_line="$(truncate_summary_line "$(sanitize_summary_line "$context_line")" 180)"
+        [[ -z "$context_line" ]] && continue
+        [[ "$context_line" == "$failure_reason" ]] && continue
+        if [[ $printed_context -ne 1 ]]; then
+          echo "    context:"
+          printed_context=1
+        fi
+        echo "      ${context_line}"
+      done < <(printf '%s\n' "$failure_context")
       [[ -n "$failure_elapsed" ]] && echo "    elapsed: ${failure_elapsed}"
     fi
   done < <(find "$TEST_LOG_DIR" -maxdepth 1 -type f -name "test_*.run.log" | sort)


### PR DESCRIPTION
## 变更说明
- 改进 essential tests 的失败摘要提取逻辑，让 panic 类失败可以明确输出 `reason` 和栈 `location`
- 对超长结构体、JSON dump 这类低信号兜底行降权，在没有 panic 或 timeout 时优先提取失败尾部更有价值的上下文
- 修正 SyntaxFlow 扫描测试中的通知 goroutine 行为，避免在父测试结束后继续用后台 goroutine 对测试句柄做断言

## 验证
- `bash -n scripts/ci/test-run.sh`
- `go test -count=20 -run '^(TestGRPCMUSTPASS_SyntaxFlow_Scan|TestGRPCMUSTPASS_SyntaxFlow_Scan_Cancel)$' ./common/yakgrpc`
- 在打开这个 PR 之前，曾用一个临时 probe 验证 panic 摘要输出效果；该 probe 已经移除：
  - https://github.com/yaklang/yaklang/actions/runs/24435151444/job/71388378426

```text
Failed tests:
  - test_common_yakgrpc :: TestGRPCMUSTPASS_Other_PanicSummaryProbe/panic_after_subtest_completion
    reason: panic: Fail in goroutine after TestGRPCMUSTPASS_Other_PanicSummaryProbe/panic_after_subtest_completion has completed
    location: /home/runner/work/yaklang/yaklang/common/yakgrpc/grpc_other_panic_summary_probe_test.go:21 +0x47
    elapsed: 3m27s
```
