### PR TITLE
fix(mcp): prevent SSE MCP notify path from panicking on client discon…

### DIFF
--- a/common/mcp/mcp-go/server/sse.go
+++ b/common/mcp/mcp-go/server/sse.go
@@ -28,6 +28,7 @@ type SSEServer struct {
 
 // sseSession represents an active SSE connection.
 type sseSession struct {
+	mu        sync.Mutex
 	writer    http.ResponseWriter
 	flusher   http.Flusher
 	closeOnce sync.Once
@@ -48,8 +49,33 @@ var allowedMessageOriginLocalHosts = map[string]struct{}{
 
 func (s *sseSession) Close() {
 	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
 		close(s.done)
 	})
+}
+
+func (sess *sseSession) writeMessageEvent(eventData []byte) (err error) {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
+	select {
+	case <-sess.done:
+		return fmt.Errorf("session closed")
+	default:
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("sse write: %v", r)
+		}
+	}()
+	_, werr := fmt.Fprintf(sess.writer, "event: message\ndata: %s\n\n", eventData)
+	if werr != nil {
+		return werr
+	}
+	sess.flusher.Flush()
+	return nil
 }
 
 // NewSSEServer creates a new SSE server instance with the given MCP server and base URL.
@@ -188,9 +214,6 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		closeOnce: sync.Once{},
 	}
 
-	s.sessions.Store(sessionID, session)
-	defer s.sessions.Delete(sessionID)
-
 	messageEndpoint := fmt.Sprintf(
 		"%s/message?sessionId=%s",
 		s.baseURL,
@@ -198,6 +221,9 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	)
 	fmt.Fprintf(w, "event: endpoint\ndata: %s\r\n\r\n", messageEndpoint)
 	flusher.Flush()
+
+	s.sessions.Store(sessionID, session)
+	defer s.sessions.Delete(sessionID)
 
 	<-r.Context().Done()
 	session.Close()
@@ -261,8 +287,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 	// Only send response if there is one (not for notifications)
 	if response != nil {
 		eventData, _ := json.Marshal(response)
-		fmt.Fprintf(session.writer, "event: message\ndata: %s\n\n", eventData)
-		session.flusher.Flush()
+		_ = session.writeMessageEvent(eventData)
 
 		// Send HTTP response
 		w.Header().Set("Content-Type", "application/json")
@@ -360,12 +385,5 @@ func (s *SSEServer) SendEventToSession(
 		return err
 	}
 
-	select {
-	case <-session.done:
-		return fmt.Errorf("session closed")
-	default:
-		fmt.Fprintf(session.writer, "event: message\ndata: %s\n\n", eventData)
-		session.flusher.Flush()
-		return nil
-	}
+	return session.writeMessageEvent(eventData)
 }

--- a/common/mcp/mcp-go/server/sse_test.go
+++ b/common/mcp/mcp-go/server/sse_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -555,5 +556,59 @@ func TestSSEServer(t *testing.T) {
 		if !strings.Contains(response.Error.Message, "legacy SSE transport") {
 			t.Fatalf("Expected legacy SSE rejection, got %q", response.Error.Message)
 		}
+	})
+
+	t.Run("SendEvent concurrent with SSE disconnect does not panic", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0", WithResourceCapabilities(true, true))
+		sseServer := &SSEServer{
+			server:       mcpServer,
+			dispatchDone: make(chan struct{}),
+		}
+		sseServer.startNotificationDispatcher()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/sse":
+				sseServer.handleSSE(w, r)
+			case "/message":
+				sseServer.handleMessage(w, r)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer ts.Close()
+		sseServer.baseURL = ts.URL
+
+		sseResp, messageURL := openSSESession(t, ts)
+		u, err := url.Parse(messageURL)
+		if err != nil {
+			t.Fatalf("parse message url: %v", err)
+		}
+		sessionID := u.Query().Get("sessionId")
+		if sessionID == "" {
+			t.Fatal("missing sessionId in message url")
+		}
+
+		stop := make(chan struct{})
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						_ = sseServer.SendEventToSession(sessionID, map[string]string{"k": "v"})
+					}
+				}
+			}()
+		}
+
+		time.Sleep(20 * time.Millisecond)
+		_ = sseResp.Body.Close()
+		time.Sleep(150 * time.Millisecond)
+		close(stop)
+		wg.Wait()
 	})
 }


### PR DESCRIPTION
…nect

1. Add per-session mutex; Close closes done under the same lock as writes.
2. Route SSE message writes through writeMessageEvent with recover on Write/Flush.
3. Store session in sync.Map only after the endpoint handshake is flushed.
@https://github.com/yaklang/yakit/issues/3655
