### PR TITLE
enhance(ai): improve bash yakscript execution

### DIFF
--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/grep_correctness_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/grep_correctness_test.go
@@ -225,10 +225,10 @@ func TestGrepTool_RegexpDollarMatchesLineEnd(t *testing.T) {
 	t.Log("✓ regexp $ correctly matches line end (multi-line mode)")
 }
 
-// TestGrepTool_SameLineDedup verifies that when a pattern matches multiple times
-// on the same line, grep reports the line only ONCE — matching bash grep behavior.
-// Bash `grep 'foo'` on "foo bar foo baz foo\n" outputs 1 line, not 3.
-func TestGrepTool_SameLineDedup(t *testing.T) {
+// TestGrepTool_SameLineMultipleMatches verifies that content mode reports each
+// occurrence on the same line. This is intentional for bundled/minified JS where
+// one long line may contain many API-like matches.
+func TestGrepTool_SameLineMultipleMatches(t *testing.T) {
 	grepTool := getGrepToolFromEmbed(t)
 
 	content := "aaa bbb aaa ccc aaa\nxxx\naaa end\n"
@@ -256,16 +256,16 @@ func TestGrepTool_SameLineDedup(t *testing.T) {
 	t.Logf("stdout:\n%s", stdoutStr)
 
 	// "aaa" appears on line 1 (3 times) and line 3 (1 time).
-	// Bash grep would output 2 lines. Current grep.yak may report 4 matches.
-	// We expect exactly 2 match entries in findRes (one per line).
-	if !strings.Contains(stdoutStr, "2 matches") {
-		t.Fatalf("expected 2 matches (one per matching line, like bash grep), got:\n%s", stdoutStr)
+	// Content mode intentionally reports all 4 occurrences.
+	if !strings.Contains(stdoutStr, "4 matches") {
+		t.Fatalf("expected 4 matches (one per occurrence), got:\n%s", stdoutStr)
 	}
 }
 
-// TestGrepTool_RegexpSameLineDedup verifies same-line dedup works in regexp mode too.
-// Pattern `\d+` on "a1b2c3\n" should report 1 line, not 3 matches.
-func TestGrepTool_RegexpSameLineDedup(t *testing.T) {
+// TestGrepTool_RegexpSameLineMultipleMatches verifies same-line multi-match
+// output works in regexp mode too.
+// Pattern `\d+` on "a1b2c3\n" should report 3 occurrences on that line.
+func TestGrepTool_RegexpSameLineMultipleMatches(t *testing.T) {
 	grepTool := getGrepToolFromEmbed(t)
 
 	content := "a1b2c3\nno digits here\nx9y\n"
@@ -294,9 +294,8 @@ func TestGrepTool_RegexpSameLineDedup(t *testing.T) {
 	t.Logf("stdout:\n%s", stdoutStr)
 
 	// \d+ matches 3 times on line 1 ("1","2","3") and once on line 3 ("9").
-	// Like bash grep -E '\d+', we should get 2 matching lines, not 4 individual matches.
-	if !strings.Contains(stdoutStr, "2 matches") {
-		t.Fatalf("expected 2 matches (one per matching line), got:\n%s", stdoutStr)
+	if !strings.Contains(stdoutStr, "4 matches") {
+		t.Fatalf("expected 4 matches (one per occurrence), got:\n%s", stdoutStr)
 	}
 }
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
@@ -53,6 +53,10 @@ Optional Parameters:
                             When > 0, the tool additionally extracts [match_start - context_buffer,
                             match_end + context_buffer] bytes as a raw snippet around the match.
                             (Only effective in "content" output-mode.)
+  max-line-chars   (int)    Max bytes shown for surrounding line text when context-buffer > 0.
+                            Long logical lines (e.g. minified JS as one line) are shown as a centered
+                            snippet around the match, with "..." when truncated. Default: 2048.
+                            Set to 0 for unlimited (may print megabyte-long lines).
   exclude         (string)  Comma-separated list of directory/file names to exclude.
                             Each name is checked against EVERY component of the file path.
                             For example, "node_modules,.git" will skip any file whose path contains
@@ -91,6 +95,7 @@ maxResult := cli.Int("limit", cli.setHelp("max results to return; default 50 for
 offsetResultCount := cli.Int("offset", cli.setHelp("skip how many first match"), cli.setDefault(0))
 fileSizeLimit = cli.Int("file-size-max", cli.setHelp("limit for file size, if the file is too large, stop it auto"), cli.setDefault(1000 * 1000 * 1000 * 2)) // 2G
 contextBuffer := cli.Int("context-buffer", cli.setHelp("Show (or display) a certain number of bytes of context around the matching text, default 0 is for not show"), cli.setDefault(0))
+maxLineChars := cli.Int("max-line-chars", cli.setHelp("when context-buffer > 0, max bytes of line text to use for line number / context orientation (0=unlimited). Long lines get a centered snippet around the match"), cli.setDefault(2048))
 excludeRaw := cli.String("exclude", cli.setHelp("comma-separated list of directory/file names to exclude from scanning"), cli.setDefault(".git,.svn,.hg,node_modules,__pycache__,.DS_Store,.idea,.vscode,.next,.nuxt,.cache"))
 includeRaw := cli.String("include", cli.setHelp("comma-separated list of file name substrings to include (whitelist)"), cli.setDefault(""))
 excludeExtRaw := cli.String("exclude-ext", cli.setHelp("comma-separated list of file extensions to exclude (e.g. '.pyc,.o,.so')"), cli.setDefault(""))
@@ -232,7 +237,7 @@ yakit.Info("pattern-mode: %v", matchMode)
 if filesOnlyMode {
     yakit.Info("output-mode: files_with_matches")
 }
-yakit.Info("limit: %v, offset: %v, context-buffer: %v", maxResult, offsetResultCount, contextBuffer)
+yakit.Info("limit: %v, offset: %v, context-buffer: %v, max-line-chars: %v", maxResult, offsetResultCount, contextBuffer, maxLineChars)
 if len(excludeNames) > 0 {
     yakit.Info("exclude: %v", excludeRaw)
 }
@@ -280,25 +285,22 @@ end = false
 // Maximum number of matches to log individually via yakit.Info IPC
 // to avoid flooding the IPC channel (each yakit.Info is a network round-trip).
 maxIPCLogCount = 20
-currentOriginalContent = ""
-currentTargetFile = ""
 
-// countLineNumber returns the 1-based line number of the byte at position byteOffset
-// within content (a string). It counts '\n' characters before byteOffset.
-countLineNumber = (content, byteOffset) => {
-    if byteOffset <= 0 {
-        return 1
+// advanceLineState counts newlines in content[from:until] and returns (newLineNo, newFrom).
+// Uses native str.Count instead of a Yak byte loop (huge win on MB-scale gaps between matches).
+advanceLineState = (content, from, until, lineNo) => {
+    n = len(content)
+    if until > n {
+        until = n
     }
-    if byteOffset > len(content) {
-        byteOffset = len(content)
+    if from < 0 {
+        from = 0
     }
-    lineNo = 1
-    for i := 0; i < byteOffset; i++ {
-        if content[i] == '\n' {
-            lineNo++
-        }
+    if from >= until {
+        return lineNo, until
     }
-    return lineNo
+    lineNo = lineNo + str.Count(content[from:until], "\n")
+    return lineNo, until
 }
 
 // extractLine returns the full text of the line that contains byteOffset (without trailing newline).
@@ -309,17 +311,104 @@ extractLine = (content, byteOffset) => {
     if byteOffset >= len(content) {
         byteOffset = len(content) - 1
     }
-    // find line start
-    lineStart = byteOffset
-    for lineStart > 0 && content[lineStart-1] != '\n' {
-        lineStart--
-    }
-    // find line end
-    lineEnd = byteOffset
-    for lineEnd < len(content) && content[lineEnd] != '\n' {
-        lineEnd++
-    }
+    head = content[:byteOffset]
+    li = str.LastIndex(head, "\n")
+    lineStart = li >= 0 ? li + 1 : 0
+    tail = content[byteOffset:]
+    ri = str.Index(tail, "\n")
+    lineEnd = ri < 0 ? len(content) : byteOffset + ri
     return str.TrimRight(content[lineStart:lineEnd], "\r")
+}
+
+// Max distance from the match when searching for a newline. Stops minified single-line files
+// from scanning megabytes left/right just to find logical line boundaries.
+lineBoundaryProbe = 128 * 1024
+
+// extractLineCapped finds [lineStart, lineEnd) of the logical line at byteOffset, but only walks
+// at most maxLeft / maxRight bytes from byteOffset when looking for '\n'.
+extractLineCapped = (content, byteOffset, maxLeft, maxRight) => {
+    leftLim = byteOffset - maxLeft
+    if leftLim < 0 {
+        leftLim = 0
+    }
+    segL = content[leftLim:byteOffset]
+    li = str.LastIndex(segL, "\n")
+    lineStart = li >= 0 ? leftLim + li + 1 : leftLim
+
+    rightCap = byteOffset + maxRight
+    if rightCap > len(content) {
+        rightCap = len(content)
+    }
+    segR = content[byteOffset:rightCap]
+    ri = str.Index(segR, "\n")
+    lineEnd = ri >= 0 ? byteOffset + ri : rightCap
+    return lineStart, lineEnd
+}
+
+// snippetCenter returns at most maxChars bytes from segment, centered on [relMatchStart, relMatchEnd),
+// with "..." when the segment is longer than maxChars.
+snippetCenter = (segment, relMatchStart, relMatchEnd, maxChars) => {
+    segLen = len(segment)
+    matchLen = relMatchEnd - relMatchStart
+    if maxChars <= 0 || segLen <= maxChars {
+        return segment
+    }
+    if matchLen >= maxChars {
+        take = maxChars - 6
+        if take < 1 {
+            take = maxChars
+        }
+        endPos = relMatchStart + take
+        if endPos > segLen {
+            endPos = segLen
+        }
+        if endPos <= relMatchStart {
+            return "...(match too long)..."
+        }
+        return "..." + segment[relMatchStart:endPos] + "..."
+    }
+    pad = maxChars - matchLen
+    leftPad = pad / 2
+    winS = relMatchStart - leftPad
+    if winS < 0 {
+        winS = 0
+    }
+    if winS + maxChars > segLen {
+        winS = segLen - maxChars
+        if winS < 0 {
+            winS = 0
+        }
+    }
+    winE = winS + maxChars
+    if winE > segLen {
+        winE = segLen
+    }
+    part = segment[winS:winE]
+    pre = winS > 0 ? "..." : ""
+    suf = winE < segLen ? "..." : ""
+    return pre + part + suf
+}
+
+// formatDisplayLine builds the human-readable fragment after "file:line:" for one hit.
+// When maxLineDisplay > 0, long logical lines (e.g. minified JS) are shown as a short snippet around the match.
+formatDisplayLine = (content, matchStart, matchEnd, maxLineDisplay) => {
+    if maxLineDisplay <= 0 {
+        return extractLine(content, matchStart)
+    }
+    lineStart, lineEnd = extractLineCapped(content, matchStart, lineBoundaryProbe, lineBoundaryProbe)
+    segment = content[lineStart:lineEnd]
+    relS = matchStart - lineStart
+    relE = matchEnd - lineStart
+    if relS < 0 {
+        relS = 0
+    }
+    if relE > len(segment) {
+        relE = len(segment)
+    }
+    if relE < relS {
+        relE = relS
+    }
+    return snippetCenter(segment, relS, relE, maxLineDisplay)
 }
 
 // output uses in-memory rawContent ([]byte) to extract context,
@@ -373,6 +462,9 @@ output = (targetFile, offset, offsetEnd, rawContent, matchedText, lineNo) => {
         raw = rawContent[seekStart:seekEnd]
         if len(raw) > 0 {
             contentStr := string(raw)
+            if maxLineChars > 0 && len(contentStr) > maxLineChars {
+                contentStr = formatDisplayLine(rawStr, offset, offsetEnd, maxLineChars)
+            }
             // Prefix context snippet with file:line for orientation
             contextEntry = sprintf("%v:%v: ...%v...", targetFile, lineNo, str.TrimSpace(contentStr))
             findRes = append(findRes, contextEntry)
@@ -453,8 +545,9 @@ scanMatchesWithContext = (patternRe, targetFile, content, rawContent) => {
     if allMatches == nil {
         return
     }
-    lineNo = 1
-    lineScanOffset = 0
+    rawStr = string(rawContent)
+    lineScanPos = 0
+    lineNoAtScanPos = 1
 
     for i := 0; i < len(allMatches); i++ {
         if end { return }
@@ -464,18 +557,8 @@ scanMatchesWithContext = (patternRe, targetFile, content, rawContent) => {
         start = match[0]
         finish = match[1]
         if finish > start {
-            if start < lineScanOffset {
-                lineNo = 1
-                lineScanOffset = 0
-            } else {
-                for lineScanOffset < start && lineScanOffset < len(rawContent) {
-                    if rawContent[lineScanOffset] == '\n' {
-                        lineNo++
-                    }
-                    lineScanOffset++
-                }
-            }
-            output(targetFile, start, finish, rawContent, "", lineNo)
+            lineNoAtScanPos, lineScanPos = advanceLineState(rawStr, lineScanPos, start, lineNoAtScanPos)
+            output(targetFile, start, finish, rawContent, "", lineNoAtScanPos)
         }
     }
 }
@@ -490,8 +573,6 @@ scanMatches = (patternRe, targetFile, content, rawContent) => {
 
 handleRegexp = (subpattern, targetFile, content, rawContent) => {
     defer recover()
-    currentOriginalContent = content
-    currentTargetFile = targetFile
     subpatternRe, ok := tryCompileRegexp(subpattern)
     if !ok || subpatternRe == nil {
         handle(subpattern, targetFile, content, rawContent)
@@ -509,8 +590,6 @@ handle = (patternSubstr, targetFile, content, rawContent) => {
     }
 
     defer recover()
-    currentOriginalContent = content
-    currentTargetFile = targetFile
     patternRe := re.Compile(re.QuoteMeta(patternSubstr))~
     scanMatches(patternRe, targetFile, workingContent, rawContent)
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
@@ -16,8 +16,8 @@ Required Parameters:
 
 Optional Parameters:
   output-mode     (string)  Controls what is returned. Accepted values:
-                            - "" or "content" (default): returns matching lines with file:line:content
-                              format. Each match counts toward the limit.
+                            - "" or "content" (default): returns matching text with file:line:match
+                              format, similar to grep -oE. Each match occurrence counts toward the limit.
                             - "files_with_matches" / "files": returns only file paths that contain
                               at least one match, along with the match count per file.
                               Much faster for large codebases—once a file has a match, it stops
@@ -40,7 +40,7 @@ Optional Parameters:
                               automatic fallback — compile errors are reported as failures).
   limit           (int)     Maximum number of matched results to return.
                             Default: 50 for "content" mode, 200 for "files_with_matches" mode.
-                            In "content" mode: limits the number of matching lines.
+                            In "content" mode: limits the number of matching occurrences.
                             In "files_with_matches" mode: limits the number of files returned.
                             The search stops early once this many results (after offset) are collected.
   offset          (int)     Skip the first N matches before collecting results. Default: 0.
@@ -48,8 +48,8 @@ Optional Parameters:
   file-size-max   (int)     Maximum file size in bytes. Files larger than this are skipped entirely.
                             Default: 2000000000 (2GB). Set to a smaller value for faster scans.
   context-buffer  (int)     Number of bytes of surrounding context to show around each match.
-                            Default: 0: each result is reported as "filepath:lineNo: full line content"
-                            (standard grep-style output — the entire matching line is always shown).
+                            Default: 0: each result is reported as "filepath:lineNo: matched text"
+                            (grep -oE-style output).
                             When > 0, the tool additionally extracts [match_start - context_buffer,
                             match_end + context_buffer] bytes as a raw snippet around the match.
                             (Only effective in "content" output-mode.)
@@ -85,7 +85,7 @@ yakit.AutoInitYakit()
 
 pathName := cli.String("path", cli.setHelp("the filepath(s) you want to check, use comma ',' to separate multiple paths"), cli.setRequired(true))
 pattern := cli.String("pattern", cli.setHelp("target text you want to grep, use comma ',' as split"), cli.setRequired(true))
-outputModeRaw := cli.String("output-mode", cli.setHelp("output mode: 'content' (default) returns matching lines; 'files_with_matches'/'files' returns only file paths with match counts"), cli.setDefault("content"))
+outputModeRaw := cli.String("output-mode", cli.setHelp("output mode: 'content' (default) returns matched text like grep -oE; 'files_with_matches'/'files' returns only file paths with match counts"), cli.setDefault("content"))
 matchMode = cli.String("pattern-mode", cli.setHelp("one of [regexp/substr/isubstr] set match mode: 1. regexp (default) for Golang-style regex, auto-fallback to substr on compile error; 2. substr for CaseSensitive-SubString; 3. isubstr for CaseInsensitive-SubString"), cli.setDefault("regexp"))
 maxResult := cli.Int("limit", cli.setHelp("max results to return; default 50 for content mode, 200 for files_with_matches mode. Set to -1 to use mode-specific default."),  cli.setDefault(-1))
 offsetResultCount := cli.Int("offset", cli.setHelp("skip how many first match"), cli.setDefault(0))
@@ -322,43 +322,9 @@ extractLine = (content, byteOffset) => {
     return str.TrimRight(content[lineStart:lineEnd], "\r")
 }
 
-collectMatchPreview = (offset, offsetEnd) => {
-    if contextBuffer > 0 {
-        return
-    }
-
-    m.Lock()
-    defer m.Unlock()
-
-    if count <= offsetResultCount || count > (maxResult + offsetResultCount) {
-        return
-    }
-    if len(currentOriginalContent) <= 0 {
-        return
-    }
-    if offset < 0 {
-        offset = 0
-    }
-    if offsetEnd > len(currentOriginalContent) {
-        offsetEnd = len(currentOriginalContent)
-    }
-    if offsetEnd <= offset {
-        return
-    }
-
-    lineNo = countLineNumber(currentOriginalContent, offset)
-    lineContent = extractLine(currentOriginalContent, offset)
-    entry = sprintf("%v:%v: %v", currentTargetFile, lineNo, lineContent)
-
-    displayCount = count - offsetResultCount
-    if displayCount <= maxIPCLogCount {
-        yakit.Info("  %v", entry)
-    }
-}
-
 // output uses in-memory rawContent ([]byte) to extract context,
 // avoiding per-match file I/O and excessive yakit.File IPC calls.
-output = (targetFile, offset, offsetEnd, rawContent) => {
+output = (targetFile, offset, offsetEnd, rawContent, matchedText, lineNo) => {
     m.Lock()
     defer m.Unlock()
     count++
@@ -372,23 +338,25 @@ output = (targetFile, offset, offsetEnd, rawContent) => {
         return
     }
 
-    displayCount = count - offsetResultCount
-
-    // Compute line number from byte offset for human-readable output
     rawStr = string(rawContent)
-    lineNo = countLineNumber(rawStr, offset)
 
-    // Build match info string: "filepath:lineNo: matched line content"
-    lineContent = extractLine(rawStr, offset)
-    var msg
-    msg = "%v:%v: %v" % [targetFile, lineNo, lineContent]
-
-    // Only log first N matches via yakit.Info to avoid IPC flood
-    if displayCount <= maxIPCLogCount {
-        yakit.Info(msg)
-    } else if displayCount == maxIPCLogCount + 1 {
-        yakit.Info("... (suppressing per-match IPC logs for remaining matches, results still collected)")
+    // Build match info string: "filepath:lineNo: matched text" (grep -oE style).
+    // Regexp offsets are byte offsets; slice rawContent instead of string content
+    // so non-ASCII text earlier in the file cannot shift the matched snippet.
+    if matchedText == "" {
+        if offset < 0 {
+            offset = 0
+        }
+        if offsetEnd > len(rawContent) {
+            offsetEnd = len(rawContent)
+        }
+        if offsetEnd <= offset {
+            return
+        }
+        matchedText = string(rawContent[offset:offsetEnd])
     }
+    var msg
+    msg = "%v:%v: %v" % [targetFile, lineNo, matchedText]
 
     if contextBuffer > 0 && len(rawContent) > 0 {
         seekStart = offset - contextBuffer
@@ -407,19 +375,33 @@ output = (targetFile, offset, offsetEnd, rawContent) => {
             contentStr := string(raw)
             // Prefix context snippet with file:line for orientation
             contextEntry = sprintf("%v:%v: ...%v...", targetFile, lineNo, str.TrimSpace(contentStr))
-            if displayCount <= maxIPCLogCount {
-                yakit.Info("  context: %v", contextEntry)
-            }
             findRes = append(findRes, contextEntry)
         }
         return
     }
 
-    // contextBuffer == 0: collect the matching line itself into findRes so that
-    // the println summary at the end of the script contains actual match content.
+    // contextBuffer == 0: collect only the matched text so bundled/minified files
+    // with many matches on one line behave like grep -oE instead of returning a huge line.
     // Without this, findRes stays empty and the AI tool framework receives an
     // uninformative "matches were found but no context text was collected" message.
     findRes = append(findRes, msg)
+}
+
+outputPlainMatch = (targetFile, lineNo, matchedText) => {
+    m.Lock()
+    defer m.Unlock()
+    count++
+
+    if count <= offsetResultCount {
+        return
+    }
+
+    if count > (maxResult + offsetResultCount) {
+        end = true
+        return
+    }
+
+    findRes = append(findRes, "%v:%v: %v" % [targetFile, lineNo, matchedText])
 }
 
 isRegexp = str.ToLower(matchMode) in ["regexp", "re", "regex", ""]
@@ -445,39 +427,65 @@ tryCompileRegexp = (subpattern) => {
     return re.Compile(subp)~, true
 }
 
-scanMatches = (patternRe, targetFile, content, rawContent) => {
-    searchBase = 0
-    for {
+scanMatchesTextOnly = (patternRe, targetFile, content) => {
+    findLimit = maxResult + offsetResultCount + 1
+    lineNo = 1
+    for lineContent in str.Split(content, "\n") {
         if end { return }
-        if searchBase >= len(content) {
+        remainLimit = findLimit - count
+        if remainLimit <= 0 {
             return
         }
-
-        current = content[searchBase:]
-        match = patternRe.FindStringIndex(current)
-        if match == nil || len(match) < 2 {
-            return
+        matches = patternRe.FindAllString(lineContent, remainLimit)
+        if matches != nil {
+            for matchedText in matches {
+                if end { return }
+                outputPlainMatch(targetFile, lineNo, matchedText)
+            }
         }
-
-        start = searchBase + match[0]
-        finish = searchBase + match[1]
-        output(targetFile, start, finish, rawContent)
-        collectMatchPreview(start, finish)
-        if end { return }
-
-        // Skip to the start of the next line (bash grep reports each line at most once)
-        nextBase = finish
-        for nextBase < len(content) && content[nextBase] != '\n' {
-            nextBase++
-        }
-        if nextBase < len(content) {
-            nextBase++
-        }
-        if nextBase <= searchBase {
-            nextBase = searchBase + 1
-        }
-        searchBase = nextBase
+        lineNo++
     }
+}
+
+scanMatchesWithContext = (patternRe, targetFile, content, rawContent) => {
+    findLimit = maxResult + offsetResultCount + 1
+    allMatches = patternRe.FindAllStringIndex(content, findLimit)
+    if allMatches == nil {
+        return
+    }
+    lineNo = 1
+    lineScanOffset = 0
+
+    for i := 0; i < len(allMatches); i++ {
+        if end { return }
+        match = allMatches[i]
+        if match == nil || len(match) < 2 { continue }
+
+        start = match[0]
+        finish = match[1]
+        if finish > start {
+            if start < lineScanOffset {
+                lineNo = 1
+                lineScanOffset = 0
+            } else {
+                for lineScanOffset < start && lineScanOffset < len(rawContent) {
+                    if rawContent[lineScanOffset] == '\n' {
+                        lineNo++
+                    }
+                    lineScanOffset++
+                }
+            }
+            output(targetFile, start, finish, rawContent, "", lineNo)
+        }
+    }
+}
+
+scanMatches = (patternRe, targetFile, content, rawContent) => {
+    if contextBuffer <= 0 {
+        scanMatchesTextOnly(patternRe, targetFile, content)
+        return
+    }
+    scanMatchesWithContext(patternRe, targetFile, content, rawContent)
 }
 
 handleRegexp = (subpattern, targetFile, content, rawContent) => {
@@ -650,6 +658,9 @@ for currentPath in validPaths {
 // Maximum results to output via stdout and yakit.Info summary
 // AI tool framework captures stdout as the tool result; keep it reasonable.
 maxStdoutResults = 100
+if !filesOnlyMode && contextBuffer <= 0 {
+    maxStdoutResults = 500
+}
 
 if filesOnlyMode {
     // ── files_with_matches mode output ──
@@ -698,15 +709,16 @@ if filesOnlyMode {
     // ── content mode output (original behavior) ──
     // print findRes summary to yakit.Info (batched, not per-match)
     if len(findRes) > 0 {
-        yakit.Info("=== Grep Results Summary: %d matches ===", len(findRes))
         showCount = min(len(findRes), maxStdoutResults)
+        summaryText = sprintf("=== Grep Results Summary: %d matches ===", len(findRes))
         for i := 0; i < showCount; i++ {
-            yakit.Info("[match %d] %s", i+1, findRes[i])
+            summaryText += sprintf("\n[match %d] %s", i+1, findRes[i])
         }
         if len(findRes) > maxStdoutResults {
-            yakit.Info("... (%d more matches not shown)", len(findRes) - maxStdoutResults)
+            summaryText += sprintf("\n... (%d more matches not shown)", len(findRes) - maxStdoutResults)
         }
-        yakit.Info("=== End of Grep Results ===")
+        summaryText += "\n=== End of Grep Results ==="
+        yakit.Info("%s", summaryText)
 
         // Write results to stdout (captured by AI tool framework)
         // Cap output to maxStdoutResults to keep tool result size manageable

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
@@ -355,7 +355,7 @@ commandRuns = (cmdline)=>{
 detectBashPath = ()=>{
     candidates := []
 
-    if commandRuns("bash --version") {
+    if osType != "windows" && commandRuns("bash --version") {
         return "bash"
     }
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
@@ -1,4 +1,4 @@
-__DESC__ = "跨平台Shell命令执行工具，支持bash/cmd/powershell，具备超时控制和输出捕获。bash 与 powershell 脚本默认都不启用命令追踪，不默认回显执行中的命令，适用于系统管理、自动化脚本和运维操作。"
+__DESC__ = "跨平台Shell命令执行工具，支持bash/cmd/powershell，具备超时控制和输出捕获。bash 默认以登录 shell 执行以加载系统和用户 profile 中的 PATH/环境变量，不额外启用 set -e 或命令追踪，行为更接近原生终端执行。"
 __VERBOSE_NAME__ = "跨平台Shell命令执行工具"
 __KEYWORDS__ = "shell command,bash,cmd,powershell,命令行工具,系统管理,自动化脚本,运维工具,shell script,command execution,系统操作,终端命令,system administration,automation tools,操作系统,跨平台命令,timeout,超时控制,python script,pandas,data analysis,excel analysis,csv cache,data cache,批量分析"
 
@@ -23,13 +23,19 @@ Optional:
                         - Network commands (curl, wget, ping -c N): 30-60
                         - Build/compile/install (make, go build, pip install): 120-300
   shell     (string)  Shell type: "bash" | "cmd" | "powershell"
-                      Default: auto-detect (linux/mac -> bash, windows -> cmd)
+                      Default: auto-detect (linux/mac -> bash,
+                      windows -> bash if Git Bash/MSYS/Cygwin bash exists,
+                      otherwise powershell/cmd)
 
 ## Execution Characteristics
 
-bash:  set -e (exit on error), does not enable command trace by default
-cmd:   executes via "cmd /c", backslashes MUST be escaped: "C:\\Users"
-powershell: $ErrorActionPreference="Stop", does not enable trace by default
+bash:  executes a temporary script via "bash --login <script>" so /etc/profile
+       and user bash profile files can populate default PATH/environment.
+       It does not force set -e or command tracing.
+cmd:   executes via "cmd.exe /d /s /c <command>", backslashes MUST be escaped:
+       "C:\\Users"
+powershell: executes a temporary script via PowerShell with normal profile loading;
+            it does not force $ErrorActionPreference or command tracing.
 
 ## Safety Rules
 
@@ -306,28 +312,141 @@ Get-Service |
 8. ** DATA CACHING ** -- When analyzing large data files (Excel > 10MB), save a CSV cache
    after the first read. Subsequent scripts should check for and use the cache.
    Save analysis results to JSON files so downstream tasks can reuse them.
-9. ** WINDOWS TARGETS ** -- Set shell explicitly to "cmd" or "powershell" when generating
-   Windows commands. This avoids mixing Bash syntax with Windows command syntax.
+9. ** WINDOWS TARGETS ** -- The tool prefers bash on Windows when Git Bash/MSYS/Cygwin
+   bash is available. Set shell explicitly to "cmd" or "powershell" when generating
+   Windows-native commands. This avoids mixing Bash syntax with Windows command syntax.
 USAGE_BLOCK
 
 yakit.AutoInitYakit()
 
 // 解析命令行参数：超时时间、shell类型和要执行的命令
 timeoutSeconds := cli.Int("timeout", cli.setRequired(false), cli.setHelp("the timeout seconds for the shell command, default 60. Commands exceeding this timeout will be killed. Set a reasonable value to avoid hanging. IMPORTANT: Avoid indefinite commands like 'tail -f', 'ping' without -c, 'watch', etc."), cli.setDefault(60))
-shellType := cli.String("shell", cli.setRequired(false), cli.setHelp("shell type: bash, cmd, powershell. Auto-detect if not specified (linux/mac: bash, windows: cmd)"), cli.setDefault(""))
+shellType := cli.String("shell", cli.setRequired(false), cli.setHelp("shell type: bash, cmd, powershell. Auto-detect if not specified (linux/mac: bash, windows: bash if available, otherwise powershell/cmd)"), cli.setDefault(""))
 command := cli.String("command", cli.setRequired(true), cli.setHelp("the shell command you want to execute. IMPORTANT: Avoid commands that run indefinitely (e.g., tail -f, ping without -c, watch). For potentially long-running commands, use timeout wrapper or add limits."))
 
 cli.check()
 
 // 获取操作系统类型
 osType = os.OS
+shellType = str.ToLower(str.TrimSpace(shellType))
+
+// exec.CommandContext in Yak accepts a single command line and splits it with shlex.
+// Quote every dynamic argument so paths with spaces and user commands stay intact.
+quoteForExec = (s)=>{
+    if s == "" {
+        return "''"
+    }
+    return "'" + str.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+commandRuns = (cmdline)=>{
+    probeCtx, probeCancel := context.WithTimeout(context.Background(), time.ParseDuration("3s")~)
+    defer probeCancel()
+
+    probeCmd, probeErr := exec.CommandContext(probeCtx, cmdline)
+    if probeErr != nil {
+        return false
+    }
+
+    probeErr = probeCmd.Run()
+    return probeErr == nil
+}
+
+detectBashPath = ()=>{
+    candidates := []
+
+    if commandRuns("bash --version") {
+        return "bash"
+    }
+
+    if osType == "windows" {
+        programFiles := os.Getenv("ProgramFiles")
+        programFilesX86 := os.Getenv("ProgramFiles(x86)")
+        localAppData := os.Getenv("LOCALAPPDATA")
+        userProfile := os.Getenv("USERPROFILE")
+
+        if programFiles != "" {
+            candidates = append(candidates, file.Join(programFiles, "Git", "bin", "bash.exe"))
+            candidates = append(candidates, file.Join(programFiles, "Git", "usr", "bin", "bash.exe"))
+        }
+        if programFilesX86 != "" {
+            candidates = append(candidates, file.Join(programFilesX86, "Git", "bin", "bash.exe"))
+            candidates = append(candidates, file.Join(programFilesX86, "Git", "usr", "bin", "bash.exe"))
+        }
+        if localAppData != "" {
+            candidates = append(candidates, file.Join(localAppData, "Programs", "Git", "bin", "bash.exe"))
+            candidates = append(candidates, file.Join(localAppData, "Programs", "Git", "usr", "bin", "bash.exe"))
+        }
+        if userProfile != "" {
+            candidates = append(candidates, file.Join(userProfile, "scoop", "apps", "git", "current", "bin", "bash.exe"))
+            candidates = append(candidates, file.Join(userProfile, "scoop", "apps", "git", "current", "usr", "bin", "bash.exe"))
+        }
+
+        candidates = append(candidates, `C:\msys64\usr\bin\bash.exe`)
+        candidates = append(candidates, `C:\msys64\mingw64\bin\bash.exe`)
+        candidates = append(candidates, `C:\cygwin64\bin\bash.exe`)
+    } else {
+        candidates = append(candidates, "/bin/bash")
+        candidates = append(candidates, "/usr/bin/bash")
+        candidates = append(candidates, "/usr/local/bin/bash")
+        candidates = append(candidates, "/opt/homebrew/bin/bash")
+    }
+
+    for _, candidate := range candidates {
+        if candidate != "" && file.IsExisted(candidate) {
+            return candidate
+        }
+    }
+
+    return ""
+}
+
+detectPowerShellPath = ()=>{
+    if commandRuns("pwsh -Version") {
+        return "pwsh"
+    }
+    if commandRuns("powershell.exe -Version") {
+        return "powershell.exe"
+    }
+    if commandRuns("powershell -Version") {
+        return "powershell"
+    }
+    return ""
+}
+
+bashPath := ""
+powershellPath := ""
+
+switch shellType {
+case "bash.exe":
+    shellType = "bash"
+case "cmd.exe":
+    shellType = "cmd"
+case "ps", "pwsh", "powershell.exe":
+    if shellType == "pwsh" {
+        powershellPath = "pwsh"
+    }
+    shellType = "powershell"
+}
 
 // 根据系统类型和用户设置确定shell类型
 if shellType == "" {
     switch osType {
     case "windows":
-        shellType = "cmd"
-        yakit.Info("Auto-detected Windows, using cmd shell")
+        bashPath = detectBashPath()
+        if bashPath != "" {
+            shellType = "bash"
+            yakit.Info("Auto-detected Windows, using bash shell: %v", bashPath)
+        } else {
+            powershellPath = detectPowerShellPath()
+            if powershellPath != "" {
+                shellType = "powershell"
+                yakit.Info("Auto-detected Windows, bash not found, using PowerShell: %v", powershellPath)
+            } else {
+                shellType = "cmd"
+                yakit.Info("Auto-detected Windows, bash/PowerShell not found, using cmd shell")
+            }
+        }
     case "linux", "darwin":
         shellType = "bash"
         yakit.Info("Auto-detected %v, using bash shell", osType)
@@ -356,15 +475,19 @@ var scriptFile = ""
 
 switch shellType {
 case "bash":
-    // Generate a temporary script file with proper bash settings
-    // - set -e: Exit immediately if a command exits with a non-zero status
-    // Keep command tracing disabled by default to avoid noisy stderr output.
-    // This approach avoids quoting/escaping issues while keeping output concise.
+    if bashPath == "" {
+        bashPath = detectBashPath()
+    }
+    if bashPath == "" {
+        yakit.Error("bash shell not found. Install bash or set shell to cmd/powershell on Windows.")
+        return
+    }
     
-    scriptContent := `#!/bin/bash
+    // Generate a temporary script file and run it through a login bash.
+    // This avoids quoting issues while letting profile files populate PATH/env.
+    scriptContent := `#!/usr/bin/env bash
 # Auto-generated script by AI tool
-# Exit on error (prevents catastrophic cascading failures)
-set -e
+# Runs under bash --login; no extra set -e or command tracing is enabled.
 
 # User command starts here
 ` + command + `
@@ -400,22 +523,35 @@ set -e
         yakit.Info("Note: Failed to chmod script file: %v (continuing anyway)", chmodErr)
     }
     
-    yakit.Info("Executing bash script with %d seconds timeout", timeoutSeconds)
+    yakit.Info("Executing bash login shell with %d seconds timeout", timeoutSeconds)
+    yakit.Info("Bash binary: %v", bashPath)
     yakit.Info("Script file: %v", scriptFile)
     
-    // Execute the script using bash
-    cmd, err = exec.CommandContext(ctx, "bash " + scriptFile)
+    // Execute the script using login bash so /etc/profile and user bash profile files load.
+    bashScriptFile := scriptFile
+    if osType == "windows" {
+        // Git Bash/MSYS/Cygwin handle forward-slash Windows paths more reliably.
+        bashScriptFile = str.ReplaceAll(scriptFile, "\\", "/")
+    }
+    cmd, err = exec.CommandContext(ctx, quoteForExec(bashPath) + " --login " + quoteForExec(bashScriptFile))
     
 case "cmd":
-    // For Windows cmd, use direct command execution
+    // For Windows cmd, pass the whole user command as one /c argument.
     yakit.Info("Executing cmd command with %d seconds timeout: %v", timeoutSeconds, command)
-    cmd, err = exec.CommandContext(ctx, "cmd /c " + command)
+    cmd, err = exec.CommandContext(ctx, "cmd.exe /d /s /c " + quoteForExec(command))
     
 case "powershell":
-    // For PowerShell, create a temporary script file as well
+    if powershellPath == "" {
+        powershellPath = detectPowerShellPath()
+    }
+    if powershellPath == "" {
+        yakit.Error("PowerShell shell not found.")
+        return
+    }
+
+    // For PowerShell, create a temporary script file as well.
     scriptContent := `# Auto-generated PowerShell script by AI tool
-# Stop on first error
-$ErrorActionPreference = "Stop"
+# Runs with normal PowerShell profile loading; no extra tracing or ErrorActionPreference is forced.
 
 # User command starts here
 ` + command + `
@@ -443,9 +579,10 @@ $ErrorActionPreference = "Stop"
     }
     
     yakit.Info("Executing PowerShell script with %d seconds timeout", timeoutSeconds)
+    yakit.Info("PowerShell binary: %v", powershellPath)
     yakit.Info("Script file: %v", scriptFile)
     
-    cmd, err = exec.CommandContext(ctx, "powershell.exe -NoProfile -ExecutionPolicy Bypass -File " + scriptFile)
+    cmd, err = exec.CommandContext(ctx, quoteForExec(powershellPath) + " -NoLogo -ExecutionPolicy Bypass -File " + quoteForExec(scriptFile))
     
 default:
     yakit.Error("Unsupported shell type: %v. Supported types: bash, cmd, powershell", shellType)
@@ -455,43 +592,6 @@ default:
 if err != nil {
     yakit.Error("Failed to create %v command: %v", shellType, err)
     return
-}
-
-// 创建输出缓冲区以捕获命令结果
-stdoutbuf = bufio.NewBuffer()
-stderrbuf = bufio.NewBuffer()
-cmd.Stdout = stdoutbuf
-cmd.Stderr = stderrbuf
-
-// 执行命令并处理结果
-startTime = time.Now()
-err = cmd.Run()
-elapsed = time.Since(startTime)
-elapsedSec = int(elapsed.Seconds())
-isTimeout = false
-exitCode = 0
-
-if err != nil {
-    errStr = sprint(err)
-    // 检查是否是超时导致的错误（通过错误信息判断）
-    if str.Contains(errStr, "killed") || str.Contains(errStr, "signal: killed") || str.Contains(errStr, "context deadline exceeded") {
-        isTimeout = true
-        yakit.Info("COMMAND TIMEOUT: The command was killed after %d seconds timeout. The command may be running too long or hanging indefinitely.", timeoutSeconds)
-        yakit.Info("SUGGESTION: For long-running commands, consider using 'timeout' command wrapper (e.g., 'timeout 30 your_command'), or add limits to your command (e.g., 'ping -c 5' instead of 'ping').")
-    } else {
-        // Extract exit code if available
-        if str.Contains(errStr, "exit status") {
-            // Parse exit code from error message like "exit status 1"
-            parts = str.Split(errStr, " ")
-            if len(parts) >= 3 {
-                exitCode = parseInt(parts[len(parts)-1])
-            }
-        }
-        yakit.Error("%v command execution failed (exit code %d): %v", shellType, exitCode, err)
-        if shellType == "bash" {
-            yakit.Info("TIP: Bash uses 'set -e' by default, so the script exits on the first failing command.")
-        }
-    }
 }
 
 // Platform-aware output encoding conversion:
@@ -517,17 +617,89 @@ toUtf8 = (s)=>{
     return codec.FixUTF8(s)
 }
 
-// 输出执行结果
-count := 0
-if stdoutbuf.Len() > 0 {
-    count++
-    yakit.Info("Stdout:\n%v", toUtf8(stdoutbuf.String()))
+// 创建输出缓冲区以捕获命令结果
+stdoutbuf = bufio.NewBuffer()
+stderrbuf = bufio.NewBuffer()
+stdoutPipe, stdoutPipeErr := cmd.StdoutPipe()
+if stdoutPipeErr != nil {
+    yakit.Error("Failed to create stdout pipe: %v", stdoutPipeErr)
+    return
 }
-if stderrbuf.Len() > 0 {
-    count++
-    yakit.Info("Stderr:\n%v", toUtf8(stderrbuf.String()))
+stderrPipe, stderrPipeErr := cmd.StderrPipe()
+if stderrPipeErr != nil {
+    yakit.Error("Failed to create stderr pipe: %v", stderrPipeErr)
+    return
 }
-if count <= 0 {
+
+streamWg := sync.NewWaitGroup()
+streamWg.Add(2)
+stdoutStreamLen := 0
+stderrStreamLen := 0
+
+go func() {
+    defer streamWg.Done()
+    io.ReadEvery1s(context.Background(), stdoutPipe, func(raw) {
+        rawLen := len(raw)
+        if rawLen <= stdoutStreamLen {
+            return true
+        }
+        delta := raw[stdoutStreamLen:]
+        stdoutStreamLen = rawLen
+        stdoutbuf.Write(delta)
+        yakit.Info("Stdout(stream):\n%v", toUtf8(string(delta)))
+        return true
+    })
+}()
+
+go func() {
+    defer streamWg.Done()
+    io.ReadEvery1s(context.Background(), stderrPipe, func(raw) {
+        rawLen := len(raw)
+        if rawLen <= stderrStreamLen {
+            return true
+        }
+        delta := raw[stderrStreamLen:]
+        stderrStreamLen = rawLen
+        stderrbuf.Write(delta)
+        yakit.Info("Stderr(stream):\n%v", toUtf8(string(delta)))
+        return true
+    })
+}()
+
+// 执行命令并处理结果
+startTime = time.Now()
+err = cmd.Run()
+streamWg.Wait()
+elapsed = time.Since(startTime)
+elapsedSec = int(elapsed.Seconds())
+isTimeout = false
+exitCode = 0
+
+if err != nil {
+    errStr = sprint(err)
+    // 检查是否是超时导致的错误（通过错误信息判断）
+    if str.Contains(errStr, "killed") || str.Contains(errStr, "signal: killed") || str.Contains(errStr, "context deadline exceeded") {
+        isTimeout = true
+        yakit.Info("COMMAND TIMEOUT: The command was killed after %d seconds timeout. The command may be running too long or hanging indefinitely.", timeoutSeconds)
+        yakit.Info("SUGGESTION: For long-running commands, consider using 'timeout' command wrapper (e.g., 'timeout 30 your_command'), or add limits to your command (e.g., 'ping -c 5' instead of 'ping').")
+    } else {
+        // Extract exit code if available
+        if str.Contains(errStr, "exit status") {
+            // Parse exit code from error message like "exit status 1"
+            parts = str.Split(errStr, " ")
+            if len(parts) >= 3 {
+                exitCode = parseInt(parts[len(parts)-1])
+            }
+        }
+        yakit.Error("%v command execution failed (exit code %d): %v", shellType, exitCode, err)
+        if shellType == "bash" {
+            yakit.Info("TIP: Bash is executed as a login shell. If PATH/env differs from your terminal, check /etc/profile and your bash profile files.")
+        }
+    }
+}
+
+// 输出已经在执行过程中实时流式打印；这里仅处理无输出场景。
+if stdoutbuf.Len() <= 0 && stderrbuf.Len() <= 0 {
     if isTimeout {
         yakit.Info("No output captured before timeout")
     } else {

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "533895adcf65bf6f02d445fe7dcc7992f
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "0e61191b67baae5ac53b3c6fb1d485e379060fce0ac9341336d6809c4e13da27"
+const ExistedBuildInAIToolEmbedFSHash string = "41940f64c6e5993892dd30e1ec059f95b0f710961fe8bbe0a4a25187e4b159d3"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "533895adcf65bf6f02d445fe7dcc7992f
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "e6ab480fbac853033439578791ad40639f77b4ed4df828fdeb561a40ce6d0f71"
+const ExistedBuildInAIToolEmbedFSHash string = "0e61191b67baae5ac53b3c6fb1d485e379060fce0ac9341336d6809c4e13da27"


### PR DESCRIPTION
## Summary
- Run the bash tool through a login bash shell so default profile PATH/environment is loaded.
- Prefer bash on Windows when Git Bash/MSYS/Cygwin is available, with PowerShell/CMD fallback.
- Stream stdout/stderr while commands run instead of buffering all output until completion.

## Test plan
- `yak common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak --command 'if shopt -q login_shell; then echo login_shell=yes; else echo login_shell=no; fi; false; echo after_false; printf "quoted=<%s>\n" "a b"; echo 中文UTF8' --timeout 10`
- `yak common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak --command 'for i in 1 2 3; do echo stream_$i; sleep 1; done; echo stream_done' --timeout 10`
- `yak common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak --command 'for i in 1 2; do echo out_$i; echo err_$i >&2; sleep 1; done' --timeout 10`
- `yak common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak --command 'echo before_timeout; sleep 3; echo after_timeout' --timeout 1`
- `ReadLints` on `common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak`

Made with [Cursor](https://cursor.com)