### PR TITLE
feat(yakgrpc): persist wire HTTP response for History bare view

### DIFF
--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -64,6 +64,9 @@ func SaveLowHTTPFlow(r *lowhttp.LowhttpResponse, forceSaveFlowSync bool) {
 	reqIns = r.RequestInstance
 
 	wireRsp, displayRsp, keepWire := lowhttpResponsePackets(r)
+	if r.TooLarge {
+		displayRsp = rsp
+	}
 	saveOpts := []CreateHTTPFlowOptions{
 		CreateHTTPFlowWithRequestIns(reqIns),
 		CreateHTTPFlowWithTags(strings.Join(r.Tags, "|")),

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -63,18 +63,28 @@ func SaveLowHTTPFlow(r *lowhttp.LowhttpResponse, forceSaveFlowSync bool) {
 	}
 	reqIns = r.RequestInstance
 
-	// db := consts.GetGormProjectDatabase()
-	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
-		https,
-		req,
-		rsp,
-		"scan",
-		url,
-		remoteAddr,
+	wireRsp, displayRsp, keepWire := lowhttpResponsePackets(r)
+	saveOpts := []CreateHTTPFlowOptions{
 		CreateHTTPFlowWithRequestIns(reqIns),
 		CreateHTTPFlowWithTags(strings.Join(r.Tags, "|")),
 		CreateHTTPFlowWithDuration(duration),
 		CreateHTTPFlowWithAfterSave(r.AfterSaveHTTPFlowHandler...),
+		CreateHTTPFlowWithResponseRaw(displayRsp),
+	}
+	if len(wireRsp) > 0 {
+		saveOpts = append(saveOpts, CreateHTTPFlowWithBareResponseRaw(wireRsp))
+	}
+	if keepWire {
+		saveOpts = append(saveOpts, CreateHTTPFlowWithNoFixContentLength(true))
+	}
+	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
+		https,
+		req,
+		displayRsp,
+		"scan",
+		url,
+		remoteAddr,
+		saveOpts...,
 	)
 	if err != nil {
 		log.Errorf("create httpflow from lowhttp failed: %s", err)
@@ -93,7 +103,9 @@ func SaveLowHTTPFlow(r *lowhttp.LowhttpResponse, forceSaveFlowSync bool) {
 	flow.RuntimeId = runtimeId
 	flow.HiddenIndex = hiddenIndex
 	flow.Payload = strings.Join(payloads, ",")
-	flow.Tags = strings.Join(tags, "|")
+	if len(tags) > 0 {
+		flow.AddTag(tags...)
+	}
 	err = InsertHTTPFlowEx(flow, forceSaveFlowSync)
 	if err != nil {
 		log.Errorf("insert httpflow failed: %s", err)
@@ -113,7 +125,9 @@ type CreateHTTPFlowConfig struct {
 	isHttps            bool
 	reqRaw             []byte
 	rspRaw             []byte
+	bareRspRaw         []byte // wire packet; sidecar KV when it differs from display response
 	fixRspRaw          []byte // 如果设置了，则不会再修复rspRaw
+	noFixContentLength bool   // keep wire in DB (NoFix / 不修复数据包)
 	source             string
 	url                string
 	remoteAddr         string
@@ -172,6 +186,20 @@ func CreateHTTPFlowWithRequestRaw(reqRaw []byte) CreateHTTPFlowOptions {
 func CreateHTTPFlowWithResponseRaw(rspRaw []byte) CreateHTTPFlowOptions {
 	return func(c *CreateHTTPFlowConfig) {
 		c.rspRaw = rspRaw
+	}
+}
+
+// CreateHTTPFlowWithBareResponseRaw sets wire-original response bytes (e.g. LowhttpResponse.BareResponse).
+func CreateHTTPFlowWithBareResponseRaw(bareRspRaw []byte) CreateHTTPFlowOptions {
+	return func(c *CreateHTTPFlowConfig) {
+		c.bareRspRaw = bareRspRaw
+	}
+}
+
+// CreateHTTPFlowWithNoFixContentLength keeps the wire response in DB (WebFuzzer「不修复数据包」).
+func CreateHTTPFlowWithNoFixContentLength(noFix bool) CreateHTTPFlowOptions {
+	return func(c *CreateHTTPFlowConfig) {
+		c.noFixContentLength = noFix
 	}
 }
 
@@ -296,11 +324,13 @@ func CreateHTTPFlow(opts ...CreateHTTPFlowOptions) (*schema.HTTPFlow, error) {
 	}
 
 	var (
-		isHttps            = c.isHttps
-		reqRaw             = c.reqRaw
-		rspRaw             = c.rspRaw
+		isHttps             = c.isHttps
+		reqRaw              = c.reqRaw
+		rspRaw              = c.rspRaw
+		bareRspRaw         = c.bareRspRaw
 		fixRspRaw          = c.fixRspRaw
-		source             = c.source
+		noFixContentLength = c.noFixContentLength
+		source              = c.source
 		url                = c.url
 		remoteAddr         = c.remoteAddr
 		reqIns             = c.reqIns
@@ -333,18 +363,12 @@ func CreateHTTPFlow(opts ...CreateHTTPFlowOptions) (*schema.HTTPFlow, error) {
 		log.Errorf("[BUG] requestRaw is invalid: %s", requestRaw)
 	}
 
-	// 如果已经修复过响应，则不会再修复
-	if len(fixRspRaw) == 0 {
-		rawNoGzip, _, _ := lowhttp.FixHTTPResponse(rspRaw)
-		if len(rawNoGzip) > 0 {
-			rspRaw = rawNoGzip
-		}
-	} else {
-		rspRaw = fixRspRaw
-	}
+	wireRsp := httpFlowWireResponse(bareRspRaw, rspRaw)
+	rspRaw = httpFlowDisplayResponse(wireRsp, rspRaw, fixRspRaw, noFixContentLength)
 	if rspRaw == nil {
 		rspRaw = make([]byte, 0)
 	}
+	storeBareWire := httpFlowShouldStoreBareWire(wireRsp, rspRaw, noFixContentLength)
 
 	var rspContentType string
 	rspRaw = truncateHTTPPacketBodyForStorage(rspRaw, maxStoredHTTPFlowResponseBodyBytes)
@@ -357,7 +381,12 @@ func CreateHTTPFlow(opts ...CreateHTTPFlowOptions) (*schema.HTTPFlow, error) {
 	_ = header
 	responseRaw := strconv.Quote(string(rspRaw))
 
+	if storeBareWire {
+		c.afterSaveHandlers = append(c.afterSaveHandlers, afterSaveHTTPFlowBareResponse(wireRsp))
+	}
+
 	flow := &schema.HTTPFlow{
+		NoFixContentLength:         noFixContentLength,
 		IsHTTPS:                    isHttps,
 		Url:                        url,
 		Path:                       requestUri,
@@ -378,6 +407,9 @@ func CreateHTTPFlow(opts ...CreateHTTPFlowOptions) (*schema.HTTPFlow, error) {
 		TooLargeResponseBodyFile:   tooLargeBodyFile,
 		TooLargeResponseHeaderFile: tooLargeHeaderFile,
 		FromPlugin:                 fromPlugin,
+	}
+	if storeBareWire {
+		flow.AddTagToFirst(HTTPFlowTagAutoFixResponse)
 	}
 	if len(c.afterSaveHandlers) > 0 {
 		flow.AfterSaveHandlers = append([]func(*schema.HTTPFlow){}, c.afterSaveHandlers...)
@@ -502,6 +534,12 @@ func createHTTPFlowFromHTTP(isHttps bool, req *http.Request, rsp *http.Response,
 	} else {
 		plainResponse = make([]byte, 0)
 	}
+
+	wireResponse := httpctx.GetBareResponseBytes(req)
+	if len(wireResponse) == 0 {
+		wireResponse = plainResponse
+	}
+	opts = append(opts, CreateHTTPFlowWithBareResponseRaw(wireResponse))
 
 	return CreateHTTPFlowFromHTTPWithBodySavedFromRaw(isHttps, plainRequest, plainResponse, source, urlRaw, remoteAddr, opts...)
 }

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -364,7 +364,7 @@ func CreateHTTPFlow(opts ...CreateHTTPFlowOptions) (*schema.HTTPFlow, error) {
 	}
 
 	wireRsp := httpFlowWireResponse(bareRspRaw, rspRaw)
-	rspRaw = httpFlowDisplayResponse(wireRsp, rspRaw, fixRspRaw, noFixContentLength)
+	rspRaw = resolveHTTPFlowStoredResponse(wireRsp, rspRaw, fixRspRaw, noFixContentLength)
 	if rspRaw == nil {
 		rspRaw = make([]byte, 0)
 	}

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -74,7 +74,7 @@ func SaveLowHTTPFlow(r *lowhttp.LowhttpResponse, forceSaveFlowSync bool) {
 		CreateHTTPFlowWithAfterSave(r.AfterSaveHTTPFlowHandler...),
 		CreateHTTPFlowWithResponseRaw(displayRsp),
 	}
-	if len(wireRsp) > 0 {
+	if len(wireRsp) > 0 && !r.TooLarge {
 		saveOpts = append(saveOpts, CreateHTTPFlowWithBareResponseRaw(wireRsp))
 	}
 	if keepWire {

--- a/common/yakgrpc/yakit/httpflow_bare.go
+++ b/common/yakgrpc/yakit/httpflow_bare.go
@@ -1,0 +1,112 @@
+package yakit
+
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/jinzhu/gorm"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+)
+
+// HTTPFlowTagAutoFixResponse: DB Response is fixed; wire is in KV (GetHTTPFlowBare, same as MITM bare).
+const HTTPFlowTagAutoFixResponse = "[自动修复]"
+
+func httpFlowBareResponseKey(flowID uint) string {
+	return strconv.FormatUint(uint64(flowID), 10) + "_response"
+}
+
+func httpFlowWireResponse(wirePacket, rspHint []byte) []byte {
+	if len(wirePacket) > 0 {
+		return wirePacket
+	}
+	return rspHint
+}
+
+func httpFlowDisplayResponse(wire, rspHint, fixOverride []byte, noFixContentLength bool) []byte {
+	return resolveHTTPFlowStoredResponse(wire, rspHint, fixOverride, noFixContentLength)
+}
+
+func httpFlowShouldStoreBareWire(wire, display []byte, noFixContentLength bool) bool {
+	if noFixContentLength || len(wire) == 0 {
+		return false
+	}
+	return !httpFlowResponsePacketsEqual(wire, display)
+}
+
+func resolveHTTPFlowStoredResponse(wire, rspRaw, fixRspRaw []byte, noFixContentLength bool) []byte {
+	if len(fixRspRaw) > 0 {
+		return fixRspRaw
+	}
+	if noFixContentLength {
+		if len(wire) > 0 {
+			return wire
+		}
+		return rspRaw
+	}
+	if len(wire) == 0 {
+		wire = rspRaw
+	}
+	if len(wire) == 0 {
+		return nil
+	}
+	fixed, _, err := lowhttp.FixHTTPResponse(wire)
+	if err != nil || len(fixed) == 0 {
+		return wire
+	}
+	if len(rspRaw) > 0 && bytes.Equal(rspRaw, fixed) {
+		return rspRaw
+	}
+	return fixed
+}
+
+func httpFlowResponsePacketsEqual(a, b []byte) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	at := truncateHTTPPacketBodyForStorage(a, maxStoredHTTPFlowResponseBodyBytes)
+	bt := truncateHTTPPacketBodyForStorage(b, maxStoredHTTPFlowResponseBodyBytes)
+	return bytes.Equal(at, bt)
+}
+
+func saveHTTPFlowBareResponse(db *gorm.DB, flowID uint, wire []byte) error {
+	if db == nil {
+		db = consts.GetGormProjectDatabase()
+	}
+	if flowID == 0 || len(wire) == 0 {
+		return nil
+	}
+	wire = truncateHTTPPacketBodyForStorage(wire, maxStoredHTTPFlowResponseBodyBytes)
+	return SetProjectKeyWithGroup(db, httpFlowBareResponseKey(flowID), wire, BARE_RESPONSE_GROUP)
+}
+
+func afterSaveHTTPFlowBareResponse(wire []byte) func(*schema.HTTPFlow) {
+	wire = bytes.Clone(wire)
+	return func(flow *schema.HTTPFlow) {
+		if flow == nil || flow.ID == 0 {
+			return
+		}
+		if err := saveHTTPFlowBareResponse(nil, flow.ID, wire); err != nil {
+			log.Errorf("save httpflow bare response failed: %s", err)
+		}
+	}
+}
+
+// lowhttpResponsePackets: BareResponse=wire, RawPacket=display (fixed unless NoFix).
+func lowhttpResponsePackets(r *lowhttp.LowhttpResponse) (wire, display []byte, noFixContentLength bool) {
+	if r == nil {
+		return nil, nil, false
+	}
+	wire = r.BareResponse
+	if len(wire) == 0 {
+		wire = r.RawPacket
+	}
+	display = r.RawPacket
+	if len(display) == 0 {
+		display = r.BareResponse
+	}
+	noFixContentLength = len(r.BareResponse) > 0 && bytes.Equal(r.RawPacket, r.BareResponse)
+	return wire, display, noFixContentLength
+}

--- a/common/yakgrpc/yakit/httpflow_bare.go
+++ b/common/yakgrpc/yakit/httpflow_bare.go
@@ -3,6 +3,8 @@ package yakit
 import (
 	"bytes"
 	"strconv"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/jinzhu/gorm"
 	"github.com/yaklang/yaklang/common/consts"
@@ -26,10 +28,29 @@ func httpFlowWireResponse(wirePacket, rspHint []byte) []byte {
 }
 
 func httpFlowShouldStoreBareWire(wire, display []byte, noFixContentLength bool) bool {
-	if noFixContentLength || len(wire) == 0 {
+	if noFixContentLength || len(wire) == 0 || httpFlowResponsePacketsEqual(wire, display) {
 		return false
 	}
-	return !httpFlowResponsePacketsEqual(wire, display)
+	return httpFlowAutoFixedCharset(wire, display)
+}
+
+// httpFlowAutoFixedCharset detects FixHTTPResponse charset/body conversion (not header-only or replacer edits).
+func httpFlowAutoFixedCharset(wire, display []byte) bool {
+	_, wireBody := lowhttp.SplitHTTPHeadersAndBodyFromPacket(wire)
+	_, displayBody := lowhttp.SplitHTTPHeadersAndBodyFromPacket(display)
+	if bytes.Equal(wireBody, displayBody) {
+		return false
+	}
+	if len(displayBody) > 0 && utf8.Valid(displayBody) && len(wireBody) > 0 && !utf8.Valid(wireBody) {
+		return true
+	}
+	wct := strings.ToLower(lowhttp.GetHTTPPacketHeader(wire, "Content-Type"))
+	dct := strings.ToLower(lowhttp.GetHTTPPacketHeader(display, "Content-Type"))
+	if wct == dct {
+		return false
+	}
+	return strings.Contains(dct, "charset=utf-8") &&
+		(strings.Contains(wct, "charset=gbk") || strings.Contains(wct, "charset=gb2312") || strings.Contains(wct, "charset:gbk"))
 }
 
 func resolveHTTPFlowStoredResponse(wire, rspRaw, fixRspRaw []byte, noFixContentLength bool) []byte {

--- a/common/yakgrpc/yakit/httpflow_bare.go
+++ b/common/yakgrpc/yakit/httpflow_bare.go
@@ -25,10 +25,6 @@ func httpFlowWireResponse(wirePacket, rspHint []byte) []byte {
 	return rspHint
 }
 
-func httpFlowDisplayResponse(wire, rspHint, fixOverride []byte, noFixContentLength bool) []byte {
-	return resolveHTTPFlowStoredResponse(wire, rspHint, fixOverride, noFixContentLength)
-}
-
 func httpFlowShouldStoreBareWire(wire, display []byte, noFixContentLength bool) bool {
 	if noFixContentLength || len(wire) == 0 {
 		return false

--- a/common/yakgrpc/yakit/httpflow_bare.go
+++ b/common/yakgrpc/yakit/httpflow_bare.go
@@ -63,15 +63,19 @@ func resolveHTTPFlowStoredResponse(wire, rspRaw, fixRspRaw []byte, noFixContentL
 		}
 		return rspRaw
 	}
-	if len(wire) == 0 {
-		wire = rspRaw
+	fixSource := wire
+	if len(rspRaw) > 0 && len(wire) > 0 && !bytes.Equal(wire, rspRaw) {
+		// MITM hijack/replacer, too-large placeholder, etc.: display packet is authoritative.
+		fixSource = rspRaw
+	} else if len(fixSource) == 0 {
+		fixSource = rspRaw
 	}
-	if len(wire) == 0 {
+	if len(fixSource) == 0 {
 		return nil
 	}
-	fixed, _, err := lowhttp.FixHTTPResponse(wire)
+	fixed, _, err := lowhttp.FixHTTPResponse(fixSource)
 	if err != nil || len(fixed) == 0 {
-		return wire
+		return fixSource
 	}
 	if len(rspRaw) > 0 && bytes.Equal(rspRaw, fixed) {
 		return rspRaw

--- a/common/yakgrpc/yakit/httpflow_bare_test.go
+++ b/common/yakgrpc/yakit/httpflow_bare_test.go
@@ -97,6 +97,21 @@ func TestHTTPFlowAutoFixedCharset(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, httpFlowShouldStoreBareWire(wire, display, false))
 	})
+
+	t.Run("mitm_hijack_prefers_display", func(t *testing.T) {
+		wire := []byte("HTTP/1.1 200 OK\r\n\r\noriginal-token")
+		display := []byte("HTTP/1.1 200 OK\r\n\r\nreplaced-token")
+		stored := resolveHTTPFlowStoredResponse(wire, display, nil, false)
+		require.Contains(t, string(stored), "replaced-token")
+		require.NotContains(t, string(stored), "original-token")
+	})
+
+	t.Run("too_large_placeholder_prefers_display", func(t *testing.T) {
+		wire := []byte("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n" + strings.Repeat("a", 100))
+		display := []byte("HTTP/1.1 200 OK\r\nContent-Length: 50\r\n\r\n[[response too large(4MB), truncated]] find more in web fuzzer history!")
+		stored := resolveHTTPFlowStoredResponse(wire, display, nil, false)
+		require.Contains(t, string(stored), "[[response too large")
+	})
 }
 
 func TestCreateHTTPFlowBareSidecar(t *testing.T) {

--- a/common/yakgrpc/yakit/httpflow_bare_test.go
+++ b/common/yakgrpc/yakit/httpflow_bare_test.go
@@ -26,165 +26,184 @@ func testHTTPFlowBareResponseMissing(db *gorm.DB, flowID uint) bool {
 	return err != nil
 }
 
-func TestCreateHTTPFlow_PersistsBareWhenFixDiffers(t *testing.T) {
-	db := consts.GetGormProjectDatabase()
-	token := uuid.NewString()
-
+func testHTTPFlowGBKWirePacket(t *testing.T) []byte {
+	t.Helper()
 	gbkBody, err := codec.Utf8ToGB18030([]byte("你好"))
 	require.NoError(t, err)
-	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
-	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
+	return []byte(fmt.Sprintf(
+		"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s",
+		len(gbkBody), string(gbkBody),
+	))
+}
 
-	var savedFlow *schema.HTTPFlow
-	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
-		false,
-		req,
-		wire,
-		"scan",
-		fmt.Sprintf("http://example.com/%s", token),
-		"127.0.0.1:80",
-		CreateHTTPFlowWithBareResponseRaw(wire),
-		CreateHTTPFlowWithAfterSave(func(f *schema.HTTPFlow) {
-			savedFlow = f
-		}),
-	)
-	require.NoError(t, err)
+func testHTTPFlowJSONWirePacket(body string) []byte {
+	return []byte(fmt.Sprintf(
+		"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s",
+		len(body), body,
+	))
+}
+
+func testHTTPFlowScanRequest(t *testing.T, token string) []byte {
+	t.Helper()
+	return lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
+}
+
+func insertTestHTTPFlow(t *testing.T, db *gorm.DB, flow *schema.HTTPFlow, afterSave ...func(*schema.HTTPFlow)) *schema.HTTPFlow {
+	t.Helper()
+	if len(afterSave) > 0 {
+		flow.AfterSaveHandlers = append(flow.AfterSaveHandlers, afterSave...)
+	}
 	require.NoError(t, InsertHTTPFlow(db, flow))
-	require.NotNil(t, savedFlow)
-	require.Greater(t, int(savedFlow.ID), 0)
-	defer db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{})
-
-	stored := savedFlow.GetResponse()
-	require.Contains(t, stored, "charset=utf-8")
-	require.Contains(t, stored, "你好")
-	require.Contains(t, savedFlow.Tags, HTTPFlowTagAutoFixResponse)
-
-	bare := loadTestHTTPFlowBareResponse(t, db, savedFlow.ID)
-	require.Contains(t, string(bare), "charset=gbk")
-	require.NotContains(t, string(bare), "charset=utf-8")
-}
-
-func TestCreateHTTPFlow_SkipsBareKVWhenSame(t *testing.T) {
-	db := consts.GetGormProjectDatabase()
-	token := uuid.NewString()
-
-	body := `{"ok":true}`
-	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body))
-	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
-
-	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
-		false,
-		req,
-		wire,
-		"scan",
-		fmt.Sprintf("http://example.com/%s", token),
-		"127.0.0.1:80",
-		CreateHTTPFlowWithBareResponseRaw(wire),
-	)
-	require.NoError(t, err)
-	require.NoError(t, InsertHTTPFlow(db, flow))
-	defer db.Where("id = ?", flow.ID).Delete(&schema.HTTPFlow{})
-
-	require.True(t, testHTTPFlowBareResponseMissing(db, flow.ID))
-	require.NotContains(t, flow.Tags, HTTPFlowTagAutoFixResponse)
-}
-
-func TestSaveLowHTTPFlow_PersistsBareWhenLowhttpFixed(t *testing.T) {
-	db := consts.GetGormProjectDatabase()
-	token := uuid.NewString()
-
-	gbkBody, err := codec.Utf8ToGB18030([]byte("你好"))
-	require.NoError(t, err)
-	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
-	fixed, _, err := lowhttp.FixHTTPResponse(wire)
-	require.NoError(t, err)
-	require.NotEqual(t, string(wire), string(fixed))
-
-	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
-	var savedFlow *schema.HTTPFlow
-	SaveLowHTTPFlow(&lowhttp.LowhttpResponse{
-		Https:        false,
-		RawRequest:   req,
-		RawPacket:    fixed,
-		BareResponse: wire,
-		Url:          fmt.Sprintf("http://example.com/%s", token),
-		RemoteAddr:   "127.0.0.1:80",
-		Source:       "scan",
-		RuntimeId:    "runtime-" + token,
-		TraceInfo:    &lowhttp.LowhttpTraceInfo{},
-		AfterSaveHTTPFlowHandler: []func(*schema.HTTPFlow){
-			func(f *schema.HTTPFlow) { savedFlow = f },
-		},
-	}, true)
-	require.NotNil(t, savedFlow)
-	defer db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{})
-
-	require.Contains(t, savedFlow.GetResponse(), "charset=utf-8")
-	require.Contains(t, savedFlow.Tags, HTTPFlowTagAutoFixResponse)
-	bare := loadTestHTTPFlowBareResponse(t, db, savedFlow.ID)
-	require.True(t, strings.Contains(string(bare), "charset=gbk"))
-}
-
-func TestSaveLowHTTPFlow_NoBareKVWhenNoFixAndSameWire(t *testing.T) {
-	db := consts.GetGormProjectDatabase()
-	token := uuid.NewString()
-
-	body := `{"ok":true}`
-	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body))
-	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
-
-	var savedFlow *schema.HTTPFlow
-	SaveLowHTTPFlow(&lowhttp.LowhttpResponse{
-		Https:        false,
-		RawRequest:   req,
-		RawPacket:    wire,
-		BareResponse: wire,
-		Url:          fmt.Sprintf("http://example.com/%s", token),
-		RemoteAddr:   "127.0.0.1:80",
-		Source:       "scan",
-		TraceInfo:    &lowhttp.LowhttpTraceInfo{},
-		AfterSaveHTTPFlowHandler: []func(*schema.HTTPFlow){
-			func(f *schema.HTTPFlow) { savedFlow = f },
-		},
-	}, true)
-	require.NotNil(t, savedFlow)
-	require.True(t, savedFlow.NoFixContentLength)
-	defer db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{})
-
-	require.True(t, testHTTPFlowBareResponseMissing(db, savedFlow.ID))
-}
-
-func TestCreateHTTPFlow_FixesEvenWhenRspRawDiffersFromWire(t *testing.T) {
-	db := consts.GetGormProjectDatabase()
-	token := uuid.NewString()
-
-	gbkBody, err := codec.Utf8ToGB18030([]byte("你好"))
-	require.NoError(t, err)
-	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
-	// simulate MITM plainResponse: same bytes as wire but passed as rspRaw (not charset-fixed)
-	plain := append([]byte(nil), wire...)
-	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
-
-	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
-		false, req, plain, "scan", fmt.Sprintf("http://example.com/%s", token), "127.0.0.1:80",
-		CreateHTTPFlowWithBareResponseRaw(wire),
-	)
-	require.NoError(t, err)
-	require.NoError(t, InsertHTTPFlow(db, flow))
-	defer db.Where("id = ?", flow.ID).Delete(&schema.HTTPFlow{})
-
-	require.Contains(t, flow.GetResponse(), "charset=utf-8")
-	require.Contains(t, flow.GetResponse(), "你好")
+	t.Cleanup(func() { db.Where("id = ?", flow.ID).Delete(&schema.HTTPFlow{}) })
+	return flow
 }
 
 func TestResolveHTTPFlowStoredResponse(t *testing.T) {
-	gbkBody, _ := codec.Utf8ToGB18030([]byte("你好"))
-	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
-	fixed, _, _ := lowhttp.FixHTTPResponse(wire)
+	wire := testHTTPFlowGBKWirePacket(t)
+	fixed, _, err := lowhttp.FixHTTPResponse(wire)
+	require.NoError(t, err)
 
-	stored := resolveHTTPFlowStoredResponse(wire, fixed, nil, false)
-	require.Contains(t, string(stored), "charset=utf-8")
+	t.Run("auto_fix", func(t *testing.T) {
+		stored := resolveHTTPFlowStoredResponse(wire, fixed, nil, false)
+		require.Contains(t, string(stored), "charset=utf-8")
+		require.Contains(t, string(stored), "你好")
+	})
 
-	skip := resolveHTTPFlowStoredResponse(wire, fixed, nil, true)
-	require.Equal(t, string(wire), string(skip))
+	t.Run("no_fix", func(t *testing.T) {
+		stored := resolveHTTPFlowStoredResponse(wire, fixed, nil, true)
+		require.Equal(t, string(wire), string(stored))
+	})
+}
+
+func TestCreateHTTPFlowBareSidecar(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+
+	t.Run("persists_kv_and_tag_when_wire_differs", func(t *testing.T) {
+		token := uuid.NewString()
+		wire := testHTTPFlowGBKWirePacket(t)
+		req := testHTTPFlowScanRequest(t, token)
+
+		var savedFlow *schema.HTTPFlow
+		flow, err := CreateHTTPFlow(
+			CreateHTTPFlowWithHTTPS(false),
+			CreateHTTPFlowWithRequestRaw(req),
+			CreateHTTPFlowWithResponseRaw(wire),
+			CreateHTTPFlowWithBareResponseRaw(wire),
+			CreateHTTPFlowWithSource("scan"),
+			CreateHTTPFlowWithURL(fmt.Sprintf("http://example.com/%s", token)),
+			CreateHTTPFlowWithRemoteAddr("127.0.0.1:80"),
+			CreateHTTPFlowWithAfterSave(func(f *schema.HTTPFlow) { savedFlow = f }),
+		)
+		require.NoError(t, err)
+		insertTestHTTPFlow(t, db, flow)
+		require.NotNil(t, savedFlow)
+
+		require.Contains(t, savedFlow.GetResponse(), "charset=utf-8")
+		require.Contains(t, savedFlow.Tags, HTTPFlowTagAutoFixResponse)
+		bare := loadTestHTTPFlowBareResponse(t, db, savedFlow.ID)
+		require.Contains(t, string(bare), "charset=gbk")
+		require.NotContains(t, string(bare), "charset=utf-8")
+	})
+
+	t.Run("no_kv_when_wire_equals_display", func(t *testing.T) {
+		token := uuid.NewString()
+		wire := testHTTPFlowJSONWirePacket(`{"ok":true}`)
+		req := testHTTPFlowScanRequest(t, token)
+
+		flow, err := CreateHTTPFlow(
+			CreateHTTPFlowWithHTTPS(false),
+			CreateHTTPFlowWithRequestRaw(req),
+			CreateHTTPFlowWithResponseRaw(wire),
+			CreateHTTPFlowWithBareResponseRaw(wire),
+			CreateHTTPFlowWithSource("scan"),
+			CreateHTTPFlowWithURL(fmt.Sprintf("http://example.com/%s", token)),
+			CreateHTTPFlowWithRemoteAddr("127.0.0.1:80"),
+		)
+		require.NoError(t, err)
+		insertTestHTTPFlow(t, db, flow)
+
+		require.True(t, testHTTPFlowBareResponseMissing(db, flow.ID))
+		require.NotContains(t, flow.Tags, HTTPFlowTagAutoFixResponse)
+	})
+
+	t.Run("fixes_from_wire_when_rsp_hint_is_plain_only", func(t *testing.T) {
+		token := uuid.NewString()
+		wire := testHTTPFlowGBKWirePacket(t)
+		req := testHTTPFlowScanRequest(t, token)
+		plain := append([]byte(nil), wire...) // MITM: rsp hint equals wire, not pre-fixed
+
+		flow, err := CreateHTTPFlow(
+			CreateHTTPFlowWithHTTPS(false),
+			CreateHTTPFlowWithRequestRaw(req),
+			CreateHTTPFlowWithResponseRaw(plain),
+			CreateHTTPFlowWithBareResponseRaw(wire),
+			CreateHTTPFlowWithSource("scan"),
+			CreateHTTPFlowWithURL(fmt.Sprintf("http://example.com/%s", token)),
+			CreateHTTPFlowWithRemoteAddr("127.0.0.1:80"),
+		)
+		require.NoError(t, err)
+		insertTestHTTPFlow(t, db, flow)
+
+		require.Contains(t, flow.GetResponse(), "charset=utf-8")
+		require.Contains(t, flow.GetResponse(), "你好")
+	})
+}
+
+func TestSaveLowHTTPFlowBareSidecar(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+
+	t.Run("persists_kv_when_bare_differs_from_fixed_packet", func(t *testing.T) {
+		token := uuid.NewString()
+		wire := testHTTPFlowGBKWirePacket(t)
+		fixed, _, err := lowhttp.FixHTTPResponse(wire)
+		require.NoError(t, err)
+		require.NotEqual(t, string(wire), string(fixed))
+
+		var savedFlow *schema.HTTPFlow
+		SaveLowHTTPFlow(&lowhttp.LowhttpResponse{
+			Https:        false,
+			RawRequest:   testHTTPFlowScanRequest(t, token),
+			RawPacket:    fixed,
+			BareResponse: wire,
+			Url:          fmt.Sprintf("http://example.com/%s", token),
+			RemoteAddr:   "127.0.0.1:80",
+			Source:       "scan",
+			RuntimeId:    "runtime-" + token,
+			TraceInfo:    &lowhttp.LowhttpTraceInfo{},
+			AfterSaveHTTPFlowHandler: []func(*schema.HTTPFlow){
+				func(f *schema.HTTPFlow) { savedFlow = f },
+			},
+		}, true)
+		require.NotNil(t, savedFlow)
+		t.Cleanup(func() { db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{}) })
+
+		require.Contains(t, savedFlow.GetResponse(), "charset=utf-8")
+		require.Contains(t, savedFlow.Tags, HTTPFlowTagAutoFixResponse)
+		require.True(t, strings.Contains(string(loadTestHTTPFlowBareResponse(t, db, savedFlow.ID)), "charset=gbk"))
+	})
+
+	t.Run("no_kv_when_no_fix", func(t *testing.T) {
+		token := uuid.NewString()
+		wire := testHTTPFlowJSONWirePacket(`{"ok":true}`)
+
+		var savedFlow *schema.HTTPFlow
+		SaveLowHTTPFlow(&lowhttp.LowhttpResponse{
+			Https:        false,
+			RawRequest:   testHTTPFlowScanRequest(t, token),
+			RawPacket:    wire,
+			BareResponse: wire,
+			Url:          fmt.Sprintf("http://example.com/%s", token),
+			RemoteAddr:   "127.0.0.1:80",
+			Source:       "scan",
+			TraceInfo:    &lowhttp.LowhttpTraceInfo{},
+			AfterSaveHTTPFlowHandler: []func(*schema.HTTPFlow){
+				func(f *schema.HTTPFlow) { savedFlow = f },
+			},
+		}, true)
+		require.NotNil(t, savedFlow)
+		require.True(t, savedFlow.NoFixContentLength)
+		t.Cleanup(func() { db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{}) })
+
+		require.True(t, testHTTPFlowBareResponseMissing(db, savedFlow.ID))
+	})
 }

--- a/common/yakgrpc/yakit/httpflow_bare_test.go
+++ b/common/yakgrpc/yakit/httpflow_bare_test.go
@@ -75,6 +75,30 @@ func TestResolveHTTPFlowStoredResponse(t *testing.T) {
 	})
 }
 
+func TestHTTPFlowAutoFixedCharset(t *testing.T) {
+	t.Run("gbk_body", func(t *testing.T) {
+		wire := testHTTPFlowGBKWirePacket(t)
+		display, _, _ := lowhttp.FixHTTPResponse(wire)
+		require.True(t, httpFlowAutoFixedCharset(wire, display))
+	})
+
+	t.Run("header_only_no_tag", func(t *testing.T) {
+		token := uuid.NewString()
+		wire := []byte("HTTP/1.1 200 OK\r\n\r\n" + token)
+		display, _, err := lowhttp.FixHTTPResponse(wire)
+		require.NoError(t, err)
+		require.False(t, httpFlowAutoFixedCharset(wire, display))
+	})
+
+	t.Run("analyze_raw_packet_no_tag", func(t *testing.T) {
+		token := uuid.NewString()
+		wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\n\r\n%s", token))
+		display, _, err := lowhttp.FixHTTPResponse(wire)
+		require.NoError(t, err)
+		require.False(t, httpFlowShouldStoreBareWire(wire, display, false))
+	})
+}
+
 func TestCreateHTTPFlowBareSidecar(t *testing.T) {
 	db := consts.GetGormProjectDatabase()
 

--- a/common/yakgrpc/yakit/httpflow_bare_test.go
+++ b/common/yakgrpc/yakit/httpflow_bare_test.go
@@ -1,0 +1,190 @@
+package yakit
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
+)
+
+func loadTestHTTPFlowBareResponse(t *testing.T, db *gorm.DB, flowID uint) []byte {
+	t.Helper()
+	raw, err := GetProjectKeyWithError(db, httpFlowBareResponseKey(flowID))
+	require.NoError(t, err)
+	return []byte(raw)
+}
+
+func testHTTPFlowBareResponseMissing(db *gorm.DB, flowID uint) bool {
+	_, err := GetProjectKeyWithError(db, httpFlowBareResponseKey(flowID))
+	return err != nil
+}
+
+func TestCreateHTTPFlow_PersistsBareWhenFixDiffers(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	token := uuid.NewString()
+
+	gbkBody, err := codec.Utf8ToGB18030([]byte("你好"))
+	require.NoError(t, err)
+	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
+	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
+
+	var savedFlow *schema.HTTPFlow
+	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
+		false,
+		req,
+		wire,
+		"scan",
+		fmt.Sprintf("http://example.com/%s", token),
+		"127.0.0.1:80",
+		CreateHTTPFlowWithBareResponseRaw(wire),
+		CreateHTTPFlowWithAfterSave(func(f *schema.HTTPFlow) {
+			savedFlow = f
+		}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, InsertHTTPFlow(db, flow))
+	require.NotNil(t, savedFlow)
+	require.Greater(t, int(savedFlow.ID), 0)
+	defer db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{})
+
+	stored := savedFlow.GetResponse()
+	require.Contains(t, stored, "charset=utf-8")
+	require.Contains(t, stored, "你好")
+	require.Contains(t, savedFlow.Tags, HTTPFlowTagAutoFixResponse)
+
+	bare := loadTestHTTPFlowBareResponse(t, db, savedFlow.ID)
+	require.Contains(t, string(bare), "charset=gbk")
+	require.NotContains(t, string(bare), "charset=utf-8")
+}
+
+func TestCreateHTTPFlow_SkipsBareKVWhenSame(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	token := uuid.NewString()
+
+	body := `{"ok":true}`
+	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body))
+	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
+
+	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
+		false,
+		req,
+		wire,
+		"scan",
+		fmt.Sprintf("http://example.com/%s", token),
+		"127.0.0.1:80",
+		CreateHTTPFlowWithBareResponseRaw(wire),
+	)
+	require.NoError(t, err)
+	require.NoError(t, InsertHTTPFlow(db, flow))
+	defer db.Where("id = ?", flow.ID).Delete(&schema.HTTPFlow{})
+
+	require.True(t, testHTTPFlowBareResponseMissing(db, flow.ID))
+	require.NotContains(t, flow.Tags, HTTPFlowTagAutoFixResponse)
+}
+
+func TestSaveLowHTTPFlow_PersistsBareWhenLowhttpFixed(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	token := uuid.NewString()
+
+	gbkBody, err := codec.Utf8ToGB18030([]byte("你好"))
+	require.NoError(t, err)
+	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
+	fixed, _, err := lowhttp.FixHTTPResponse(wire)
+	require.NoError(t, err)
+	require.NotEqual(t, string(wire), string(fixed))
+
+	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
+	var savedFlow *schema.HTTPFlow
+	SaveLowHTTPFlow(&lowhttp.LowhttpResponse{
+		Https:        false,
+		RawRequest:   req,
+		RawPacket:    fixed,
+		BareResponse: wire,
+		Url:          fmt.Sprintf("http://example.com/%s", token),
+		RemoteAddr:   "127.0.0.1:80",
+		Source:       "scan",
+		RuntimeId:    "runtime-" + token,
+		TraceInfo:    &lowhttp.LowhttpTraceInfo{},
+		AfterSaveHTTPFlowHandler: []func(*schema.HTTPFlow){
+			func(f *schema.HTTPFlow) { savedFlow = f },
+		},
+	}, true)
+	require.NotNil(t, savedFlow)
+	defer db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{})
+
+	require.Contains(t, savedFlow.GetResponse(), "charset=utf-8")
+	require.Contains(t, savedFlow.Tags, HTTPFlowTagAutoFixResponse)
+	bare := loadTestHTTPFlowBareResponse(t, db, savedFlow.ID)
+	require.True(t, strings.Contains(string(bare), "charset=gbk"))
+}
+
+func TestSaveLowHTTPFlow_NoBareKVWhenNoFixAndSameWire(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	token := uuid.NewString()
+
+	body := `{"ok":true}`
+	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body))
+	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
+
+	var savedFlow *schema.HTTPFlow
+	SaveLowHTTPFlow(&lowhttp.LowhttpResponse{
+		Https:        false,
+		RawRequest:   req,
+		RawPacket:    wire,
+		BareResponse: wire,
+		Url:          fmt.Sprintf("http://example.com/%s", token),
+		RemoteAddr:   "127.0.0.1:80",
+		Source:       "scan",
+		TraceInfo:    &lowhttp.LowhttpTraceInfo{},
+		AfterSaveHTTPFlowHandler: []func(*schema.HTTPFlow){
+			func(f *schema.HTTPFlow) { savedFlow = f },
+		},
+	}, true)
+	require.NotNil(t, savedFlow)
+	require.True(t, savedFlow.NoFixContentLength)
+	defer db.Where("id = ?", savedFlow.ID).Delete(&schema.HTTPFlow{})
+
+	require.True(t, testHTTPFlowBareResponseMissing(db, savedFlow.ID))
+}
+
+func TestCreateHTTPFlow_FixesEvenWhenRspRawDiffersFromWire(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	token := uuid.NewString()
+
+	gbkBody, err := codec.Utf8ToGB18030([]byte("你好"))
+	require.NoError(t, err)
+	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
+	// simulate MITM plainResponse: same bytes as wire but passed as rspRaw (not charset-fixed)
+	plain := append([]byte(nil), wire...)
+	req := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /%s HTTP/1.1\r\nHost: example.com\r\n\r\n", token)))
+
+	flow, err := CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
+		false, req, plain, "scan", fmt.Sprintf("http://example.com/%s", token), "127.0.0.1:80",
+		CreateHTTPFlowWithBareResponseRaw(wire),
+	)
+	require.NoError(t, err)
+	require.NoError(t, InsertHTTPFlow(db, flow))
+	defer db.Where("id = ?", flow.ID).Delete(&schema.HTTPFlow{})
+
+	require.Contains(t, flow.GetResponse(), "charset=utf-8")
+	require.Contains(t, flow.GetResponse(), "你好")
+}
+
+func TestResolveHTTPFlowStoredResponse(t *testing.T) {
+	gbkBody, _ := codec.Utf8ToGB18030([]byte("你好"))
+	wire := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=gbk\r\nContent-Length: %d\r\n\r\n%s", len(gbkBody), string(gbkBody)))
+	fixed, _, _ := lowhttp.FixHTTPResponse(wire)
+
+	stored := resolveHTTPFlowStoredResponse(wire, fixed, nil, false)
+	require.Contains(t, string(stored), "charset=utf-8")
+
+	skip := resolveHTTPFlowStoredResponse(wire, fixed, nil, true)
+	require.Equal(t, string(wire), string(skip))
+}


### PR DESCRIPTION
Store fixed packets in HTTPFlow.Response and wire originals in project KV when they differ, tagged [自动修复] for GetHTTPFlowBare. SaveLowHTTPFlow honors NoFixContentLength and merges tags without clearing auto-fix marks.