### PR TITLE
fix(ai-tool): 优化 AI 工具文档，优先推荐 write_file/ExcelCLI，中文化描述

### DIFF
--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/query_excel_data.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/query_excel_data.yak
@@ -1,48 +1,49 @@
-__DESC__ = "Excel data query tool for SIMPLE one-off lookups: column selection, row filtering, sorting, single aggregation, pagination. PERFORMANCE WARNING: Each call re-parses the entire file (30+ seconds for large files). For multi-step analysis requiring 2+ queries on the same file, strongly prefer using bash tool to write a Python pandas script instead - it reads the file once and runs all computations in-memory, which is 10x faster for batch analysis."
-__VERBOSE_NAME__ = "Excel Data Query"
-__KEYWORDS__ = "excel query,data filter,sort,aggregate,sum,count,avg,group by,xlsx,spreadsheet,data analysis,column select,pagination,excel search,transaction analysis,financial data,excel read"
+__DESC__ = "Excel 数据查询工具，适用于简单的一次性查询：列选择、行过滤、排序、单维度聚合、分页。性能警告：每次调用都会重新解析整个文件（40MB 文件约需 30 秒）。对于需要 3 次以上查询的多步骤分析，如果数据已通过 ExcelCLI 入库，应优先使用 `excelcli query` 命令通过 SQL 进行批量分析。仅当 ExcelCLI 不可用时，才使用 Python pandas 作为兜底方案。"
+__VERBOSE_NAME__ = "Excel 数据查询"
+__KEYWORDS__ = "excel query,data filter,sort,aggregate,sum,count,avg,group by,xlsx,spreadsheet,data analysis,column select,pagination,excel search,transaction analysis,financial data,excel read,excelcli,query,SQL 分析,excelcli query,数据库查询,批量分析"
 
 __USAGE__ = <<<USAGE_BLOCK
-Excel Data Query Tool - Parameter Description for JSON Tool Calls
+Excel 数据查询工具 —— 用于 JSON 工具调用的参数说明
 
-Queries Excel data with filtering, sorting, aggregation, and pagination.
-Use read_excel_info first to understand the data schema.
+对 Excel 数据执行过滤、排序、聚合和分页查询。
+请先使用 read_excel_info 了解数据结构。
 
-## CRITICAL: Performance & Tool Selection Guide
+## ⚠️ 性能与工具选择指南
 
-Each call to this tool re-parses the ENTIRE Excel file from disk.
-For a 40MB file, parsing alone takes ~30 seconds per call.
+每次调用本工具都会从磁盘**重新解析整个 Excel 文件**。
+对于 40MB 的文件，单次解析约需 30 秒。
 
-### When to use this tool (GOOD):
-- Single one-off query: quick filter, lookup specific rows, verify data
-- Simple aggregation: one group-by with one metric
-- You only need 1-2 calls total on this file
+### ✅ 何时使用本工具（适合）：
+- 一次性的简单查询：快速过滤、查看特定行、验证数据
+- 单维度聚合：一个 group-by + 一个指标
+- 仅需对该文件执行 1-2 次查询
 
-### When NOT to use this tool (use Python via bash instead):
-- You need 3+ different statistics from the same file
-  (e.g., count by type AND sum by type AND yearly trend AND top-10 etc.)
-- You need derived field grouping (e.g., group by YEAR extracted from datetime)
-- You need cross-file joins or correlations (e.g., match transactions across 2 files)
-- You need complex analytics (percentiles, pivot tables, Union-Find clustering)
-- You need multi-dimensional aggregation in one pass
+### ❌ 何时不应使用本工具：
 
-### Recommended: Python script for batch analysis
+#### 场景一：数据已通过 ExcelCLI 入库（数据库分析优先）
 
-When you need comprehensive analysis, write ONE Python script via bash tool:
+如果数据已通过 `excelcli import` 导入到 SQLite 数据库，应优先使用 `excelcli query` 通过 SQL 进行批量分析：
+
+```
+excelcli query "<数据库路径>" --sql "SELECT account_name, COUNT(*) as cnt, SUM(amount) as total FROM bank_transactions GROUP BY account_name" --json
+```
+
+对于一个 SQL 查询即可覆盖多个维度的场景，`excelcli query` 是最高效的方式，无需反复解析 Excel 文件。
+
+#### 场景二：ExcelCLI 不可用或数据未入库（Python pandas 兜底）
+
+仅在 ExcelCLI 不可用、不支持当前文件格式、或数据未入库的情况下，才使用 Python pandas 通过 bash 工具编写分析脚本：
 
 ```python
-import pandas as pd
-import json
+import pandas as pd, json
 
 df = pd.read_excel('/path/to/data.xlsx')
 results = {}
 
-# Multiple aggregations in one pass (replaces 5+ query_excel_data calls)
+# 一次读取，批量计算（替代多次 query_excel_data 调用）
 results['total_rows'] = len(df)
 results['by_type_count'] = df.groupby('Type')['Amount'].count().to_dict()
 results['by_type_sum'] = df.groupby('Type')['Amount'].sum().to_dict()
-results['by_year'] = df.groupby(df['Date'].dt.year)['Amount'].agg(['count','sum']).to_dict()
-results['top10_by_amount'] = df.nlargest(10, 'Amount')[['Name','Amount','Date']].to_dict('records')
 results['amount_max'] = float(df['Amount'].max())
 results['amount_min'] = float(df['Amount'].min())
 results['amount_mean'] = float(df['Amount'].mean())
@@ -50,41 +51,49 @@ results['amount_mean'] = float(df['Amount'].mean())
 print(json.dumps(results, ensure_ascii=False, indent=2, default=str))
 ```
 
-This reads the file ONCE (~30s) and computes EVERYTHING in-memory (milliseconds).
-Compared to 7 separate query_excel_data calls (7x30s = 210s), this saves ~180 seconds.
+Python 方案将文件读取一次（~30s），所有计算在内存中完成（毫秒级）。
+相比多次 query_excel_data 调用（7×30s = 210s），可节省约 180 秒。
 
-## Parameters
+### 工具选择优先级总结
 
-Required Parameters:
-  input           (string)  Path to the Excel file (.xls or .xlsx).
+| 场景 | 推荐工具 | 说明 |
+|------|---------|------|
+| 1-2 次简单查询 | `query_excel_data` | 单次过滤/聚合，简单直接 |
+| 数据已入库，需批量分析 | `excelcli query` + SQL | 首选方案，无需重复解析文件 |
+| ExcelCLI 不可用 | Python pandas via bash | 兜底方案 |
 
