### PR TITLE
fix(netx): retry GMTLS dial with ECC, ECDHE, then all cipher suites

### DIFF
--- a/common/netx/dialx.go
+++ b/common/netx/dialx.go
@@ -323,26 +323,26 @@ func DialX(target string, opt ...DialXOption) (net.Conn, error) {
 		if config.Debug {
 			log.Infof("dial %v with tls strategy: %v, SNI: %s", target, strategy, tempTlsConfig.ServerName)
 		}
-		conn, err := dialPlainTCPConnWithRetry(target, config)
-		if err != nil {
-			return nil, err
-		}
+		startTLSHandshake := time.Now()
+		var tlsConn net.Conn
+		var tlsErr error
 
 		switch strategy {
 		case TLS_Strategy_Ordinary:
-			tempTlsConfig.GMSupport = nil
-		case TLS_Strategy_GMDail:
-			tempTlsConfig.GMSupport = &gmtls.GMSupport{
-				WorkMode: gmtls.ModeGMSSLOnly,
+			conn, err := dialPlainTCPConnWithRetry(target, config)
+			if err != nil {
+				return nil, err
 			}
+			tempTlsConfig.GMSupport = nil
+			tlsConn, tlsErr = UpgradeToTLSConnectionWithTimeout(conn, sni, tempTlsConfig, tlsTimeout, clientHelloSpec, config.TLSNextProto...)
+		case TLS_Strategy_GMDail:
+			tlsConn, tlsErr = dialTLSWithGMTLSCipherFallback(target, config, tempTlsConfig, sni, tlsTimeout, clientHelloSpec)
 		default:
 			return nil, utils.Errorf("unknown tls strategy %v", strategy)
 		}
 
-		startTLSHandshake := time.Now()
-		tlsConn, err := UpgradeToTLSConnectionWithTimeout(conn, sni, tempTlsConfig, tlsTimeout, clientHelloSpec, config.TLSNextProto...)
-		if err != nil {
-			errs = append(errs, err)
+		if tlsErr != nil {
+			errs = append(errs, tlsErr)
 			continue
 		}
 		config.TraceInfo.SetTLSHandshakeDuration(time.Since(startTLSHandshake))

--- a/common/netx/dialx.go
+++ b/common/netx/dialx.go
@@ -323,9 +323,9 @@ func DialX(target string, opt ...DialXOption) (net.Conn, error) {
 		if config.Debug {
 			log.Infof("dial %v with tls strategy: %v, SNI: %s", target, strategy, tempTlsConfig.ServerName)
 		}
-		startTLSHandshake := time.Now()
 		var tlsConn net.Conn
 		var tlsErr error
+		var tlsHandshakeDur time.Duration
 
 		switch strategy {
 		case TLS_Strategy_Ordinary:
@@ -334,9 +334,11 @@ func DialX(target string, opt ...DialXOption) (net.Conn, error) {
 				return nil, err
 			}
 			tempTlsConfig.GMSupport = nil
+			startUpgrade := time.Now()
 			tlsConn, tlsErr = UpgradeToTLSConnectionWithTimeout(conn, sni, tempTlsConfig, tlsTimeout, clientHelloSpec, config.TLSNextProto...)
+			tlsHandshakeDur = time.Since(startUpgrade)
 		case TLS_Strategy_GMDail:
-			tlsConn, tlsErr = dialTLSWithGMTLSCipherFallback(target, config, tempTlsConfig, sni, tlsTimeout, clientHelloSpec)
+			tlsConn, tlsHandshakeDur, tlsErr = dialTLSWithGMTLSCipherFallback(target, config, tempTlsConfig, sni, tlsTimeout, clientHelloSpec)
 		default:
 			return nil, utils.Errorf("unknown tls strategy %v", strategy)
 		}
@@ -345,7 +347,7 @@ func DialX(target string, opt ...DialXOption) (net.Conn, error) {
 			errs = append(errs, tlsErr)
 			continue
 		}
-		config.TraceInfo.SetTLSHandshakeDuration(time.Since(startTLSHandshake))
+		config.TraceInfo.SetTLSHandshakeDuration(tlsHandshakeDur)
 		return tlsConn, nil
 	}
 	if len(errs) > 0 {

--- a/common/netx/dialx_config.go
+++ b/common/netx/dialx_config.go
@@ -63,9 +63,10 @@ type dialXConfig struct {
 	TLSConfig               *gmtls.Config
 	//ShouldOverrideGMTLSConfig bool
 	//GMTLSConfig               *gmtls.Config
-	GMTLSSupport      bool
-	GMTLSPrefer       bool
-	GMTLSOnly         bool
+	GMTLSSupport               bool
+	GMTLSPrefer                bool
+	GMTLSOnly                  bool
+	GMTLSCompatMode            bool // 国密兼容模式：按 ECC×2 → ECDHE×2 → 四套 分轮握手（默认关闭）
 	TLSTimeout        time.Duration
 	ShouldOverrideSNI bool // High priority (will overwrite TlsConfig)
 	SNI               string
@@ -226,6 +227,13 @@ func DialX_WithGMTLSPrefer(b bool) DialXOption {
 func DialX_WithGMTLSOnly(b bool) DialXOption {
 	return func(c *dialXConfig) {
 		c.GMTLSOnly = b
+	}
+}
+
+// DialX_WithGMTLSCompatMode 开启国密兼容模式（默认关闭：单次 ClientHello 提供四套套件）。
+func DialX_WithGMTLSCompatMode(b bool) DialXOption {
+	return func(c *dialXConfig) {
+		c.GMTLSCompatMode = b
 	}
 }
 

--- a/common/netx/dialx_config.go
+++ b/common/netx/dialx_config.go
@@ -66,7 +66,7 @@ type dialXConfig struct {
 	GMTLSSupport               bool
 	GMTLSPrefer                bool
 	GMTLSOnly                  bool
-	GMTLSCompatMode            bool // 国密兼容模式：按 ECC×2 → ECDHE×2 → 四套 分轮握手（默认关闭）
+	GMTLSDisableCompatMode     bool // 关闭国密兼容模式；默认 false 表示兼容开启（四套 → ECC×2 → ECDHE×2）
 	TLSTimeout        time.Duration
 	ShouldOverrideSNI bool // High priority (will overwrite TlsConfig)
 	SNI               string
@@ -230,10 +230,14 @@ func DialX_WithGMTLSOnly(b bool) DialXOption {
 	}
 }
 
-// DialX_WithGMTLSCompatMode 开启国密兼容模式（默认关闭：单次 ClientHello 提供四套套件）。
-func DialX_WithGMTLSCompatMode(b bool) DialXOption {
+// DialX_WithGMTLSDisableCompatMode 关闭国密兼容模式；不传参等价于 true。
+func DialX_WithGMTLSDisableCompatMode(disable ...bool) DialXOption {
+	v := true
+	if len(disable) > 0 {
+		v = disable[0]
+	}
 	return func(c *dialXConfig) {
-		c.GMTLSCompatMode = b
+		c.GMTLSDisableCompatMode = v
 	}
 }
 

--- a/common/netx/dialx_gmtls.go
+++ b/common/netx/dialx_gmtls.go
@@ -1,0 +1,99 @@
+package netx
+
+import (
+	"net"
+	"strings"
+	"time"
+
+	"github.com/yaklang/yaklang/common/gmsm/gmtls"
+	"github.com/yaklang/yaklang/common/log"
+	utls "github.com/refraction-networking/utls"
+)
+
+// 国密四套件的密钥协商分两类：静态 ECC（证书 SM2）与 ECDHE（需 ServerKeyExchange）。
+var (
+	eccGMTLSCipherSuites = []uint16{
+		gmtls.GMTLS_ECC_SM4_CBC_SM3, // 0xe013，Tongsuo: ECC-SM2-SM4-CBC-SM3
+		gmtls.GMTLS_ECC_SM4_GCM_SM3, // 0xe053
+	}
+	ecdheGMTLSCipherSuites = []uint16{
+		gmtls.GMTLS_ECDHE_SM4_CBC_SM3, // 0xe011
+		gmtls.GMTLS_ECDHE_SM4_GCM_SM3, // 0xe051
+	}
+	allGMTLSCipherSuites = []uint16{
+		gmtls.GMTLS_ECC_SM4_CBC_SM3,
+		gmtls.GMTLS_ECC_SM4_GCM_SM3,
+		gmtls.GMTLS_ECDHE_SM4_CBC_SM3,
+		gmtls.GMTLS_ECDHE_SM4_GCM_SM3,
+	}
+)
+
+// gmtlsCipherSuiteDialAttempts 返回国密握手时的套件重试顺序（最多三轮）：
+// 1) 仅 ECC 静态  2) 仅 ECDHE  3) 四套全开（兼容只接受「全列表」协商的站点）。
+func gmtlsCipherSuiteDialAttempts(base *gmtls.Config) [][]uint16 {
+	if len(base.CipherSuites) > 0 {
+		return [][]uint16{base.CipherSuites}
+	}
+	return [][]uint16{
+		eccGMTLSCipherSuites,
+		ecdheGMTLSCipherSuites,
+		allGMTLSCipherSuites,
+	}
+}
+
+func shouldRetryGMTLSWithOtherCipherSuites(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "missing ServerKeyExchange message") ||
+		strings.Contains(msg, "SM2 verification failure") ||
+		strings.Contains(msg, "processServerKeyExchange") ||
+		strings.Contains(msg, "server chose an unconfigured cipher suite") ||
+		strings.Contains(msg, "handshake failure") ||
+		strings.Contains(msg, "unconfigured cipher suite")
+}
+
+func dialTLSWithGMTLSCipherFallback(
+	target string,
+	config *dialXConfig,
+	baseConfig *gmtls.Config,
+	sni string,
+	tlsTimeout time.Duration,
+	clientHelloSpec *utls.ClientHelloSpec,
+) (net.Conn, error) {
+	attempts := gmtlsCipherSuiteDialAttempts(baseConfig)
+	var lastErr error
+
+	for i, cipherSuites := range attempts {
+		tempTlsConfig := baseConfig.Clone()
+		tempTlsConfig.GMSupport = &gmtls.GMSupport{WorkMode: gmtls.ModeGMSSLOnly}
+		tempTlsConfig.CipherSuites = cipherSuites
+
+		if config.Debug {
+			log.Infof("dial %v gmtls cipher attempt %d/%d: cipher suites %v", target, i+1, len(attempts), cipherSuites)
+		}
+
+		conn, err := dialPlainTCPConnWithRetry(target, config)
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConn, err := UpgradeToTLSConnectionWithTimeout(conn, sni, tempTlsConfig, tlsTimeout, clientHelloSpec, config.TLSNextProto...)
+		if err == nil {
+			return tlsConn, nil
+		}
+		lastErr = err
+		_ = conn.Close()
+
+		// 错误与套件无关（如连接被拒）时不必再换套件重连
+		if !shouldRetryGMTLSWithOtherCipherSuites(err) {
+			break
+		}
+		if config.Debug {
+			log.Infof("dial %v gmtls cipher attempt %d failed: %v, retrying with next cipher set", target, i+1, err)
+		}
+	}
+
+	return nil, lastErr
+}

--- a/common/netx/dialx_gmtls.go
+++ b/common/netx/dialx_gmtls.go
@@ -30,20 +30,20 @@ var (
 
 // gmtlsCipherSuiteDialAttempts 返回国密握手每轮 ClientHello 的套件列表。
 // - 已设置 CipherSuites：仅一轮（用户指定）
-// - 默认：一轮、四套全开（与 gmtls 默认 getCipherSuites 一致）
-// - 兼容模式：三轮 ECC×2 → ECDHE×2 → 四套（部分站点需避免首轮同时提供 ECDHE）
-func gmtlsCipherSuiteDialAttempts(base *gmtls.Config, compatMode bool) [][]uint16 {
+// - 关闭兼容模式（DisableCompat=true）：一轮、四套全开
+// - 兼容模式（默认）：三轮 四套 → ECC×2 → ECDHE×2（首轮全发提高一次握手成功率）
+func gmtlsCipherSuiteDialAttempts(base *gmtls.Config, disableCompat bool) [][]uint16 {
 	if len(base.CipherSuites) > 0 {
 		return [][]uint16{base.CipherSuites}
 	}
-	if compatMode {
-		return [][]uint16{
-			eccGMTLSCipherSuitesCompat,
-			ecdheGMTLSCipherSuitesCompat,
-			allGMTLSCipherSuites,
-		}
+	if disableCompat {
+		return [][]uint16{allGMTLSCipherSuites}
 	}
-	return [][]uint16{allGMTLSCipherSuites}
+	return [][]uint16{
+		allGMTLSCipherSuites,
+		eccGMTLSCipherSuitesCompat,
+		ecdheGMTLSCipherSuitesCompat,
+	}
 }
 
 func shouldRetryGMTLSWithOtherCipherSuites(err error) bool {
@@ -66,8 +66,8 @@ func dialTLSWithGMTLSCipherFallback(
 	sni string,
 	tlsTimeout time.Duration,
 	clientHelloSpec *utls.ClientHelloSpec,
-) (net.Conn, error) {
-	attempts := gmtlsCipherSuiteDialAttempts(baseConfig, config.GMTLSCompatMode)
+) (net.Conn, time.Duration, error) {
+	attempts := gmtlsCipherSuiteDialAttempts(baseConfig, config.GMTLSDisableCompatMode)
 	var lastErr error
 
 	for i, cipherSuites := range attempts {
@@ -81,12 +81,14 @@ func dialTLSWithGMTLSCipherFallback(
 
 		conn, err := dialPlainTCPConnWithRetry(target, config)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
+		startUpgrade := time.Now()
 		tlsConn, err := UpgradeToTLSConnectionWithTimeout(conn, sni, tempTlsConfig, tlsTimeout, clientHelloSpec, config.TLSNextProto...)
+		handshakeDur := time.Since(startUpgrade)
 		if err == nil {
-			return tlsConn, nil
+			return tlsConn, handshakeDur, nil
 		}
 		lastErr = err
 		_ = conn.Close()
@@ -100,5 +102,5 @@ func dialTLSWithGMTLSCipherFallback(
 		}
 	}
 
-	return nil, lastErr
+	return nil, 0, lastErr
 }

--- a/common/netx/dialx_gmtls.go
+++ b/common/netx/dialx_gmtls.go
@@ -10,15 +10,15 @@ import (
 	utls "github.com/refraction-networking/utls"
 )
 
-// 国密四套件的密钥协商分两类：静态 ECC（证书 SM2）与 ECDHE（需 ServerKeyExchange）。
+// 国密套件按密钥协商分两类：静态 ECC 与 ECDHE。CBC/GCM 为 SM4 不同模式，同族套件可放在同一轮 ClientHello。
 var (
-	eccGMTLSCipherSuites = []uint16{
-		gmtls.GMTLS_ECC_SM4_CBC_SM3, // 0xe013，Tongsuo: ECC-SM2-SM4-CBC-SM3
-		gmtls.GMTLS_ECC_SM4_GCM_SM3, // 0xe053
+	eccGMTLSCipherSuitesCompat = []uint16{
+		gmtls.GMTLS_ECC_SM4_CBC_SM3,
+		gmtls.GMTLS_ECC_SM4_GCM_SM3,
 	}
-	ecdheGMTLSCipherSuites = []uint16{
-		gmtls.GMTLS_ECDHE_SM4_CBC_SM3, // 0xe011
-		gmtls.GMTLS_ECDHE_SM4_GCM_SM3, // 0xe051
+	ecdheGMTLSCipherSuitesCompat = []uint16{
+		gmtls.GMTLS_ECDHE_SM4_CBC_SM3,
+		gmtls.GMTLS_ECDHE_SM4_GCM_SM3,
 	}
 	allGMTLSCipherSuites = []uint16{
 		gmtls.GMTLS_ECC_SM4_CBC_SM3,
@@ -28,17 +28,22 @@ var (
 	}
 )
 
-// gmtlsCipherSuiteDialAttempts 返回国密握手时的套件重试顺序（最多三轮）：
-// 1) 仅 ECC 静态  2) 仅 ECDHE  3) 四套全开（兼容只接受「全列表」协商的站点）。
-func gmtlsCipherSuiteDialAttempts(base *gmtls.Config) [][]uint16 {
+// gmtlsCipherSuiteDialAttempts 返回国密握手每轮 ClientHello 的套件列表。
+// - 已设置 CipherSuites：仅一轮（用户指定）
+// - 默认：一轮、四套全开（与 gmtls 默认 getCipherSuites 一致）
+// - 兼容模式：三轮 ECC×2 → ECDHE×2 → 四套（部分站点需避免首轮同时提供 ECDHE）
+func gmtlsCipherSuiteDialAttempts(base *gmtls.Config, compatMode bool) [][]uint16 {
 	if len(base.CipherSuites) > 0 {
 		return [][]uint16{base.CipherSuites}
 	}
-	return [][]uint16{
-		eccGMTLSCipherSuites,
-		ecdheGMTLSCipherSuites,
-		allGMTLSCipherSuites,
+	if compatMode {
+		return [][]uint16{
+			eccGMTLSCipherSuitesCompat,
+			ecdheGMTLSCipherSuitesCompat,
+			allGMTLSCipherSuites,
+		}
 	}
+	return [][]uint16{allGMTLSCipherSuites}
 }
 
 func shouldRetryGMTLSWithOtherCipherSuites(err error) bool {
@@ -62,7 +67,7 @@ func dialTLSWithGMTLSCipherFallback(
 	tlsTimeout time.Duration,
 	clientHelloSpec *utls.ClientHelloSpec,
 ) (net.Conn, error) {
-	attempts := gmtlsCipherSuiteDialAttempts(baseConfig)
+	attempts := gmtlsCipherSuiteDialAttempts(baseConfig, config.GMTLSCompatMode)
 	var lastErr error
 
 	for i, cipherSuites := range attempts {

--- a/common/utils/lowhttp/config.go
+++ b/common/utils/lowhttp/config.go
@@ -43,7 +43,7 @@ type LowhttpExecConfig struct {
 	GmTLSOnly                        bool
 	GmTLSPrefer                      bool
 	GmTLSCipherSuites                []uint16
-	GmTLSCompatMode                  bool
+	GmTLSDisableCompatMode           bool
 	OverrideEnableSystemProxyFromEnv bool
 	EnableSystemProxyFromEnv         bool
 	ConnectTimeout                   time.Duration
@@ -485,10 +485,14 @@ func WithGmTLSCipherSuite(suites ...int) LowhttpOpt {
 	}
 }
 
-// WithGmTLSCompatMode 开启国密兼容模式（默认关闭）。
-func WithGmTLSCompatMode(b bool) LowhttpOpt {
+// WithGmTLSDisableCompatMode 关闭国密兼容模式；不传参等价于 true。
+func WithGmTLSDisableCompatMode(disable ...bool) LowhttpOpt {
+	v := true
+	if len(disable) > 0 {
+		v = disable[0]
+	}
 	return func(o *LowhttpExecConfig) {
-		o.GmTLSCompatMode = b
+		o.GmTLSDisableCompatMode = v
 	}
 }
 

--- a/common/utils/lowhttp/config.go
+++ b/common/utils/lowhttp/config.go
@@ -42,6 +42,8 @@ type LowhttpExecConfig struct {
 	GmTLS                            bool
 	GmTLSOnly                        bool
 	GmTLSPrefer                      bool
+	GmTLSCipherSuites                []uint16
+	GmTLSCompatMode                  bool
 	OverrideEnableSystemProxyFromEnv bool
 	EnableSystemProxyFromEnv         bool
 	ConnectTimeout                   time.Duration
@@ -473,6 +475,32 @@ func WithGmTLSOnly(b bool) LowhttpOpt {
 	return func(o *LowhttpExecConfig) {
 		o.GmTLSOnly = b
 	}
+}
+
+// WithGmTLSCipherSuite 指定国密 ClientHello 套件（套件 ID 使用 tls.GMTLS_* 常量，可传多个）。
+// 设置后仅协商所列套件，不再使用 netx 默认的 ECC→ECDHE→全套 三轮回退。
+func WithGmTLSCipherSuite(suites ...int) LowhttpOpt {
+	return func(o *LowhttpExecConfig) {
+		o.GmTLSCipherSuites = intsToGMTLSCipherSuites(suites)
+	}
+}
+
+// WithGmTLSCompatMode 开启国密兼容模式（默认关闭）。
+func WithGmTLSCompatMode(b bool) LowhttpOpt {
+	return func(o *LowhttpExecConfig) {
+		o.GmTLSCompatMode = b
+	}
+}
+
+func intsToGMTLSCipherSuites(suites []int) []uint16 {
+	if len(suites) == 0 {
+		return nil
+	}
+	out := make([]uint16, len(suites))
+	for i, id := range suites {
+		out[i] = uint16(id)
+	}
+	return out
 }
 
 // WithDNSNoCache is not effective

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -267,6 +267,8 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 		gmTLS                   = option.GmTLS
 		onlyGMTLS               = option.GmTLSOnly
 		preferGMTLS             = option.GmTLSPrefer
+		gmTLSCipherSuites           = option.GmTLSCipherSuites
+		gmTLSCompatMode             = option.GmTLSCompatMode
 		host                    = option.Host
 		port                    = option.Port
 		requestPacket           = option.Packet
@@ -654,12 +656,16 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 
 	if https {
 		if gmTLS {
-			dialopts = append(dialopts, netx.DialX_WithGMTLSConfig(&gmtls.Config{
+			gmCfg := &gmtls.Config{
 				GMSupport:          &gmtls.GMSupport{WorkMode: gmtls.ModeAutoSwitch},
 				NextProtos:         nextProto,
 				ServerName:         host,
 				InsecureSkipVerify: !option.VerifyCertificate,
-			}))
+			}
+			if len(gmTLSCipherSuites) > 0 {
+				gmCfg.CipherSuites = gmTLSCipherSuites
+			}
+			dialopts = append(dialopts, netx.DialX_WithGMTLSConfig(gmCfg))
 		} else {
 			dialopts = append(dialopts, netx.DialX_WithTLSConfig(&gmtls.Config{
 				NextProtos:         nextProto,
@@ -667,7 +673,13 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 				InsecureSkipVerify: !option.VerifyCertificate,
 			}))
 		}
-		dialopts = append(dialopts, netx.DialX_WithGMTLSSupport(gmTLS), netx.DialX_WithTLS(https), netx.DialX_WithGMTLSOnly(onlyGMTLS), netx.DialX_WithGMTLSPrefer(preferGMTLS))
+		dialopts = append(dialopts,
+			netx.DialX_WithGMTLSSupport(gmTLS),
+			netx.DialX_WithTLS(https),
+			netx.DialX_WithGMTLSOnly(onlyGMTLS),
+			netx.DialX_WithGMTLSPrefer(preferGMTLS),
+			netx.DialX_WithGMTLSCompatMode(gmTLSCompatMode),
+		)
 
 		if clientHelloSpec != nil {
 			dialopts = append(dialopts, netx.DialX_WithClientHelloSpec(clientHelloSpec))

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -268,7 +268,7 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 		onlyGMTLS               = option.GmTLSOnly
 		preferGMTLS             = option.GmTLSPrefer
 		gmTLSCipherSuites           = option.GmTLSCipherSuites
-		gmTLSCompatMode             = option.GmTLSCompatMode
+		gmTLSDisableCompatMode      = option.GmTLSDisableCompatMode
 		host                    = option.Host
 		port                    = option.Port
 		requestPacket           = option.Packet
@@ -678,7 +678,7 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 			netx.DialX_WithTLS(https),
 			netx.DialX_WithGMTLSOnly(onlyGMTLS),
 			netx.DialX_WithGMTLSPrefer(preferGMTLS),
-			netx.DialX_WithGMTLSCompatMode(gmTLSCompatMode),
+			netx.DialX_WithGMTLSDisableCompatMode(gmTLSDisableCompatMode),
 		)
 
 		if clientHelloSpec != nil {

--- a/common/utils/lowhttp/poc/poc.go
+++ b/common/utils/lowhttp/poc/poc.go
@@ -107,9 +107,11 @@ type PocConfig struct {
 	ClientHelloSpec *utls.ClientHelloSpec
 	RandomJA3       bool
 
-	GmTLS       bool
-	GmTLSOnly   bool
-	GmTLSPrefer bool
+	GmTLS                      bool
+	GmTLSOnly                  bool
+	GmTLSPrefer                bool
+	GmTLSCipherSuites          []uint16
+	GmTLSCompatMode            bool
 
 	// random chunked
 	EnableRandomChunked bool
@@ -262,6 +264,16 @@ func (c *PocConfig) ToLowhttpOptions() []lowhttp.LowhttpOpt {
 	}
 	if c.GmTLSPrefer {
 		opts = append(opts, lowhttp.WithGmTLSPrefer(c.GmTLSPrefer))
+	}
+	if len(c.GmTLSCipherSuites) > 0 {
+		suiteIDs := make([]int, len(c.GmTLSCipherSuites))
+		for i, id := range c.GmTLSCipherSuites {
+			suiteIDs[i] = int(id)
+		}
+		opts = append(opts, lowhttp.WithGmTLSCipherSuite(suiteIDs...))
+	}
+	if c.GmTLSCompatMode {
+		opts = append(opts, lowhttp.WithGmTLSCompatMode(true))
 	}
 	if c.EnableRandomChunked {
 		opts = append(opts, lowhttp.WithEnableRandomChunked(c.EnableRandomChunked))
@@ -2102,6 +2114,32 @@ func WithGmTLSPrefer() PocConfigOption {
 	}
 }
 
+// WithGmTLSCipherSuite 指定国密 TLS 套件，使用 tls.GMTLS_* 常量（可传多个）。
+// Example:
+// ```
+// poc.Get("https://example.com", poc.gmTLS(true), poc.gmTLSCipherSuite(tls.GMTLS_ECC_SM4_CBC_SM3))
+// ```
+func WithGmTLSCipherSuite(suites ...int) PocConfigOption {
+	return func(c *PocConfig) {
+		c.GmTLSCipherSuites = make([]uint16, len(suites))
+		for i, id := range suites {
+			c.GmTLSCipherSuites[i] = uint16(id)
+		}
+	}
+}
+
+// WithGmTLSCompatMode 开启国密兼容模式（默认关闭：单次 ClientHello 提供四套套件）。
+// 适用于服务端在「四套同发」时会误选 ECDHE 的站点（如部分银行 GM 网关）。
+// Example:
+// ```
+// poc.Get(url, poc.gmTLS(true), poc.gmTLSCompatMode(true))
+// ```
+func WithGmTLSCompatMode(b bool) PocConfigOption {
+	return func(c *PocConfig) {
+		c.GmTLSCompatMode = b
+	}
+}
+
 // fixQueryEscape 是一个请求选项参数，用于指定是否修复查询参数中的 URL 编码，默认为 false 即会自动修复URL编码
 // Example:
 // ```
@@ -2475,6 +2513,8 @@ var PoCExports = map[string]interface{}{
 	"gmTls":                WithGmTls,
 	"gmTlsOnly":            WithGmTlsOnly,
 	"gmTLSPrefer":          WithGmTLSPrefer,
+	"gmTLSCipherSuite":     WithGmTLSCipherSuite,
+	"gmTLSCompatMode":           WithGmTLSCompatMode,
 	"fixQueryEscape":       WithFixQueryEscape,
 	// download options
 	"downloadProgress": WithDownloadProgress,

--- a/common/utils/lowhttp/poc/poc.go
+++ b/common/utils/lowhttp/poc/poc.go
@@ -111,7 +111,7 @@ type PocConfig struct {
 	GmTLSOnly                  bool
 	GmTLSPrefer                bool
 	GmTLSCipherSuites          []uint16
-	GmTLSCompatMode            bool
+	GmTLSDisableCompatMode     bool
 
 	// random chunked
 	EnableRandomChunked bool
@@ -272,8 +272,8 @@ func (c *PocConfig) ToLowhttpOptions() []lowhttp.LowhttpOpt {
 		}
 		opts = append(opts, lowhttp.WithGmTLSCipherSuite(suiteIDs...))
 	}
-	if c.GmTLSCompatMode {
-		opts = append(opts, lowhttp.WithGmTLSCompatMode(true))
+	if c.GmTLSDisableCompatMode {
+		opts = append(opts, lowhttp.WithGmTLSDisableCompatMode())
 	}
 	if c.EnableRandomChunked {
 		opts = append(opts, lowhttp.WithEnableRandomChunked(c.EnableRandomChunked))
@@ -2128,15 +2128,20 @@ func WithGmTLSCipherSuite(suites ...int) PocConfigOption {
 	}
 }
 
-// WithGmTLSCompatMode 开启国密兼容模式（默认关闭：单次 ClientHello 提供四套套件）。
-// 适用于服务端在「四套同发」时会误选 ECDHE 的站点（如部分银行 GM 网关）。
+// WithGmTLSDisableCompatMode 关闭国密兼容模式；不传参等价于 true（仅单次四套）。
 // Example:
 // ```
-// poc.Get(url, poc.gmTLS(true), poc.gmTLSCompatMode(true))
+// poc.Get(url, poc.gmTLS(true)) // 默认兼容模式开启
+// poc.Get(url, poc.gmTLS(true), poc.gmTLSDisableCompatMode()) // 关闭兼容
+// poc.Get(url, poc.gmTLS(true), poc.gmTLSDisableCompatMode(false)) // 显式保持兼容开启
 // ```
-func WithGmTLSCompatMode(b bool) PocConfigOption {
+func WithGmTLSDisableCompatMode(disable ...bool) PocConfigOption {
+	v := true
+	if len(disable) > 0 {
+		v = disable[0]
+	}
 	return func(c *PocConfig) {
-		c.GmTLSCompatMode = b
+		c.GmTLSDisableCompatMode = v
 	}
 }
 
@@ -2514,7 +2519,7 @@ var PoCExports = map[string]interface{}{
 	"gmTlsOnly":            WithGmTlsOnly,
 	"gmTLSPrefer":          WithGmTLSPrefer,
 	"gmTLSCipherSuite":     WithGmTLSCipherSuite,
-	"gmTLSCompatMode":           WithGmTLSCompatMode,
+	"gmTLSDisableCompatMode":    WithGmTLSDisableCompatMode,
 	"fixQueryEscape":       WithFixQueryEscape,
 	// download options
 	"downloadProgress": WithDownloadProgress,

--- a/common/yak/yaklib/tls.go
+++ b/common/yak/yaklib/tls.go
@@ -83,4 +83,10 @@ var TlsExports = map[string]interface{}{
 	// --- 密钥材料选项 ---
 	"privateKeyFromFile": tlsutils.WithPrivateKeyFromFile,
 	"privateKeyFromRaw":  tlsutils.WithPrivateKeyFromBytes,
+
+	// --- 国密 TLS 套件（供 poc.gmTLSCipherSuite / tls.GMTLS_* 使用，见 tls_gmtls.go）---
+	"GMTLS_ECC_SM4_CBC_SM3":   GMTLS_ECC_SM4_CBC_SM3,
+	"GMTLS_ECC_SM4_GCM_SM3":   GMTLS_ECC_SM4_GCM_SM3,
+	"GMTLS_ECDHE_SM4_CBC_SM3": GMTLS_ECDHE_SM4_CBC_SM3,
+	"GMTLS_ECDHE_SM4_GCM_SM3": GMTLS_ECDHE_SM4_GCM_SM3,
 }

--- a/common/yak/yaklib/tls_gmtls.go
+++ b/common/yak/yaklib/tls_gmtls.go
@@ -1,0 +1,20 @@
+package yaklib
+
+import "github.com/yaklang/yaklang/common/gmsm/gmtls"
+
+// 国密 TLCP/GMSSL ClientHello 套件 ID（与 common/gmsm/gmtls 一致）。
+// 在 poc 中与 poc.gmTLSCipherSuite(tls.GMTLS_*) 配合使用；未指定时由引擎默认四套单次握手，或 poc.gmTLSCompatMode 分轮兼容。
+const (
+	// GMTLS_ECC_SM4_CBC_SM3 静态 ECC + SM4-CBC + SM3（0xe013）。
+	// 密钥协商使用证书中的 SM2，无需 ECDHE ServerKeyExchange；部分国密网关优先或仅支持此套件。
+	GMTLS_ECC_SM4_CBC_SM3 = int(gmtls.GMTLS_ECC_SM4_CBC_SM3)
+
+	// GMTLS_ECC_SM4_GCM_SM3 静态 ECC + SM4-GCM + SM3（0xe053）。与上一套件同一类密钥协商，仅分组模式为 GCM。
+	GMTLS_ECC_SM4_GCM_SM3 = int(gmtls.GMTLS_ECC_SM4_GCM_SM3)
+
+	// GMTLS_ECDHE_SM4_CBC_SM3 临时 ECDHE + SM4-CBC + SM3（0xe011）。需要完整的 ECDHE ServerKeyExchange 握手。
+	GMTLS_ECDHE_SM4_CBC_SM3 = int(gmtls.GMTLS_ECDHE_SM4_CBC_SM3)
+
+	// GMTLS_ECDHE_SM4_GCM_SM3 临时 ECDHE + SM4-GCM + SM3（0xe051）。
+	GMTLS_ECDHE_SM4_GCM_SM3 = int(gmtls.GMTLS_ECDHE_SM4_GCM_SM3)
+)

--- a/common/yak/yaklib/tls_gmtls.go
+++ b/common/yak/yaklib/tls_gmtls.go
@@ -3,7 +3,7 @@ package yaklib
 import "github.com/yaklang/yaklang/common/gmsm/gmtls"
 
 // 国密 TLCP/GMSSL ClientHello 套件 ID（与 common/gmsm/gmtls 一致）。
-// 在 poc 中与 poc.gmTLSCipherSuite(tls.GMTLS_*) 配合使用；未指定时由引擎默认四套单次握手，或 poc.gmTLSCompatMode 分轮兼容。
+// 在 poc 中与 poc.gmTLSCipherSuite(tls.GMTLS_*) 配合使用；未指定时默认开启兼容模式（四套 → ECC×2 → ECDHE×2），可用 poc.gmTLSDisableCompatMode() 关闭。
 const (
 	// GMTLS_ECC_SM4_CBC_SM3 静态 ECC + SM4-CBC + SM3（0xe013）。
 	// 密钥协商使用证书中的 SM2，无需 ECDHE ServerKeyExchange；部分国密网关优先或仅支持此套件。


### PR DESCRIPTION
When only IsGmTLS is enabled, some GM sites negotiate ECDHE and fail with missing ServerKeyExchange while ECC static suites work. Retry GMTLS in three explicit cipher rounds (new TCP each time).