### PR TITLE
fix(lowhttp): replace duplicated query params consistently

### DIFF
--- a/common/utils/lowhttp/modifier_test.go
+++ b/common/utils/lowhttp/modifier_test.go
@@ -1767,6 +1767,17 @@ a=1&b=2%3D`,
 			whitelists: []string{"\r\n\r\na=3%3D&b=2", "Content-Type: application/x-www-form-urlencoded"},
 			blacklists: []string{"a=1", "%25"},
 		},
+		{
+			origin: `POST /submit HTTP/1.1
+Host: 127.0.0.1:8787
+Content-Type: application/x-www-form-urlencoded
+
+c=index&c=index2`,
+			key:        "c",
+			value:      "value",
+			whitelists: []string{"\r\n\r\nc=value&c=value", "Content-Type: application/x-www-form-urlencoded"},
+			blacklists: []string{"c=index", "c=index2"},
+		},
 	}
 	for _, testcase := range testcases {
 

--- a/common/utils/lowhttp/modifier_test.go
+++ b/common/utils/lowhttp/modifier_test.go
@@ -1534,6 +1534,16 @@ Host: www.baidu.com
 Host: www.baidu.com
 `,
 		},
+		{
+			origin: `GET /user/id-b64-json?c=index&c=index2 HTTP/1.1
+Host: 127.0.0.1:8787
+`,
+			key:   "c",
+			value: "value",
+			expected: `GET /user/id-b64-json?c=value&c=value HTTP/1.1
+Host: 127.0.0.1:8787
+`,
+		},
 	}
 	for _, testcase := range testcases {
 		actual := ReplaceHTTPPacketQueryParam([]byte(testcase.origin), testcase.key, testcase.value)
@@ -1559,6 +1569,16 @@ Host: www.baidu.com
 			value: "%26",
 			expected: `GET /?a=%26&b=2 HTTP/1.1
 Host: www.baidu.com
+`,
+		},
+		{
+			origin: `GET /user/id-b64-json?c=index&c=index2 HTTP/1.1
+Host: 127.0.0.1:8787
+`,
+			key:   "c",
+			value: "%26",
+			expected: `GET /user/id-b64-json?c=%26&c=%26 HTTP/1.1
+Host: 127.0.0.1:8787
 `,
 		},
 	}

--- a/common/utils/lowhttp/query.go
+++ b/common/utils/lowhttp/query.go
@@ -255,13 +255,17 @@ func (q *QueryParams) Set(key, val string, forceNoEncode ...bool) {
 		noAutoEncode = forceNoEncode[0]
 	}
 
+	found := false
 	for i := 0; i < len(q.Items); i++ {
 		if q.Items[i].Key == key && q.Items[i].Position == q.Position {
 			q.Items[i].Value = val
 			q.Items[i].NoAutoEncode = noAutoEncode
 			q.Items[i].Position = q.Position
-			return
+			found = true
 		}
+	}
+	if found {
+		return
 	}
 	q.Items = append(q.Items,
 		&QueryParamItem{

--- a/common/utils/lowhttp/query_test.go
+++ b/common/utils/lowhttp/query_test.go
@@ -18,6 +18,9 @@ func TestQueryParams1(t *testing.T) {
 	params.Add("c", "4")
 	test.Equal("a=22&b=2&c=3&c=4", params.Encode())
 
+	params.Set("c", "6")
+	test.Equal("a=22&b=2&c=6&c=6", params.Encode())
+
 	params.Del("c")
 	test.Equal("a=22&b=2", params.Encode())
 


### PR DESCRIPTION
修复了 lowhttp 中重复 query 参数只替换第一项的问题，使 ReplaceHTTPPacketQueryParam / WithoutEscape 会一致替换同名参数的全部出现并