### PR TITLE
fix(ai): speed up grep matched output

### DIFF
--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/grep_correctness_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/grep_correctness_test.go
@@ -225,10 +225,10 @@ func TestGrepTool_RegexpDollarMatchesLineEnd(t *testing.T) {
 	t.Log("✓ regexp $ correctly matches line end (multi-line mode)")
 }
 
-// TestGrepTool_SameLineDedup verifies that when a pattern matches multiple times
-// on the same line, grep reports the line only ONCE — matching bash grep behavior.
-// Bash `grep 'foo'` on "foo bar foo baz foo\n" outputs 1 line, not 3.
-func TestGrepTool_SameLineDedup(t *testing.T) {
+// TestGrepTool_SameLineMultipleMatches verifies that content mode reports each
+// occurrence on the same line. This is intentional for bundled/minified JS where
+// one long line may contain many API-like matches.
+func TestGrepTool_SameLineMultipleMatches(t *testing.T) {
 	grepTool := getGrepToolFromEmbed(t)
 
 	content := "aaa bbb aaa ccc aaa\nxxx\naaa end\n"
@@ -256,16 +256,16 @@ func TestGrepTool_SameLineDedup(t *testing.T) {
 	t.Logf("stdout:\n%s", stdoutStr)
 
 	// "aaa" appears on line 1 (3 times) and line 3 (1 time).
-	// Bash grep would output 2 lines. Current grep.yak may report 4 matches.
-	// We expect exactly 2 match entries in findRes (one per line).
-	if !strings.Contains(stdoutStr, "2 matches") {
-		t.Fatalf("expected 2 matches (one per matching line, like bash grep), got:\n%s", stdoutStr)
+	// Content mode intentionally reports all 4 occurrences.
+	if !strings.Contains(stdoutStr, "4 matches") {
+		t.Fatalf("expected 4 matches (one per occurrence), got:\n%s", stdoutStr)
 	}
 }
 
-// TestGrepTool_RegexpSameLineDedup verifies same-line dedup works in regexp mode too.
-// Pattern `\d+` on "a1b2c3\n" should report 1 line, not 3 matches.
-func TestGrepTool_RegexpSameLineDedup(t *testing.T) {
+// TestGrepTool_RegexpSameLineMultipleMatches verifies same-line multi-match
+// output works in regexp mode too.
+// Pattern `\d+` on "a1b2c3\n" should report 3 occurrences on that line.
+func TestGrepTool_RegexpSameLineMultipleMatches(t *testing.T) {
 	grepTool := getGrepToolFromEmbed(t)
 
 	content := "a1b2c3\nno digits here\nx9y\n"
@@ -294,9 +294,8 @@ func TestGrepTool_RegexpSameLineDedup(t *testing.T) {
 	t.Logf("stdout:\n%s", stdoutStr)
 
 	// \d+ matches 3 times on line 1 ("1","2","3") and once on line 3 ("9").
-	// Like bash grep -E '\d+', we should get 2 matching lines, not 4 individual matches.
-	if !strings.Contains(stdoutStr, "2 matches") {
-		t.Fatalf("expected 2 matches (one per matching line), got:\n%s", stdoutStr)
+	if !strings.Contains(stdoutStr, "4 matches") {
+		t.Fatalf("expected 4 matches (one per occurrence), got:\n%s", stdoutStr)
 	}
 }
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
@@ -16,8 +16,8 @@ Required Parameters:
 
 Optional Parameters:
   output-mode     (string)  Controls what is returned. Accepted values:
-                            - "" or "content" (default): returns matching lines with file:line:content
-                              format. Each match counts toward the limit.
+                            - "" or "content" (default): returns matching text with file:line:match
+                              format, similar to grep -oE. Each match occurrence counts toward the limit.
                             - "files_with_matches" / "files": returns only file paths that contain
                               at least one match, along with the match count per file.
                               Much faster for large codebases—once a file has a match, it stops
@@ -40,7 +40,7 @@ Optional Parameters:
                               automatic fallback — compile errors are reported as failures).
   limit           (int)     Maximum number of matched results to return.
                             Default: 50 for "content" mode, 200 for "files_with_matches" mode.
-                            In "content" mode: limits the number of matching lines.
+                            In "content" mode: limits the number of matching occurrences.
                             In "files_with_matches" mode: limits the number of files returned.
                             The search stops early once this many results (after offset) are collected.
   offset          (int)     Skip the first N matches before collecting results. Default: 0.
@@ -48,8 +48,8 @@ Optional Parameters:
   file-size-max   (int)     Maximum file size in bytes. Files larger than this are skipped entirely.
                             Default: 2000000000 (2GB). Set to a smaller value for faster scans.
   context-buffer  (int)     Number of bytes of surrounding context to show around each match.
-                            Default: 0: each result is reported as "filepath:lineNo: full line content"
-                            (standard grep-style output — the entire matching line is always shown).
+                            Default: 0: each result is reported as "filepath:lineNo: matched text"
+                            (grep -oE-style output).
                             When > 0, the tool additionally extracts [match_start - context_buffer,
                             match_end + context_buffer] bytes as a raw snippet around the match.
                             (Only effective in "content" output-mode.)
@@ -85,7 +85,7 @@ yakit.AutoInitYakit()
 
 pathName := cli.String("path", cli.setHelp("the filepath(s) you want to check, use comma ',' to separate multiple paths"), cli.setRequired(true))
 pattern := cli.String("pattern", cli.setHelp("target text you want to grep, use comma ',' as split"), cli.setRequired(true))
-outputModeRaw := cli.String("output-mode", cli.setHelp("output mode: 'content' (default) returns matching lines; 'files_with_matches'/'files' returns only file paths with match counts"), cli.setDefault("content"))
+outputModeRaw := cli.String("output-mode", cli.setHelp("output mode: 'content' (default) returns matched text like grep -oE; 'files_with_matches'/'files' returns only file paths with match counts"), cli.setDefault("content"))
 matchMode = cli.String("pattern-mode", cli.setHelp("one of [regexp/substr/isubstr] set match mode: 1. regexp (default) for Golang-style regex, auto-fallback to substr on compile error; 2. substr for CaseSensitive-SubString; 3. isubstr for CaseInsensitive-SubString"), cli.setDefault("regexp"))
 maxResult := cli.Int("limit", cli.setHelp("max results to return; default 50 for content mode, 200 for files_with_matches mode. Set to -1 to use mode-specific default."),  cli.setDefault(-1))
 offsetResultCount := cli.Int("offset", cli.setHelp("skip how many first match"), cli.setDefault(0))
@@ -322,43 +322,9 @@ extractLine = (content, byteOffset) => {
     return str.TrimRight(content[lineStart:lineEnd], "\r")
 }
 
-collectMatchPreview = (offset, offsetEnd) => {
-    if contextBuffer > 0 {
-        return
-    }
-
-    m.Lock()
-    defer m.Unlock()
-
-    if count <= offsetResultCount || count > (maxResult + offsetResultCount) {
-        return
-    }
-    if len(currentOriginalContent) <= 0 {
-        return
-    }
-    if offset < 0 {
-        offset = 0
-    }
-    if offsetEnd > len(currentOriginalContent) {
-        offsetEnd = len(currentOriginalContent)
-    }
-    if offsetEnd <= offset {
-        return
-    }
-
-    lineNo = countLineNumber(currentOriginalContent, offset)
-    lineContent = extractLine(currentOriginalContent, offset)
-    entry = sprintf("%v:%v: %v", currentTargetFile, lineNo, lineContent)
-
-    displayCount = count - offsetResultCount
-    if displayCount <= maxIPCLogCount {
-        yakit.Info("  %v", entry)
-    }
-}
-
 // output uses in-memory rawContent ([]byte) to extract context,
 // avoiding per-match file I/O and excessive yakit.File IPC calls.
-output = (targetFile, offset, offsetEnd, rawContent) => {
+output = (targetFile, offset, offsetEnd, rawContent, matchedText, lineNo) => {
     m.Lock()
     defer m.Unlock()
     count++
@@ -372,23 +338,25 @@ output = (targetFile, offset, offsetEnd, rawContent) => {
         return
     }
 
-    displayCount = count - offsetResultCount
-
-    // Compute line number from byte offset for human-readable output
     rawStr = string(rawContent)
-    lineNo = countLineNumber(rawStr, offset)
 
-    // Build match info string: "filepath:lineNo: matched line content"
-    lineContent = extractLine(rawStr, offset)
-    var msg
-    msg = "%v:%v: %v" % [targetFile, lineNo, lineContent]
-
-    // Only log first N matches via yakit.Info to avoid IPC flood
-    if displayCount <= maxIPCLogCount {
-        yakit.Info(msg)
-    } else if displayCount == maxIPCLogCount + 1 {
-        yakit.Info("... (suppressing per-match IPC logs for remaining matches, results still collected)")
+    // Build match info string: "filepath:lineNo: matched text" (grep -oE style).
+    // Regexp offsets are byte offsets; slice rawContent instead of string content
+    // so non-ASCII text earlier in the file cannot shift the matched snippet.
+    if matchedText == "" {
+        if offset < 0 {
+            offset = 0
+        }
+        if offsetEnd > len(rawContent) {
+            offsetEnd = len(rawContent)
+        }
+        if offsetEnd <= offset {
+            return
+        }
+        matchedText = string(rawContent[offset:offsetEnd])
     }
+    var msg
+    msg = "%v:%v: %v" % [targetFile, lineNo, matchedText]
 
     if contextBuffer > 0 && len(rawContent) > 0 {
         seekStart = offset - contextBuffer
@@ -407,19 +375,33 @@ output = (targetFile, offset, offsetEnd, rawContent) => {
             contentStr := string(raw)
             // Prefix context snippet with file:line for orientation
             contextEntry = sprintf("%v:%v: ...%v...", targetFile, lineNo, str.TrimSpace(contentStr))
-            if displayCount <= maxIPCLogCount {
-                yakit.Info("  context: %v", contextEntry)
-            }
             findRes = append(findRes, contextEntry)
         }
         return
     }
 
-    // contextBuffer == 0: collect the matching line itself into findRes so that
-    // the println summary at the end of the script contains actual match content.
+    // contextBuffer == 0: collect only the matched text so bundled/minified files
+    // with many matches on one line behave like grep -oE instead of returning a huge line.
     // Without this, findRes stays empty and the AI tool framework receives an
     // uninformative "matches were found but no context text was collected" message.
     findRes = append(findRes, msg)
+}
+
+outputPlainMatch = (targetFile, lineNo, matchedText) => {
+    m.Lock()
+    defer m.Unlock()
+    count++
+
+    if count <= offsetResultCount {
+        return
+    }
+
+    if count > (maxResult + offsetResultCount) {
+        end = true
+        return
+    }
+
+    findRes = append(findRes, "%v:%v: %v" % [targetFile, lineNo, matchedText])
 }
 
 isRegexp = str.ToLower(matchMode) in ["regexp", "re", "regex", ""]
@@ -445,39 +427,65 @@ tryCompileRegexp = (subpattern) => {
     return re.Compile(subp)~, true
 }
 
-scanMatches = (patternRe, targetFile, content, rawContent) => {
-    searchBase = 0
-    for {
+scanMatchesTextOnly = (patternRe, targetFile, content) => {
+    findLimit = maxResult + offsetResultCount + 1
+    lineNo = 1
+    for lineContent in str.Split(content, "\n") {
         if end { return }
-        if searchBase >= len(content) {
+        remainLimit = findLimit - count
+        if remainLimit <= 0 {
             return
         }
-
-        current = content[searchBase:]
-        match = patternRe.FindStringIndex(current)
-        if match == nil || len(match) < 2 {
-            return
+        matches = patternRe.FindAllString(lineContent, remainLimit)
+        if matches != nil {
+            for matchedText in matches {
+                if end { return }
+                outputPlainMatch(targetFile, lineNo, matchedText)
+            }
         }
-
-        start = searchBase + match[0]
-        finish = searchBase + match[1]
-        output(targetFile, start, finish, rawContent)
-        collectMatchPreview(start, finish)
-        if end { return }
-
-        // Skip to the start of the next line (bash grep reports each line at most once)
-        nextBase = finish
-        for nextBase < len(content) && content[nextBase] != '\n' {
-            nextBase++
-        }
-        if nextBase < len(content) {
-            nextBase++
-        }
-        if nextBase <= searchBase {
-            nextBase = searchBase + 1
-        }
-        searchBase = nextBase
+        lineNo++
     }
+}
+
+scanMatchesWithContext = (patternRe, targetFile, content, rawContent) => {
+    findLimit = maxResult + offsetResultCount + 1
+    allMatches = patternRe.FindAllStringIndex(content, findLimit)
+    if allMatches == nil {
+        return
+    }
+    lineNo = 1
+    lineScanOffset = 0
+
+    for i := 0; i < len(allMatches); i++ {
+        if end { return }
+        match = allMatches[i]
+        if match == nil || len(match) < 2 { continue }
+
+        start = match[0]
+        finish = match[1]
+        if finish > start {
+            if start < lineScanOffset {
+                lineNo = 1
+                lineScanOffset = 0
+            } else {
+                for lineScanOffset < start && lineScanOffset < len(rawContent) {
+                    if rawContent[lineScanOffset] == '\n' {
+                        lineNo++
+                    }
+                    lineScanOffset++
+                }
+            }
+            output(targetFile, start, finish, rawContent, "", lineNo)
+        }
+    }
+}
+
+scanMatches = (patternRe, targetFile, content, rawContent) => {
+    if contextBuffer <= 0 {
+        scanMatchesTextOnly(patternRe, targetFile, content)
+        return
+    }
+    scanMatchesWithContext(patternRe, targetFile, content, rawContent)
 }
 
 handleRegexp = (subpattern, targetFile, content, rawContent) => {
@@ -650,6 +658,9 @@ for currentPath in validPaths {
 // Maximum results to output via stdout and yakit.Info summary
 // AI tool framework captures stdout as the tool result; keep it reasonable.
 maxStdoutResults = 100
+if !filesOnlyMode && contextBuffer <= 0 {
+    maxStdoutResults = 500
+}
 
 if filesOnlyMode {
     // ── files_with_matches mode output ──
@@ -698,15 +709,16 @@ if filesOnlyMode {
     // ── content mode output (original behavior) ──
     // print findRes summary to yakit.Info (batched, not per-match)
     if len(findRes) > 0 {
-        yakit.Info("=== Grep Results Summary: %d matches ===", len(findRes))
         showCount = min(len(findRes), maxStdoutResults)
+        summaryText = sprintf("=== Grep Results Summary: %d matches ===", len(findRes))
         for i := 0; i < showCount; i++ {
-            yakit.Info("[match %d] %s", i+1, findRes[i])
+            summaryText += sprintf("\n[match %d] %s", i+1, findRes[i])
         }
         if len(findRes) > maxStdoutResults {
-            yakit.Info("... (%d more matches not shown)", len(findRes) - maxStdoutResults)
+            summaryText += sprintf("\n... (%d more matches not shown)", len(findRes) - maxStdoutResults)
         }
-        yakit.Info("=== End of Grep Results ===")
+        summaryText += "\n=== End of Grep Results ==="
+        yakit.Info("%s", summaryText)
 
         // Write results to stdout (captured by AI tool framework)
         // Cap output to maxStdoutResults to keep tool result size manageable

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "533895adcf65bf6f02d445fe7dcc7992f
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "e6ab480fbac853033439578791ad40639f77b4ed4df828fdeb561a40ce6d0f71"
+const ExistedBuildInAIToolEmbedFSHash string = "52e5702415a9d3d8048e3a757511efb1bf10d031abf654b6915e828f36d112f0"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "533895adcf65bf6f02d445fe7dcc7992f
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "8e8ea8424207783b5fa1f657dc3962c8bffb526419f292d98f4e507776e430dd"
+const ExistedBuildInAIToolEmbedFSHash string = "e6ab480fbac853033439578791ad40639f77b4ed4df828fdeb561a40ce6d0f71"


### PR DESCRIPTION
## Summary
- Change grep content output to return matched text occurrences, similar to `grep -oE`, instead of whole matching lines.
- Add a fast no-context scan path and batch result logging to avoid IPC overhead on bundled/minified files.
- Raise the no-context stdout cap so API extraction results are not truncated early.

## Test plan
- `yak .../grep.yak --path /Users/cnrstar/Desktop/guanwag/13994-3653cb07cd27df7d.js --pattern 'https?://api\\.[A-Za-z0-9._:/?=&%-]+|/api/[A-Za-z0-9._/?=&%-]+' --pattern-mode regexp --limit 200`
- Compared with `grep -oE` on the same file: both returned 143 matches and 124 unique API strings.
- Checked edited file lints in Cursor: no diagnostics.


Made with [Cursor](https://cursor.com)