### PR TITLE
fix(project): reject duplicate names on UpdateProject

### DIFF
--- a/common/yakgrpc/grpc_project.go
+++ b/common/yakgrpc/grpc_project.go
@@ -218,6 +218,13 @@ func (s *Server) UpdateProject(ctx context.Context, req *ypb.NewProjectRequest) 
 	if CheckDefault(req.GetProjectName(), req.GetType(), req.GetFolderId(), req.GetChildFolderId()) {
 		return nil, utils.Errorf("cannot use this builtin name: %s", yakit.INIT_DATABASE_RECORD_NAME)
 	}
+
+	// check this name exist (exclude current project)
+	pro, _ := yakit.GetProjectByWhere(s.GetProfileDatabase(), req.GetProjectName(), req.GetFolderId(), req.GetChildFolderId(), req.GetType(), req.GetId())
+	if pro != nil {
+		return nil, utils.Error("Project or directory name can not be duplicated in the same directory")
+	}
+
 	oldPro, err := yakit.GetProjectByID(s.GetProfileDatabase(), req.GetId())
 	if err != nil {
 		return nil, utils.Errorf("update row not exist: %v", err)

--- a/common/yakgrpc/grpc_project_test.go
+++ b/common/yakgrpc/grpc_project_test.go
@@ -20,6 +20,45 @@ import (
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
 
+func TestServer_UpdateProject_DuplicateName(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	nameA := uuid.NewString()
+	nameB := uuid.NewString()
+	pjcA, err := client.NewProject(context.Background(), &ypb.NewProjectRequest{
+		ProjectName:   nameA,
+		Description:   "project-a",
+		Type:          yakit.TypeProject,
+		ChildFolderId: 0,
+		FolderId:      0,
+	})
+	require.NoError(t, err)
+	pjcB, err := client.NewProject(context.Background(), &ypb.NewProjectRequest{
+		ProjectName:   nameB,
+		Description:   "project-b",
+		Type:          yakit.TypeProject,
+		ChildFolderId: 0,
+		FolderId:      0,
+	})
+	require.NoError(t, err)
+	defer func() {
+		_, _ = client.DeleteProject(context.Background(), &ypb.DeleteProjectRequest{Id: pjcA.Id, IsDeleteLocal: true})
+		_, _ = client.DeleteProject(context.Background(), &ypb.DeleteProjectRequest{Id: pjcB.Id, IsDeleteLocal: true})
+	}()
+
+	_, err = client.UpdateProject(context.Background(), &ypb.NewProjectRequest{
+		Id:            pjcB.Id,
+		ProjectName:   nameA,
+		Description:   "rename-to-duplicate",
+		Type:          yakit.TypeProject,
+		ChildFolderId: 0,
+		FolderId:      0,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicated")
+}
+
 func TestServer_UpdateProject(t *testing.T) {
 	client, err := NewLocalClient()
 	require.NoError(t, err)


### PR DESCRIPTION
UpdateProject now checks for an existing project with the same name in the same folder, matching NewProject behavior.