-Optional Parameters:
-  sheet           (string)  Sheet name to query. If omitted, uses the first sheet.
-  columns         (string)  Comma-separated column names to select.
-                            Example: "Name,Amount,Date"
-                            If omitted, all columns are returned.
-  filter          (string)  Filter expression. Supports multiple conditions separated by AND.
-                            Operators: ==, !=, >, <, >=, <=, contains, !contains, startswith, endswith
-                            Examples:
+## 参数说明
+
+必填参数：
+  input           (string)  Excel 文件路径（.xls 或 .xlsx）。
+
+可选参数：
+  sheet           (string)  要查询的工作表名称。省略则使用第一个工作表。
+  columns         (string)  逗号分隔的列名列表。
+                            示例："Name,Amount,Date"
+                            省略则返回所有列。
+  filter          (string)  过滤表达式。支持多个条件以 AND 分隔。
+                            运算符：==, !=, >, <, >=, <=, contains, !contains, startswith, endswith
+                            示例：
                               "Amount>50000"
                               "Status==completed"
                               "Name contains Zhang"
                               "Amount>10000 AND Type==income"
-                            Column names and values are trimmed automatically.
-  sort_by         (string)  Column name to sort by.
-  sort_desc       (bool)    Sort in descending order. Default: false.
-  limit           (int)     Max rows to return. Default: 50.
-  offset          (int)     Number of rows to skip (for pagination). Default: 0.
-  group_by        (string)  Column name to group by for aggregation.
-  agg             (string)  Aggregation function: count, sum, avg, min, max.
-                            Requires group_by to be set.
-  agg_column      (string)  Column to aggregate on. Required for sum/avg/min/max.
-  output_format   (string)  Output format: table (default), csv, json.
-  output          (string)  Output file path. If omitted, prints to stdout.
+                            列名和值会自动去除首尾空格。
+  sort_by         (string)  排序列名。
+  sort_desc       (bool)    降序排序。默认：false。
+  limit           (int)     最大返回行数。默认：50。
+  offset          (int)     跳过的行数（用于分页）。默认：0。
+  group_by        (string)  分组聚合的列名。
+  agg             (string)  聚合函数：count, sum, avg, min, max。
+                            需要设置 group_by。
+  agg_column      (string)  聚合目标列。sum/avg/min/max 必须设置。
+  output_format   (string)  输出格式：table（默认）、csv、json。
+  output          (string)  输出文件路径。省略则打印到标准输出。
 
-Examples:
+示例：
 
-1. Basic query with filter (GOOD - single query):
+1. 带过滤的基本查询（适合——单次查询）：
 ```json
 {
   "@action": "call-tool",
@@ -100,7 +109,7 @@ Examples:
 }
 ```
 
-2. Aggregation query (GOOD - single aggregation):
+2. 聚合查询（适合——单次聚合）：
 ```json
 {
   "@action": "call-tool",
@@ -117,9 +126,10 @@ Examples:
 }
 ```
 
-3. BAD PRACTICE - DO NOT DO THIS:
-   Calling this tool 5+ times on the same large file for different aggregations.
-   Each call re-parses the file (~30s each). Write ONE Python script via bash instead.
+3. 不推荐的做法——不要这样做：
+   对同一个大文件反复调用本工具 5 次以上做不同维度的聚合。
+   每次调用都会重新解析文件（~30s/次）。应优先使用 ExcelCLI query（数据已入库时）
+   或 Python pandas 方案（ExcelCLI 不可用时）。
 USAGE_BLOCK
 
 yakit.AutoInitYakit()
