### PR TITLE
fix(java2ssa): avoid infinite loop in JSP javascript href preprocess

### DIFF
--- a/common/yak/java/jsp/visitor_creator.go
+++ b/common/yak/java/jsp/visitor_creator.go
@@ -104,14 +104,20 @@ func wrapStandaloneJSPFragment(src string) string {
 	return "<yak:fragment>" + src + "</yak:fragment>"
 }
 
+// preprocessJavascriptHrefQuotes normalizes href="javascript:..."> bodies so nested
+// double quotes do not break the JSP/HTML lexer. Each match spans from after `="` to
+// the closing `">` of that attribute value.
 func preprocessJavascriptHrefQuotes(src string) string {
 	const marker = `="javascript:`
+	// searchFrom advances per match; do not restart Index from 0 after edits/skips.
+	searchFrom := 0
 	for {
-		start := strings.Index(src, marker)
-		if start < 0 {
+		relStart := strings.Index(src[searchFrom:], marker)
+		if relStart < 0 {
 			return src
 		}
-		bodyStart := start + 2
+		start := searchFrom + relStart
+		bodyStart := start + 2 // skip leading `="` of marker
 		endRel := strings.Index(src[bodyStart:], `">`)
 		if endRel < 0 {
 			return src
@@ -121,8 +127,10 @@ func preprocessJavascriptHrefQuotes(src string) string {
 		if strings.Count(body, `"`) > 0 {
 			body = strings.ReplaceAll(body, `"`, `'`)
 			src = src[:bodyStart] + body + src[end:]
+			searchFrom = bodyStart + len(body)
 		} else {
-			src = src[:end] + src[end:]
+			// Nothing to rewrite; must still skip past `">` or the same match repeats forever.
+			searchFrom = end + 2
 		}
 	}
 }

--- a/common/yak/java/jsp/visitor_creator_test.go
+++ b/common/yak/java/jsp/visitor_creator_test.go
@@ -1,0 +1,58 @@
+package jsp
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for pprof F3 (20260519): preprocessJavascriptHrefQuotes used to
+// loop forever on ="javascript:..."> when the href body contains no embedded ".
+const maxPreprocessJavascriptHrefQuotesDuration = 200 * time.Millisecond
+
+func TestPreprocessJavascriptHrefQuotes_noInfiniteLoopOnPlainJavascriptHref(t *testing.T) {
+	src := `<jsp:page/><a href="javascript:alert(1)">click</a>`
+	require.True(t, strings.Contains(src, `="javascript:`),
+		"fixture must hit preprocessJavascriptHrefQuotes marker")
+
+	done := make(chan struct{})
+	var got string
+	go func() {
+		got = preprocessJavascriptHrefQuotes(src)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// After fix: body has no inner quotes, output should be unchanged.
+		require.Equal(t, src, got)
+	case <-time.After(maxPreprocessJavascriptHrefQuotesDuration):
+		t.Fatal("preprocessJavascriptHrefQuotes did not return: infinite loop on " +
+			`="javascript:..."> when href body has no embedded double quotes`)
+	}
+}
+
+func TestFront_javascriptHrefWithoutInnerQuotesCompletesQuickly(t *testing.T) {
+	src := `<jsp:page/><a href="javascript:alert(1)">click</a>`
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := Front(src)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(maxPreprocessJavascriptHrefQuotesDuration):
+		t.Fatal("jsp.Front did not return: preprocessJavascriptHrefQuotes infinite loop")
+	}
+}
+
+func TestPreprocessJavascriptHrefQuotes_replacesEmbeddedQuotesInBody(t *testing.T) {
+	src := `<jsp:page/><a href="javascript:foo("bar")">click</a>`
+	got := preprocessJavascriptHrefQuotes(src)
+	require.Equal(t, `<jsp:page/><a href="javascript:foo('bar')">click</a>`, got)
+}


### PR DESCRIPTION
When href="javascript:..."> had no embedded double quotes, the preprocessor never advanced and SSA pre-handler could hang with massive allocations. Advance searchFrom past each match and add regression tests.