### PR TITLE
fix(jsonpath): escape special object keys in iter paths

### DIFF
--- a/common/jsonpath/iter.go
+++ b/common/jsonpath/iter.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
+	"text/scanner"
 
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
@@ -14,6 +17,23 @@ import (
 type iterKey struct {
 	Key      string
 	JsonPath string
+}
+
+func isSimpleObjectKey(key string) bool {
+	var s scanner.Scanner
+	s.Init(strings.NewReader(key))
+	s.Mode = scanner.ScanIdents
+	if s.Scan() != scanner.Ident {
+		return false
+	}
+	return s.Scan() == scanner.EOF
+}
+
+func buildObjectJSONPath(prefix, key string) string {
+	if isSimpleObjectKey(key) {
+		return prefix + key
+	}
+	return strings.TrimSuffix(prefix, ".") + "[" + strconv.Quote(key) + "]"
 }
 
 func iterKeys(l *list.List, raw any, prefix string) *list.List {
@@ -33,16 +53,18 @@ func iterKeys(l *list.List, raw any, prefix string) *list.List {
 	switch refType.Kind() {
 	case reflect.Map:
 		for k, v := range utils.InterfaceToMapInterface(raw) {
-			l.PushBack(&iterKey{Key: utils.InterfaceToString(k), JsonPath: prefix + k})
+			key := utils.InterfaceToString(k)
+			keyPath := buildObjectJSONPath(prefix, key)
+			l.PushBack(&iterKey{Key: key, JsonPath: keyPath})
 			fixedVal, err := utils.InterfaceToMapInterfaceE(v)
 			if err == nil {
-				iterKeys(l, fixedVal, prefix+k+".")
+				iterKeys(l, fixedVal, keyPath+".")
 				continue
 			}
 
 			if raw, err := utils.InterfaceToSliceInterfaceE(v); err == nil {
 				for index, val := range raw {
-					jp := prefix + fmt.Sprintf("%v[%v]", k, index)
+					jp := fmt.Sprintf("%s[%v]", keyPath, index)
 					l.PushBack(&iterKey{JsonPath: jp})
 					iterKeys(l, val, jp+".")
 				}

--- a/common/jsonpath/replace_test.go
+++ b/common/jsonpath/replace_test.go
@@ -3,6 +3,7 @@ package jsonpath
 import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/yaklang/yaklang/common/utils"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -172,5 +173,23 @@ func TestReplace3List(t *testing.T) {
 		}
 		spew.Dump(result)
 		spew.Dump("h1", hash1, "h2", hash2)
+	}
+}
+
+func TestReplaceSpecialKey(t *testing.T) {
+	raw := `{"Api-Key":"v1","nested":{"X-Auth":"v2"},"list":[{"Set-Cookie":"v3"}]}`
+	result := RecursiveDeepReplaceString(raw, "112")
+	sort.Strings(result)
+	expected := []string{
+		`{"Api-Key":"112","list":[{"Set-Cookie":"v3"}],"nested":{"X-Auth":"v2"}}`,
+		`{"Api-Key":"v1","list":"112","nested":{"X-Auth":"v2"}}`,
+		`{"Api-Key":"v1","list":["112"],"nested":{"X-Auth":"v2"}}`,
+		`{"Api-Key":"v1","list":[{"Set-Cookie":"112"}],"nested":{"X-Auth":"v2"}}`,
+		`{"Api-Key":"v1","list":[{"Set-Cookie":"v3"}],"nested":"112"}`,
+		`{"Api-Key":"v1","list":[{"Set-Cookie":"v3"}],"nested":{"X-Auth":"112"}}`,
+	}
+	sort.Strings(expected)
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("unexpected replace results\nexpected: %#v\nactual: %#v", expected, result)
 	}
 }


### PR DESCRIPTION
# 问题
jsonpath 在递归枚举并替换 JSON 节点时，对带特殊字符的对象键名（如 Api-Key、Set-Cookie、X-Auth）错误地生成了点号路径 $.Api-Key，导致解析器把 - 当成非法 token，出现 unexpected token - 告警
# 修复方式
在 common/jsonpath/iter.go 里给对象键名增加合法标识符判断，普通键继续生成点号路径，带特殊字符的键自动改为 bracket 形式如 $["Api-Key"]