### PR TITLE
refactor(yakvm): simplify current frame management

### DIFF
--- a/common/yak/antlr4yak/engine.go
+++ b/common/yak/antlr4yak/engine.go
@@ -468,6 +468,35 @@ func (n *Engine) SafeEvalInline(ctx context.Context, code string) (err error) {
 	return
 }
 
+func (n *Engine) SafeEvalInlineWithResult(ctx context.Context, code string) (ret *yakvm.Value, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = utils.Error(fmt.Sprint(e))
+		}
+	}()
+
+	compiler, err := n._compile(code, n.rootSymbol)
+	if err != nil {
+		return nil, utils.Errorf("compile error: \n%s", err)
+	}
+
+	n.vm.SetDebug(n.debug)
+	n.vm.SetDebugMode(n.debugMode, code, compiler.GetOpcodes(), n.debugInit, n.debugCallBack)
+	n.vm.SetCallFuncCallback(n.callFuncCallback)
+
+	codes := compiler.GetOpcodes()
+	err = n.vm.Exec(ctx, func(frame *yakvm.Frame) {
+		frame.SetVerbose("__yak_main__")
+		frame.SetOriginCode(code)
+		frame.Exec(codes)
+		ret = frame.GetLastStackValue()
+	}, yakvm.Inline)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func (n *Engine) FormattedAndSyntaxChecking(code string) (string, error) {
 	compiler, err := n._compile(code, n.rootSymbol)
 	if err != nil {
@@ -480,12 +509,7 @@ func (n *Engine) ExecuteAsBooleanExpression(expr string, dependencies map[string
 	if dependencies != nil {
 		n.ImportLibs(dependencies)
 	}
-	err := n.SafeEvalInline(context.Background(), expr)
-	if err != nil {
-		return false, err
-	}
-
-	val, err := n.GetLastStackValue()
+	val, err := n.SafeEvalInlineWithResult(context.Background(), expr)
 	if err != nil {
 		return false, err
 	}
@@ -505,13 +529,7 @@ func (n *Engine) ExecuteAsExpression(expr string, dependencies map[string]interf
 	if dependencies != nil {
 		n.ImportLibs(dependencies)
 	}
-
-	err := n.SafeEvalInline(context.Background(), expr)
-	if err != nil {
-		return nil, err
-	}
-
-	val, err := n.GetLastStackValue()
+	val, err := n.SafeEvalInlineWithResult(context.Background(), expr)
 	if err != nil {
 		return nil, err
 	}

--- a/common/yak/antlr4yak/yakvm/current_frame_test.go
+++ b/common/yak/antlr4yak/yakvm/current_frame_test.go
@@ -1,0 +1,33 @@
+package yakvm
+
+import (
+	"context"
+	"testing"
+)
+
+func TestExecPanicClearsCurrentFrame(t *testing.T) {
+	vm := New()
+
+	gotPanic := false
+	func() {
+		defer func() {
+			if recover() != nil {
+				gotPanic = true
+			}
+		}()
+
+		err := vm.Exec(context.Background(), func(frame *Frame) {
+			panic("boom")
+		})
+		if err != nil {
+			t.Fatalf("unexpected exec error: %v", err)
+		}
+	}()
+
+	if !gotPanic {
+		t.Fatal("expected panic from Exec")
+	}
+	if frame := vm.CurrentFM(); frame != nil {
+		t.Fatalf("expected current frame to be cleared after panic, got %#v", frame)
+	}
+}

--- a/common/yak/antlr4yak/yakvm/func.go
+++ b/common/yak/antlr4yak/yakvm/func.go
@@ -249,10 +249,10 @@ func (vm *Frame) CallYakFunction(asyncCall bool, f *Function, vs []*Value) inter
 	params := YakVMValuesToFunctionMap(f, vs, vm.vm.config.GetFunctionNumberCheck())
 
 	if asyncCall {
-		vm.vm.ExecAsyncYakFunction(vm.ctx, f, params)
+		vm.vm.ExecAsyncYakFunction(vm.ctx, vm, f, params)
 		return nil
 	}
-	v, _ := vm.vm.ExecYakFunction(vm.ctx, f, params)
+	v, _ := vm.vm.execYakFunctionWithParentFrame(vm.ctx, vm, f, params, nil)
 
 	return v
 }
@@ -265,7 +265,7 @@ func (vm *Frame) CallLuaFunction(asyncCall bool, f *Function, vs []*Value) inter
 	//	vm.vm.ExecAsyncYakFunction(f, params)
 	//	return nil
 	//}
-	v, _ := vm.vm.ExecYakFunction(vm.ctx, f, params)
+	v, _ := vm.vm.execYakFunctionWithParentFrame(vm.ctx, vm, f, params, nil)
 
 	return v
 }

--- a/common/yak/antlr4yak/yakvm/virtual_machine.go
+++ b/common/yak/antlr4yak/yakvm/virtual_machine.go
@@ -34,11 +34,6 @@ func GetFlag(flags ...ExecFlag) ExecFlag {
 	return flag
 }
 
-// vmCurrentFrameKey is the context key for the current executing Frame.
-// Storing the frame in context makes sub-function calls goroutine-safe:
-// each call chain carries its own Frame reference instead of sharing VMStack.Peek().
-type vmCurrentFrameKey struct{}
-
 type YakitFeedbacker interface{}
 type (
 	BreakPointFactoryFun func(v *VirtualMachine) bool
@@ -47,8 +42,6 @@ type (
 		globalVar        *limitedmap.ReadOnlyMap
 		runtimeGlobalVar *limitedmap.SafeMap
 
-		VMStack       *vmstack.Stack
-		vmstackMu     sync.Mutex
 		frameStacksMu sync.RWMutex
 		frameStacks   map[int64]*vmstack.Stack
 		rootScope     *Scope
@@ -152,7 +145,6 @@ func NewWithSymbolTable(table *SymbolTable) *VirtualMachine {
 	v := &VirtualMachine{
 		// rootSymbol: table,
 		rootScope:        NewScope(table),
-		VMStack:          vmstack.New(),
 		frameStacks:      make(map[int64]*vmstack.Stack),
 		globalVar:        limitedmap.NewReadOnlyMap(map[string]any{}),
 		runtimeGlobalVar: limitedmap.NewSafeMap(map[string]any{}),
@@ -255,16 +247,20 @@ func (n *VirtualMachine) GetDebugger() *Debugger {
 }
 
 func (v *VirtualMachine) ExecYakFunction(ctx context.Context, f *Function, args map[int]*Value, flags ...ExecFlag) (interface{}, error) {
-	return v.ExecYakFunctionEx(ctx, f, args, nil, flags...)
+	return v.execYakFunctionWithParentFrame(ctx, nil, f, args, nil, flags...)
 }
 
 func (v *VirtualMachine) ExecYakFunctionEx(ctx context.Context, f *Function, args map[int]*Value, frameCallback func(*Frame), flags ...ExecFlag) (interface{}, error) {
+	return v.execYakFunctionWithParentFrame(ctx, nil, f, args, frameCallback, flags...)
+}
+
+func (v *VirtualMachine) execYakFunctionWithParentFrame(ctx context.Context, parentFrame *Frame, f *Function, args map[int]*Value, frameCallback func(*Frame), flags ...ExecFlag) (interface{}, error) {
 	var value interface{}
 	finalFlags := []ExecFlag{Sub}
 	if len(flags) > 0 {
 		finalFlags = flags
 	}
-	err := v.Exec(ctx, func(frame *Frame) {
+	err := v.exec(ctx, parentFrame, func(frame *Frame) {
 		if v.sandboxMode && f.defineFrame != nil {
 			frame = NewSubFrame(f.defineFrame)
 		}
@@ -296,15 +292,14 @@ func (v *VirtualMachine) ExecYakFunctionEx(ctx context.Context, f *Function, arg
 	return value, nil
 }
 
-func (v *VirtualMachine) ExecAsyncYakFunction(ctx context.Context, f *Function, args map[int]*Value) error {
+func (v *VirtualMachine) ExecAsyncYakFunction(ctx context.Context, parentFrame *Frame, f *Function, args map[int]*Value) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
-	parentFrame, _ := ctx.Value(vmCurrentFrameKey{}).(*Frame)
 	if parentFrame == nil && !(v.sandboxMode && f.defineFrame != nil) {
-		log.Errorf("BUG: VMStack is empty(Sub)")
-		return utils.Error("BUG: VMStack is empty(Sub)")
+		log.Errorf("BUG: current frame is empty(Sub)")
+		return utils.Error("BUG: current frame is empty(Sub)")
 	}
 
 	var frame *Frame
@@ -324,7 +319,6 @@ func (v *VirtualMachine) ExecAsyncYakFunction(ctx context.Context, f *Function, 
 		frame.CurrentScope().NewValueByID(id, arg)
 	}
 
-	ctx = context.WithValue(ctx, vmCurrentFrameKey{}, frame)
 	frame.ctx = ctx
 
 	go func() {
@@ -362,6 +356,10 @@ func (v *VirtualMachine) InlineExecYakCode(ctx context.Context, codes []*Code, f
 }
 
 func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags ...ExecFlag) error {
+	return v.exec(ctx, nil, f, flags...)
+}
+
+func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(frame *Frame), flags ...ExecFlag) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -370,24 +368,20 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 
 	var frame *Frame
 	if flag&Sub == Sub {
-		// Get parent frame from context instead of VMStack.Peek().
-		// This makes concurrent calls goroutine-safe: each call chain carries its
-		// own Frame via context rather than competing on a shared VMStack.
-		parentFrame, _ := ctx.Value(vmCurrentFrameKey{}).(*Frame)
 		if parentFrame == nil {
-			log.Errorf("BUG: VMStack is empty(Sub)")
-			return utils.Error("BUG: VMStack is empty(Sub)")
+			parentFrame = v.peekCurrentFrame()
+		}
+		if parentFrame == nil {
+			log.Errorf("BUG: current frame is empty(Sub)")
+			return utils.Error("BUG: current frame is empty(Sub)")
 		}
 		frame = NewSubFrame(parentFrame)
 	} else if flag&Inline == Inline {
-		// Inline mode reuses the current frame in-place (used by eval/debugger).
-		// It is not designed for concurrent use; keep VMStack-based lookup here.
 		topFrame := v.peekCurrentFrame()
 
 		if topFrame == nil {
 			topFrame = NewFrame(v)
-			v.pushCurrentFrame(topFrame)
-			log.Debugf("VMStack is empty(Inline), we create new frame")
+			log.Debugf("current frame is empty(Inline), create new frame")
 		}
 
 		frame = topFrame
@@ -408,14 +402,13 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 		frame.coroutine = NewCoroutine()
 	}
 
-	// Store the current frame in context so nested Sub-mode calls (child function
-	// invocations) can find their correct parent frame without touching VMStack.
-	ctx = context.WithValue(ctx, vmCurrentFrameKey{}, frame)
-	// frame.ctx propagates the updated context to child calls via
-	// frame.CallYakFunction(vm.ctx, ...) in func.go.
 	frame.ctx = ctx
 
 	v.pushCurrentFrame(frame)
+	shouldPop := flag&Trace != Trace
+	if shouldPop {
+		defer v.popCurrentFrame()
+	}
 
 	frame.debug = v.debug
 	if v.debugMode && v.debugger != nil && v.debugger.initFunc != nil {
@@ -424,9 +417,6 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 
 	f(frame)
 
-	if flag&Trace != Trace {
-		v.popCurrentFrame()
-	}
 	if flag&Asnyc != Asnyc {
 		if lastPanic := frame.recover(); lastPanic != nil {
 			lastPanic.contextInfos.Peek().(*PanicInfo).SetPositionVerbose(frame.GetVerbose())
@@ -465,7 +455,7 @@ func currentGoroutineID() int64 {
 	return id
 }
 
-func (v *VirtualMachine) getCurrentFrameStack(gid int64, create bool) *vmstack.Stack {
+func (v *VirtualMachine) getGoroutineFrameStack(gid int64, create bool) *vmstack.Stack {
 	v.frameStacksMu.Lock()
 	defer v.frameStacksMu.Unlock()
 
@@ -481,7 +471,7 @@ func (v *VirtualMachine) getCurrentFrameStack(gid int64, create bool) *vmstack.S
 
 func (v *VirtualMachine) pushCurrentFrame(frame *Frame) {
 	gid := currentGoroutineID()
-	stack := v.getCurrentFrameStack(gid, true)
+	stack := v.getGoroutineFrameStack(gid, true)
 	stack.Push(frame)
 }
 


### PR DESCRIPTION
把 YakVM 的 current frame 管理做了一次性清理：去掉了 ctx 中隐式传递 frame 的做法，改成函数调用链显式传 parentFrame；保留 goroutine-local frameStacks 作为唯一的当前执行态来源；同步调整 Exec() 为 defer 成对
清理当前 frame，避免 panic/recover 后残留脏 stack；同时删除已废弃的 VMStack/vmstackMu 冗余代码，并补了一条测试覆盖 panic 后 current frame 必须被清空的边界场景。