### PR TITLE
feat(tls): implement TLS retry mechanism with detailed error handling…

### DIFF
--- a/common/netx/dialx.go
+++ b/common/netx/dialx.go
@@ -329,15 +329,14 @@ func DialX(target string, opt ...DialXOption) (net.Conn, error) {
 
 		switch strategy {
 		case TLS_Strategy_Ordinary:
-			conn, err := dialPlainTCPConnWithRetry(target, config)
-			if err != nil {
-				return nil, err
-			}
 			tempTlsConfig.GMSupport = nil
-			startUpgrade := time.Now()
-			tlsConn, tlsErr = UpgradeToTLSConnectionWithTimeout(conn, sni, tempTlsConfig, tlsTimeout, clientHelloSpec, config.TLSNextProto...)
-			tlsHandshakeDur = time.Since(startUpgrade)
+			tlsConn, tlsHandshakeDur, tlsErr = dialTLSWithRetry(target, config, tempTlsConfig, sni, tlsTimeout, clientHelloSpec, strategy)
 		case TLS_Strategy_GMDail:
+			if len(errs) > 0 {
+				config.TraceInfo.AddTLSRetryTip("普通 TLS 失败，已尝试国密 TLS 兼容握手")
+			} else {
+				config.TraceInfo.AddTLSRetryTip("已尝试国密 TLS 兼容握手")
+			}
 			tlsConn, tlsHandshakeDur, tlsErr = dialTLSWithGMTLSCipherFallback(target, config, tempTlsConfig, sni, tlsTimeout, clientHelloSpec)
 		default:
 			return nil, utils.Errorf("unknown tls strategy %v", strategy)
@@ -352,30 +351,37 @@ func DialX(target string, opt ...DialXOption) (net.Conn, error) {
 	}
 	if len(errs) > 0 {
 		lastErr := errs[len(errs)-1]
-		reasonEN, reasonCN, suggestion := getFriendlyTLSError(lastErr)
-
-		var configParts []string
-		if config.ForceDisableProxy {
-			configParts = append(configParts, "proxy=disabled")
-		} else if len(config.Proxy) > 0 {
-			configParts = append(configParts, fmt.Sprintf("proxy=%v", config.Proxy))
-		} else if config.EnableSystemProxyFromEnv {
-			configParts = append(configParts, "proxy=system")
-		} else {
-			configParts = append(configParts, "proxy=none")
-		}
-		if config.SNI != "" {
-			sniInfo := fmt.Sprintf("sni=%v", config.SNI)
-			if config.ShouldOverrideSNI {
-				sniInfo += "(override)"
+		displayErr := lastErr
+		retrySummary := ""
+		tlsReason := ""
+		tlsSuggestion := ""
+		var retryErr *tlsRetryError
+		if errors.As(lastErr, &retryErr) {
+			if retryErr.LastError() != nil {
+				displayErr = retryErr.LastError()
 			}
-			configParts = append(configParts, sniInfo)
+			tlsReason = retryErr.Reason()
+			retrySummary = retryErr.RetrySummary()
+			tlsSuggestion = retryErr.suggestion
 		}
-		configStr := strings.Join(configParts, ", ")
-
-		return nil, utils.Errorf("all tls strategy failed: TLS Connection Failed(%s): %s | Raw Error: %v | Config: %s\nTLS连接失败(%s): %s | 原始错误: %v | 调试配置: %s\n%s",
-			target, reasonEN, lastErr, configStr,
-			target, reasonCN, lastErr, configStr, suggestion)
+		_, reasonCN, suggestion := getFriendlyTLSError(displayErr)
+		if tlsReason != "" {
+			reasonCN = tlsReason
+		}
+		if tlsSuggestion != "" {
+			suggestion = "建议: " + tlsSuggestion
+		}
+		errLines := []string{fmt.Sprintf("TLS连接失败(%s): %s", target, reasonCN)}
+		if displayErr != nil {
+			errLines = append(errLines, fmt.Sprintf("原始错误: %v", displayErr))
+		}
+		if retrySummary != "" {
+			errLines = append(errLines, fmt.Sprintf("TLS重试: %s", retrySummary))
+		}
+		if suggestion != "" {
+			errLines = append(errLines, suggestion)
+		}
+		return nil, utils.Error(strings.Join(errLines, "\n"))
 	}
 	return nil, utils.Error("unknown tls strategy error, BUG here!")
 }

--- a/common/netx/dialx_config.go
+++ b/common/netx/dialx_config.go
@@ -20,6 +20,10 @@ type DialXTraceInfo struct {
 	TCPtime time.Duration
 	// tls 握手耗时
 	TLSHandshakeTime time.Duration
+	// tls retry count
+	TLSRetryCount int
+	// tls retry tips
+	TLSRetryTips []string
 }
 
 func NewDialXTraceInfo() *DialXTraceInfo {
@@ -47,6 +51,18 @@ func (d *DialXTraceInfo) SetTCPDuration(t time.Duration) {
 	d.TCPtime = t
 }
 
+func (d *DialXTraceInfo) AddTLSRetryTip(tip string) {
+	if d == nil || tip == "" {
+		return
+	}
+	for _, exists := range d.TLSRetryTips {
+		if exists == tip {
+			return
+		}
+	}
+	d.TLSRetryTips = append(d.TLSRetryTips, tip)
+}
+
 type dialXConfig struct {
 	Timeout           time.Duration
 	ForceDisableProxy bool
@@ -63,14 +79,14 @@ type dialXConfig struct {
 	TLSConfig               *gmtls.Config
 	//ShouldOverrideGMTLSConfig bool
 	//GMTLSConfig               *gmtls.Config
-	GMTLSSupport               bool
-	GMTLSPrefer                bool
-	GMTLSOnly                  bool
-	GMTLSDisableCompatMode     bool // 关闭国密兼容模式；默认 false 表示兼容开启（四套 → ECC×2 → ECDHE×2）
-	TLSTimeout        time.Duration
-	ShouldOverrideSNI bool // High priority (will overwrite TlsConfig)
-	SNI               string
-	TLSNextProto      []string
+	GMTLSSupport           bool
+	GMTLSPrefer            bool
+	GMTLSOnly              bool
+	GMTLSDisableCompatMode bool // 关闭国密兼容模式；默认 false 表示兼容开启（四套 → ECC×2 → ECDHE×2）
+	TLSTimeout             time.Duration
+	ShouldOverrideSNI      bool // High priority (will overwrite TlsConfig)
+	SNI                    string
+	TLSNextProto           []string
 
 	// Retry
 	EnableTimeoutRetry  bool

--- a/common/netx/dialx_gmtls.go
+++ b/common/netx/dialx_gmtls.go
@@ -1,13 +1,14 @@
 package netx
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"time"
 
+	utls "github.com/refraction-networking/utls"
 	"github.com/yaklang/yaklang/common/gmsm/gmtls"
 	"github.com/yaklang/yaklang/common/log"
-	utls "github.com/refraction-networking/utls"
 )
 
 // 国密套件按密钥协商分两类：静态 ECC 与 ECDHE。CBC/GCM 为 SM4 不同模式，同族套件可放在同一轮 ClientHello。
@@ -96,6 +97,12 @@ func dialTLSWithGMTLSCipherFallback(
 		// 错误与套件无关（如连接被拒）时不必再换套件重连
 		if !shouldRetryGMTLSWithOtherCipherSuites(err) {
 			break
+		}
+		if i+1 < len(attempts) {
+			if config.TraceInfo != nil {
+				config.TraceInfo.TLSRetryCount++
+			}
+			config.TraceInfo.AddTLSRetryTip(fmt.Sprintf("国密 TLS 握手失败，已尝试切换国密 cipher suites（第 %d 轮）", i+2))
 		}
 		if config.Debug {
 			log.Infof("dial %v gmtls cipher attempt %d failed: %v, retrying with next cipher set", target, i+1, err)

--- a/common/netx/dialx_tls_retry.go
+++ b/common/netx/dialx_tls_retry.go
@@ -1,0 +1,448 @@
+package netx
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	utls "github.com/refraction-networking/utls"
+	"github.com/yaklang/yaklang/common/gmsm/gmtls"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+const (
+	tlsErrorKindUnknown     = "unknown"
+	tlsErrorKindNotTLS      = "not_tls"
+	tlsErrorKindHandshake   = "handshake"
+	tlsErrorKindALPN        = "alpn"
+	tlsErrorKindSNI         = "sni"
+	tlsErrorKindVersion     = "version"
+	tlsErrorKindCertificate = "certificate"
+)
+
+type tlsRetryAttempt struct {
+	name       string
+	reason     string
+	suggestion string
+	err        error
+	success    bool
+	duration   time.Duration
+}
+
+type tlsRetryError struct {
+	target     string
+	kind       string
+	attempts   []tlsRetryAttempt
+	suggestion string
+}
+
+func (e *tlsRetryError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("tls retry failed for %s: %v", e.target, e.LastError())
+}
+
+func (e *tlsRetryError) LastError() error {
+	if e == nil {
+		return nil
+	}
+	for i := len(e.attempts) - 1; i >= 0; i-- {
+		if e.attempts[i].err != nil {
+			return e.attempts[i].err
+		}
+	}
+	return nil
+}
+
+func (e *tlsRetryError) Unwrap() error {
+	return e.LastError()
+}
+
+func (e *tlsRetryError) RetrySummary() string {
+	if e == nil {
+		return ""
+	}
+	var retryNames []string
+	for _, attempt := range e.attempts {
+		if strings.Contains(attempt.name, "baseline") {
+			continue
+		}
+		retryNames = append(retryNames, attempt.name)
+	}
+	if len(retryNames) == 0 {
+		return "未进行 TLS 兼容重试"
+	}
+	return fmt.Sprintf("已进行 %d 次 TLS 兼容重试：%s", len(retryNames), strings.Join(retryNames, ", "))
+}
+
+func (e *tlsRetryError) Reason() string {
+	if e == nil {
+		return ""
+	}
+	switch e.kind {
+	case tlsErrorKindNotTLS:
+		return "目标端口疑似不是 TLS 服务"
+	case tlsErrorKindCertificate:
+		return "TLS 证书/客户端证书问题"
+	case tlsErrorKindSNI:
+		return "TLS SNI 可能不匹配"
+	case tlsErrorKindVersion:
+		return "TLS 版本不兼容"
+	case tlsErrorKindALPN:
+		return "TLS ALPN 不兼容"
+	case tlsErrorKindHandshake:
+		return "TLS 握手失败"
+	default:
+		return "TLS 连接失败"
+	}
+}
+
+type tlsRetryCandidate struct {
+	name       string
+	reason     string
+	tip        string
+	suggestion string
+	sni        string
+	nextProtos []string
+	spec       *utls.ClientHelloSpec
+	config     func(*gmtls.Config)
+}
+
+func classifyTLSError(err error) (kind string, retryable bool, suggestion string) {
+	if err == nil {
+		return tlsErrorKindUnknown, false, ""
+	}
+	msg := strings.ToLower(err.Error())
+
+	switch {
+	case strings.Contains(msg, "first record does not look like a tls handshake"),
+		strings.Contains(msg, "server gave http response to https client"),
+		strings.Contains(msg, "not tls conn"),
+		strings.Contains(msg, "plain http"),
+		strings.Contains(msg, "http/1.0"),
+		strings.Contains(msg, "http/1.1"),
+		strings.Contains(msg, "http/2"):
+		return tlsErrorKindNotTLS, false, "目标端口疑似不是 TLS 服务，请确认协议是否应为 HTTP/明文 TCP，或检查端口是否正确；如果是通过代理访问，也可能是代理返回了明文响应，请检查代理配置"
+	case strings.Contains(msg, "certificate required"),
+		strings.Contains(msg, "bad certificate"),
+		strings.Contains(msg, "unknown ca"),
+		strings.Contains(msg, "alert(116)"):
+		return tlsErrorKindCertificate, false, "目标可能要求客户端证书，请配置 P12/客户端证书后重试；如果是证书校验问题，请检查 CA 或跳过证书校验配置"
+	case strings.Contains(msg, "unrecognized_name"),
+		strings.Contains(msg, "unrecognized name"),
+		strings.Contains(msg, "certificate is valid for"),
+		strings.Contains(msg, "hostname"):
+		return tlsErrorKindSNI, true, "TLS SNI 可能不匹配，请检查目标域名、Host 与 SNI 配置；如果使用 IP 直连，可尝试指定正确 SNI"
+	case strings.Contains(msg, "protocol version"),
+		strings.Contains(msg, "unsupported protocol"),
+		strings.Contains(msg, "no supported versions"),
+		strings.Contains(msg, "server selected unsupported protocol version"):
+		return tlsErrorKindVersion, true, "TLS 版本不兼容，请检查全局 TLS 版本配置，目标可能只支持较旧 TLS 版本"
+	case strings.Contains(msg, "no application protocol"),
+		strings.Contains(msg, "no_application_protocol"),
+		strings.Contains(msg, "alpn"):
+		return tlsErrorKindALPN, true, "目标可能不兼容当前 ALPN，可尝试仅使用 http/1.1 或关闭 ALPN"
+	case strings.Contains(msg, "handshake failure"),
+		strings.Contains(msg, "decode error"),
+		strings.Contains(msg, "illegal parameter"),
+		strings.Contains(msg, "unexpected eof"),
+		strings.Contains(msg, "connection reset"):
+		return tlsErrorKindHandshake, true, "TLS 握手失败，可能是服务端不兼容 Go 默认 TLS 指纹，可尝试开启/调整 TLS 指纹；如果目标是国密站点，可尝试启用 GMTLS"
+	case errors.Is(err, io.EOF):
+		return tlsErrorKindHandshake, true, "TLS 握手阶段连接被关闭，可能是服务端不兼容当前 TLS 参数；请确认协议、端口、代理与 TLS 指纹配置"
+	case strings.Contains(msg, "certificate"), strings.Contains(msg, "x509"):
+		return tlsErrorKindCertificate, false, "目标可能要求客户端证书，请配置 P12/客户端证书后重试；如果是证书校验问题，请检查 CA 或跳过证书校验配置"
+	default:
+		return tlsErrorKindUnknown, true, "TLS 握手失败，可尝试调整 TLS 指纹、ALPN、SNI 或 TLS 版本配置"
+	}
+}
+
+func dialTLSWithRetry(
+	target string,
+	config *dialXConfig,
+	tlsConfig *gmtls.Config,
+	sni string,
+	tlsTimeout time.Duration,
+	clientHelloSpec *utls.ClientHelloSpec,
+	strategy TLSStrategy,
+) (net.Conn, time.Duration, error) {
+	var attempts []tlsRetryAttempt
+	var totalHandshakeDuration time.Duration
+
+	baseConn, err := dialPlainTCPConnWithRetry(target, config)
+	if err != nil {
+		return nil, 0, err
+	}
+	baseConfig := tlsConfig.Clone()
+	baseConfig.GMSupport = nil
+
+	startUpgrade := time.Now()
+	tlsConn, err := UpgradeToTLSConnectionWithTimeout(baseConn, sni, baseConfig, tlsTimeout, clientHelloSpec, config.TLSNextProto...)
+	handshakeDuration := time.Since(startUpgrade)
+	totalHandshakeDuration += handshakeDuration
+	if err == nil {
+		return tlsConn, totalHandshakeDuration, nil
+	}
+	_ = baseConn.Close()
+	kind, retryable, suggestion := classifyTLSError(err)
+	attempts = append(attempts, tlsRetryAttempt{
+		name:       fmt.Sprintf("%s-baseline", strategy),
+		reason:     "baseline tls handshake",
+		suggestion: suggestion,
+		err:        err,
+		duration:   handshakeDuration,
+	})
+
+	if !retryable {
+		addTLSNoRetryTip(config.TraceInfo, kind, suggestion)
+		return nil, totalHandshakeDuration, &tlsRetryError{target: target, kind: kind, attempts: attempts, suggestion: suggestion}
+	}
+
+	candidates := buildTLSRetryCandidates(target, config, tlsConfig, sni, clientHelloSpec, kind, suggestion)
+	if len(candidates) == 0 {
+		addTLSNoRetryTip(config.TraceInfo, kind, suggestion)
+		return nil, totalHandshakeDuration, &tlsRetryError{target: target, kind: kind, attempts: attempts, suggestion: suggestion}
+	}
+
+	for _, candidate := range candidates {
+		if config.Debug {
+			log.Infof("dial %v tls retry candidate %s: %s", target, candidate.name, candidate.reason)
+		}
+		if config.TraceInfo != nil {
+			config.TraceInfo.TLSRetryCount++
+		}
+		config.TraceInfo.AddTLSRetryTip(candidate.tip)
+
+		conn, err := dialPlainTCPConnWithRetry(target, config)
+		if err != nil {
+			attempts = append(attempts, tlsRetryAttempt{
+				name:       candidate.name,
+				reason:     candidate.reason,
+				suggestion: candidate.suggestion,
+				err:        err,
+			})
+			continue
+		}
+
+		tempTlsConfig := tlsConfig.Clone()
+		tempTlsConfig.GMSupport = nil
+		if candidate.config != nil {
+			candidate.config(tempTlsConfig)
+		}
+
+		startUpgrade := time.Now()
+		tlsConn, err = UpgradeToTLSConnectionWithTimeout(conn, candidate.sni, tempTlsConfig, tlsTimeout, candidate.spec, candidate.nextProtos...)
+		handshakeDuration = time.Since(startUpgrade)
+		totalHandshakeDuration += handshakeDuration
+		attempt := tlsRetryAttempt{
+			name:       candidate.name,
+			reason:     candidate.reason,
+			suggestion: candidate.suggestion,
+			err:        err,
+			success:    err == nil,
+			duration:   handshakeDuration,
+		}
+		attempts = append(attempts, attempt)
+		if err == nil {
+			return tlsConn, totalHandshakeDuration, nil
+		}
+		_ = conn.Close()
+	}
+
+	return nil, totalHandshakeDuration, &tlsRetryError{target: target, kind: kind, attempts: attempts, suggestion: suggestion}
+}
+
+func addTLSNoRetryTip(traceInfo *DialXTraceInfo, kind, suggestion string) {
+	switch kind {
+	case tlsErrorKindNotTLS:
+		traceInfo.AddTLSRetryTip("目标端口疑似非 TLS 服务，未继续进行 TLS 兼容重试；请确认协议或端口")
+	case tlsErrorKindCertificate:
+		traceInfo.AddTLSRetryTip("TLS 握手失败，目标可能要求客户端证书，未进行 TLS 指纹重试；请配置客户端证书")
+	case tlsErrorKindSNI:
+		traceInfo.AddTLSRetryTip("TLS SNI 可能不匹配，未静默覆盖用户配置；请检查目标域名、Host 与 SNI 配置")
+	case tlsErrorKindVersion:
+		traceInfo.AddTLSRetryTip("TLS 版本不兼容，未进行 TLS 版本重试；请检查全局 TLS 版本配置")
+	default:
+		if suggestion != "" {
+			traceInfo.AddTLSRetryTip("TLS 握手失败，未进行 TLS 兼容重试；" + suggestion)
+		}
+	}
+}
+
+func buildTLSRetryCandidates(
+	target string,
+	config *dialXConfig,
+	tlsConfig *gmtls.Config,
+	sni string,
+	clientHelloSpec *utls.ClientHelloSpec,
+	kind string,
+	suggestion string,
+) []tlsRetryCandidate {
+	candidates := make([]tlsRetryCandidate, 0, 3)
+	added := make(map[string]struct{})
+	add := func(candidate tlsRetryCandidate) {
+		if len(candidates) >= 3 {
+			return
+		}
+		key := tlsRetryCandidateKey(candidate)
+		if _, ok := added[key]; ok {
+			return
+		}
+		added[key] = struct{}{}
+		candidates = append(candidates, candidate)
+	}
+
+	addTLS12Candidate := func() {
+		if tlsConfig.MinVersion > gmtls.VersionTLS12 || tlsConfig.MaxVersion < gmtls.VersionTLS12 {
+			config.TraceInfo.AddTLSRetryTip("TLS 版本不兼容，未尝试 TLS1.2 only；当前全局 TLS 版本配置不允许 TLS1.2")
+			return
+		}
+		add(tlsRetryCandidate{
+			name:       "tls12-only",
+			reason:     "retry with TLS1.2 only",
+			tip:        "TLS 版本不兼容，已尝试 TLS1.2 only",
+			suggestion: suggestion,
+			sni:        sni,
+			nextProtos: cloneStringSlice(config.TLSNextProto),
+			spec:       clientHelloSpec,
+			config: func(c *gmtls.Config) {
+				c.MinVersion = gmtls.VersionTLS12
+				c.MaxVersion = gmtls.VersionTLS12
+			},
+		})
+	}
+
+	addChromeCandidate := func() {
+		spec, err := utls.UTLSIdToSpec(utls.HelloChrome_120)
+		if err != nil {
+			config.TraceInfo.AddTLSRetryTip("TLS 握手失败，生成 Chrome TLS 指纹失败，未进行指纹重试")
+			return
+		}
+		reason := "retry with Chrome TLS fingerprint"
+		if clientHelloSpec != nil {
+			reason = "fallback from custom ClientHello to Chrome TLS fingerprint"
+		}
+		add(tlsRetryCandidate{
+			name:       "chrome-client-hello",
+			reason:     reason,
+			tip:        "TLS 握手失败，已尝试 Chrome TLS 指纹重试",
+			suggestion: suggestion,
+			sni:        sni,
+			nextProtos: cloneStringSlice(config.TLSNextProto),
+			spec:       &spec,
+		})
+	}
+
+	addALPNCandidates := func() {
+		if !containsString(config.TLSNextProto, "h2") {
+			return
+		}
+		add(tlsRetryCandidate{
+			name:       "alpn-http11",
+			reason:     "retry with ALPN http/1.1 only",
+			tip:        "TLS 握手失败，已尝试调整 ALPN 为 http/1.1",
+			suggestion: "目标可能不兼容当前 ALPN，可尝试仅使用 http/1.1 或关闭 ALPN",
+			sni:        sni,
+			nextProtos: []string{"http/1.1"},
+			spec:       clientHelloSpec,
+			config: func(c *gmtls.Config) {
+				c.NextProtos = []string{"http/1.1"}
+			},
+		})
+		add(tlsRetryCandidate{
+			name:       "alpn-disabled",
+			reason:     "retry without ALPN",
+			tip:        "TLS 握手失败，已尝试移除 ALPN",
+			suggestion: "目标可能不兼容当前 ALPN，可尝试仅使用 http/1.1 或关闭 ALPN",
+			sni:        sni,
+			nextProtos: nil,
+			spec:       clientHelloSpec,
+			config: func(c *gmtls.Config) {
+				c.NextProtos = nil
+			},
+		})
+	}
+
+	addSNICandidate := func() {
+		if config.ShouldOverrideSNI {
+			config.TraceInfo.AddTLSRetryTip("TLS SNI 可能不匹配，用户已显式设置 SNI，未静默覆盖；请检查目标域名、Host 与 SNI 配置")
+			return
+		}
+		host := utils.ExtractHost(target)
+		nextSNI := ""
+		if sni == "" && host != "" {
+			nextSNI = host
+		} else if sni != "" {
+			nextSNI = ""
+		}
+		if nextSNI == sni {
+			return
+		}
+		add(tlsRetryCandidate{
+			name:       "sni-adjusted",
+			reason:     "retry with adjusted SNI",
+			tip:        "TLS 握手失败，已尝试调整 SNI",
+			suggestion: "TLS SNI 可能不匹配，请检查目标域名、Host 与 SNI 配置；如果使用 IP 直连，可尝试指定正确 SNI",
+			sni:        nextSNI,
+			nextProtos: cloneStringSlice(config.TLSNextProto),
+			spec:       clientHelloSpec,
+			config: func(c *gmtls.Config) {
+				c.ServerName = nextSNI
+			},
+		})
+	}
+
+	switch kind {
+	case tlsErrorKindVersion:
+		addTLS12Candidate()
+	case tlsErrorKindALPN:
+		addALPNCandidates()
+	case tlsErrorKindSNI:
+		addSNICandidate()
+	case tlsErrorKindHandshake, tlsErrorKindUnknown:
+		addChromeCandidate()
+		addALPNCandidates()
+		addSNICandidate()
+	}
+
+	return candidates
+}
+
+func tlsRetryCandidateKey(candidate tlsRetryCandidate) string {
+	specKey := "default"
+	if candidate.spec != nil {
+		specKey = "custom"
+		if candidate.name == "chrome-client-hello" {
+			specKey = "chrome120"
+		}
+	}
+	return strings.Join([]string{
+		candidate.sni,
+		specKey,
+		strings.Join(candidate.nextProtos, ","),
+		candidate.name,
+	}, "|")
+}
+
+func cloneStringSlice(v []string) []string {
+	if len(v) == 0 {
+		return nil
+	}
+	ret := make([]string, len(v))
+	copy(ret, v)
+	return ret
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/common/netx/dialx_tls_retry_test.go
+++ b/common/netx/dialx_tls_retry_test.go
@@ -1,0 +1,183 @@
+package netx
+
+import (
+	"io"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/gmsm/gmtls"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/tlsutils"
+)
+
+func TestClassifyTLSError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantKind  string
+		retryable bool
+	}{
+		{
+			name:      "not tls",
+			err:       io.ErrUnexpectedEOF,
+			wantKind:  tlsErrorKindHandshake,
+			retryable: true,
+		},
+		{
+			name:      "plain http",
+			err:       errString("tls: first record does not look like a TLS handshake"),
+			wantKind:  tlsErrorKindNotTLS,
+			retryable: false,
+		},
+		{
+			name:      "client certificate required",
+			err:       errString("remote error: tls: certificate required"),
+			wantKind:  tlsErrorKindCertificate,
+			retryable: false,
+		},
+		{
+			name:      "alpn",
+			err:       errString("remote error: tls: no application protocol"),
+			wantKind:  tlsErrorKindALPN,
+			retryable: true,
+		},
+		{
+			name:      "version",
+			err:       errString("remote error: tls: protocol version not supported"),
+			wantKind:  tlsErrorKindVersion,
+			retryable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, retryable, suggestion := classifyTLSError(tt.err)
+			require.Equal(t, tt.wantKind, kind)
+			require.Equal(t, tt.retryable, retryable)
+			require.NotEmpty(t, suggestion)
+		})
+	}
+}
+
+func TestBuildTLSRetryCandidates(t *testing.T) {
+	config := &dialXConfig{
+		TLSNextProto: []string{"h2", "http/1.1"},
+		TraceInfo:    NewDialXTraceInfo(),
+	}
+	tlsConfig := &gmtls.Config{
+		MinVersion: gmtls.VersionTLS10,
+		MaxVersion: gmtls.VersionTLS13,
+	}
+
+	candidates := buildTLSRetryCandidates("example.com:443", config, tlsConfig, "example.com", nil, tlsErrorKindALPN, "alpn suggestion")
+	require.Len(t, candidates, 2)
+	require.Equal(t, "alpn-http11", candidates[0].name)
+	require.Equal(t, "alpn-disabled", candidates[1].name)
+
+	candidates = buildTLSRetryCandidates("example.com:443", config, tlsConfig, "example.com", nil, tlsErrorKindVersion, "version suggestion")
+	require.Len(t, candidates, 1)
+	require.Equal(t, "tls12-only", candidates[0].name)
+
+	config.ShouldOverrideSNI = true
+	candidates = buildTLSRetryCandidates("example.com:443", config, tlsConfig, "bad.example", nil, tlsErrorKindSNI, "sni suggestion")
+	require.Empty(t, candidates)
+	require.Contains(t, strings.Join(config.TraceInfo.TLSRetryTips, "\n"), "用户已显式设置 SNI")
+}
+
+func TestDialXTLSRetryChromeFallbackSuccess(t *testing.T) {
+	addr, closeServer := startTLSRetryTestServer(t, func(n int32, conn net.Conn) {
+		if n == 1 {
+			_ = conn.Close()
+			return
+		}
+		tlsConn := tlsutils.NewDefaultTLSServer(conn)
+		_, _ = tlsConn.Write([]byte("ok"))
+		_ = tlsConn.Close()
+	})
+	defer closeServer()
+
+	trace := NewDialXTraceInfo()
+	conn, err := DialX(
+		addr,
+		DialX_WithTLS(true),
+		DialX_WithDialTraceInfo(trace),
+		DialX_WithTimeout(2*time.Second),
+		DialX_WithTLSTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	buf := make([]byte, 2)
+	_, err = io.ReadFull(conn, buf)
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(buf))
+	require.GreaterOrEqual(t, trace.TLSRetryCount, 1)
+	require.Contains(t, strings.Join(trace.TLSRetryTips, "\n"), "Chrome TLS 指纹重试")
+}
+
+func TestDialXTLSRetryNotTLSNoRetry(t *testing.T) {
+	addr, closeServer := startTLSRetryTestServer(t, func(_ int32, conn net.Conn) {
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"))
+		_ = conn.Close()
+	})
+	defer closeServer()
+
+	trace := NewDialXTraceInfo()
+	conn, err := DialX(
+		addr,
+		DialX_WithTLS(true),
+		DialX_WithDialTraceInfo(trace),
+		DialX_WithTimeout(2*time.Second),
+		DialX_WithTLSTimeout(2*time.Second),
+	)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	require.Error(t, err)
+	require.Zero(t, trace.TLSRetryCount)
+	require.Contains(t, strings.Join(trace.TLSRetryTips, "\n"), "疑似非 TLS 服务")
+	require.Contains(t, err.Error(), "目标端口疑似不是 TLS 服务")
+	require.Contains(t, err.Error(), "原始错误")
+	require.Contains(t, err.Error(), "TLS重试: 未进行 TLS 兼容重试")
+	require.NotContains(t, err.Error(), "调试配置")
+}
+
+func startTLSRetryTestServer(t *testing.T, serve func(int32, net.Conn)) (string, func()) {
+	t.Helper()
+
+	port := utils.GetRandomAvailableTCPPort()
+	addr := utils.HostPort("127.0.0.1", port)
+	listener, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	var count atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go serve(count.Add(1), conn)
+		}
+	}()
+
+	return addr, func() {
+		_ = listener.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+type errString string
+
+func (e errString) Error() string {
+	return string(e)
+}

--- a/common/utils/lowhttp/config.go
+++ b/common/utils/lowhttp/config.go
@@ -343,12 +343,15 @@ type LowhttpTraceInfo struct {
 	TLSHandshakeTime time.Duration
 	// tcp dial 耗时
 	TCPTime time.Duration
+	// 原始 dial trace，保留底层更细的连接耗时与重试信息
+	DialTraceInfo *netx.DialXTraceInfo
 }
 
 func (l *LowhttpTraceInfo) ParseDialXTraceInfo(info *netx.DialXTraceInfo) {
 	if info == nil {
 		return
 	}
+	l.DialTraceInfo = info
 	l.ConnTime = info.TotalTime
 	l.TCPTime = info.TCPtime
 	l.TLSHandshakeTime = info.TLSHandshakeTime

--- a/common/utils/lowhttp/exec_test.go
+++ b/common/utils/lowhttp/exec_test.go
@@ -1564,6 +1564,24 @@ func TestNoBodyBuffer_NoErrorLog(t *testing.T) {
 	require.NotNil(t, rsp)
 }
 
+func TestLowhttpTraceInfo_ParseDialXTraceInfo(t *testing.T) {
+	dialTrace := &netx.DialXTraceInfo{
+		TotalTime:        123 * time.Millisecond,
+		TCPtime:          45 * time.Millisecond,
+		TLSHandshakeTime: 67 * time.Millisecond,
+		TLSRetryCount:    2,
+		TLSRetryTips:     []string{"tip-a", "tip-b"},
+	}
+	trace := &LowhttpTraceInfo{}
+
+	trace.ParseDialXTraceInfo(dialTrace)
+
+	require.Same(t, dialTrace, trace.DialTraceInfo)
+	require.Equal(t, dialTrace.TotalTime, trace.ConnTime)
+	require.Equal(t, dialTrace.TCPtime, trace.TCPTime)
+	require.Equal(t, dialTrace.TLSHandshakeTime, trace.TLSHandshakeTime)
+}
+
 // TestNoBodyBuffer_NormalRequestsUnaffected verifies normal requests still work correctly
 func TestNoBodyBuffer_NormalRequestsUnaffected(t *testing.T) {
 	// This test ensures that the NoBodyBuffer condition in FixHTTPResponse doesn't affect normal requests

--- a/common/yakgrpc/grpc_fuzzer_config_test.go
+++ b/common/yakgrpc/grpc_fuzzer_config_test.go
@@ -161,7 +161,7 @@ func TestGRPCMUSTPASS_HTTPFuzzer_SNI(t *testing.T) {
 				}
 				t.Fatal(err)
 			}
-			if strings.Contains(recv.Reason, "all tls strategy failed") {
+			if strings.Contains(recv.Reason, "TLS连接失败") {
 				handShankErrorCheck = true
 			}
 		}
@@ -187,7 +187,7 @@ func TestGRPCMUSTPASS_HTTPFuzzer_SNI(t *testing.T) {
 				}
 				t.Fatal(err)
 			}
-			if strings.Contains(recv.Reason, "all tls strategy failed") || strings.Contains(recv.Reason, token) {
+			if strings.Contains(recv.Reason, "TLS连接失败") || strings.Contains(recv.Reason, token) {
 				handShankErrorCheck = true
 			}
 		}


### PR DESCRIPTION
# 当前工作区改动摘要

本次 `common/netx` 工作区主要围绕 **DialX 的 TLS 重试与错误提示** 做了增强，覆盖了普通 TLS 与国密 TLS 两条路径。

## 改动范围

- `common/netx/dialx.go`
  - 将普通 TLS 握手抽成 `dialTLSWithRetry` 统一处理。
  - 失败时不再直接返回单一错误字符串，而是组装更结构化的失败信息。
  - 当普通 TLS 失败后切换到国密 TLS 时，会补充重试提示。

- `common/netx/dialx_config.go`
  - `DialXTraceInfo` 新增 `TLSRetryCount` 和 `TLSRetryTips`，用于记录 TLS 重试次数与提示信息。
  - 新增 `AddTLSRetryTip`，避免重复写入相同提示。
  - `dialXConfig` 字段排版做了整理，但行为未变。

- `common/netx/dialx_gmtls.go`
  - 国密 TLS 失败后切换 cipher suites 时，会统计重试次数并写入提示。
  - 增加 `fmt` 依赖，用于生成重试提示文本。

- `common/netx/dialx_tls_retry.go`
  - 新增 TLS 失败分类、重试候选构造、重试错误封装等逻辑。
  - 支持根据失败类型切换 Chrome 指纹、ALPN、SNI、TLS1.2 only 等重试策略。
  - 增加更友好的错误原因与建议输出。

- `common/netx/dialx_tls_retry_test.go`
  - 新增回归测试，覆盖：
    - TLS 失败分类
    - 重试候选生成
    - Chrome 指纹重试成功
    - 非 TLS 服务不做重试

## 整体效果

这次改动让 `DialX` 在 TLS 握手失败时更“会自救”，并且能把 **失败原因、重试过程、建议** 更清晰地反馈给调用方和 TraceInfo。对排查端口协议不匹配、ALPN/SNI/TLS 版本不兼容、以及国密套件兼容问题会更有帮助。
