### PR TITLE
fix(yak2ssa): skip unhandled-error when multi-value call is only return 

### DIFF
--- a/common/yak/ssa4analyze/type_check.go
+++ b/common/yak/ssa4analyze/type_check.go
@@ -467,6 +467,11 @@ func (t *TypeCheck) TypeCheckCall(c *ssa.Call) {
 		if !c.Unpack {
 			if hasError {
 				hasError := true
+				// return call(...) propagates the full multi-value result (including error)
+				// to the caller; check error handling at call sites of this function instead.
+				if callReturnsErrorToCaller(c) {
+					hasError = false
+				}
 				for key := range c.GetAllMember() {
 					if c, ok := ssa.ToConstInst(key); ok {
 						if c.IsNumber() {
@@ -496,4 +501,19 @@ func (t *TypeCheck) TypeCheckCall(c *ssa.Call) {
 			return
 		}
 	}
+}
+
+// callReturnsErrorToCaller is true when every use of c is a return that passes the
+// full call result (including a trailing error) to the enclosing function's caller.
+func callReturnsErrorToCaller(c *ssa.Call) bool {
+	users := c.GetUsers()
+	if len(users) == 0 {
+		return false
+	}
+	for _, user := range users {
+		if _, ok := ssa.ToReturn(user); !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/common/yak/yak2ssa/test/error_propagation_test.go
+++ b/common/yak/yak2ssa/test/error_propagation_test.go
@@ -1,0 +1,117 @@
+package test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/yak/ssa4analyze"
+	test "github.com/yaklang/yaklang/common/yak/ssaapi/test/ssatest"
+)
+
+func TestErrorPropagationViaReturn(t *testing.T) {
+	t.Run("wrapper returns single error - no report inside wrapper", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			getError = func() {
+				return getError1()
+			}
+			`,
+			Want: []string{},
+			ExternValue: map[string]any{
+				"getError1": func() error { return errors.New("err") },
+			},
+		})
+	})
+
+	t.Run("caller discards wrapper return - no report", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			getError = func() {
+				return getError1()
+			}
+			getError()
+			`,
+			Want: []string{},
+			ExternValue: map[string]any{
+				"getError1": func() error { return errors.New("err") },
+			},
+		})
+	})
+
+	t.Run("caller assigns wrapper error without handling", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			getError = func() {
+				return getError1()
+			}
+			err = getError()
+			`,
+			Want: []string{
+				ssa4analyze.ErrorUnhandled(),
+			},
+			ExternValue: map[string]any{
+				"getError1": func() error { return errors.New("err") },
+			},
+		})
+	})
+
+	t.Run("closure returns multi-value with error - no report inside wrapper", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			wrapHTTP = func() {
+				return getError2()
+			}
+			`,
+			Want: []string{},
+			ExternValue: map[string]any{
+				"getError2": func() (int, error) { return 1, errors.New("err") },
+			},
+		})
+	})
+
+	t.Run("closure like sendPacket0 returns mockHTTP - no report inside", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			sendPacket0 = func(target, payload) {
+				return mockHTTP(target, payload)
+			}
+			`,
+			Want: []string{},
+			ExternValue: map[string]any{
+				"mockHTTP": func(any, any) (any, error) { return nil, errors.New("err") },
+			},
+		})
+	})
+
+	t.Run("caller assigns multi-value from wrapper without handling err", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			sendPacket0 = func(target, payload) {
+				return mockHTTP(target, payload)
+			}
+			rsp, err = sendPacket0("a", "b")
+			`,
+			Want: []string{
+				ssa4analyze.ErrorUnhandled(),
+			},
+			ExternValue: map[string]any{
+				"mockHTTP": func(any, any) (any, error) { return nil, errors.New("err") },
+			},
+		})
+	})
+
+	t.Run("nested call without return still reports", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			other(getError2())
+			`,
+			Want: []string{
+				ssa4analyze.ErrorUnhandledWithType("number, error"),
+			},
+			ExternValue: map[string]any{
+				"getError2": func() (int, error) { return 1, errors.New("err") },
+				"other":     func(any) {},
+			},
+		})
+	})
+}

--- a/common/yak/yak2ssa/test/error_propagation_test.go
+++ b/common/yak/yak2ssa/test/error_propagation_test.go
@@ -8,95 +8,110 @@ import (
 	test "github.com/yaklang/yaklang/common/yak/ssaapi/test/ssatest"
 )
 
+func getError2Extern() map[string]any {
+	return map[string]any{
+		"getError2": func() (int, error) { return 1, errors.New("err") },
+	}
+}
+
 func TestErrorPropagationViaReturn(t *testing.T) {
-	t.Run("wrapper returns single error - no report inside wrapper", func(t *testing.T) {
-		test.CheckError(t, test.TestCase{
-			Code: `
-			getError = func() {
-				return getError1()
-			}
-			`,
-			Want: []string{},
-			ExternValue: map[string]any{
-				"getError1": func() error { return errors.New("err") },
-			},
-		})
-	})
+	ext2 := getError2Extern()
 
-	t.Run("caller discards wrapper return - no report", func(t *testing.T) {
+	t.Run("direct return passes multi-value to caller", func(t *testing.T) {
 		test.CheckError(t, test.TestCase{
 			Code: `
-			getError = func() {
-				return getError1()
-			}
-			getError()
-			`,
-			Want: []string{},
-			ExternValue: map[string]any{
-				"getError1": func() error { return errors.New("err") },
-			},
-		})
-	})
-
-	t.Run("caller assigns wrapper error without handling", func(t *testing.T) {
-		test.CheckError(t, test.TestCase{
-			Code: `
-			getError = func() {
-				return getError1()
-			}
-			err = getError()
-			`,
-			Want: []string{
-				ssa4analyze.ErrorUnhandled(),
-			},
-			ExternValue: map[string]any{
-				"getError1": func() error { return errors.New("err") },
-			},
-		})
-	})
-
-	t.Run("closure returns multi-value with error - no report inside wrapper", func(t *testing.T) {
-		test.CheckError(t, test.TestCase{
-			Code: `
-			wrapHTTP = func() {
+			wrap = func() {
 				return getError2()
 			}
 			`,
-			Want: []string{},
-			ExternValue: map[string]any{
-				"getError2": func() (int, error) { return 1, errors.New("err") },
-			},
+			Want:        []string{},
+			ExternValue: ext2,
 		})
 	})
 
-	t.Run("closure like sendPacket0 returns mockHTTP - no report inside", func(t *testing.T) {
+	t.Run("unpack then return both values propagates error", func(t *testing.T) {
 		test.CheckError(t, test.TestCase{
 			Code: `
-			sendPacket0 = func(target, payload) {
-				return mockHTTP(target, payload)
+			wrap = func() {
+				a, e = getError2()
+				return a, e
 			}
 			`,
-			Want: []string{},
-			ExternValue: map[string]any{
-				"mockHTTP": func(any, any) (any, error) { return nil, errors.New("err") },
-			},
+			Want:        []string{},
+			ExternValue: ext2,
 		})
 	})
 
-	t.Run("caller assigns multi-value from wrapper without handling err", func(t *testing.T) {
+	t.Run("unpack then return error only propagates error", func(t *testing.T) {
 		test.CheckError(t, test.TestCase{
 			Code: `
-			sendPacket0 = func(target, payload) {
-				return mockHTTP(target, payload)
+			wrap = func() {
+				a, e = getError2()
+				return e
 			}
-			rsp, err = sendPacket0("a", "b")
+			`,
+			Want:        []string{},
+			ExternValue: ext2,
+		})
+	})
+
+	t.Run("unpack then return value only drops error", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			wrap = func() {
+				a, e = getError2()
+				return a
+			}
 			`,
 			Want: []string{
 				ssa4analyze.ErrorUnhandled(),
 			},
-			ExternValue: map[string]any{
-				"mockHTTP": func(any, any) (any, error) { return nil, errors.New("err") },
+			ExternValue: ext2,
+		})
+	})
+
+	t.Run("unpack handle error then return", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			wrap = func() {
+				a, e = getError2()
+				if e != nil {
+					return 0, e
+				}
+				return a, nil
+			}
+			`,
+			Want:        []string{},
+			ExternValue: ext2,
+		})
+	})
+
+	t.Run("unpack without return reports inside function", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			wrap = func() {
+				a, e = getError2()
+			}
+			`,
+			Want: []string{
+				ssa4analyze.ErrorUnhandled(),
 			},
+			ExternValue: ext2,
+		})
+	})
+
+	t.Run("caller assigns from wrapper without handling err", func(t *testing.T) {
+		test.CheckError(t, test.TestCase{
+			Code: `
+			wrap = func() {
+				return getError2()
+			}
+			_, err = wrap()
+			`,
+			Want: []string{
+				ssa4analyze.ErrorUnhandled(),
+			},
+			ExternValue: ext2,
 		})
 	})
 


### PR DESCRIPTION


When a call returning (T, error) is used solely by return, propagate the error to callers instead of reporting inside the wrapper function.