### PR TITLE
fix: improve multi-auth bypass plugin usability

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -834,7 +834,7 @@ jobs:
             artifact_file: "essential-tests-coreplugin.tar.gz"
             test_configs: |
               [
-                {"package": "./common/coreplugin", "timeout": "6m", "skip": "^(TestAnalyzeMustPASSCorePlugin|TestAnalyzeMustPASSCorePlugin_Debug|TestGRPCMUSTPASS_MITM|TestGRPCMUSTPASS_Fastjson|TestGRPCMUSTPASS_SQL.*|TestGRPCMUSTPASS_XSS.*|TestGRPCMUSTPASS_Shiro.*|TestGRPCMUSTPASS_SSRF.*|TestGRPCMUSTPASS_SSTI.*|TestGRPCMUSTPASS_Smuggle.*|TestGRPCMUSTPASS_Pipeline_Negative_Chunked.*|TestGRPCMUSTPASS_CSRF.*|TestGRPCMUSTPASS_OPEN_REDIRECT.*|TestGRPCMUSTPASS_SwaggerJson.*)$"}
+                {"package": "./common/coreplugin", "timeout": "6m", "skip": "^(TestAnalyzeMustPASSCorePlugin|TestAnalyzeMustPASSCorePlugin_Debug|TestGRPCMUSTPASS_MITM|TestGRPCMUSTPASS_Fastjson|TestGRPCMUSTPASS_SQL.*|TestGRPCMUSTPASS_XSS.*|TestGRPCMUSTPASS_Shiro.*|TestGRPCMUSTPASS_SSRF.*|TestGRPCMUSTPASS_SSTI.*|TestGRPCMUSTPASS_Smuggle.*|TestGRPCMUSTPASS_Pipeline_Negative_Chunked.*|TestGRPCMUSTPASS_CSRF.*|TestGRPCMUSTPASS_OPEN_REDIRECT.*|TestGRPCMUSTPASS_SwaggerJson.*|TestDEBUG_MITM|TestFastjson)$"}
               ]
     steps:
       - name: Checkout

--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -828,6 +828,14 @@ jobs:
               [
                 {"package": "./common/coreplugin", "timeout": "6m", "run": "^(TestGRPCMUSTPASS_XSS.*|TestGRPCMUSTPASS_Shiro.*|TestGRPCMUSTPASS_SSRF.*|TestGRPCMUSTPASS_SSTI.*|TestGRPCMUSTPASS_Smuggle.*|TestGRPCMUSTPASS_Pipeline_Negative_Chunked.*|TestGRPCMUSTPASS_CSRF.*|TestGRPCMUSTPASS_OPEN_REDIRECT.*|TestGRPCMUSTPASS_SwaggerJson.*)$"}
               ]
