### PR TITLE
fix(lowtun): use per-GOOS TUNLinkOffset for gVisor TUN link layer

### DIFF
--- a/common/lowtun/netstack/rwendpoint/readwrite_endpoint.go
+++ b/common/lowtun/netstack/rwendpoint/readwrite_endpoint.go
@@ -35,7 +35,7 @@ func NewReadWriteCloserEndpoint(rw io.ReadWriteCloser, mtu uint32, offset int) (
 }
 
 func NewWireGuardDeviceEndpoint(device lowtun.Device) (*ReadWriteEndpoint, error) {
-	offset := 4
+	offset := lowtun.TUNLinkOffset()
 
 	mtuInt, err := device.MTU()
 	if err != nil {

--- a/common/lowtun/offload_linux_test.go
+++ b/common/lowtun/offload_linux_test.go
@@ -7,6 +7,7 @@ package lowtun
 
 import (
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/yaklang/yaklang/common/lowtun/conn"
@@ -15,9 +16,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	offset = virtioNetHdrLen
-)
+// offset is the IP start index in test buffers; same as production TUNLinkOffset() on linux.
+var offset = TUNLinkOffset()
 
 var (
 	ip4PortA = netip.MustParseAddrPort("192.0.2.1:1")
@@ -27,6 +27,35 @@ var (
 	ip6PortB = netip.MustParseAddrPort("[2001:db8::2]:1")
 	ip6PortC = netip.MustParseAddrPort("[2001:db8::3]:1")
 )
+
+func TestTUNLinkOffsetMatchesVirtioNetHdrLen(t *testing.T) {
+	if got := TUNLinkOffset(); got != virtioNetHdrLen {
+		t.Fatalf("TUNLinkOffset() = %d, want virtioNetHdrLen %d", got, virtioNetHdrLen)
+	}
+}
+
+func TestHandleGRO_acceptsTUNLinkOffset(t *testing.T) {
+	pkt := tcp4Packet(ip4PortA, ip4PortB, header.TCPFlagSyn, 0, 1)
+	toWrite := make([]int, 0, 1)
+	if err := handleGRO([][]byte{pkt}, offset, newTCPGROTable(), newUDPGROTable(), false, &toWrite); err != nil {
+		t.Fatalf("handleGRO(..., offset=%d): %v", offset, err)
+	}
+	if len(toWrite) < 1 {
+		t.Fatalf("expected at least one write index, got %v", toWrite)
+	}
+}
+
+func TestHandleGRO_rejectsOffsetBelowVirtioNetHdrLen(t *testing.T) {
+	pkt := tcp4Packet(ip4PortA, ip4PortB, header.TCPFlagSyn, 0, 1)
+	toWrite := make([]int, 0, 1)
+	err := handleGRO([][]byte{pkt}, 4, newTCPGROTable(), newUDPGROTable(), false, &toWrite)
+	if err == nil {
+		t.Fatal("handleGRO(..., offset=4): expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid offset") {
+		t.Fatalf("expected invalid offset, got: %v", err)
+	}
+}
 
 func udp4PacketMutateIPFields(srcIPPort, dstIPPort netip.AddrPort, payloadLen int, ipFn func(*header.IPv4Fields)) []byte {
 	totalLen := 28 + payloadLen

--- a/common/lowtun/tun_darwin.go
+++ b/common/lowtun/tun_darwin.go
@@ -334,3 +334,9 @@ func socketCloexec(family, sotype, proto int) (fd int, err error) {
 	}
 	return
 }
+
+// TUNLinkOffset is the L3 packet start index for gVisor rwendpoint ↔ Device.
+// NativeTun Read/Write use a 4-byte PI header at buf[offset-4:offset].
+func TUNLinkOffset() int {
+	return 4
+}

--- a/common/lowtun/tun_freebsd.go
+++ b/common/lowtun/tun_freebsd.go
@@ -433,3 +433,9 @@ func (tun *NativeTun) MTU() (int, error) {
 func (tun *NativeTun) BatchSize() int {
 	return 1
 }
+
+// TUNLinkOffset is the L3 packet start index for gVisor rwendpoint ↔ Device.
+// NativeTun Read/Write use a 4-byte PI header at buf[offset-4:offset].
+func TUNLinkOffset() int {
+	return 4
+}

--- a/common/lowtun/tun_linux.go
+++ b/common/lowtun/tun_linux.go
@@ -658,3 +658,9 @@ func CreateUnmonitoredTUNFromFD(fd int) (Device, string, error) {
 	}
 	return tun, name, err
 }
+
+// TUNLinkOffset is the L3 packet start index for gVisor rwendpoint ↔ Device.
+// IFF_VNET_HDR TUN write path uses handleGRO, which requires offset >= virtioNetHdrLen.
+func TUNLinkOffset() int {
+	return virtioNetHdrLen
+}

--- a/common/lowtun/tun_openbsd.go
+++ b/common/lowtun/tun_openbsd.go
@@ -331,3 +331,9 @@ func (tun *NativeTun) MTU() (int, error) {
 func (tun *NativeTun) BatchSize() int {
 	return 1
 }
+
+// TUNLinkOffset is the L3 packet start index for gVisor rwendpoint ↔ Device.
+// NativeTun Read/Write use a 4-byte PI header at buf[offset-4:offset].
+func TUNLinkOffset() int {
+	return 4
+}

--- a/common/lowtun/tun_windows.go
+++ b/common/lowtun/tun_windows.go
@@ -239,3 +239,9 @@ func (rate *rateJuggler) update(packetLen uint64) {
 		rate.changing.Store(false)
 	}
 }
+
+// TUNLinkOffset is the L3 packet start index for gVisor rwendpoint ↔ Device.
+// Wintun passes raw L3 frames with no PI/virtio prefix.
+func TUNLinkOffset() int {
+	return 0
+}

--- a/common/netstackvm/tunvm.go
+++ b/common/netstackvm/tunvm.go
@@ -84,7 +84,7 @@ func NewTunVirtualMachine(ctx context.Context) (*TunVirtualMachine, error) {
 	baseCtx, cancel := context.WithCancel(ctx)
 
 	mtu := uint32(TUN_MTU)
-	offset := 4
+	offset := tun.TUNLinkOffset()
 	log.Infof("Creating TUN endpoint with MTU: %d", mtu)
 	tunEp, err := rwendpoint.NewReadWriteCloserEndpointContext(
 		ctx, rwendpoint.NewWireGuardReadWriteCloserWrapper(device, mtu, offset),
@@ -250,7 +250,7 @@ func NewTunVirtualMachineFromDevice(ctx context.Context, device tun.Device) (*Tu
 	baseCtx, cancel := context.WithCancel(ctx)
 
 	mtu := uint32(TUN_MTU)
-	offset := 4
+	offset := tun.TUNLinkOffset()
 	log.Infof("Creating TUN endpoint with MTU: %d", mtu)
 	tunEp, err := rwendpoint.NewReadWriteCloserEndpointContext(
 		ctx, rwendpoint.NewWireGuardReadWriteCloserWrapper(device, mtu, offset),


### PR DESCRIPTION
Define TUNLinkOffset in each tun_$GOOS.go (linux: virtioNetHdrLen, BSD: 4, windows: 0) and use it from tunvm and rwendpoint instead of a hardcoded 4. Linux tests use the same offset via TUNLinkOffset() and assert handleGRO.

Fixes yaklang/yakit#3722