### PR TITLE
fix(yakgrpc): preserve duplicate params in debug plugin requests

### DIFF
--- a/common/yakgrpc/grpc_http_request_builder.go
+++ b/common/yakgrpc/grpc_http_request_builder.go
@@ -155,17 +155,11 @@ Host: example.com
 	if len(req.GetPath()) > 0 {
 		freq = freq.FuzzPath(req.GetPath()...)
 	}
-	for _, p := range req.GetGetParams() {
-		freq = freq.FuzzGetParams(p.GetKey(), p.GetValue())
-	}
 	for _, p := range req.GetCookie() {
 		freq = freq.FuzzCookie(p.GetKey(), p.GetValue())
 	}
 	for _, p := range req.GetHeaders() {
 		freq = freq.FuzzHTTPHeader(p.GetKey(), p.GetValue())
-	}
-	for _, p := range req.GetPostParams() {
-		freq = freq.FuzzPostParams(p.GetKey(), p.GetValue())
 	}
 	for _, p := range req.GetMultipartParams() {
 		freq = freq.FuzzUploadKVPair(p.GetKey(), p.GetValue())
@@ -186,6 +180,12 @@ Host: example.com
 			if raw == nil || len(raw) <= 0 {
 				continue
 			}
+			if len(req.GetGetParams()) > 0 {
+				raw = appendQueryParamsToPacket(raw, req.GetGetParams())
+			}
+			if len(req.GetPostParams()) > 0 && len(req.GetBody()) == 0 && len(req.GetMultipartParams()) == 0 && len(req.GetMultipartFileParams()) == 0 {
+				raw = appendPostParamsToPacket(raw, req.GetPostParams())
+			}
 			raw = bytes.ReplaceAll(raw, []byte(tempTag), []byte("{{Hostname}}"))
 
 			results = append(results, &ypb.HTTPRequestBuilderResult{
@@ -193,7 +193,11 @@ Host: example.com
 				HTTPRequest: raw,
 			})
 
-			paths = append(paths, "{{BaseURL}}"+r.RequestURI)
+			requestURI := r.RequestURI
+			if urlIns, err := lowhttp.ExtractURLFromHTTPRequestRaw(raw, isHttps); err == nil && urlIns != nil {
+				requestURI = urlIns.RequestURI()
+			}
+			paths = append(paths, "{{BaseURL}}"+requestURI)
 			if method == "" {
 				method = r.Method
 			}
@@ -241,6 +245,42 @@ Host: example.com
 	encoder.Close()
 	templates := utils.EscapeInvalidUTF8Byte(buf.Bytes())
 	return &ypb.HTTPRequestBuilderResponse{Templates: templates, Results: results}, nil
+}
+
+func appendQueryParamsToPacket(packet []byte, params []*ypb.KVPair) []byte {
+	if len(packet) == 0 || len(params) == 0 {
+		return packet
+	}
+
+	_, requestURI, _ := lowhttp.GetHTTPPacketFirstLine(packet)
+	if requestURI == "" {
+		return packet
+	}
+
+	urlIns := lowhttp.ForceStringToUrl(requestURI)
+	queryParams := lowhttp.ParseQueryParams(urlIns.RawQuery)
+	for _, item := range params {
+		queryParams.Add(item.GetKey(), item.GetValue())
+	}
+	return lowhttp.ReplaceHTTPPacketQueryParamRaw(packet, queryParams.Encode())
+}
+
+func appendPostParamsToPacket(packet []byte, params []*ypb.KVPair) []byte {
+	if len(packet) == 0 || len(params) == 0 {
+		return packet
+	}
+
+	headers, body := lowhttp.SplitHTTPHeadersAndBodyFromPacket(packet)
+	postParams := lowhttp.ParseQueryParams(string(body))
+	for _, item := range params {
+		postParams.Add(item.GetKey(), item.GetValue())
+	}
+
+	packet = lowhttp.ReplaceHTTPPacketBody([]byte(headers), []byte(postParams.Encode()), false)
+	if lowhttp.GetHTTPPacketHeader(packet, "Content-Type") == "" {
+		packet = lowhttp.ReplaceHTTPPacketHeader(packet, "Content-Type", "application/x-www-form-urlencoded")
+	}
+	return packet
 }
 
 func (s *Server) PluginListGenerator(plugin *ypb.HybridScanPluginConfig, ctx context.Context) (res []string) {

--- a/common/yakgrpc/grpc_http_request_builder.go
+++ b/common/yakgrpc/grpc_http_request_builder.go
@@ -180,12 +180,7 @@ Host: example.com
 			if raw == nil || len(raw) <= 0 {
 				continue
 			}
-			if len(req.GetGetParams()) > 0 {
-				raw = appendQueryParamsToPacket(raw, req.GetGetParams())
-			}
-			if len(req.GetPostParams()) > 0 && len(req.GetBody()) == 0 && len(req.GetMultipartParams()) == 0 && len(req.GetMultipartFileParams()) == 0 {
-				raw = appendPostParamsToPacket(raw, req.GetPostParams())
-			}
+			raw, requestURI := applyOrderedParamsToPacket(raw, req)
 			raw = bytes.ReplaceAll(raw, []byte(tempTag), []byte("{{Hostname}}"))
 
 			results = append(results, &ypb.HTTPRequestBuilderResult{
@@ -193,9 +188,8 @@ Host: example.com
 				HTTPRequest: raw,
 			})
 
-			requestURI := r.RequestURI
-			if urlIns, err := lowhttp.ExtractURLFromHTTPRequestRaw(raw, isHttps); err == nil && urlIns != nil {
-				requestURI = urlIns.RequestURI()
+			if requestURI == "" {
+				requestURI = r.RequestURI
 			}
 			paths = append(paths, "{{BaseURL}}"+requestURI)
 			if method == "" {
@@ -245,6 +239,23 @@ Host: example.com
 	encoder.Close()
 	templates := utils.EscapeInvalidUTF8Byte(buf.Bytes())
 	return &ypb.HTTPRequestBuilderResponse{Templates: templates, Results: results}, nil
+}
+
+// requestURI is the second token of the request line, e.g. "/test?a=1&a=2".
+func applyOrderedParamsToPacket(packet []byte, req *ypb.HTTPRequestBuilderParams) ([]byte, string) {
+	if len(packet) == 0 {
+		return packet, ""
+	}
+
+	if len(req.GetGetParams()) > 0 {
+		packet = appendQueryParamsToPacket(packet, req.GetGetParams())
+	}
+	if len(req.GetPostParams()) > 0 && len(req.GetBody()) == 0 && len(req.GetMultipartParams()) == 0 && len(req.GetMultipartFileParams()) == 0 {
+		packet = appendPostParamsToPacket(packet, req.GetPostParams())
+	}
+
+	_, requestURI, _ := lowhttp.GetHTTPPacketFirstLine(packet)
+	return packet, requestURI
 }
 
 func appendQueryParamsToPacket(packet []byte, params []*ypb.KVPair) []byte {

--- a/common/yakgrpc/grpc_http_request_builder_test.go
+++ b/common/yakgrpc/grpc_http_request_builder_test.go
@@ -361,6 +361,23 @@ Host: baidu.com
 	}
 
 	rsp, err = client.HTTPRequestBuilder(context.Background(), &ypb.HTTPRequestBuilderParams{
+		Method: "GET",
+		Path:   []string{"/dup"},
+		GetParams: []*ypb.KVPair{
+			{Key: "a", Value: "1"},
+			{Key: "a", Value: "2"},
+		},
+	})
+	require.NoError(t, err)
+	keepDuplicateQuery := false
+	for _, i := range rsp.Results {
+		if strings.Contains(string(i.HTTPRequest), "GET /dup?a=1&a=2 HTTP/1.1") {
+			keepDuplicateQuery = true
+		}
+	}
+	require.True(t, keepDuplicateQuery, "duplicate query should be kept in built request")
+
+	rsp, err = client.HTTPRequestBuilder(context.Background(), &ypb.HTTPRequestBuilderParams{
 		Method:              "GET",
 		Path:                []string{"a?c=1"},
 		Cookie:              []*ypb.KVPair{{Key: "aaa", Value: "111"}, {Key: "bbb", Value: "222"}},
@@ -445,6 +462,25 @@ Host: baidu.com
 	if !ceq1 {
 		t.Fatal("body no raw (using) path query not keep")
 	}
+
+	rsp, err = client.HTTPRequestBuilder(context.Background(), &ypb.HTTPRequestBuilderParams{
+		Method: "POST",
+		Path:   []string{"/dup-post"},
+		PostParams: []*ypb.KVPair{
+			{Key: "a", Value: "1"},
+			{Key: "a", Value: "2"},
+		},
+	})
+	require.NoError(t, err)
+	keepDuplicatePostParams := false
+	for _, i := range rsp.Results {
+		if strings.Contains(string(i.HTTPRequest), "POST /dup-post HTTP/1.1") &&
+			strings.Contains(string(i.HTTPRequest), "Content-Type: application/x-www-form-urlencoded") &&
+			strings.Contains(string(i.HTTPRequest), "a=1&a=2") {
+			keepDuplicatePostParams = true
+		}
+	}
+	require.True(t, keepDuplicatePostParams, "duplicate post params should be kept in built request")
 
 	// multipart
 	rsp, err = client.HTTPRequestBuilder(context.Background(), &ypb.HTTPRequestBuilderParams{
@@ -793,6 +829,38 @@ func TestBuild_Http_Request_Packet(t *testing.T) {
 	if count != 3 {
 		t.Fatal("build packet error")
 	}
+
+	targetInput = "http://www.example.com/test?a=1&a=2"
+	p = &ypb.HTTPRequestBuilderParams{
+		IsHttps:          false,
+		IsRawHTTPRequest: false,
+		Method:           "GET",
+	}
+	packets, err = BuildHttpRequestPacket(consts.GetGormProjectDatabase(), p, targetInput)
+	require.NoError(t, err)
+	packet, ok := <-packets
+	require.True(t, ok, "expected built packet")
+	require.Contains(t, packet.Url, "/test?a=1&a=2")
+	require.Contains(t, string(packet.Request), "GET /test?a=1&a=2 HTTP/1.1")
+
+	targetInput = "http://www.example.com/test-post"
+	p = &ypb.HTTPRequestBuilderParams{
+		IsHttps:          false,
+		IsRawHTTPRequest: false,
+		Method:           "POST",
+		PostParams: []*ypb.KVPair{
+			{Key: "a", Value: "1"},
+			{Key: "a", Value: "2"},
+		},
+	}
+	packets, err = BuildHttpRequestPacket(consts.GetGormProjectDatabase(), p, targetInput)
+	require.NoError(t, err)
+	packet, ok = <-packets
+	require.True(t, ok, "expected built packet")
+	require.Contains(t, packet.Url, "/test-post")
+	require.Contains(t, string(packet.Request), "POST /test-post HTTP/1.1")
+	require.Contains(t, string(packet.Request), "Content-Type: application/x-www-form-urlencoded")
+	require.Contains(t, string(packet.Request), "a=1&a=2")
 }
 
 func TestBuild_Http_Request_Packet_Smoking(t *testing.T) {

--- a/common/yakgrpc/grpc_http_request_debug.go
+++ b/common/yakgrpc/grpc_http_request_debug.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yaklang/yaklang/common/mutate"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/cli"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
 	"github.com/yaklang/yaklang/common/yak"
 	"github.com/yaklang/yaklang/common/yak/antlr4yak"
 	"github.com/yaklang/yaklang/common/yak/yaklib"
@@ -470,12 +471,10 @@ func mergeBuildParams(params *ypb.HTTPRequestBuilderParams, t *url.URL) *ypb.HTT
 		res.Path = append(res.Path, t.Path)
 	}
 
-	for key, values := range t.Query() { // 插入所有的 get 参数
-		for _, value := range values {
-			res.GetParams = append(res.GetParams, &ypb.KVPair{
-				Key: key, Value: value,
-			})
-		}
+	for _, item := range lowhttp.ParseQueryParams(t.RawQuery).Items { // 按原始顺序插入所有的 get 参数
+		res.GetParams = append(res.GetParams, &ypb.KVPair{
+			Key: item.Key, Value: item.Value,
+		})
 	}
 
 	if t.Scheme != "" { // 目标标识优先级更高

--- a/common/yakgrpc/grpc_http_request_debug_test.go
+++ b/common/yakgrpc/grpc_http_request_debug_test.go
@@ -166,6 +166,99 @@ mirrorFilteredHTTPFlow = (https, url, req, rsp, body) => {
 	}
 }
 
+func TestGRPCMUSTPASS_HTTP_Server_DebugPlugin_MITM_InputURLKeepDuplicateQuery(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keepDuplicateQuery := false
+	host, port := utils.DebugMockHTTPHandlerFuncContext(ctx, func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write([]byte("hello"))
+		raw, _ := utils.HttpDumpWithBody(request, true)
+		if strings.Contains(string(raw), "GET /test?a=1&a=2 HTTP/1.1") {
+			keepDuplicateQuery = true
+			go func() {
+				time.Sleep(200 * time.Millisecond)
+				cancel()
+			}()
+		}
+	})
+
+	targetURL := "http://" + utils.HostPort(host, port) + "/test?a=1&a=2"
+	stream, err := client.DebugPlugin(ctx, &ypb.DebugPluginRequest{
+		Code: `
+mirrorFilteredHTTPFlow = func(isHttps, url, req, rsp, body) {
+    dump(url)
+}
+`,
+		PluginType: "mitm",
+		Input:      targetURL,
+	})
+	require.NoError(t, err)
+
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			break
+		}
+	}
+
+	require.True(t, keepDuplicateQuery, "duplicate query should be kept in mitm debug input URL")
+}
+
+func TestGRPCMUSTPASS_HTTP_Server_DebugPlugin_MITM_HTTPRequestTemplateKeepDuplicatePostParams(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keepDuplicatePostParams := false
+	host, port := utils.DebugMockHTTPHandlerFuncContext(ctx, func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write([]byte("hello"))
+		raw, _ := utils.HttpDumpWithBody(request, true)
+		if strings.Contains(string(raw), "POST /test-post HTTP/1.1") &&
+			strings.Contains(string(raw), "Content-Type: application/x-www-form-urlencoded") &&
+			strings.Contains(string(raw), "a=1&a=2") {
+			keepDuplicatePostParams = true
+			go func() {
+				time.Sleep(200 * time.Millisecond)
+				cancel()
+			}()
+		}
+	})
+
+	targetURL := "http://" + utils.HostPort(host, port) + "/test-post"
+	stream, err := client.DebugPlugin(ctx, &ypb.DebugPluginRequest{
+		Code: `
+mirrorFilteredHTTPFlow = func(isHttps, url, req, rsp, body) {
+    dump(url)
+}
+`,
+		PluginType: "mitm",
+		Input:      targetURL,
+		HTTPRequestTemplate: &ypb.HTTPRequestBuilderParams{
+			Method: "POST",
+			PostParams: []*ypb.KVPair{
+				{Key: "a", Value: "1"},
+				{Key: "a", Value: "2"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			break
+		}
+	}
+
+	require.True(t, keepDuplicatePostParams, "duplicate post params should be kept in mitm debug http request template")
+}
+
 //func TestGRPCMUSTPASS_HTTP_Server_DebugPlugin_MITM_WithRawPacket(t *testing.T) {
 //    client, err := NewLocalClient()
 //    if err != nil {


### PR DESCRIPTION
调试插件发出的数据，多个同名的参数会变成一个参数。
- 此前输入 URL 中的重复 GET 参数，以及手动配置的重复 GET/POST 参数，在请求重建过程中会误走Fuzz包里的FuzzGetParams/FuzzPostParams ，导致同名参数只保留最后一个。
- 本修复改为按原始顺序追加参数，保留重复项
- 感觉插件调试应该程度构建请求包责任，而不是Fuzz责任

<img width="2103" height="822" alt="image" src="https://github.com/user-attachments/assets/ca058b9c-c1fa-4d8f-bbaa-3b72ae476c69" />