+
+          - name: "Test Coreplugin Other"
+            artifact_name: "essential-tests-coreplugin"
+            artifact_file: "essential-tests-coreplugin.tar.gz"
+            test_configs: |
+              [
+                {"package": "./common/coreplugin", "timeout": "6m", "skip": "^(TestAnalyzeMustPASSCorePlugin|TestAnalyzeMustPASSCorePlugin_Debug|TestGRPCMUSTPASS_MITM|TestGRPCMUSTPASS_Fastjson|TestGRPCMUSTPASS_SQL.*|TestGRPCMUSTPASS_XSS.*|TestGRPCMUSTPASS_Shiro.*|TestGRPCMUSTPASS_SSRF.*|TestGRPCMUSTPASS_SSTI.*|TestGRPCMUSTPASS_Smuggle.*|TestGRPCMUSTPASS_Pipeline_Negative_Chunked.*|TestGRPCMUSTPASS_CSRF.*|TestGRPCMUSTPASS_OPEN_REDIRECT.*|TestGRPCMUSTPASS_SwaggerJson.*)$"}
+              ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -374,6 +374,7 @@ jobs:
     needs: prepare-yak
     if: needs.prepare-yak.result == 'success'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -398,7 +399,7 @@ jobs:
             test_configs: |
               [
                 {"package": "./common/yak/yaktest/mustpass", "timeout": "5m"},
-                {"package": ".common/crep/...", "timeout": "5m"}
+                {"package": "./common/crep/...", "timeout": "5m"}
               ]
 
           - name: "Test Utils Infra / Parser / Net in 2min USE gRPC"
@@ -646,6 +647,7 @@ jobs:
     needs: [prepare-yak, prepare-yakgrpc]
     if: needs.prepare-yak.result == 'success' && needs.prepare-yakgrpc.result == 'success'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -5,7 +5,7 @@ package consts
 // ExistedCorePluginEmbedFSHash contains the SHA256 hash of the embedded core plugin filesystem.
 // This hash is used to verify the integrity of core plugins and detect changes in the plugin bundle.
 // The hash is automatically generated during the build process and should not be manually modified.
-const ExistedCorePluginEmbedFSHash string = "09e796d1d90208e91e371cc354c4f17b2c1705573b42eea5166170dee1b45fe5"
+const ExistedCorePluginEmbedFSHash string = "bf5b7fff8bc5d7072715df0eb86f5ce2cea52fc954a064bb3e037e90c03f0d94"
 
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -15,7 +15,7 @@ const ExistedSyntaxFlowEmbedFSHash string = "654ac380b8b147d0dbf12ebc476e6f77353
 // ExistedBuildInForgeEmbedFSHash contains the SHA256 hash of the embedded build-in forge filesystem.
 // This hash is used to verify the integrity of the built-in forge templates and resources.
 // The forge system provides templates for code generation and vulnerability testing scenarios.
-const ExistedBuildInForgeEmbedFSHash string = "647e85a0d30b0ae37f5ac2a44ba20a07565529de82e12270a4b84a355d36d528"
+const ExistedBuildInForgeEmbedFSHash string = "fc4a4e2d78964fe9d2d693e9f6f484e390a41b720802fb5b832245cff2a0bc01"
 
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.

--- a/common/coreplugin/base-yak-plugin/SyntaxFlow Searcher.yak
+++ b/common/coreplugin/base-yak-plugin/SyntaxFlow Searcher.yak
@@ -57,7 +57,7 @@ func getCache(k) {
     }
     resID := parseInt(value)
     // check  result id is valid
-    res, err := ssa.NewResultFromDB(resID)
+    res, err := ssa.NewResultFromDB(resID, true)
     if err == nil {
         log.info("cache resultId is valid, use it. with-key:%s" , key)
         return resID

--- a/common/coreplugin/base-yak-plugin/多认证综合越权测试.yak
+++ b/common/coreplugin/base-yak-plugin/多认证综合越权测试.yak
@@ -1,5 +1,8 @@
+kvHelp = "配置参与测试的认证信息。每行一条，可选择 Header 或 Cookie；如需测试整条 Cookie 头，请选择 Header 并把 Key 填为 Cookie。多个需要同时替换的认证项可设置相同分组。"
+
 args = cli.Json(
-    "kv", 
+    "kv",
+    cli.setHelp(kvHelp),
     cli.setJsonSchema(
         <<<JSON
 {
@@ -15,17 +18,17 @@ args = cli.Json(
             "title": "认证类型",
             "type": "string",
             "enum": [
-                "Header",
-                "Cookie"
+              "Header",
+              "Cookie"
             ],
             "default": "Header",
             "description": "设置认证信息，如果需要对整体 Cookie 进行测试，请使用 Header 模式，Key 填写 Cookie 即可"
-            },
+          },
           "force": {
             "type": "boolean",
             "default": true,
             "title": "强制添加",
-            "description":"默认如果源数据包不存在这个认证信息，则不测试，勾选本选项后，即使源数据包不存在这个认证信息，也会测试"
+            "description": "默认如果源数据包不存在这个认证信息，则不测试，勾选本选项后，即使源数据包不存在这个认证信息，也会测试"
           },
           "key": {
             "type": "string",
@@ -35,7 +38,7 @@ args = cli.Json(
           "value": {
             "type": "string",
             "title": "Value",
-            "description": "认证字段值（单行），如果需要多个认证，请添加新的认证信息，如果有多个关联的认证信息，请设置分组"
+            "description": "认证字段值（支持多行），如果需要多个认证，请添加新的认证信息，如果有多个关联的认证信息，请设置分组"
           },
           "group": {
             "type": "string",
@@ -66,47 +69,117 @@ args = cli.Json(
     }
   }
 }
-JSON, 
+JSON,
         cli.setUISchema(
             cli.uiGroups(cli.uiGroup(cli.uiField(
-                "kvs", 
-                1, 
-                cli.uiFieldWidget(cli.uiWidgetTable), 
+                "kvs",
+                1,
+                cli.uiFieldWidget(cli.uiWidgetTable),
                 cli.uiFieldGroups(cli.uiGroup(cli.uiField(
-                    "items", 
-                    1, 
+                    "items",
+                    1,
                     cli.uiFieldGroups(cli.uiGroup(
                         cli.uiTableField("kind", 100),
                         cli.uiTableField("key", 100),
                         cli.uiTableField("value", 260, cli.uiFieldWidget(cli.uiWidgetTextarea)),
                         cli.uiTableField("force", 86),
                         cli.uiTableField("group", 86)
-                    )), 
-                ))), 
+                    )),
+                ))),
             ))),
             cli.uiGlobalFieldPosition(cli.uiPosHorizontal),
-        ), 
-    ), 
-    cli.setRequired(true), 
+        ),
+    ),
+    cli.setRequired(true),
 )