@@ -756,8 +766,10 @@ cacheHint = sprintf("/tmp/%v_cache.csv", baseName)
 if totalDataRows > 500 {
     yakit.Info("Query completed: %v rows returned (source: %v total data rows)", len(filteredRows), totalDataRows)
     yakit.Info("[PERFORMANCE NOTICE] This file has %v rows. Each query_excel_data call re-parses the entire file from disk (~30s for large files).", totalDataRows)
-    yakit.Info("  If you need additional statistics from this same file, DO NOT call this tool again.")
-    yakit.Info("  Instead, use bash tool with a Python pandas script that reads the file once and computes all metrics.")
+    yakit.Info("  If you need additional statistics, DO NOT call this tool again.")
+    yakit.Info("  Option A (PREFERRED if data was imported via ExcelCLI): Use `excelcli query` with SQL for batch analysis.")
+    yakit.Info("    Example: excelcli query \"<db_path>\" --sql \"SELECT ... FROM bank_transactions GROUP BY ...\" --json")
+    yakit.Info("  Option B (FALLBACK): Use Python pandas via bash to read file once and compute all metrics.")
     yakit.Info("[CACHING TIP] Check if a CSV cache exists at: %v", cacheHint)
     yakit.Info("  If it exists, use pd.read_csv('%v') in your Python script (~1s vs ~30s for Excel).", cacheHint)
     yakit.Info("  If not, create one: df = pd.read_excel('%v'); df.to_csv('%v', index=False)", inputFile, cacheHint)

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_excel_info.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_excel_info.yak
@@ -1,41 +1,37 @@
-__DESC__ = "Excel file structure exploration tool. Reads an Excel file and outputs sheet list, column names with inferred data types, row counts, and preview rows. Use this FIRST to understand data layout. IMPORTANT: This tool is for structure exploration only. For transaction data, financial records, bank statements, invoice data, or any case investigation data analysis (3+ queries), use ExcelCLI (excelcli-analysis skill) for proper data import, database storage, and structured SQL analysis via bash tool. Python pandas via bash is a fallback only when ExcelCLI is unavailable or cannot handle the file format."
-__VERBOSE_NAME__ = "Excel Structure Explorer"
+__DESC__ = "Excel 文件结构探索工具。读取 Excel 文件并输出工作表列表、列名及推断数据类型、行数和预览行。先用此工具了解数据布局。重要：本工具仅用于结构探索。对于交易数据、银行流水、发票数据、金融记录或任何案件调查数据的多步骤分析（3 次以上查询），应使用 ExcelCLI（excelcli-analysis 技能）进行数据导入入库，然后通过 bash 工具执行结构化 SQL 分析。仅当 ExcelCLI 不可用时，Python pandas 才作为兜底方案。"
+__VERBOSE_NAME__ = "Excel 结构探索"
 __KEYWORDS__ = "excel,xlsx,xls,spreadsheet,data exploration,column names,sheet list,data types,row count,preview,schema,structure,data analysis,excel info,excel schema,transaction data,financial analysis,bank statement,excelcli,数据入库,案件分析,办案数据,银行流水,发票数据"
 
 __USAGE__ = <<<USAGE_BLOCK
-Excel Structure Explorer Tool - Parameter Description for JSON Tool Calls
+Excel 文件结构探索工具 —— 用于 JSON 工具调用的参数说明
 
-Reads an Excel file and outputs structured information: sheet names, column headers,
-inferred data types, row counts, and preview data. Use this tool FIRST before
-query_excel_data to understand the data layout.
+读取 Excel 文件并输出结构化信息：工作表名称、列头、推断的数据类型、行数和预览数据。
+在执行 query_excel_data 之前，请先使用此工具了解数据布局。
 
-## Important: When to Use ExcelCLI vs Python
+## 重要：何时使用 ExcelCLI vs Python
 
-This tool is for structure exploration ONLY. For subsequent data analysis:
+本工具仅用于结构探索。后续数据分析的优先级：
 
-1. **EXCELCLI (PREFERRED)** — For transaction data, financial records, bank statements,
-   invoice data, or any case investigation data that requires 3+ analysis steps:
-   Use the ExcelCLI skill (excelcli-analysis) to import data into a structured database,
-   then use bash tool with SQL queries for analysis. This is the recommended workflow
-   for all financial/case analysis tasks.
+1. **ExcelCLI（首选）** — 对于交易数据、银行流水、发票数据、金融记录或任何需要
+   3 次以上分析步骤的案件调查数据：使用 ExcelCLI 技能（excelcli-analysis）将数据
+   导入到结构化数据库，然后通过 bash 工具执行 SQL 查询进行分析。这是所有金融/案件
+   分析任务的首选工作流。
 
-2. **Python pandas (FALLBACK)** — Only use Python pandas via bash when ExcelCLI is
-   unavailable or cannot handle the specific file format. Python is NOT the default
-   approach for transaction/financial data analysis.
+2. **Python pandas（兜底）** — 仅在 ExcelCLI 不可用或不支持当前文件格式时，
+   才使用 Python pandas 通过 bash 工具进行分析。Python 不是交易/金融数据分析的默认方案。
 
-3. **query_excel_data** — Suitable for 1-2 simple queries. Avoid for complex analysis
-   as each call re-parses the entire file.
+3. **query_excel_data** — 适合 1-2 次简单查询。避免用于复杂分析，因为每次调用都会
+   重新解析整个文件。
 
-Required Parameters:
-  input           (string)  Path to the Excel file (.xls or .xlsx).
+必填参数：
+  input           (string)  Excel 文件路径（.xls 或 .xlsx）。
 
-Optional Parameters:
-  sheet           (string)  Specific sheet name to inspect. If omitted, all sheets are shown.
-  preview_rows    (int)     Number of preview rows to display. Default: 5.
-                            Set to 0 to skip preview.
-  output          (string)  Output file path. If omitted, results are printed to stdout.
+可选参数：
+  sheet           (string)  要检查的特定工作表名称。省略则显示所有工作表。
+  preview_rows    (int)     预览行数。默认：5。设为 0 跳过预览。
+  output          (string)  输出文件路径。省略则打印到标准输出。
 
-Example:
+示例：
 
 ```json
 {
@@ -366,3 +362,4 @@ if totalRows > 500 {
     yakit.Info("[IMPORTANT] For transaction/financial/case data analysis tasks, ALWAYS prefer ExcelCLI")
     yakit.Info("  data import + database analysis. Python pandas is a fallback mechanism, NOT the default.")
     yakit.Info("")
+}

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_excel_info.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_excel_info.yak
@@ -1,6 +1,6 @@
-__DESC__ = "Excel file structure exploration tool. Reads an Excel file and outputs sheet list, column names with inferred data types, row counts, and preview rows. Use this FIRST to understand data layout. IMPORTANT: For subsequent multi-step data analysis (3+ queries), prefer writing a Python pandas script via bash tool instead of calling query_excel_data repeatedly - each query_excel_data call re-parses the entire file."
+__DESC__ = "Excel file structure exploration tool. Reads an Excel file and outputs sheet list, column names with inferred data types, row counts, and preview rows. Use this FIRST to understand data layout. IMPORTANT: This tool is for structure exploration only. For transaction data, financial records, bank statements, invoice data, or any case investigation data analysis (3+ queries), use ExcelCLI (excelcli-analysis skill) for proper data import, database storage, and structured SQL analysis via bash tool. Python pandas via bash is a fallback only when ExcelCLI is unavailable or cannot handle the file format."
 __VERBOSE_NAME__ = "Excel Structure Explorer"
-__KEYWORDS__ = "excel,xlsx,xls,spreadsheet,data exploration,column names,sheet list,data types,row count,preview,schema,structure,data analysis,excel info,excel schema"
+__KEYWORDS__ = "excel,xlsx,xls,spreadsheet,data exploration,column names,sheet list,data types,row count,preview,schema,structure,data analysis,excel info,excel schema,transaction data,financial analysis,bank statement,excelcli,数据入库,案件分析,办案数据,银行流水,发票数据"
 
 __USAGE__ = <<<USAGE_BLOCK
 Excel Structure Explorer Tool - Parameter Description for JSON Tool Calls
@@ -8,6 +8,23 @@ Excel Structure Explorer Tool - Parameter Description for JSON Tool Calls
 Reads an Excel file and outputs structured information: sheet names, column headers,
 inferred data types, row counts, and preview data. Use this tool FIRST before
 query_excel_data to understand the data layout.
+
+## Important: When to Use ExcelCLI vs Python
+
+This tool is for structure exploration ONLY. For subsequent data analysis:
+
+1. **EXCELCLI (PREFERRED)** — For transaction data, financial records, bank statements,
+   invoice data, or any case investigation data that requires 3+ analysis steps:
+   Use the ExcelCLI skill (excelcli-analysis) to import data into a structured database,
+   then use bash tool with SQL queries for analysis. This is the recommended workflow
+   for all financial/case analysis tasks.
+
+2. **Python pandas (FALLBACK)** — Only use Python pandas via bash when ExcelCLI is
+   unavailable or cannot handle the specific file format. Python is NOT the default
+   approach for transaction/financial data analysis.
+
+3. **query_excel_data** — Suitable for 1-2 simple queries. Avoid for complex analysis
+   as each call re-parses the entire file.
 
 Required Parameters:
   input           (string)  Path to the Excel file (.xls or .xlsx).
@@ -340,17 +357,12 @@ if totalRows > 500 {
     yakit.Info("[NEXT STEP RECOMMENDATION] This file has %v data rows across %v sheet(s).", totalRows, len(sheetNames))
     yakit.Info("  Sheet names: %v", str.Join(sheetNames, ", "))
     yakit.Info("  Option A (1-2 simple queries): Use query_excel_data for a single filter or aggregation.")
-    yakit.Info("  Option B (complex analysis, STRONGLY RECOMMENDED): Use bash tool with Python pandas.")
+    yakit.Info("  Option B (multi-step analysis, RECOMMENDED): Use ExcelCLI skill to import data into database")
+    yakit.Info("           and then use structured SQL analysis via bash tool. This is the PREFERRED approach")
+    yakit.Info("           for transaction data, financial records, bank statements, invoice data, or any")
+    yakit.Info("           case investigation data that requires 3+ analysis steps.")
+    yakit.Info("  Option C (fallback): Only if ExcelCLI is unavailable, use Python pandas via bash tool.")
     yakit.Info("")
-    yakit.Info("[DATA CACHING TIP] Your FIRST Python script should create a CSV cache for 10x faster subsequent reads:")
-    yakit.Info("  import pandas as pd, os")
-    yakit.Info("  CACHE = '/tmp/%v_cache.csv'", baseName)
-    yakit.Info("  if os.path.exists(CACHE):")
-    yakit.Info("      df = pd.read_csv(CACHE)  # ~1 second")
-    yakit.Info("  else:")
-    yakit.Info("      df = pd.read_excel('%v', sheet_name='%v')  # ~30s for large files", inputFile, firstSheet)
-    yakit.Info("      df.to_csv(CACHE, index=False)")
+    yakit.Info("[IMPORTANT] For transaction/financial/case data analysis tasks, ALWAYS prefer ExcelCLI")
+    yakit.Info("  data import + database analysis. Python pandas is a fallback mechanism, NOT the default.")
     yakit.Info("")
-    yakit.Info("  RULE: If your analysis requires 3+ statistics, ALWAYS use Python via bash with caching.")
-    yakit.Info("  Schema reference file: %v", schemaFile)
-}

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
@@ -1,6 +1,6 @@
-__DESC__ = "跨平台Shell命令执行工具，支持bash/cmd/powershell，具备超时控制和输出捕获。bash 默认以登录 shell 执行以加载系统和用户 profile 中的 PATH/环境变量，不额外启用 set -e 或命令追踪，行为更接近原生终端执行。"
+__DESC__ = "跨平台Shell命令执行工具，支持bash/cmd/powershell，具备超时控制和输出捕获。bash 默认以登录 shell 执行以加载系统和用户 profile 中的 PATH/环境变量，不额外启用 set -e 或命令追踪，行为更接近原生终端执行。注意：对于文件创建/写入操作，应优先使用 write_file 工具；对于文件局部修改，应优先使用 modify_file 工具。仅当专用工具无法满足需求时，才使用 bash 的 cat/echo 重定向操作文件。"
 __VERBOSE_NAME__ = "跨平台Shell命令执行工具"
-__KEYWORDS__ = "shell command,bash,cmd,powershell,命令行工具,系统管理,自动化脚本,运维工具,shell script,command execution,系统操作,终端命令,system administration,automation tools,操作系统,跨平台命令,timeout,超时控制,python script,pandas,data analysis,excel analysis,csv cache,data cache,批量分析"
+__KEYWORDS__ = "shell command,bash,cmd,powershell,命令行工具,系统管理,自动化脚本,运维工具,shell script,command execution,系统操作,终端命令,system administration,automation tools,操作系统,跨平台命令,timeout,超时控制,python script,pandas,data analysis,excel analysis,csv cache,data cache,批量分析,write_file优先,文件操作优先,modify_file优先"
 
 __USAGE__ = <<<USAGE_BLOCK
 Cross-Platform Shell Command Execution Tool - Usage Guide for AI Parameter Generation
@@ -138,27 +138,29 @@ else
 fi
 <|TOOL_PARAM_command_END_{NONCE}|>
 
-### Example 5: Python script execution (WRITE-THEN-RUN pattern - MANDATORY)
+### Example 5: Python script execution (MANDATORY - use write_file first)
 
 IMPORTANT: For Python scripts longer than 5 lines, NEVER pipe code directly via
-heredoc (python3 << 'EOF'). This causes shell parse errors with Python shebangs,
-docstrings, and complex string formatting.
+heredoc (python3 << 'EOF') or use cat/echo redirect. This causes shell parse errors
+with Python shebangs, docstrings, and complex string formatting.
 
-Instead, use cat to WRITE the script to a .py file first, then EXECUTE it:
+Instead, use the `write_file` tool to write the script file FIRST, then use bash
+to execute it:
 
+Step 1 - Write the script via write_file:
 ```json
 {
   "@action": "call-tool",
-  "tool": "bash",
-  "identifier": "python_data_analysis",
+  "tool": "write_file",
+  "identifier": "write_python_script",
   "params": {
-    "timeout": 120
+    "file": "analysis_script.py",
+    "force": true
   }
 }
 ```
 
-<|TOOL_PARAM_command_{NONCE}|>
-cat > analysis_script.py << 'PYEOF'
+<|TOOL_PARAM_content_{NONCE}|>
 #!/usr/bin/env python3
 """This script analyzes data - docstrings are safe here."""
 import json
@@ -171,16 +173,25 @@ with open(data_file) as f:
 print(f"Records: {len(data)}")
 for key, value in data.items():
     print(f"  {key}: {value}")
-PYEOF
+<|TOOL_PARAM_content_END_{NONCE}|>
 
-python3 analysis_script.py
-<|TOOL_PARAM_command_END_{NONCE}|>
+Step 2 - Execute via bash:
+```json
+{
+  "@action": "call-tool",
+  "tool": "bash",
+  "identifier": "run_python_script",
+  "params": {
+    "command": "python3 analysis_script.py",
+    "timeout": 120
+  }
+}
+```
 
 Key points:
-  - cat > file.py << 'PYEOF' safely writes ANY Python syntax (shebangs, docstrings, f-strings)
-  - The PYEOF delimiter must be on its own line with no leading whitespace
-  - After writing, execute with: python3 file.py
-  - Both steps happen in ONE bash tool call, no need to call write_file separately
+  - ALWAYS use write_file tool first to create scripts, THEN use bash to execute
+  - write_file safely handles multi-line content with AITAG blocks
+  - DO NOT use cat/echo heredoc in bash to create files — use write_file/modify_file instead
   - For multi-step data analysis on large files, prefer Python pandas over repeated query_excel_data calls
 
 For short Python one-liners (< 5 lines without docstrings), you may use:
@@ -197,24 +208,26 @@ For short Python one-liners (< 5 lines without docstrings), you may use:
 }
 ```
 
-### Example 6: Python data analysis with caching (RECOMMENDED for large files)
+### Example 6: Python data analysis with caching (write_file + bash execution)
 
 For Excel/CSV files > 10MB or analysis spanning multiple bash tool calls,
-use a cache-first pattern to avoid re-reading large files every time:
+use a cache-first pattern to avoid re-reading large files every time.
+ALWAYS use write_file to create the script, then bash to execute:
 
+Step 1 - Write the analysis script via write_file:
 ```json
 {
   "@action": "call-tool",
-  "tool": "bash",
-  "identifier": "cached_data_analysis",
+  "tool": "write_file",
+  "identifier": "write_cached_analysis",
   "params": {
-    "timeout": 120
+    "file": "/tmp/analysis_with_cache.py",
+    "force": true
   }
 }
 ```
 
-<|TOOL_PARAM_command_{NONCE}|>
-cat > /tmp/analysis_with_cache.py << 'PYEOF'
+<|TOOL_PARAM_content_{NONCE}|>
 import pandas as pd, json, os
 
 EXCEL_FILE = "/path/to/large_data.xlsx"
@@ -237,15 +250,27 @@ print(json.dumps(results, ensure_ascii=False, indent=2, default=str))
 with open("/tmp/analysis_results.json", "w") as f:
     json.dump(results, f, ensure_ascii=False, indent=2, default=str)
 print(f"Results saved to /tmp/analysis_results.json")
-PYEOF
-python3 /tmp/analysis_with_cache.py
-<|TOOL_PARAM_command_END_{NONCE}|>
+<|TOOL_PARAM_content_END_{NONCE}|>
+
+Step 2 - Execute via bash:
+```json
+{
+  "@action": "call-tool",
+  "tool": "bash",
+  "identifier": "run_cached_analysis",
+  "params": {
+    "command": "python3 /tmp/analysis_with_cache.py",
+    "timeout": 120
+  }
+}
+```
 
 Key caching rules:
   - First script: pd.read_excel() + df.to_csv() to create cache
   - All subsequent scripts: pd.read_csv() from cache (10x faster)
   - Save analysis results to JSON files for downstream tasks to read
   - Use /tmp/ for cache files (auto-cleaned on reboot)
+  - Use write_file to create scripts, NOT cat heredoc in bash
 
 ### Example 7: Windows CMD one-line command (explicit shell)
 
@@ -305,14 +330,19 @@ Get-Service |
 4. Limit output: pipe through | head -N; limit search: add -maxdepth to find
 5. Use fallback chains for cross-platform: cmd1 2>/dev/null || cmd2 || echo "not available"
 6. NEVER generate indefinite commands (no tail -f, no watch, no ping without -c)
-7. ** PYTHON SCRIPTS ** -- For Python scripts > 5 lines, ALWAYS use the WRITE-THEN-RUN
-   pattern: cat > script.py << 'PYEOF' to write the file, then python3 script.py to run.
-   NEVER pipe Python code directly via python3 << 'EOF'. This avoids shell parse errors
-   with shebangs, docstrings, and complex string formatting.
+7. ** PYTHON SCRIPTS ** -- For Python scripts > 5 lines, ALWAYS use write_file tool
+   to create the script file first, then bash to execute it. NEVER use cat/echo heredoc
+   to write files in bash. This avoids shell parse errors and follows the principle of
+   using dedicated tools for file operations.
 8. ** DATA CACHING ** -- When analyzing large data files (Excel > 10MB), save a CSV cache
    after the first read. Subsequent scripts should check for and use the cache.
    Save analysis results to JSON files so downstream tasks can reuse them.
-9. ** WINDOWS TARGETS ** -- The tool prefers bash on Windows when Git Bash/MSYS/Cygwin
+9. ** FILE OPERATIONS PREFERENCE ** -- When you need to create or write files (scripts,
+   configs, documents, etc.), ALWAYS use `write_file` tool instead of bash heredoc/cat.
+   When modifying existing files, ALWAYS use `modify_file` tool instead of bash sed/echo.
+   Only use bash for file operations as a fallback when write_file/modify_file cannot
+   handle the specific requirement.
+10. ** WINDOWS TARGETS ** -- The tool prefers bash on Windows when Git Bash/MSYS/Cygwin
    bash is available. Set shell explicitly to "cmd" or "powershell" when generating
    Windows-native commands. This avoids mixing Bash syntax with Windows command syntax.
 USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
@@ -3,52 +3,52 @@ __VERBOSE_NAME__ = "跨平台Shell命令执行工具"
 __KEYWORDS__ = "shell command,bash,cmd,powershell,命令行工具,系统管理,自动化脚本,运维工具,shell script,command execution,系统操作,终端命令,system administration,automation tools,操作系统,跨平台命令,timeout,超时控制,python script,pandas,data analysis,excel analysis,csv cache,data cache,批量分析,write_file优先,文件操作优先,modify_file优先"
 
 __USAGE__ = <<<USAGE_BLOCK
-Cross-Platform Shell Command Execution Tool - Usage Guide for AI Parameter Generation
+跨平台 Shell 命令执行工具 —— AI 参数生成使用指南
 
-## Parameters
+## 参数说明
 
-Required:
-  command   (string)  The shell command or script to execute.
-                      Single-line commands: put directly in JSON params.command
-                      Multi-line scripts: MUST use AITAG format for the command parameter
+必填：
+  command   (string)  要执行的 Shell 命令或脚本。
+                      单行命令：直接在 JSON params.command 中填写。
+                      多行脚本：必须使用 AITAG 格式传递 command 参数。
 
-Optional:
-  timeout   (int)     *** CRITICAL: YOU MUST ALWAYS SET THIS PARAMETER ***
-                      Max execution time in seconds. Process is KILLED when timeout is reached.
-                      Default: 60 (but DO NOT rely on the default -- always set explicitly!)
-                      If the command hangs or runs forever, the entire tool call blocks.
-                      Recommended values:
-                        - Quick queries (ls, cat, echo, uname, whoami): 10-15
-                        - File operations (find, grep, du): 15-30
-                        - Network commands (curl, wget, ping -c N): 30-60
-                        - Build/compile/install (make, go build, pip install): 120-300
-  shell     (string)  Shell type: "bash" | "cmd" | "powershell"
-                      Default: auto-detect (linux/mac -> bash,
-                      windows -> bash if Git Bash/MSYS/Cygwin bash exists,
-                      otherwise powershell/cmd)
+可选：
+  timeout   (int)     *** 关键：必须始终设置此参数 ***
+                      最大执行时间（秒）。超时后进程将被强制终止。
+                      默认值：60（但不要依赖默认值——始终显式设置！）
+                      如果命令挂起或永远运行，整个工具调用将被阻塞。
+                      推荐值：
+                        - 快速查询（ls, cat, echo, uname, whoami）：10-15
+                        - 文件操作（find, grep, du）：15-30
+                        - 网络命令（curl, wget, ping -c N）：30-60
+                        - 构建/编译/安装（make, go build, pip install）：120-300
+  shell     (string)  Shell 类型："bash" | "cmd" | "powershell"
+                      默认：自动检测（linux/mac -> bash，
+                      windows -> 如果存在 Git Bash/MSYS/Cygwin bash 则用 bash，
+                      否则用 powershell/cmd）
 
-## Execution Characteristics
+## 执行特性
 
-bash:  executes a temporary script via "bash --login <script>" so /etc/profile
-       and user bash profile files can populate default PATH/environment.
-       It does not force set -e or command tracing.
-cmd:   executes via "cmd.exe /d /s /c <command>", backslashes MUST be escaped:
-       "C:\\Users"
-powershell: executes a temporary script via PowerShell with normal profile loading;
-            it does not force $ErrorActionPreference or command tracing.
+bash：  通过 "bash --login <script>" 执行临时脚本，使 /etc/profile
+        和用户的 bash profile 文件可以加载默认 PATH/环境变量。
+        不会强制启用 set -e 或命令追踪。
+cmd：   通过 "cmd.exe /d /s /c <command>" 执行，反斜杠必须转义：
+        "C:\\Users"
+powershell：通过 PowerShell 执行临时脚本，正常加载 profile；
+            不会强制 $ErrorActionPreference 或命令追踪。
 
-## Safety Rules
+## 安全规则
 
-FORBIDDEN: find / , ls -R / , sudo, su, chmod 777, rm -rf /, access to /etc/shadow
-MUST have limits: ping -c N, find ... -maxdepth N, tail -n N (never -f), pipe | head -N
+禁止：find / , ls -R / , sudo, su, chmod 777, rm -rf /, 访问 /etc/shadow
+必须加限制：ping -c N, find ... -maxdepth N, tail -n N（不能用 -f）, 管道 | head -N
 
-## Few-Shot Examples
+## 少样本示例
 
-Replace {NONCE} with the actual nonce from the response format section.
+将 {NONCE} 替换为响应格式部分中的实际 nonce。
 
-### Example 1: Simple one-line command (JSON params, explicit timeout)
+### 示例 1：简单单行命令（JSON 参数，显式设置超时）
 
-User intent: "Check disk space"
+用户意图："检查磁盘空间"
 
 ```json
 {
@@ -62,9 +62,9 @@ User intent: "Check disk space"
 }
 ```
 
-### Example 2: Multi-line diagnostic script (AITAG for command)
+### 示例 2：多行诊断脚本（使用 AITAG 传递命令）
 
-User intent: "Show system status: OS, memory, and top processes"
+用户意图："显示系统状态：操作系统、内存和 top 进程"
 
 ```json
 {
@@ -88,9 +88,9 @@ echo "=== Top 5 CPU Processes ==="
 ps aux --sort=-%cpu 2>/dev/null | head -6 || ps aux | head -6
 <|TOOL_PARAM_command_END_{NONCE}|>
 
-### Example 3: File search with safety limits (AITAG for command)
+### 示例 3：带安全限制的文件搜索（使用 AITAG 传递命令）
 
-User intent: "Find large log files in /var/log"
+用户意图："在 /var/log 中查找大日志文件"
 
 ```json
 {
@@ -110,9 +110,9 @@ echo ""
 du -sh /var/log 2>/dev/null || echo "Cannot access /var/log"
 <|TOOL_PARAM_command_END_{NONCE}|>
 
-### Example 4: Complex script with conditional logic (AITAG for command)
+### 示例 4：带条件逻辑的复杂脚本（使用 AITAG 传递命令）
 
-User intent: "Check if Python3 is installed, show version and packages"
+用户意图："检查是否安装了 Python3，显示版本和包列表"
 
 ```json
 {
@@ -138,16 +138,15 @@ else
 fi
 <|TOOL_PARAM_command_END_{NONCE}|>
 
-### Example 5: Python script execution (MANDATORY - use write_file first)
+### 示例 5：Python 脚本执行（必须——先用 write_file 写入）
 
-IMPORTANT: For Python scripts longer than 5 lines, NEVER pipe code directly via
-heredoc (python3 << 'EOF') or use cat/echo redirect. This causes shell parse errors
-with Python shebangs, docstrings, and complex string formatting.
+重要：对于超过 5 行的 Python 脚本，绝对不要通过 heredoc（python3 << 'EOF'）
+或 cat/echo 重定向直接传递代码。这会导致 Shell 解析错误，特别是在包含
+Python shebang、docstring 和复杂字符串格式化时。
 
-Instead, use the `write_file` tool to write the script file FIRST, then use bash
-to execute it:
+正确的做法：先使用 `write_file` 工具写入脚本文件，再用 bash 执行：
 
-Step 1 - Write the script via write_file:
+步骤 1 - 通过 write_file 写入脚本：
 ```json
 {
   "@action": "call-tool",
@@ -175,7 +174,7 @@ for key, value in data.items():
     print(f"  {key}: {value}")
 <|TOOL_PARAM_content_END_{NONCE}|>
 
-Step 2 - Execute via bash:
+步骤 2 - 通过 bash 执行：
 ```json
 {
   "@action": "call-tool",
@@ -188,13 +187,14 @@ Step 2 - Execute via bash:
 }
 ```
 
-Key points:
-  - ALWAYS use write_file tool first to create scripts, THEN use bash to execute
-  - write_file safely handles multi-line content with AITAG blocks
-  - DO NOT use cat/echo heredoc in bash to create files — use write_file/modify_file instead
-  - For multi-step data analysis on large files, prefer ExcelCLI query (data imported) or Python pandas (fallback) over repeated query_excel_data calls
+要点：
+  - 始终先用 write_file 工具创建脚本，再用 bash 执行
+  - write_file 通过 AITAG 块安全处理多行内容
+  - 不要在 bash 中使用 cat/echo heredoc 创建文件——改用 write_file/modify_file
+  - 对于大文件的多步骤数据分析，优先使用 ExcelCLI query（数据已入库时）或 Python pandas（兜底），
+    避免重复调用 query_excel_data
 
-For short Python one-liners (< 5 lines without docstrings), you may use:
+对于短小 Python 单行代码（< 5 行，不含 docstring），可以直接使用：
 
 ```json
 {
@@ -208,13 +208,13 @@ For short Python one-liners (< 5 lines without docstrings), you may use:
 }
 ```
 
-### Example 6: Python data analysis with caching (write_file + bash execution)
+### 示例 6：带缓存的 Python 数据分析（write_file + bash 执行）
 
-For Excel/CSV files > 10MB or analysis spanning multiple bash tool calls,
-use a cache-first pattern to avoid re-reading large files every time.
-ALWAYS use write_file to create the script, then bash to execute:
+对于超过 10MB 的 Excel/CSV 文件，或需要跨多次 bash 调用的分析，
+使用缓存优先模式避免重复读取大文件。
+始终使用 write_file 创建脚本，再用 bash 执行：
 
-Step 1 - Write the analysis script via write_file:
+步骤 1 - 通过 write_file 写入分析脚本：
 ```json
 {
   "@action": "call-tool",
@@ -252,7 +252,7 @@ with open("/tmp/analysis_results.json", "w") as f:
 print(f"Results saved to /tmp/analysis_results.json")
 <|TOOL_PARAM_content_END_{NONCE}|>
 
-Step 2 - Execute via bash:
+步骤 2 - 通过 bash 执行：
 ```json
 {
   "@action": "call-tool",
@@ -265,17 +265,17 @@ Step 2 - Execute via bash:
 }
 ```
 
-Key caching rules:
-  - PREFERRED (data imported via ExcelCLI): Use `excelcli query` with SQL for batch analysis
-  - FALLBACK (ExcelCLI unavailable): First script uses pd.read_excel() + df.to_csv() to create cache
-  - All subsequent scripts: pd.read_csv() from cache (10x faster)
-  - Save analysis results to JSON files for downstream tasks to read
-  - Use /tmp/ for cache files (auto-cleaned on reboot)
-  - Use write_file to create scripts, NOT cat heredoc in bash
+缓存规则：
+  - 首选（数据已通过 ExcelCLI 入库）：使用 `excelcli query` 通过 SQL 进行批量分析
+  - 兜底（ExcelCLI 不可用）：第一个脚本使用 pd.read_excel() + df.to_csv() 创建缓存
+  - 后续所有脚本：从缓存 pd.read_csv() 读取（快 10 倍）
+  - 将分析结果保存到 JSON 文件供下游任务复用
+  - 使用 /tmp/ 存放缓存文件（重启后自动清理）
+  - 使用 write_file 创建脚本，不要在 bash 中用 cat heredoc
 
-### Example 7: Windows CMD one-line command (explicit shell)
+### 示例 7：Windows CMD 单行命令（显式指定 shell）
 
-User intent: "On a Windows host, show OS version, current user, and a system directory"
+用户意图："在 Windows 主机上显示操作系统版本、当前用户和系统目录"
 
 ```json
 {
@@ -290,9 +290,9 @@ User intent: "On a Windows host, show OS version, current user, and a system dir
 }
 ```
 
-### Example 8: Windows PowerShell diagnostic script (AITAG + explicit shell)
+### 示例 8：Windows PowerShell 诊断脚本（AITAG + 显式指定 shell）
 
-User intent: "On a Windows host, show top memory processes and running services"
+用户意图："在 Windows 主机上显示内存占用最高的进程和正在运行的服务"
 
 ```json
 {
@@ -321,32 +321,30 @@ Get-Service |
   Select-Object -First 10 Name, DisplayName, Status
 <|TOOL_PARAM_command_END_{NONCE}|>
 
-## Key Rules
+## 核心规则
 
-1. ** TIMEOUT IS MANDATORY ** -- Always set timeout explicitly. Do NOT rely on the default 60s.
-   Estimate how long the command should take, and set timeout to ~1.5x that estimate.
-   A command that hangs without timeout will block the entire agent workflow.
-2. Multi-line commands -> ALWAYS use AITAG for the command parameter
-3. Single-line commands -> Use JSON params.command directly
-4. Limit output: pipe through | head -N; limit search: add -maxdepth to find
-5. Use fallback chains for cross-platform: cmd1 2>/dev/null || cmd2 || echo "not available"
-6. NEVER generate indefinite commands (no tail -f, no watch, no ping without -c)
-7. ** PYTHON SCRIPTS ** -- For Python scripts > 5 lines, ALWAYS use write_file tool
-   to create the script file first, then bash to execute it. NEVER use cat/echo heredoc
-   to write files in bash. This avoids shell parse errors and follows the principle of
-   using dedicated tools for file operations.
-8. ** DATA CACHING ** -- When analyzing large data files (Excel > 10MB):
-   PREFERRED: If data has been imported via ExcelCLI, use `excelcli query` with SQL for batch analysis.
-   FALLBACK: Use Python pandas with CSV cache (pd.read_excel + pd.to_csv for cache, pd.read_csv for subsequent reads).
-   Save analysis results to JSON files so downstream tasks can reuse them.
-9. ** FILE OPERATIONS PREFERENCE ** -- When you need to create or write files (scripts,
-   configs, documents, etc.), ALWAYS use `write_file` tool instead of bash heredoc/cat.
-   When modifying existing files, ALWAYS use `modify_file` tool instead of bash sed/echo.
-   Only use bash for file operations as a fallback when write_file/modify_file cannot
-   handle the specific requirement.
-10. ** WINDOWS TARGETS ** -- The tool prefers bash on Windows when Git Bash/MSYS/Cygwin
-   bash is available. Set shell explicitly to "cmd" or "powershell" when generating
-   Windows-native commands. This avoids mixing Bash syntax with Windows command syntax.
+1. **必须设置超时（TIMEOUT）** —— 始终显式设置 timeout。不要依赖默认的 60 秒。
+   预估命令应执行的时间，将 timeout 设为该预估值的约 1.5 倍。
+   没有超时的命令如果挂起，将阻塞整个 agent 工作流。
+2. 多行命令 -> 始终使用 AITAG 格式传递 command 参数
+3. 单行命令 -> 直接在 JSON params.command 中填写
+4. 限制输出：通过管道 | head -N；限制搜索：为 find 添加 -maxdepth
+5. 跨平台使用降级链：cmd1 2>/dev/null || cmd2 || echo "not available"
+6. 绝对不要生成无限期命令（不要 tail -f, 不要 watch, 不要不带 -c 的 ping）
+7. **Python 脚本** —— 对于超过 5 行的 Python 脚本，始终使用 write_file 工具
+   先创建脚本文件，再用 bash 执行。绝不要在 bash 中使用 cat/echo heredoc
+   来写文件。这可以避免 Shell 解析错误，遵循使用专用工具进行文件操作的原则。
+8. **数据缓存** —— 分析大文件（Excel > 10MB）时：
+   首选：如果数据已通过 ExcelCLI 入库，使用 `excelcli query` 通过 SQL 进行批量分析。
+   兜底：使用 Python pandas 配合 CSV 缓存（首次 pd.read_excel + pd.to_csv 创建缓存，
+   后续使用 pd.read_csv 读取）。将分析结果保存到 JSON 文件供下游任务复用。
+9. **文件操作优先级** —— 需要创建或写入文件（脚本、配置、文档等）时，
+   始终使用 `write_file` 工具代替 bash heredoc/cat。
+   修改现有文件时，始终使用 `modify_file` 工具代替 bash sed/echo。
+   仅在 write_file/modify_file 无法满足特定需求时，才使用 bash 进行文件操作。
+10. **Windows 目标** —— 在 Windows 上，当 Git Bash/MSYS/Cygwin bash 可用时，
+   工具优先使用 bash。生成 Windows 原生命令时，显式将 shell 设为 "cmd" 或 "powershell"。
+   这可以避免 Bash 语法与 Windows 命令语法混用。
 USAGE_BLOCK
 
 yakit.AutoInitYakit()

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
@@ -1,4 +1,4 @@
-__DESC__ = "跨平台Shell命令执行工具，支持bash/cmd/powershell，具备超时控制和输出捕获。bash 默认以登录 shell 执行以加载系统和用户 profile 中的 PATH/环境变量，不额外启用 set -e 或命令追踪，行为更接近原生终端执行。注意：对于文件创建/写入操作，应优先使用 write_file 工具；对于文件局部修改，应优先使用 modify_file 工具。仅当专用工具无法满足需求时，才使用 bash 的 cat/echo 重定向操作文件。"
+__DESC__ = "跨平台Shell命令执行工具，支持bash/cmd/powershell，具备超时控制和输出捕获。bash 默认以登录 shell 执行以加载系统和用户 profile 中的 PATH/环境变量，不额外启用 set -e 或命令追踪，行为更接近原生终端执行。注意：对于文件创建/写入操作，应优先使用 write_file 工具；对于文件局部修改，应优先使用 modify_file 工具。仅当专用工具无法满足需求时，才使用 bash 的 cat/echo 重定向操作文件。对于已通过 ExcelCLI 入库的数据分析任务，应优先使用 `excelcli query` 命令通过 SQL 分析，而非编写 Python 脚本。"
 __VERBOSE_NAME__ = "跨平台Shell命令执行工具"
 __KEYWORDS__ = "shell command,bash,cmd,powershell,命令行工具,系统管理,自动化脚本,运维工具,shell script,command execution,系统操作,终端命令,system administration,automation tools,操作系统,跨平台命令,timeout,超时控制,python script,pandas,data analysis,excel analysis,csv cache,data cache,批量分析,write_file优先,文件操作优先,modify_file优先"
 
@@ -192,7 +192,7 @@ Key points:
   - ALWAYS use write_file tool first to create scripts, THEN use bash to execute
   - write_file safely handles multi-line content with AITAG blocks
   - DO NOT use cat/echo heredoc in bash to create files — use write_file/modify_file instead
-  - For multi-step data analysis on large files, prefer Python pandas over repeated query_excel_data calls
+  - For multi-step data analysis on large files, prefer ExcelCLI query (data imported) or Python pandas (fallback) over repeated query_excel_data calls
 
 For short Python one-liners (< 5 lines without docstrings), you may use:
 
@@ -266,7 +266,8 @@ Step 2 - Execute via bash:
 ```
 
 Key caching rules:
-  - First script: pd.read_excel() + df.to_csv() to create cache
+  - PREFERRED (data imported via ExcelCLI): Use `excelcli query` with SQL for batch analysis
+  - FALLBACK (ExcelCLI unavailable): First script uses pd.read_excel() + df.to_csv() to create cache
   - All subsequent scripts: pd.read_csv() from cache (10x faster)
   - Save analysis results to JSON files for downstream tasks to read
   - Use /tmp/ for cache files (auto-cleaned on reboot)
@@ -334,8 +335,9 @@ Get-Service |
    to create the script file first, then bash to execute it. NEVER use cat/echo heredoc
    to write files in bash. This avoids shell parse errors and follows the principle of
    using dedicated tools for file operations.
-8. ** DATA CACHING ** -- When analyzing large data files (Excel > 10MB), save a CSV cache
-   after the first read. Subsequent scripts should check for and use the cache.
+8. ** DATA CACHING ** -- When analyzing large data files (Excel > 10MB):
+   PREFERRED: If data has been imported via ExcelCLI, use `excelcli query` with SQL for batch analysis.
+   FALLBACK: Use Python pandas with CSV cache (pd.read_excel + pd.to_csv for cache, pd.read_csv for subsequent reads).
    Save analysis results to JSON files so downstream tasks can reuse them.
 9. ** FILE OPERATIONS PREFERENCE ** -- When you need to create or write files (scripts,
    configs, documents, etc.), ALWAYS use `write_file` tool instead of bash heredoc/cat.

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "173fa79eda73ae004147dd39d26ac6fff
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "8eab5dd68fcf9e963bee5fc8af44ceb86163759ac65a9615b2f390b96dd77317"
+const ExistedBuildInAIToolEmbedFSHash string = "276d675aba155454c765493ab9cddb648b31188fec442ed546a204e3cfc0571c"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -5,7 +5,7 @@ package consts
 // ExistedCorePluginEmbedFSHash contains the SHA256 hash of the embedded core plugin filesystem.
 // This hash is used to verify the integrity of core plugins and detect changes in the plugin bundle.
 // The hash is automatically generated during the build process and should not be manually modified.
-const ExistedCorePluginEmbedFSHash string = "8c736fa9d75f952b229ff44e3e886283dbd715523a0d49c8ef37f13c7c6a119f"
+const ExistedCorePluginEmbedFSHash string = "5ac866e18978b3d02d428c5a099f977f996a03ca4e3c35fde991ceea54238313"
 
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.


### PR DESCRIPTION
## 修改内容

修改了 3 个 AI 工具的文档描述，解决以下问题：

### 1. `bash.yak` — Shell 命令执行工具
- **文件操作优先使用 write_file/modify_file**：在 DESC 和 USAGE 中明确要求创建文件用 `write_file`、修改文件用 `modify_file`，bash 仅为兜底
- **移除 heredoc 推荐**：示例 5、6 从 `cat heredoc` 改为 `write_file` + `bash` 执行的两步模式
- **数据缓存优先推荐 ExcelCLI**：规则 8 和示例 6 缓存说明改为首选 `excelcli query`，Python 为兜底
- **文档全部中文化**

### 2. `read_excel_info.yak` — Excel 结构探索工具
- **推荐 ExcelCLI 入库分析**：DESC 和 USAGE 明确交易/金融/案件数据应使用 ExcelCLI 入库 + SQL 分析
- **Python 仅为兜底**：仅当 ExcelCLI 不可用时才用 Python pandas
- **文档全部中文化**

### 3. `query_excel_data.yak` — Excel 数据查询工具
- **替换 Python pandas 推荐**：将原有 "strongly prefer Python pandas" 改为优先推荐 `excelcli query`（数据已入库时）
- **新增场景区分**：数据已入库 → `excelcli query`；ExcelCLI 不可用 → Python pandas 兜底；1-2 次简单查询 → 本工具
- **新增工具选择优先级表格**
- **运行时输出也同步更新**：`yakit.Info` 推荐改为 ExcelCLI query 优先
- **文档全部中文化**

## 背景

之前的文档中 `query_excel_data.yak` 一直推荐 "use Python pandas"，导致 agent 即使通过 ExcelCLI 完成了数据入库，分析阶段仍然转向写 Python 脚本而不使用 `excelcli query` 命令。

Made with [Cursor](https://cursor.com)