### PR TITLE
Rookie/enhance/aiagent/verification

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -245,7 +245,7 @@ type Config struct {
 	TimelineTotalContentLimit int // in tokens
 
 	// triage
-	MemoryTriage         MemoryTriage
+	MemoryTriage MemoryTriage
 
 	TimelineArchiveStore TimelineArchiveStore
 	MemoryPoolSize       int64
@@ -355,7 +355,8 @@ type Config struct {
 		Lazy WorkDir for semantic artifact directory naming
 	*/
 	// DatabaseRecordID is the gorm primary key ID from AIAgentRuntime
-	DatabaseRecordID uint
+	DisableCreateDBRuntime bool // some liteforge or async lite agent , not save runtime to database, keep persistSession data clean
+	DatabaseRecordID       uint
 	// workDir is the lazily-created working directory path (set once, never changes)
 	workDir         string
 	workDirOnce     sync.Once
@@ -555,6 +556,18 @@ func WithPersistentSessionId(sid string) ConfigOption {
 		}
 		c.m.Lock()
 		c.PersistentSessionId = sid
+		c.m.Unlock()
+		return nil
+	}
+}
+
+func WithDisableCreateDBRuntime(disable bool) ConfigOption {
+	return func(c *Config) error {
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		c.DisableCreateDBRuntime = disable
 		c.m.Unlock()
 		return nil
 	}
@@ -2521,6 +2534,24 @@ func (c *Config) GetRuntimeId() string {
 	return c.Id
 }
 
+// CreateOrUpdateRuntimeRecord persists a runtime record unless DB runtime creation is disabled.
+func (c *Config) CreateOrUpdateRuntimeRecord(runtime *schema.AIAgentRuntime) error {
+	if c == nil || runtime == nil {
+		return nil
+	}
+	if c.DisableCreateDBRuntime || c.GetDB() == nil {
+		return nil
+	}
+
+	dbID, err := yakit.CreateOrUpdateAIAgentRuntime(c.GetDB(), runtime)
+	if err != nil {
+		return err
+	}
+	c.DatabaseRecordID = dbID
+	runtime.ID = dbID
+	return nil
+}
+
 // IsWorkDirReady checks if the working directory has been created
 func (c *Config) IsWorkDirReady() bool {
 	c.workDirMu.RLock()
@@ -3113,6 +3144,7 @@ func (c *Config) InvokeLiteForge(prompt string, opts ...any) (*ForgeResult, erro
 	} else {
 		opts = append(opts, WithFastAICallback(c.QualityPriorityAICallback))
 	}
+	opts = append(opts, WithDisableCreateDBRuntime(true)) // Avoid creating runtime records for lite forge calls
 	return InvokeLiteForge(prompt, opts...)
 }
 

--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -267,8 +267,9 @@ type Config struct {
 	PlanPrompt string
 
 	// result processer
-	GenerateReport  bool
-	MaxTaskContinue int64
+	GenerateReport               bool
+	MaxTaskContinue              int64
+	PeriodicVerificationInterval int64
 
 	// other
 	ExtendedActionCallback map[string]func(config *Config, action *Action)
@@ -477,6 +478,7 @@ func newConfig(ctx context.Context) *Config {
 		MemoryPoolSize:                     10 * 1024, // 10k tokens
 		MemoryPool:                         omap.NewOrderedMap(make(map[string]*MemoryEntity)),
 		MaxTaskContinue:                    3,
+		PeriodicVerificationInterval:       5,
 		GenerateReport:                     true,
 		DisallowMCPServers:                 false, // 默认启用 MCP Servers
 		MemoryTriageId:                     "default",
@@ -2089,6 +2091,21 @@ func WithMaxTaskContinue(n int64) ConfigOption {
 	}
 }
 
+func WithPeriodicVerificationInterval(n int64) ConfigOption {
+	return func(c *Config) error {
+		if n < 0 {
+			return nil
+		}
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		c.PeriodicVerificationInterval = n
+		c.m.Unlock()
+		return nil
+	}
+}
+
 func WithAppendOtherOption(opts any) ConfigOption {
 	return func(c *Config) error {
 		if opts == nil {
@@ -2994,6 +3011,9 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 	if i.MaxTaskContinue > 0 {
 		opts = append(opts, WithMaxTaskContinue(i.MaxTaskContinue))
 	}
+
+	opts = append(opts, WithPeriodicVerificationInterval(i.PeriodicVerificationInterval))
+
 	if i.PerTaskUserInteractiveLimitedTimes > 0 {
 		opts = append(opts, WithPerTaskUserInteractiveLimitedTimes(i.PerTaskUserInteractiveLimitedTimes))
 	}

--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -31,6 +31,8 @@ import (
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
 
+const DefaultPeriodicVerificationInterval = 5
+
 type ConfigOption func(*Config) error
 
 var configOptionIDRegistry sync.Map
@@ -478,7 +480,7 @@ func newConfig(ctx context.Context) *Config {
 		MemoryPoolSize:                     10 * 1024, // 10k tokens
 		MemoryPool:                         omap.NewOrderedMap(make(map[string]*MemoryEntity)),
 		MaxTaskContinue:                    3,
-		PeriodicVerificationInterval:       5,
+		PeriodicVerificationInterval:       DefaultPeriodicVerificationInterval,
 		GenerateReport:                     true,
 		DisallowMCPServers:                 false, // 默认启用 MCP Servers
 		MemoryTriageId:                     "default",

--- a/common/ai/aid/aicommon/config_test.go
+++ b/common/ai/aid/aicommon/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
 
 func TestConfig_Smoking(t *testing.T) {
@@ -189,4 +190,48 @@ func TestConfig_ConvertConfigToOptions_PropagatesTimelineArchiveStore(t *testing
 	got := child.Timeline.timelineArchiveStore()
 	require.NotNil(t, got)
 	require.True(t, got == store)
+}
+
+func TestConfig_CreateOrUpdateRuntimeRecord(t *testing.T) {
+	runtimeUUID := uuid.NewString()
+	config := NewConfig(context.Background(), WithID(runtimeUUID))
+	require.NoError(t, config.GetDB().AutoMigrate(&schema.AIAgentRuntime{}).Error)
+	t.Cleanup(func() {
+		require.NoError(t, config.GetDB().Unscoped().Where("uuid = ?", runtimeUUID).Delete(&schema.AIAgentRuntime{}).Error)
+	})
+
+	runtime := &schema.AIAgentRuntime{
+		Uuid: runtimeUUID,
+		Name: "config-runtime-record-test",
+	}
+	require.NoError(t, config.CreateOrUpdateRuntimeRecord(runtime))
+	require.NotZero(t, config.DatabaseRecordID)
+	require.Equal(t, config.DatabaseRecordID, runtime.ID)
+
+	saved, err := yakit.GetAgentRuntime(config.GetDB(), runtimeUUID)
+	require.NoError(t, err)
+	require.Equal(t, runtimeUUID, saved.Uuid)
+	require.Equal(t, "config-runtime-record-test", saved.Name)
+}
+
+func TestConfig_CreateOrUpdateRuntimeRecord_Disabled(t *testing.T) {
+	runtimeUUID := uuid.NewString()
+	config := NewConfig(context.Background(), WithID(runtimeUUID))
+	require.NoError(t, config.GetDB().AutoMigrate(&schema.AIAgentRuntime{}).Error)
+	t.Cleanup(func() {
+		require.NoError(t, config.GetDB().Unscoped().Where("uuid = ?", runtimeUUID).Delete(&schema.AIAgentRuntime{}).Error)
+	})
+
+	config.DisableCreateDBRuntime = true
+	runtime := &schema.AIAgentRuntime{
+		Uuid: runtimeUUID,
+		Name: "config-runtime-record-disabled",
+	}
+	require.NoError(t, config.CreateOrUpdateRuntimeRecord(runtime))
+	require.Zero(t, config.DatabaseRecordID)
+	require.Zero(t, runtime.ID)
+
+	var count int
+	require.NoError(t, config.GetDB().Model(&schema.AIAgentRuntime{}).Where("uuid = ?", runtimeUUID).Count(&count).Error)
+	require.Zero(t, count)
 }

--- a/common/ai/aid/aireact/actions.go
+++ b/common/ai/aid/aireact/actions.go
@@ -12,5 +12,6 @@ const (
 	ActionRequestPlanExecution    ActionType = schema.AI_REACT_LOOP_ACTION_REQUEST_PLAN_EXECUTION
 	ActionAskForClarification     ActionType = schema.AI_REACT_LOOP_ACTION_ASK_FOR_CLARIFICATION
 	ActionKnowledgeEnhanceAnswer  ActionType = schema.AI_REACT_LOOP_ACTION_KNOWLEDGE_ENHANCE
+	ActionRequestVerification     ActionType = schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION
 	ActionWriteYaklangCode        ActionType = "write_yaklang_code"
 )

--- a/common/ai/aid/aireact/invoke_liteforge.go
+++ b/common/ai/aid/aireact/invoke_liteforge.go
@@ -49,7 +49,11 @@ func (r *ReAct) invokeLiteForgeWithCallback(cb aicommon.AICallbackType, ctx cont
 	}
 	forgeResult, err := f.Execute(ctx, []*ypb.ExecParamItem{
 		{Key: "query", Value: prompt},
-	}, aicommon.WithAgreeYOLO(), aicommon.WithFastAICallback(execCb), aicommon.WithPersistentSessionId(r.config.PersistentSessionId))
+	},
+		aicommon.WithAgreeYOLO(),
+		aicommon.WithFastAICallback(execCb),
+		aicommon.WithPersistentSessionId(r.config.PersistentSessionId),
+		aicommon.WithDisableCreateDBRuntime(true)) // disable create db runtime because ReAct loop will create it before invoking liteforge, and creating it again in liteforge may
 	if err != nil {
 		return nil, utils.Wrap(err, "invoke liteforge failed")
 	}

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -302,19 +302,15 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 	case <-done:
 	}
 
-	dbId, err := yakit.CreateOrUpdateAIAgentRuntime(
-		react.config.GetDB(), &schema.AIAgentRuntime{
-			Uuid:              cfg.GetRuntimeId(),
-			Name:              "[re-act-runtime]",
-			Seq:               cfg.Seq,
-			TypeName:          schema.AIAgentRuntimeType_ReAct,
-			PersistentSession: cfg.PersistentSessionId,
-		},
-	)
-	if err != nil {
+	if err := cfg.CreateOrUpdateRuntimeRecord(&schema.AIAgentRuntime{
+		Uuid:              cfg.GetRuntimeId(),
+		Name:              "[re-act-runtime]",
+		Seq:               cfg.Seq,
+		TypeName:          schema.AIAgentRuntimeType_ReAct,
+		PersistentSession: cfg.PersistentSessionId,
+	}); err != nil {
 		return nil, err
 	}
-	cfg.DatabaseRecordID = dbId
 	cfg.FlushRestoredSessionEvidence()
 	// EmitPinDirectory is deferred to ensureWorkDirectory when user input arrives
 

--- a/common/ai/aid/aireact/re-act_free_input.go
+++ b/common/ai/aid/aireact/re-act_free_input.go
@@ -117,7 +117,7 @@ func (r *ReAct) DumpCurrentEnhanceData() string {
 	if r.config.EnhanceKnowledgeManager == nil {
 		return ""
 	}
-	data := r.config.EnhanceKnowledgeManager.DumpTaskAboutKnowledge(r.GetCurrentTask().GetId())
+	data := r.config.EnhanceKnowledgeManager.DumpTaskAboutKnowledge(r.GetCurrentTaskId())
 	if r.config.DebugEvent {
 		log.Infof("Dumped enhance data: %s", data)
 	}

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -244,6 +244,7 @@ func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTas
 		reactloops.WithMemoryPool(r.config.MemoryPool),
 		reactloops.WithMemorySizeLimit(int(r.config.MemoryPoolSize)),
 		reactloops.WithEnableSelfReflection(r.config.EnableSelfReflection),
+		reactloops.WithPeriodicVerificationInterval(int(r.config.PeriodicVerificationInterval)),
 		reactloops.WithOnAsyncTaskTrigger(func(i *reactloops.LoopAction, task aicommon.AIStatefulTask) {
 			r.SetCurrentPlanExecutionTask(task)
 		}),

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -239,12 +239,8 @@ func (r *ReAct) ExecuteLoopTaskIF(taskTypeName string, task aicommon.AIStatefulT
 func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTask, options ...reactloops.ReActLoopOption) (bool, error) {
 	memoryFlushBuffer := aicommon.NewMemoryFlushBuffer("react", r.config.TimelineDiffer, nil)
 	defer memoryFlushBuffer.Close()
-	defaultOptions := []reactloops.ReActLoopOption{
-		reactloops.WithMemoryTriage(r.memoryTriage),
-		reactloops.WithMemoryPool(r.config.MemoryPool),
-		reactloops.WithMemorySizeLimit(int(r.config.MemoryPoolSize)),
-		reactloops.WithEnableSelfReflection(r.config.EnableSelfReflection),
-		reactloops.WithPeriodicVerificationInterval(int(r.config.PeriodicVerificationInterval)),
+	defaultOptions := reactloops.BasicAICommonConfigOption(r.config)
+	defaultOptions = append(defaultOptions,
 		reactloops.WithOnAsyncTaskTrigger(func(i *reactloops.LoopAction, task aicommon.AIStatefulTask) {
 			r.SetCurrentPlanExecutionTask(task)
 		}),
@@ -325,7 +321,7 @@ func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTas
 			})
 		}),
 		reactloops.WithAllowAIForge(r.config.EnablePlanAndExec),
-	}
+	)
 
 	defaultOptions = append(defaultOptions, options...)
 

--- a/common/ai/aid/aireact/re-act_test.go
+++ b/common/ai/aid/aireact/re-act_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aimem"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -231,4 +232,60 @@ func TestReAct_Invoker_FreeInputShouldNotSet(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, reactInvoker.pureInvokerMode)
 	require.False(t, reactInvoker.config.InputEventManager.IsFreeInputCallbackSet())
+}
+
+func TestReAct_LoopCoverPeriodicVerificationIntervalOption(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	basicOption := []aicommon.ConfigOption{
+		aicommon.WithMemoryTriage(aimem.NewMockMemoryTriage()),
+		aicommon.WithEnableSelfReflection(false),
+		aicommon.WithContext(ctx),
+		aicommon.WithDisallowMCPServers(true),
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			return &aicommon.AIResponse{}, nil
+		}),
+	}
+
+	t.Run("default config", func(t *testing.T) {
+		r, err := NewReAct(basicOption...)
+		require.NoError(t, err)
+		mainloop, err := reactloops.CreateLoopByName(
+			schema.AI_REACT_LOOP_NAME_DEFAULT, r,
+			reactloops.BasicAICommonConfigOption(r.config)...,
+		)
+		require.NoError(t, err)
+		require.Equal(t, mainloop.GetPeriodicVerificationInterval(), aicommon.DefaultPeriodicVerificationInterval)
+	})
+
+	t.Run("zero config", func(t *testing.T) {
+		Option := append(basicOption,
+			aicommon.WithPeriodicVerificationInterval(0),
+		)
+
+		r, err := NewReAct(Option...)
+		require.NoError(t, err)
+		mainloop, err := reactloops.CreateLoopByName(
+			schema.AI_REACT_LOOP_NAME_DEFAULT, r,
+			reactloops.BasicAICommonConfigOption(r.config)...,
+		)
+		require.NoError(t, err)
+		require.Equal(t, mainloop.GetPeriodicVerificationInterval(), 0)
+	})
+
+	t.Run("custom config", func(t *testing.T) {
+		Option := append(basicOption,
+			aicommon.WithPeriodicVerificationInterval(10),
+		)
+
+		r, err := NewReAct(Option...)
+		require.NoError(t, err)
+		mainloop, err := reactloops.CreateLoopByName(
+			schema.AI_REACT_LOOP_NAME_DEFAULT, r,
+			reactloops.BasicAICommonConfigOption(r.config)...,
+		)
+		require.NoError(t, err)
+		require.Equal(t, mainloop.GetPeriodicVerificationInterval(), 10)
+	})
+
 }

--- a/common/ai/aid/aireact/reactloops/action_buildin.go
+++ b/common/ai/aid/aireact/reactloops/action_buildin.go
@@ -9,8 +9,14 @@ import (
 )
 
 var loopAction_Finish = &LoopAction{
-	ActionType:  "finish",
-	Description: "Finish the task. Add 'human_readable_thought' only if a brief closing note is needed.",
+	ActionType: "finish",
+	Description: "Mark the current task as finished and exit the loop IMMEDIATELY. " +
+		"PREFERRED completion action whenever evidence/results are already present in the timeline " +
+		"(tool outputs are captured automatically and the system will synthesize a summary). " +
+		"Do NOT precede this action with bash echo/cat/tee/printf calls that only restate facts " +
+		"already produced by earlier tool calls — that wastes iterations. " +
+		"Use 'directly_answer' instead only when the user explicitly needs a structured Markdown " +
+		"answer emitted to the chat right now. Add 'human_readable_thought' only if a brief closing note is needed.",
 	ActionHandler: func(loop *ReActLoop, action *aicommon.Action, operator *LoopActionHandlerOperator) {
 		loop.invoker.AddToTimeline("finish", "AI decided mark the current Task is finished")
 		operator.Exit()

--- a/common/ai/aid/aireact/reactloops/action_from_tool.go
+++ b/common/ai/aid/aireact/reactloops/action_from_tool.go
@@ -199,23 +199,20 @@ func ConvertAIToolToLoopAction(tool *aitool.Tool) *LoopAction {
 				utils.Errorf("tool '%s' executed successfully", tool.GetName()).Error(),
 			)
 
-			// Verify user satisfaction
 			task := loop.GetCurrentTask()
-			if task != nil {
-				verifyResult, err := invoker.VerifyUserSatisfaction(ctx, task.GetUserInput(), true, tool.GetName())
-				if err != nil {
-					operator.Fail(err)
-					return
-				}
-				loop.PushSatisfactionRecordWithCompletedTaskIndex(verifyResult.Satisfied, verifyResult.Reasoning, verifyResult.CompletedTaskIndex, verifyResult.NextMovements, verifyResult.Evidence, verifyResult.OutputFiles, verifyResult.EvidenceOps)
-				if len(verifyResult.EvidenceOps) > 0 {
-					loop.GetConfig().ApplySessionEvidenceOps(verifyResult.EvidenceOps)
-				}
+			if task == nil {
+				operator.Continue()
+				return
+			}
 
-				if verifyResult.Satisfied {
-					operator.Exit()
-					return
-				}
+			verifyResult, triggered, err := loop.MaybeVerifyUserSatisfaction(ctx, task.GetUserInput(), true, tool.GetName())
+			if err != nil {
+				operator.Fail(err)
+				return
+			}
+			if triggered && verifyResult != nil && verifyResult.Satisfied {
+				operator.Exit()
+				return
 			}
 
 			// Continue to next action

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -476,6 +476,11 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 		}
 	}
 
+	r.startVerificationWatchdog(task)
+	defer func() {
+		r.stopVerificationWatchdogForTask(task) // 退出循环则停止验证看门狗，因为异步长任务不需要验证
+	}()
+
 	done := utils.NewOnce()
 	abort := func(err error) {
 		result := task.GetResult()
@@ -585,6 +590,7 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 LOOP:
 	for {
 		iterationCount++
+		r.currentIterationIndex = iterationCount
 		if iterationCount > maxIterations {
 			maxIterErr := utils.Errorf("reached max iterations (%d), stopping code generation loop", maxIterations)
 			postOp := r.finishIterationLoopWithError(iterationCount, task, maxIterErr)
@@ -633,7 +639,6 @@ LOOP:
 			needSummary.SetTo(true)
 			return finalError
 		}
-
 		// Save prompt to file in debug mode
 		if r.isDebugModeEnabled() {
 			r.savePromptToFile(task, iterationCount, prompt)
@@ -671,11 +676,10 @@ LOOP:
 
 		// 记录当前迭代索引和 Action 信息
 		r.actionHistoryMutex.Lock()
-		r.currentIterationIndex = iterationCount
 		actionRecord := &ActionRecord{
 			ActionType:     actionParams.ActionType(),
 			ActionName:     actionName,
-			ActionParams:   make(map[string]interface{}),
+			ActionParams:   actionParams.GetParams(),
 			IterationIndex: iterationCount,
 		}
 		// 复制 Action 参数（避免并发修改）

--- a/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
+++ b/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
@@ -47,6 +47,28 @@
 - 如果同一任务同时覆盖多个端点、多个上下文或多个漏洞子类型，不要把它压成一次 `directly_answer`。优先 `request_plan_and_execution` 或拆成更小的执行步骤。
 - 对 SQL 注入和 XSS，优先考虑 `do_http_request`、`send_http_request_packet`、浏览器相关能力或专门工具；不要因为技能已经加载就停止在方法论层面。
 
+
+### 任务完成原则（必须遵守，避免浪费迭代）
+
+当你判断本轮任务的目标已经达成、关键证据已经通过前序工具调用落入 timeline 后，**必须在下一次动作直接结束**，不允许再做任何"包装性"调用。
+
+**结束动作二选一**：
+
+1. **`{"@action": "finish"}`** —— **首选**（尤其是 Plan-Execution 子任务、扫描/检查类执行任务）。
+   - 工具输出已经自动写入 timeline，系统会基于 timeline + evidence 自动生成结构化总结。
+   - 你不需要、也不应该自己再写一份总结文本。
+2. **`{"@action": "directly_answer"}` + `<|FINAL_ANSWER_{{ .Nonce }}|> ... <|FINAL_ANSWER_END_{{ .Nonce }}|>` Markdown** —— 仅当用户**当下**就需要看到一段结构化 Markdown 结论（对话式问答、需要立刻把结论呈现给用户的场景）。**一次性输出完整内容，不允许在之前再追加任何 echo / cat / tee / printf 的准备动作**。
+
+**严禁的反模式（会被判定为浪费迭代）**：
+
+- **禁止**在 `finish` / `directly_answer` 之前，用 `bash` / `directly_call_tool bash` 执行仅包含 `echo "=== Summary ==="`、`cat << EOF`、`printf "..."`、`tee` 等只是复述前面工具结果的命令。这些命令不会产生任何新信息，只会徒增一次迭代。
+- **禁止**把已经出现在 timeline 里的事实，再用 `bash echo` 打印一遍当作"保存"。Timeline 就是系统的记忆，echo 不等于持久化。
+- **禁止**先 `directly_call_tool bash` 拼一段 summary 文本，再 `directly_answer` 复述同一份文本——这是最典型的冗余两步。
+- 如果确实有需要长期留存的关键结论，使用 `output_evidence`（若可用）或让 `finish` / `directly_answer` 自身触发系统总结，而不是用 bash echo 来"存"。
+
+**判断标准**：如果你即将发起的动作只是在"重新组织 / 复述 / 回显"已经存在的事实，没有获取任何新信息、也没有产生任何副作用，就应该改成 `finish`。
+
+
 `human_readable_thought` 写法要求：
 
 - 只写一句。

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_load_capability.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_load_capability.go
@@ -129,63 +129,7 @@ func handleLoadTool(
 	}
 
 	result, directly, err := invoker.ExecuteToolRequiredAndCall(taskCtx, identifier)
-	if err != nil {
-		errMsg := fmt.Sprintf("Tool '%s' execution failed: %v.", identifier, err)
-		invoker.AddToTimeline("[LOAD_CAPABILITY_TOOL_ERROR]", errMsg)
-		op.Feedback(errMsg + " Please try a different tool or approach.")
-		op.SetReflectionLevel(reactloops.ReflectionLevel_Critical)
-		op.SetReflectionData("tool_error", err.Error())
-		op.SetReflectionData("tool_name", identifier)
-		op.Continue()
-		return
-	}
-	if directly {
-		answer, err := invoker.DirectlyAnswer(taskCtx, "在上一次工具调用中，用户中断了工具执行，要求直接回答一些问题", nil)
-		if err != nil {
-			op.Fail(utils.Error("DirectlyAnswer fail, reason: " + err.Error()))
-			return
-		}
-		invoker.AddToTimeline("directly-answer", answer)
-		op.Exit()
-		return
-	}
-	if result == nil {
-		invoker.AddToTimeline("error", fmt.Sprintf("load_capability tool[%v] returned nil result", identifier))
-		op.Continue()
-		return
-	}
-	if result.Error != "" {
-		invoker.AddToTimeline("call["+identifier+"] error", result.Error)
-	}
-
-	task = loop.GetCurrentTask()
-	if task == nil {
-		op.Continue()
-		return
-	}
-	verifyResult, err := invoker.VerifyUserSatisfaction(taskCtx, task.GetUserInput(), true, identifier)
-	if err != nil {
-		op.Fail(err)
-		return
-	}
-	loop.PushSatisfactionRecordWithCompletedTaskIndex(
-		verifyResult.Satisfied, verifyResult.Reasoning,
-		verifyResult.CompletedTaskIndex, verifyResult.NextMovements, verifyResult.Evidence, verifyResult.OutputFiles,
-		verifyResult.EvidenceOps,
-	)
-	if len(verifyResult.EvidenceOps) > 0 {
-		loop.GetConfig().ApplySessionEvidenceOps(verifyResult.EvidenceOps)
-	}
-	if verifyResult.Satisfied {
-		op.Exit()
-		return
-	}
-	feedbackMsg := fmt.Sprintf("[Verification] Task not yet satisfied.\nReasoning: %s", verifyResult.Reasoning)
-	if summary := aicommon.FormatVerifyNextMovementsSummary(verifyResult.NextMovements); summary != "" {
-		feedbackMsg += fmt.Sprintf("\nNext Steps: %s", summary)
-	}
-	op.Feedback(feedbackMsg)
-	op.Continue()
+	handleToolCallResult(loop, taskCtx, invoker, identifier, result, directly, err, op)
 }
 
 // handleLoadForgeWithSkillFallback tries loading as forge first. If forge is rejected

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_request_verification.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_request_verification.go
@@ -1,0 +1,105 @@
+package loopinfra
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func buildDefaultVerificationPayload(loop *reactloops.ReActLoop) string {
+	if loop == nil {
+		return "Agent explicitly requested verification of the current work."
+	}
+
+	var parts []string
+	parts = append(parts, "Agent explicitly requested verification of the current work.")
+	parts = append(parts, fmt.Sprintf("Current iteration: %d.", loop.GetCurrentIterationIndex()))
+
+	if last := loop.GetLastAction(); last != nil {
+		parts = append(parts, fmt.Sprintf("Last action: %s (iteration %d).", last.ActionType, last.IterationIndex))
+	}
+
+	if recent := loop.GetLastNAction(3); len(recent) > 0 {
+		names := make([]string, 0, len(recent))
+		for _, item := range recent {
+			if item == nil || strings.TrimSpace(item.ActionType) == "" {
+				continue
+			}
+			names = append(names, item.ActionType)
+		}
+		if len(names) > 0 {
+			parts = append(parts, fmt.Sprintf("Recent actions: %s.", strings.Join(names, " -> ")))
+		}
+	}
+
+	parts = append(parts, "Use the full timeline, TODO snapshot, and shared context as the primary evidence for acceptance.")
+	return strings.Join(parts, "\n")
+}
+
+var loopAction_RequestVerification = &reactloops.LoopAction{
+	ActionType:  schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION,
+	Description: "Actively trigger a verification pass to check whether the current work already satisfies the task goal.",
+	Options: []aitool.ToolOption{
+		aitool.WithStringParam(
+			"verification_payload",
+			aitool.WithParam_Description("Optional concise summary of the current progress, deliverables, or observations that should be used as the direct verification input. If omitted, the runtime will build a default checkpoint summary from recent actions."),
+		),
+	},
+	StreamFields: []*reactloops.LoopStreamField{
+		{FieldName: "verification_payload", AINodeId: "verification_payload"},
+	},
+	ActionVerifier: func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
+		payload := strings.TrimSpace(action.GetString("verification_payload"))
+		if payload == "" {
+			payload = strings.TrimSpace(action.GetInvokeParams("next_action").GetString("verification_payload"))
+		}
+		loop.Set("verification_payload", payload)
+		return nil
+	},
+	ActionHandler: func(loop *reactloops.ReActLoop, action *aicommon.Action, operator *reactloops.LoopActionHandlerOperator) {
+		task := loop.GetCurrentTask()
+		if task == nil {
+			operator.Feedback("request_verification requires an active task context")
+			operator.Continue()
+			return
+		}
+
+		payload := strings.TrimSpace(loop.Get("verification_payload"))
+		if payload == "" {
+			payload = buildDefaultVerificationPayload(loop)
+		}
+
+		invoker := loop.GetInvoker()
+		invoker.AddToTimeline("[REQUEST_VERIFICATION]", payload)
+
+		ctx := invoker.GetConfig().GetContext()
+		if task.GetContext() != nil {
+			ctx = task.GetContext()
+		}
+
+		verifyResult, err := loop.VerifyUserSatisfactionNow(ctx, task.GetUserInput(), false, payload)
+		if err != nil {
+			operator.Fail(err)
+			return
+		}
+		if verifyResult == nil {
+			operator.Continue()
+			return
+		}
+		if verifyResult.Satisfied {
+			operator.Exit()
+			return
+		}
+
+		feedbackMsg := fmt.Sprintf("[Verification] Task not yet satisfied.\nReasoning: %s", verifyResult.Reasoning)
+		if summary := aicommon.FormatVerifyNextMovementsSummary(verifyResult.NextMovements); summary != "" {
+			feedbackMsg += fmt.Sprintf("\nNext Steps: %s", summary)
+		}
+		operator.Feedback(feedbackMsg)
+		operator.Continue()
+	},
+}

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_request_verification_test.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_request_verification_test.go
@@ -1,0 +1,91 @@
+package loopinfra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+type requestVerificationTestInvoker struct {
+	*testInvoker
+	verifyQuery      string
+	verifyPayload    string
+	verifyIsToolCall bool
+	verifyCalls      int
+}
+
+func (t *requestVerificationTestInvoker) VerifyUserSatisfaction(ctx context.Context, query string, isToolCall bool, payload string) (*aicommon.VerifySatisfactionResult, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.verifyCalls++
+	t.verifyQuery = query
+	t.verifyPayload = payload
+	t.verifyIsToolCall = isToolCall
+	return t.verifySatisfactionResult, nil
+}
+
+func buildRequestVerificationAction(payload string) *aicommon.Action {
+	action, err := aicommon.ExtractAction(payload, schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION)
+	if err != nil {
+		panic(err)
+	}
+	return action
+}
+
+func TestRequestVerification_Handler_UsesExplicitPayloadAndForcesVerification(t *testing.T) {
+	ctx := context.Background()
+	invoker := &requestVerificationTestInvoker{testInvoker: newTestInvoker(ctx)}
+	invoker.verifySatisfactionResult = aicommon.NewVerifySatisfactionResult(true, "done", "")
+
+	task := newTestTask(ctx)
+	invoker.currentTask = task
+
+	loop := reactloops.NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.SetCurrentTask(task)
+
+	action := buildRequestVerificationAction(`{
+		"@action": "request_verification",
+		"verification_payload": "implemented the current change and want explicit acceptance now"
+	}`)
+
+	require.NoError(t, loopAction_RequestVerification.ActionVerifier(loop, action))
+	op := reactloops.NewActionHandlerOperator(task)
+	loopAction_RequestVerification.ActionHandler(loop, action, op)
+
+	assert.Equal(t, 1, invoker.verifyCalls)
+	assert.Equal(t, task.GetUserInput(), invoker.verifyQuery)
+	assert.Equal(t, "implemented the current change and want explicit acceptance now", invoker.verifyPayload)
+	assert.False(t, invoker.verifyIsToolCall)
+	terminated, err := op.IsTerminated()
+	require.NoError(t, err)
+	assert.True(t, terminated)
+}
+
+func TestRequestVerification_Handler_BuildsDefaultPayloadWhenEmpty(t *testing.T) {
+	ctx := context.Background()
+	invoker := &requestVerificationTestInvoker{testInvoker: newTestInvoker(ctx)}
+	invoker.verifySatisfactionResult = aicommon.NewVerifySatisfactionResult(false, "need one more step", "")
+
+	task := newTestTask(ctx)
+	invoker.currentTask = task
+
+	loop := reactloops.NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.SetCurrentTask(task)
+
+	action := buildRequestVerificationAction(`{"@action": "request_verification"}`)
+	require.NoError(t, loopAction_RequestVerification.ActionVerifier(loop, action))
+	op := reactloops.NewActionHandlerOperator(task)
+	loopAction_RequestVerification.ActionHandler(loop, action, op)
+
+	assert.Equal(t, 1, invoker.verifyCalls)
+	assert.Contains(t, invoker.verifyPayload, "Agent explicitly requested verification")
+	assert.Contains(t, invoker.verifyPayload, "Current iteration:")
+	assert.Contains(t, invoker.verifyPayload, "Use the full timeline, TODO snapshot, and shared context as the primary evidence for acceptance.")
+	assert.True(t, op.IsContinued())
+	assert.Contains(t, op.GetFeedback().String(), "need one more step")
+}

--- a/common/ai/aid/aireact/reactloops/loopinfra/register.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/register.go
@@ -17,5 +17,4 @@ func init() {
 	reactloops.RegisterAction(loopAction_LoadSkillResources)
 	reactloops.RegisterAction(loopAction_SearchCapabilities)
 	reactloops.RegisterAction(loopAction_LoadCapability)
-	reactloops.RegisterAction(loopAction_RequestVerification)
 }

--- a/common/ai/aid/aireact/reactloops/loopinfra/register.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/register.go
@@ -17,4 +17,5 @@ func init() {
 	reactloops.RegisterAction(loopAction_LoadSkillResources)
 	reactloops.RegisterAction(loopAction_SearchCapabilities)
 	reactloops.RegisterAction(loopAction_LoadCapability)
+	reactloops.RegisterAction(loopAction_RequestVerification)
 }

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
@@ -71,38 +71,20 @@ func handleToolCallResult(
 	}
 
 	task := loop.GetCurrentTask()
-	verifyResult, verifyErr := invoker.VerifyUserSatisfaction(ctx, task.GetUserInput(), true, toolPayload)
+	if task == nil {
+		operator.Continue()
+		return
+	}
+
+	verifyResult, triggered, verifyErr := loop.MaybeVerifyUserSatisfaction(ctx, task.GetUserInput(), true, toolPayload)
 	if verifyErr != nil {
 		operator.Fail(verifyErr)
 		return
 	}
-
-	if len(verifyResult.OutputFiles) > 0 {
-		cfg := loop.GetConfig()
-		for _, filePath := range verifyResult.OutputFiles {
-			providerName := "output_file:" + filePath
-			cfg.GetContextProviderManager().RegisterTracedContent(
-				providerName,
-				aicommon.OutputFileContextProvider(filePath),
-			)
-			if emitter := cfg.GetEmitter(); emitter != nil {
-				emitter.EmitPinFilename(filePath)
-			}
-		}
+	if !triggered || verifyResult == nil {
+		operator.Continue()
+		return
 	}
-
-	loop.PushSatisfactionRecordWithCompletedTaskIndex(
-		verifyResult.Satisfied, verifyResult.Reasoning,
-		verifyResult.CompletedTaskIndex, verifyResult.NextMovements, verifyResult.Evidence, verifyResult.OutputFiles,
-		verifyResult.EvidenceOps,
-	)
-
-	if len(verifyResult.EvidenceOps) > 0 {
-		loop.GetConfig().ApplySessionEvidenceOps(verifyResult.EvidenceOps)
-	}
-
-	// T2: perception after verification (async, non-blocking)
-	loop.MaybeTriggerPerceptionAfterVerification()
 
 	if verifyResult.Satisfied {
 		operator.Exit()

--- a/common/ai/aid/aireact/reactloops/options.go
+++ b/common/ai/aid/aireact/reactloops/options.go
@@ -510,3 +510,14 @@ func WithToolCallIntervalReviewExtraPrompt(prompt string) ReActLoopOption {
 		r.config.SetConfig(aicommon.ConfigKeyToolCallIntervalReviewExtraPrompt, prompt)
 	}
 }
+
+func BasicAICommonConfigOption(c *aicommon.Config) []ReActLoopOption {
+	basicOptions := []ReActLoopOption{
+		WithMemoryTriage(c.MemoryTriage),
+		WithMemoryPool(c.MemoryPool),
+		WithPeriodicVerificationInterval(int(c.PeriodicVerificationInterval)),
+		WithMemorySizeLimit(int(c.MemoryPoolSize)),
+		WithEnableSelfReflection(c.EnableSelfReflection),
+	}
+	return basicOptions
+}

--- a/common/ai/aid/aireact/reactloops/options.go
+++ b/common/ai/aid/aireact/reactloops/options.go
@@ -492,7 +492,7 @@ func WithPeriodicCheckpointInterval(interval int) ReActLoopOption {
 		if r == nil || interval <= 0 {
 			return
 		}
-		r.periodicCheckpointInterval = interval
+		r.periodicVerificationCount = interval
 		if r.perception != nil {
 			r.perception.iterationTriggerInterval = interval
 		}

--- a/common/ai/aid/aireact/reactloops/options.go
+++ b/common/ai/aid/aireact/reactloops/options.go
@@ -484,18 +484,15 @@ func WithDisableLoopPerception(disable ...bool) ReActLoopOption {
 	}
 }
 
-// WithPeriodicCheckpointInterval sets the shared iteration interval used by
-// loop-level periodic checkpoint behaviors such as perception and generic
+// WithPeriodicVerificationInterval sets the  iteration interval used by
+// loop-level periodic checkpoint behaviors
 // auto-verification.
-func WithPeriodicCheckpointInterval(interval int) ReActLoopOption {
+func WithPeriodicVerificationInterval(interval int) ReActLoopOption {
 	return func(r *ReActLoop) {
-		if r == nil || interval <= 0 {
+		if r == nil {
 			return
 		}
-		r.periodicVerificationCount = interval
-		if r.perception != nil {
-			r.perception.iterationTriggerInterval = interval
-		}
+		r.periodicVerificationInterval = interval
 	}
 }
 

--- a/common/ai/aid/aireact/reactloops/options.go
+++ b/common/ai/aid/aireact/reactloops/options.go
@@ -484,6 +484,21 @@ func WithDisableLoopPerception(disable ...bool) ReActLoopOption {
 	}
 }
 
+// WithPeriodicCheckpointInterval sets the shared iteration interval used by
+// loop-level periodic checkpoint behaviors such as perception and generic
+// auto-verification.
+func WithPeriodicCheckpointInterval(interval int) ReActLoopOption {
+	return func(r *ReActLoop) {
+		if r == nil || interval <= 0 {
+			return
+		}
+		r.periodicCheckpointInterval = interval
+		if r.perception != nil {
+			r.perception.iterationTriggerInterval = interval
+		}
+	}
+}
+
 // WithToolCallIntervalReviewExtraPrompt injects extra instructions into the prompt
 // used by interval review while tools are running.
 func WithToolCallIntervalReviewExtraPrompt(prompt string) ReActLoopOption {

--- a/common/ai/aid/aireact/reactloops/perception.go
+++ b/common/ai/aid/aireact/reactloops/perception.go
@@ -493,7 +493,7 @@ func (r *ReActLoop) MaybeTriggerPerceptionAfterAction(iterationIndex int) {
 	if r.perception == nil {
 		return
 	}
-	if !r.ShouldTriggerPeriodicCheckpointOnIteration(iterationIndex) {
+	if !r.perception.shouldTriggerOnIteration(iterationIndex) {
 		return
 	}
 	go r.TriggerPerception(PerceptionTriggerPostAction, false)

--- a/common/ai/aid/aireact/reactloops/perception.go
+++ b/common/ai/aid/aireact/reactloops/perception.go
@@ -117,12 +117,15 @@ type midtermTimelineRecallScheduler interface {
 	ScheduleMidtermTimelineRecallFromPerception(summary string, topics []string, keywords []string)
 }
 
-func newPerceptionController() *perceptionController {
+func newPerceptionController(iterationTriggerInterval int) *perceptionController {
+	if iterationTriggerInterval <= 0 {
+		iterationTriggerInterval = perceptionDefaultIterationInterval
+	}
 	return &perceptionController{
 		minInterval:              perceptionDefaultMinInterval,
 		maxInterval:              perceptionMaxInterval,
 		currentInterval:          perceptionDefaultMinInterval,
-		iterationTriggerInterval: perceptionDefaultIterationInterval,
+		iterationTriggerInterval: iterationTriggerInterval,
 	}
 }
 
@@ -490,7 +493,7 @@ func (r *ReActLoop) MaybeTriggerPerceptionAfterAction(iterationIndex int) {
 	if r.perception == nil {
 		return
 	}
-	if !r.perception.shouldTriggerOnIteration(iterationIndex) {
+	if !r.ShouldTriggerPeriodicCheckpointOnIteration(iterationIndex) {
 		return
 	}
 	go r.TriggerPerception(PerceptionTriggerPostAction, false)

--- a/common/ai/aid/aireact/reactloops/perception_test.go
+++ b/common/ai/aid/aireact/reactloops/perception_test.go
@@ -49,7 +49,7 @@ func TestTriggerPerception_SchedulesMidtermRecallSummary(t *testing.T) {
 
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
 	loop.loopName = "perception-midterm-test"
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 	loop.maxIterations = 100
 	loop.actionHistory = make([]*ActionRecord, 0)
 	loop.actionHistoryMutex = new(sync.Mutex)

--- a/common/ai/aid/aireact/reactloops/perception_test.go
+++ b/common/ai/aid/aireact/reactloops/perception_test.go
@@ -49,7 +49,7 @@ func TestTriggerPerception_SchedulesMidtermRecallSummary(t *testing.T) {
 
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
 	loop.loopName = "perception-midterm-test"
-	loop.perception = newPerceptionController()
+	loop.perception = newPerceptionController(loop.periodicCheckpointInterval)
 	loop.maxIterations = 100
 	loop.actionHistory = make([]*ActionRecord, 0)
 	loop.actionHistoryMutex = new(sync.Mutex)
@@ -156,7 +156,7 @@ func TestPerceptionState_ShouldUpdate_NilNewState(t *testing.T) {
 }
 
 func TestPerceptionController_IntervalThrottling(t *testing.T) {
-	pc := newPerceptionController()
+	pc := newPerceptionController(perceptionDefaultIterationInterval)
 
 	state1 := &PerceptionState{
 		Topics:      []string{"Topic A"},
@@ -174,7 +174,7 @@ func TestPerceptionController_IntervalThrottling(t *testing.T) {
 }
 
 func TestPerceptionController_ExponentialBackoff(t *testing.T) {
-	pc := newPerceptionController()
+	pc := newPerceptionController(perceptionDefaultIterationInterval)
 	pc.currentInterval = 10 * time.Millisecond
 	pc.minInterval = 10 * time.Millisecond
 	pc.maxInterval = 100 * time.Millisecond
@@ -199,7 +199,7 @@ func TestPerceptionController_ExponentialBackoff(t *testing.T) {
 }
 
 func TestPerceptionController_IntervalResetOnChange(t *testing.T) {
-	pc := newPerceptionController()
+	pc := newPerceptionController(perceptionDefaultIterationInterval)
 	pc.currentInterval = 10 * time.Millisecond
 	pc.minInterval = 10 * time.Millisecond
 
@@ -228,7 +228,7 @@ func TestPerceptionController_IntervalResetOnChange(t *testing.T) {
 }
 
 func TestPerceptionController_ShouldTriggerOnIteration(t *testing.T) {
-	pc := newPerceptionController()
+	pc := newPerceptionController(perceptionDefaultIterationInterval)
 	pc.iterationTriggerInterval = 2
 
 	if pc.shouldTriggerOnIteration(0) {
@@ -249,7 +249,7 @@ func TestPerceptionController_ShouldTriggerOnIteration(t *testing.T) {
 }
 
 func TestPerceptionController_EpochIncrements(t *testing.T) {
-	pc := newPerceptionController()
+	pc := newPerceptionController(perceptionDefaultIterationInterval)
 	s1 := &PerceptionState{Topics: []string{"A"}, Changed: true, LastTrigger: PerceptionTriggerForced}
 	pc.applyResult(s1)
 	if pc.getCurrent().Epoch != 1 {

--- a/common/ai/aid/aireact/reactloops/perception_test.go
+++ b/common/ai/aid/aireact/reactloops/perception_test.go
@@ -49,7 +49,7 @@ func TestTriggerPerception_SchedulesMidtermRecallSummary(t *testing.T) {
 
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
 	loop.loopName = "perception-midterm-test"
-	loop.perception = newPerceptionController(loop.periodicCheckpointInterval)
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
 	loop.maxIterations = 100
 	loop.actionHistory = make([]*ActionRecord, 0)
 	loop.actionHistoryMutex = new(sync.Mutex)

--- a/common/ai/aid/aireact/reactloops/prompt_observation.go
+++ b/common/ai/aid/aireact/reactloops/prompt_observation.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/ai/ytoken"
 	"github.com/yaklang/yaklang/common/utils"
 )
 
@@ -48,6 +49,7 @@ type PromptObservation struct {
 	Nonce                string                      `json:"nonce"`
 	GeneratedAt          time.Time                   `json:"generated_at"`
 	PromptBytes          int                         `json:"prompt_bytes"`
+	PromptTokens         int                         `json:"prompt_tokens"`
 	PromptLines          int                         `json:"prompt_lines"`
 	SectionCount         int                         `json:"section_count"`
 	IncludedSectionCount int                         `json:"included_section_count"`
@@ -71,6 +73,7 @@ type PromptObservationStatus struct {
 	LoopName             string                 `json:"loop_name"`
 	Nonce                string                 `json:"nonce"`
 	PromptBytes          int                    `json:"prompt_bytes"`
+	PromptTokens         int                    `json:"prompt_tokens"`
 	PromptLines          int                    `json:"prompt_lines"`
 	SectionCount         int                    `json:"section_count"`
 	IncludedSectionCount int                    `json:"included_section_count"`
@@ -102,12 +105,13 @@ func newPromptSectionObservation(
 
 func buildPromptObservation(loopName string, nonce string, prompt string, sections []*PromptSectionObservation) *PromptObservation {
 	observation := &PromptObservation{
-		LoopName:    loopName,
-		Nonce:       nonce,
-		GeneratedAt: time.Now(),
-		PromptBytes: len(prompt),
-		PromptLines: countPromptLines(prompt),
-		Sections:    sections,
+		LoopName:     loopName,
+		Nonce:        nonce,
+		GeneratedAt:  time.Now(),
+		PromptBytes:  len(prompt),
+		PromptTokens: ytoken.CalcTokenCount(prompt),
+		PromptLines:  countPromptLines(prompt),
+		Sections:     sections,
 	}
 
 	for _, section := range sections {
@@ -503,6 +507,7 @@ func (o *PromptObservation) BuildStatus(maxSummaryBytes int) *PromptObservationS
 		LoopName:             o.LoopName,
 		Nonce:                o.Nonce,
 		PromptBytes:          o.PromptBytes,
+		PromptTokens:         o.PromptTokens,
 		PromptLines:          o.PromptLines,
 		SectionCount:         o.SectionCount,
 		IncludedSectionCount: o.IncludedSectionCount,

--- a/common/ai/aid/aireact/reactloops/prompt_observation_test.go
+++ b/common/ai/aid/aireact/reactloops/prompt_observation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/ai/ytoken"
 	"github.com/yaklang/yaklang/common/utils/omap"
 )
 
@@ -75,6 +76,7 @@ func TestGenerateLoopPrompt_RecordsObservation(t *testing.T) {
 	require.Equal(t, "prompt-observation-loop", observation.LoopName)
 	require.Equal(t, "nonce1", observation.Nonce)
 	require.Equal(t, len(prompt), observation.PromptBytes)
+	require.Equal(t, ytoken.CalcTokenCount(prompt), observation.PromptTokens)
 	require.Len(t, observation.Sections, 10)
 	require.Greater(t, observation.SectionCount, len(observation.Sections))
 
@@ -126,6 +128,7 @@ func TestGenerateLoopPrompt_RecordsObservation(t *testing.T) {
 	require.Equal(t, observation.LoopName, status.LoopName)
 	require.Equal(t, observation.Nonce, status.Nonce)
 	require.Equal(t, observation.PromptBytes, status.PromptBytes)
+	require.Equal(t, observation.PromptTokens, status.PromptTokens)
 	require.NotEmpty(t, status.Sections)
 	require.Equal(t, "background", status.Sections[0].Key)
 	require.NotEmpty(t, status.Sections[0].Children)

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -54,11 +54,6 @@ type ReActLoop struct {
 
 	maxIterations int
 
-	// periodicCheckpointInterval controls how often loop-level periodic
-	// checkpoint behaviors should run during iterations, such as perception
-	// and generic auto-verification.
-	periodicCheckpointInterval int
-
 	loopName string
 
 	persistentInstructionProvider   ContextProviderFunc
@@ -121,6 +116,14 @@ type ReActLoop struct {
 	// action history tracking
 	actionHistory      []*ActionRecord
 	actionHistoryMutex *sync.Mutex
+
+	// verificationRuntimeSnapshot stores the last verification gate baseline so
+	// generic auto-verification can compare the current loop state against the
+	// previous accepted checkpoint.
+	periodicVerificationCount int // when == 0 , trigger every iteration;
+	verificationRuntimeSnapshot *VerificationRuntimeSnapshot
+	verificationMutex           *sync.Mutex
+	verificationWatchdogTimer   *time.Timer
 
 	// timeline differ for tracking changes during task execution
 	timelineDiffer        *aicommon.TimelineDiffer
@@ -347,7 +350,7 @@ func NewMinimalReActLoop(cfg aicommon.AICallerConfigIf, invoker aicommon.AIInvok
 		config:                     cfg,
 		invoker:                    invoker,
 		emitter:                    cfg.GetEmitter(),
-		periodicCheckpointInterval: perceptionDefaultIterationInterval,
+		verificationMutex:          new(sync.Mutex),
 		vars:                       omap.NewEmptyOrderedMap[string, any](),
 		taskMutex:                  new(sync.Mutex),
 		historySatisfactionReasons: make([]*SatisfactionRecord, 0),
@@ -369,7 +372,8 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 		config:                      config,
 		emitter:                     config.GetEmitter(),
 		maxIterations:               100,
-		periodicCheckpointInterval:  perceptionDefaultIterationInterval,
+		periodicVerificationCount:   verificationIterationTriggerInterval,
+		verificationMutex:           new(sync.Mutex),
 		actions:                     omap.NewEmptyOrderedMap[string, *LoopAction](),
 		loopActions:                 omap.NewEmptyOrderedMap[string, LoopActionFactory](),
 		streamFields:                omap.NewEmptyOrderedMap[string, *LoopStreamField](),
@@ -616,6 +620,9 @@ func (r *ReActLoop) FinishAsyncTask(t aicommon.AIStatefulTask, err error) {
 		return
 	}
 	t.Finish(err)
+	if t.IsFinished() {
+		r.stopVerificationWatchdogForTask(t)
+	}
 	if r.onAsyncTaskFinished != nil {
 		r.onAsyncTaskFinished(t)
 	}

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -30,13 +30,13 @@ type FeedbackProviderFunc func(loop *ReActLoop, feedback *bytes.Buffer, nonce st
 
 // SatisfactionRecord 记录满意度验证的结果，包含验证状态、原因、已完成任务索引和下一步行动计划
 type SatisfactionRecord struct {
-	Satisfactory       bool                           `json:"satisfactory"`         // 是否满足用户需求
-	Reason             string                         `json:"reason"`               // 满意/不满意的原因分析
-	CompletedTaskIndex string                         `json:"completed_task_index"` // AI 判断已完成的任务索引，如 "1-1" 或 "1-1,1-2"
-	NextMovements      []aicommon.VerifyNextMovement  `json:"next_movements"`       // AI 下一步行动计划，用于任务执行中状态追踪
-	Evidence           string                         `json:"evidence"`             // 运行期新增的证据 Markdown (legacy)
-	EvidenceOps        []aicommon.EvidenceOperation   `json:"evidence_ops"`         // 结构化证据增量操作
-	OutputFiles        []string                       `json:"output_files"`         // 本轮验证识别出的交付文件
+	Satisfactory       bool                          `json:"satisfactory"`         // 是否满足用户需求
+	Reason             string                        `json:"reason"`               // 满意/不满意的原因分析
+	CompletedTaskIndex string                        `json:"completed_task_index"` // AI 判断已完成的任务索引，如 "1-1" 或 "1-1,1-2"
+	NextMovements      []aicommon.VerifyNextMovement `json:"next_movements"`       // AI 下一步行动计划，用于任务执行中状态追踪
+	Evidence           string                        `json:"evidence"`             // 运行期新增的证据 Markdown (legacy)
+	EvidenceOps        []aicommon.EvidenceOperation  `json:"evidence_ops"`         // 结构化证据增量操作
+	OutputFiles        []string                      `json:"output_files"`         // 本轮验证识别出的交付文件
 }
 
 // ActionRecord 记录每次迭代执行的 Action 信息
@@ -53,6 +53,11 @@ type ReActLoop struct {
 	emitter *aicommon.Emitter
 
 	maxIterations int
+
+	// periodicCheckpointInterval controls how often loop-level periodic
+	// checkpoint behaviors should run during iterations, such as perception
+	// and generic auto-verification.
+	periodicCheckpointInterval int
 
 	loopName string
 
@@ -339,11 +344,15 @@ func (r *ReActLoop) GetBaseFrameContext() map[string]any {
 // It sets up config, invoker, and emitter but skips full action registration.
 func NewMinimalReActLoop(cfg aicommon.AICallerConfigIf, invoker aicommon.AIInvokeRuntime) *ReActLoop {
 	return &ReActLoop{
-		config:    cfg,
-		invoker:   invoker,
-		emitter:   cfg.GetEmitter(),
-		vars:      omap.NewEmptyOrderedMap[string, any](),
-		taskMutex: new(sync.Mutex),
+		config:                     cfg,
+		invoker:                    invoker,
+		emitter:                    cfg.GetEmitter(),
+		periodicCheckpointInterval: perceptionDefaultIterationInterval,
+		vars:                       omap.NewEmptyOrderedMap[string, any](),
+		taskMutex:                  new(sync.Mutex),
+		historySatisfactionReasons: make([]*SatisfactionRecord, 0),
+		actionHistory:              make([]*ActionRecord, 0),
+		actionHistoryMutex:         new(sync.Mutex),
 	}
 }
 
@@ -360,6 +369,7 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 		config:                      config,
 		emitter:                     config.GetEmitter(),
 		maxIterations:               100,
+		periodicCheckpointInterval:  perceptionDefaultIterationInterval,
 		actions:                     omap.NewEmptyOrderedMap[string, *LoopAction](),
 		loopActions:                 omap.NewEmptyOrderedMap[string, LoopActionFactory](),
 		streamFields:                omap.NewEmptyOrderedMap[string, *LoopStreamField](),
@@ -377,7 +387,7 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 		sameLogicSpinThreshold:      3, // 默认连续 3 次相同逻辑触发 AI 检测
 		maxConsecutiveSpinWarnings:  3, // 默认连续 3 次 SPIN 警告后强制退出
 		extraCapabilities:           NewExtraCapabilitiesManager(),
-		perception:                  newPerceptionController(),
+		perception:                  newPerceptionController(perceptionDefaultIterationInterval),
 	}
 
 	for _, action := range []*LoopAction{
@@ -472,6 +482,12 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 	if _, ok := r.actions.Get(schema.AI_REACT_LOOP_ACTION_LOAD_CAPABILITY); !ok {
 		if loadCap, ok := GetLoopAction(schema.AI_REACT_LOOP_ACTION_LOAD_CAPABILITY); ok {
 			r.actions.Set(loadCap.ActionType, loadCap)
+		}
+	}
+
+	if _, ok := r.actions.Get(schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION); !ok {
+		if verifyNow, ok := GetLoopAction(schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION); ok {
+			r.actions.Set(verifyNow.ActionType, verifyNow)
 		}
 	}
 

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -218,6 +218,10 @@ func (r *ReActLoop) GetMaxIterations() int {
 	return r.maxIterations
 }
 
+func (r *ReActLoop) GetPeriodicVerificationInterval() int {
+	return r.periodicVerificationInterval
+}
+
 func (r *ReActLoop) getRenderInfo() (string, map[string]any, error) {
 	var tools []*aitool.Tool
 	if r.toolsGetter == nil {

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -120,10 +120,10 @@ type ReActLoop struct {
 	// verificationRuntimeSnapshot stores the last verification gate baseline so
 	// generic auto-verification can compare the current loop state against the
 	// previous accepted checkpoint.
-	periodicVerificationCount int // when == 0 , trigger every iteration;
-	verificationRuntimeSnapshot *VerificationRuntimeSnapshot
-	verificationMutex           *sync.Mutex
-	verificationWatchdogTimer   *time.Timer
+	periodicVerificationInterval int // when == 0 , trigger every iteration;
+	verificationRuntimeSnapshot  *VerificationRuntimeSnapshot
+	verificationMutex            *sync.Mutex
+	verificationWatchdogTimer    *time.Timer
 
 	// timeline differ for tracking changes during task execution
 	timelineDiffer        *aicommon.TimelineDiffer
@@ -367,31 +367,31 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 	config := invoker.GetConfig()
 
 	r := &ReActLoop{
-		invoker:                     invoker,
-		loopName:                    name,
-		config:                      config,
-		emitter:                     config.GetEmitter(),
-		maxIterations:               100,
-		periodicVerificationCount:   verificationIterationTriggerInterval,
-		verificationMutex:           new(sync.Mutex),
-		actions:                     omap.NewEmptyOrderedMap[string, *LoopAction](),
-		loopActions:                 omap.NewEmptyOrderedMap[string, LoopActionFactory](),
-		streamFields:                omap.NewEmptyOrderedMap[string, *LoopStreamField](),
-		aiTagFields:                 omap.NewEmptyOrderedMap[string, *LoopAITagField](),
-		vars:                        omap.NewEmptyOrderedMap[string, any](),
-		taskMutex:                   new(sync.Mutex),
-		currentMemories:             omap.NewEmptyOrderedMap[string, *aicommon.MemoryEntity](),
-		memorySizeLimit:             10 * 1024,
-		enableSelfReflection:        true,
-		historySatisfactionReasons:  make([]*SatisfactionRecord, 0),
-		actionHistory:               make([]*ActionRecord, 0),
-		actionHistoryMutex:          new(sync.Mutex),
-		currentIterationIndex:       0,
-		sameActionTypeSpinThreshold: 3, // 默认连续 3 次相同 Action 触发检测
-		sameLogicSpinThreshold:      3, // 默认连续 3 次相同逻辑触发 AI 检测
-		maxConsecutiveSpinWarnings:  3, // 默认连续 3 次 SPIN 警告后强制退出
-		extraCapabilities:           NewExtraCapabilitiesManager(),
-		perception:                  newPerceptionController(perceptionDefaultIterationInterval),
+		invoker:                      invoker,
+		loopName:                     name,
+		config:                       config,
+		emitter:                      config.GetEmitter(),
+		maxIterations:                100,
+		periodicVerificationInterval: verificationIterationTriggerInterval,
+		verificationMutex:            new(sync.Mutex),
+		actions:                      omap.NewEmptyOrderedMap[string, *LoopAction](),
+		loopActions:                  omap.NewEmptyOrderedMap[string, LoopActionFactory](),
+		streamFields:                 omap.NewEmptyOrderedMap[string, *LoopStreamField](),
+		aiTagFields:                  omap.NewEmptyOrderedMap[string, *LoopAITagField](),
+		vars:                         omap.NewEmptyOrderedMap[string, any](),
+		taskMutex:                    new(sync.Mutex),
+		currentMemories:              omap.NewEmptyOrderedMap[string, *aicommon.MemoryEntity](),
+		memorySizeLimit:              10 * 1024,
+		enableSelfReflection:         true,
+		historySatisfactionReasons:   make([]*SatisfactionRecord, 0),
+		actionHistory:                make([]*ActionRecord, 0),
+		actionHistoryMutex:           new(sync.Mutex),
+		currentIterationIndex:        0,
+		sameActionTypeSpinThreshold:  3, // 默认连续 3 次相同 Action 触发检测
+		sameLogicSpinThreshold:       3, // 默认连续 3 次相同逻辑触发 AI 检测
+		maxConsecutiveSpinWarnings:   3, // 默认连续 3 次 SPIN 警告后强制退出
+		extraCapabilities:            NewExtraCapabilitiesManager(),
+		perception:                   newPerceptionController(perceptionDefaultIterationInterval),
 	}
 
 	for _, action := range []*LoopAction{

--- a/common/ai/aid/aireact/reactloops/verification_gate.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate.go
@@ -11,7 +11,7 @@ import (
 const (
 	verificationAutoTriggerMaxSnapshotAge = 30 * time.Second
 	verificationAutoTriggerMinPromptDelta = 500
-	verificationIterationTriggerInterval  = 5
+	verificationIterationTriggerInterval  = aicommon.DefaultPeriodicVerificationInterval
 )
 
 var verificationWatchdogIdleTimeout = 2 * time.Minute

--- a/common/ai/aid/aireact/reactloops/verification_gate.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate.go
@@ -91,7 +91,7 @@ func (r *ReActLoop) ShouldTriggerPeriodicCheckpointOnIteration(iterationIndex in
 	if r == nil {
 		return false
 	}
-	interval := r.periodicVerificationCount
+	interval := r.periodicVerificationInterval
 	if interval <= 0 {
 		return true
 	}
@@ -317,5 +317,5 @@ func (r *ReActLoop) getVerificationIterationTriggerInterval() int {
 	if r == nil {
 		return verificationIterationTriggerInterval
 	}
-	return r.periodicVerificationCount
+	return r.periodicVerificationInterval
 }

--- a/common/ai/aid/aireact/reactloops/verification_gate.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate.go
@@ -2,9 +2,88 @@ package reactloops
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 )
+
+const (
+	verificationAutoTriggerMaxSnapshotAge = 30 * time.Second
+	verificationAutoTriggerMinPromptDelta = 500
+	verificationIterationTriggerInterval  = 5
+)
+
+var verificationWatchdogIdleTimeout = 2 * time.Minute
+
+type VerificationRuntimeSnapshot struct {
+	GeneratedAt      time.Time `json:"generated_at"`
+	IterationIndex   int       `json:"iteration_index"`
+	LoopPromptTokens int       `json:"loop_prompt_tokens,omitempty"`
+}
+
+// RefreshVerificationRuntimeSnapshot rebuilds the runtime snapshot from the
+// current loop state and replaces the previously stored snapshot pointer.
+func (r *ReActLoop) RefreshVerificationRuntimeSnapshot() *VerificationRuntimeSnapshot {
+	if r == nil {
+		return nil
+	}
+
+	snapshot := r.buildVerificationRuntimeSnapshot(time.Now())
+	r.actionHistoryMutex.Lock()
+	defer r.actionHistoryMutex.Unlock()
+	r.verificationRuntimeSnapshot = snapshot
+	return r.verificationRuntimeSnapshot
+}
+
+// GetVerificationRuntimeSnapshot returns the currently stored snapshot pointer.
+// Callers should treat the returned pointer as read-only.
+func (r *ReActLoop) GetVerificationRuntimeSnapshot() *VerificationRuntimeSnapshot {
+	if r == nil {
+		return nil
+	}
+
+	r.actionHistoryMutex.Lock()
+	defer r.actionHistoryMutex.Unlock()
+	return r.verificationRuntimeSnapshot
+}
+
+func (r *ReActLoop) buildVerificationRuntimeSnapshot(generatedAt time.Time) *VerificationRuntimeSnapshot {
+	if r == nil {
+		return nil
+	}
+
+	snapshot := &VerificationRuntimeSnapshot{
+		GeneratedAt:      generatedAt,
+		LoopPromptTokens: r.getVerificationRuntimePromptTokens(),
+	}
+	r.actionHistoryMutex.Lock()
+	snapshot.IterationIndex = r.currentIterationIndex
+	r.actionHistoryMutex.Unlock()
+	return snapshot
+}
+
+func (r *ReActLoop) setVerificationRuntimeSnapshot(snapshot *VerificationRuntimeSnapshot) {
+	if r == nil {
+		return
+	}
+	r.actionHistoryMutex.Lock()
+	defer r.actionHistoryMutex.Unlock()
+	r.verificationRuntimeSnapshot = snapshot
+}
+
+func (r *ReActLoop) getVerificationRuntimePromptTokens() int {
+	if r == nil {
+		return 0
+	}
+	if observation := r.GetLastPromptObservation(); observation != nil {
+		return observation.PromptTokens
+	}
+	if status := r.GetLastPromptObservationStatus(); status != nil {
+		return status.PromptTokens
+	}
+	return 0
+}
 
 // ShouldTriggerPeriodicCheckpointOnIteration reports whether periodic
 // checkpoints such as perception/verification should run on this iteration.
@@ -12,9 +91,9 @@ func (r *ReActLoop) ShouldTriggerPeriodicCheckpointOnIteration(iterationIndex in
 	if r == nil {
 		return false
 	}
-	interval := r.periodicCheckpointInterval
+	interval := r.periodicVerificationCount
 	if interval <= 0 {
-		interval = perceptionDefaultIterationInterval
+		return true
 	}
 	if iterationIndex > 0 && iterationIndex%interval == 0 {
 		return true
@@ -71,16 +150,25 @@ func (r *ReActLoop) VerifyUserSatisfactionNow(
 	if r == nil || r.invoker == nil {
 		return nil, nil
 	}
+	r.touchVerificationWatchdog()
+	if r.verificationMutex != nil {
+		r.verificationMutex.Lock()
+		defer r.verificationMutex.Unlock()
+	}
 	result, err := r.invoker.VerifyUserSatisfaction(ctx, originalQuery, isToolCall, payload)
 	if err != nil {
 		return nil, err
 	}
+	r.setVerificationRuntimeSnapshot(r.buildVerificationRuntimeSnapshot(time.Now()))
 	r.ApplyVerificationResult(result)
 	return result, nil
 }
 
 // MaybeVerifyUserSatisfaction gates generic automatic verification to avoid
-// running it after every tool call.
+// running it after every tool call. In addition to the shared periodic
+// checkpoint rule, it only re-runs auto-verification when the last accepted
+// verification baseline is absent, stale, or the loop prompt has changed
+// materially.
 func (r *ReActLoop) MaybeVerifyUserSatisfaction(
 	ctx context.Context,
 	originalQuery string,
@@ -90,13 +178,144 @@ func (r *ReActLoop) MaybeVerifyUserSatisfaction(
 	if r == nil || r.invoker == nil {
 		return nil, false, nil
 	}
-	if !r.ShouldTriggerPeriodicCheckpointOnIteration(r.GetCurrentIterationIndex()) {
+	r.touchVerificationWatchdog()
+	currentSnapshot := r.buildVerificationRuntimeSnapshot(time.Now())
+	if !r.shouldTriggerAutomaticVerification(currentSnapshot) {
+		return nil, false, nil
+	}
+	if r.verificationMutex != nil {
+		r.verificationMutex.Lock()
+		defer r.verificationMutex.Unlock()
+	}
+	currentSnapshot = r.buildVerificationRuntimeSnapshot(time.Now())
+	if !r.shouldTriggerAutomaticVerification(currentSnapshot) {
 		return nil, false, nil
 	}
 	result, err := r.invoker.VerifyUserSatisfaction(ctx, originalQuery, isToolCall, payload)
 	if err != nil {
 		return nil, true, err
 	}
+	r.setVerificationRuntimeSnapshot(currentSnapshot)
 	r.ApplyVerificationResult(result)
 	return result, true, nil
+}
+
+func (r *ReActLoop) startVerificationWatchdog(task aicommon.AIStatefulTask) {
+	if r == nil || task == nil || r.verificationMutex == nil {
+		return
+	}
+	r.verificationMutex.Lock()
+	defer r.verificationMutex.Unlock()
+	if r.verificationWatchdogTimer != nil {
+		r.verificationWatchdogTimer.Stop()
+	}
+	r.verificationWatchdogTimer = time.AfterFunc(verificationWatchdogIdleTimeout, func() {
+		r.triggerVerificationWatchdog(task)
+	})
+}
+
+func (r *ReActLoop) touchVerificationWatchdog() {
+	if r == nil {
+		return
+	}
+	task := r.GetCurrentTask()
+	if task == nil {
+		return
+	}
+	r.startVerificationWatchdog(task)
+}
+
+func (r *ReActLoop) stopVerificationWatchdogForTask(task aicommon.AIStatefulTask) {
+	if r == nil || task == nil || r.verificationMutex == nil {
+		return
+	}
+	r.verificationMutex.Lock()
+	defer r.verificationMutex.Unlock()
+	if r.verificationWatchdogTimer != nil {
+		r.verificationWatchdogTimer.Stop()
+		r.verificationWatchdogTimer = nil
+	}
+}
+
+func (r *ReActLoop) triggerVerificationWatchdog(task aicommon.AIStatefulTask) {
+	if r == nil || task == nil || task.IsFinished() {
+		return
+	}
+	select {
+	case <-task.GetContext().Done():
+		return
+	default:
+	}
+	if r.GetInvoker() == nil {
+		return
+	}
+	payload := r.buildVerificationWatchdogPayload(task)
+	r.GetInvoker().AddToTimeline("[ASYNC_VERIFICATION_WATCHDOG]", payload)
+	result, err := r.VerifyUserSatisfactionNow(task.GetContext(), task.GetUserInput(), false, payload)
+	if err != nil {
+		r.GetInvoker().AddToTimeline("verification_watchdog_error", err.Error())
+		return
+	}
+	if result == nil {
+		return
+	}
+	if result.Satisfied {
+		task.Finish(nil)
+		r.stopVerificationWatchdogForTask(task)
+		return
+	}
+	r.GetInvoker().AddToTimeline("verification_watchdog_unsatisfied", result.Reasoning)
+}
+
+func (r *ReActLoop) buildVerificationWatchdogPayload(task aicommon.AIStatefulTask) string {
+	if r == nil {
+		return "Verification watchdog triggered because MaybeVerifyUserSatisfaction has been idle for too long."
+	}
+	payload := "Verification watchdog triggered because MaybeVerifyUserSatisfaction has been idle for too long."
+	payload += fmt.Sprintf("\nCurrent iteration: %d.", r.GetCurrentIterationIndex())
+	if last := r.GetLastAction(); last != nil {
+		payload += "\nLast action: " + last.ActionType + "."
+	}
+	if task != nil {
+		payload += "\nPlease verify whether the current work already satisfies the user goal."
+	}
+	return payload
+}
+
+func (r *ReActLoop) shouldTriggerAutomaticVerification(current *VerificationRuntimeSnapshot) bool {
+	if r == nil || current == nil {
+		return false
+	}
+	if r.maxIterations > 0 && current.IterationIndex == r.maxIterations {
+		return true
+	}
+	previous := r.GetVerificationRuntimeSnapshot()
+	if previous == nil {
+		return r.ShouldTriggerPeriodicCheckpointOnIteration(current.IterationIndex)
+	}
+	if current.GeneratedAt.Sub(previous.GeneratedAt) >= verificationAutoTriggerMaxSnapshotAge {
+		return true
+	}
+	if current.IterationIndex-previous.IterationIndex >= r.getVerificationIterationTriggerInterval() {
+		return true
+	}
+	return verificationPromptTokenDelta(previous, current) >= verificationAutoTriggerMinPromptDelta
+}
+
+func verificationPromptTokenDelta(previous *VerificationRuntimeSnapshot, current *VerificationRuntimeSnapshot) int {
+	if previous == nil || current == nil {
+		return 0
+	}
+	delta := current.LoopPromptTokens - previous.LoopPromptTokens
+	if delta < 0 {
+		return -delta
+	}
+	return delta
+}
+
+func (r *ReActLoop) getVerificationIterationTriggerInterval() int {
+	if r == nil {
+		return verificationIterationTriggerInterval
+	}
+	return r.periodicVerificationCount
 }

--- a/common/ai/aid/aireact/reactloops/verification_gate.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate.go
@@ -1,0 +1,102 @@
+package reactloops
+
+import (
+	"context"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+)
+
+// ShouldTriggerPeriodicCheckpointOnIteration reports whether periodic
+// checkpoints such as perception/verification should run on this iteration.
+func (r *ReActLoop) ShouldTriggerPeriodicCheckpointOnIteration(iterationIndex int) bool {
+	if r == nil {
+		return false
+	}
+	interval := r.periodicCheckpointInterval
+	if interval <= 0 {
+		interval = perceptionDefaultIterationInterval
+	}
+	if iterationIndex > 0 && iterationIndex%interval == 0 {
+		return true
+	}
+	return r.maxIterations > 0 && iterationIndex > 0 && iterationIndex == r.maxIterations
+}
+
+// ApplyVerificationResult stores verification side effects in the loop state.
+func (r *ReActLoop) ApplyVerificationResult(result *aicommon.VerifySatisfactionResult) {
+	if r == nil || result == nil {
+		return
+	}
+
+	cfg := r.GetConfig()
+	if cfg != nil && len(result.OutputFiles) > 0 {
+		if providerManager := cfg.GetContextProviderManager(); providerManager != nil {
+			for _, filePath := range result.OutputFiles {
+				providerName := "output_file:" + filePath
+				providerManager.RegisterTracedContent(
+					providerName,
+					aicommon.OutputFileContextProvider(filePath),
+				)
+				if emitter := cfg.GetEmitter(); emitter != nil {
+					emitter.EmitPinFilename(filePath)
+				}
+			}
+		}
+	}
+
+	r.PushSatisfactionRecordWithCompletedTaskIndex(
+		result.Satisfied,
+		result.Reasoning,
+		result.CompletedTaskIndex,
+		result.NextMovements,
+		result.Evidence,
+		result.OutputFiles,
+		result.EvidenceOps,
+	)
+	if cfg != nil && len(result.EvidenceOps) > 0 {
+		cfg.ApplySessionEvidenceOps(result.EvidenceOps)
+	}
+	r.MaybeTriggerPerceptionAfterVerification()
+}
+
+// VerifyUserSatisfactionNow forces a verification pass immediately, bypassing
+// periodic checkpoint throttling. This is used by explicit AI-triggered
+// verification actions.
+func (r *ReActLoop) VerifyUserSatisfactionNow(
+	ctx context.Context,
+	originalQuery string,
+	isToolCall bool,
+	payload string,
+) (*aicommon.VerifySatisfactionResult, error) {
+	if r == nil || r.invoker == nil {
+		return nil, nil
+	}
+	result, err := r.invoker.VerifyUserSatisfaction(ctx, originalQuery, isToolCall, payload)
+	if err != nil {
+		return nil, err
+	}
+	r.ApplyVerificationResult(result)
+	return result, nil
+}
+
+// MaybeVerifyUserSatisfaction gates generic automatic verification to avoid
+// running it after every tool call.
+func (r *ReActLoop) MaybeVerifyUserSatisfaction(
+	ctx context.Context,
+	originalQuery string,
+	isToolCall bool,
+	payload string,
+) (*aicommon.VerifySatisfactionResult, bool, error) {
+	if r == nil || r.invoker == nil {
+		return nil, false, nil
+	}
+	if !r.ShouldTriggerPeriodicCheckpointOnIteration(r.GetCurrentIterationIndex()) {
+		return nil, false, nil
+	}
+	result, err := r.invoker.VerifyUserSatisfaction(ctx, originalQuery, isToolCall, payload)
+	if err != nil {
+		return nil, true, err
+	}
+	r.ApplyVerificationResult(result)
+	return result, true, nil
+}

--- a/common/ai/aid/aireact/reactloops/verification_gate_test.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate_test.go
@@ -29,8 +29,8 @@ func TestShouldTriggerPeriodicCheckpointOnIteration_UsesLoopInterval(t *testing.
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 4
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.periodicVerificationInterval = 4
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 
 	require.False(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(2))
 	require.True(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(4))
@@ -41,7 +41,7 @@ func TestShouldTriggerPeriodicCheckpointOnIteration_FallbackWithoutPerception(t 
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 2
+	loop.periodicVerificationInterval = 2
 	loop.perception = nil
 	loop.maxIterations = 5
 
@@ -55,8 +55,8 @@ func TestMaybeVerifyUserSatisfaction_UsesSharedCheckpointRule(t *testing.T) {
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 2
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.periodicVerificationInterval = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
 	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 100})
 
@@ -84,8 +84,8 @@ func TestMaybeVerifyUserSatisfaction_SkipsWhenPromptDeltaIsSmall(t *testing.T) {
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 2
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.periodicVerificationInterval = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
 
 	loop.currentIterationIndex = 2
@@ -111,8 +111,8 @@ func TestMaybeVerifyUserSatisfaction_TriggersWhenPromptDeltaIsLarge(t *testing.T
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 2
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.periodicVerificationInterval = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
 	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
 		GeneratedAt:      time.Now(),
@@ -135,8 +135,8 @@ func TestMaybeVerifyUserSatisfaction_TriggersWhenIterationDeltaIsLarge(t *testin
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 3
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.periodicVerificationInterval = 3
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
 	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
 		GeneratedAt:      time.Now(),
@@ -159,8 +159,8 @@ func TestMaybeVerifyUserSatisfaction_TriggersWhenSnapshotIsStale(t *testing.T) {
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 2
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.periodicVerificationInterval = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
 	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
 		GeneratedAt:      time.Now().Add(-verificationAutoTriggerMaxSnapshotAge - time.Second),
@@ -182,8 +182,8 @@ func TestMaybeVerifyUserSatisfaction_SkipsOnlyWhenAllSignalsAreWeak(t *testing.T
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 3
-	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.periodicVerificationInterval = 3
+	loop.perception = newPerceptionController(loop.periodicVerificationInterval)
 	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
 	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
 		GeneratedAt:      time.Now(),
@@ -235,7 +235,7 @@ func TestVerificationWatchdog_ResetsWhenMaybeVerifyRuns(t *testing.T) {
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicVerificationCount = 100
+	loop.periodicVerificationInterval = 100
 	task := aicommon.NewStatefulTaskBase("watchdog-reset-task", "query", context.Background(), nil, true)
 	loop.SetCurrentTask(task)
 	loop.startVerificationWatchdog(task)

--- a/common/ai/aid/aireact/reactloops/verification_gate_test.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate_test.go
@@ -2,8 +2,8 @@ package reactloops
 
 import (
 	"context"
-	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
@@ -13,10 +13,14 @@ import (
 type verificationGateTestInvoker struct {
 	*mockcfg.MockInvoker
 	verifyCalls int
+	result      *aicommon.VerifySatisfactionResult
 }
 
 func (i *verificationGateTestInvoker) VerifyUserSatisfaction(ctx context.Context, query string, isToolCall bool, payload string) (*aicommon.VerifySatisfactionResult, error) {
 	i.verifyCalls++
+	if i.result != nil {
+		return i.result, nil
+	}
 	return aicommon.NewVerifySatisfactionResult(false, "keep iterating", ""), nil
 }
 
@@ -25,8 +29,8 @@ func TestShouldTriggerPeriodicCheckpointOnIteration_UsesLoopInterval(t *testing.
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.periodicCheckpointInterval = 4
-	loop.perception = newPerceptionController(loop.periodicCheckpointInterval)
+	loop.periodicVerificationCount = 4
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
 
 	require.False(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(2))
 	require.True(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(4))
@@ -37,6 +41,7 @@ func TestShouldTriggerPeriodicCheckpointOnIteration_FallbackWithoutPerception(t 
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicVerificationCount = 2
 	loop.perception = nil
 	loop.maxIterations = 5
 
@@ -50,9 +55,10 @@ func TestMaybeVerifyUserSatisfaction_UsesSharedCheckpointRule(t *testing.T) {
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
 	}
 	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
-	loop.perception = newPerceptionController(loop.periodicCheckpointInterval)
-	loop.actionHistoryMutex = new(sync.Mutex)
+	loop.periodicVerificationCount = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
 	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 100})
 
 	loop.currentIterationIndex = 1
 	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
@@ -69,4 +75,213 @@ func TestMaybeVerifyUserSatisfaction_UsesSharedCheckpointRule(t *testing.T) {
 	require.NotNil(t, result)
 	require.Equal(t, 1, invoker.verifyCalls)
 	require.Len(t, loop.historySatisfactionReasons, 1)
+	require.NotNil(t, loop.GetVerificationRuntimeSnapshot())
+	require.Equal(t, 100, loop.GetVerificationRuntimeSnapshot().LoopPromptTokens)
+}
+
+func TestMaybeVerifyUserSatisfaction_SkipsWhenPromptDeltaIsSmall(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicVerificationCount = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
+
+	loop.currentIterationIndex = 2
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 100})
+	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.True(t, triggered)
+	require.NotNil(t, result)
+
+	loop.currentIterationIndex = 3
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 100 + verificationAutoTriggerMinPromptDelta - 1})
+	result, triggered, err = loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.False(t, triggered)
+	require.Nil(t, result)
+	require.Equal(t, 1, invoker.verifyCalls)
+	require.Equal(t, 2, loop.GetVerificationRuntimeSnapshot().IterationIndex)
+	require.Equal(t, 100, loop.GetVerificationRuntimeSnapshot().LoopPromptTokens)
+}
+
+func TestMaybeVerifyUserSatisfaction_TriggersWhenPromptDeltaIsLarge(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicVerificationCount = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
+	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
+		GeneratedAt:      time.Now(),
+		IterationIndex:   2,
+		LoopPromptTokens: 120,
+	})
+	loop.currentIterationIndex = 4
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 120 + verificationAutoTriggerMinPromptDelta})
+
+	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.True(t, triggered)
+	require.NotNil(t, result)
+	require.Equal(t, 1, invoker.verifyCalls)
+	require.Equal(t, 4, loop.GetVerificationRuntimeSnapshot().IterationIndex)
+}
+
+func TestMaybeVerifyUserSatisfaction_TriggersWhenIterationDeltaIsLarge(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicVerificationCount = 3
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
+	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
+		GeneratedAt:      time.Now(),
+		IterationIndex:   2,
+		LoopPromptTokens: 120,
+	})
+	loop.currentIterationIndex = 5
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 120})
+
+	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.True(t, triggered)
+	require.NotNil(t, result)
+	require.Equal(t, 1, invoker.verifyCalls)
+	require.Equal(t, 5, loop.GetVerificationRuntimeSnapshot().IterationIndex)
+}
+
+func TestMaybeVerifyUserSatisfaction_TriggersWhenSnapshotIsStale(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicVerificationCount = 2
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
+	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
+		GeneratedAt:      time.Now().Add(-verificationAutoTriggerMaxSnapshotAge - time.Second),
+		IterationIndex:   2,
+		LoopPromptTokens: 120,
+	})
+	loop.currentIterationIndex = 4
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 120})
+
+	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.True(t, triggered)
+	require.NotNil(t, result)
+	require.Equal(t, 1, invoker.verifyCalls)
+}
+
+func TestMaybeVerifyUserSatisfaction_SkipsOnlyWhenAllSignalsAreWeak(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicVerificationCount = 3
+	loop.perception = newPerceptionController(loop.periodicVerificationCount)
+	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
+	loop.setVerificationRuntimeSnapshot(&VerificationRuntimeSnapshot{
+		GeneratedAt:      time.Now(),
+		IterationIndex:   2,
+		LoopPromptTokens: 120,
+	})
+	loop.currentIterationIndex = 3
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 120 + verificationAutoTriggerMinPromptDelta - 1})
+
+	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.False(t, triggered)
+	require.Nil(t, result)
+	require.Equal(t, 0, invoker.verifyCalls)
+}
+
+func TestVerificationWatchdog_TriggersAfterIdle(t *testing.T) {
+	previousTimeout := verificationWatchdogIdleTimeout
+	verificationWatchdogIdleTimeout = 20 * time.Millisecond
+	defer func() {
+		verificationWatchdogIdleTimeout = previousTimeout
+	}()
+
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+		result:      aicommon.NewVerifySatisfactionResult(true, "done", ""),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	task := aicommon.NewStatefulTaskBase("watchdog-task", "query", context.Background(), nil, true)
+	loop.SetCurrentTask(task)
+	loop.startVerificationWatchdog(task)
+	defer loop.stopVerificationWatchdogForTask(task)
+
+	require.Eventually(t, func() bool {
+		return task.IsFinished()
+	}, time.Second, 10*time.Millisecond)
+	require.GreaterOrEqual(t, invoker.verifyCalls, 1)
+	require.Equal(t, aicommon.AITaskState_Completed, task.GetStatus())
+}
+
+func TestVerificationWatchdog_ResetsWhenMaybeVerifyRuns(t *testing.T) {
+	previousTimeout := verificationWatchdogIdleTimeout
+	verificationWatchdogIdleTimeout = 40 * time.Millisecond
+	defer func() {
+		verificationWatchdogIdleTimeout = previousTimeout
+	}()
+
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicVerificationCount = 100
+	task := aicommon.NewStatefulTaskBase("watchdog-reset-task", "query", context.Background(), nil, true)
+	loop.SetCurrentTask(task)
+	loop.startVerificationWatchdog(task)
+	defer loop.stopVerificationWatchdogForTask(task)
+
+	time.Sleep(20 * time.Millisecond)
+	_, _, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+
+	time.Sleep(25 * time.Millisecond)
+	require.Equal(t, 0, invoker.verifyCalls)
+}
+
+func TestRefreshVerificationRuntimeSnapshot_ReplacesStoredPointer(t *testing.T) {
+	invoker := mockcfg.NewMockInvoker(context.Background())
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.currentIterationIndex = 2
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 96})
+
+	first := loop.RefreshVerificationRuntimeSnapshot()
+	require.NotNil(t, first)
+	require.Same(t, first, loop.GetVerificationRuntimeSnapshot())
+	require.Equal(t, 2, first.IterationIndex)
+	require.Equal(t, 96, first.LoopPromptTokens)
+
+	time.Sleep(time.Millisecond)
+	loop.currentIterationIndex = 3
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: 144})
+
+	second := loop.RefreshVerificationRuntimeSnapshot()
+	require.NotNil(t, second)
+	require.NotSame(t, first, second)
+	require.Same(t, second, loop.GetVerificationRuntimeSnapshot())
+	require.True(t, second.GeneratedAt.After(first.GeneratedAt))
+	require.Equal(t, 3, second.IterationIndex)
+	require.Equal(t, 144, second.LoopPromptTokens)
+}
+
+func TestRefreshVerificationRuntimeSnapshot_UsesPromptStatusFallback(t *testing.T) {
+	invoker := mockcfg.NewMockInvoker(context.Background())
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.currentIterationIndex = 2
+	loop.SetLastPromptObservationStatus(&PromptObservationStatus{PromptTokens: 72})
+
+	snapshot := loop.RefreshVerificationRuntimeSnapshot()
+	require.NotNil(t, snapshot)
+	require.Equal(t, 2, snapshot.IterationIndex)
+	require.Equal(t, 72, snapshot.LoopPromptTokens)
 }

--- a/common/ai/aid/aireact/reactloops/verification_gate_test.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate_test.go
@@ -1,0 +1,72 @@
+package reactloops
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	mockcfg "github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+)
+
+type verificationGateTestInvoker struct {
+	*mockcfg.MockInvoker
+	verifyCalls int
+}
+
+func (i *verificationGateTestInvoker) VerifyUserSatisfaction(ctx context.Context, query string, isToolCall bool, payload string) (*aicommon.VerifySatisfactionResult, error) {
+	i.verifyCalls++
+	return aicommon.NewVerifySatisfactionResult(false, "keep iterating", ""), nil
+}
+
+func TestShouldTriggerPeriodicCheckpointOnIteration_UsesLoopInterval(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.periodicCheckpointInterval = 4
+	loop.perception = newPerceptionController(loop.periodicCheckpointInterval)
+
+	require.False(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(2))
+	require.True(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(4))
+}
+
+func TestShouldTriggerPeriodicCheckpointOnIteration_FallbackWithoutPerception(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.perception = nil
+	loop.maxIterations = 5
+
+	require.False(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(1))
+	require.True(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(2))
+	require.True(t, loop.ShouldTriggerPeriodicCheckpointOnIteration(5))
+}
+
+func TestMaybeVerifyUserSatisfaction_UsesSharedCheckpointRule(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.perception = newPerceptionController(loop.periodicCheckpointInterval)
+	loop.actionHistoryMutex = new(sync.Mutex)
+	loop.historySatisfactionReasons = make([]*SatisfactionRecord, 0)
+
+	loop.currentIterationIndex = 1
+	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.False(t, triggered)
+	require.Nil(t, result)
+	require.Equal(t, 0, invoker.verifyCalls)
+	require.Len(t, loop.historySatisfactionReasons, 0)
+
+	loop.currentIterationIndex = 2
+	result, triggered, err = loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.True(t, triggered)
+	require.NotNil(t, result)
+	require.Equal(t, 1, invoker.verifyCalls)
+	require.Len(t, loop.historySatisfactionReasons, 1)
+}

--- a/common/ai/aid/aireact/tools.go
+++ b/common/ai/aid/aireact/tools.go
@@ -76,6 +76,7 @@ func NewTestReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 		aicommon.WithDisableAutoSkills(true),
 		aicommon.WithGenerateReport(false),
 		aicommon.WithDisableDynamicPlanning(true),
+		aicommon.WithPeriodicVerificationInterval(0),
 	}
 	basicOption = append(basicOption, opts...)
 	ins, err := NewReAct(

--- a/common/ai/aid/coordinator_invoker.go
+++ b/common/ai/aid/coordinator_invoker.go
@@ -66,6 +66,7 @@ func (c *Coordinator) ExecuteLoopTask(taskTypeName string, task aicommon.AIState
 	defaultOptions := []reactloops.ReActLoopOption{
 		reactloops.WithMemoryTriage(c.MemoryTriage),
 		reactloops.WithMemoryPool(c.MemoryPool),
+		reactloops.WithPeriodicVerificationInterval(int(c.PeriodicVerificationInterval)),
 		reactloops.WithMemorySizeLimit(int(c.MemoryPoolSize)),
 		reactloops.WithEnableSelfReflection(c.EnableSelfReflection),
 		reactloops.WithOnPostIteraction(func(loop *reactloops.ReActLoop, iteration int, task aicommon.AIStatefulTask, isDone bool, reason any, operator *reactloops.OnPostIterationOperator) {

--- a/common/ai/aid/coordinator_invoker.go
+++ b/common/ai/aid/coordinator_invoker.go
@@ -63,12 +63,9 @@ func (c *Coordinator) ExecuteLoopTask(taskTypeName string, task aicommon.AIState
 		return fmt.Errorf("创建 AI 调用运行时失败: %v", err)
 	}
 
-	defaultOptions := []reactloops.ReActLoopOption{
-		reactloops.WithMemoryTriage(c.MemoryTriage),
-		reactloops.WithMemoryPool(c.MemoryPool),
-		reactloops.WithPeriodicVerificationInterval(int(c.PeriodicVerificationInterval)),
-		reactloops.WithMemorySizeLimit(int(c.MemoryPoolSize)),
-		reactloops.WithEnableSelfReflection(c.EnableSelfReflection),
+	defaultOptions := reactloops.BasicAICommonConfigOption(c.Config)
+
+	defaultOptions = append(defaultOptions,
 		reactloops.WithOnPostIteraction(func(loop *reactloops.ReActLoop, iteration int, task aicommon.AIStatefulTask, isDone bool, reason any, operator *reactloops.OnPostIterationOperator) {
 			operator.DeferAfterCallbacks(func() {
 				if c.MemoryTriage == nil {
@@ -125,8 +122,7 @@ func (c *Coordinator) ExecuteLoopTask(taskTypeName string, task aicommon.AIState
 					}()
 				})
 			})
-		}),
-	}
+		}))
 
 	defaultOptions = append(defaultOptions, options...)
 

--- a/common/ai/aid/database.go
+++ b/common/ai/aid/database.go
@@ -4,7 +4,6 @@ import (
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
-	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
 
 func (c *Coordinator) CreateDatabaseSchema(input string) *schema.AIAgentRuntime {
@@ -16,10 +15,8 @@ func (c *Coordinator) CreateDatabaseSchema(input string) *schema.AIAgentRuntime 
 		QuotedUserInput:   codec.StrConvQuote(input),
 		ForgeName:         c.Config.ForgeName,
 	}
-	dbId, err := yakit.CreateOrUpdateAIAgentRuntime(c.Config.GetDB(), rt)
-	if err != nil {
+	if err := c.Config.CreateOrUpdateRuntimeRecord(rt); err != nil {
 		log.Errorf("BUG: cannot create coordinator runtime record: %v", err)
 	}
-	c.Config.DatabaseRecordID = dbId
 	return rt
 }

--- a/common/ai/aid/test/config_sync_task_test.go
+++ b/common/ai/aid/test/config_sync_task_test.go
@@ -229,6 +229,7 @@ func TestCoordinator_SyncTask_Upgrade(t *testing.T) {
 
 	ins, err := aid.NewCoordinator(
 		"test-upgrade",
+		aicommon.WithPeriodicVerificationInterval(0),
 		aicommon.WithTools(aid.EchoTool(), aid.ErrorTool()),
 		aicommon.WithMemoryTriage(aimem.NewMockMemoryTriage()),
 		aicommon.WithAIAutoRetry(1),

--- a/common/schema/ai_event.go
+++ b/common/schema/ai_event.go
@@ -42,6 +42,7 @@ const (
 	AI_REACT_LOOP_ACTION_LOAD_SKILL_RESOURCES     = "load_skill_resources"
 	AI_REACT_LOOP_ACTION_LOAD_CAPABILITY          = "load_capability"
 	AI_REACT_LOOP_ACTION_DIRECTLY_CALL_TOOL       = "directly_call_tool"
+	AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION     = "request_verification"
 )
 
 const (


### PR DESCRIPTION
**当前 verification 触发模式**

- 显式触发
   由 request_verification action 主动触发，立即执行一次验收。

-   自动触发
   由 MaybeVerifyUserSatisfaction(...) 触发，只要满足任意一个“运行态变化信号”就会执行验收。
   当前参与判断的信号包括：**已达到最大迭代次数 、 距离上次验收的时间差达到阈值、距离上次验收的迭代差达到阈值、距离上次验收的 prompt token 增量达到阈值**

-   异步兜底触发
   如果 verification 长时间未被触发，watchdog 会异步补一次验收，避免 loop 长时间悬挂。需要说明的是，异步监控会在loop退出的时候结束，也就是说，不会监控开启异步执行的任务