-enableUnauth = cli.Bool("enable-unauth", cli.setRequired(true), cli.setVerboseName("未授权检测"), cli.setHelp("【开启】会测试两种场景：1) 用配置的认证信息发送请求（横向越权检测）；2) 移除认证信息发送请求（未授权访问检测）。【关闭】仅测试：用配置的认证信息发送请求（横向越权检测），不测试未授权访问。注意：此功能仅在配置了认证信息且认证Value不为空时生效"), cli.setDefault(true))
-disableDomain = cli.String("disable-domain", cli.setRequired(false), cli.setVerboseName("不检测的域名"), cli.setCliGroup("高级（可选参数）"))
-disablePath = cli.String("disable-path", cli.setRequired(false), cli.setVerboseName("不检测的路径"), cli.setCliGroup("高级（可选参数）"))
-disableTypes = cli.StringSlice("disable-types", cli.setMultipleSelect(true), cli.setSelectOption("js", "js"), cli.setSelectOption("css", "css"), cli.setSelectOption("img", "img"), cli.setSelectOption("font", "font"), cli.setDefault("js,css,img,font"), cli.setRequired(false), cli.setVerboseName("忽略静态资源类型"), cli.setCliGroup("高级（可选参数）"))
-disableSuffix = cli.StringSlice("disable-suffix", cli.setVerboseName("不检测的后缀类型"), cli.setCliGroup("高级（可选参数）"), cli.setMultipleSelect(true))
 
+enableUnauth = cli.Bool(
+    "enable-unauth",
+    cli.setRequired(true),
+    cli.setVerboseName("未授权检测"),
+    cli.setHelp("【开启】会测试两种场景：1) 用配置的认证信息发送请求（横向越权检测）；2) 移除认证信息发送请求（未授权访问检测）。【关闭】仅测试：用配置的认证信息发送请求（横向越权检测），不测试未授权访问。注意：此功能仅在配置了认证信息且认证Value不为空时生效"),
+    cli.setDefault(true),
+)
 
-enableDomain = cli.String("enable-domain", cli.setRequired(false), cli.setVerboseName("需检测域名"), cli.setCliGroup("高级（可选参数）"))
-enablePath = cli.String("enable-path", cli.setRequired(false), cli.setVerboseName("需检测路径"), cli.setCliGroup("高级（可选参数）"))
-enableResponseKeyword = cli.Text("enable-response-content", cli.setRequired(false), cli.setVerboseName("需检测响应内容标志值"), cli.setCliGroup("高级（可选参数）"))
+disableDomain = cli.StringSlice(
+    "disable-domain",
+    cli.setMultipleSelect(true),
+    cli.setRequired(false),
+    cli.setVerboseName("不检测的域名"),
+    cli.setHelp("支持多条输入，也兼容单条中使用英文逗号分隔；支持 glob 匹配"),
+    cli.setCliGroup("高级（可选参数）"),
+)
+
+disablePath = cli.StringSlice(
+    "disable-path",
+    cli.setMultipleSelect(true),
+    cli.setRequired(false),
+    cli.setVerboseName("不检测的路径"),
+    cli.setHelp("支持多条输入，也兼容单条中使用英文逗号分隔；支持 glob 匹配"),
+    cli.setCliGroup("高级（可选参数）"),
+)
+
+disableTypes = cli.StringSlice(
+    "disable-types",
+    cli.setMultipleSelect(true),
+    cli.setSelectOption("js", "js"),
+    cli.setSelectOption("css", "css"),
+    cli.setSelectOption("img", "img"),
+    cli.setSelectOption("font", "font"),
+    cli.setDefault("js,css,img,font"),
+    cli.setRequired(false),
+    cli.setVerboseName("忽略静态资源类型"),
+    cli.setCliGroup("高级（可选参数）"),
+)
+
+disableSuffix = cli.StringSlice(
+    "disable-suffix",
+    cli.setMultipleSelect(true),
+    cli.setVerboseName("不检测的后缀类型"),
+    cli.setHelp("支持多条输入，也兼容单条中使用英文逗号分隔，例如 .pdf、.zip"),
+    cli.setCliGroup("高级（可选参数）"),
+)
+
+enableDomain = cli.StringSlice(
+    "enable-domain",
+    cli.setMultipleSelect(true),
+    cli.setRequired(false),
+    cli.setVerboseName("需检测域名"),
+    cli.setHelp("支持多条输入，也兼容单条中使用英文逗号分隔；支持 glob 匹配"),
+    cli.setCliGroup("高级（可选参数）"),
+)
+
+enablePath = cli.StringSlice(
+    "enable-path",
+    cli.setMultipleSelect(true),
+    cli.setRequired(false),
+    cli.setVerboseName("需检测路径"),
+    cli.setHelp("支持多条输入，也兼容单条中使用英文逗号分隔；支持 glob 匹配"),
+    cli.setCliGroup("高级（可选参数）"),
+)
+
+enableResponseKeyword = cli.Text(
+    "enable-response-content",
+    cli.setRequired(false),
+    cli.setVerboseName("需检测响应内容标志值"),
+    cli.setHelp("按行输入需要命中的响应内容；开启正则后，每行按正则表达式处理"),
+    cli.setCliGroup("高级（可选参数）"),
+)
+
 enableResponseKeywordRegexp = cli.Bool(
     "enable-response-content-regexp",
     cli.setRequired(false),
     cli.setVerboseName("响应内容标志值开启正则"),
     cli.setCliGroup("高级（可选参数）"),
 )
