### PR TITLE
Rookie/fix/plan and exec/cache rate hit

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -2955,7 +2955,26 @@ func (c *Config) RetryPromptBuilder(s string, err error) string {
 	if err == nil {
 		return s
 	}
-	return s + "\n\n[Retry due to error: " + err.Error() + "]"
+	errText := strings.TrimSpace(err.Error())
+	if errText == "" {
+		errText = "(empty error)"
+	}
+
+	var b strings.Builder
+	b.WriteString(s)
+	if !strings.HasSuffix(s, "\n") {
+		b.WriteString("\n")
+	}
+	b.WriteString("\n# RETRY CORRECTION - PREVIOUS RESPONSE WAS REJECTED\n")
+	b.WriteString("[Retry due to error: see validation error block below]\n\n")
+	b.WriteString("The previous response failed validation. Treat this retry correction as mandatory and higher priority than the failed response.\n")
+	b.WriteString("You MUST correct the exact validation error below in the next response.\n")
+	b.WriteString("Do NOT repeat the same invalid output. Do NOT explain the retry. Return a fresh valid response only.\n")
+	b.WriteString("If the error mentions a required tag, nonce, JSON field, schema, action name, or output format, follow that requirement exactly.\n\n")
+	b.WriteString("Validation error:\n---\n")
+	b.WriteString(errText)
+	b.WriteString("\n---\n# END RETRY CORRECTION")
+	return b.String()
 }
 
 func (c *Config) GetEmitter() *Emitter {

--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -519,10 +519,9 @@ func newConfig(ctx context.Context) *Config {
 	// NOTE: session_artifacts provider is intentionally NOT registered into
 	// ContextProviderManager. Routing the artifacts listing through Pure
 	// Dynamic / AutoContext flooded the dynamic segment with file metadata
-	// every turn. The listing is now embedded directly into the Workspace
-	// block (timeline-open segment) via RenderSessionArtifactsListing, where
-	// it lives alongside OS/Arch / working dir / glance.
-	// 关键词: session_artifacts 反注册, Workspace 内嵌, Pure Dynamic 反污染
+	// every turn. Prompt materials now render artifacts through first-class
+	// frozen/open blocks via RenderSessionArtifactsFrozenOpen.
+	// 关键词: session_artifacts 反注册, 一级 frozen/open, Pure Dynamic 反污染
 
 	// Initialize emitter
 	config.Emitter = NewEmitter(id, func(e *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
@@ -3354,6 +3353,18 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 	}
 	if i.SessionPromptState != nil {
 		opts = append(opts, WithSessionPromptState(i.SessionPromptState))
+	}
+	if i.KeyValueConfig != nil {
+		if existing, ok := i.GetConfig(frozenBlockPartitionProducersConfigKey); ok {
+			switch producers := existing.(type) {
+			case []FrozenBlockPartitionProducer:
+				for _, producer := range producers {
+					opts = append(opts, WithFrozenBlockPartitionProducer(producer))
+				}
+			case FrozenBlockPartitionProducer:
+				opts = append(opts, WithFrozenBlockPartitionProducer(producers))
+			}
+		}
 	}
 
 	if i.Seq > 0 {

--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -283,6 +283,9 @@ type Config struct {
 	// This content appears once during plan initialization and does not affect subsequent task execution.
 	PlanPrompt string
 
+	// FrozenBlockPartitionProducer holds explicit prompt frozen-block partitions.
+	FrozenBlockPartitionProducer *FrozenBlockPartitionProducer
+
 	// result processer
 	GenerateReport               bool
 	MaxTaskContinue              int64
@@ -3354,17 +3357,8 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 	if i.SessionPromptState != nil {
 		opts = append(opts, WithSessionPromptState(i.SessionPromptState))
 	}
-	if i.KeyValueConfig != nil {
-		if existing, ok := i.GetConfig(frozenBlockPartitionProducersConfigKey); ok {
-			switch producers := existing.(type) {
-			case []FrozenBlockPartitionProducer:
-				for _, producer := range producers {
-					opts = append(opts, WithFrozenBlockPartitionProducer(producer))
-				}
-			case FrozenBlockPartitionProducer:
-				opts = append(opts, WithFrozenBlockPartitionProducer(producers))
-			}
-		}
+	if i.FrozenBlockPartitionProducer != nil {
+		opts = append(opts, WithFrozenBlockPartitionProducer(i.FrozenBlockPartitionProducer))
 	}
 
 	if i.Seq > 0 {

--- a/common/ai/aid/aicommon/contextprovider.go
+++ b/common/ai/aid/aicommon/contextprovider.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 	"unicode"
 
 	"github.com/yaklang/yaklang/common/consts"
@@ -457,153 +456,16 @@ func KnowledgeBaseSystemFlagContextProvider(flag string, userPrompt ...string) C
 // ArtifactsContextMaxTokens is the maximum size (in tokens) for the artifacts context output.
 const ArtifactsContextMaxTokens = 8 * 1024
 
-// artifactFileEntry holds metadata for a single file in the artifacts directory.
-type artifactFileEntry struct {
-	RelPath string
-	Size    int64
-	ModTime time.Time
-}
-
-// RenderSessionArtifactsListing scans the session's working directory and
-// renders a structured listing of all task output files. The output is the
-// listing **body only** (without any leading "# Session Artifacts" heading);
-// the caller is expected to wrap it under whatever heading suits its host
-// section (currently the Workspace block uses "## Session Artifacts").
-//
-// Behavior preserved from the original ArtifactsContextProvider:
-//   - Walks workdir, groups by top-level task dir, sorts by mtime desc,
-//     formats each entry with size + HH:MM:SS;
-//   - Result is shrunk to ArtifactsContextMaxTokens via ShrinkTextBlockByTokens
-//     when oversized;
-//   - Returns an empty string when there is no workdir, the dir does not
-//     exist, or there are zero files.
-//
-// 关键词: RenderSessionArtifactsListing, Session Artifacts 抽离 helper,
-//
-//	Workspace 内嵌, 8K token shrink
-func RenderSessionArtifactsListing(config AICallerConfigIf) string {
-	if config == nil {
-		return ""
-	}
-	workDir := config.GetOrCreateWorkDir()
-	if workDir == "" {
-		return ""
-	}
-	info, err := os.Stat(workDir)
-	if err != nil || !info.IsDir() {
-		return ""
-	}
-
-	var entries []artifactFileEntry
-	walkErr := filepath.Walk(workDir, func(path string, fi os.FileInfo, err error) error {
-		if err != nil {
-			log.Warnf("[SessionArtifactsListing] walk error for %s: %v", path, err)
-			return nil // skip errors
-		}
-		if fi.IsDir() {
-			return nil
-		}
-		relPath, err := filepath.Rel(workDir, path)
-		if err != nil {
-			relPath = path
-		}
-		log.Infof("[SessionArtifactsListing] found file: %s", relPath)
-		entries = append(entries, artifactFileEntry{
-			RelPath: relPath,
-			Size:    fi.Size(),
-			ModTime: fi.ModTime(),
-		})
-		return nil
-	})
-	if walkErr != nil {
-		log.Warnf("session artifacts listing: walk error: %v", walkErr)
-	}
-
-	log.Infof("[SessionArtifactsListing] total entries found: %d in workDir: %s", len(entries), workDir)
-
-	if len(entries) == 0 {
-		return ""
-	}
-
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].ModTime.After(entries[j].ModTime)
-	})
-
-	taskGroups := omap.NewOrderedMap(make(map[string][]artifactFileEntry))
-	var rootFiles []artifactFileEntry
-
-	for _, e := range entries {
-		parts := strings.SplitN(e.RelPath, string(filepath.Separator), 2)
-		if len(parts) == 1 {
-			rootFiles = append(rootFiles, e)
-		} else {
-			taskDir := parts[0]
-			existing, _ := taskGroups.Get(taskDir)
-			taskGroups.Set(taskDir, append(existing, e))
-		}
-	}
-
-	var sb strings.Builder
-	// Caller owns the outer heading; this helper emits only the body.
-	sb.WriteString(fmt.Sprintf("artifacts_dir: %s\n", workDir))
-	sb.WriteString(fmt.Sprintf("total_files: %d\n\n", len(entries)))
-
-	taskGroups.ForEach(func(taskDir string, files []artifactFileEntry) bool {
-		var latestMod time.Time
-		for _, f := range files {
-			if f.ModTime.After(latestMod) {
-				latestMod = f.ModTime
-			}
-		}
-		sb.WriteString(fmt.Sprintf("### %s (modified: %s)\n",
-			taskDir,
-			latestMod.Format("2006-01-02 15:04:05"),
-		))
-		for _, f := range files {
-			innerPath := strings.TrimPrefix(f.RelPath, taskDir+string(filepath.Separator))
-			sb.WriteString(fmt.Sprintf("- %s (%s, %s)\n",
-				innerPath,
-				formatFileSize(f.Size),
-				f.ModTime.Format("15:04:05"),
-			))
-		}
-		sb.WriteString("\n")
-		return true
-	})
-
-	if len(rootFiles) > 0 {
-		sb.WriteString("### [root files]\n")
-		for _, f := range rootFiles {
-			sb.WriteString(fmt.Sprintf("- %s (%s, %s)\n",
-				f.RelPath,
-				formatFileSize(f.Size),
-				f.ModTime.Format("15:04:05"),
-			))
-		}
-		sb.WriteString("\n")
-	}
-
-	result := sb.String()
-	if MeasureTokens(result) > ArtifactsContextMaxTokens {
-		result = ShrinkTextBlockByTokens(result, ArtifactsContextMaxTokens)
-	}
-	return result
-}
-
 // ArtifactsContextProvider is a thin wrapper around RenderSessionArtifactsListing
 // that adds the legacy "# Session Artifacts" heading expected by older callers
-// and existing tests. New code should call RenderSessionArtifactsListing
-// directly and own the heading.
+// and existing tests. New prompt code should call RenderSessionArtifactsFrozenOpen
+// and render artifacts as first-class frozen/open blocks.
 //
 // Deprecated: this provider used to be registered into ContextProviderManager
-// (which routed it into Pure Dynamic / AutoContext). That registration has
-// been removed; the listing is now embedded into the Workspace block via
-// RenderSessionArtifactsListing. The wrapper is kept only to preserve the
-// existing test surface.
+// (which routed it into Pure Dynamic / AutoContext). That registration has been
+// removed; the wrapper is kept only to preserve the existing test surface.
 //
-// 关键词: ArtifactsContextProvider 薄壳, 兼容旧 surface,
-//
-//	Workspace 内嵌路径, 不再注册到 ContextProviderManager
+// 关键词: ArtifactsContextProvider 薄壳, 兼容旧 surface, 不再注册到 ContextProviderManager
 func ArtifactsContextProvider(config AICallerConfigIf, emitter *Emitter, key string) (string, error) {
 	listing := RenderSessionArtifactsListing(config)
 	if listing == "" {

--- a/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
+++ b/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
@@ -55,7 +55,8 @@ type TaskReviewPromptData struct {
 	OSArch           string
 	WorkingDir       string
 	WorkingDirGlance string
-	Timeline         string
+	TimelineFrozen   string
+	TimelineOpen     string
 	Nonce            string
 	TaskDetails      string
 	ShortSummary     string
@@ -130,7 +131,7 @@ func generateTaskReviewPrompt(config *Config, materials aitool.InvokeParams) (st
 	}
 
 	if t := config.GetTimeline(); t != nil {
-		data.Timeline = t.Dump()
+		data.TimelineFrozen, data.TimelineOpen = t.DumpFrozenOpen()
 	}
 
 	if !utils.IsNil(materials) {
@@ -158,7 +159,8 @@ func generateTaskReviewPrompt(config *Config, materials aitool.InvokeParams) (st
 		TaskInstruction:  strings.TrimSpace(aiTaskReviewInstructionTemplate),
 		Schema:           strings.TrimSpace(aiTaskReviewSchemaTemplate),
 		OutputExample:    strings.TrimSpace(aiTaskReviewOutputExampleTemplate),
-		TimelineOpen:     data.Timeline,
+		TimelineFrozen:   data.TimelineFrozen,
+		TimelineOpen:     data.TimelineOpen,
 		CurrentTime:      data.CurrentTime,
 		OSArch:           data.OSArch,
 		WorkingDir:       data.WorkingDir,

--- a/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
+++ b/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
@@ -55,8 +55,6 @@ type TaskReviewPromptData struct {
 	OSArch           string
 	WorkingDir       string
 	WorkingDirGlance string
-	TimelineFrozen   string
-	TimelineOpen     string
 	Nonce            string
 	TaskDetails      string
 	ShortSummary     string
@@ -130,9 +128,7 @@ func generateTaskReviewPrompt(config *Config, materials aitool.InvokeParams) (st
 		data.WorkingDirGlance = filesys.Glance(data.WorkingDir)
 	}
 
-	if t := config.GetTimeline(); t != nil {
-		data.TimelineFrozen, data.TimelineOpen = t.DumpFrozenOpen()
-	}
+	frozenOpen := BuildPromptFrozenOpenMaterials(config)
 
 	if !utils.IsNil(materials) {
 		data.ShortSummary = materials.GetString("short_summary")
@@ -159,14 +155,13 @@ func generateTaskReviewPrompt(config *Config, materials aitool.InvokeParams) (st
 		TaskInstruction:  strings.TrimSpace(aiTaskReviewInstructionTemplate),
 		Schema:           strings.TrimSpace(aiTaskReviewSchemaTemplate),
 		OutputExample:    strings.TrimSpace(aiTaskReviewOutputExampleTemplate),
-		TimelineFrozen:   data.TimelineFrozen,
-		TimelineOpen:     data.TimelineOpen,
 		CurrentTime:      data.CurrentTime,
 		OSArch:           data.OSArch,
 		WorkingDir:       data.WorkingDir,
 		WorkingDirGlance: data.WorkingDirGlance,
 		Workspace:        strings.TrimSpace(data.OSArch+data.WorkingDir+data.WorkingDirGlance) != "",
 	}
+	ApplyPromptFrozenOpenMaterials(prefixMaterials, frozenOpen)
 	if err := PopulateToolInventoryFromConfig(prefixMaterials, config); err != nil {
 		return "", fmt.Errorf("populate task review tool inventory failed: %w", err)
 	}

--- a/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
+++ b/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
@@ -159,7 +159,6 @@ func generateTaskReviewPrompt(config *Config, materials aitool.InvokeParams) (st
 		TaskInstruction:  strings.TrimSpace(aiTaskReviewInstructionTemplate),
 		Schema:           strings.TrimSpace(aiTaskReviewSchemaTemplate),
 		OutputExample:    strings.TrimSpace(aiTaskReviewOutputExampleTemplate),
-		ToolInventory:    true,
 		TimelineFrozen:   data.TimelineFrozen,
 		TimelineOpen:     data.TimelineOpen,
 		CurrentTime:      data.CurrentTime,
@@ -167,6 +166,9 @@ func generateTaskReviewPrompt(config *Config, materials aitool.InvokeParams) (st
 		WorkingDir:       data.WorkingDir,
 		WorkingDirGlance: data.WorkingDirGlance,
 		Workspace:        strings.TrimSpace(data.OSArch+data.WorkingDir+data.WorkingDirGlance) != "",
+	}
+	if err := PopulateToolInventoryFromConfig(prefixMaterials, config); err != nil {
+		return "", fmt.Errorf("populate task review tool inventory failed: %w", err)
 	}
 
 	return NewDefaultPromptPrefixBuilder().AssemblePromptWithDynamicSection(

--- a/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
+++ b/common/ai/aid/aicommon/do_wait_agree_dynamic_planning.go
@@ -159,6 +159,7 @@ func generateTaskReviewPrompt(config *Config, materials aitool.InvokeParams) (st
 		TaskInstruction:  strings.TrimSpace(aiTaskReviewInstructionTemplate),
 		Schema:           strings.TrimSpace(aiTaskReviewSchemaTemplate),
 		OutputExample:    strings.TrimSpace(aiTaskReviewOutputExampleTemplate),
+		ToolInventory:    true,
 		TimelineFrozen:   data.TimelineFrozen,
 		TimelineOpen:     data.TimelineOpen,
 		CurrentTime:      data.CurrentTime,

--- a/common/ai/aid/aicommon/frozen_partition.go
+++ b/common/ai/aid/aicommon/frozen_partition.go
@@ -1,0 +1,159 @@
+package aicommon
+
+import (
+	"sort"
+	"strings"
+)
+
+type FrozenBlockPartition struct {
+	ID      string
+	Title   string
+	Nonce   string
+	Content string
+	Order   int
+}
+
+type FrozenBlockPartitionProducer func() []FrozenBlockPartition
+
+const frozenBlockPartitionProducersConfigKey = "frozen_block_partition_producers"
+
+func NewFrozenBlockPartition(id string, title string, content string, order int) (FrozenBlockPartition, bool) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return FrozenBlockPartition{}, false
+	}
+	id = NormalizeFrozenPartitionID(id)
+	title = strings.TrimSpace(title)
+	if title == "" {
+		title = id
+	}
+	nonce := StablePromptNonce("frozen-partition", id, content)
+	return FrozenBlockPartition{
+		ID:      id,
+		Title:   title,
+		Nonce:   nonce,
+		Content: content,
+		Order:   order,
+	}, true
+}
+
+func NormalizeFrozenPartitionID(id string) string {
+	id = strings.ToLower(strings.TrimSpace(id))
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range id {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if r == '_' || r == '-' || r == '.' || r == '/' || r == ' ' || r == '\t' {
+			if !lastUnderscore && b.Len() > 0 {
+				b.WriteByte('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	normalized := strings.Trim(b.String(), "_")
+	if normalized == "" {
+		return "partition"
+	}
+	return normalized
+}
+
+func NormalizeFrozenBlockPartitions(partitions []FrozenBlockPartition) []FrozenBlockPartition {
+	if len(partitions) == 0 {
+		return nil
+	}
+	byID := make(map[string]FrozenBlockPartition, len(partitions))
+	for _, partition := range partitions {
+		content := strings.TrimSpace(partition.Content)
+		if content == "" {
+			continue
+		}
+		id := NormalizeFrozenPartitionID(partition.ID)
+		title := strings.TrimSpace(partition.Title)
+		if title == "" {
+			title = id
+		}
+		nonce := strings.TrimSpace(partition.Nonce)
+		if nonce == "" {
+			nonce = StablePromptNonce("frozen-partition", id, content)
+		}
+		partition.ID = id
+		partition.Title = title
+		partition.Nonce = nonce
+		partition.Content = content
+		byID[id] = partition
+	}
+	if len(byID) == 0 {
+		return nil
+	}
+	out := make([]FrozenBlockPartition, 0, len(byID))
+	for _, partition := range byID {
+		out = append(out, partition)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Order != out[j].Order {
+			return out[i].Order < out[j].Order
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func WithFrozenBlockPartitionProducer(producer FrozenBlockPartitionProducer) ConfigOption {
+	return func(c *Config) error {
+		if c == nil || producer == nil {
+			return nil
+		}
+		if c.KeyValueConfig == nil {
+			c.KeyValueConfig = NewKeyValueConfig()
+		}
+		var producers []FrozenBlockPartitionProducer
+		if existing, ok := c.GetConfig(frozenBlockPartitionProducersConfigKey); ok {
+			switch typed := existing.(type) {
+			case []FrozenBlockPartitionProducer:
+				producers = append(producers, typed...)
+			case FrozenBlockPartitionProducer:
+				producers = append(producers, typed)
+			}
+		}
+		producers = append(producers, producer)
+		c.SetConfig(frozenBlockPartitionProducersConfigKey, producers)
+		return nil
+	}
+}
+
+func FrozenBlockPartitionsFromConfig(config AICallerConfigIf) []FrozenBlockPartition {
+	if config == nil {
+		return nil
+	}
+	if cfg, ok := config.(*Config); ok && cfg.KeyValueConfig == nil {
+		return nil
+	}
+	existing, ok := config.GetConfig(frozenBlockPartitionProducersConfigKey)
+	if !ok {
+		return nil
+	}
+
+	var producers []FrozenBlockPartitionProducer
+	switch typed := existing.(type) {
+	case []FrozenBlockPartitionProducer:
+		producers = typed
+	case FrozenBlockPartitionProducer:
+		producers = []FrozenBlockPartitionProducer{typed}
+	default:
+		return nil
+	}
+
+	var partitions []FrozenBlockPartition
+	for _, producer := range producers {
+		if producer == nil {
+			continue
+		}
+		partitions = append(partitions, producer()...)
+	}
+	return NormalizeFrozenBlockPartitions(partitions)
+}

--- a/common/ai/aid/aicommon/frozen_partition.go
+++ b/common/ai/aid/aicommon/frozen_partition.go
@@ -225,3 +225,10 @@ func FrozenBlockPartitionsFromConfig(config AICallerConfigIf) []FrozenBlockParti
 	}
 	return producer.ProducePartitions()
 }
+
+const ( // stable partition orders for prefix cache , users can also define their own partitions with custom orders
+	PersistentMemoryOrder = 90
+
+	PlanFactsFrozenPartitionOrder    = 100
+	PlanDocumentFrozenPartitionOrder = 110
+)

--- a/common/ai/aid/aicommon/frozen_partition.go
+++ b/common/ai/aid/aicommon/frozen_partition.go
@@ -3,6 +3,7 @@ package aicommon
 import (
 	"sort"
 	"strings"
+	"sync"
 )
 
 type FrozenBlockPartition struct {
@@ -13,9 +14,116 @@ type FrozenBlockPartition struct {
 	Order   int
 }
 
-type FrozenBlockPartitionProducer func() []FrozenBlockPartition
+type FrozenBlockPartitionProducer struct {
+	m sync.RWMutex
 
-const frozenBlockPartitionProducersConfigKey = "frozen_block_partition_producers"
+	partitions []FrozenBlockPartition
+}
+
+func NewFrozenBlockPartitionProducer(partitions ...FrozenBlockPartition) *FrozenBlockPartitionProducer {
+	producer := &FrozenBlockPartitionProducer{}
+	producer.AppendPartitions(partitions...)
+	return producer
+}
+
+func (p *FrozenBlockPartitionProducer) AppendPartition(partition FrozenBlockPartition) {
+	if p == nil {
+		return
+	}
+	partitions := NormalizeFrozenBlockPartitions([]FrozenBlockPartition{partition})
+	if len(partitions) == 0 {
+		return
+	}
+	p.m.Lock()
+	p.partitions = append(p.partitions, partitions[0])
+	p.m.Unlock()
+}
+
+func (p *FrozenBlockPartitionProducer) AppendPartitions(partitions ...FrozenBlockPartition) {
+	if p == nil || len(partitions) == 0 {
+		return
+	}
+	partitions = NormalizeFrozenBlockPartitions(partitions)
+	if len(partitions) == 0 {
+		return
+	}
+	p.m.Lock()
+	p.partitions = append(p.partitions, partitions...)
+	p.m.Unlock()
+}
+
+func (p *FrozenBlockPartitionProducer) AppendNewPartition(id string, title string, content string, order int) {
+	if p == nil {
+		return
+	}
+	partition, ok := NewFrozenBlockPartition(id, title, content, order)
+	if !ok {
+		return
+	}
+	p.AppendPartition(partition)
+}
+
+func (p *FrozenBlockPartitionProducer) ProducePartitions() []FrozenBlockPartition {
+	if p == nil {
+		return nil
+	}
+	p.m.RLock()
+	partitions := append([]FrozenBlockPartition(nil), p.partitions...)
+	p.m.RUnlock()
+	return NormalizeFrozenBlockPartitions(partitions)
+}
+
+func (c *Config) GetOrCreateFrozenBlockPartitionProducer() *FrozenBlockPartitionProducer {
+	if c == nil {
+		return nil
+	}
+	if c.m == nil {
+		c.m = &sync.Mutex{}
+	}
+	c.m.Lock()
+	defer c.m.Unlock()
+	if c.FrozenBlockPartitionProducer == nil {
+		c.FrozenBlockPartitionProducer = NewFrozenBlockPartitionProducer()
+	}
+	return c.FrozenBlockPartitionProducer
+}
+
+func (c *Config) AppendFrozenBlockPartition(id string, title string, content string, order int) {
+	producer := c.GetOrCreateFrozenBlockPartitionProducer()
+	if producer == nil {
+		return
+	}
+	producer.AppendNewPartition(id, title, content, order)
+}
+
+func WithFrozenBlockPartitionProducer(producer *FrozenBlockPartitionProducer) ConfigOption {
+	return func(c *Config) error {
+		if c == nil || producer == nil {
+			return nil
+		}
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		c.FrozenBlockPartitionProducer = producer
+		c.m.Unlock()
+		return nil
+	}
+}
+
+func WithFrozenBlockPartitions(partitions ...FrozenBlockPartition) ConfigOption {
+	return func(c *Config) error {
+		if c == nil || len(partitions) == 0 {
+			return nil
+		}
+		producer := c.GetOrCreateFrozenBlockPartitionProducer()
+		if producer == nil {
+			return nil
+		}
+		producer.AppendPartitions(partitions...)
+		return nil
+	}
+}
 
 func NewFrozenBlockPartition(id string, title string, content string, order int) (FrozenBlockPartition, bool) {
 	content = strings.TrimSpace(content)
@@ -103,57 +211,17 @@ func NormalizeFrozenBlockPartitions(partitions []FrozenBlockPartition) []FrozenB
 	return out
 }
 
-func WithFrozenBlockPartitionProducer(producer FrozenBlockPartitionProducer) ConfigOption {
-	return func(c *Config) error {
-		if c == nil || producer == nil {
-			return nil
-		}
-		if c.KeyValueConfig == nil {
-			c.KeyValueConfig = NewKeyValueConfig()
-		}
-		var producers []FrozenBlockPartitionProducer
-		if existing, ok := c.GetConfig(frozenBlockPartitionProducersConfigKey); ok {
-			switch typed := existing.(type) {
-			case []FrozenBlockPartitionProducer:
-				producers = append(producers, typed...)
-			case FrozenBlockPartitionProducer:
-				producers = append(producers, typed)
-			}
-		}
-		producers = append(producers, producer)
-		c.SetConfig(frozenBlockPartitionProducersConfigKey, producers)
-		return nil
-	}
-}
-
 func FrozenBlockPartitionsFromConfig(config AICallerConfigIf) []FrozenBlockPartition {
 	if config == nil {
 		return nil
 	}
-	if cfg, ok := config.(*Config); ok && cfg.KeyValueConfig == nil {
+	cfg, ok := config.(*Config)
+	if !ok || cfg == nil {
 		return nil
 	}
-	existing, ok := config.GetConfig(frozenBlockPartitionProducersConfigKey)
-	if !ok {
+	producer := cfg.FrozenBlockPartitionProducer
+	if producer == nil {
 		return nil
 	}
-
-	var producers []FrozenBlockPartitionProducer
-	switch typed := existing.(type) {
-	case []FrozenBlockPartitionProducer:
-		producers = typed
-	case FrozenBlockPartitionProducer:
-		producers = []FrozenBlockPartitionProducer{typed}
-	default:
-		return nil
-	}
-
-	var partitions []FrozenBlockPartition
-	for _, producer := range producers {
-		if producer == nil {
-			continue
-		}
-		partitions = append(partitions, producer()...)
-	}
-	return NormalizeFrozenBlockPartitions(partitions)
+	return producer.ProducePartitions()
 }

--- a/common/ai/aid/aicommon/frozen_partition_test.go
+++ b/common/ai/aid/aicommon/frozen_partition_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestNewFrozenBlockPartition(t *testing.T) {
-	_, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "  \n", 100)
+	_, ok := NewFrozenBlockPartition("static_facts", "Static Facts", "  \n", 100)
 	require.False(t, ok)
 
-	p, ok := NewFrozenBlockPartition("Plan-Facts/One", " Plan Facts ", " facts body ", 100)
+	p, ok := NewFrozenBlockPartition("Static-Facts/One", " Static Facts ", " facts body ", 100)
 	require.True(t, ok)
-	require.Equal(t, "plan_facts_one", p.ID)
-	require.Equal(t, "Plan Facts", p.Title)
+	require.Equal(t, "static_facts_one", p.ID)
+	require.Equal(t, "Static Facts", p.Title)
 	require.Equal(t, "facts body", p.Content)
 	require.NotEmpty(t, p.Nonce)
 	for _, r := range p.ID {
@@ -23,11 +23,11 @@ func TestNewFrozenBlockPartition(t *testing.T) {
 }
 
 func TestFrozenBlockPartitionNonceStable(t *testing.T) {
-	a, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts body", 100)
+	a, ok := NewFrozenBlockPartition("static_facts", "Static Facts", "facts body", 100)
 	require.True(t, ok)
-	b, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts body", 100)
+	b, ok := NewFrozenBlockPartition("static_facts", "Static Facts", "facts body", 100)
 	require.True(t, ok)
-	c, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "changed body", 100)
+	c, ok := NewFrozenBlockPartition("static_facts", "Static Facts", "changed body", 100)
 	require.True(t, ok)
 
 	require.Equal(t, a.Nonce, b.Nonce)
@@ -36,51 +36,47 @@ func TestFrozenBlockPartitionNonceStable(t *testing.T) {
 
 func TestNormalizeFrozenBlockPartitionsSortAndDedup(t *testing.T) {
 	partitions := []FrozenBlockPartition{
-		{ID: "plan_document", Title: "Old", Content: "old", Order: 110},
-		{ID: "plan_facts", Title: "Plan Facts", Content: "facts", Order: 100},
-		{ID: "plan_document", Title: "Plan Document", Content: "new", Order: 110},
+		{ID: "static_document", Title: "Old", Content: "old", Order: 110},
+		{ID: "static_facts", Title: "Static Facts", Content: "facts", Order: 100},
+		{ID: "static_document", Title: "Static Document", Content: "new", Order: 110},
 		{ID: "empty", Content: "   ", Order: 90},
 	}
 	got := NormalizeFrozenBlockPartitions(partitions)
 	require.Len(t, got, 2)
-	require.Equal(t, "plan_facts", got[0].ID)
-	require.Equal(t, "plan_document", got[1].ID)
+	require.Equal(t, "static_facts", got[0].ID)
+	require.Equal(t, "static_document", got[1].ID)
 	require.Equal(t, "new", got[1].Content, "later duplicate ID should overwrite earlier entry")
 	require.NotEmpty(t, got[0].Nonce)
 	require.NotEmpty(t, got[1].Nonce)
 }
 
 func TestFrozenBlockTemplateRendersPartitionTags(t *testing.T) {
-	p, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts body", 100)
+	p, ok := NewFrozenBlockPartition("static_facts", "Static Facts", "facts body", 100)
 	require.True(t, ok)
 	materials := &PromptMaterials{FrozenPartitions: []FrozenBlockPartition{p}}
 	rendered, err := RenderPromptTemplate("test-frozen", SharedFrozenBlockTemplate, materials.FrozenBlockData())
 	require.NoError(t, err)
 
-	start := "<|FROZEN_PARTITION_plan_facts_" + p.Nonce + "|>"
-	end := "<|FROZEN_PARTITION_END_plan_facts_" + p.Nonce + "|>"
-	require.Contains(t, rendered, "# Plan Facts")
+	start := "<|FROZEN_PARTITION_static_facts_" + p.Nonce + "|>"
+	end := "<|FROZEN_PARTITION_END_static_facts_" + p.Nonce + "|>"
+	require.Contains(t, rendered, "# Static Facts")
 	require.Contains(t, rendered, start)
 	require.Contains(t, rendered, end)
 	require.Less(t, strings.Index(rendered, start), strings.Index(rendered, end))
 }
 
 func TestFrozenBlockPartitionsFromConfig(t *testing.T) {
-	cfg := NewConfig(nil,
-		WithFrozenBlockPartitionProducer(func() []FrozenBlockPartition {
-			p, ok := NewFrozenBlockPartition("plan_document", "Plan Document", "document", 110)
-			require.True(t, ok)
-			return []FrozenBlockPartition{p}
-		}),
-		WithFrozenBlockPartitionProducer(func() []FrozenBlockPartition {
-			p, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts", 100)
-			require.True(t, ok)
-			return []FrozenBlockPartition{p}
-		}),
-	)
+	document, ok := NewFrozenBlockPartition("static_document", "Static Document", "document", 110)
+	require.True(t, ok)
+	facts, ok := NewFrozenBlockPartition("static_facts", "Static Facts", "facts", 100)
+	require.True(t, ok)
+	producer := NewFrozenBlockPartitionProducer()
+	producer.AppendPartition(document)
+	producer.AppendPartition(facts)
+	cfg := NewConfig(nil, WithFrozenBlockPartitionProducer(producer))
 
 	partitions := FrozenBlockPartitionsFromConfig(cfg)
 	require.Len(t, partitions, 2)
-	require.Equal(t, "plan_facts", partitions[0].ID)
-	require.Equal(t, "plan_document", partitions[1].ID)
+	require.Equal(t, "static_facts", partitions[0].ID)
+	require.Equal(t, "static_document", partitions[1].ID)
 }

--- a/common/ai/aid/aicommon/frozen_partition_test.go
+++ b/common/ai/aid/aicommon/frozen_partition_test.go
@@ -1,0 +1,86 @@
+package aicommon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFrozenBlockPartition(t *testing.T) {
+	_, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "  \n", 100)
+	require.False(t, ok)
+
+	p, ok := NewFrozenBlockPartition("Plan-Facts/One", " Plan Facts ", " facts body ", 100)
+	require.True(t, ok)
+	require.Equal(t, "plan_facts_one", p.ID)
+	require.Equal(t, "Plan Facts", p.Title)
+	require.Equal(t, "facts body", p.Content)
+	require.NotEmpty(t, p.Nonce)
+	for _, r := range p.ID {
+		require.True(t, (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_')
+	}
+}
+
+func TestFrozenBlockPartitionNonceStable(t *testing.T) {
+	a, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts body", 100)
+	require.True(t, ok)
+	b, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts body", 100)
+	require.True(t, ok)
+	c, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "changed body", 100)
+	require.True(t, ok)
+
+	require.Equal(t, a.Nonce, b.Nonce)
+	require.NotEqual(t, a.Nonce, c.Nonce)
+}
+
+func TestNormalizeFrozenBlockPartitionsSortAndDedup(t *testing.T) {
+	partitions := []FrozenBlockPartition{
+		{ID: "plan_document", Title: "Old", Content: "old", Order: 110},
+		{ID: "plan_facts", Title: "Plan Facts", Content: "facts", Order: 100},
+		{ID: "plan_document", Title: "Plan Document", Content: "new", Order: 110},
+		{ID: "empty", Content: "   ", Order: 90},
+	}
+	got := NormalizeFrozenBlockPartitions(partitions)
+	require.Len(t, got, 2)
+	require.Equal(t, "plan_facts", got[0].ID)
+	require.Equal(t, "plan_document", got[1].ID)
+	require.Equal(t, "new", got[1].Content, "later duplicate ID should overwrite earlier entry")
+	require.NotEmpty(t, got[0].Nonce)
+	require.NotEmpty(t, got[1].Nonce)
+}
+
+func TestFrozenBlockTemplateRendersPartitionTags(t *testing.T) {
+	p, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts body", 100)
+	require.True(t, ok)
+	materials := &PromptMaterials{FrozenPartitions: []FrozenBlockPartition{p}}
+	rendered, err := RenderPromptTemplate("test-frozen", SharedFrozenBlockTemplate, materials.FrozenBlockData())
+	require.NoError(t, err)
+
+	start := "<|FROZEN_PARTITION_plan_facts_" + p.Nonce + "|>"
+	end := "<|FROZEN_PARTITION_END_plan_facts_" + p.Nonce + "|>"
+	require.Contains(t, rendered, "# Plan Facts")
+	require.Contains(t, rendered, start)
+	require.Contains(t, rendered, end)
+	require.Less(t, strings.Index(rendered, start), strings.Index(rendered, end))
+}
+
+func TestFrozenBlockPartitionsFromConfig(t *testing.T) {
+	cfg := NewConfig(nil,
+		WithFrozenBlockPartitionProducer(func() []FrozenBlockPartition {
+			p, ok := NewFrozenBlockPartition("plan_document", "Plan Document", "document", 110)
+			require.True(t, ok)
+			return []FrozenBlockPartition{p}
+		}),
+		WithFrozenBlockPartitionProducer(func() []FrozenBlockPartition {
+			p, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "facts", 100)
+			require.True(t, ok)
+			return []FrozenBlockPartition{p}
+		}),
+	)
+
+	partitions := FrozenBlockPartitionsFromConfig(cfg)
+	require.Len(t, partitions, 2)
+	require.Equal(t, "plan_facts", partitions[0].ID)
+	require.Equal(t, "plan_document", partitions[1].ID)
+}

--- a/common/ai/aid/aicommon/invoke_runtime.go
+++ b/common/ai/aid/aicommon/invoke_runtime.go
@@ -210,8 +210,8 @@ type LoopPromptAssemblyInput struct {
 
 	// FrozenUserContext 用于承载 PE-TASK 等场景下"PLAN 阶段产出 + 用户原始
 	// 输入"两类只读上下文。注: 命名虽为 "Frozen", 但实际并不放入冻结段;
-	// 跨同一 plan 周期内同一子任务执行的多次 turn 字节稳定, 但子任务切换 +
-	// EvidenceOps 嵌入 root user input 仍会让其内容抖动, 故不适合 cache。
+	// 跨同一 plan 周期内同一子任务执行的多次 turn 字节稳定, 但子任务切换仍
+	// 会让其内容抖动, 故不适合 cache。
 	//
 	// 物理位置: 包装为 <|PLAN_CONTEXT_<stable-nonce>|>...<|PLAN_CONTEXT_END_
 	// <stable-nonce>|> 后, 注入到 timeline-open 段最末尾 (UserHistory 之后)。
@@ -222,8 +222,8 @@ type LoopPromptAssemblyInput struct {
 	//   - v1: 注入 dynamic 段 (turn nonce), 完全不可缓存;
 	//   - v2: 迁到 frozen-block, 但 root task / 普通 ReAct 时为空, 渲染态
 	//     抖动破坏 AI_CACHE_FROZEN 命中;
-	//   - v3: 迁到 semi-dynamic, 但 EvidenceOps 嵌入 root user input + 子任务
-	//     切换仍让其内容抖动, 破坏 AI_CACHE_SEMI 命中;
+	//   - v3: 迁到 semi-dynamic, 但子任务切换仍让其内容抖动, 破坏
+	//     AI_CACHE_SEMI 命中;
 	//   - v4 (当前): 迁到 timeline-open 末尾, 主动让其落在所有 cache 边界外,
 	//     不再追求自身缓存, 而是保护更上游 SYSTEM / FROZEN / SEMI 三段缓存。
 	//
@@ -233,6 +233,10 @@ type LoopPromptAssemblyInput struct {
 	// 关键词: FrozenUserContext, PLAN_CONTEXT 段, timeline-open 末尾注入,
 	//        缓存边界外, 上游缓存保护, PE-TASK PLAN 产物
 	FrozenUserContext string
+
+	// FrozenPartitions 是业务侧提供的通用 frozen-block 分区。共享模板只识别
+	// FrozenBlockPartition，不直接依赖 planAndExec / FACTS / DOCUMENT 等业务类型。
+	FrozenPartitions []FrozenBlockPartition
 }
 
 type LoopPromptAssemblyResult struct {

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -43,19 +43,19 @@ type PromptMaterials struct {
 	ForgeInventory bool
 	AIForgeList    string
 
-	TimelineFrozen   string
-	TimelineOpen     string
-	CurrentTime      string
-	Workspace        bool
-	OSArch           string
-	WorkingDir       string
-	WorkingDirGlance string
-	// SessionArtifactsListing 是会话工件目录的结构化清单 (path / size /
-	// mtime, 按 task 分组 + mtime desc), 由 RenderSessionArtifactsListing
-	// 生成. 之前作为 ContextProviderManager 的 "session_artifacts" 注册项
-	// 落到 Pure Dynamic / AutoContext 段, 现已下沉到 Workspace 块, 与 OS /
-	// working dir / glance 一起渲染, 段位仍属 timeline-open.
-	// 关键词: SessionArtifactsListing, Workspace 内嵌, Pure Dynamic 反污染
+	TimelineFrozen         string
+	TimelineOpen           string
+	FrozenPartitions       []FrozenBlockPartition
+	SessionArtifactsFrozen string
+	SessionArtifactsOpen   string
+	CurrentTime            string
+	Workspace              bool
+	OSArch                 string
+	WorkingDir             string
+	WorkingDirGlance       string
+
+	// Deprecated: SessionArtifactsListing 保留给旧测试 / 兼容调用面。新 prompt
+	// 主路径使用 SessionArtifactsFrozen / SessionArtifactsOpen 两个一级字段。
 	SessionArtifactsListing string
 	SessionEvidence         string
 	// TodoSnapshot 是会话级 TODO 列表渲染结果 (含 <|TODO_LIST_<nonce>|>...
@@ -111,22 +111,24 @@ func (m *PromptMaterials) FrozenBlockData() map[string]any {
 		return map[string]any{}
 	}
 	return map[string]any{
-		"ToolInventory":  m.ToolInventory,
-		"ToolsCount":     m.ToolsCount,
-		"TopToolsCount":  m.TopToolsCount,
-		"TopTools":       m.TopTools,
-		"HasMoreTools":   m.HasMoreTools,
-		"MoreToolsCount": m.MoreToolsCount,
-		"ForgeInventory": m.ForgeInventory,
-		"AIForgeList":    m.AIForgeList,
-		"TimelineFrozen": m.TimelineFrozen,
+		"ToolInventory":          m.ToolInventory,
+		"ToolsCount":             m.ToolsCount,
+		"TopToolsCount":          m.TopToolsCount,
+		"TopTools":               m.TopTools,
+		"HasMoreTools":           m.HasMoreTools,
+		"MoreToolsCount":         m.MoreToolsCount,
+		"ForgeInventory":         m.ForgeInventory,
+		"AIForgeList":            m.AIForgeList,
+		"FrozenPartitions":       NormalizeFrozenBlockPartitions(m.FrozenPartitions),
+		"SessionArtifactsFrozen": m.SessionArtifactsFrozen,
+		"TimelineFrozen":         m.TimelineFrozen,
 	}
 }
 
 // TimelineOpenData 供 timeline-open 模板消费, 模板字段渲染顺序 (P1-C3):
 //
-//	Timeline (Open Tail) -> SessionEvidence -> Workspace -> UserHistory ->
-//	Current Time -> PlanContext (末尾)
+//	Timeline (Open Tail) -> SessionEvidence -> TodoSnapshot -> Workspace ->
+//	SessionArtifactsOpen -> UserHistory -> Current Time -> PlanContext (末尾)
 //
 // 段内排序原则:
 //  1. Timeline (Open Tail) 在最前: 时间线最末桶是模型理解"刚发生了什么"的
@@ -142,8 +144,8 @@ func (m *PromptMaterials) FrozenBlockData() map[string]any {
 //  5. Current Time 紧跟 UserHistory: 当前时间是最末稳定的时序锚点, 形成
 //     "历史输入 -> 现在"时间递进, 同时与下方 PlanContext 形成"时间 ->
 //     任务"语义衔接。
-//  6. PlanContext (PE-TASK PLAN 产物 PARENT_TASK + CURRENT_TASK + INSTRUCTION
-//     + 父链 FACTS/DOCUMENT) 在段最末尾。本段不被 AI_CACHE_FROZEN /
+//  6. PlanContext (PE-TASK PLAN 产物 PARENT_TASK + CURRENT_TASK + INSTRUCTION)
+//     在段最末尾。本段不被 AI_CACHE_FROZEN /
 //     AI_CACHE_SEMI 任何缓存边界包裹, 是 prompt 的"易变尾段", 让 PlanContext
 //     的子任务切换抖动不会污染上游 system / frozen / semi 三段缓存命中。
 //
@@ -160,17 +162,16 @@ func (m *PromptMaterials) TimelineOpenData() map[string]any {
 		return map[string]any{}
 	}
 	return map[string]any{
-		"TimelineOpen":            m.TimelineOpen,
-		"SessionEvidence":         m.SessionEvidence,
-		"TodoSnapshot":            m.TodoSnapshot,
-		"Workspace":               m.Workspace,
-		"OSArch":                  m.OSArch,
-		"WorkingDir":              m.WorkingDir,
-		"WorkingDirGlance":        m.WorkingDirGlance,
-		"SessionArtifactsListing": m.SessionArtifactsListing,
-		"UserHistory":             m.UserHistory,
-		"CurrentTime":             m.CurrentTime,
-		"PlanContext":             m.FrozenUserContext,
+		"TimelineOpen":         m.TimelineOpen,
+		"SessionEvidence":      m.SessionEvidence,
+		"TodoSnapshot":         m.TodoSnapshot,
+		"Workspace":            m.Workspace,
+		"OSArch":               m.OSArch,
+		"WorkingDir":           m.WorkingDir,
+		"WorkingDirGlance":     m.WorkingDirGlance,
+		"SessionArtifactsOpen": m.SessionArtifactsOpen,
+		"UserHistory":          m.UserHistory,
+		"CurrentTime":          m.CurrentTime,
+		"PlanContext":          m.FrozenUserContext,
 	}
 }
-

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -45,6 +45,7 @@ type PromptMaterials struct {
 
 	TimelineFrozen         string
 	TimelineOpen           string
+	TimelineFrozenTimeUnix int64
 	FrozenPartitions       []FrozenBlockPartition
 	SessionArtifactsFrozen string
 	SessionArtifactsOpen   string
@@ -122,6 +123,7 @@ func (m *PromptMaterials) FrozenBlockData() map[string]any {
 		"FrozenPartitions":       NormalizeFrozenBlockPartitions(m.FrozenPartitions),
 		"SessionArtifactsFrozen": m.SessionArtifactsFrozen,
 		"TimelineFrozen":         m.TimelineFrozen,
+		"TimelineFrozenTimeUnix": m.TimelineFrozenTimeUnix,
 	}
 }
 
@@ -162,16 +164,96 @@ func (m *PromptMaterials) TimelineOpenData() map[string]any {
 		return map[string]any{}
 	}
 	return map[string]any{
-		"TimelineOpen":         m.TimelineOpen,
-		"SessionEvidence":      m.SessionEvidence,
-		"TodoSnapshot":         m.TodoSnapshot,
-		"Workspace":            m.Workspace,
-		"OSArch":               m.OSArch,
-		"WorkingDir":           m.WorkingDir,
-		"WorkingDirGlance":     m.WorkingDirGlance,
-		"SessionArtifactsOpen": m.SessionArtifactsOpen,
-		"UserHistory":          m.UserHistory,
-		"CurrentTime":          m.CurrentTime,
-		"PlanContext":          m.FrozenUserContext,
+		"TimelineOpen":           m.TimelineOpen,
+		"TimelineFrozenTimeUnix": m.TimelineFrozenTimeUnix,
+		"SessionEvidence":        m.SessionEvidence,
+		"TodoSnapshot":           m.TodoSnapshot,
+		"Workspace":              m.Workspace,
+		"OSArch":                 m.OSArch,
+		"WorkingDir":             m.WorkingDir,
+		"WorkingDirGlance":       m.WorkingDirGlance,
+		"SessionArtifactsOpen":   m.SessionArtifactsOpen,
+		"UserHistory":            m.UserHistory,
+		"CurrentTime":            m.CurrentTime,
+		"PlanContext":            m.FrozenUserContext,
 	}
+}
+
+type TimelineFrozenOpenBlocks struct {
+	Frozen         string
+	Open           string
+	FrozenTimeUnix int64
+}
+
+func RenderTimelineFrozenOpen(timeline *Timeline) TimelineFrozenOpenBlocks {
+	if timeline == nil {
+		return TimelineFrozenOpenBlocks{}
+	}
+	rb := timeline.GroupByMinutes(TimelineDumpDefaultIntervalMinutes).GetAllRenderable()
+	return TimelineFrozenOpenBlocks{
+		Frozen:         rb.RenderFrozenOnly(TimelineDumpDefaultAITagName),
+		Open:           rb.RenderOpenOnly(TimelineDumpDefaultAITagName),
+		FrozenTimeUnix: timelineFrozenTimeUnixFromRenderable(rb),
+	}
+}
+
+type PromptFrozenOpenMaterials struct {
+	TimelineFrozen         string
+	TimelineOpen           string
+	TimelineFrozenTimeUnix int64
+
+	SessionArtifactsFrozen string
+	SessionArtifactsOpen   string
+}
+
+func BuildPromptFrozenOpenMaterials(config *Config) PromptFrozenOpenMaterials {
+	if config == nil {
+		return PromptFrozenOpenMaterials{}
+	}
+	timelineBlocks := RenderTimelineFrozenOpen(config.GetTimeline())
+	artifactBlocks := RenderSessionArtifactsFrozenOpen(config, timelineBlocks.FrozenTimeUnix)
+	return PromptFrozenOpenMaterials{
+		TimelineFrozen:         timelineBlocks.Frozen,
+		TimelineOpen:           timelineBlocks.Open,
+		TimelineFrozenTimeUnix: timelineBlocks.FrozenTimeUnix,
+		SessionArtifactsFrozen: artifactBlocks.Frozen,
+		SessionArtifactsOpen:   artifactBlocks.Open,
+	}
+}
+
+func ApplyPromptFrozenOpenMaterials(materials *PromptMaterials, frozenOpen PromptFrozenOpenMaterials) {
+	if materials == nil {
+		return
+	}
+	materials.TimelineFrozen = frozenOpen.TimelineFrozen
+	materials.TimelineOpen = frozenOpen.TimelineOpen
+	materials.TimelineFrozenTimeUnix = frozenOpen.TimelineFrozenTimeUnix
+	materials.SessionArtifactsFrozen = frozenOpen.SessionArtifactsFrozen
+	materials.SessionArtifactsOpen = frozenOpen.SessionArtifactsOpen
+}
+
+func timelineFrozenTimeUnixFromRenderable(blocks TimelineRenderableBlocks) int64 {
+	if len(blocks) == 0 {
+		return 0
+	}
+	var lastFrozenEnd int64
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+		interval, ok := block.(*TimelineIntervalBlock)
+		if !ok || interval == nil {
+			continue
+		}
+		if block.IsOpen() {
+			if !interval.BucketStart.IsZero() {
+				return interval.BucketStart.Unix()
+			}
+			return 0
+		}
+		if !interval.BucketEnd.IsZero() {
+			lastFrozenEnd = interval.BucketEnd.Unix()
+		}
+	}
+	return lastFrozenEnd
 }

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -201,6 +201,7 @@ type PromptFrozenOpenMaterials struct {
 	TimelineFrozen         string
 	TimelineOpen           string
 	TimelineFrozenTimeUnix int64
+	FrozenPartitions       []FrozenBlockPartition
 
 	SessionArtifactsFrozen string
 	SessionArtifactsOpen   string
@@ -216,6 +217,7 @@ func BuildPromptFrozenOpenMaterials(config *Config) PromptFrozenOpenMaterials {
 		TimelineFrozen:         timelineBlocks.Frozen,
 		TimelineOpen:           timelineBlocks.Open,
 		TimelineFrozenTimeUnix: timelineBlocks.FrozenTimeUnix,
+		FrozenPartitions:       FrozenBlockPartitionsFromConfig(config),
 		SessionArtifactsFrozen: artifactBlocks.Frozen,
 		SessionArtifactsOpen:   artifactBlocks.Open,
 	}
@@ -228,6 +230,7 @@ func ApplyPromptFrozenOpenMaterials(materials *PromptMaterials, frozenOpen Promp
 	materials.TimelineFrozen = frozenOpen.TimelineFrozen
 	materials.TimelineOpen = frozenOpen.TimelineOpen
 	materials.TimelineFrozenTimeUnix = frozenOpen.TimelineFrozenTimeUnix
+	materials.FrozenPartitions = append([]FrozenBlockPartition(nil), NormalizeFrozenBlockPartitions(frozenOpen.FrozenPartitions)...)
 	materials.SessionArtifactsFrozen = frozenOpen.SessionArtifactsFrozen
 	materials.SessionArtifactsOpen = frozenOpen.SessionArtifactsOpen
 }

--- a/common/ai/aid/aicommon/prompt_section_builder.go
+++ b/common/ai/aid/aicommon/prompt_section_builder.go
@@ -118,6 +118,7 @@ func (b *PromptPrefixBuilder) AssemblePromptPrefix(materials *PromptMaterials) (
 	if materials == nil {
 		materials = &PromptMaterials{}
 	}
+	materials.FrozenPartitions = NormalizeFrozenBlockPartitions(materials.FrozenPartitions)
 
 	highStatic, err := RenderPromptTemplate(b.HighStaticTemplateName, b.HighStaticTemplate, materials.HighStaticData())
 	if err != nil {

--- a/common/ai/aid/aicommon/prompts/prefix/frozen_block_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/frozen_block_section.txt
@@ -22,5 +22,16 @@ You have access to {{ .ToolsCount }} built-in tools. Below are {{ .TopToolsCount
 以下是当前可直接调用的 AI 蓝图列表：
 {{ .AIForgeList }}{{ end }}
 
+{{ range .FrozenPartitions }}
+{{ if .Content }}# {{ .Title }}
+<|FROZEN_PARTITION_{{ .ID }}_{{ .Nonce }}|>
+{{ .Content }}
+<|FROZEN_PARTITION_END_{{ .ID }}_{{ .Nonce }}|>
+{{ end }}
+{{ end }}
+
+{{ if .SessionArtifactsFrozen }}# Session Artifacts (Frozen)
+{{ .SessionArtifactsFrozen }}{{ end }}
+
 {{ if .TimelineFrozen }}# Timeline Memory (Frozen Prefix)
 {{ .TimelineFrozen }}{{ end }}

--- a/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
@@ -21,16 +21,16 @@
 
 {{ if .Workspace }}# Workspace Context
 
-工作区上下文给出 Agent 当前运行环境的"物理坐标"：操作系统 / 架构、当前工作目录的绝对路径、该目录顶层结构概览，以及本会话已经累积的工件文件清单（Session Artifacts）。
+工作区上下文给出 Agent 当前运行环境的"物理坐标"：操作系统 / 架构、当前工作目录的绝对路径、该目录顶层结构概览。
 所有涉及文件读写、脚本执行工具调用，都应以下方 working dir 为锚点来构造路径；working dir glance 提供"这个目录里有什么"的快速参考，可用于判断目标文件是否已经存在、是否需要先列目录确认。
-Session Artifacts 段由历轮任务/工具产生的输出文件汇总而来（按 task 子目录分组、按修改时间倒序），仅给出文件名、大小、修改时间——不嵌入文件正文；若需查看具体内容，请通过文件读取动作显式访问。
 
 OS/Arch: {{ .OSArch }}
 {{ if .WorkingDir }}working dir: {{ .WorkingDir }}
 {{ end }}{{ if .WorkingDirGlance }}working dir glance: {{ .WorkingDirGlance }}
-{{ end }}{{ if .SessionArtifactsListing }}
-## Session Artifacts
-{{ .SessionArtifactsListing }}{{ end }}{{ end }}
+{{ end }}{{ end }}
+
+{{ if .SessionArtifactsOpen }}# Session Artifacts (Open)
+{{ .SessionArtifactsOpen }}{{ end }}
 
 {{ if .UserHistory }}
 以下 PREV_USER_INPUT 块是当前会话内用户在此前各轮的原始输入文本，按时间先后给出，用于跨回合维持上下文连贯：理解用户的真实意图、追溯尚未完成的请求、避免反复询问用户早已明确说过的信息。

--- a/common/ai/aid/aicommon/review_split_test.go
+++ b/common/ai/aid/aicommon/review_split_test.go
@@ -2,6 +2,7 @@ package aicommon
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,6 +64,9 @@ func TestSplit_TaskReviewPrompt_FourSections(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	cfg := NewTestConfig(ctx)
+	cfg.Timeline.SetTimelineBucketByteSize(80)
+	cfg.Timeline.PushText(101, "frozen task review timeline "+strings.Repeat("A", 120))
+	cfg.Timeline.PushText(102, "open task review timeline "+strings.Repeat("B", 120))
 
 	materials := aitool.InvokeParams{
 		"short_summary": "OK",
@@ -84,6 +88,14 @@ func TestSplit_TaskReviewPrompt_FourSections(t *testing.T) {
 
 	require.Equal(t, sec1[aicache.SectionHighStatic][0].Hash, sec2[aicache.SectionHighStatic][0].Hash,
 		"task-review high-static hash must be byte-stable across calls")
+	require.Contains(t, prompt1, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, prompt1, "frozen task review timeline")
+	require.Contains(t, prompt1, "<|PROMPT_SECTION_timeline-open|>")
+	require.Contains(t, prompt1, "open task review timeline")
+	frozenEnd := strings.Index(prompt1, "<|AI_CACHE_FROZEN_END_semi-dynamic|>")
+	openStart := strings.Index(prompt1, "<|PROMPT_SECTION_timeline-open|>")
+	require.Greater(t, frozenEnd, 0)
+	require.Greater(t, openStart, frozenEnd, "frozen timeline must be outside and before timeline-open")
 }
 
 func TestSplit_ToolCallReviewPrompt_FourSections(t *testing.T) {

--- a/common/ai/aid/aicommon/review_split_test.go
+++ b/common/ai/aid/aicommon/review_split_test.go
@@ -89,6 +89,7 @@ func TestSplit_TaskReviewPrompt_FourSections(t *testing.T) {
 	require.Equal(t, sec1[aicache.SectionHighStatic][0].Hash, sec2[aicache.SectionHighStatic][0].Hash,
 		"task-review high-static hash must be byte-stable across calls")
 	require.Contains(t, prompt1, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, prompt1, "# Tool Inventory")
 	require.Contains(t, prompt1, "frozen task review timeline")
 	require.Contains(t, prompt1, "<|PROMPT_SECTION_timeline-open|>")
 	require.Contains(t, prompt1, "open task review timeline")

--- a/common/ai/aid/aicommon/review_split_test.go
+++ b/common/ai/aid/aicommon/review_split_test.go
@@ -90,6 +90,7 @@ func TestSplit_TaskReviewPrompt_FourSections(t *testing.T) {
 		"task-review high-static hash must be byte-stable across calls")
 	require.Contains(t, prompt1, "<|AI_CACHE_FROZEN_semi-dynamic|>")
 	require.Contains(t, prompt1, "# Tool Inventory")
+	require.NotContains(t, prompt1, "You have access to 0 built-in tools")
 	require.Contains(t, prompt1, "frozen task review timeline")
 	require.Contains(t, prompt1, "<|PROMPT_SECTION_timeline-open|>")
 	require.Contains(t, prompt1, "open task review timeline")

--- a/common/ai/aid/aicommon/session_artifacts.go
+++ b/common/ai/aid/aicommon/session_artifacts.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/yaklang/yaklang/common/log"
@@ -24,9 +25,34 @@ type SessionArtifactTaskGroup struct {
 	LatestMod int64
 }
 
+type SessionArtifactTaskGroupSnapshot struct {
+	TaskDir   string
+	Files     []SessionArtifactEntry
+	LatestMod int64
+}
+
 type SessionArtifactsPromptBlocks struct {
 	Frozen string
 	Open   string
+}
+
+type SessionArtifactsRenderState struct {
+	m sync.Mutex
+
+	WorkDir string
+
+	LastFrozenTimeUnix int64
+	LastFrozenRendered string
+
+	FrozenGroups map[string]SessionArtifactTaskGroupSnapshot
+}
+
+var sessionArtifactsStateByWorkDir sync.Map
+
+func NewSessionArtifactsRenderState() *SessionArtifactsRenderState {
+	return &SessionArtifactsRenderState{
+		FrozenGroups: make(map[string]SessionArtifactTaskGroupSnapshot),
+	}
 }
 
 func CollectSessionArtifactEntries(config AICallerConfigIf) ([]SessionArtifactEntry, string) {
@@ -96,9 +122,7 @@ func GroupSessionArtifactsByTask(entries []SessionArtifactEntry) []SessionArtifa
 	for taskDir, files := range groupByTask {
 		groups = append(groups, buildSessionArtifactTaskGroup(taskDir, files))
 	}
-	sort.SliceStable(groups, func(i, j int) bool {
-		return compareSessionArtifactTaskDir(groups[i].TaskDir, groups[j].TaskDir) < 0
-	})
+	sortSessionArtifactTaskGroups(groups)
 	if len(rootFiles) > 0 {
 		groups = append(groups, buildSessionArtifactTaskGroup("", rootFiles))
 	}
@@ -179,13 +203,35 @@ func RenderSessionArtifactGroups(workDir string, groups []SessionArtifactTaskGro
 	return result
 }
 
-func RenderSessionArtifactsFrozenOpen(config AICallerConfigIf) SessionArtifactsPromptBlocks {
+func RenderSessionArtifactsFrozenOpen(config AICallerConfigIf, frozenTimeUnix int64) SessionArtifactsPromptBlocks {
 	entries, workDir := CollectSessionArtifactEntries(config)
 	groups := GroupSessionArtifactsByTask(entries)
-	frozenGroups, openGroups := SplitSessionArtifactGroups(groups)
+	state := getSessionArtifactsRenderState(config, workDir)
+	if state == nil {
+		state = NewSessionArtifactsRenderState()
+	}
+
+	state.m.Lock()
+	defer state.m.Unlock()
+
+	if state.WorkDir != strings.TrimSpace(workDir) {
+		resetSessionArtifactsRenderState(state, workDir)
+	}
+	if frozenTimeUnix < state.LastFrozenTimeUnix {
+		resetSessionArtifactsRenderState(state, workDir)
+	}
+
+	frozen := state.LastFrozenRendered
+	if frozenTimeUnix > state.LastFrozenTimeUnix {
+		UpdateSessionArtifactsFrozenState(state, workDir, groups, frozenTimeUnix)
+		state.LastFrozenTimeUnix = frozenTimeUnix
+		frozen = RenderSessionArtifactsFrozenFromState(state)
+		state.LastFrozenRendered = frozen
+	}
+
 	return SessionArtifactsPromptBlocks{
-		Frozen: RenderSessionArtifactGroups(workDir, frozenGroups),
-		Open:   RenderSessionArtifactGroups(workDir, openGroups),
+		Frozen: frozen,
+		Open:   RenderSessionArtifactsOpenFromLiveGroups(state, workDir, groups, frozenTimeUnix),
 	}
 }
 
@@ -193,6 +239,238 @@ func RenderSessionArtifactsListing(config AICallerConfigIf) string {
 	entries, workDir := CollectSessionArtifactEntries(config)
 	groups := GroupSessionArtifactsByTask(entries)
 	return RenderSessionArtifactGroups(workDir, groups)
+}
+
+func UpdateSessionArtifactsFrozenState(
+	state *SessionArtifactsRenderState,
+	workDir string,
+	groups []SessionArtifactTaskGroup,
+	frozenTimeUnix int64,
+) {
+	if state == nil {
+		return
+	}
+	if state.FrozenGroups == nil {
+		state.FrozenGroups = make(map[string]SessionArtifactTaskGroupSnapshot)
+	}
+	workDir = strings.TrimSpace(workDir)
+	if state.WorkDir != workDir {
+		resetSessionArtifactsRenderState(state, workDir)
+	}
+	if frozenTimeUnix <= 0 {
+		return
+	}
+	for _, group := range groups {
+		normalizeSessionArtifactTaskGroup(&group)
+		taskDir := strings.TrimSpace(group.TaskDir)
+		if taskDir == "" {
+			continue
+		}
+		if _, exists := state.FrozenGroups[taskDir]; exists {
+			continue
+		}
+		if group.LatestMod < frozenTimeUnix {
+			state.FrozenGroups[taskDir] = snapshotSessionArtifactTaskGroup(group)
+		}
+	}
+}
+
+func RenderSessionArtifactsFrozenFromState(state *SessionArtifactsRenderState) string {
+	if state == nil || len(state.FrozenGroups) == 0 {
+		return ""
+	}
+	groups := make([]SessionArtifactTaskGroup, 0, len(state.FrozenGroups))
+	for _, snapshot := range state.FrozenGroups {
+		groups = append(groups, SessionArtifactTaskGroup{
+			TaskDir:   snapshot.TaskDir,
+			Files:     append([]SessionArtifactEntry{}, snapshot.Files...),
+			LatestMod: snapshot.LatestMod,
+		})
+	}
+	sortSessionArtifactTaskGroups(groups)
+	return renderSessionArtifactPromptGroups(
+		state.WorkDir,
+		groups,
+		state.LastFrozenTimeUnix,
+		nil,
+	)
+}
+
+func RenderSessionArtifactsOpenFromLiveGroups(
+	state *SessionArtifactsRenderState,
+	workDir string,
+	groups []SessionArtifactTaskGroup,
+	frozenTimeUnix int64,
+) string {
+	if len(groups) == 0 {
+		return ""
+	}
+	if state == nil {
+		state = NewSessionArtifactsRenderState()
+	}
+	openGroups := make([]SessionArtifactTaskGroup, 0, len(groups))
+	headerSuffix := make(map[string]string)
+
+	for _, group := range groups {
+		normalizeSessionArtifactTaskGroup(&group)
+		taskDir := strings.TrimSpace(group.TaskDir)
+		if taskDir == "" {
+			openGroups = append(openGroups, group)
+			continue
+		}
+
+		if snapshot, frozen := state.FrozenGroups[taskDir]; frozen {
+			delta := diffSessionArtifactTaskGroup(snapshot, group)
+			if len(delta.Files) > 0 {
+				openGroups = append(openGroups, delta)
+				headerSuffix[taskDir] = " (updates after frozen snapshot)"
+			}
+			continue
+		}
+
+		// A non-sealed group is always kept open. In the normal path, eligible
+		// groups are sealed when FrozenTimeUnix advances; this also prevents a
+		// newly-created/backdated group from disappearing while FrozenTimeUnix is
+		// unchanged.
+		openGroups = append(openGroups, group)
+	}
+	sortSessionArtifactTaskGroups(openGroups)
+	return renderSessionArtifactPromptGroups(workDir, openGroups, frozenTimeUnix, headerSuffix)
+}
+
+func getSessionArtifactsRenderState(config AICallerConfigIf, workDir string) *SessionArtifactsRenderState {
+	if cfg, ok := config.(*Config); ok && cfg != nil {
+		if cfg.SessionPromptState == nil {
+			if cfg.m != nil {
+				cfg.m.Lock()
+				if cfg.SessionPromptState == nil {
+					cfg.SessionPromptState = NewSessionPromptState()
+				}
+				cfg.m.Unlock()
+			} else {
+				cfg.SessionPromptState = NewSessionPromptState()
+			}
+		}
+		return cfg.SessionPromptState.GetOrCreateSessionArtifactsRenderState()
+	}
+
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return NewSessionArtifactsRenderState()
+	}
+	state, _ := sessionArtifactsStateByWorkDir.LoadOrStore(workDir, NewSessionArtifactsRenderState())
+	if typed, ok := state.(*SessionArtifactsRenderState); ok {
+		return typed
+	}
+	return NewSessionArtifactsRenderState()
+}
+
+func resetSessionArtifactsRenderState(state *SessionArtifactsRenderState, workDir string) {
+	if state == nil {
+		return
+	}
+	state.WorkDir = strings.TrimSpace(workDir)
+	state.LastFrozenTimeUnix = 0
+	state.LastFrozenRendered = ""
+	state.FrozenGroups = make(map[string]SessionArtifactTaskGroupSnapshot)
+}
+
+func snapshotSessionArtifactTaskGroup(group SessionArtifactTaskGroup) SessionArtifactTaskGroupSnapshot {
+	normalizeSessionArtifactTaskGroup(&group)
+	return SessionArtifactTaskGroupSnapshot{
+		TaskDir:   strings.TrimSpace(group.TaskDir),
+		Files:     append([]SessionArtifactEntry{}, group.Files...),
+		LatestMod: group.LatestMod,
+	}
+}
+
+func diffSessionArtifactTaskGroup(
+	snapshot SessionArtifactTaskGroupSnapshot,
+	live SessionArtifactTaskGroup,
+) SessionArtifactTaskGroup {
+	normalizeSessionArtifactTaskGroup(&live)
+	seen := make(map[string]SessionArtifactEntry, len(snapshot.Files))
+	for _, file := range snapshot.Files {
+		seen[file.RelPath] = file
+	}
+
+	delta := SessionArtifactTaskGroup{TaskDir: live.TaskDir}
+	for _, file := range live.Files {
+		prev, ok := seen[file.RelPath]
+		if ok && prev.Size == file.Size && prev.ModUnix == file.ModUnix {
+			continue
+		}
+		delta.Files = append(delta.Files, file)
+	}
+	normalizeSessionArtifactTaskGroup(&delta)
+	return delta
+}
+
+func renderSessionArtifactPromptGroups(
+	workDir string,
+	groups []SessionArtifactTaskGroup,
+	frozenTimeUnix int64,
+	headerSuffix map[string]string,
+) string {
+	if len(groups) == 0 {
+		return ""
+	}
+
+	normalized := make([]SessionArtifactTaskGroup, 0, len(groups))
+	for _, group := range groups {
+		normalizeSessionArtifactTaskGroup(&group)
+		if len(group.Files) == 0 {
+			continue
+		}
+		normalized = append(normalized, group)
+	}
+	if len(normalized) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	if workDir = strings.TrimSpace(workDir); workDir != "" {
+		sb.WriteString(fmt.Sprintf("artifacts_dir: %s\n", workDir))
+	}
+	sb.WriteString(fmt.Sprintf("frozen_time: %s\n\n", formatArtifactModTime(frozenTimeUnix, "2006-01-02 15:04:05")))
+
+	for _, group := range normalized {
+		taskDir := strings.TrimSpace(group.TaskDir)
+		if taskDir == "" {
+			sb.WriteString("### [root files]\n")
+		} else {
+			sb.WriteString(fmt.Sprintf("### %s%s\n", taskDir, headerSuffix[taskDir]))
+		}
+		for _, file := range group.Files {
+			displayPath := file.RelPath
+			if taskDir != "" {
+				displayPath = strings.TrimPrefix(displayPath, taskDir+"/")
+			}
+			sb.WriteString(fmt.Sprintf("- %s (%s, %s)\n",
+				displayPath,
+				formatFileSize(file.Size),
+				formatArtifactModTime(file.ModUnix, "2006-01-02 15:04:05"),
+			))
+		}
+		sb.WriteString("\n")
+	}
+
+	result := sb.String()
+	if MeasureTokens(result) > ArtifactsContextMaxTokens {
+		result = ShrinkTextBlockByTokens(result, ArtifactsContextMaxTokens)
+	}
+	return result
+}
+
+func sortSessionArtifactTaskGroups(groups []SessionArtifactTaskGroup) {
+	sort.SliceStable(groups, func(i, j int) bool {
+		leftRoot := strings.TrimSpace(groups[i].TaskDir) == ""
+		rightRoot := strings.TrimSpace(groups[j].TaskDir) == ""
+		if leftRoot != rightRoot {
+			return !leftRoot
+		}
+		return compareSessionArtifactTaskDir(groups[i].TaskDir, groups[j].TaskDir) < 0
+	})
 }
 
 func sessionArtifactTaskDir(relPath string) (string, bool) {
@@ -217,6 +495,8 @@ func normalizeSessionArtifactTaskGroup(group *SessionArtifactTaskGroup) {
 	if group == nil {
 		return
 	}
+	group.TaskDir = strings.TrimSpace(group.TaskDir)
+	group.LatestMod = 0
 	for i := range group.Files {
 		group.Files[i].RelPath = filepath.ToSlash(strings.TrimSpace(group.Files[i].RelPath))
 		if group.Files[i].ModUnix > group.LatestMod {

--- a/common/ai/aid/aicommon/session_artifacts.go
+++ b/common/ai/aid/aicommon/session_artifacts.go
@@ -1,0 +1,296 @@
+package aicommon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/yaklang/yaklang/common/log"
+)
+
+type SessionArtifactEntry struct {
+	RelPath string
+	Size    int64
+	ModUnix int64
+}
+
+type SessionArtifactTaskGroup struct {
+	TaskDir   string
+	Files     []SessionArtifactEntry
+	LatestMod int64
+}
+
+type SessionArtifactsPromptBlocks struct {
+	Frozen string
+	Open   string
+}
+
+func CollectSessionArtifactEntries(config AICallerConfigIf) ([]SessionArtifactEntry, string) {
+	if config == nil {
+		return nil, ""
+	}
+	workDir := config.GetOrCreateWorkDir()
+	if workDir == "" {
+		return nil, ""
+	}
+	info, err := os.Stat(workDir)
+	if err != nil || !info.IsDir() {
+		return nil, workDir
+	}
+
+	var entries []SessionArtifactEntry
+	walkErr := filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			log.Warnf("[SessionArtifacts] walk error for %s: %v", path, err)
+			return nil
+		}
+		if d == nil || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			log.Warnf("[SessionArtifacts] stat error for %s: %v", path, err)
+			return nil
+		}
+		relPath, err := filepath.Rel(workDir, path)
+		if err != nil {
+			relPath = path
+		}
+		entries = append(entries, SessionArtifactEntry{
+			RelPath: filepath.ToSlash(relPath),
+			Size:    info.Size(),
+			ModUnix: info.ModTime().Unix(),
+		})
+		return nil
+	})
+	if walkErr != nil {
+		log.Warnf("session artifacts: walk error: %v", walkErr)
+	}
+	return entries, workDir
+}
+
+func GroupSessionArtifactsByTask(entries []SessionArtifactEntry) []SessionArtifactTaskGroup {
+	if len(entries) == 0 {
+		return nil
+	}
+	groupByTask := make(map[string][]SessionArtifactEntry)
+	var rootFiles []SessionArtifactEntry
+	for _, entry := range entries {
+		entry.RelPath = filepath.ToSlash(strings.TrimSpace(entry.RelPath))
+		if entry.RelPath == "" {
+			continue
+		}
+		taskDir, ok := sessionArtifactTaskDir(entry.RelPath)
+		if !ok {
+			rootFiles = append(rootFiles, entry)
+			continue
+		}
+		groupByTask[taskDir] = append(groupByTask[taskDir], entry)
+	}
+
+	groups := make([]SessionArtifactTaskGroup, 0, len(groupByTask)+1)
+	for taskDir, files := range groupByTask {
+		groups = append(groups, buildSessionArtifactTaskGroup(taskDir, files))
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		return compareSessionArtifactTaskDir(groups[i].TaskDir, groups[j].TaskDir) < 0
+	})
+	if len(rootFiles) > 0 {
+		groups = append(groups, buildSessionArtifactTaskGroup("", rootFiles))
+	}
+	return groups
+}
+
+func SplitSessionArtifactGroups(groups []SessionArtifactTaskGroup) (frozen []SessionArtifactTaskGroup, open []SessionArtifactTaskGroup) {
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	var taskGroups []SessionArtifactTaskGroup
+	var rootGroups []SessionArtifactTaskGroup
+	for _, group := range groups {
+		if strings.TrimSpace(group.TaskDir) == "" {
+			rootGroups = append(rootGroups, group)
+			continue
+		}
+		taskGroups = append(taskGroups, group)
+	}
+	if len(taskGroups) > 1 {
+		frozen = append(frozen, taskGroups[:len(taskGroups)-1]...)
+		open = append(open, taskGroups[len(taskGroups)-1])
+	} else if len(taskGroups) == 1 {
+		open = append(open, taskGroups[0])
+	}
+	open = append(open, rootGroups...)
+	return frozen, open
+}
+
+func RenderSessionArtifactGroups(workDir string, groups []SessionArtifactTaskGroup) string {
+	if len(groups) == 0 {
+		return ""
+	}
+	workDir = strings.TrimSpace(workDir)
+	totalFiles := 0
+	for i := range groups {
+		normalizeSessionArtifactTaskGroup(&groups[i])
+		totalFiles += len(groups[i].Files)
+	}
+	if totalFiles == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	if workDir != "" {
+		sb.WriteString(fmt.Sprintf("artifacts_dir: %s\n", workDir))
+	}
+	sb.WriteString(fmt.Sprintf("total_files: %d\n\n", totalFiles))
+	for _, group := range groups {
+		if len(group.Files) == 0 {
+			continue
+		}
+		if strings.TrimSpace(group.TaskDir) == "" {
+			sb.WriteString("### [root files]\n")
+		} else {
+			sb.WriteString(fmt.Sprintf("### %s (modified: %s)\n",
+				group.TaskDir,
+				formatArtifactModTime(group.LatestMod, "2006-01-02 15:04:05"),
+			))
+		}
+		for _, file := range group.Files {
+			displayPath := file.RelPath
+			if group.TaskDir != "" {
+				displayPath = strings.TrimPrefix(displayPath, group.TaskDir+"/")
+			}
+			sb.WriteString(fmt.Sprintf("- %s (%s, %s)\n",
+				displayPath,
+				formatFileSize(file.Size),
+				formatArtifactModTime(file.ModUnix, "15:04:05"),
+			))
+		}
+		sb.WriteString("\n")
+	}
+	result := sb.String()
+	if MeasureTokens(result) > ArtifactsContextMaxTokens {
+		result = ShrinkTextBlockByTokens(result, ArtifactsContextMaxTokens)
+	}
+	return result
+}
+
+func RenderSessionArtifactsFrozenOpen(config AICallerConfigIf) SessionArtifactsPromptBlocks {
+	entries, workDir := CollectSessionArtifactEntries(config)
+	groups := GroupSessionArtifactsByTask(entries)
+	frozenGroups, openGroups := SplitSessionArtifactGroups(groups)
+	return SessionArtifactsPromptBlocks{
+		Frozen: RenderSessionArtifactGroups(workDir, frozenGroups),
+		Open:   RenderSessionArtifactGroups(workDir, openGroups),
+	}
+}
+
+func RenderSessionArtifactsListing(config AICallerConfigIf) string {
+	entries, workDir := CollectSessionArtifactEntries(config)
+	groups := GroupSessionArtifactsByTask(entries)
+	return RenderSessionArtifactGroups(workDir, groups)
+}
+
+func sessionArtifactTaskDir(relPath string) (string, bool) {
+	parts := strings.SplitN(filepath.ToSlash(relPath), "/", 2)
+	if len(parts) < 2 {
+		return "", false
+	}
+	taskDir := strings.TrimSpace(parts[0])
+	if !strings.HasPrefix(taskDir, "task_") {
+		return "", false
+	}
+	return taskDir, true
+}
+
+func buildSessionArtifactTaskGroup(taskDir string, files []SessionArtifactEntry) SessionArtifactTaskGroup {
+	group := SessionArtifactTaskGroup{TaskDir: taskDir, Files: append([]SessionArtifactEntry{}, files...)}
+	normalizeSessionArtifactTaskGroup(&group)
+	return group
+}
+
+func normalizeSessionArtifactTaskGroup(group *SessionArtifactTaskGroup) {
+	if group == nil {
+		return
+	}
+	for i := range group.Files {
+		group.Files[i].RelPath = filepath.ToSlash(strings.TrimSpace(group.Files[i].RelPath))
+		if group.Files[i].ModUnix > group.LatestMod {
+			group.LatestMod = group.Files[i].ModUnix
+		}
+	}
+	sort.SliceStable(group.Files, func(i, j int) bool {
+		return group.Files[i].RelPath < group.Files[j].RelPath
+	})
+}
+
+func compareSessionArtifactTaskDir(a string, b string) int {
+	aIdx, aOK := parseSessionArtifactTaskIndex(a)
+	bIdx, bOK := parseSessionArtifactTaskIndex(b)
+	if aOK && bOK {
+		for i := 0; i < len(aIdx) || i < len(bIdx); i++ {
+			var av, bv int
+			if i < len(aIdx) {
+				av = aIdx[i]
+			}
+			if i < len(bIdx) {
+				bv = bIdx[i]
+			}
+			if av < bv {
+				return -1
+			}
+			if av > bv {
+				return 1
+			}
+		}
+	}
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+func parseSessionArtifactTaskIndex(taskDir string) ([]int, bool) {
+	taskDir = strings.TrimPrefix(strings.TrimSpace(taskDir), "task_")
+	if taskDir == "" {
+		return nil, false
+	}
+	end := len(taskDir)
+	for i, r := range taskDir {
+		if (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			continue
+		}
+		end = i
+		break
+	}
+	index := strings.Trim(taskDir[:end], "-.")
+	if index == "" {
+		return nil, false
+	}
+	parts := strings.FieldsFunc(index, func(r rune) bool {
+		return r == '-' || r == '.'
+	})
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	return out, len(out) > 0
+}
+
+func formatArtifactModTime(unix int64, layout string) string {
+	if unix <= 0 {
+		return "unknown"
+	}
+	return time.Unix(unix, 0).Format(layout)
+}

--- a/common/ai/aid/aicommon/session_artifacts_test.go
+++ b/common/ai/aid/aicommon/session_artifacts_test.go
@@ -126,11 +126,16 @@ func TestBuildPromptFrozenOpenMaterialsCoordinatesTimelineAndArtifacts(t *testin
 	cfg := NewConfig(context.Background())
 	cfg.Workdir = dir
 	cfg.Timeline = timeline
+	partition, ok := NewFrozenBlockPartition("plan_facts", "Plan Facts", "stable facts", 100)
+	require.True(t, ok)
+	cfg.GetOrCreateFrozenBlockPartitionProducer().AppendPartition(partition)
 
 	materials := BuildPromptFrozenOpenMaterials(cfg)
 	require.Equal(t, baseTime.Add(3*time.Minute).Unix(), materials.TimelineFrozenTimeUnix)
 	require.Contains(t, materials.TimelineFrozen, "scan-ok")
 	require.Contains(t, materials.TimelineOpen, "verify-ok")
+	require.Len(t, materials.FrozenPartitions, 1)
+	require.Equal(t, "plan_facts", materials.FrozenPartitions[0].ID)
 	require.Contains(t, materials.SessionArtifactsFrozen, "task_1-1_scan")
 	require.Contains(t, materials.SessionArtifactsOpen, "task_1-2_verify")
 }

--- a/common/ai/aid/aicommon/session_artifacts_test.go
+++ b/common/ai/aid/aicommon/session_artifacts_test.go
@@ -24,12 +24,12 @@ func TestRenderSessionArtifactsFrozenOpenEmpty(t *testing.T) {
 	cfg := NewConfig(context.Background())
 	cfg.Workdir = dir
 
-	blocks := RenderSessionArtifactsFrozenOpen(cfg)
+	blocks := RenderSessionArtifactsFrozenOpen(cfg, 0)
 	require.Empty(t, blocks.Frozen)
 	require.Empty(t, blocks.Open)
 }
 
-func TestRenderSessionArtifactsFrozenOpenSplitsLastTaskGroupOpen(t *testing.T) {
+func TestRenderSessionArtifactsFrozenOpenSplitsByFrozenTime(t *testing.T) {
 	dir := t.TempDir()
 	baseTime := time.Unix(1700000000, 0)
 	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
@@ -38,26 +38,29 @@ func TestRenderSessionArtifactsFrozenOpenSplitsLastTaskGroupOpen(t *testing.T) {
 	cfg := NewConfig(context.Background())
 	cfg.Workdir = dir
 
-	blocks := RenderSessionArtifactsFrozenOpen(cfg)
+	blocks := RenderSessionArtifactsFrozenOpen(cfg, baseTime.Add(30*time.Second).Unix())
 	require.Contains(t, blocks.Frozen, "task_1-1_scan")
 	require.NotContains(t, blocks.Frozen, "task_1-2_verify")
 	require.Contains(t, blocks.Open, "task_1-2_verify")
 	require.NotContains(t, blocks.Open, "task_1-1_scan")
+	require.NotContains(t, blocks.Frozen, "total_files")
+	require.Contains(t, blocks.Frozen, "frozen_time:")
 }
 
-func TestRenderSessionArtifactsFrozenOpenSingleTaskGroupOpenOnly(t *testing.T) {
+func TestRenderSessionArtifactsFrozenOpenEqualFrozenTimeStaysOpen(t *testing.T) {
 	dir := t.TempDir()
-	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", time.Unix(1700000000, 0))
+	baseTime := time.Unix(1700000000, 0)
+	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
 
 	cfg := NewConfig(context.Background())
 	cfg.Workdir = dir
 
-	blocks := RenderSessionArtifactsFrozenOpen(cfg)
+	blocks := RenderSessionArtifactsFrozenOpen(cfg, baseTime.Unix())
 	require.Empty(t, blocks.Frozen)
 	require.Contains(t, blocks.Open, "task_1-1_scan")
 }
 
-func TestRenderSessionArtifactsFrozenOpenStableFrozenWhenOpenGroupChanges(t *testing.T) {
+func TestRenderSessionArtifactsFrozenOpenStableFrozenWhenFrozenGroupChanges(t *testing.T) {
 	dir := t.TempDir()
 	baseTime := time.Unix(1700000000, 0)
 	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
@@ -66,16 +69,18 @@ func TestRenderSessionArtifactsFrozenOpenStableFrozenWhenOpenGroupChanges(t *tes
 	cfg := NewConfig(context.Background())
 	cfg.Workdir = dir
 
-	before := RenderSessionArtifactsFrozenOpen(cfg)
-	writeArtifactFile(t, dir, "task_1-2_verify/details.txt", "details", baseTime.Add(2*time.Minute))
-	after := RenderSessionArtifactsFrozenOpen(cfg)
+	frozenTime := baseTime.Add(30 * time.Second).Unix()
+	before := RenderSessionArtifactsFrozenOpen(cfg, frozenTime)
+	writeArtifactFile(t, dir, "task_1-1_scan/details.txt", "details", baseTime.Add(2*time.Minute))
+	after := RenderSessionArtifactsFrozenOpen(cfg, frozenTime)
 
 	require.Equal(t, before.Frozen, after.Frozen)
 	require.NotEqual(t, before.Open, after.Open)
 	require.Contains(t, after.Open, "details.txt")
+	require.Contains(t, after.Open, "task_1-1_scan (updates after frozen snapshot)")
 }
 
-func TestRenderSessionArtifactsFrozenOpenNewTaskFreezesOldOpenGroup(t *testing.T) {
+func TestRenderSessionArtifactsFrozenOpenFrozenTimeAdvanceSealsEligibleGroup(t *testing.T) {
 	dir := t.TempDir()
 	baseTime := time.Unix(1700000000, 0)
 	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
@@ -83,14 +88,51 @@ func TestRenderSessionArtifactsFrozenOpenNewTaskFreezesOldOpenGroup(t *testing.T
 	cfg := NewConfig(context.Background())
 	cfg.Workdir = dir
 
-	before := RenderSessionArtifactsFrozenOpen(cfg)
+	before := RenderSessionArtifactsFrozenOpen(cfg, baseTime.Unix())
 	require.Empty(t, before.Frozen)
 	require.Contains(t, before.Open, "task_1-1_scan")
 
-	writeArtifactFile(t, dir, "task_1-2_verify/result.txt", "verify", baseTime.Add(time.Minute))
-	after := RenderSessionArtifactsFrozenOpen(cfg)
+	after := RenderSessionArtifactsFrozenOpen(cfg, baseTime.Add(time.Second).Unix())
 	require.Contains(t, after.Frozen, "task_1-1_scan")
-	require.Contains(t, after.Open, "task_1-2_verify")
+	require.NotContains(t, after.Open, "task_1-1_scan")
+}
+
+func TestRenderSessionArtifactsFrozenOpenRootFilesAlwaysOpen(t *testing.T) {
+	dir := t.TempDir()
+	baseTime := time.Unix(1700000000, 0)
+	writeArtifactFile(t, dir, "session_summary.txt", "root", baseTime)
+	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
+
+	cfg := NewConfig(context.Background())
+	cfg.Workdir = dir
+
+	blocks := RenderSessionArtifactsFrozenOpen(cfg, baseTime.Add(time.Hour).Unix())
+	require.Contains(t, blocks.Frozen, "task_1-1_scan")
+	require.NotContains(t, blocks.Frozen, "session_summary.txt")
+	require.Contains(t, blocks.Open, "[root files]")
+	require.Contains(t, blocks.Open, "session_summary.txt")
+}
+
+func TestBuildPromptFrozenOpenMaterialsCoordinatesTimelineAndArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	baseTime := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime.Add(30*time.Second))
+	writeArtifactFile(t, dir, "task_1-2_verify/result.txt", "verify", baseTime.Add(4*time.Minute))
+
+	timeline := NewTimeline(nil, nil)
+	injectTimelineItem(timeline, 1, baseTime.Add(30*time.Second), makeToolResult(1, "scan", true, "scan-ok"))
+	injectTimelineItem(timeline, 2, baseTime.Add(4*time.Minute), makeToolResult(2, "verify", true, "verify-ok"))
+
+	cfg := NewConfig(context.Background())
+	cfg.Workdir = dir
+	cfg.Timeline = timeline
+
+	materials := BuildPromptFrozenOpenMaterials(cfg)
+	require.Equal(t, baseTime.Add(3*time.Minute).Unix(), materials.TimelineFrozenTimeUnix)
+	require.Contains(t, materials.TimelineFrozen, "scan-ok")
+	require.Contains(t, materials.TimelineOpen, "verify-ok")
+	require.Contains(t, materials.SessionArtifactsFrozen, "task_1-1_scan")
+	require.Contains(t, materials.SessionArtifactsOpen, "task_1-2_verify")
 }
 
 func TestSessionArtifactsTemplatesPlacement(t *testing.T) {

--- a/common/ai/aid/aicommon/session_artifacts_test.go
+++ b/common/ai/aid/aicommon/session_artifacts_test.go
@@ -1,0 +1,119 @@
+package aicommon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeArtifactFile(t *testing.T, root string, rel string, body string, mod time.Time) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0644))
+	require.NoError(t, os.Chtimes(path, mod, mod))
+}
+
+func TestRenderSessionArtifactsFrozenOpenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cfg := NewConfig(context.Background())
+	cfg.Workdir = dir
+
+	blocks := RenderSessionArtifactsFrozenOpen(cfg)
+	require.Empty(t, blocks.Frozen)
+	require.Empty(t, blocks.Open)
+}
+
+func TestRenderSessionArtifactsFrozenOpenSplitsLastTaskGroupOpen(t *testing.T) {
+	dir := t.TempDir()
+	baseTime := time.Unix(1700000000, 0)
+	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
+	writeArtifactFile(t, dir, "task_1-2_verify/result.txt", "verify", baseTime.Add(time.Minute))
+
+	cfg := NewConfig(context.Background())
+	cfg.Workdir = dir
+
+	blocks := RenderSessionArtifactsFrozenOpen(cfg)
+	require.Contains(t, blocks.Frozen, "task_1-1_scan")
+	require.NotContains(t, blocks.Frozen, "task_1-2_verify")
+	require.Contains(t, blocks.Open, "task_1-2_verify")
+	require.NotContains(t, blocks.Open, "task_1-1_scan")
+}
+
+func TestRenderSessionArtifactsFrozenOpenSingleTaskGroupOpenOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", time.Unix(1700000000, 0))
+
+	cfg := NewConfig(context.Background())
+	cfg.Workdir = dir
+
+	blocks := RenderSessionArtifactsFrozenOpen(cfg)
+	require.Empty(t, blocks.Frozen)
+	require.Contains(t, blocks.Open, "task_1-1_scan")
+}
+
+func TestRenderSessionArtifactsFrozenOpenStableFrozenWhenOpenGroupChanges(t *testing.T) {
+	dir := t.TempDir()
+	baseTime := time.Unix(1700000000, 0)
+	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
+	writeArtifactFile(t, dir, "task_1-2_verify/result.txt", "verify", baseTime.Add(time.Minute))
+
+	cfg := NewConfig(context.Background())
+	cfg.Workdir = dir
+
+	before := RenderSessionArtifactsFrozenOpen(cfg)
+	writeArtifactFile(t, dir, "task_1-2_verify/details.txt", "details", baseTime.Add(2*time.Minute))
+	after := RenderSessionArtifactsFrozenOpen(cfg)
+
+	require.Equal(t, before.Frozen, after.Frozen)
+	require.NotEqual(t, before.Open, after.Open)
+	require.Contains(t, after.Open, "details.txt")
+}
+
+func TestRenderSessionArtifactsFrozenOpenNewTaskFreezesOldOpenGroup(t *testing.T) {
+	dir := t.TempDir()
+	baseTime := time.Unix(1700000000, 0)
+	writeArtifactFile(t, dir, "task_1-1_scan/result.txt", "scan", baseTime)
+
+	cfg := NewConfig(context.Background())
+	cfg.Workdir = dir
+
+	before := RenderSessionArtifactsFrozenOpen(cfg)
+	require.Empty(t, before.Frozen)
+	require.Contains(t, before.Open, "task_1-1_scan")
+
+	writeArtifactFile(t, dir, "task_1-2_verify/result.txt", "verify", baseTime.Add(time.Minute))
+	after := RenderSessionArtifactsFrozenOpen(cfg)
+	require.Contains(t, after.Frozen, "task_1-1_scan")
+	require.Contains(t, after.Open, "task_1-2_verify")
+}
+
+func TestSessionArtifactsTemplatesPlacement(t *testing.T) {
+	materials := &PromptMaterials{
+		SessionArtifactsFrozen: "artifacts_dir: /tmp/session\ntotal_files: 1\n\n### task_1-1_done\n- result.txt (1B, 00:00:00)\n",
+		SessionArtifactsOpen:   "artifacts_dir: /tmp/session\ntotal_files: 1\n\n### task_1-2_open\n- result.txt (1B, 00:00:00)\n",
+		Workspace:              true,
+		OSArch:                 "darwin/arm64",
+		WorkingDir:             "/tmp/session",
+	}
+
+	frozen, err := RenderPromptTemplate("test-frozen-artifacts", SharedFrozenBlockTemplate, materials.FrozenBlockData())
+	require.NoError(t, err)
+	open, err := RenderPromptTemplate("test-open-artifacts", SharedTimelineOpenTemplate, materials.TimelineOpenData())
+	require.NoError(t, err)
+
+	require.Contains(t, frozen, "# Session Artifacts (Frozen)")
+	require.Contains(t, frozen, "task_1-1_done")
+	require.Contains(t, open, "# Session Artifacts (Open)")
+	require.Contains(t, open, "task_1-2_open")
+	require.NotContains(t, open, "## Session Artifacts")
+
+	workspaceIdx := strings.Index(open, "# Workspace Context")
+	artifactsIdx := strings.Index(open, "# Session Artifacts (Open)")
+	require.Greater(t, artifactsIdx, workspaceIdx)
+}

--- a/common/ai/aid/aicommon/session_prompt_state.go
+++ b/common/ai/aid/aicommon/session_prompt_state.go
@@ -30,10 +30,27 @@ type SessionPromptState struct {
 	// 关键词: todoJSON, VerificationTodoStore 序列化, SessionEvidence 同构,
 	//        全局 TODO 持久态
 	todoJSON string
+
+	// sessionArtifactsState keeps the sealed frozen artifact snapshots for the
+	// current session/workdir. It is intentionally in-memory only; persistent
+	// restore can add serialization later without changing the prompt API.
+	sessionArtifactsState *SessionArtifactsRenderState
 }
 
 func NewSessionPromptState() *SessionPromptState {
 	return &SessionPromptState{}
+}
+
+func (s *SessionPromptState) GetOrCreateSessionArtifactsRenderState() *SessionArtifactsRenderState {
+	if s == nil {
+		return NewSessionArtifactsRenderState()
+	}
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.sessionArtifactsState == nil {
+		s.sessionArtifactsState = NewSessionArtifactsRenderState()
+	}
+	return s.sessionArtifactsState
 }
 
 func (s *SessionPromptState) GetUserInputHistory() []schema.AIAgentUserInputRecord {

--- a/common/ai/aid/aicommon/stable_prompt_nonce.go
+++ b/common/ai/aid/aicommon/stable_prompt_nonce.go
@@ -24,12 +24,12 @@ var stablePromptNonceAlphabet = []byte("abcdefghijklmnopqrstuvwxyz0123456789")
 // StablePromptNonce 把任意若干字符串 part 哈希成跨调用稳定的 6 字符 nonce。
 //
 // 使用场景:
-//   1) 任何在 prompt 中以 <|TAG_<nonce>|>...<|TAG_END_<nonce>|> 形式出现的
-//      AITag, 如果该段内容跨多次调用字节稳定, 都应该用 StablePromptNonce
-//      派生 nonce, 替代 utils.RandStringBytes(6) 这类反模式。
-//   2) 派生时把语义明确的 part (rootTaskID / planEpoch / "PARENT_TASK" 等)
-//      作为参数传入, 不同 part 组合自然产出不同 nonce 而互不冲突, 不需要
-//      手工维护命名空间。
+//  1. 任何在 prompt 中以 <|TAG_<nonce>|>...<|TAG_END_<nonce>|> 形式出现的
+//     AITag, 如果该段内容跨多次调用字节稳定, 都应该用 StablePromptNonce
+//     派生 nonce, 替代 utils.RandStringBytes(6) 这类反模式。
+//  2. 派生时把语义明确的 part (rootTaskID / planEpoch / "PARENT_TASK" 等)
+//     作为参数传入, 不同 part 组合自然产出不同 nonce 而互不冲突, 不需要
+//     手工维护命名空间。
 //
 // 同一组 part 反复调用必返回相同 nonce; part 顺序敏感, "a","b" 与 "b","a"
 // 派生的 nonce 不同。
@@ -61,19 +61,22 @@ func StablePromptNonce(parts ...string) string {
 // (frozenUserContext, 例如 PARENT_TASK / CURRENT_TASK / INSTRUCTION 三联块)"。
 //
 // rawQuery: 当前 turn 的用户原始输入或当前任务的轻量 query, 进入 dynamic 段
-//   USER_QUERY 块。
+//
+//	USER_QUERY 块。
+//
 // frozenUserContext: 包装成 PLAN_CONTEXT 后注入 timeline-open 段最末尾
-//   (UserHistory 之后)。注意: 字段名虽为 "frozen", 但物理位置在 timeline-open
-//   段, 不被任何 cache 边界包裹。这是 v4 迭代的最终设计: 之前尝试放 frozen-block /
-//   semi-dynamic 都因 EvidenceOps 嵌入 root user input + 子任务切换造成内容
-//   抖动, 反而破坏上游缓存命中。现采用"放弃 PlanContext 自身缓存, 保护上游
-//   SYSTEM / FROZEN / SEMI 三段缓存"策略。
+//
+//	(UserHistory 之后)。注意: 字段名虽为 "frozen", 但物理位置在 timeline-open
+//	段, 不被任何 cache 边界包裹。这是 v4 迭代的最终设计: 之前尝试放 frozen-block /
+//	semi-dynamic 都因 PE-TASK 子任务切换造成内容抖动, 反而破坏上游缓存命中。
+//	现采用"放弃 PlanContext 自身缓存, 保护上游 SYSTEM / FROZEN / SEMI 三段缓存"策略。
 //
 // 老路径 (普通 ReAct loop / focus mode 等没有 plan 上下文的场景) 不实现该
 // 接口, 框架自动 fallback 到原始 task.GetUserInput() 语义, 行为保持不变。
 //
 // 关键词: CacheableUserInputProvider, PE-TASK PLAN 产物,
-//        frozenUserContext, timeline-open 末尾注入, 缓存边界外
+//
+//	frozenUserContext, timeline-open 末尾注入, 缓存边界外
 type CacheableUserInputProvider interface {
 	GetUserInputSplitForCache() (rawQuery, frozenUserContext string)
 }

--- a/common/ai/aid/aicommon/timeline.go
+++ b/common/ai/aid/aicommon/timeline.go
@@ -80,9 +80,11 @@ const MaxTimelineSaveSize = 1536 * 1024
 // 离线重放实验 (见 TIMELINE_BUCKET_TUNING.md) 在真实 session (90 events) 上显示:
 //   - 16K 默认: net_cost = -1.99M (基线)
 //   - 64K 默认: net_cost = -3.12M (省 1.13M, 提升 56%)
+//
 // 在密集工具场景 (dense_tools, 20 events / 3 min):
 //   - 16K 默认: net_cost = +127K (亏损)
 //   - 64K 默认: net_cost = -215K (转亏为盈)
+//
 // 64K 在所有测过的场景里都 ≥ 16K, 不存在劣化。
 //
 // 关键词: TimelineDumpDefaultBucketByteSize, 字节子桶默认, 主动缓存调优, 64K
@@ -777,9 +779,8 @@ func (m *Timeline) DumpFrozenOpen() (frozen string, open string) {
 	if m == nil {
 		return "", ""
 	}
-	rb := m.GroupByMinutes(TimelineDumpDefaultIntervalMinutes).GetAllRenderable()
-	return rb.RenderFrozenOnly(TimelineDumpDefaultAITagName),
-		rb.RenderOpenOnly(TimelineDumpDefaultAITagName)
+	blocks := RenderTimelineFrozenOpen(m)
+	return blocks.Frozen, blocks.Open
 }
 
 // DumpBefore 输出 ID <= beforeId 的部分 timeline，结构与 Dump 一致

--- a/common/ai/aid/aicommon/tool_inventory_materials.go
+++ b/common/ai/aid/aicommon/tool_inventory_materials.go
@@ -1,0 +1,151 @@
+package aicommon
+
+import "github.com/yaklang/yaklang/common/ai/aid/aitool"
+
+type ToolInventoryData struct {
+	ToolInventory  bool
+	ToolsCount     int
+	TopToolsCount  int
+	TopTools       []*aitool.Tool
+	HasMoreTools   bool
+	MoreToolsCount int
+}
+
+func PrioritizeToolsForInventory(tools []*aitool.Tool, maxCount int, extraPriority ...string) []*aitool.Tool {
+	if len(tools) == 0 || maxCount <= 0 {
+		return nil
+	}
+
+	priorityNames := []string{
+		"search_capabilities",
+		"web_search",
+		"grep",
+		"read_file",
+		"write_file",
+		"modify_file",
+		"find_file",
+		"tree",
+		"bash",
+		"cmd",
+		"encode",
+		"decode",
+		"auto_decode",
+		"scan_port",
+		"git-clone",
+		"do_http_request",
+		"batch_do_http_request",
+		"simple_crawler",
+		"cybersecurity-risk",
+		"brute",
+	}
+
+	if len(extraPriority) > 0 {
+		seen := make(map[string]bool, len(extraPriority))
+		merged := make([]string, 0, len(extraPriority)+len(priorityNames))
+		for _, n := range extraPriority {
+			if n == "" || seen[n] {
+				continue
+			}
+			seen[n] = true
+			merged = append(merged, n)
+		}
+		for _, n := range priorityNames {
+			if seen[n] {
+				continue
+			}
+			seen[n] = true
+			merged = append(merged, n)
+		}
+		priorityNames = merged
+	}
+
+	toolMap := make(map[string]*aitool.Tool, len(tools))
+	for _, tool := range tools {
+		if tool == nil {
+			continue
+		}
+		toolMap[tool.Name] = tool
+	}
+
+	result := make([]*aitool.Tool, 0, min(maxCount, len(tools)))
+	usedNames := make(map[string]bool, len(tools))
+	for _, name := range priorityNames {
+		if len(result) >= maxCount {
+			break
+		}
+		if tool, exists := toolMap[name]; exists {
+			result = append(result, tool)
+			usedNames[name] = true
+		}
+	}
+	for _, tool := range tools {
+		if len(result) >= maxCount {
+			break
+		}
+		if tool == nil || usedNames[tool.Name] {
+			continue
+		}
+		result = append(result, tool)
+		usedNames[tool.Name] = true
+	}
+	return result
+}
+
+func BuildToolInventoryData(tools []*aitool.Tool, topToolsCount int, scenarioWhitelist ...string) ToolInventoryData {
+	tools = FilterToolsByVisibility(tools, scenarioWhitelist)
+	if len(tools) == 0 {
+		return ToolInventoryData{}
+	}
+
+	candidate := PrioritizeToolsForInventory(tools, topToolsCount, scenarioWhitelist...)
+	display := SelectToolsByTokenBudget(candidate, ToolInventoryTokenBudget, ToolInventoryMinCount)
+	more := len(tools) - len(display)
+	if more < 0 {
+		more = 0
+	}
+
+	return ToolInventoryData{
+		ToolInventory:  true,
+		ToolsCount:     len(tools),
+		TopToolsCount:  len(display),
+		TopTools:       display,
+		HasMoreTools:   len(tools) > len(display),
+		MoreToolsCount: more,
+	}
+}
+
+func BuildToolInventoryDataFromConfig(config *Config, scenarioWhitelist ...string) (ToolInventoryData, error) {
+	if config == nil {
+		return ToolInventoryData{}, nil
+	}
+	toolMgr := config.GetAiToolManager()
+	if toolMgr == nil {
+		return ToolInventoryData{}, nil
+	}
+	tools, err := toolMgr.GetEnableTools()
+	if err != nil {
+		return ToolInventoryData{}, err
+	}
+	return BuildToolInventoryData(tools, config.GetTopToolsCount(), scenarioWhitelist...), nil
+}
+
+func ApplyToolInventoryData(materials *PromptMaterials, data ToolInventoryData) {
+	if materials == nil {
+		return
+	}
+	materials.ToolInventory = data.ToolInventory
+	materials.ToolsCount = data.ToolsCount
+	materials.TopToolsCount = data.TopToolsCount
+	materials.TopTools = data.TopTools
+	materials.HasMoreTools = data.HasMoreTools
+	materials.MoreToolsCount = data.MoreToolsCount
+}
+
+func PopulateToolInventoryFromConfig(materials *PromptMaterials, config *Config, scenarioWhitelist ...string) error {
+	data, err := BuildToolInventoryDataFromConfig(config, scenarioWhitelist...)
+	if err != nil {
+		return err
+	}
+	ApplyToolInventoryData(materials, data)
+	return nil
+}

--- a/common/ai/aid/aireact/artifacts_visibility_test.go
+++ b/common/ai/aid/aireact/artifacts_visibility_test.go
@@ -209,11 +209,8 @@ WAIT_SECOND:
 
 	secondPrompt := capturedPrompts[len(capturedPrompts)-1]
 
-	// SessionArtifacts 现在嵌入 Workspace 块 (timeline-open 段) 而非 Pure Dynamic
-	// 段, 但作为字符串仍出现在最终 prompt 中.
-	// 关键词: artifacts visibility, Workspace 内嵌, Pure Dynamic 反污染
 	assert.Contains(t, secondPrompt, "Session Artifacts",
-		"subsequent conversation prompt should still surface 'Session Artifacts' (now inside Workspace block)")
+		"subsequent conversation prompt should still surface Session Artifacts as a first-class prompt block")
 	assert.Contains(t, secondPrompt, "task_1-1_network_scan",
 		"subsequent conversation prompt should contain task_1-1 directory name")
 	assert.Contains(t, secondPrompt, "task_1-2_vuln_analysis",
@@ -226,8 +223,7 @@ WAIT_SECOND:
 		"subsequent conversation prompt should contain result summary filename")
 
 	// 反向断言: Pure Dynamic / AutoContext 段对应的 <|AUTO_PROVIDE_CTX_*|> tag
-	// 不应再含 Session Artifacts; 即使包裹 tag 没出现 (provider 已退役), Session
-	// Artifacts 也只能出现在 Workspace 块下. 通过裁切验证: 若 Session Artifacts
+	// 不应再含 Session Artifacts; 通过裁切验证: 若 Session Artifacts
 	// 出现的位置, 不在 AutoContext tag 之间.
 	// 关键词: 反向断言, AUTO_PROVIDE_CTX 不含 Session Artifacts
 	if autoIdx := strings.Index(secondPrompt, "<|AUTO_PROVIDE_CTX_"); autoIdx >= 0 {
@@ -239,14 +235,15 @@ WAIT_SECOND:
 		}
 	}
 
-	// Workspace 块在 timeline-open 段, 字面上含 # Workspace Context 标题与
-	// Session Artifacts 子段; 二者前后相邻是新归属的标志.
-	// 关键词: Workspace 内嵌, ## Session Artifacts 子段
+	// Workspace 与 Session Artifacts 都在 timeline-open 段, 但 Artifacts 是
+	// Workspace 后面的一级块，不再作为 Workspace 子段。
 	wsIdx := strings.Index(secondPrompt, "# Workspace Context")
-	saIdx := strings.Index(secondPrompt, "Session Artifacts")
+	saIdx := strings.Index(secondPrompt, "# Session Artifacts (Open)")
 	if wsIdx >= 0 && saIdx >= 0 {
 		assert.Greater(t, saIdx, wsIdx,
-			"Session Artifacts should be embedded under Workspace Context block")
+			"Session Artifacts should render after Workspace Context")
+		assert.NotContains(t, secondPrompt[wsIdx:saIdx], "## Session Artifacts",
+			"Workspace Context must not contain the legacy Session Artifacts subsection")
 	}
 
 	t.Logf("artifacts section found in prompt (extracting Workspace portion):")

--- a/common/ai/aid/aireact/invoke_toolcall_multicall_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_multicall_test.go
@@ -104,9 +104,9 @@ func TestReAct_ToolUse_MultiCalls(t *testing.T) {
 		}
 	}()
 
-	du := time.Duration(10)
+	du := time.Duration(5)
 	if utils.InGithubActions() {
-		du = time.Duration(5)
+		du = time.Duration(10)
 	}
 	after := time.After(du * time.Second)
 

--- a/common/ai/aid/aireact/midterm_context_provider.go
+++ b/common/ai/aid/aireact/midterm_context_provider.go
@@ -47,35 +47,7 @@ func buildTimelineDumpWithMidtermMemory(react *ReAct, timeline *aicommon.Timelin
 	return "timeline:\n" + midtermPrefix + body
 }
 
-// buildTimelineFrozenForPrompt 渲染 timeline 的冻结前缀 (reducer + 非末 interval),
-// 不含 midterm 检索结果, 不含 frozen 边界 tag。供"按稳定性分层"路径下塞进
-// AI_CACHE_FROZEN 块使用; 全 open / timeline 为空时返回空串。
-//
-// 关键词: buildTimelineFrozenForPrompt, RenderFrozenOnly, frozen 前缀
-func buildTimelineFrozenForPrompt(timeline *aicommon.Timeline) string {
-	if timeline == nil {
-		return ""
-	}
-	return timeline.GroupByMinutes(aicommon.TimelineDumpDefaultIntervalMinutes).
-		GetAllRenderable().
-		RenderFrozenOnly(aicommon.TimelineDumpDefaultAITagName)
-}
-
-// buildTimelineOpenWithMidtermForPrompt 渲染 timeline 的开放尾段 (最末 interval),
-// 并把 midterm 检索结果以 prefix 形式拼到前面。配合 buildTimelineFrozenForPrompt
-// 完成"frozen / open"两半渲染。midterm 是 turn 级易变内容, 与最末 interval 同等不稳,
-// 因此一并放在 open 段。
-//
-// 全 timeline 为空且无 midterm 时返回空串。
-//
-// 关键词: buildTimelineOpenWithMidtermForPrompt, RenderOpenOnly, midterm 前缀, open 尾段
-func buildTimelineOpenWithMidtermForPrompt(react *ReAct, timeline *aicommon.Timeline) string {
-	openBody := ""
-	if timeline != nil {
-		openBody = timeline.GroupByMinutes(aicommon.TimelineDumpDefaultIntervalMinutes).
-			GetAllRenderable().
-			RenderOpenOnly(aicommon.TimelineDumpDefaultAITagName)
-	}
+func prependMidtermTimelinePrefixForPrompt(react *ReAct, openBody string) string {
 	queries := react.consumePendingMidtermTimelineQueries()
 	if len(queries) == 0 {
 		return openBody

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -223,15 +223,15 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 		materials.OSArch = base.OSArch
 		materials.WorkingDir = base.WorkingDir
 		materials.WorkingDirGlance = base.WorkingDirGlance
-		// session_artifacts 不再走 ContextProviderManager / Pure Dynamic; 在
-		// 构造 materials 时直接调 RenderSessionArtifactsListing 抓取 workdir
-		// 文件清单, 后续由 renderWorkspaceBlock 嵌入 Workspace 块下方.
-		// 关键词: SessionArtifactsListing 注入, Workspace 内嵌, Pure Dynamic 反污染
 		if pm != nil && pm.react != nil && pm.react.config != nil {
-			materials.SessionArtifactsListing = aicommon.RenderSessionArtifactsListing(pm.react.config)
+			artifactBlocks := aicommon.RenderSessionArtifactsFrozenOpen(pm.react.config)
+			materials.SessionArtifactsFrozen = artifactBlocks.Frozen
+			materials.SessionArtifactsOpen = artifactBlocks.Open
 		}
-		materials.Workspace = strings.TrimSpace(base.OSArch+base.WorkingDir+base.WorkingDirGlance) != "" ||
-			strings.TrimSpace(materials.SessionArtifactsListing) != ""
+		materials.Workspace = strings.TrimSpace(base.OSArch+base.WorkingDir+base.WorkingDirGlance) != ""
+	}
+	if pm != nil && pm.react != nil && pm.react.config != nil {
+		materials.FrozenPartitions = append(materials.FrozenPartitions, aicommon.FrozenBlockPartitionsFromConfig(pm.react.config)...)
 	}
 
 	if input != nil {
@@ -252,18 +252,19 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 		// PE-TASK PLAN 产物 (PARENT_TASK + CURRENT_TASK + INSTRUCTION) 通过
 		// FrozenUserContext 字段透传, 渲染时位于 timeline-open 段最末尾
 		// (UserHistory 之后), 落在所有 cache 边界之外。早期版本曾尝试
-		// frozen-block / semi-dynamic, 但 EVIDENCE 嵌入 root user input
-		// + 子任务切换造成 PlanContext 内容剧烈抖动, 破坏了上游缓存命中,
-		// 现采用"放弃自身缓存, 保护上游缓存"策略。
+		// frozen-block / semi-dynamic, 但子任务切换会让 PlanContext 内容
+		// 抖动, 破坏上游缓存命中, 现采用"放弃自身缓存, 保护上游缓存"策略。
 		// 关键词: FrozenUserContext 透传, PLAN_CONTEXT, timeline-open 末尾,
 		//        缓存边界外
 		materials.FrozenUserContext = input.FrozenUserContext
+		materials.FrozenPartitions = append(materials.FrozenPartitions, input.FrozenPartitions...)
 	}
 	if base != nil {
 		// UserHistory 来自 LoopPromptBaseMaterials (config.FormatUserInputHistoryAITag)
 		materials.UserHistory = base.UserHistory
 	}
 
+	materials.FrozenPartitions = aicommon.NormalizeFrozenBlockPartitions(materials.FrozenPartitions)
 	return materials
 }
 
@@ -351,6 +352,8 @@ func (pm *PromptManager) buildLoopPromptSectionData(base *reactloops.LoopPromptB
 		"WorkingDir":              "",
 		"WorkingDirGlance":        "",
 		"SessionArtifactsListing": "",
+		"SessionArtifactsFrozen":  "",
+		"SessionArtifactsOpen":    "",
 		"Workspace":               false,
 		"AutoContext":             "",
 		"UserHistory":             "",
@@ -372,17 +375,7 @@ func (pm *PromptManager) buildLoopPromptSectionData(base *reactloops.LoopPromptB
 		data["OSArch"] = base.OSArch
 		data["WorkingDir"] = base.WorkingDir
 		data["WorkingDirGlance"] = base.WorkingDirGlance
-		// session_artifacts 已合入 Workspace 块, 这里同步把 listing 注入 data
-		// 让 legacy timeline section / 兼容路径模板都能消费; Workspace 启用
-		// 判定也跟着 listing 状态走, 避免环境为空但 artifacts 非空时被过滤掉.
-		// 关键词: SessionArtifactsListing 兼容路径注入, Workspace 启用扩展
-		var artifactsListing string
-		if pm != nil && pm.react != nil && pm.react.config != nil {
-			artifactsListing = aicommon.RenderSessionArtifactsListing(pm.react.config)
-		}
-		data["SessionArtifactsListing"] = artifactsListing
-		data["Workspace"] = strings.TrimSpace(base.OSArch+base.WorkingDir+base.WorkingDirGlance) != "" ||
-			strings.TrimSpace(artifactsListing) != ""
+		data["Workspace"] = strings.TrimSpace(base.OSArch+base.WorkingDir+base.WorkingDirGlance) != ""
 		data["AutoContext"] = base.AutoContext
 		data["UserHistory"] = base.UserHistory
 		data["ToolsCount"] = base.ToolsCount
@@ -490,6 +483,32 @@ func (pm *PromptManager) buildFrozenBlockObservation(
 			true,
 			renderForgeInventoryBlock(materials),
 		),
+	}
+	var partitions []aicommon.FrozenBlockPartition
+	if materials != nil {
+		partitions = aicommon.NormalizeFrozenBlockPartitions(materials.FrozenPartitions)
+	}
+	for _, partition := range partitions {
+		label := partition.Title
+		if strings.TrimSpace(label) == "" {
+			label = partition.ID
+		}
+		children = append(children, reactloops.NewPromptSectionObservation(
+			"section.frozen_block.partition."+partition.ID,
+			label,
+			reactloops.PromptSectionRoleFrozenBlock,
+			true,
+			renderFrozenPartitionBlock(partition),
+		))
+	}
+	children = append(children,
+		reactloops.NewPromptSectionObservation(
+			"section.frozen_block.session_artifacts_frozen",
+			"Session Artifacts (Frozen)",
+			reactloops.PromptSectionRoleFrozenBlock,
+			true,
+			renderSessionArtifactsFrozenBlock(materials),
+		),
 		reactloops.NewPromptSectionObservation(
 			"section.frozen_block.timeline_frozen",
 			"Timeline (Frozen Prefix)",
@@ -497,7 +516,7 @@ func (pm *PromptManager) buildFrozenBlockObservation(
 			true,
 			renderTimelineFrozenBlock(materials),
 		),
-	}
+	)
 	section.Children = filterIncludedPromptSections(children)
 	if strings.TrimSpace(rendered) != "" {
 		section.Content = ""
@@ -515,10 +534,7 @@ func (pm *PromptManager) buildFrozenBlockObservation(
 //
 // 物理位置: timeline-open 段最末尾 (UserHistory 之后)。timeline-open 段不被
 // AI_CACHE_FROZEN / AI_CACHE_SEMI 任何缓存边界包裹, 是"易变尾段"。这样安排
-// 是因为 PlanContext 内容会随两个独立维度抖动:
-//   - PE-TASK 子任务切换 (CURRENT_TASK 内容变化);
-//   - root user input 因 EvidenceOps 触发 syncRootTaskPlanContextDocs 嵌入
-//     新 FACTS/DOCUMENT 块而变化。
+// 是因为 PlanContext 内容会随 PE-TASK 子任务切换抖动 (CURRENT_TASK 内容变化)。
 //
 // 早期版本试图把 PlanContext 放进 frozen-block / semi-dynamic 等"可缓存段",
 // 但这种本质易变的内容不适合缓存; 保护策略改为让其落在所有 cache 边界外,
@@ -592,8 +608,8 @@ func (pm *PromptManager) buildSemiDynamic1Observation(
 // user3 (ephemeral cc), 与 buildSemiDynamic1Observation 一起被 dashscope 视作
 // 合并 prefix cache 计算 (cc 锚点落在本段末尾, prefix 跨过 semi-1).
 //
-// PlanContext 已彻底迁出本段 (历史曾位于 semi-dynamic 段, 但 EVIDENCE 嵌入 root
-// user input 导致内容抖动破坏 AI_CACHE_SEMI 命中; 现已迁到 timeline-open 段末尾,
+// PlanContext 已彻底迁出本段 (历史曾位于 semi-dynamic 段, 但子任务切换会让
+// 内容抖动并破坏 AI_CACHE_SEMI 命中; 现已迁到 timeline-open 段末尾,
 // 落在所有 cache 边界之外, 见 buildTimelineOpenObservation)。
 //
 // 关键词: buildSemiDynamic2Observation, TaskInstruction, Schema, OutputExample,
@@ -657,8 +673,8 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 }
 
 // buildTimelineOpenObservation 给"PROMPT_SECTION_timeline-open 段"做观测树:
-// Timeline 末桶 (+ midterm 检索结果) + SessionEvidence + Workspace +
-// UserHistory + Current Time + PlanContext (末尾)。
+// Timeline 末桶 (+ midterm 检索结果) + SessionEvidence + TodoSnapshot + Workspace +
+// SessionArtifactsOpen + UserHistory + Current Time + PlanContext (末尾)。
 //
 // 段内排序原则 (P1-C3 调整):
 //  1. Timeline (Open Tail) 在最前: 时间线最末桶是模型理解"刚发生了什么"的
@@ -666,15 +682,18 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 //  2. Session Evidence 紧跟其后: SESSION_ARTIFACTS 是 Config 级持久化观测
 //     (跨 turn 累积的工件证据), 与 Timeline 末桶共同构成"会话级实证"语料,
 //     物理上贴近 Timeline 让两者形成连续语义块。
-//  3. Workspace 居中: OS/Arch + working dir + glance 是相对静态的环境标识,
+//  3. TodoSnapshot 紧跟 SessionEvidence, 暴露全局待办状态。
+//  4. Workspace 居中: OS/Arch + working dir + glance 是相对静态的环境标识,
 //     既不属于"刚发生", 也不属于"用户视角", 居中过渡。
-//  4. User History 在 Workspace 之后: PREV_USER_INPUT 是用户历史输入轨迹,
+//  5. Session Artifacts (Open) 在 Workspace 之后: 最近 task group 与 root files
+//     仍属易变尾段, 不污染 frozen prefix。
+//  6. User History 在 Artifacts 之后: PREV_USER_INPUT 是用户历史输入轨迹,
 //     与 Current Time 一起构成"时序前缀", 紧贴当前时间。
-//  5. Current Time 紧跟 User History: 当前时间是最末稳定的时序锚点, 放在
+//  7. Current Time 紧跟 User History: 当前时间是最末稳定的时序锚点, 放在
 //     User History 之后形成"历史输入 -> 现在"的时间递进, 同时与下方
 //     PlanContext (任务规划) 形成"时间 -> 任务"的语义衔接。
-//  6. Plan Context 末尾: PE-TASK PLAN 产物本质易变 (子任务切换 +
-//     FACTS/DOCUMENT 嵌入 root user input), 放最末让其落在所有 cache
+//  8. Plan Context 末尾: PE-TASK PLAN 产物本质易变 (子任务切换),
+//     放最末让其落在所有 cache
 //     边界外, 不污染上游 system / frozen / semi 三段缓存命中率。
 //
 // timeline-open 整段位于 system / frozen / semi 三段缓存之外, 是 prompt 的
@@ -682,7 +701,7 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 //
 // 关键词: buildTimelineOpenObservation, Timeline 末桶, SessionEvidence,
 //
-//	Workspace, UserHistory, Current Time, PlanContext 末尾,
+//	Workspace, SessionArtifactsOpen, UserHistory, Current Time, PlanContext 末尾,
 //	段内排序原则, P1-C3 顺序调整, 缓存边界外
 func (pm *PromptManager) buildTimelineOpenObservation(
 	materials *reactloops.PromptPrefixMaterials,
@@ -697,8 +716,8 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 	// "Timeline Open & Workspace" 已经表达层级.
 	// 关键词: section.timeline_open 子节点 Name 去前缀, UI 信息密度
 	//
-	// 子节点排列顺序 (P1-C3): timeline_open -> session_evidence -> workspace ->
-	// user_history -> current_time -> plan_context. 该顺序与 timeline_open_section.txt
+	// 子节点排列顺序: timeline_open -> session_evidence -> todo_list -> workspace ->
+	// session_artifacts_open -> user_history -> current_time -> plan_context. 该顺序与 timeline_open_section.txt
 	// 模板渲染顺序严格一致, 让"上下文成分"面板看到的层级与实际 prompt 字节
 	// 流顺序保持同步.
 	// 关键词: P1-C3 子节点顺序, observation 与模板对齐
@@ -738,6 +757,13 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 			true,
 			renderWorkspaceBlock(materials),
 		),
+		reactloops.NewPromptSectionObservation(
+			"section.timeline_open.session_artifacts_open",
+			"Session Artifacts (Open)",
+			reactloops.PromptSectionRoleTimelineOpen,
+			true,
+			renderSessionArtifactsOpenBlock(materials),
+		),
 		// P1-C3: UserHistory 在 Workspace 之后, 与下方 Current Time 共同
 		// 构成"用户输入历史 -> 现在"的时序前缀.
 		reactloops.NewPromptSectionObservation(
@@ -757,8 +783,8 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 			renderCurrentTimeBlock(materials),
 		),
 		// PlanContext (PE-TASK PLAN 产物) 末尾注入: 该字段仅 PE-TASK 子任务
-		// 非空, 内容随子任务切换 + EvidenceOps 嵌入 root user input 抖动剧烈,
-		// 不适合放任何 cache 边界内。放 timeline-open 段最末让其落在所有
+		// 非空, 内容随子任务切换抖动, 不适合放任何 cache 边界内。
+		// 放 timeline-open 段最末让其落在所有
 		// cache 边界之外, 不污染上游 system / frozen / semi 三段缓存命中。
 		// 关键词: section.timeline_open.plan_context, PLAN_CONTEXT 末尾,
 		//        缓存边界外, 上游缓存保护
@@ -921,27 +947,18 @@ func renderSchemaBlock(schema string) string {
 
 // renderWorkspaceBlock 渲染 timeline-open 段中 Workspace 子块.
 //
-// 之前 SessionArtifacts 走 ContextProviderManager 落到 Pure Dynamic /
-// AutoContext 段, 每次 prompt build 都把 workdir 文件清单塞进 dynamic 区,
-// 干扰严重且与 OS / WorkingDir / Glance 等环境信息分离. 现在直接把
-// SessionArtifactsListing 拼到 Workspace 块下方 (## Session Artifacts 子段),
-// 与文件系统语义合一; Pure Dynamic 段 auto_context 不再含此清单.
+// SessionArtifacts 已迁出 Workspace，作为 SessionArtifactsFrozen /
+// SessionArtifactsOpen 一级块渲染。Workspace 只保留 OS / working dir / glance。
 //
-// 启用判定: 任意 OS/Arch / WorkingDir / WorkingDirGlance / SessionArtifactsListing
-// 之一非空即整块输出, 避免环境字段全空但 artifacts 非空时被过滤掉.
-//
-// 关键词: renderWorkspaceBlock, ## Session Artifacts 子段, Workspace 内嵌,
-//
-//	Pure Dynamic 反污染, SessionArtifactsListing 注入
+// 关键词: renderWorkspaceBlock, Workspace 不再内嵌 Session Artifacts
 func renderWorkspaceBlock(materials *reactloops.PromptPrefixMaterials) string {
 	if materials == nil {
 		return ""
 	}
-	listing := strings.TrimSpace(materials.SessionArtifactsListing)
 	hasEnv := strings.TrimSpace(materials.OSArch) != "" ||
 		strings.TrimSpace(materials.WorkingDir) != "" ||
 		strings.TrimSpace(materials.WorkingDirGlance) != ""
-	if !materials.Workspace || (!hasEnv && listing == "") {
+	if !materials.Workspace || !hasEnv {
 		return ""
 	}
 	var lines []string
@@ -955,12 +972,45 @@ func renderWorkspaceBlock(materials *reactloops.PromptPrefixMaterials) string {
 	if materials.WorkingDirGlance != "" {
 		lines = append(lines, "working dir glance: "+materials.WorkingDirGlance)
 	}
-	if listing != "" {
-		lines = append(lines, "")
-		lines = append(lines, "## Session Artifacts")
-		lines = append(lines, listing)
-	}
 	return strings.Join(lines, "\n")
+}
+
+func renderFrozenPartitionBlock(partition aicommon.FrozenBlockPartition) string {
+	partition.Content = strings.TrimSpace(partition.Content)
+	if partition.Content == "" {
+		return ""
+	}
+	partition.ID = aicommon.NormalizeFrozenPartitionID(partition.ID)
+	partition.Title = strings.TrimSpace(partition.Title)
+	if partition.Title == "" {
+		partition.Title = partition.ID
+	}
+	partition.Nonce = strings.TrimSpace(partition.Nonce)
+	if partition.Nonce == "" {
+		partition.Nonce = aicommon.StablePromptNonce("frozen-partition", partition.ID, partition.Content)
+	}
+	return fmt.Sprintf("# %s\n<|FROZEN_PARTITION_%s_%s|>\n%s\n<|FROZEN_PARTITION_END_%s_%s|>",
+		partition.Title,
+		partition.ID,
+		partition.Nonce,
+		partition.Content,
+		partition.ID,
+		partition.Nonce,
+	)
+}
+
+func renderSessionArtifactsFrozenBlock(materials *reactloops.PromptPrefixMaterials) string {
+	if materials == nil || strings.TrimSpace(materials.SessionArtifactsFrozen) == "" {
+		return ""
+	}
+	return "# Session Artifacts (Frozen)\n" + materials.SessionArtifactsFrozen
+}
+
+func renderSessionArtifactsOpenBlock(materials *reactloops.PromptPrefixMaterials) string {
+	if materials == nil || strings.TrimSpace(materials.SessionArtifactsOpen) == "" {
+		return ""
+	}
+	return "# Session Artifacts (Open)\n" + materials.SessionArtifactsOpen
 }
 
 // renderToolInventoryBlock 是给 observation 树 (UI / 调试) 用的镜像渲染, 必须

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -223,10 +223,6 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 		materials.WorkingDirGlance = base.WorkingDirGlance
 		materials.Workspace = strings.TrimSpace(base.OSArch+base.WorkingDir+base.WorkingDirGlance) != ""
 	}
-	if pm != nil && pm.react != nil && pm.react.config != nil {
-		materials.FrozenPartitions = append(materials.FrozenPartitions, aicommon.FrozenBlockPartitionsFromConfig(pm.react.config)...)
-	}
-
 	if input != nil {
 		materials.TaskInstruction = input.TaskInstruction
 		materials.OutputExample = input.OutputExample

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -94,13 +94,12 @@ func (pm *PromptManager) GetLoopPromptBaseMaterials(tools []*aitool.Tool, nonce 
 	materials.AutoContext = pm.AutoContextWithNonce(nonce)
 	materials.UserHistory = pm.UserHistoryContextWithNonce(nonce)
 
-	// 按稳定性分层渲染 timeline:
-	//   TimelineFrozen: reducer + 非末 interval, 字节稳定, 进 AI_CACHE_FROZEN 块
-	//   TimelineOpen: 最末 interval (+ midterm 检索结果, midterm 在此处一次性消费)
-	// 关键词: GetLoopPromptBaseMaterials, timeline frozen/open 拆分, midterm 一次消费
-	timeline := pm.react.config.GetTimeline()
-	materials.TimelineFrozen = buildTimelineFrozenForPrompt(timeline)
-	materials.TimelineOpen = buildTimelineOpenWithMidtermForPrompt(pm.react, timeline)
+	// Timeline frozen/open 与 Session Artifacts frozen/open 必须共享同一轮
+	// FrozenTimeUnix；midterm recall 是 turn 级 open prefix，在统一切分之后追加。
+	// 关键词: BuildPromptFrozenOpenMaterials, artifacts frozen time, midterm open
+	frozenOpen := aicommon.BuildPromptFrozenOpenMaterials(pm.react.config)
+	frozenOpen.TimelineOpen = prependMidtermTimelinePrefixForPrompt(pm.react, frozenOpen.TimelineOpen)
+	materials.PromptFrozenOpenMaterials = frozenOpen
 
 	allowPlanAndExec := pm.react.config.GetEnablePlanAndExec() && pm.react.GetCurrentPlanExecutionTask() == nil
 	allowToolCall := true
@@ -217,17 +216,11 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 		materials.ForgeInventory = base.ShowForgeInventory && strings.TrimSpace(base.AIForgeList) != ""
 		materials.AIForgeList = base.AIForgeList
 
-		materials.TimelineFrozen = base.TimelineFrozen
-		materials.TimelineOpen = base.TimelineOpen
+		aicommon.ApplyPromptFrozenOpenMaterials(materials, base.PromptFrozenOpenMaterials)
 		materials.CurrentTime = base.CurrentTime
 		materials.OSArch = base.OSArch
 		materials.WorkingDir = base.WorkingDir
 		materials.WorkingDirGlance = base.WorkingDirGlance
-		if pm != nil && pm.react != nil && pm.react.config != nil {
-			artifactBlocks := aicommon.RenderSessionArtifactsFrozenOpen(pm.react.config)
-			materials.SessionArtifactsFrozen = artifactBlocks.Frozen
-			materials.SessionArtifactsOpen = artifactBlocks.Open
-		}
 		materials.Workspace = strings.TrimSpace(base.OSArch+base.WorkingDir+base.WorkingDirGlance) != ""
 	}
 	if pm != nil && pm.react != nil && pm.react.config != nil {
@@ -385,6 +378,8 @@ func (pm *PromptManager) buildLoopPromptSectionData(base *reactloops.LoopPromptB
 		data["ToolInventory"] = base.AllowToolCall && base.ToolsCount > 0
 		data["AIForgeList"] = base.AIForgeList
 		data["ForgeInventory"] = base.ShowForgeInventory && strings.TrimSpace(base.AIForgeList) != ""
+		data["SessionArtifactsFrozen"] = base.SessionArtifactsFrozen
+		data["SessionArtifactsOpen"] = base.SessionArtifactsOpen
 	}
 	if input != nil {
 		data["Nonce"] = input.Nonce

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -139,48 +139,16 @@ func (pm *PromptManager) GetLoopPromptBaseMaterials(tools []*aitool.Tool, nonce 
 	}
 
 	if allowToolCall && len(tools) > 0 {
-		// 0. hidden tool pattern: 先按可见性过滤掉 VisibilityHidden 与 VisibilityScenario
-		//    工具, 让默认 Tool Inventory 不出现 amap / 已被 do_http_request
-		//    覆盖的 send_http_request_* / url_content_summary / ssa-* 这类
-		//    工具. 若当前 loop (典型: yak focus mode) 通过
-		//    WithScenarioToolWhitelist 显式声明了 scenario 拉回名单, 命中
-		//    名单的 scenario 工具会被保留, 并在后面通过 getPrioritizedTools
-		//    的 extraPriority 参数置顶展示. hidden 工具一律不复活.
-		//    这一步必须在 ToolsCount 统计之前做完, 否则模板里
-		//    "You have access to N built-in tools" / MoreToolsCount 会把
-		//    被过滤掉的工具也算进去, 误导 AI.
-		//    关键词: hidden tool pattern, FilterToolsByVisibility, scenario whitelist,
-		//           Tool Inventory render entry filter
-		scenarioWL := pm.react.GetCurrentLoop().GetScenarioToolWhitelist()
-		tools = aicommon.FilterToolsByVisibility(tools, scenarioWL)
-		if len(tools) == 0 {
-			return materials, nil
+		scenarioWL := []string(nil)
+		if currentLoop := pm.react.GetCurrentLoop(); currentLoop != nil {
+			scenarioWL = currentLoop.GetScenarioToolWhitelist()
 		}
-
-		// 1. 先用 GetTopToolsCount 作为"候选池上限"取出 prioritized 的前 N 个
-		//    (默认 100, 用户可用 WithTopToolsCount(N) 缩窄).
-		// 2. 再用 SelectToolsByTokenBudget 按 token 预算 (3K) 从候选池里二次裁剪,
-		//    同时保底 ToolInventoryMinCount (20) 个工具, 即便描述很长也不会
-		//    出现"Top 15 tools"那种被武断截短的局面.
-		// 3. HasMoreTools / MoreToolsCount 以"全部 tools - 实际展示"计算, 让
-		//    模板里能给出具体剩余数字, search_capabilities 提示更具象.
-		// 关键词: GetLoopPromptBaseMaterials tool budget, SelectToolsByTokenBudget,
-		//        TopToolsCount 候选池上限, 保底 20
-		topCount := pm.react.config.GetTopToolsCount()
-		candidate := pm.react.getPrioritizedTools(tools, topCount, scenarioWL...)
-		display := aicommon.SelectToolsByTokenBudget(
-			candidate,
-			aicommon.ToolInventoryTokenBudget,
-			aicommon.ToolInventoryMinCount,
-		)
-		materials.ToolsCount = len(tools)
-		materials.TopTools = display
-		materials.TopToolsCount = len(display)
-		materials.HasMoreTools = len(tools) > len(display)
-		materials.MoreToolsCount = len(tools) - len(display)
-		if materials.MoreToolsCount < 0 {
-			materials.MoreToolsCount = 0
-		}
+		inventory := aicommon.BuildToolInventoryData(tools, pm.react.config.GetTopToolsCount(), scenarioWL...)
+		materials.ToolsCount = inventory.ToolsCount
+		materials.TopTools = inventory.TopTools
+		materials.TopToolsCount = inventory.TopToolsCount
+		materials.HasMoreTools = inventory.HasMoreTools
+		materials.MoreToolsCount = inventory.MoreToolsCount
 	}
 
 	return materials, nil
@@ -708,12 +676,14 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 //  6. Plan Context 末尾: PE-TASK PLAN 产物本质易变 (子任务切换 +
 //     FACTS/DOCUMENT 嵌入 root user input), 放最末让其落在所有 cache
 //     边界外, 不污染上游 system / frozen / semi 三段缓存命中率。
+//
 // timeline-open 整段位于 system / frozen / semi 三段缓存之外, 是 prompt 的
 // "易变尾段", 段内子块顺序不影响上游 prefix cache, 仅影响 LLM 理解顺序。
 //
 // 关键词: buildTimelineOpenObservation, Timeline 末桶, SessionEvidence,
-//        Workspace, UserHistory, Current Time, PlanContext 末尾,
-//        段内排序原则, P1-C3 顺序调整, 缓存边界外
+//
+//	Workspace, UserHistory, Current Time, PlanContext 末尾,
+//	段内排序原则, P1-C3 顺序调整, 缓存边界外
 func (pm *PromptManager) buildTimelineOpenObservation(
 	materials *reactloops.PromptPrefixMaterials,
 	rendered string,

--- a/common/ai/aid/aireact/prompt_loop_materials_test.go
+++ b/common/ai/aid/aireact/prompt_loop_materials_test.go
@@ -2,6 +2,8 @@ package aireact
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -384,11 +386,70 @@ func TestPromptManager_AssemblePromptPrefix(t *testing.T) {
 	require.Len(t, prefix.Sections, 5)
 	require.Contains(t, prefix.Prompt, "<|TRAITS|>")
 	require.Contains(t, prefix.Prompt, "<|SCHEMA|>")
+	require.NotContains(t, prefix.Prompt, "Plan Facts")
+	require.NotContains(t, prefix.Prompt, "Plan Document")
 	require.Equal(t, "section.high_static", prefix.Sections[0].Key)
 	require.Equal(t, "section.frozen_block", prefix.Sections[1].Key)
 	require.Equal(t, "section.semi_dynamic_1", prefix.Sections[2].Key)
 	require.Equal(t, "section.semi_dynamic_2", prefix.Sections[3].Key)
 	require.Equal(t, "section.timeline_open", prefix.Sections[4].Key)
+}
+
+func TestPromptManager_AssemblePromptPrefix_FrozenPartitionsInFrozenBlock(t *testing.T) {
+	react, err := NewTestReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			rsp := i.NewAIResponse()
+			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action":"object","next_action":{"type":"directly_answer","answer_payload":"ok"},"cumulative_summary":"ok","human_readable_thought":"ok"}`))
+			rsp.Close()
+			return rsp, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	facts, ok := aicommon.NewFrozenBlockPartition("plan_facts", "Plan Facts", "## Facts\n- stable", 100)
+	require.True(t, ok)
+	document, ok := aicommon.NewFrozenBlockPartition("plan_document", "Plan Document", "## Document\n- stable", 110)
+	require.True(t, ok)
+
+	prefix, err := react.promptManager.AssemblePromptPrefix(&aicommon.PromptMaterials{
+		FrozenPartitions: []aicommon.FrozenBlockPartition{document, facts},
+	})
+	require.NoError(t, err)
+	require.Contains(t, prefix.FrozenBlock, "# Plan Facts")
+	require.Contains(t, prefix.FrozenBlock, "# Plan Document")
+	require.Less(t, strings.Index(prefix.FrozenBlock, "# Plan Facts"), strings.Index(prefix.FrozenBlock, "# Plan Document"))
+	require.Contains(t, prefix.FrozenBlock, "<|FROZEN_PARTITION_plan_facts_"+facts.Nonce+"|>")
+	require.Contains(t, prefix.FrozenBlock, "<|FROZEN_PARTITION_END_plan_document_"+document.Nonce+"|>")
+
+	frozen := prefix.Sections[1]
+	require.Equal(t, "section.frozen_block", frozen.Key)
+	var keys []string
+	for _, child := range frozen.Children {
+		keys = append(keys, child.Key)
+	}
+	require.Contains(t, keys, "section.frozen_block.partition.plan_facts")
+	require.Contains(t, keys, "section.frozen_block.partition.plan_document")
+}
+
+func TestPromptManager_NewPromptMaterials_ConfigFrozenPartitionProducer(t *testing.T) {
+	produced, ok := aicommon.NewFrozenBlockPartition("plan_facts", "Plan Facts", "## Facts\n- from config", 100)
+	require.True(t, ok)
+	react, err := NewTestReAct(
+		aicommon.WithFrozenBlockPartitionProducer(func() []aicommon.FrozenBlockPartition {
+			return []aicommon.FrozenBlockPartition{produced}
+		}),
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			rsp := i.NewAIResponse()
+			rsp.Close()
+			return rsp, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	materials := react.promptManager.NewPromptMaterials(&reactloops.LoopPromptBaseMaterials{}, nil)
+	require.Len(t, materials.FrozenPartitions, 1)
+	require.Equal(t, "plan_facts", materials.FrozenPartitions[0].ID)
+	require.Equal(t, produced.Content, materials.FrozenPartitions[0].Content)
 }
 
 // TestPromptManager_AssembleLoopPrompt_HijackFiveSegment 验证 aireact 主路径
@@ -517,6 +578,55 @@ func TestPromptManager_AssembleLoopPrompt_HijackFiveSegment(t *testing.T) {
 	require.NotContains(t, user4Content, "<|AI_CACHE_SEMI2_semi|>",
 		"user4 must NOT contain semi-2 START tag")
 	requireMessageHasNoCacheControl(t, user4, "user4 open+dynamic")
+}
+
+func TestPromptManager_AssembleLoopPrompt_HijackArtifactsFrozenOpenPlacement(t *testing.T) {
+	restore := aicache.SetMinCachableUserSegmentBytesForTest(0)
+	defer restore()
+
+	workDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "task_1-1_done"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "task_1-1_done", "result.txt"), []byte("done"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "task_1-2_open"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "task_1-2_open", "result.txt"), []byte("open"), 0644))
+
+	react, err := NewTestReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			rsp := i.NewAIResponse()
+			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action":"object","next_action":{"type":"directly_answer","answer_payload":"ok"},"cumulative_summary":"ok","human_readable_thought":"ok"}`))
+			rsp.Close()
+			return rsp, nil
+		}),
+	)
+	require.NoError(t, err)
+	react.config.Workdir = workDir
+
+	tool := aitool.NewWithoutCallback("tool-a", aitool.WithDescription("tool a desc"))
+	result, err := react.promptManager.AssembleLoopPrompt([]*aitool.Tool{tool}, &reactloops.LoopPromptAssemblyInput{
+		Nonce:           "artifacts01",
+		UserQuery:       "user query body",
+		TaskInstruction: "follow task rules",
+		OutputExample:   "example output",
+		Schema:          `{"type":"object","properties":{"@action":{"type":"string"}}}`,
+	})
+	require.NoError(t, err)
+
+	hijack := aicache.Observe("test-model", result.Prompt)
+	require.NotNil(t, hijack)
+	require.True(t, hijack.IsHijacked)
+	require.Len(t, hijack.Messages, 5)
+
+	user1Content := chatDetailContentString(hijack.Messages[1])
+	require.Contains(t, user1Content, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, user1Content, "# Session Artifacts (Frozen)")
+	require.Contains(t, user1Content, "task_1-1_done")
+	require.NotContains(t, user1Content, "task_1-2_open")
+
+	user4Content := chatDetailContentString(hijack.Messages[4])
+	require.Contains(t, user4Content, "<|PROMPT_SECTION_timeline-open|>")
+	require.Contains(t, user4Content, "# Session Artifacts (Open)")
+	require.Contains(t, user4Content, "task_1-2_open")
+	require.NotContains(t, user4Content, "task_1-1_done")
 }
 
 func TestPromptManager_AssembleLoopPrompt_EmptySemiDynamic1StillKeepsWrapper(t *testing.T) {

--- a/common/ai/aid/aireact/prompt_loop_materials_test.go
+++ b/common/ai/aid/aireact/prompt_loop_materials_test.go
@@ -586,7 +586,10 @@ func TestPromptManager_AssembleLoopPrompt_HijackArtifactsFrozenOpenPlacement(t *
 
 	workDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "task_1-1_done"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(workDir, "task_1-1_done", "result.txt"), []byte("done"), 0644))
+	donePath := filepath.Join(workDir, "task_1-1_done", "result.txt")
+	require.NoError(t, os.WriteFile(donePath, []byte("done"), 0644))
+	oldArtifactTime := time.Unix(946684800, 0)
+	require.NoError(t, os.Chtimes(donePath, oldArtifactTime, oldArtifactTime))
 	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "task_1-2_open"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(workDir, "task_1-2_open", "result.txt"), []byte("open"), 0644))
 
@@ -600,6 +603,7 @@ func TestPromptManager_AssembleLoopPrompt_HijackArtifactsFrozenOpenPlacement(t *
 	)
 	require.NoError(t, err)
 	react.config.Workdir = workDir
+	react.config.GetTimeline().PushText(1, "timeline anchor")
 
 	tool := aitool.NewWithoutCallback("tool-a", aitool.WithDescription("tool a desc"))
 	result, err := react.promptManager.AssembleLoopPrompt([]*aitool.Tool{tool}, &reactloops.LoopPromptAssemblyInput{

--- a/common/ai/aid/aireact/prompt_loop_materials_test.go
+++ b/common/ai/aid/aireact/prompt_loop_materials_test.go
@@ -434,10 +434,9 @@ func TestPromptManager_AssemblePromptPrefix_FrozenPartitionsInFrozenBlock(t *tes
 func TestPromptManager_NewPromptMaterials_ConfigFrozenPartitionProducer(t *testing.T) {
 	produced, ok := aicommon.NewFrozenBlockPartition("plan_facts", "Plan Facts", "## Facts\n- from config", 100)
 	require.True(t, ok)
+	producer := aicommon.NewFrozenBlockPartitionProducer(produced)
 	react, err := NewTestReAct(
-		aicommon.WithFrozenBlockPartitionProducer(func() []aicommon.FrozenBlockPartition {
-			return []aicommon.FrozenBlockPartition{produced}
-		}),
+		aicommon.WithFrozenBlockPartitionProducer(producer),
 		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
 			rsp := i.NewAIResponse()
 			rsp.Close()
@@ -446,7 +445,9 @@ func TestPromptManager_NewPromptMaterials_ConfigFrozenPartitionProducer(t *testi
 	)
 	require.NoError(t, err)
 
-	materials := react.promptManager.NewPromptMaterials(&reactloops.LoopPromptBaseMaterials{}, nil)
+	materials := react.promptManager.NewPromptMaterials(&reactloops.LoopPromptBaseMaterials{
+		PromptFrozenOpenMaterials: aicommon.BuildPromptFrozenOpenMaterials(react.config),
+	}, nil)
 	require.Len(t, materials.FrozenPartitions, 1)
 	require.Equal(t, "plan_facts", materials.FrozenPartitions[0].ID)
 	require.Equal(t, produced.Content, materials.FrozenPartitions[0].Content)

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -302,28 +302,11 @@ func (pm *PromptManager) GetBasicPromptInfo(tools []*aitool.Tool) (string, map[s
 		// token 预算二次裁剪, 保底 ToolInventoryMinCount 个工具, base.txt 模板
 		// 与 frozen_block_section.txt 看到同一份 TopTools / MoreToolsCount.
 		// 关键词: GetBasicPromptInfo token budget, 与主路径口径对齐
-		if len(tools) > 0 {
-			topCount := pm.react.config.GetTopToolsCount()
-			candidate := pm.react.getPrioritizedTools(tools, topCount)
-			display := aicommon.SelectToolsByTokenBudget(
-				candidate,
-				aicommon.ToolInventoryTokenBudget,
-				aicommon.ToolInventoryMinCount,
-			)
-			more := len(tools) - len(display)
-			if more < 0 {
-				more = 0
-			}
-			result["TopTools"] = display
-			result["TopToolsCount"] = len(display)
-			result["HasMoreTools"] = len(tools) > len(display)
-			result["MoreToolsCount"] = more
-		} else {
-			result["TopTools"] = []*aitool.Tool{}
-			result["TopToolsCount"] = 0
-			result["HasMoreTools"] = false
-			result["MoreToolsCount"] = 0
-		}
+		inventory := aicommon.BuildToolInventoryData(tools, pm.react.config.GetTopToolsCount())
+		result["TopTools"] = inventory.TopTools
+		result["TopToolsCount"] = inventory.TopToolsCount
+		result["HasMoreTools"] = inventory.HasMoreTools
+		result["MoreToolsCount"] = inventory.MoreToolsCount
 	}
 
 	// use timeline getter

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -470,7 +470,6 @@ func (pm *PromptManager) GenerateVerificationPrompt(originalQuery string, isTool
 	prefixMaterials.AIForgeList = ""
 	prefixMaterials.SkillsContext = ""
 	prefixMaterials.RecentToolsCache = ""
-
 	dynamicData := pm.buildLoopPromptSectionData(base, &reactloops.LoopPromptAssemblyInput{
 		Nonce:     nonceString,
 		UserQuery: originalQuery,
@@ -486,6 +485,7 @@ func (pm *PromptManager) GenerateVerificationPrompt(originalQuery string, isTool
 		dynamicData["MaxIterations"] = currentLoop.GetMaxIterations()
 	}
 
+	aicommon.PopulateToolInventoryFromConfig(prefixMaterials, pm.react.config) // verification prompt 也展示工具列表, 避免ai cache出现连锁反应
 	prompt, err := pm.assemblePromptWithDynamicSection(
 		prefixMaterials,
 		"verification-dynamic",

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -402,16 +402,10 @@ func (pm *PromptManager) GenerateToolParamsPromptWithMeta(tool *aitool.Tool) (*T
 	if err != nil {
 		return nil, err
 	}
-	prefixMaterials.AllowToolCall = false
 	prefixMaterials.AllowPlanAndExec = false
 	prefixMaterials.HasLoadCapability = false
 	prefixMaterials.TaskInstruction = strings.TrimSpace(toolParamsInstructionText)
 	prefixMaterials.OutputExample = ""
-	prefixMaterials.ToolInventory = true
-	prefixMaterials.ToolsCount = 0
-	prefixMaterials.TopToolsCount = 0
-	prefixMaterials.TopTools = nil
-	prefixMaterials.HasMoreTools = false
 	prefixMaterials.ForgeInventory = false
 	prefixMaterials.AIForgeList = ""
 	prefixMaterials.SkillsContext = ""
@@ -670,16 +664,10 @@ func (pm *PromptManager) GenerateReGenerateToolParamsPromptWithMeta(userQuery st
 	if err != nil {
 		return nil, err
 	}
-	prefixMaterials.AllowToolCall = false
 	prefixMaterials.AllowPlanAndExec = false
 	prefixMaterials.HasLoadCapability = false
 	prefixMaterials.TaskInstruction = strings.TrimSpace(wrongParamsInstructionText)
 	prefixMaterials.OutputExample = strings.TrimSpace(wrongParamsOutputExampleText)
-	prefixMaterials.ToolInventory = false
-	prefixMaterials.ToolsCount = 0
-	prefixMaterials.TopToolsCount = 0
-	prefixMaterials.TopTools = nil
-	prefixMaterials.HasMoreTools = false
 	prefixMaterials.ForgeInventory = false
 	prefixMaterials.AIForgeList = ""
 	prefixMaterials.SkillsContext = ""

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -407,7 +407,7 @@ func (pm *PromptManager) GenerateToolParamsPromptWithMeta(tool *aitool.Tool) (*T
 	prefixMaterials.HasLoadCapability = false
 	prefixMaterials.TaskInstruction = strings.TrimSpace(toolParamsInstructionText)
 	prefixMaterials.OutputExample = ""
-	prefixMaterials.ToolInventory = false
+	prefixMaterials.ToolInventory = true
 	prefixMaterials.ToolsCount = 0
 	prefixMaterials.TopToolsCount = 0
 	prefixMaterials.TopTools = nil

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -601,8 +601,7 @@ func WithBuiltinTools() aicommon.ConfigOption {
 
 // emitArtifactsSummaryToTimeline pushes a summary of the artifacts directory into the
 // timeline after plan/forge completion, and ensures EmitPinDirectory is called for UI visibility.
-// This provides an immediate notification layer; the persistent layer is ArtifactsContextProvider
-// which runs on every prompt build.
+// Prompt visibility is handled by RenderSessionArtifactsFrozenOpen during prompt build.
 func (r *ReAct) emitArtifactsSummaryToTimeline() {
 	artifactsDir := r.config.GetOrCreateWorkDir()
 	if artifactsDir == "" {

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -770,6 +770,7 @@ LOOP:
 			nonce,
 			userInputForDynamic,
 			frozenUserContext,
+			nil,
 			r.GetCurrentMemoriesContent(),
 			operator,
 		)

--- a/common/ai/aid/aireact/reactloops/prompt.go
+++ b/common/ai/aid/aireact/reactloops/prompt.go
@@ -154,20 +154,24 @@ func (r *ReActLoop) generateSchemaString(disallowExit bool) (string, error) {
 //     (跨 turn 不必稳定, 例如普通 ReAct 的用户当前轮次输入)
 //   - frozenUserContext: PE-TASK 的 PARENT_TASK + CURRENT_TASK + INSTRUCTION
 //     三联块等"用户上下文块". 注入 timeline-open 段最末尾 (UserHistory 之后),
-//     落在所有 cache 边界之外. 字段名虽含 "frozen", 但因 EvidenceOps 嵌入
-//     root user input + 子任务切换实际会抖动, 故主动放弃自身缓存以保护上游
-//     SYSTEM / FROZEN / SEMI 三段缓存命中.
+//     落在所有 cache 边界之外. 字段名虽含 "frozen", 但 PE-TASK 子任务切换
+//     会让 CURRENT_TASK 内容抖动, 故主动放弃自身缓存以保护上游 SYSTEM /
+//     FROZEN / SEMI 三段缓存命中.
 //     普通场景传空串即可, 此时 timeline-open 段 PlanContext 子块自然不渲染,
 //     段位置稳定.
+//   - frozenPartitions: 调用方显式传入的 frozen-block 分区; config 上注册的
+//     FrozenBlockPartitionProducer 会在 PromptMaterials 构造时追加.
 //   - memory: 注入 memory 段
 //   - operator: loop 运行时操作句柄
 //
 // 关键词: generateLoopPrompt, frozenUserContext, PLAN_CONTEXT 段,
-//        prefix cache, PE-TASK 缓存优化
+//
+//	prefix cache, PE-TASK 缓存优化
 func (r *ReActLoop) generateLoopPrompt(
 	nonce string,
 	userInput string,
 	frozenUserContext string,
+	frozenPartitions []aicommon.FrozenBlockPartition,
 	memory string,
 	operator *LoopActionHandlerOperator,
 ) (string, error) {
@@ -290,6 +294,7 @@ func (r *ReActLoop) generateLoopPrompt(
 		Nonce:             nonce,
 		UserQuery:         userInput,
 		FrozenUserContext: frozenUserContext,
+		FrozenPartitions:  frozenPartitions,
 		TaskInstruction:   persistent,
 		OutputExample:     outputExample,
 		Schema:            schema,

--- a/common/ai/aid/aireact/reactloops/prompt_materials.go
+++ b/common/ai/aid/aireact/reactloops/prompt_materials.go
@@ -39,8 +39,7 @@ type LoopPromptBaseMaterials struct {
 	// 关键词: MoreToolsCount, Tool Inventory 剩余工具数, search_capabilities 具象提示
 	MoreToolsCount int
 	AIForgeList    string
-	TimelineFrozen string
-	TimelineOpen   string
+	aicommon.PromptFrozenOpenMaterials
 }
 
 type LoopPromptAssemblyInput = aicommon.LoopPromptAssemblyInput
@@ -54,7 +53,8 @@ type LoopPromptAssemblyResult = aicommon.LoopPromptAssemblyResult
 // (P1-C3 段内排序原则等) 也迁移到 aicommon 包中。
 //
 // 关键词: PromptPrefixMaterials alias, aicommon.PromptMaterials,
-//        prompt 语义材料统一收敛
+//
+//	prompt 语义材料统一收敛
 type PromptPrefixMaterials = aicommon.PromptMaterials
 
 // PromptPrefixAssemblyResult 是 AssemblePromptPrefix 的输出。新路径下 Prompt

--- a/common/ai/aid/aireact/reactloops/prompt_observation_test.go
+++ b/common/ai/aid/aireact/reactloops/prompt_observation_test.go
@@ -113,7 +113,7 @@ func TestGenerateLoopPrompt_RecordsObservation(t *testing.T) {
 	task := &mockSimpleTask{id: "test-task", index: "test-index"}
 	operator := NewActionHandlerOperator(task)
 
-	prompt, err := loop.generateLoopPrompt("nonce1", "raw user input", "", "memory content", operator)
+	prompt, err := loop.generateLoopPrompt("nonce1", "raw user input", "", nil, "memory content", operator)
 	require.NoError(t, err)
 	require.NotEmpty(t, prompt)
 

--- a/common/ai/aid/aireact/tools.go
+++ b/common/ai/aid/aireact/tools.go
@@ -14,91 +14,10 @@ import (
 // 即 whitelist 命中的工具会被排在 search_capabilities 等之前.
 //
 // 关键词: getPrioritizedTools, extraPriority, scenario whitelist top,
-//        focus mode pull back ordering
+//
+//	focus mode pull back ordering
 func (r *ReAct) getPrioritizedTools(tools []*aitool.Tool, maxCount int, extraPriority ...string) []*aitool.Tool {
-	if len(tools) == 0 {
-		return tools
-	}
-
-	// Priority tool names - core tools displayed in prompt
-	// search_capabilities should be first as it's the discovery mechanism for all other tools/forges/skills
-	priorityNames := []string{
-		"search_capabilities",
-		"web_search",
-		"grep",
-		"read_file",
-		"write_file",
-		"modify_file",
-		"find_file",
-		"tree",
-		"bash",
-		"cmd",
-		"encode",
-		"decode",
-		"auto_decode",
-		"scan_port",
-		"git-clone",
-		"do_http_request",
-		"batch_do_http_request",
-		"simple_crawler",
-		"cybersecurity-risk",
-		"brute",
-	}
-
-	// extraPriority 拼到内置优先名单的"前面", 让 focus mode 拉回的 scenario
-	// 工具占据第一梯队. 同时去重, 避免外部传入与内置 priorityNames 同名时
-	// 出现重复.
-	if len(extraPriority) > 0 {
-		seen := make(map[string]bool, len(extraPriority))
-		merged := make([]string, 0, len(extraPriority)+len(priorityNames))
-		for _, n := range extraPriority {
-			if n == "" {
-				continue
-			}
-			if seen[n] {
-				continue
-			}
-			seen[n] = true
-			merged = append(merged, n)
-		}
-		for _, n := range priorityNames {
-			if seen[n] {
-				continue
-			}
-			seen[n] = true
-			merged = append(merged, n)
-		}
-		priorityNames = merged
-	}
-
-	// Create map for quick lookup
-	toolMap := make(map[string]*aitool.Tool)
-	for _, tool := range tools {
-		toolMap[tool.Name] = tool
-	}
-
-	var result []*aitool.Tool
-	usedNames := make(map[string]bool)
-
-	// Add priority tools first
-	for _, name := range priorityNames {
-		if tool, exists := toolMap[name]; exists && len(result) < maxCount {
-			result = append(result, tool)
-			usedNames[name] = true
-		}
-	}
-
-	// Add remaining tools if we haven't reached maxCount
-	for _, tool := range tools {
-		if len(result) >= maxCount {
-			break
-		}
-		if !usedNames[tool.Name] {
-			result = append(result, tool)
-		}
-	}
-
-	return result
+	return aicommon.PrioritizeToolsForInventory(tools, maxCount, extraPriority...)
 }
 
 func NewTestReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {

--- a/common/ai/aid/coordinator_invoker.go
+++ b/common/ai/aid/coordinator_invoker.go
@@ -47,9 +47,6 @@ func (c *Coordinator) ExecuteLoopTask(taskTypeName string, task aicommon.AIState
 		aicommon.WithConsumption(c.GetConsumptionConfig()),
 		aicommon.WithEnablePlanAndExec(false),
 		aicommon.WithHotPatchOptionChan(hotpatchChan),
-		aicommon.WithFrozenBlockPartitionProducer(func() []aicommon.FrozenBlockPartition {
-			return BuildPlanStaticFrozenPartitions(c)
-		}),
 	)
 
 	invoker, err := aicommon.AIRuntimeInvokerGetter(c.GetContext(), baseOpts...)

--- a/common/ai/aid/coordinator_invoker.go
+++ b/common/ai/aid/coordinator_invoker.go
@@ -47,6 +47,9 @@ func (c *Coordinator) ExecuteLoopTask(taskTypeName string, task aicommon.AIState
 		aicommon.WithConsumption(c.GetConsumptionConfig()),
 		aicommon.WithEnablePlanAndExec(false),
 		aicommon.WithHotPatchOptionChan(hotpatchChan),
+		aicommon.WithFrozenBlockPartitionProducer(func() []aicommon.FrozenBlockPartition {
+			return BuildPlanStaticFrozenPartitions(c)
+		}),
 	)
 
 	invoker, err := aicommon.AIRuntimeInvokerGetter(c.GetContext(), baseOpts...)

--- a/common/ai/aid/memory.go
+++ b/common/ai/aid/memory.go
@@ -3,6 +3,7 @@ package aid
 import (
 	"bytes"
 	"fmt"
+	"github.com/google/uuid"
 	osRuntime "runtime"
 	"strings"
 	"text/template"
@@ -113,6 +114,7 @@ func (m *PromptContextProvider) BindCoordinator(c *Coordinator) {
 		return config.Keywords
 	})
 	m.PushPersistentData(config.PersistentMemory...)
+	config.AppendFrozenBlockPartition(uuid.NewString(), "persistent_context", strings.Join(config.PersistentMemory, "\n"), aicommon.PersistentMemoryOrder)
 	m.timeline.SoftBindConfig(config, config)
 }
 

--- a/common/ai/aid/plan.go
+++ b/common/ai/aid/plan.go
@@ -147,12 +147,12 @@ func (pr *planRequest) Invoke() (*PlanResponse, error) {
 		if planRes.RootTask != nil {
 			pr.cod.standardizeTaskTreeAndNotify(planRes.RootTask, "mock plan initialized")
 		}
-		if pr.cod.ContextProvider != nil {
+		if pr.cod.Config != nil {
 			if strings.TrimSpace(planRes.Facts) != "" {
-				pr.cod.ContextProvider.SetPersistentData(planFactsPersistentKey, planRes.Facts)
+				appendPlanFactsFrozenPartition(pr.cod.Config, planRes.Facts)
 			}
 			if strings.TrimSpace(planRes.Document) != "" {
-				pr.cod.ContextProvider.SetPersistentData(planDocumentPersistentKey, planRes.Document)
+				appendPlanDocumentFrozenPartition(pr.cod.Config, planRes.Document)
 			}
 		}
 		return planRes, nil
@@ -233,12 +233,16 @@ func (pr *planRequest) Invoke() (*PlanResponse, error) {
 
 					if facts := loop.Get(loop_plan.PLAN_FACTS_KEY); facts != "" {
 						planFacts = facts
-						pr.cod.ContextProvider.SetPersistentData(planFactsPersistentKey, facts)
+						if pr.cod.Config != nil {
+							appendPlanFactsFrozenPartition(pr.cod.Config, facts)
+						}
 					}
 
 					if doc := loop.Get(loop_plan.PLAN_DOCUMENT_KEY); doc != "" {
 						planDocument = doc
-						pr.cod.ContextProvider.SetPersistentData(planDocumentPersistentKey, doc)
+						if pr.cod.Config != nil {
+							appendPlanDocumentFrozenPartition(pr.cod.Config, doc)
+						}
 					}
 				})
 			}
@@ -248,11 +252,11 @@ func (pr *planRequest) Invoke() (*PlanResponse, error) {
 	}
 	pr.cod.standardizeTaskTreeAndNotify(rootTask, "initial plan generated")
 
-	if planFacts != "" && rootTask.Coordinator != nil && rootTask.Coordinator.ContextProvider != nil {
-		rootTask.Coordinator.ContextProvider.SetPersistentData(planFactsPersistentKey, planFacts)
+	if planFacts != "" && rootTask.Coordinator != nil && rootTask.Coordinator.Config != nil {
+		appendPlanFactsFrozenPartition(rootTask.Coordinator.Config, planFacts)
 	}
-	if planDocument != "" && rootTask.Coordinator != nil && rootTask.Coordinator.ContextProvider != nil {
-		rootTask.Coordinator.ContextProvider.SetPersistentData(planDocumentPersistentKey, planDocument)
+	if planDocument != "" && rootTask.Coordinator != nil && rootTask.Coordinator.Config != nil {
+		appendPlanDocumentFrozenPartition(rootTask.Coordinator.Config, planDocument)
 	}
 
 	resp := pr.cod.newPlanResponse(rootTask)

--- a/common/ai/aid/plan.go
+++ b/common/ai/aid/plan.go
@@ -147,6 +147,14 @@ func (pr *planRequest) Invoke() (*PlanResponse, error) {
 		if planRes.RootTask != nil {
 			pr.cod.standardizeTaskTreeAndNotify(planRes.RootTask, "mock plan initialized")
 		}
+		if pr.cod.ContextProvider != nil {
+			if strings.TrimSpace(planRes.Facts) != "" {
+				pr.cod.ContextProvider.SetPersistentData(planFactsPersistentKey, planRes.Facts)
+			}
+			if strings.TrimSpace(planRes.Document) != "" {
+				pr.cod.ContextProvider.SetPersistentData(planDocumentPersistentKey, planRes.Document)
+			}
+		}
 		return planRes, nil
 	}
 
@@ -245,12 +253,6 @@ func (pr *planRequest) Invoke() (*PlanResponse, error) {
 	}
 	if planDocument != "" && rootTask.Coordinator != nil && rootTask.Coordinator.ContextProvider != nil {
 		rootTask.Coordinator.ContextProvider.SetPersistentData(planDocumentPersistentKey, planDocument)
-	}
-
-	// Inject PLAN context docs (FACTS + DOCUMENT + EVIDENCE) as prefix blocks
-	// in the root task's user input so every subtask can see them.
-	if planFacts != "" || planDocument != "" {
-		syncRootTaskPlanContextDocs(rootTask)
 	}
 
 	resp := pr.cod.newPlanResponse(rootTask)

--- a/common/ai/aid/plan_and_exec_prompt_builder.go
+++ b/common/ai/aid/plan_and_exec_prompt_builder.go
@@ -52,8 +52,18 @@ func newAidPromptMaterials(instruction string, schema string) *aicommon.PromptMa
 	}
 }
 
+func newAidPromptMaterialsForConfig(config *aicommon.Config, instruction string, schema string) *aicommon.PromptMaterials {
+	materials := newAidPromptMaterials(instruction, schema)
+	aicommon.ApplyPromptFrozenOpenMaterials(materials, aicommon.BuildPromptFrozenOpenMaterials(config))
+	return materials
+}
+
 func newAidPlanReviewPromptMaterials(pr *planRequest, instruction string, schemaKey string) *aicommon.PromptMaterials {
-	return newAidPromptMaterials(instruction, pr.cod.ContextProvider.Schema()[schemaKey])
+	var config *aicommon.Config
+	if pr != nil && pr.cod != nil {
+		config = pr.cod.Config
+	}
+	return newAidPromptMaterialsForConfig(config, instruction, pr.cod.ContextProvider.Schema()[schemaKey])
 }
 
 func (pr *planRequest) assemblePlanReviewPrompt(
@@ -99,7 +109,7 @@ func buildCreateSubtaskTargetPlansDetail(c *Coordinator, targetPlans []string) s
 func (t *AiTask) buildDeepthinkPrompt(userInput string) (string, error) {
 	builder := aicommon.NewDefaultPromptPrefixBuilder()
 	nonce := utils.RandStringBytes(6)
-	materials := newAidPromptMaterials(__prompt_deepthinkInstruction, t.ContextProvider.Schema()["PlanJsonSchema"])
+	materials := newAidPromptMaterialsForConfig(t.Config, __prompt_deepthinkInstruction, t.ContextProvider.Schema()["PlanJsonSchema"])
 	return builder.AssemblePromptWithDynamicSection(
 		materials,
 		"aid-deepthink-dynamic",
@@ -115,12 +125,9 @@ func (t *AiTask) buildDeepthinkPrompt(userInput string) (string, error) {
 }
 
 func (t *AiTask) buildDynamicPlanPrompt(userInput string) (string, error) {
-	frozen, open := t.ContextProvider.TimelineDumpFrozenOpen()
 	builder := aicommon.NewDefaultPromptPrefixBuilder()
 	nonce := utils.RandStringBytes(6)
-	materials := newAidPromptMaterials(__prompt_dynamicPlanInstruction, t.ContextProvider.Schema()["RePlanJsonSchema"])
-	materials.TimelineFrozen = frozen
-	materials.TimelineOpen = open
+	materials := newAidPromptMaterialsForConfig(t.Config, __prompt_dynamicPlanInstruction, t.ContextProvider.Schema()["RePlanJsonSchema"])
 	return builder.AssemblePromptWithDynamicSection(
 		materials,
 		"aid-dynamic-plan-dynamic",

--- a/common/ai/aid/plan_facts.go
+++ b/common/ai/aid/plan_facts.go
@@ -34,67 +34,6 @@ type discoveredAITagBlock struct {
 	End     int
 }
 
-func buildFactsBlock(facts string) string {
-	return buildPlanContextBlock("FACTS", facts)
-}
-
-func buildEvidenceBlock(evidence string) string {
-	return buildPlanContextBlock("EVIDENCE", evidence)
-}
-
-func buildDocumentBlock(document string) string {
-	return buildPlanContextBlock("DOCUMENT", document)
-}
-
-// buildPlanContextBlock 构造 <|TAG_<nonce>|>...<|TAG_END_<nonce>|> 块。
-//
-// 缓存优化: nonce 由 (tag, content) 通过 aicommon.StablePromptNonce 派生，
-// 同样的 content 跨多次调用必产出相同 nonce，避免老反模式
-// utils.RandStringBytes(6) 让相同 FACTS/DOCUMENT/EVIDENCE body 在每次重渲染
-// 时都换 nonce，从而打破上游的 prefix cache。
-//
-// content 一旦变化 (例如 plan 演化新增 facts), nonce 自然变化, 这是预期
-// 行为, 让旧缓存自然失效。
-//
-// 关键词: buildPlanContextBlock, plan facts/document/evidence nonce 稳定,
-//        反 RandStringBytes 反模式, prefix cache
-func buildPlanContextBlock(tag string, content string) string {
-	content = strings.TrimSpace(content)
-	if content == "" {
-		return ""
-	}
-	nonce := aicommon.StablePromptNonce("plan-context", tag, content)
-	return fmt.Sprintf("<|%s_%s|>\n%s\n<|%s_END_%s|>", tag, nonce, content, tag, nonce)
-}
-
-func prependPlanFactsToRenderedPlan(base string, facts string) string {
-	return prependPlanContextDocsToRenderedPlan(base, facts, "", "")
-}
-
-func prependPlanContextDocsToRenderedPlan(base string, facts string, document string, evidence string) string {
-	facts = strings.TrimSpace(facts)
-	document = strings.TrimSpace(document)
-	evidence = strings.TrimSpace(evidence)
-	if facts == "" && document == "" && evidence == "" {
-		return base
-	}
-	blocks := make([]string, 0, 3)
-	if facts != "" {
-		blocks = append(blocks, buildFactsBlock(facts))
-	}
-	if document != "" {
-		blocks = append(blocks, buildDocumentBlock(document))
-	}
-	if evidence != "" {
-		blocks = append(blocks, buildEvidenceBlock(evidence))
-	}
-	joinedBlocks := strings.Join(blocks, "\n\n")
-	if strings.TrimSpace(base) == "" {
-		return joinedBlocks
-	}
-	return joinedBlocks + "\n\n" + base
-}
-
 func extractPlanFactsFromText(content string) string {
 	return extractPlanContextFromText(content, planFactsAITags...)
 }
@@ -245,16 +184,8 @@ func parseAITagStartToken(token string) (string, string, bool) {
 	return tagName, nonce, true
 }
 
-func getTaskPlanFacts(task *AiTask) string {
-	return getTaskPlanPersistentMarkdown(task, planFactsPersistentKey, extractPlanFactsFromText)
-}
-
 func getTaskPlanEvidence(task *AiTask) string {
 	return getTaskPlanPersistentMarkdown(task, planEvidencePersistentKey, extractPlanEvidenceFromText)
-}
-
-func getTaskPlanDocument(task *AiTask) string {
-	return getTaskPlanPersistentMarkdown(task, planDocumentPersistentKey, extractPlanDocumentFromText)
 }
 
 func getTaskPlanPersistentMarkdown(task *AiTask, key string, extractor func(string) string) string {
@@ -313,7 +244,6 @@ func appendTaskPlanEvidence(task *AiTask, incoming string) (string, bool) {
 	if task.Coordinator != nil && task.Coordinator.ContextProvider != nil {
 		task.Coordinator.ContextProvider.SetPersistentData(planEvidencePersistentKey, merged)
 	}
-	syncRootTaskPlanContextDocs(task)
 	return merged, true
 }
 
@@ -402,34 +332,6 @@ func sanitizeTaskPlanOutputFilePath(filePath string) string {
 		return ""
 	}
 	return cleaned
-}
-
-// syncRootTaskPlanContextDocs 把 root task 的 FACTS + DOCUMENT 同步嵌入到
-// root user input 前缀, 让所有子任务通过 GetUserInput / parentInputs 链路看到
-// 这两份 plan 周期级稳定文档。
-//
-// EVIDENCE 故意不再嵌入: 历史上曾把 EVIDENCE 作为第三份 prefix 嵌入, 但 EVIDENCE
-// 由 EvidenceOps 增量演化, 每次写入都会让 root user input 字节变化, 进而让
-// PlanContext (PARENT_TASK + CURRENT_TASK + INSTRUCTION 三联块, 内部依赖父链
-// user input) 跨子任务剧烈抖动, 破坏 prompt 缓存命中。现 EVIDENCE 统一由
-// SessionPromptState 渲染 (SESSION_EVIDENCE 段, 位于 timeline-open), 单一
-// 数据源, 不再污染 root user input。
-//
-// 关键词: syncRootTaskPlanContextDocs, FACTS + DOCUMENT 嵌入,
-//        EVIDENCE 已剥离, PlanContext 抖动修复, SessionPromptState 单源
-func syncRootTaskPlanContextDocs(task *AiTask) {
-	if task == nil {
-		return
-	}
-	root := task
-	for root.ParentTask != nil {
-		root = root.ParentTask
-	}
-	if root.AIStatefulTaskBase == nil {
-		return
-	}
-	base := stripPlanContextBlocks(root.AIStatefulTaskBase.GetUserInput())
-	root.SetUserInput(prependPlanContextDocsToRenderedPlan(base, getTaskPlanFacts(root), getTaskPlanDocument(root), ""))
 }
 
 func buildVerificationCarryoverEvidenceOps(task *AiTask, reasoning string, outputFiles []string) []aicommon.EvidenceOperation {
@@ -522,7 +424,6 @@ func applyTaskPlanEvidenceOps(task *AiTask, ops []aicommon.EvidenceOperation) (s
 	if task.Coordinator != nil && task.Coordinator.ContextProvider != nil {
 		task.Coordinator.ContextProvider.SetPersistentData(planEvidencePersistentKey, merged)
 	}
-	syncRootTaskPlanContextDocs(task)
 	return merged, true
 }
 

--- a/common/ai/aid/plan_static_frozen_partitions.go
+++ b/common/ai/aid/plan_static_frozen_partitions.go
@@ -7,27 +7,30 @@ const (
 	planDocumentFrozenPartitionOrder = 110
 )
 
-func BuildPlanStaticFrozenPartitions(c *Coordinator) []aicommon.FrozenBlockPartition {
-	if c == nil || c.ContextProvider == nil {
+func appendPlanFactsFrozenPartition(config *aicommon.Config, facts string) {
+	if config == nil {
+		return
+	}
+	config.AppendFrozenBlockPartition("plan_facts", "Plan Facts", facts, planFactsFrozenPartitionOrder)
+}
+
+func appendPlanDocumentFrozenPartition(config *aicommon.Config, document string) {
+	if config == nil {
+		return
+	}
+	config.AppendFrozenBlockPartition("plan_document", "Plan Document", document, planDocumentFrozenPartitionOrder)
+}
+
+func BuildPlanStaticFrozenPartitions(producer *aicommon.FrozenBlockPartitionProducer) []aicommon.FrozenBlockPartition {
+	if producer == nil {
 		return nil
 	}
 	var out []aicommon.FrozenBlockPartition
-	if p, ok := aicommon.NewFrozenBlockPartition("plan_facts", "Plan Facts", getCoordinatorPlanPersistentData(c, planFactsPersistentKey), planFactsFrozenPartitionOrder); ok {
-		out = append(out, p)
-	}
-	if p, ok := aicommon.NewFrozenBlockPartition("plan_document", "Plan Document", getCoordinatorPlanPersistentData(c, planDocumentPersistentKey), planDocumentFrozenPartitionOrder); ok {
-		out = append(out, p)
+	for _, partition := range producer.ProducePartitions() {
+		switch partition.ID {
+		case "plan_facts", "plan_document":
+			out = append(out, partition)
+		}
 	}
 	return out
-}
-
-func getCoordinatorPlanPersistentData(c *Coordinator, key string) string {
-	if c == nil || c.ContextProvider == nil {
-		return ""
-	}
-	content, ok := c.ContextProvider.GetPersistentData(key)
-	if !ok {
-		return ""
-	}
-	return content
 }

--- a/common/ai/aid/plan_static_frozen_partitions.go
+++ b/common/ai/aid/plan_static_frozen_partitions.go
@@ -2,23 +2,18 @@ package aid
 
 import "github.com/yaklang/yaklang/common/ai/aid/aicommon"
 
-const (
-	planFactsFrozenPartitionOrder    = 100
-	planDocumentFrozenPartitionOrder = 110
-)
-
 func appendPlanFactsFrozenPartition(config *aicommon.Config, facts string) {
 	if config == nil {
 		return
 	}
-	config.AppendFrozenBlockPartition("plan_facts", "Plan Facts", facts, planFactsFrozenPartitionOrder)
+	config.AppendFrozenBlockPartition("plan_facts", "Plan Facts", facts, aicommon.PlanFactsFrozenPartitionOrder)
 }
 
 func appendPlanDocumentFrozenPartition(config *aicommon.Config, document string) {
 	if config == nil {
 		return
 	}
-	config.AppendFrozenBlockPartition("plan_document", "Plan Document", document, planDocumentFrozenPartitionOrder)
+	config.AppendFrozenBlockPartition("plan_document", "Plan Document", document, aicommon.PlanDocumentFrozenPartitionOrder)
 }
 
 func BuildPlanStaticFrozenPartitions(producer *aicommon.FrozenBlockPartitionProducer) []aicommon.FrozenBlockPartition {

--- a/common/ai/aid/plan_static_frozen_partitions.go
+++ b/common/ai/aid/plan_static_frozen_partitions.go
@@ -1,0 +1,33 @@
+package aid
+
+import "github.com/yaklang/yaklang/common/ai/aid/aicommon"
+
+const (
+	planFactsFrozenPartitionOrder    = 100
+	planDocumentFrozenPartitionOrder = 110
+)
+
+func BuildPlanStaticFrozenPartitions(c *Coordinator) []aicommon.FrozenBlockPartition {
+	if c == nil || c.ContextProvider == nil {
+		return nil
+	}
+	var out []aicommon.FrozenBlockPartition
+	if p, ok := aicommon.NewFrozenBlockPartition("plan_facts", "Plan Facts", getCoordinatorPlanPersistentData(c, planFactsPersistentKey), planFactsFrozenPartitionOrder); ok {
+		out = append(out, p)
+	}
+	if p, ok := aicommon.NewFrozenBlockPartition("plan_document", "Plan Document", getCoordinatorPlanPersistentData(c, planDocumentPersistentKey), planDocumentFrozenPartitionOrder); ok {
+		out = append(out, p)
+	}
+	return out
+}
+
+func getCoordinatorPlanPersistentData(c *Coordinator, key string) string {
+	if c == nil || c.ContextProvider == nil {
+		return ""
+	}
+	content, ok := c.ContextProvider.GetPersistentData(key)
+	if !ok {
+		return ""
+	}
+	return content
+}

--- a/common/ai/aid/plan_static_frozen_partitions_test.go
+++ b/common/ai/aid/plan_static_frozen_partitions_test.go
@@ -18,10 +18,10 @@ func TestBuildPlanStaticFrozenPartitions(t *testing.T) {
 	root := cod.generateAITaskWithName("Root", "root goal")
 	root.Index = "1"
 
-	mem.SetPersistentData(planFactsPersistentKey, "## Facts\n- stable fact")
-	mem.SetPersistentData(planDocumentPersistentKey, "## Document\n- stable guidance")
+	appendPlanFactsFrozenPartition(cod.Config, "## Facts\n- stable fact")
+	appendPlanDocumentFrozenPartition(cod.Config, "## Document\n- stable guidance")
 
-	partitions := BuildPlanStaticFrozenPartitions(cod)
+	partitions := BuildPlanStaticFrozenPartitions(cod.Config.GetOrCreateFrozenBlockPartitionProducer())
 	require.Len(t, partitions, 2)
 	require.Equal(t, "plan_facts", partitions[0].ID)
 	require.Equal(t, "Plan Facts", partitions[0].Title)
@@ -32,7 +32,7 @@ func TestBuildPlanStaticFrozenPartitions(t *testing.T) {
 	require.Equal(t, "## Document\n- stable guidance", partitions[1].Content)
 	require.Equal(t, 110, partitions[1].Order)
 
-	again := BuildPlanStaticFrozenPartitions(cod)
+	again := BuildPlanStaticFrozenPartitions(cod.Config.GetOrCreateFrozenBlockPartitionProducer())
 	require.Equal(t, partitions[0].Nonce, again[0].Nonce)
 	require.Equal(t, partitions[1].Nonce, again[1].Nonce)
 }
@@ -64,7 +64,7 @@ root input`)
 	cod.rootTask = root
 	mem.RootTask = root
 
-	require.Empty(t, BuildPlanStaticFrozenPartitions(cod), "plan static partitions must come from coordinator persistent data, not task user input")
+	require.Empty(t, BuildPlanStaticFrozenPartitions(cod.Config.GetOrCreateFrozenBlockPartitionProducer()), "plan static partitions must come from explicit config append, not task user input")
 }
 
 func TestTaskProgressDoesNotPrependPlanStaticDocs(t *testing.T) {
@@ -76,8 +76,8 @@ func TestTaskProgressDoesNotPrependPlanStaticDocs(t *testing.T) {
 	}
 	root := cod.generateAITaskWithName("Root", "root goal")
 	root.Index = "1"
-	mem.SetPersistentData(planFactsPersistentKey, "## Facts\n- stable fact")
-	mem.SetPersistentData(planDocumentPersistentKey, "## Document\n- stable guidance")
+	appendPlanFactsFrozenPartition(cod.Config, "## Facts\n- stable fact")
+	appendPlanDocumentFrozenPartition(cod.Config, "## Document\n- stable guidance")
 
 	progress := root.Progress()
 	require.Contains(t, progress, "Root")

--- a/common/ai/aid/plan_static_frozen_partitions_test.go
+++ b/common/ai/aid/plan_static_frozen_partitions_test.go
@@ -1,0 +1,88 @@
+package aid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+)
+
+func TestBuildPlanStaticFrozenPartitions(t *testing.T) {
+	mem := GetDefaultContextProvider()
+	cod := &Coordinator{
+		Config:          &aicommon.Config{Ctx: context.Background()},
+		ContextProvider: mem,
+		userInput:       "test",
+	}
+	root := cod.generateAITaskWithName("Root", "root goal")
+	root.Index = "1"
+
+	mem.SetPersistentData(planFactsPersistentKey, "## Facts\n- stable fact")
+	mem.SetPersistentData(planDocumentPersistentKey, "## Document\n- stable guidance")
+
+	partitions := BuildPlanStaticFrozenPartitions(cod)
+	require.Len(t, partitions, 2)
+	require.Equal(t, "plan_facts", partitions[0].ID)
+	require.Equal(t, "Plan Facts", partitions[0].Title)
+	require.Equal(t, "## Facts\n- stable fact", partitions[0].Content)
+	require.Equal(t, 100, partitions[0].Order)
+	require.Equal(t, "plan_document", partitions[1].ID)
+	require.Equal(t, "Plan Document", partitions[1].Title)
+	require.Equal(t, "## Document\n- stable guidance", partitions[1].Content)
+	require.Equal(t, 110, partitions[1].Order)
+
+	again := BuildPlanStaticFrozenPartitions(cod)
+	require.Equal(t, partitions[0].Nonce, again[0].Nonce)
+	require.Equal(t, partitions[1].Nonce, again[1].Nonce)
+}
+
+func TestBuildPlanStaticFrozenPartitionsEmpty(t *testing.T) {
+	require.Empty(t, BuildPlanStaticFrozenPartitions(nil))
+}
+
+func TestBuildPlanStaticFrozenPartitionsDoesNotParseTaskInput(t *testing.T) {
+	mem := GetDefaultContextProvider()
+	cod := &Coordinator{
+		Config:          &aicommon.Config{Ctx: context.Background()},
+		ContextProvider: mem,
+		userInput:       "test",
+	}
+	root := cod.generateAITaskWithName("Root", "root goal")
+	root.Index = "1"
+	root.SetUserInput(`<|FACTS_n1|>
+## Facts
+- from task
+<|FACTS_END_n1|>
+
+<|DOCUMENT_n2|>
+## Document
+- from task
+<|DOCUMENT_END_n2|>
+
+root input`)
+	cod.rootTask = root
+	mem.RootTask = root
+
+	require.Empty(t, BuildPlanStaticFrozenPartitions(cod), "plan static partitions must come from coordinator persistent data, not task user input")
+}
+
+func TestTaskProgressDoesNotPrependPlanStaticDocs(t *testing.T) {
+	mem := GetDefaultContextProvider()
+	cod := &Coordinator{
+		Config:          &aicommon.Config{Ctx: context.Background()},
+		ContextProvider: mem,
+		userInput:       "test",
+	}
+	root := cod.generateAITaskWithName("Root", "root goal")
+	root.Index = "1"
+	mem.SetPersistentData(planFactsPersistentKey, "## Facts\n- stable fact")
+	mem.SetPersistentData(planDocumentPersistentKey, "## Document\n- stable guidance")
+
+	progress := root.Progress()
+	require.Contains(t, progress, "Root")
+	require.NotContains(t, progress, "FACTS_")
+	require.NotContains(t, progress, "DOCUMENT_")
+	require.NotContains(t, progress, "stable fact")
+	require.NotContains(t, progress, "stable guidance")
+}

--- a/common/ai/aid/runtime.go
+++ b/common/ai/aid/runtime.go
@@ -132,7 +132,7 @@ func (t *AiTask) Progress() string {
 	}
 	var buf bytes.Buffer
 	t.dumpProgress(0, &buf)
-	return prependPlanContextDocsToRenderedPlan(buf.String(), getTaskPlanFacts(t), getTaskPlanDocument(t), getTaskPlanEvidence(t))
+	return buf.String()
 }
 
 func (t *AiTask) ProgressWithDetail() string {
@@ -141,7 +141,7 @@ func (t *AiTask) ProgressWithDetail() string {
 	}
 	var buf bytes.Buffer
 	t.dumpProgressEx(0, &buf, true)
-	return prependPlanContextDocsToRenderedPlan(buf.String(), getTaskPlanFacts(t), getTaskPlanDocument(t), getTaskPlanEvidence(t))
+	return buf.String()
 }
 
 func (r *runtime) Progress() string {
@@ -153,7 +153,7 @@ func (r *runtime) Progress() string {
 	}
 	var buf bytes.Buffer
 	r.RootTask.dumpProgress(0, &buf)
-	return prependPlanContextDocsToRenderedPlan(buf.String(), getTaskPlanFacts(r.RootTask), getTaskPlanDocument(r.RootTask), getTaskPlanEvidence(r.RootTask))
+	return buf.String()
 }
 
 func (r *runtime) NextStep() (*AiTask, bool) {

--- a/common/ai/aid/task.go
+++ b/common/ai/aid/task.go
@@ -99,7 +99,7 @@ func (t *AiTask) GetUserInput() string {
 
 		// 添加当前层父任务的输入
 		if task.ParentTask.AIStatefulTaskBase != nil {
-			input := task.ParentTask.AIStatefulTaskBase.GetUserInput()
+			input := stripPlanContextBlocks(task.ParentTask.AIStatefulTaskBase.GetUserInput())
 			if input != "" {
 				inputs = append(inputs, input)
 			}
@@ -117,7 +117,7 @@ func (t *AiTask) GetUserInput() string {
 	// 获取当前任务的输入
 	var currentInput string
 	if t.AIStatefulTaskBase != nil {
-		currentInput = t.AIStatefulTaskBase.GetUserInput()
+		currentInput = stripPlanContextBlocks(t.AIStatefulTaskBase.GetUserInput())
 	}
 
 	var rawUserInput string
@@ -136,8 +136,8 @@ func (t *AiTask) GetUserInput() string {
 	//
 	// 新实现: 用 (rawUserInput, parentInputsJoined) 派生稳定 nonce，
 	// 让同一个 plan 周期内的所有 PE-TASK 子任务共用同一个 nonce。plan 重新
-	// 生成 / facts/document 演化时, parentInputsJoined 自然变化, nonce 随之
-	// 变化, 不会污染新 plan 的缓存。
+	// 生成时, rawUserInput / parentInputsJoined 自然变化, nonce 随之变化,
+	// 不会污染新 plan 的缓存。
 	//
 	// 关键词: task user input nonce, plan scoped nonce, prefix cache,
 	//        反 RandStringBytes 反模式
@@ -199,7 +199,8 @@ func (t *AiTask) GetUserInput() string {
 // 走老语义即可, 这里返回 (root user input, "")。
 //
 // 关键词: GetUserInputSplitForCache, PE-TASK frozen user context,
-//        rawQuery 留空, prefix cache
+//
+//	rawQuery 留空, prefix cache
 func (t *AiTask) GetUserInputSplitForCache() (rawQuery, frozenUserContext string) {
 	if utils.IsNil(t.ParentTask) {
 		// 普通 ReAct / root 任务: 用户原话保留在 dynamic 段, 不冻结

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -786,6 +786,7 @@ func (t *AiTask) GenerateTaskSummaryPrompt() (string, error) {
 		}
 	}
 	return assembleTaskSummaryPrompt(
+		t.Coordinator.Config,
 		cp.Schema()["TaskSummarySchema"],
 		timelineFrozen,
 		timelineOpen,
@@ -797,12 +798,14 @@ type taskSummaryDynamicData struct {
 	CurrentTaskInfo string
 }
 
-func assembleTaskSummaryPrompt(schema string, currentTaskTimelineFrozen string, currentTaskTimelineOpen string, currentTaskInfo string) (string, error) {
+func assembleTaskSummaryPrompt(config *aicommon.Config, schema string, currentTaskTimelineFrozen string, currentTaskTimelineOpen string, currentTaskInfo string) (string, error) {
 	materials := &aicommon.PromptMaterials{
 		TaskInstruction: strings.TrimSpace(__prompt_TaskSummaryInstruction),
 		Schema:          strings.TrimSpace(schema),
 		OutputExample:   strings.TrimSpace(__prompt_TaskSummaryOutputExample),
-		ToolInventory:   true,
+	}
+	if err := aicommon.PopulateToolInventoryFromConfig(materials, config); err != nil {
+		return "", fmt.Errorf("populate task summary tool inventory failed: %w", err)
 	}
 	if currentTaskTimelineFrozen = strings.TrimSpace(currentTaskTimelineFrozen); currentTaskTimelineFrozen != "" {
 		materials.TimelineFrozen = currentTaskTimelineFrozen

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -779,17 +779,9 @@ func (t *AiTask) GenerateTaskSummaryPrompt() (string, error) {
 		return "", fmt.Errorf("context provider is nil")
 	}
 	cp := t.Coordinator.ContextProvider
-	var timelineFrozen, timelineOpen string
-	if t.Coordinator.Config != nil {
-		if timeline := t.Coordinator.Config.GetTimeline(); timeline != nil {
-			timelineFrozen, timelineOpen = timeline.DumpFrozenOpen()
-		}
-	}
 	return assembleTaskSummaryPrompt(
 		t.Coordinator.Config,
 		cp.Schema()["TaskSummarySchema"],
-		timelineFrozen,
-		timelineOpen,
 		cp.CurrentTaskInfo(),
 	)
 }
@@ -798,20 +790,15 @@ type taskSummaryDynamicData struct {
 	CurrentTaskInfo string
 }
 
-func assembleTaskSummaryPrompt(config *aicommon.Config, schema string, currentTaskTimelineFrozen string, currentTaskTimelineOpen string, currentTaskInfo string) (string, error) {
+func assembleTaskSummaryPrompt(config *aicommon.Config, schema string, currentTaskInfo string) (string, error) {
 	materials := &aicommon.PromptMaterials{
 		TaskInstruction: strings.TrimSpace(__prompt_TaskSummaryInstruction),
 		Schema:          strings.TrimSpace(schema),
 		OutputExample:   strings.TrimSpace(__prompt_TaskSummaryOutputExample),
 	}
+	aicommon.ApplyPromptFrozenOpenMaterials(materials, aicommon.BuildPromptFrozenOpenMaterials(config))
 	if err := aicommon.PopulateToolInventoryFromConfig(materials, config); err != nil {
 		return "", fmt.Errorf("populate task summary tool inventory failed: %w", err)
-	}
-	if currentTaskTimelineFrozen = strings.TrimSpace(currentTaskTimelineFrozen); currentTaskTimelineFrozen != "" {
-		materials.TimelineFrozen = currentTaskTimelineFrozen
-	}
-	if currentTaskTimelineOpen = strings.TrimSpace(currentTaskTimelineOpen); currentTaskTimelineOpen != "" {
-		materials.TimelineOpen = currentTaskTimelineOpen
 	}
 	return aicommon.NewDefaultPromptPrefixBuilder().AssemblePromptWithDynamicSection(
 		materials,

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -779,10 +779,17 @@ func (t *AiTask) GenerateTaskSummaryPrompt() (string, error) {
 		return "", fmt.Errorf("context provider is nil")
 	}
 	cp := t.Coordinator.ContextProvider
+	var timelineFrozen, timelineOpen string
+	if t.Coordinator.Config != nil {
+		if timeline := t.Coordinator.Config.GetTimeline(); timeline != nil {
+			timelineFrozen, timelineOpen = timeline.DumpFrozenOpen()
+		}
+	}
 	return assembleTaskSummaryPrompt(
 		cp.Schema()["TaskSummarySchema"],
 		cp.PersistentMemory(),
-		cp.CurrentTaskTimeline(),
+		timelineFrozen,
+		timelineOpen,
 		cp.CurrentTaskInfo(),
 	)
 }
@@ -791,7 +798,7 @@ type taskSummaryDynamicData struct {
 	CurrentTaskInfo string
 }
 
-func assembleTaskSummaryPrompt(schema string, persistentMemory string, currentTaskTimeline string, currentTaskInfo string) (string, error) {
+func assembleTaskSummaryPrompt(schema string, persistentMemory string, currentTaskTimelineFrozen string, currentTaskTimelineOpen string, currentTaskInfo string) (string, error) {
 	materials := &aicommon.PromptMaterials{
 		TaskInstruction: strings.TrimSpace(__prompt_TaskSummaryInstruction),
 		Schema:          strings.TrimSpace(schema),
@@ -800,8 +807,11 @@ func assembleTaskSummaryPrompt(schema string, persistentMemory string, currentTa
 	if persistentMemory = strings.TrimSpace(persistentMemory); persistentMemory != "" {
 		materials.SkillsContext = "# 牢记\n" + persistentMemory
 	}
-	if currentTaskTimeline = strings.TrimSpace(currentTaskTimeline); currentTaskTimeline != "" {
-		materials.TimelineOpen = fmt.Sprintf("## 当前任务的历史时间线\n<summary>\n%s\n</summary>", currentTaskTimeline)
+	if currentTaskTimelineFrozen = strings.TrimSpace(currentTaskTimelineFrozen); currentTaskTimelineFrozen != "" {
+		materials.TimelineFrozen = fmt.Sprintf("## 当前任务的历史时间线\n<summary>\n%s\n</summary>", currentTaskTimelineFrozen)
+	}
+	if currentTaskTimelineOpen = strings.TrimSpace(currentTaskTimelineOpen); currentTaskTimelineOpen != "" {
+		materials.TimelineOpen = fmt.Sprintf("## 当前任务的历史时间线\n<summary>\n%s\n</summary>", currentTaskTimelineOpen)
 	}
 	return aicommon.NewDefaultPromptPrefixBuilder().AssemblePromptWithDynamicSection(
 		materials,

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -787,7 +787,6 @@ func (t *AiTask) GenerateTaskSummaryPrompt() (string, error) {
 	}
 	return assembleTaskSummaryPrompt(
 		cp.Schema()["TaskSummarySchema"],
-		cp.PersistentMemory(),
 		timelineFrozen,
 		timelineOpen,
 		cp.CurrentTaskInfo(),
@@ -798,20 +797,18 @@ type taskSummaryDynamicData struct {
 	CurrentTaskInfo string
 }
 
-func assembleTaskSummaryPrompt(schema string, persistentMemory string, currentTaskTimelineFrozen string, currentTaskTimelineOpen string, currentTaskInfo string) (string, error) {
+func assembleTaskSummaryPrompt(schema string, currentTaskTimelineFrozen string, currentTaskTimelineOpen string, currentTaskInfo string) (string, error) {
 	materials := &aicommon.PromptMaterials{
 		TaskInstruction: strings.TrimSpace(__prompt_TaskSummaryInstruction),
 		Schema:          strings.TrimSpace(schema),
 		OutputExample:   strings.TrimSpace(__prompt_TaskSummaryOutputExample),
-	}
-	if persistentMemory = strings.TrimSpace(persistentMemory); persistentMemory != "" {
-		materials.SkillsContext = "# 牢记\n" + persistentMemory
+		ToolInventory:   true,
 	}
 	if currentTaskTimelineFrozen = strings.TrimSpace(currentTaskTimelineFrozen); currentTaskTimelineFrozen != "" {
-		materials.TimelineFrozen = fmt.Sprintf("## 当前任务的历史时间线\n<summary>\n%s\n</summary>", currentTaskTimelineFrozen)
+		materials.TimelineFrozen = currentTaskTimelineFrozen
 	}
 	if currentTaskTimelineOpen = strings.TrimSpace(currentTaskTimelineOpen); currentTaskTimelineOpen != "" {
-		materials.TimelineOpen = fmt.Sprintf("## 当前任务的历史时间线\n<summary>\n%s\n</summary>", currentTaskTimelineOpen)
+		materials.TimelineOpen = currentTaskTimelineOpen
 	}
 	return aicommon.NewDefaultPromptPrefixBuilder().AssemblePromptWithDynamicSection(
 		materials,

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -92,11 +92,11 @@ func (t *AiTask) execute() error {
 				allOps = append(allOps, buildVerificationCarryoverEvidenceOps(t, summary, outputFiles)...)
 				if len(allOps) > 0 {
 					// EVIDENCE 单写到 SessionPromptState (SESSION_EVIDENCE 段)。
-					// 历史曾同时写 task plan_evidence + syncRootTaskPlanContextDocs
-					// 把 EVIDENCE 块嵌入 root user input, 但这会让 PlanContext 跨子
-					// 任务抖动并破坏多个 prompt cache 命中。现仅保留 SESSION_EVIDENCE
-					// 单一渲染源, 其它 evidence 入口 (如 output_evidence action) 写入
-					// 的 task plan_evidence 不再被任何 prompt 模板读取。
+					// 历史曾把 EVIDENCE 块嵌入 root user input, 但这会让 PlanContext
+					// 跨子任务抖动并破坏多个 prompt cache 命中。现仅保留
+					// SESSION_EVIDENCE 单一渲染源, 其它 evidence 入口 (如
+					// output_evidence action) 写入的 task plan_evidence 不再被任何
+					// prompt 模板读取。
 					// 关键词: EVIDENCE 单写, ApplySessionEvidenceOps, PlanContext 抖动修复
 					log.Infof("task %s applying session evidence ops, count=%d", t.Index, len(allOps))
 					if incremental := aicommon.FormatEvidenceOpsLines(allOps, t.GetLanguage()); incremental != "" {

--- a/common/ai/aid/task_summary_split_test.go
+++ b/common/ai/aid/task_summary_split_test.go
@@ -1,6 +1,7 @@
 package aid
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,8 @@ import (
 type taskSummaryFixture struct {
 	Schema          string
 	CurrentTaskInfo string
-	Timeline        string
+	TimelineFrozen  string
+	TimelineOpen    string
 	Persistent      string
 }
 
@@ -27,7 +29,8 @@ func renderTaskSummaryFixture(t *testing.T, fixture taskSummaryFixture) string {
 	prompt, err := assembleTaskSummaryPrompt(
 		fixture.Schema,
 		fixture.Persistent,
-		fixture.Timeline,
+		fixture.TimelineFrozen,
+		fixture.TimelineOpen,
 		fixture.CurrentTaskInfo,
 	)
 	require.NoError(t, err)
@@ -51,7 +54,7 @@ func TestSplit_TaskSummaryPrompt_FourSections(t *testing.T) {
 	stub := taskSummaryFixture{
 		Schema:          `{"type":"object"}`,
 		CurrentTaskInfo: "current task: scan /tmp",
-		Timeline:        "interval-1 -> shell ls\ninterval-2 -> shell ps",
+		TimelineOpen:    "interval-2 -> shell ps",
 		Persistent:      "<persistent>vm-host=darwin</persistent>",
 	}
 
@@ -78,4 +81,51 @@ func TestSplit_TaskSummaryPrompt_FourSections(t *testing.T) {
 		require.Equal(t, sec1[aicache.SectionSemiDynamic1][0].Hash, sec3[aicache.SectionSemiDynamic1][0].Hash,
 			"task-summary semi-dynamic-1 hash should remain stable when only dynamic input changes")
 	}
+}
+
+func TestSplit_TaskSummaryPrompt_FrozenTimelineLandsInFrozenBlock(t *testing.T) {
+	stub := taskSummaryFixture{
+		Schema:          `{"type":"object"}`,
+		CurrentTaskInfo: "current task: scan /tmp",
+		TimelineFrozen:  "<|TIMELINE_r1t100|>\nfrozen task timeline\n<|TIMELINE_END_r1t100|>",
+		TimelineOpen:    "<|TIMELINE_r2t200|>\nopen task timeline\n<|TIMELINE_END_r2t200|>",
+		Persistent:      "<persistent>vm-host=darwin</persistent>",
+	}
+
+	prompt := renderTaskSummaryFixture(t, stub)
+	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, prompt, "frozen task timeline")
+	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_END_semi-dynamic|>")
+	require.Contains(t, prompt, "<|PROMPT_SECTION_timeline-open|>")
+
+	frozenStart := strings.Index(prompt, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	frozenEnd := strings.Index(prompt, "<|AI_CACHE_FROZEN_END_semi-dynamic|>")
+	openStart := strings.Index(prompt, "<|PROMPT_SECTION_timeline-open|>")
+	require.GreaterOrEqual(t, frozenStart, 0)
+	require.Greater(t, frozenEnd, frozenStart)
+	require.Greater(t, openStart, frozenEnd)
+	require.NotContains(t, prompt[frozenStart:frozenEnd], "open task timeline")
+	require.Contains(t, prompt[openStart:], "open task timeline")
+}
+
+func TestGenerateTaskSummaryPrompt_UsesConfigTimelineFrozenOpen(t *testing.T) {
+	_, task, _, _ := newPlanExecPromptFixture(t)
+	timeline := task.ContextProvider.GetTimelineInstance()
+	require.NotNil(t, timeline)
+	task.Config.Timeline = timeline
+	timeline.SetTimelineBucketByteSize(80)
+
+	timeline.PushText(101, "first current task timeline block "+strings.Repeat("A", 120))
+	timeline.PushText(102, "second current task timeline block "+strings.Repeat("B", 120))
+
+	prompt, err := task.GenerateTaskSummaryPrompt()
+	require.NoError(t, err)
+	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, prompt, "first current task timeline block")
+	require.Contains(t, prompt, "<|PROMPT_SECTION_timeline-open|>")
+	require.Contains(t, prompt, "second current task timeline block")
+	frozenEnd := strings.Index(prompt, "<|AI_CACHE_FROZEN_END_semi-dynamic|>")
+	openStart := strings.Index(prompt, "<|PROMPT_SECTION_timeline-open|>")
+	require.Greater(t, frozenEnd, 0)
+	require.Greater(t, openStart, frozenEnd, "frozen timeline must be outside and before timeline-open")
 }

--- a/common/ai/aid/task_summary_split_test.go
+++ b/common/ai/aid/task_summary_split_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aicache"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools"
 )
 
 // 关键词: aicache.Split 单测, P0-A5, task-summary.txt 段稳定性回归
@@ -23,9 +26,21 @@ type taskSummaryFixture struct {
 	TimelineOpen    string
 }
 
+func taskSummaryToolConfig() *aicommon.Config {
+	tool := aitool.NewWithoutCallback("grep", aitool.WithDescription("grep tool"))
+	return &aicommon.Config{
+		AiToolManager: buildinaitools.NewToolManagerByToolGetter(
+			func() []*aitool.Tool { return []*aitool.Tool{tool} },
+			buildinaitools.WithEnableAllTools(),
+		),
+		TopToolsCount: 100,
+	}
+}
+
 func renderTaskSummaryFixture(t *testing.T, fixture taskSummaryFixture) string {
 	t.Helper()
 	prompt, err := assembleTaskSummaryPrompt(
+		taskSummaryToolConfig(),
 		fixture.Schema,
 		fixture.TimelineFrozen,
 		fixture.TimelineOpen,
@@ -66,6 +81,7 @@ func TestSplit_TaskSummaryPrompt_FourSections(t *testing.T) {
 	require.Empty(t, sec1[aicache.SectionRaw], "task-summary prompt should not produce raw/noise chunk; rendered:\n%s", prompt1)
 	require.Contains(t, prompt1, "<|AI_CACHE_FROZEN_semi-dynamic|>")
 	require.Contains(t, prompt1, "# Tool Inventory")
+	require.Contains(t, prompt1, "`grep`: grep tool")
 	require.NotContains(t, prompt1, "# 牢记")
 
 	require.Equal(t, sec1[aicache.SectionHighStatic][0].Hash, sec2[aicache.SectionHighStatic][0].Hash,
@@ -94,6 +110,7 @@ func TestSplit_TaskSummaryPrompt_FrozenTimelineLandsInFrozenBlock(t *testing.T) 
 	prompt := renderTaskSummaryFixture(t, stub)
 	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_semi-dynamic|>")
 	require.Contains(t, prompt, "# Tool Inventory")
+	require.Contains(t, prompt, "`grep`: grep tool")
 	require.Contains(t, prompt, "frozen task timeline")
 	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_END_semi-dynamic|>")
 	require.Contains(t, prompt, "<|PROMPT_SECTION_timeline-open|>")
@@ -115,6 +132,8 @@ func TestGenerateTaskSummaryPrompt_UsesConfigTimelineFrozenOpen(t *testing.T) {
 	timeline := task.ContextProvider.GetTimelineInstance()
 	require.NotNil(t, timeline)
 	task.Config.Timeline = timeline
+	task.Config.AiToolManager = taskSummaryToolConfig().AiToolManager
+	task.Config.TopToolsCount = 100
 	timeline.SetTimelineBucketByteSize(80)
 
 	timeline.PushText(101, "first current task timeline block "+strings.Repeat("A", 120))
@@ -123,6 +142,7 @@ func TestGenerateTaskSummaryPrompt_UsesConfigTimelineFrozenOpen(t *testing.T) {
 	prompt, err := task.GenerateTaskSummaryPrompt()
 	require.NoError(t, err)
 	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, prompt, "`grep`: grep tool")
 	require.Contains(t, prompt, "first current task timeline block")
 	require.Contains(t, prompt, "<|PROMPT_SECTION_timeline-open|>")
 	require.Contains(t, prompt, "second current task timeline block")

--- a/common/ai/aid/task_summary_split_test.go
+++ b/common/ai/aid/task_summary_split_test.go
@@ -21,14 +21,12 @@ type taskSummaryFixture struct {
 	CurrentTaskInfo string
 	TimelineFrozen  string
 	TimelineOpen    string
-	Persistent      string
 }
 
 func renderTaskSummaryFixture(t *testing.T, fixture taskSummaryFixture) string {
 	t.Helper()
 	prompt, err := assembleTaskSummaryPrompt(
 		fixture.Schema,
-		fixture.Persistent,
 		fixture.TimelineFrozen,
 		fixture.TimelineOpen,
 		fixture.CurrentTaskInfo,
@@ -55,7 +53,6 @@ func TestSplit_TaskSummaryPrompt_FourSections(t *testing.T) {
 		Schema:          `{"type":"object"}`,
 		CurrentTaskInfo: "current task: scan /tmp",
 		TimelineOpen:    "interval-2 -> shell ps",
-		Persistent:      "<persistent>vm-host=darwin</persistent>",
 	}
 
 	prompt1 := renderTaskSummaryFixture(t, stub)
@@ -67,6 +64,9 @@ func TestSplit_TaskSummaryPrompt_FourSections(t *testing.T) {
 	require.NotEmpty(t, sec1[aicache.SectionHighStatic], "task-summary prompt must expose high-static chunk")
 	require.NotEmpty(t, sec1[aicache.SectionDynamic], "task-summary prompt must expose dynamic chunk")
 	require.Empty(t, sec1[aicache.SectionRaw], "task-summary prompt should not produce raw/noise chunk; rendered:\n%s", prompt1)
+	require.Contains(t, prompt1, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, prompt1, "# Tool Inventory")
+	require.NotContains(t, prompt1, "# 牢记")
 
 	require.Equal(t, sec1[aicache.SectionHighStatic][0].Hash, sec2[aicache.SectionHighStatic][0].Hash,
 		"task-summary high-static hash must be byte-stable across calls")
@@ -89,11 +89,11 @@ func TestSplit_TaskSummaryPrompt_FrozenTimelineLandsInFrozenBlock(t *testing.T) 
 		CurrentTaskInfo: "current task: scan /tmp",
 		TimelineFrozen:  "<|TIMELINE_r1t100|>\nfrozen task timeline\n<|TIMELINE_END_r1t100|>",
 		TimelineOpen:    "<|TIMELINE_r2t200|>\nopen task timeline\n<|TIMELINE_END_r2t200|>",
-		Persistent:      "<persistent>vm-host=darwin</persistent>",
 	}
 
 	prompt := renderTaskSummaryFixture(t, stub)
 	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_semi-dynamic|>")
+	require.Contains(t, prompt, "# Tool Inventory")
 	require.Contains(t, prompt, "frozen task timeline")
 	require.Contains(t, prompt, "<|AI_CACHE_FROZEN_END_semi-dynamic|>")
 	require.Contains(t, prompt, "<|PROMPT_SECTION_timeline-open|>")
@@ -105,7 +105,9 @@ func TestSplit_TaskSummaryPrompt_FrozenTimelineLandsInFrozenBlock(t *testing.T) 
 	require.Greater(t, frozenEnd, frozenStart)
 	require.Greater(t, openStart, frozenEnd)
 	require.NotContains(t, prompt[frozenStart:frozenEnd], "open task timeline")
+	require.NotContains(t, prompt[frozenStart:frozenEnd], "<summary>")
 	require.Contains(t, prompt[openStart:], "open task timeline")
+	require.NotContains(t, prompt[openStart:], "<summary>")
 }
 
 func TestGenerateTaskSummaryPrompt_UsesConfigTimelineFrozenOpen(t *testing.T) {

--- a/common/ai/aid/task_summary_split_test.go
+++ b/common/ai/aid/task_summary_split_test.go
@@ -39,11 +39,21 @@ func taskSummaryToolConfig() *aicommon.Config {
 
 func renderTaskSummaryFixture(t *testing.T, fixture taskSummaryFixture) string {
 	t.Helper()
+	cfg := taskSummaryToolConfig()
+	if fixture.TimelineFrozen != "" || fixture.TimelineOpen != "" {
+		timeline := aicommon.NewTimeline(cfg, nil)
+		timeline.SetTimelineBucketByteSize(80)
+		if fixture.TimelineFrozen != "" {
+			timeline.PushText(101, fixture.TimelineFrozen+" "+strings.Repeat("A", 120))
+		}
+		if fixture.TimelineOpen != "" {
+			timeline.PushText(102, fixture.TimelineOpen+" "+strings.Repeat("B", 120))
+		}
+		cfg.Timeline = timeline
+	}
 	prompt, err := assembleTaskSummaryPrompt(
-		taskSummaryToolConfig(),
+		cfg,
 		fixture.Schema,
-		fixture.TimelineFrozen,
-		fixture.TimelineOpen,
 		fixture.CurrentTaskInfo,
 	)
 	require.NoError(t, err)
@@ -67,7 +77,6 @@ func TestSplit_TaskSummaryPrompt_FourSections(t *testing.T) {
 	stub := taskSummaryFixture{
 		Schema:          `{"type":"object"}`,
 		CurrentTaskInfo: "current task: scan /tmp",
-		TimelineOpen:    "interval-2 -> shell ps",
 	}
 
 	prompt1 := renderTaskSummaryFixture(t, stub)
@@ -103,8 +112,8 @@ func TestSplit_TaskSummaryPrompt_FrozenTimelineLandsInFrozenBlock(t *testing.T) 
 	stub := taskSummaryFixture{
 		Schema:          `{"type":"object"}`,
 		CurrentTaskInfo: "current task: scan /tmp",
-		TimelineFrozen:  "<|TIMELINE_r1t100|>\nfrozen task timeline\n<|TIMELINE_END_r1t100|>",
-		TimelineOpen:    "<|TIMELINE_r2t200|>\nopen task timeline\n<|TIMELINE_END_r2t200|>",
+		TimelineFrozen:  "frozen task timeline",
+		TimelineOpen:    "open task timeline",
 	}
 
 	prompt := renderTaskSummaryFixture(t, stub)

--- a/common/ai/aid/test/config_skip_subtask_test.go
+++ b/common/ai/aid/test/config_skip_subtask_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/yaklang/yaklang/common/ai/aid/aicache"
 	"regexp"
 	"strings"
 	"sync"
@@ -26,6 +27,16 @@ import (
 // extractCurrentTaskContent 从 prompt 中提取 <|CURRENT_TASK_{{nonce}}|> 和 <|CURRENT_TASK_END_{{nonce}}|> 之间的内容
 // 返回提取的内容，如果未找到则返回空字符串
 func extractCurrentTaskContent(prompt string) string {
+	splitRes := aicache.Split(prompt)
+	for _, chunk := range splitRes.Chunks {
+		if chunk.Section == aicache.SectionDynamic {
+			re := regexp.MustCompile(`(?s)<\|CURRENT_TASK(?:_[a-z0-9]+)?\|>(.*?)<\|CURRENT_TASK_END(?:_[a-z0-9]+)?\|>`)
+			matches := re.FindStringSubmatch(chunk.Content)
+			if len(matches) >= 2 {
+				return matches[1]
+			}
+		}
+	}
 	re := regexp.MustCompile(`(?s)<\|CURRENT_TASK(?:_[a-z0-9]+)?\|>(.*?)<\|CURRENT_TASK_END(?:_[a-z0-9]+)?\|>`)
 	matches := re.FindStringSubmatch(prompt)
 	if len(matches) >= 2 {


### PR DESCRIPTION
本分支主要优化 plan-and-exec / ReAct prompt 的 prefix cache 命中稳定性。原先部分内容如 plan facts/document、session artifacts、task summary timeline、tool inventory 等分散在 dynamic、
  workspace 或 task input 路径里，容易因子任务切换、工件文件变化或 prompt 结构跳变污染上游缓存。

  ## 改动

  - 新增统一的 FrozenBlockPartition 机制，用于承载可进入 frozen block 的稳定上下文。
  - 将 Plan Facts / Plan Document 改为显式 frozen partition 注入，不再拼进 root task progress / task input。
  - Session Artifacts 按 timeline frozen cutoff 拆成：
      - Session Artifacts (Frozen)：已封存的历史 task artifacts；
      - Session Artifacts (Open)：最新 task、root files 或 frozen 后增量。
  - ReAct / plan-and-exec / task summary / task review prompt 统一复用 BuildPromptFrozenOpenMaterials，保证 timeline 与 artifacts 使用同一 frozen/open 分界。
  - 抽出 Tool Inventory 构造逻辑到 aicommon，复用工具可见性过滤、优先级排序和 token budget 裁剪规则。
  - 为 task summary、task review、verification 等 prompt 补齐 Tool Inventory，避免 prompt 结构在不同调用路径中跳变。
  - 优化 retry correction 文案，让 validation error 在重试 prompt 中更明确。