### PR TITLE
fix(webfuzzer): parallelize hotpatch hook execution

### DIFF
--- a/common/yak/antlr4yak/builtin_functions.go
+++ b/common/yak/antlr4yak/builtin_functions.go
@@ -18,7 +18,10 @@ import (
 // ```
 func (e *Engine) YakBuiltinEval(code string) {
 	vm := e.vm
-	topFrame := vm.VMStack.Peek().(*yakvm.Frame)
+	topFrame := vm.CurrentFM()
+	if topFrame == nil {
+		panic("current frame is empty")
+	}
 	ctx := topFrame.GetContext()
 	if utils.IsNil(ctx) {
 		ctx = context.Background()

--- a/common/yak/antlr4yak/engine.go
+++ b/common/yak/antlr4yak/engine.go
@@ -37,11 +37,11 @@ func (e *Engine) RuntimeInfo(infoType string, params ...any) (res any, err error
 			err = fmt.Errorf("%v", e)
 		}
 	}()
-	frame := e.GetVM().VMStack.Peek()
+	frame := e.GetVM().CurrentFM()
 	if frame == nil {
 		return nil, fmt.Errorf("not found runtime.GetInfo")
 	}
-	runtimeLib, ok := frame.(*yakvm.Frame).GlobalVariables.Load("runtime")
+	runtimeLib, ok := frame.GlobalVariables.Load("runtime")
 	if !ok || runtimeLib == nil {
 		return nil, fmt.Errorf("current frame not import runtime lib")
 	}

--- a/common/yak/antlr4yak/yakvm/virtual_machine.go
+++ b/common/yak/antlr4yak/yakvm/virtual_machine.go
@@ -31,6 +31,11 @@ func GetFlag(flags ...ExecFlag) ExecFlag {
 	return flag
 }
 
+// vmCurrentFrameKey is the context key for the current executing Frame.
+// Storing the frame in context makes sub-function calls goroutine-safe:
+// each call chain carries its own Frame reference instead of sharing VMStack.Peek().
+type vmCurrentFrameKey struct{}
+
 type YakitFeedbacker interface{}
 type (
 	BreakPointFactoryFun func(v *VirtualMachine) bool
@@ -39,8 +44,9 @@ type (
 		globalVar        *limitedmap.ReadOnlyMap
 		runtimeGlobalVar *limitedmap.SafeMap
 
-		VMStack   *vmstack.Stack
-		rootScope *Scope
+		VMStack     *vmstack.Stack
+		vmstackMu   sync.Mutex
+		rootScope   *Scope
 
 		// asyncWaitGroup
 		asyncWaitGroup *sync.WaitGroup
@@ -332,10 +338,7 @@ func (v *VirtualMachine) InlineExecYakCode(ctx context.Context, codes []*Code, f
 	}, Trace|Sub)
 }
 
-var vmstackLock = new(sync.Mutex)
-
 func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags ...ExecFlag) error {
-	// 先检查 context 是否已取消
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -344,26 +347,27 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 
 	var frame *Frame
 	if flag&Sub == Sub {
-
-		vmstackLock.Lock()
-		topFrame := v.VMStack.Peek()
-		vmstackLock.Unlock()
-
-		if topFrame == nil {
+		// Get parent frame from context instead of VMStack.Peek().
+		// This makes concurrent calls goroutine-safe: each call chain carries its
+		// own Frame via context rather than competing on a shared VMStack.
+		parentFrame, _ := ctx.Value(vmCurrentFrameKey{}).(*Frame)
+		if parentFrame == nil {
 			log.Errorf("BUG: VMStack is empty(Sub)")
 			return utils.Error("BUG: VMStack is empty(Sub)")
 		}
-		frame = NewSubFrame(topFrame.(*Frame))
+		frame = NewSubFrame(parentFrame)
 	} else if flag&Inline == Inline {
-		vmstackLock.Lock()
+		// Inline mode reuses the current frame in-place (used by eval/debugger).
+		// It is not designed for concurrent use; keep VMStack-based lookup here.
+		v.vmstackMu.Lock()
 		topFrame := v.VMStack.Peek()
-		vmstackLock.Unlock()
+		v.vmstackMu.Unlock()
 
 		if topFrame == nil {
 			topFrame = NewFrame(v)
-			vmstackLock.Lock()
+			v.vmstackMu.Lock()
 			v.VMStack.Push(topFrame)
-			vmstackLock.Unlock()
+			v.vmstackMu.Unlock()
 			log.Debugf("VMStack is empty(Inline), we create new frame")
 		}
 
@@ -385,24 +389,29 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 		frame.coroutine = NewCoroutine()
 	}
 
-	vmstackLock.Lock()
+	// Store the current frame in context so nested Sub-mode calls (child function
+	// invocations) can find their correct parent frame without touching VMStack.
+	ctx = context.WithValue(ctx, vmCurrentFrameKey{}, frame)
+	// frame.ctx propagates the updated context to child calls via
+	// frame.CallYakFunction(vm.ctx, ...) in func.go.
+	frame.ctx = ctx
+
+	// Keep VMStack updated for inspection tools (GetVar, CurrentFM, debugger).
+	v.vmstackMu.Lock()
 	v.VMStack.Push(frame)
-	vmstackLock.Unlock()
+	v.vmstackMu.Unlock()
 
 	frame.debug = v.debug
-	// 初始化debugger
 	if v.debugMode && v.debugger != nil && v.debugger.initFunc != nil {
 		v.debugger.InitCallBack()
 	}
-	frame.ctx = ctx
 
 	f(frame)
 
-	// 未设置Trace时执行后出站
 	if flag&Trace != Trace {
-		vmstackLock.Lock()
+		v.vmstackMu.Lock()
 		v.VMStack.Pop()
-		vmstackLock.Unlock()
+		v.vmstackMu.Unlock()
 	}
 	if flag&Asnyc != Asnyc {
 		if lastPanic := frame.recover(); lastPanic != nil {

--- a/common/yak/antlr4yak/yakvm/virtual_machine.go
+++ b/common/yak/antlr4yak/yakvm/virtual_machine.go
@@ -3,6 +3,9 @@ package yakvm
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/yaklang/yaklang/common/utils/limitedmap"
@@ -44,9 +47,11 @@ type (
 		globalVar        *limitedmap.ReadOnlyMap
 		runtimeGlobalVar *limitedmap.SafeMap
 
-		VMStack     *vmstack.Stack
-		vmstackMu   sync.Mutex
-		rootScope   *Scope
+		VMStack       *vmstack.Stack
+		vmstackMu     sync.Mutex
+		frameStacksMu sync.RWMutex
+		frameStacks   map[int64]*vmstack.Stack
+		rootScope     *Scope
 
 		// asyncWaitGroup
 		asyncWaitGroup *sync.WaitGroup
@@ -148,6 +153,7 @@ func NewWithSymbolTable(table *SymbolTable) *VirtualMachine {
 		// rootSymbol: table,
 		rootScope:        NewScope(table),
 		VMStack:          vmstack.New(),
+		frameStacks:      make(map[int64]*vmstack.Stack),
 		globalVar:        limitedmap.NewReadOnlyMap(map[string]any{}),
 		runtimeGlobalVar: limitedmap.NewSafeMap(map[string]any{}),
 		config:           NewVMConfig(),
@@ -220,8 +226,8 @@ func (n *VirtualMachine) GetVarWithoutFrame(name string) (any, bool) {
 }
 
 func (n *VirtualMachine) GetVar(name string) (interface{}, bool) {
-	ivm := n.VMStack.Peek()
-	if ivm == nil {
+	frame := n.peekCurrentFrame()
+	if frame == nil {
 		val, ok := n.rootScope.GetValueByName(name)
 		if ok {
 			return val.Value, true
@@ -229,8 +235,6 @@ func (n *VirtualMachine) GetVar(name string) (interface{}, bool) {
 		return n.GetVarWithoutFrame(name)
 	}
 
-	// ivm 存在的时候，从 frame 中找变量
-	frame := ivm.(*Frame)
 	val, ok := frame.CurrentScope().GetValueByName(name)
 	if ok {
 		return val.Value, true
@@ -293,35 +297,54 @@ func (v *VirtualMachine) ExecYakFunctionEx(ctx context.Context, f *Function, arg
 }
 
 func (v *VirtualMachine) ExecAsyncYakFunction(ctx context.Context, f *Function, args map[int]*Value) error {
-	return v.Exec(ctx, func(frame *Frame) {
-		if v.sandboxMode && f.defineFrame != nil {
-			frame = NewSubFrame(f.defineFrame)
-		}
-		name := f.GetActualName()
-		frame.SetVerbose("function: " + name)
-		frame.SetFunction(f)
-		frame.SetScope(f.scope)
-		frame.CreateAndSwitchSubScope(f.symbolTable)
-		for id, arg := range args {
-			frame.CurrentScope().NewValueByID(id, arg)
-		}
-		go func() {
-			defer func() {
-				v.AsyncEnd()
-				if err := frame.recover(); err != nil {
-					log.Errorf("yakvm async function panic: %v", err)
-					// utils.PrintCurrentGoroutineRuntimeStack()
-				}
-				if err := recover(); err != nil {
-					log.Errorf("yakvm async function panic: %v", err)
-					utils.PrintCurrentGoroutineRuntimeStack()
-				}
-			}()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 
-			frame.Exec(f.codes)
-			frame.ExitScope()
+	parentFrame, _ := ctx.Value(vmCurrentFrameKey{}).(*Frame)
+	if parentFrame == nil && !(v.sandboxMode && f.defineFrame != nil) {
+		log.Errorf("BUG: VMStack is empty(Sub)")
+		return utils.Error("BUG: VMStack is empty(Sub)")
+	}
+
+	var frame *Frame
+	if v.sandboxMode && f.defineFrame != nil {
+		frame = NewSubFrame(f.defineFrame)
+	} else {
+		frame = NewSubFrame(parentFrame)
+	}
+	frame.coroutine = NewCoroutine()
+
+	name := f.GetActualName()
+	frame.SetVerbose("function: " + name)
+	frame.SetFunction(f)
+	frame.SetScope(f.scope)
+	frame.CreateAndSwitchSubScope(f.symbolTable)
+	for id, arg := range args {
+		frame.CurrentScope().NewValueByID(id, arg)
+	}
+
+	ctx = context.WithValue(ctx, vmCurrentFrameKey{}, frame)
+	frame.ctx = ctx
+
+	go func() {
+		v.pushCurrentFrame(frame)
+		defer func() {
+			v.popCurrentFrame()
+			v.AsyncEnd()
+			if err := frame.recover(); err != nil {
+				log.Errorf("yakvm async function panic: %v", err)
+			}
+			if err := recover(); err != nil {
+				log.Errorf("yakvm async function panic: %v", err)
+				utils.PrintCurrentGoroutineRuntimeStack()
+			}
 		}()
-	}, Sub, Asnyc)
+
+		frame.Exec(f.codes)
+		frame.ExitScope()
+	}()
+	return nil
 }
 
 func (v *VirtualMachine) ExecYakCode(ctx context.Context, sourceCode string, codes []*Code, flags ...ExecFlag) error {
@@ -359,19 +382,15 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 	} else if flag&Inline == Inline {
 		// Inline mode reuses the current frame in-place (used by eval/debugger).
 		// It is not designed for concurrent use; keep VMStack-based lookup here.
-		v.vmstackMu.Lock()
-		topFrame := v.VMStack.Peek()
-		v.vmstackMu.Unlock()
+		topFrame := v.peekCurrentFrame()
 
 		if topFrame == nil {
 			topFrame = NewFrame(v)
-			v.vmstackMu.Lock()
-			v.VMStack.Push(topFrame)
-			v.vmstackMu.Unlock()
+			v.pushCurrentFrame(topFrame)
 			log.Debugf("VMStack is empty(Inline), we create new frame")
 		}
 
-		frame = topFrame.(*Frame)
+		frame = topFrame
 		codes := frame.codes
 		p := frame.codePointer
 
@@ -396,10 +415,7 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 	// frame.CallYakFunction(vm.ctx, ...) in func.go.
 	frame.ctx = ctx
 
-	// Keep VMStack updated for inspection tools (GetVar, CurrentFM, debugger).
-	v.vmstackMu.Lock()
-	v.VMStack.Push(frame)
-	v.vmstackMu.Unlock()
+	v.pushCurrentFrame(frame)
 
 	frame.debug = v.debug
 	if v.debugMode && v.debugger != nil && v.debugger.initFunc != nil {
@@ -409,9 +425,7 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 	f(frame)
 
 	if flag&Trace != Trace {
-		v.vmstackMu.Lock()
-		v.VMStack.Pop()
-		v.vmstackMu.Unlock()
+		v.popCurrentFrame()
 	}
 	if flag&Asnyc != Asnyc {
 		if lastPanic := frame.recover(); lastPanic != nil {
@@ -431,7 +445,75 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 }
 
 func (v *VirtualMachine) CurrentFM() *Frame {
-	return v.VMStack.Peek().(*Frame)
+	return v.peekCurrentFrame()
+}
+
+func currentGoroutineID() int64 {
+	buf := make([]byte, 64)
+	n := runtime.Stack(buf, false)
+	if n <= 0 {
+		return 0
+	}
+	fields := strings.Fields(string(buf[:n]))
+	if len(fields) < 2 {
+		return 0
+	}
+	id, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+func (v *VirtualMachine) getCurrentFrameStack(gid int64, create bool) *vmstack.Stack {
+	v.frameStacksMu.Lock()
+	defer v.frameStacksMu.Unlock()
+
+	stack, ok := v.frameStacks[gid]
+	if ok || !create {
+		return stack
+	}
+
+	stack = vmstack.New()
+	v.frameStacks[gid] = stack
+	return stack
+}
+
+func (v *VirtualMachine) pushCurrentFrame(frame *Frame) {
+	gid := currentGoroutineID()
+	stack := v.getCurrentFrameStack(gid, true)
+	stack.Push(frame)
+}
+
+func (v *VirtualMachine) popCurrentFrame() *Frame {
+	gid := currentGoroutineID()
+
+	v.frameStacksMu.Lock()
+	defer v.frameStacksMu.Unlock()
+
+	stack, ok := v.frameStacks[gid]
+	if !ok || stack == nil {
+		return nil
+	}
+	frame, _ := stack.Pop().(*Frame)
+	if stack.Len() == 0 {
+		delete(v.frameStacks, gid)
+	}
+	return frame
+}
+
+func (v *VirtualMachine) peekCurrentFrame() *Frame {
+	gid := currentGoroutineID()
+
+	v.frameStacksMu.RLock()
+	defer v.frameStacksMu.RUnlock()
+
+	stack, ok := v.frameStacks[gid]
+	if !ok || stack == nil {
+		return nil
+	}
+	frame, _ := stack.Peek().(*Frame)
+	return frame
 }
 
 func (v *VirtualMachine) GetConfig() *VirtualMachineConfig {

--- a/common/yak/script_engine_for_fuzz.go
+++ b/common/yak/script_engine_for_fuzz.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/yak/antlr4yak"
@@ -119,8 +118,6 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 		mockHTTPRequestInstanceNumIn = ret.GetNumIn()
 	}
 
-	hookLock := new(sync.Mutex)
-
 	var hookBefore func(https bool, originReq []byte, req []byte) []byte = nil
 	var hookAfter func(https bool, originReq []byte, req []byte, originRsp []byte, rsp []byte) []byte = nil
 	var mirrorFlow func(req []byte, rsp []byte, handle map[string]string) map[string]string = nil
@@ -130,9 +127,6 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 
 	if beforeRequestOk {
 		hookBefore = func(https bool, originReq []byte, req []byte) []byte {
-			hookLock.Lock()
-			defer hookLock.Unlock()
-
 			defer func() {
 				if err := recover(); err != nil {
 					log.Errorf("beforeRequest(ORIGIN) panic: %s", err)
@@ -140,12 +134,12 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 			}()
 			if engine != nil {
 				var resultRequest any
+				var err error
 				if legacyBeforeRequest {
 					resultRequest, err = engine.CallYakFunction(context.Background(), "beforeRequest", []interface{}{req})
 				} else {
 					resultRequest, err = engine.CallYakFunction(context.Background(), "beforeRequest", []interface{}{https, originReq, req})
 				}
-
 				if err != nil {
 					log.Infof("eval beforeRequest hook failed: %s", err)
 				}
@@ -164,18 +158,14 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 
 	if afterRequestOk {
 		hookAfter = func(https bool, originReq []byte, req []byte, originRsp []byte, rsp []byte) []byte {
-			hookLock.Lock()
-			defer hookLock.Unlock()
-
 			defer func() {
 				if err := recover(); err != nil {
 					log.Errorf("afterRequest(RESPONSE) panic: %s", err)
 				}
 			}()
-
 			if engine != nil {
-
 				var resultResponse any
+				var err error
 				if legacyAfterRequest {
 					resultResponse, err = engine.CallYakFunction(context.Background(), "afterRequest", []interface{}{rsp})
 				} else {
@@ -199,15 +189,11 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 
 	if mirrorFlowOK {
 		mirrorFlow = func(req []byte, rsp []byte, existed map[string]string) map[string]string {
-			hookLock.Lock()
-			defer hookLock.Unlock()
-
 			defer func() {
 				if err := recover(); err != nil {
 					log.Errorf("mirrorHTTPFlow(request, response) data panic: %s", err)
 				}
 			}()
-
 			result := make(map[string]string)
 			if engine != nil {
 				params := []any{req, rsp}
@@ -218,7 +204,6 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 				if err != nil {
 					log.Infof("eval afterRequest hook failed: %s", err)
 				}
-
 				if ret := utils.InterfaceToMap(mirrorResult); ret != nil {
 					for k, v := range ret {
 						result[k] = strings.Join(v, ",")
@@ -231,15 +216,11 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 
 	if retryHandlerOk {
 		retryHandler = func(https bool, retryCount int, req []byte, rsp []byte, retryFunc func(...[]byte)) {
-			hookLock.Lock()
-			defer hookLock.Unlock()
-
 			defer func() {
 				if err := recover(); err != nil {
 					log.Errorf("retryHandler(request, response) data panic: %s", err)
 				}
 			}()
-
 			if engine != nil {
 				params := []any{https, retryCount, req, rsp, retryFunc}
 				if retryHandlerInstanceNumIn == 4 {
@@ -252,21 +233,16 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 					log.Infof("eval retryHandler hook failed: %s", err)
 				}
 			}
-			return
 		}
 	}
 
 	if customFailureCheckerOk {
 		customFailureChecker = func(https bool, req []byte, rsp []byte, fail func(string)) {
-			hookLock.Lock()
-			defer hookLock.Unlock()
-
 			defer func() {
 				if err := recover(); err != nil {
 					log.Errorf("customFailureChecker(request, response) data panic: %s", err)
 				}
 			}()
-
 			if engine != nil {
 				params := []any{https, req, rsp, fail}
 				if customFailureCheckerInstanceNumIn == 3 {
@@ -284,15 +260,11 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 
 	if mockHTTPRequestOk {
 		mockHTTPRequest = func(https bool, url string, req []byte, mockResponse func(rsp interface{})) {
-			hookLock.Lock()
-			defer hookLock.Unlock()
-
 			defer func() {
 				if err := recover(); err != nil {
 					log.Errorf("mockHTTPRequest(https, url, request, mockResponse) data panic: %s", err)
 				}
 			}()
-
 			if engine != nil {
 				params := []any{https, url, req, mockResponse}
 				if mockHTTPRequestInstanceNumIn == 3 {

--- a/common/yak/script_engine_for_fuzz_test.go
+++ b/common/yak/script_engine_for_fuzz_test.go
@@ -8,7 +8,93 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/yak/antlr4yak"
 )
+
+type testEventSync struct {
+	mu    sync.Mutex
+	chans map[string]chan struct{}
+	once  map[string]*sync.Once
+}
+
+func newTestEventSync() *testEventSync {
+	return &testEventSync{
+		chans: make(map[string]chan struct{}),
+		once:  make(map[string]*sync.Once),
+	}
+}
+
+func (s *testEventSync) get(name string) (chan struct{}, *sync.Once) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch, ok := s.chans[name]
+	if !ok {
+		ch = make(chan struct{})
+		s.chans[name] = ch
+	}
+	o, ok := s.once[name]
+	if !ok {
+		o = new(sync.Once)
+		s.once[name] = o
+	}
+	return ch, o
+}
+
+func (s *testEventSync) signal(name string) {
+	ch, o := s.get(name)
+	o.Do(func() {
+		close(ch)
+	})
+}
+
+func (s *testEventSync) wait(name string) {
+	ch, _ := s.get(name)
+	<-ch
+}
+
+func newTestHookEngine(t *testing.T, script string, globals map[string]any) *antlr4yak.Engine {
+	t.Helper()
+
+	scriptEngine := NewScriptEngine(1)
+	if len(globals) > 0 {
+		scriptEngine.RegisterEngineHooks(func(engine *antlr4yak.Engine) error {
+			engine.OverrideRuntimeGlobalVariables(globals)
+			return nil
+		})
+	}
+
+	engine, err := scriptEngine.ExecuteEx(script, map[string]any{})
+	require.NoError(t, err)
+	return engine
+}
+
+type hookCallResult struct {
+	result string
+	err    error
+}
+
+func invokeBeforeRequestAsync(engine *antlr4yak.Engine, name string) <-chan hookCallResult {
+	resultCh := make(chan hookCallResult, 1)
+	go func() {
+		req := []byte(name)
+		result, err := engine.CallYakFunction(context.Background(), "beforeRequest", []interface{}{false, req, req})
+		if err != nil {
+			resultCh <- hookCallResult{err: err}
+			return
+		}
+		switch ret := result.(type) {
+		case string:
+			resultCh <- hookCallResult{result: ret}
+		case []byte:
+			resultCh <- hookCallResult{result: string(ret)}
+		default:
+			resultCh <- hookCallResult{result: fmt.Sprint(ret)}
+		}
+	}()
+	return resultCh
+}
 
 // 并发调用含子函数的hook，验证VMStack不会串扰
 func TestConcurrentEngineCall_VMStackCorruption(t *testing.T) {
@@ -157,4 +243,85 @@ afterRequest = func(isHttps, originReq, req, originRsp, rsp) {
 		expected := fmt.Sprintf("rsp%d-tagged", i)
 		assert.Equal(t, expected, res, "result[%d] wrong", i)
 	}
+}
+
+// 引擎并发风险：helper/eval 如果直接读取共享栈顶，会在并发下拿到别的 goroutine 当前 frame。
+func TestMutateHookCaller_ConcurrentEvalUsesCorrectFrame(t *testing.T) {
+	syncer := newTestEventSync()
+	engine := newTestHookEngine(t, `
+beforeRequest = func(isHttps, originReq, req) {
+    localValue = string(req)
+    if localValue == "fast" {
+        signal("fast-entered")
+        wait("allow-fast-eval")
+        eval("result = localValue")
+        return result
+    }
+
+    signal("slow-entered")
+    wait("allow-slow-exit")
+    return localValue
+}
+`, map[string]any{
+		"signal": func(name string) { syncer.signal(name) },
+		"wait":   func(name string) { syncer.wait(name) },
+	})
+
+	fastResultCh := invokeBeforeRequestAsync(engine, "fast")
+	syncer.wait("fast-entered")
+
+	slowResultCh := invokeBeforeRequestAsync(engine, "slow")
+	syncer.wait("slow-entered")
+
+	// 此时 slow 的 frame 已经入栈，fast 继续执行 eval 必须仍然读取到自己的 localValue。
+	syncer.signal("allow-fast-eval")
+	fastResult := <-fastResultCh
+	require.NoError(t, fastResult.err)
+	require.Equal(t, "fast", fastResult.result)
+
+	syncer.signal("allow-slow-exit")
+	slowResult := <-slowResultCh
+	require.NoError(t, slowResult.err)
+	require.Equal(t, "slow", slowResult.result)
+}
+
+// 引擎风险：先返回的 goroutine 不能把另一个 goroutine 仍在运行的当前 frame 弹掉。
+func TestMutateHookCaller_OutOfOrderReturnDoesNotCorruptCurrentFrame(t *testing.T) {
+	syncer := newTestEventSync()
+	engine := newTestHookEngine(t, `
+beforeRequest = func(isHttps, originReq, req) {
+    localValue = string(req)
+    if localValue == "fast" {
+        signal("fast-entered")
+        wait("allow-fast-return")
+        return localValue
+    }
+
+    signal("slow-entered")
+    wait("allow-slow-eval")
+    eval("result = localValue")
+    return result
+}
+`, map[string]any{
+		"signal": func(name string) { syncer.signal(name) },
+		"wait":   func(name string) { syncer.wait(name) },
+	})
+
+	fastResultCh := invokeBeforeRequestAsync(engine, "fast")
+	syncer.wait("fast-entered")
+
+	slowResultCh := invokeBeforeRequestAsync(engine, "slow")
+	syncer.wait("slow-entered")
+
+	// 先让 fast 返回；旧实现里这里会把 slow 的 frame 从共享栈顶错误弹掉。
+	syncer.signal("allow-fast-return")
+	fastResult := <-fastResultCh
+	require.NoError(t, fastResult.err)
+	require.Equal(t, "fast", fastResult.result)
+
+	// slow 恢复后继续执行 eval，必须仍然读到自己的 localValue。
+	syncer.signal("allow-slow-eval")
+	slowResult := <-slowResultCh
+	require.NoError(t, slowResult.err)
+	require.Equal(t, "slow", slowResult.result)
 }

--- a/common/yak/script_engine_for_fuzz_test.go
+++ b/common/yak/script_engine_for_fuzz_test.go
@@ -1,0 +1,160 @@
+package yak
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 并发调用含子函数的hook，验证VMStack不会串扰
+func TestConcurrentEngineCall_VMStackCorruption(t *testing.T) {
+	scriptEngine := NewScriptEngine(1)
+	engine, err := scriptEngine.ExecuteEx(`
+tag = "ok"
+helper = func(s) {
+    return s + "-" + tag
+}
+beforeRequest = func(isHttps, originReq, req) {
+    return helper(string(req))
+}
+`, make(map[string]interface{}))
+	require.NoError(t, err)
+
+	const n = 30
+	results := make([]string, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			req := []byte(fmt.Sprintf("req%d", i))
+			result, callErr := engine.CallYakFunction(context.Background(), "beforeRequest", []interface{}{false, req, req})
+			if callErr != nil {
+				t.Errorf("goroutine %d error: %v", i, callErr)
+				return
+			}
+			switch v := result.(type) {
+			case string:
+				results[i] = v
+			case []byte:
+				results[i] = string(v)
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, res := range results {
+		expected := fmt.Sprintf("req%d-ok", i)
+		assert.Equal(t, expected, res, "result[%d] wrong (VMStack corrupted)", i)
+	}
+}
+
+// 通过MutateHookCaller API并发调用beforeRequest
+func TestMutateHookCaller_ConcurrentCorrectness(t *testing.T) {
+	hookBefore, _, _, _, _, _ := MutateHookCaller(context.Background(), `
+tag = "done"
+helper = func(s) {
+    return s + "-" + tag
+}
+beforeRequest = func(isHttps, originReq, req) {
+    return helper(string(req))
+}
+`, nil)
+	require.NotNil(t, hookBefore)
+
+	const n = 30
+	results := make([]string, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			req := []byte(fmt.Sprintf("req%d", i))
+			res := hookBefore(false, req, req)
+			results[i] = string(res)
+		}()
+	}
+	wg.Wait()
+
+	for i, res := range results {
+		expected := fmt.Sprintf("req%d-done", i)
+		assert.Equal(t, expected, res, "result[%d] wrong", i)
+	}
+}
+
+// 并发调用多层嵌套子函数(A→B→C)，验证context逐层传递正确
+func TestConcurrentEngineCall_DeepNestedCalls(t *testing.T) {
+	scriptEngine := NewScriptEngine(1)
+	engine, err := scriptEngine.ExecuteEx(`
+c = func(s) { return s + "-c" }
+b = func(s) { return c(s) + "-b" }
+a = func(s) { return b(s) + "-a" }
+process = func(isHttps, originReq, req) {
+    return a(string(req))
+}
+`, make(map[string]interface{}))
+	require.NoError(t, err)
+
+	const n = 30
+	results := make([]string, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			req := []byte(fmt.Sprintf("req%d", i))
+			result, callErr := engine.CallYakFunction(context.Background(), "process", []interface{}{false, req, req})
+			if callErr != nil {
+				t.Errorf("goroutine %d error: %v", i, callErr)
+				return
+			}
+			if s, ok := result.(string); ok {
+				results[i] = s
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, res := range results {
+		expected := fmt.Sprintf("req%d-c-b-a", i)
+		assert.Equal(t, expected, res, "result[%d] wrong (deep nesting)", i)
+	}
+}
+
+// 并发调用afterRequest hook，验证结果正确
+func TestMutateHookCaller_AfterRequestConcurrent(t *testing.T) {
+	_, hookAfter, _, _, _, _ := MutateHookCaller(context.Background(), `
+tag = func(s) { return s + "-tagged" }
+afterRequest = func(isHttps, originReq, req, originRsp, rsp) {
+    return tag(string(rsp))
+}
+`, nil)
+	require.NotNil(t, hookAfter)
+
+	const n = 30
+	results := make([]string, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			rsp := []byte(fmt.Sprintf("rsp%d", i))
+			res := hookAfter(false, nil, nil, rsp, rsp)
+			results[i] = string(res)
+		}()
+	}
+	wg.Wait()
+
+	for i, res := range results {
+		expected := fmt.Sprintf("rsp%d-tagged", i)
+		assert.Equal(t, expected, res, "result[%d] wrong", i)
+	}
+}


### PR DESCRIPTION
# 背景
	直接去掉hook函数的并发，问题不是集中在闭包问题，而是engine VM本身的并发问题。

# 问题1
	把 HotPatch hook 放开并发执行，VM 在并发调用链里的 frame 串扰问题：
  - 子函数 / helper / 闭包调用不再从共享 `VMStack.Peek()` 取父 frame
 修复方式是：
  - 改为把当前 frame 写入调用链 `context`
  - `Sub` 模式子调用从 `context` 中取自己这条链路的父 frame

# 问题2
1. 仍有部分路径直接从共享栈顶取“当前 frame”
     - 例如 `GetVar` / `CurrentFM` / `YakBuiltinEval` / `RuntimeInfo`
 2. 执行生命周期里的 push/pop 仍然使用共享 `VMStack`
     - 在并发下如果返回顺序不是严格 LIFO，可能错误弹掉别的 goroutine 的当前 frame
修复方式：
	- 在 `VirtualMachine` 内新增按 goroutine 维护的当前 frame 栈