-onlyCheckBody = cli.Bool("only-body", cli.setVerboseName("只检查响应体"), cli.setDefault(true), cli.setCliGroup("高级（可选参数）"))
 
+onlyCheckBody = cli.Bool(
+    "only-body",
+    cli.setVerboseName("只检查响应体"),
+    cli.setHelp("开启后仅比较响应体，可减少响应头差异造成的干扰"),
+    cli.setDefault(true),
+    cli.setCliGroup("高级（可选参数）"),
+)
 
 cli.check()
 
@@ -127,7 +200,6 @@ ruleMap = {
     ],
 }
 
-once = sync.NewOnce()
 groupMap = make(map[string][]any)
 disableRules = []
 
@@ -145,7 +217,6 @@ for _, item = range args["kvs"] {
 for _, types = range disableTypes {
     disableRules = append(disableRules, ruleMap[types]...)
 }
-
 
 func product(sli, curr) {
     ret = make([][]any, 0, len(sli)*len(curr))
@@ -168,15 +239,12 @@ func _jsonKind(v) {
         if s == "" {
             return ""
         }
-        
         if str.HasPrefix(s, "[") {
             return "array"
         }
-        
         if str.HasPrefix(s, "{") {
             return "object"
         }
-        
         if str.HasPrefix(s, "\"") {
             return "string"
         }
@@ -210,16 +278,40 @@ func Product(sli) {
     for i in len(sli[0]) {
         ret = append(ret, [sli[0][i]])
     }
-    for i =1;i<len(sli);i++ {
+    for i = 1; i < len(sli); i++ {
         ret = product(ret, sli[i])
     }
     return ret
 }
 
+func normalizeRuleSlice(values) {
+    rules = []
+    for _, raw = range values {
+        for _, part = range str.Split(raw, ",") {
+            item = str.TrimSpace(part)
+            if item != "" {
+                rules = append(rules, item)
+            }
+        }
+    }
+    return rules
+}
+
+func normalizeTextLines(raw) {
+    lines = []
+    for _, line = range str.ParseStringToLines(raw) {
+        item = str.TrimSpace(line)
+        if item != "" {
+            lines = append(lines, item)
+        }
+    }
+    return lines
+}
+
 handleReq = (https, reqBytes, baseResponse, handleTag) => {
-    // yakit.Code(reqBytes)
+    basePacket = baseResponse
     if onlyCheckBody {
-        baseResponse = poc.GetHTTPPacketBody(baseResponse)
+        basePacket = poc.GetHTTPPacketBody(baseResponse)
     }
 
     poc.HTTP(
@@ -240,7 +332,7 @@ handleReq = (https, reqBytes, baseResponse, handleTag) => {
                     response.Green()
                 }
             } else {
-                sim := str.CalcSimilarity(baseResponse, currentPacket)
+                sim := str.CalcSimilarity(basePacket, currentPacket)
                 if sim > 0.95 {
                     response.Red()
                 } elif sim <= 0.4 {
@@ -258,82 +350,82 @@ handleReq = (https, reqBytes, baseResponse, handleTag) => {
     )
 }
 
-mirrorFilteredHTTPFlow = (https, url, req, rsp, body) => {
-    replaceResults = []
-    emptyResults = []
-    originReq = req
-
-    // 判断当前是否存在认证信息（决定是否启用未授权测试）
-    hasAuth = false
+func hasConfiguredAuth() {
     for _, items = range groupMap {
         for _, item = range items {
             if str.TrimSpace(item.value) != "" {
-                hasAuth = true
-                break
+                return true
             }
         }
     }
+    return false
+}
+
+func shouldSkipCurrentFlow(url, req, rsp) {
+    skipped = false
+    host, _, _ = str.ParseStringToHostPort(url)
+    path = poc.GetHTTPRequestPath(req)
+    urlRawPath = poc.GetHTTPRequestPathWithoutQuery(req)
+
+    disableDomainRules = normalizeRuleSlice(disableDomain)
+    disablePathRules = normalizeRuleSlice(disablePath)
+    enableDomainRules = normalizeRuleSlice(enableDomain)
+    enablePathRules = normalizeRuleSlice(enablePath)
+    disableSuffixRules = normalizeRuleSlice(disableSuffix)
+
+    if len(disableDomainRules) > 0 {
+        skipped = str.MatchAnyOfGlob(host, disableDomainRules...)
+    }
+
+    if !skipped && len(disablePathRules) > 0 {
+        skipped = str.MatchAnyOfGlob(path, disablePathRules...)
+    }
+
+    if !skipped && len(enableDomainRules) > 0 {
+        skipped = !str.MatchAnyOfGlob(host, enableDomainRules...)
+    }
+
+    if !skipped && len(enablePathRules) > 0 {
+        skipped = !str.MatchAnyOfGlob(path, enablePathRules...)
+    }
+
+    respMatch = str.MatchAnyOfRegexp
+    if !enableResponseKeywordRegexp {
+        respMatch = str.MatchAnyOfSubString
+    }
+
+    enableResponseKeywordList = []
+    if !skipped && enableResponseKeyword != "" {
+        enableResponseKeywordList = normalizeTextLines(enableResponseKeyword)
+        if len(enableResponseKeywordList) > 0 {
+            skipped = !respMatch(rsp, enableResponseKeywordList...)
+        }
+    }
+
+    if !skipped && len(disableRules) > 0 {
+        skipped = str.MatchAnyOfGlob(str.Split(urlRawPath, "?")[0], disableRules...)
+    }
+
+    if !skipped && len(disableSuffixRules) > 0 {
+        skipped = str.StringSliceContains(disableSuffixRules, file.GetExt(urlRawPath))
+    }
+
+    return skipped
+}
+
+buildAuthTestCases = (req) => {
+    replaceResults = []
+    emptyResults = []
 
     for _, items = range groupMap {
         replacedTmp = []
-        emptyTmp  = []
+        emptyTmp = []
         for _, item = range items {
             key = item.key
             values = str.ParseStringToLines(item.value)
             kind = item.kind
             force = item.force
 
-            skipped = false
-            host, _, _ = str.ParseStringToHostPort(url)
-            path = poc.GetHTTPRequestPath(req)
-            urlRawPath = poc.GetHTTPRequestPathWithoutQuery(req)
-
-            if disableDomain != "" {
-                rules = disableDomain.Split(",").Map(i => i.Trim())
-                skipped = str.MatchAnyOfGlob(host, rules...)
-            }
-
-
-            if !skipped && disablePath != "" {
-                skipped = str.MatchAnyOfGlob(path, disablePath.Split(",").Map(i => i.Trim())...)
-            }
-
-
-            if !skipped && enableDomain {
-                skipped = !str.MatchAnyOfGlob(host, enableDomain.Split(",").Map(i => i.Trim())...)
-            }
-
-
-            if !skipped && enablePath {
-                skipped = !str.MatchAnyOfGlob(path, enablePath.Split(",").Map(i => i.Trim())...)
-            }
-
-
-            respMatch = str.MatchAnyOfRegexp
-            if !enableResponseKeywordRegexp {
-                respMatch = str.MatchAnyOfSubString
-            }
-
-
-            enableResponseKeywordList = []
-            if !skipped && enableResponseKeyword {
-                enableResponseKeywordList = enableResponseKeyword.Split("\n")
-                skipped = !respMatch(rsp, enableResponseKeywordList...)
-            }
-
-            if !skipped && len(disableRules) > 0 {
-                skipped = str.MatchAnyOfGlob(str.Split(urlRawPath, "?")[0], disableRules...)
-            }
-
-            if !skipped && len(disableSuffix) > 0 {
-                skipped = str.StringSliceContains(disableSuffix, file.GetExt(urlRawPath))
-            }
-
-            if skipped {
-                return
-            }
-
-            
             if !force {
                 if kind == "Cookie" {
                     if poc.GetHTTPPacketCookie(req, key) == "" {
@@ -347,12 +439,13 @@ mirrorFilteredHTTPFlow = (https, url, req, rsp, body) => {
             }
 
             if kind == "Header" || kind == "Cookie" {
-                 for v in values {
-                    replacedTmp.Append({"key": key, "kind": kind, "value": v})
+                for _, value = range values {
+                    replacedTmp.Append({"key": key, "kind": kind, "value": value})
                 }
                 emptyTmp.Append({"key": key, "kind": kind, "value": ""})
             }
         }
+
         if len(replacedTmp) == 0 {
             replacedTmp.Append({"key": "", "kind": "", "value": ""})
             replaceResults.Append(replacedTmp)
@@ -362,8 +455,14 @@ mirrorFilteredHTTPFlow = (https, url, req, rsp, body) => {
             emptyResults.Append(emptyTmp)
         }
     }
-    dump(replaceResults)
 
+    return {
+        "replaceResults": replaceResults,
+        "emptyResults": emptyResults,
+    }
+}
+
+runReplaceDetection = (https, originReq, rsp, replaceResults) => {
     for seq in Product(replaceResults) {
         replaceReq = originReq
         tags = []
@@ -379,29 +478,45 @@ mirrorFilteredHTTPFlow = (https, url, req, rsp, body) => {
         tag = f"值 ${str.Join(tags, ", ")}"
         handleReq(https, replaceReq, rsp, tag)
     }
+}
 
-    // 未授权测试：仅满足条件时才执行
-    // 1. 用户填写了认证信息
-    // 2. 勾选了未授权检测开关
-    if hasAuth && enableUnauth {
-        for seq in Product(emptyResults) {
-            emptyReq = originReq
-            tags = []
-            for m in seq {
-                kind, key, value = m.kind, m.key, m.value
-                if kind == "Header" {
-                    if poc.GetHTTPPacketHeader(emptyReq, key) {
-                        emptyReq = poc.ReplaceHTTPPacketHeader(emptyReq, key, value)
-                    }
-                } else if kind == "Cookie" {
-                    if poc.GetHTTPPacketCookie(emptyReq, key) {
-                        emptyReq = poc.ReplaceHTTPPacketCookie(emptyReq, key, value)
-                    }
+runUnauthDetection = (https, originReq, rsp, emptyResults) => {
+    for seq in Product(emptyResults) {
+        emptyReq = originReq
+        tags = []
+        for m in seq {
+            kind, key, value = m.kind, m.key, m.value
+            if kind == "Header" {
+                if poc.GetHTTPPacketHeader(emptyReq, key) {
+                    emptyReq = poc.ReplaceHTTPPacketHeader(emptyReq, key, value)
                 }
-                tags = append(tags, f"${kind}[${key}]")
+            } else if kind == "Cookie" {
+                if poc.GetHTTPPacketCookie(emptyReq, key) {
+                    emptyReq = poc.ReplaceHTTPPacketCookie(emptyReq, key, value)
+                }
             }
-            tag = f"未授权检测 | 移除 ${str.Join(tags, ", ")}"
-            handleReq(https, emptyReq, rsp, tag)
+            tags = append(tags, f"${kind}[${key}]")
         }
+        tag = f"未授权检测 | 移除 ${str.Join(tags, ", ")}"
+        handleReq(https, emptyReq, rsp, tag)
+    }
+}
+
+mirrorFilteredHTTPFlow = (https, url, req, rsp, body) => {
+    originReq = req
+
+    if shouldSkipCurrentFlow(url, req, rsp) {
+        return
+    }
+
+    hasAuth = hasConfiguredAuth()
+    testCases = buildAuthTestCases(req)
+    replaceResults = testCases["replaceResults"]
+    emptyResults = testCases["emptyResults"]
+
+    runReplaceDetection(https, originReq, rsp, replaceResults)
+
+    if hasAuth && enableUnauth {
+        runUnauthDetection(https, originReq, rsp, emptyResults)
     }
 }

--- a/common/coreplugin/multi_auth_bypass_plugin_test.go
+++ b/common/coreplugin/multi_auth_bypass_plugin_test.go
@@ -1,0 +1,117 @@
+package coreplugin_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/coreplugin"
+	"github.com/yaklang/yaklang/common/yak/static_analyzer/information"
+	"github.com/yaklang/yaklang/common/yakgrpc"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func inspectCorePluginParams(t *testing.T, pluginName, pluginType string) (string, map[string]*ypb.YakScriptParam) {
+	t.Helper()
+
+	codeBytes := coreplugin.GetCorePluginData(pluginName)
+	require.NotNil(t, codeBytes)
+
+	client, err := yakgrpc.NewLocalClient()
+	require.NoError(t, err)
+
+	rsp, err := client.YaklangInspectInformation(context.Background(), &ypb.YaklangInspectInformationRequest{
+		YakScriptType: pluginType,
+		YakScriptCode: string(codeBytes),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, rsp)
+
+	params := make(map[string]*ypb.YakScriptParam)
+	for _, param := range rsp.GetCliParameter() {
+		params[param.Field] = param
+	}
+	return string(codeBytes), params
+}
+
+func decodeSelectExtra(t *testing.T, raw string) *information.PluginParamSelect {
+	t.Helper()
+
+	var extra information.PluginParamSelect
+	require.NoError(t, json.Unmarshal([]byte(raw), &extra))
+	return &extra
+}
+
+func TestMultiAuthBypassPlugin_FilterParamsSupportMultiValue(t *testing.T) {
+	_, params := inspectCorePluginParams(t, "多认证综合越权测试", "mitm")
+
+	checkMultiValueFilter := func(field string) {
+		t.Helper()
+
+		param, ok := params[field]
+		require.Truef(t, ok, "missing cli param: %s", field)
+		require.Equal(t, "select", param.TypeVerbose)
+		require.Equal(t, "select", param.MethodType)
+		require.Equal(t, "高级（可选参数）", param.Group)
+
+		extra := decodeSelectExtra(t, param.ExtraSetting)
+		require.True(t, extra.Double)
+		require.Empty(t, extra.Data)
+	}
+
+	for _, field := range []string{
+		"disable-domain",
+		"disable-path",
+		"disable-suffix",
+		"enable-domain",
+		"enable-path",
+	} {
+		checkMultiValueFilter(field)
+	}
+
+	require.Contains(t, params["disable-domain"].Help, "支持多条输入")
+	require.Contains(t, params["disable-path"].Help, "支持多条输入")
+	require.Contains(t, params["disable-suffix"].Help, ".pdf、.zip")
+	require.Contains(t, params["enable-domain"].Help, "支持多条输入")
+	require.Contains(t, params["enable-path"].Help, "支持多条输入")
+}
+
+func TestMultiAuthBypassPlugin_CompatibilityAndCleanup(t *testing.T) {
+	code, params := inspectCorePluginParams(t, "多认证综合越权测试", "mitm")
+
+	require.NotContains(t, code, "dump(replaceResults)")
+
+	kvParam, ok := params["kv"]
+	require.True(t, ok)
+	require.Equal(t, "json", kvParam.TypeVerbose)
+	require.Equal(t, "json", kvParam.MethodType)
+	require.True(t, kvParam.Required)
+	require.Contains(t, kvParam.Help, "配置参与测试的认证信息")
+	require.Contains(t, kvParam.JsonSchema, "支持多行")
+
+	enableUnauth, ok := params["enable-unauth"]
+	require.True(t, ok)
+	require.Equal(t, "boolean", enableUnauth.TypeVerbose)
+	require.Equal(t, "boolean", enableUnauth.MethodType)
+	require.True(t, enableUnauth.Required)
+	require.Contains(t, enableUnauth.Help, "未授权访问检测")
+
+	responseContent, ok := params["enable-response-content"]
+	require.True(t, ok)
+	require.Equal(t, "text", responseContent.TypeVerbose)
+	require.Equal(t, "text", responseContent.MethodType)
+	require.Contains(t, responseContent.Help, "按行输入")
+
+	onlyBody, ok := params["only-body"]
+	require.True(t, ok)
+	require.Equal(t, "boolean", onlyBody.TypeVerbose)
+	require.Equal(t, "高级（可选参数）", onlyBody.Group)
+	require.Contains(t, onlyBody.Help, "仅比较响应体")
+
+	disableTypes, ok := params["disable-types"]
+	require.True(t, ok)
+	extra := decodeSelectExtra(t, disableTypes.ExtraSetting)
+	require.True(t, extra.Double)
+	require.Len(t, extra.Data, 4)
+}

--- a/common/coreplugin/syntaxflow_searcher_test.go
+++ b/common/coreplugin/syntaxflow_searcher_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
@@ -24,6 +25,27 @@ import (
 	"github.com/yaklang/yaklang/common/yakgrpc"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
+
+func syntaxflowFileResourceName(progName, path string) string {
+	return fmt.Sprintf("%q", "/"+progName+path)
+}
+
+func waitForProfileKey(t *testing.T, client ypb.YakClient, key string) string {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		res, err := client.GetKey(context.Background(), &ypb.GetKeyRequest{Key: key})
+		require.NoError(t, err)
+		if value := res.GetValue(); value != "" {
+			return value
+		}
+		if time.Now().After(deadline) {
+			return ""
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
 
 func sendSSAURL(t *testing.T, local ypb.YakClient, resultID int, programName, kind string) []*ypb.YakURLResource {
 	url := &ypb.RequestYakURLParams{
@@ -249,7 +271,7 @@ funcA(222);
 			"Undefined-funcA":          {"funcA"},
 			"Function-funcA(111)":      {"funcA(111)"},
 			"Undefined-funcA(222)":     {"funcA(222)"},
-			`"var/www/html/funcA.php"`: {code3},
+			syntaxflowFileResourceName(s.progName, "/var/www/html/funcA.php"): {code3},
 		})
 		s.SearchAndCheck(t, "all", "funcA", true, map[string][]string{
 			"Function-funcA":           {"function funcA(){}"},
@@ -259,7 +281,7 @@ funcA(222);
 			`"funcA("`:                 {"funcA("},
 			"Function-funcA(111)":      {"funcA(111)"},
 			"Undefined-funcA(222)":     {"funcA(222)"},
-			`"var/www/html/funcA.php"`: {code3},
+			syntaxflowFileResourceName(s.progName, "/var/www/html/funcA.php"): {code3},
 		})
 	})
 
@@ -293,7 +315,7 @@ funcA(222);
 
 	t.Run("check file funcA", func(t *testing.T) {
 		s.SearchAndCheck(t, "file", "funcA", false, map[string][]string{
-			`"var/www/html/funcA.php"`: {code3},
+			syntaxflowFileResourceName(s.progName, "/var/www/html/funcA.php"): {code3},
 		})
 	})
 
@@ -343,12 +365,12 @@ funcA(222);
 		`"funcA("`:                 {"funcA("},
 		"Function-funcA(111)":      {"funcA(111)"},
 		"Undefined-funcA(222)":     {"funcA(222)"},
-		`"var/www/html/funcA.php"`: {code3},
+		syntaxflowFileResourceName(s.progName, "/var/www/html/funcA.php"): {code3},
 	})
 
 	// check file
 	s.Check(t, "file", result, map[string][]string{
-		`"var/www/html/funcA.php"`: {code3},
+		syntaxflowFileResourceName(s.progName, "/var/www/html/funcA.php"): {code3},
 	})
 
 	// check function
@@ -405,11 +427,7 @@ funcA(222);
 		// check database cache
 		key := fmt.Sprint([]any{s.progName, "all", "funcA", true})
 		log.Infof("key: %s", key)
-		res, err := s.local.GetKey(context.Background(), &ypb.GetKeyRequest{
-			Key: key,
-		})
-		require.NoError(t, err)
-		got := res.GetValue()
+		got := waitForProfileKey(t, s.local, key)
 		log.Infof("got: %v", got)
 		gotResult, err := strconv.Atoi(got)
 		require.NoError(t, err)

--- a/scripts/ci/test-run-suite.sh
+++ b/scripts/ci/test-run-suite.sh
@@ -10,6 +10,7 @@ TEST_TIMEOUT="${TEST_TIMEOUT:-2m}"
 TEST_VERBOSE="${TEST_VERBOSE:-1}"
 SKIP_SYNC_EMBED_RULE_IN_GITHUB="${SKIP_SYNC_EMBED_RULE_IN_GITHUB:-true}"
 TEST_LOG_DIR="${TEST_LOG_DIR:-$TEST_BIN_DIR}"
+SUITE_TIMEOUT="${SUITE_TIMEOUT:-50m}"
 
 if [[ -z "$YAK_BINARY_PATH" || -z "$TEST_BIN_DIR" || -z "$TEST_CONFIG" ]]; then
   echo "ERROR: YAK_BINARY_PATH, TEST_BIN_DIR, and TEST_CONFIG must be set"
@@ -34,6 +35,18 @@ stop_grpc() {
   fi
 }
 
+stop_children() {
+  pkill -P $$ 2>/dev/null || true
+}
+
+terminate_suite() {
+  echo "Suite interrupted, stopping child processes..." | tee -a "${suite_log:-/dev/stderr}"
+  stop_children
+  stop_grpc
+  exit 143
+}
+
+trap terminate_suite INT TERM
 trap stop_grpc EXIT
 
 suite_log="${TEST_LOG_DIR}/suite.log"
@@ -44,6 +57,7 @@ mkdir -p "$TEST_LOG_DIR"
 rm -f "$TEST_LOG_DIR"/test_*.run.log "$grpc_log" "$suite_log"
 
 echo "=== Running suite: ${SUITE_NAME} ==="
+echo "Suite timeout: ${SUITE_TIMEOUT}"
 
 nohup env SKIP_SYNC_EMBED_RULE_IN_GITHUB="$SKIP_SYNC_EMBED_RULE_IN_GITHUB" "$YAK_BINARY_PATH" grpc >"$grpc_log" 2>&1 < /dev/null &
 grpc_pid=$!
@@ -70,4 +84,13 @@ if [[ "$SUITE_SYNC_RULE" == "1" ]]; then
 fi
 
 export TEST_LOG_DIR
-./scripts/ci/test-run.sh 2>&1 | tee -a "$suite_log"
+set +e
+timeout --signal=TERM --kill-after=30s "$SUITE_TIMEOUT" ./scripts/ci/test-run.sh 2>&1 | tee -a "$suite_log"
+suite_rc=${PIPESTATUS[0]}
+set -e
+
+if [[ "$suite_rc" -eq 124 ]]; then
+  echo "Suite timed out after ${SUITE_TIMEOUT}" | tee -a "$suite_log"
+fi
+
+exit "$suite_rc"


### PR DESCRIPTION
## 新增
- 过滤项支持多值输入：不检测域名、不检测路径、不检测的后缀类型、需检测域名、需检测路径 都改成了可多选/多值输入，且兼容单条里用英文逗号分隔。
- 响应内容标志值支持按行输入：需检测响应内容标志值 现在明确支持多行，每行一个标志值，配合正则开关一起用。
- 认证值支持多行候选值：Value 的说明改成支持多行，插件会按多行拆成多个候选值参与测试
- 关联认证分组能力被保留并说明更清楚：同组认证项会一起替换

## 修复
- 过滤逻辑统一重构：新增了规则归一化函数，保证多值/逗号分隔的过滤条件都按同一套逻辑生效
- 去掉调试输出：删掉了 dump(replaceResults)，避免执行时刷无关日志。

## 参考
@https://github.com/yaklang/yakit/issues/3568

## 其它
 - 添加之前被CI忽略的测试
 - 修复一些插件测试报错