### PR TITLE
feat(mcp): add project database management tools

### DIFF
--- a/common/mcp/command.go
+++ b/common/mcp/command.go
@@ -17,7 +17,7 @@ import (
 
 var MCPCommandUsage = `Start a mcp server for providing mcp service.
 
-Available ToolSets: codec, cve, httpflow, hybrid_scan, payload, port_scan, yak_document, yak_script, reverse_shell, http_fuzzer, brute, subdomain, crawler, dynamic, ssa
+Available ToolSets: codec, cve, httpflow, hybrid_scan, payload, port_scan, yak_document, yak_script, reverse_shell, http_fuzzer, brute, subdomain, crawler, dynamic, ssa, project_database
 
 Available ResourceSets: codec`
 

--- a/common/mcp/project_database.go
+++ b/common/mcp/project_database.go
@@ -1,0 +1,313 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/server"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+type databaseContext struct {
+	YakitHome            string                  `json:"yakit_home"`
+	DefaultProjectDBPath string                  `json:"default_project_db_path"`
+	CurrentProjectDBPath string                  `json:"current_project_db_path"`
+	CurrentProfileDBPath string                  `json:"current_profile_db_path"`
+	ProjectType          string                  `json:"project_type"`
+	CurrentProject       *ypb.ProjectDescription `json:"current_project,omitempty"`
+}
+
+type projectDatabaseItem struct {
+	ID              int64  `json:"id"`
+	ProjectName     string `json:"project_name"`
+	Description     string `json:"description,omitempty"`
+	Type            string `json:"type"`
+	DatabasePath    string `json:"database_path"`
+	IsCurrent       bool   `json:"is_current"`
+	UpdateAt        int64  `json:"updated_at"`
+	FolderName      string `json:"folder_name,omitempty"`
+	ChildFolderName string `json:"child_folder_name,omitempty"`
+}
+
+func init() {
+	AddGlobalToolSet("project_database",
+		WithTool(mcp.NewTool("get_current_database_context",
+			mcp.WithDescription("Get current MCP database context, including yakit home, current project database path, default project database path, and current project metadata"),
+			mcp.WithString("projectType",
+				mcp.Description("Project type to inspect"),
+				mcp.Enum(yakit.TypeProject, yakit.TypeSSAProject),
+			),
+		), handleGetCurrentDatabaseContext),
+		WithTool(mcp.NewTool("list_project_databases",
+			mcp.WithDescription("List available project databases from Yakit profile database, including project id, path, current status and basic project metadata"),
+			mcp.WithString("projectType",
+				mcp.Description("Project type to list"),
+				mcp.Enum(yakit.TypeProject, yakit.TypeSSAProject),
+			),
+			mcp.WithString("keyword",
+				mcp.Description("Keyword to filter project name or description"),
+			),
+			mcp.WithNumber("limit",
+				mcp.Description("Maximum number of projects to return"),
+				mcp.Default(20),
+				mcp.Min(1),
+				mcp.Max(200),
+			),
+		), handleListProjectDatabases),
+		WithTool(mcp.NewTool("switch_current_project_database",
+			mcp.WithDescription("Switch the current project database by project id. Warning: this changes the current project in the current MCP/Yak process, not just one query"),
+			mcp.WithNumber("id",
+				mcp.Description("Project id returned by list_project_databases"),
+				mcp.Required(),
+			),
+			mcp.WithString("projectType",
+				mcp.Description("Project type to switch"),
+				mcp.Enum(yakit.TypeProject, yakit.TypeSSAProject),
+			),
+		), handleSwitchCurrentProjectDatabase),
+		WithTool(mcp.NewTool("create_project_database",
+			mcp.WithDescription("Create a new project database in Yakit and optionally switch current project to the newly created project"),
+			mcp.WithString("projectName",
+				mcp.Description("Project name"),
+				mcp.Required(),
+			),
+			mcp.WithString("description",
+				mcp.Description("Project description"),
+			),
+			mcp.WithString("projectType",
+				mcp.Description("Project type to create"),
+				mcp.Enum(yakit.TypeProject, yakit.TypeSSAProject),
+			),
+			mcp.WithBool("switchToCurrent",
+				mcp.Description("Whether to switch current project to the newly created project after creation"),
+				mcp.Default(true),
+			),
+			mcp.WithString("databasePath",
+				mcp.Description("Optional absolute database path. If empty, backend auto-creates a project database file"),
+			),
+		), handleCreateProjectDatabase),
+	)
+}
+
+func normalizeProjectType(raw string) string {
+	switch raw {
+	case "", yakit.TypeProject:
+		return yakit.TypeProject
+	case yakit.TypeSSAProject:
+		return yakit.TypeSSAProject
+	default:
+		return yakit.TypeProject
+	}
+}
+
+func buildCurrentDatabaseContext(ctx context.Context, s *MCPServer, projectType string) *databaseContext {
+	projectType = normalizeProjectType(projectType)
+	currentProject, err := s.grpcClient.GetCurrentProjectEx(ctx, &ypb.GetCurrentProjectExRequest{Type: projectType})
+	if err != nil {
+		currentProject = nil
+	}
+	yakitHome := consts.GetDefaultYakitBaseDir()
+	defaultProjectDBPath := consts.GetDefaultYakitProjectDatabase(yakitHome)
+	currentProjectDBPath := consts.GetCurrentProjectDatabasePath()
+	if currentProject != nil && currentProject.GetDatabasePath() != "" && projectType == yakit.TypeProject {
+		currentProjectDBPath = currentProject.GetDatabasePath()
+	}
+
+	return &databaseContext{
+		YakitHome:            yakitHome,
+		DefaultProjectDBPath: defaultProjectDBPath,
+		CurrentProjectDBPath: currentProjectDBPath,
+		CurrentProfileDBPath: consts.GetCurrentProfileDatabasePath(),
+		ProjectType:          projectType,
+		CurrentProject:       currentProject,
+	}
+}
+
+func handleGetCurrentDatabaseContext(s *MCPServer) server.ToolHandlerFunc {
+	return func(
+		ctx context.Context,
+		request mcp.CallToolRequest,
+	) (*mcp.CallToolResult, error) {
+		projectType := normalizeProjectType(utils.MapGetString(request.Params.Arguments, "projectType"))
+		return NewCommonCallToolResult(buildCurrentDatabaseContext(ctx, s, projectType))
+	}
+}
+
+func handleListProjectDatabases(s *MCPServer) server.ToolHandlerFunc {
+	return func(
+		ctx context.Context,
+		request mcp.CallToolRequest,
+	) (*mcp.CallToolResult, error) {
+		var args struct {
+			ProjectType string `mapstructure:"projectType"`
+			Keyword     string `mapstructure:"keyword"`
+			Limit       int64  `mapstructure:"limit"`
+		}
+		if err := mapstructure.Decode(request.Params.Arguments, &args); err != nil {
+			return nil, utils.Wrap(err, "invalid argument")
+		}
+		projectType := normalizeProjectType(args.ProjectType)
+		limit := args.Limit
+		if limit <= 0 {
+			limit = 20
+		}
+
+		resp, err := s.grpcClient.GetProjects(ctx, &ypb.GetProjectsRequest{
+			ProjectName:  args.Keyword,
+			Description:  args.Keyword,
+			FrontendType: projectType,
+			Pagination: &ypb.Paging{
+				Page:    1,
+				Limit:   limit,
+				OrderBy: "updated_at",
+				Order:   "desc",
+			},
+		})
+		if err != nil {
+			return nil, utils.Wrap(err, "failed to list project databases")
+		}
+		currentProject, err := s.grpcClient.GetCurrentProjectEx(ctx, &ypb.GetCurrentProjectExRequest{Type: projectType})
+		currentProjectID := int64(0)
+		if err == nil && currentProject != nil {
+			currentProjectID = currentProject.GetId()
+		}
+
+		items := make([]*projectDatabaseItem, 0, len(resp.GetProjects()))
+		for _, project := range resp.GetProjects() {
+			if project == nil {
+				continue
+			}
+			item := &projectDatabaseItem{
+				ID:              project.GetId(),
+				ProjectName:     project.GetProjectName(),
+				Description:     project.GetDescription(),
+				Type:            project.GetType(),
+				DatabasePath:    project.GetDatabasePath(),
+				IsCurrent:       project.GetId() == currentProjectID,
+				UpdateAt:        project.GetUpdateAt(),
+				FolderName:      project.GetFolderName(),
+				ChildFolderName: project.GetChildFolderName(),
+			}
+			items = append(items, item)
+		}
+		return NewCommonCallToolResult(items)
+	}
+}
+
+func handleSwitchCurrentProjectDatabase(s *MCPServer) server.ToolHandlerFunc {
+	return func(
+		ctx context.Context,
+		request mcp.CallToolRequest,
+	) (*mcp.CallToolResult, error) {
+		var args struct {
+			ID          int64  `mapstructure:"id"`
+			ProjectType string `mapstructure:"projectType"`
+		}
+		if err := mapstructure.Decode(request.Params.Arguments, &args); err != nil {
+			return nil, utils.Wrap(err, "invalid argument")
+		}
+		if args.ID <= 0 {
+			return nil, utils.Error("id must be greater than 0")
+		}
+		projectType := normalizeProjectType(args.ProjectType)
+		_, err := s.grpcClient.SetCurrentProject(ctx, &ypb.SetCurrentProjectRequest{
+			Id:   args.ID,
+			Type: projectType,
+		})
+		if err != nil {
+			return nil, utils.Wrap(err, "failed to switch current project database")
+		}
+		return NewCommonCallToolResult(buildCurrentDatabaseContext(ctx, s, projectType))
+	}
+}
+
+func handleCreateProjectDatabase(s *MCPServer) server.ToolHandlerFunc {
+	return func(
+		ctx context.Context,
+		request mcp.CallToolRequest,
+	) (*mcp.CallToolResult, error) {
+		var args struct {
+			ProjectName     string `mapstructure:"projectName"`
+			Description     string `mapstructure:"description"`
+			ProjectType     string `mapstructure:"projectType"`
+			SwitchToCurrent *bool  `mapstructure:"switchToCurrent"`
+			DatabasePath    string `mapstructure:"databasePath"`
+		}
+		if err := mapstructure.Decode(request.Params.Arguments, &args); err != nil {
+			return nil, utils.Wrap(err, "invalid argument")
+		}
+		if args.ProjectName == "" {
+			return nil, utils.Error("projectName is required")
+		}
+
+		projectType := normalizeProjectType(args.ProjectType)
+		switchToCurrent := true
+		if args.SwitchToCurrent != nil {
+			switchToCurrent = *args.SwitchToCurrent
+		}
+
+		req := &ypb.NewProjectRequest{
+			ProjectName: args.ProjectName,
+			Description: args.Description,
+			Type:        projectType,
+			Database:    args.DatabasePath,
+		}
+		resp, err := s.grpcClient.NewProject(ctx, req)
+		if err != nil {
+			return nil, utils.Wrap(err, "failed to create project database")
+		}
+		if resp == nil || resp.GetId() <= 0 {
+			return nil, utils.Error("project created but response id is empty")
+		}
+
+		if switchToCurrent {
+			_, err = s.grpcClient.SetCurrentProject(ctx, &ypb.SetCurrentProjectRequest{
+				Id:   resp.GetId(),
+				Type: projectType,
+			})
+			if err != nil {
+				return nil, utils.Wrap(err, "project created but failed to switch current project")
+			}
+		}
+
+		project, err := s.grpcClient.GetCurrentProjectEx(ctx, &ypb.GetCurrentProjectExRequest{Type: projectType})
+		if err != nil || project == nil || (!switchToCurrent && project.GetId() != resp.GetId()) {
+			projects, listErr := s.grpcClient.GetProjects(ctx, &ypb.GetProjectsRequest{
+				ProjectName:  args.ProjectName,
+				FrontendType: projectType,
+				Pagination: &ypb.Paging{
+					Page:    1,
+					Limit:   20,
+					OrderBy: "updated_at",
+					Order:   "desc",
+				},
+			})
+			if listErr == nil {
+				for _, item := range projects.GetProjects() {
+					if item != nil && item.GetId() == resp.GetId() {
+						project = item
+						break
+					}
+				}
+			}
+		}
+
+		result := map[string]any{
+			"created_project_id":   resp.GetId(),
+			"created_project_name": resp.GetProjectName(),
+			"project_type":         projectType,
+			"switched_to_current":  switchToCurrent,
+		}
+		if project != nil {
+			result["project"] = project
+		}
+		if switchToCurrent {
+			result["current_database_context"] = buildCurrentDatabaseContext(ctx, s, projectType)
+		}
+		return NewCommonCallToolResult(result)
+	}
+}

--- a/common/mcp/project_database_test.go
+++ b/common/mcp/project_database_test.go
@@ -1,0 +1,20 @@
+package mcp
+
+import "testing"
+
+func TestProjectDatabaseToolSetRegistered(t *testing.T) {
+	set, ok := globalToolSets["project_database"]
+	if !ok {
+		t.Fatalf("project_database tool set not registered")
+	}
+	for _, name := range []string{
+		"get_current_database_context",
+		"list_project_databases",
+		"switch_current_project_database",
+		"create_project_database",
+	} {
+		if _, exists := set.Tools[name]; !exists {
+			t.Fatalf("tool not registered: %s", name)
+		}
+	}
+}

--- a/common/yakgrpc/grpc_mcp_test.go
+++ b/common/yakgrpc/grpc_mcp_test.go
@@ -2,6 +2,7 @@ package yakgrpc
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	mcpclient "github.com/yaklang/yaklang/common/mcp/mcp-go/client"
 	rawmcp "github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
 	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
 
@@ -292,4 +294,178 @@ cli.String("url", cli.setRequired(true))
 
 	// 验证工具必须存在
 	require.True(t, toolFound, "Created AI tool '%s' should be available in MCP server", toolName)
+}
+
+func TestGRPC_StartMcpServer_ProjectDatabaseTools(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req := &ypb.StartMcpServerRequest{
+		Host: "127.0.0.1",
+		Port: 0,
+		Tool: []string{"project_database"},
+	}
+
+	stream, err := client.StartMcpServer(ctx, req)
+	require.NoError(t, err)
+
+	var serverURL string
+	for i := 0; i < 5; i++ {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if resp.GetServerUrl() != "" {
+			serverURL = resp.GetServerUrl()
+		}
+		if resp.GetStatus() == "running" {
+			break
+		}
+	}
+	require.NotEmpty(t, serverURL)
+
+	mcpClient, err := mcpclient.NewSSEMCPClient(serverURL)
+	require.NoError(t, err)
+	defer mcpClient.Close()
+
+	clientCtx, clientCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer clientCancel()
+
+	require.NoError(t, mcpClient.Start(clientCtx))
+
+	initRequest := rawmcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = rawmcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = rawmcp.Implementation{
+		Name:    "test-mcp-project-database-client",
+		Version: "1.0.0",
+	}
+	_, err = mcpClient.Initialize(clientCtx, initRequest)
+	require.NoError(t, err)
+
+	projectNameA := "mcp_project_db_a_" + utils.RandStringBytes(6)
+	projectNameB := "mcp_project_db_b_" + utils.RandStringBytes(6)
+
+	var createdProjectIDs []int64
+	defer func() {
+		for _, id := range createdProjectIDs {
+			if id <= 0 {
+				continue
+			}
+			_, _ = client.DeleteProject(context.Background(), &ypb.DeleteProjectRequest{
+				Id:            id,
+				IsDeleteLocal: true,
+				Type:          yakit.TypeProject,
+			})
+		}
+	}()
+
+	createAReq := rawmcp.CallToolRequest{}
+	createAReq.Params.Name = "create_project_database"
+	createAReq.Params.Arguments = map[string]any{
+		"projectName":     projectNameA,
+		"description":     "created by grpc mcp test A",
+		"switchToCurrent": true,
+	}
+	createAResult, err := mcpClient.CallTool(clientCtx, createAReq)
+	require.NoError(t, err)
+	createAData := mustExtractToolTextJSON(t, createAResult)
+	idA := int64(createAData["created_project_id"].(float64))
+	require.Greater(t, idA, int64(0))
+	createdProjectIDs = append(createdProjectIDs, idA)
+	require.Equal(t, true, createAData["switched_to_current"])
+
+	createBReq := rawmcp.CallToolRequest{}
+	createBReq.Params.Name = "create_project_database"
+	createBReq.Params.Arguments = map[string]any{
+		"projectName":     projectNameB,
+		"description":     "created by grpc mcp test B",
+		"switchToCurrent": false,
+	}
+	createBResult, err := mcpClient.CallTool(clientCtx, createBReq)
+	require.NoError(t, err)
+	createBData := mustExtractToolTextJSON(t, createBResult)
+	idB := int64(createBData["created_project_id"].(float64))
+	require.Greater(t, idB, int64(0))
+	createdProjectIDs = append(createdProjectIDs, idB)
+	require.Equal(t, false, createBData["switched_to_current"])
+
+	listReq := rawmcp.CallToolRequest{}
+	listReq.Params.Name = "list_project_databases"
+	listReq.Params.Arguments = map[string]any{
+		"keyword": "mcp_project_db_",
+		"limit":   50,
+	}
+	listResult, err := mcpClient.CallTool(clientCtx, listReq)
+	require.NoError(t, err)
+	listItems := mustExtractToolJSONArray(t, listResult)
+	require.NotEmpty(t, listItems)
+
+	foundA := false
+	foundB := false
+	for _, item := range listItems {
+		gotID := int64(item["id"].(float64))
+		if gotID == idA {
+			foundA = true
+		}
+		if gotID == idB {
+			foundB = true
+		}
+	}
+	require.True(t, foundA, "created project A should appear in list_project_databases")
+	require.True(t, foundB, "created project B should appear in list_project_databases")
+
+	switchReq := rawmcp.CallToolRequest{}
+	switchReq.Params.Name = "switch_current_project_database"
+	switchReq.Params.Arguments = map[string]any{
+		"id": idB,
+	}
+	switchResult, err := mcpClient.CallTool(clientCtx, switchReq)
+	require.NoError(t, err)
+	switchData := mustExtractToolTextJSON(t, switchResult)
+	currentProject := switchData["current_project"].(map[string]any)
+	require.Equal(t, float64(idB), currentProject["Id"])
+
+	contextReq := rawmcp.CallToolRequest{}
+	contextReq.Params.Name = "get_current_database_context"
+	contextReq.Params.Arguments = map[string]any{}
+	contextResult, err := mcpClient.CallTool(clientCtx, contextReq)
+	require.NoError(t, err)
+	contextData := mustExtractToolTextJSON(t, contextResult)
+	currentProject = contextData["current_project"].(map[string]any)
+	require.Equal(t, float64(idB), currentProject["Id"])
+	require.NotEmpty(t, contextData["current_project_db_path"])
+}
+
+func mustExtractToolTextJSON(t *testing.T, result *rawmcp.CallToolResult) map[string]any {
+	t.Helper()
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Content)
+
+	first, ok := result.Content[0].(map[string]any)
+	require.True(t, ok, "tool content item should be map[string]any")
+	text, ok := first["text"].(string)
+	require.True(t, ok, "tool content text should be string")
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &out))
+	return out
+}
+
+func mustExtractToolJSONArray(t *testing.T, result *rawmcp.CallToolResult) []map[string]any {
+	t.Helper()
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Content)
+
+	first, ok := result.Content[0].(map[string]any)
+	require.True(t, ok, "tool content item should be map[string]any")
+	text, ok := first["text"].(string)
+	require.True(t, ok, "tool content text should be string")
+
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &out))
+	return out
 }


### PR DESCRIPTION
 新增 MCP 项目数据库管理能力：

  - get_current_database_context：查看当前 YAKIT_HOME、当前/默认项目库路径、当前 profile 库路径和当前项目信息
  - list_project_databases：列出可用项目库，返回项目 id、路径、当前状态及基础信息
  - create_project_database：通过 MCP 直接创建项目库，并支持创建后切换为当前项目
  - switch_current_project_database：按项目 id 切换当前项目库