### PR TITLE
Feat/yaklang/ai session scoped mcp

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -239,6 +239,14 @@ type Config struct {
 	DisableWebSearch    bool // disable enhanced web search tool, default false (enabled)
 	DisallowMCPServers  bool // 禁用 MCP Servers，默认为 false（即默认启用）
 
+	// ExtraMCPServers 会话级显式挂载的 MCP server（不读 profile DB、不进全局列表）。
+	// 仅在本字段非空时激活，默认 nil，对现有流程零影响。
+	ExtraMCPServers []*ExtraMCPServer
+
+	// RestrictToolsToExtraMCPServers 为 true 时，会话的工具集被钳制为仅 ExtraMCPServers
+	// 暴露的工具：禁用工具搜索/forge/内置工具，使 agent 无法触达本地 yak 工具（如 ssa-risk）。
+	RestrictToolsToExtraMCPServers bool
+
 	// Interactive(review/require_user/sync) features
 	// endpoint manager
 	Epm *EndpointManager
@@ -1571,6 +1579,45 @@ func WithDisallowMCPServers(disallow bool) ConfigOption {
 			c.AiToolManagerOption = make([]buildinaitools.ToolManagerOption, 0)
 		}
 		c.AiToolManagerOption = append(c.AiToolManagerOption, buildinaitools.WithDisallowMCPServers(disallow))
+		return nil
+	}
+}
+
+// ExtraMCPServer 描述一个会话级显式挂载的 MCP server。
+// AllowedTools 非空时，client 侧只保留名字在白名单内的工具，server 多暴露的一律丢弃。
+type ExtraMCPServer struct {
+	Server       *schema.MCPServer
+	AllowedTools []string
+}
+
+// WithExtraMCPServers 为本会话挂载额外的 MCP server（内存态，不落 profile DB、不进全局列表）。
+func WithExtraMCPServers(servers ...*ExtraMCPServer) ConfigOption {
+	return func(c *Config) error {
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		defer c.m.Unlock()
+		for _, s := range servers {
+			if s == nil || s.Server == nil {
+				continue
+			}
+			c.ExtraMCPServers = append(c.ExtraMCPServers, s)
+		}
+		return nil
+	}
+}
+
+// WithRestrictToolsToExtraMCPServers 钳制会话工具集为仅 ExtraMCPServers 暴露的工具，
+// 禁用工具搜索/forge/内置工具，确保 agent 只能调用注入的 session MCP 工具。
+func WithRestrictToolsToExtraMCPServers(restrict bool) ConfigOption {
+	return func(c *Config) error {
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		defer c.m.Unlock()
+		c.RestrictToolsToExtraMCPServers = restrict
 		return nil
 	}
 }

--- a/common/ai/aid/aicommon/config_enabled_capabilities.go
+++ b/common/ai/aid/aicommon/config_enabled_capabilities.go
@@ -189,6 +189,13 @@ func (c *Config) applyEnabledImmediateCapabilities() error {
 	if c == nil {
 		return nil
 	}
+	// A session restricted to its injected MCP servers must stay restricted:
+	// re-enabling tools/plugins/mcp_tools here (incl. via the EnabledCapabilities
+	// hotpatch, which runs after RestrictToTools) would silently defeat the
+	// restriction. Skip capability application entirely under restriction.
+	if c.RestrictToolsToExtraMCPServers {
+		return nil
+	}
 	caps := c.GetEnabledCapabilities()
 	if len(caps) == 0 {
 		return nil

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -348,7 +348,13 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 	cfg.FlushRestoredSessionEvidence()
 	// EmitPinDirectory is deferred to ensureWorkDirectory when user input arrives
 
-	if !react.config.DisallowMCPServers {
+	// When the session is restricted to its injected MCP servers, the profile/DB
+	// MCP machinery must NOT run: its background goroutine (and the
+	// tools-list-changed handler) would re-enable profile tools via
+	// OverrideToolByName AFTER loadExtraMCPServers calls RestrictToTools,
+	// silently defeating the restriction (fail-open) and racing the tool
+	// manager's enable map. Skipping it keeps the restriction authoritative.
+	if !react.config.DisallowMCPServers && !react.config.RestrictToolsToExtraMCPServers {
 		// Synchronously pre-load MCP stub tools from DB into the tool manager
 		// so they appear in the system prompt on the very first request, before
 		// the background connection goroutine has finished.
@@ -689,6 +695,10 @@ func (r *ReAct) preloadMCPStubsFromDB() {
 // 并按 AllowedTools 在 client 侧做白名单过滤后 AppendTools。
 func (r *ReAct) loadExtraMCPServers(servers []*aicommon.ExtraMCPServer) {
 	mng := r.config.GetAiToolManager()
+	if mng == nil {
+		log.Errorf("cannot mount session-scoped mcp servers: tool manager is nil")
+		return
+	}
 	var mountedNames []string
 	for _, s := range servers {
 		if s == nil || s.Server == nil {

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -717,7 +717,10 @@ func (r *ReAct) loadExtraMCPServers(servers []*aicommon.ExtraMCPServer) {
 			log.Infof("session-scoped mcp server %s mounted %d tool(s)", s.Server.Name, len(tools))
 		}
 	}
-	if r.config.RestrictToolsToExtraMCPServers && len(mountedNames) > 0 {
+	// Restrict unconditionally (deny-all when nothing mounted): if a restricted
+	// session's MCP servers are unreachable/empty, falling back to the full
+	// builtin/search toolset would be a fail-open, defeating the restriction.
+	if r.config.RestrictToolsToExtraMCPServers {
 		mng.RestrictToTools(mountedNames...)
 		log.Infof("session tools restricted to %d session-scoped mcp tool(s): %v", len(mountedNames), mountedNames)
 	}

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -360,6 +360,12 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 		react.loadMCPServers()
 	}
 
+	// 会话级显式挂载（内存态，不读 profile DB、不进全局列表）。
+	// 同步加载，保证首轮推理前工具已就绪。
+	if len(react.config.ExtraMCPServers) > 0 {
+		react.loadExtraMCPServers(react.config.ExtraMCPServers)
+	}
+
 	return react, nil
 }
 
@@ -675,6 +681,35 @@ func (r *ReAct) preloadMCPStubsFromDB() {
 	if len(stubs) > 0 {
 		mng.AppendTools(stubs...)
 		log.Infof("preloaded %d MCP tool stubs from DB cache into tool manager", len(stubs))
+	}
+}
+
+// loadExtraMCPServers mounts session-scoped MCP servers at construction time.
+// 每个 server 经 aitool.LoadAIToolsFromMCPServer 取工具（不查 profile DB），
+// 并按 AllowedTools 在 client 侧做白名单过滤后 AppendTools。
+func (r *ReAct) loadExtraMCPServers(servers []*aicommon.ExtraMCPServer) {
+	mng := r.config.GetAiToolManager()
+	var mountedNames []string
+	for _, s := range servers {
+		if s == nil || s.Server == nil {
+			continue
+		}
+		tools, err := aitool.LoadAIToolsFromMCPServer(r.config.Ctx, s.Server, s.AllowedTools)
+		if err != nil {
+			log.Errorf("load session-scoped mcp server %s failed: %v", s.Server.Name, err)
+			continue
+		}
+		if len(tools) > 0 {
+			mng.AppendTools(tools...)
+			for _, tool := range tools {
+				mountedNames = append(mountedNames, tool.Name)
+			}
+			log.Infof("session-scoped mcp server %s mounted %d tool(s)", s.Server.Name, len(tools))
+		}
+	}
+	if r.config.RestrictToolsToExtraMCPServers && len(mountedNames) > 0 {
+		mng.RestrictToTools(mountedNames...)
+		log.Infof("session tools restricted to %d session-scoped mcp tool(s): %v", len(mountedNames), mountedNames)
 	}
 }
 

--- a/common/ai/aid/aitool/buildinaitools/tool_manager.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager.go
@@ -436,6 +436,9 @@ func (m *AiToolManager) AppendTools(tools ...*aitool.Tool) error {
 // Session-scoped MCP mounts use this so the agent cannot reach builtin/profile
 // tools (e.g. the local "ssa-risk" yak tool) and is limited to the injected set.
 func (m *AiToolManager) RestrictToTools(names ...string) {
+	if m == nil {
+		return
+	}
 	m.enableAllTools = false
 	m.enableSearchTool = false
 	m.enableForgeSearchTool = false

--- a/common/ai/aid/aitool/buildinaitools/tool_manager.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager.go
@@ -431,6 +431,21 @@ func (m *AiToolManager) AppendTools(tools ...*aitool.Tool) error {
 	return nil
 }
 
+// RestrictToTools confines the manager to exactly the named tools: it clears the
+// "enable all" shortcut and both searchers, then enables only the given names.
+// Session-scoped MCP mounts use this so the agent cannot reach builtin/profile
+// tools (e.g. the local "ssa-risk" yak tool) and is limited to the injected set.
+func (m *AiToolManager) RestrictToTools(names ...string) {
+	m.enableAllTools = false
+	m.enableSearchTool = false
+	m.enableForgeSearchTool = false
+	enabled := make(map[string]bool, len(names))
+	for _, name := range names {
+		enabled[name] = true
+	}
+	m.toolEnabled = enabled
+}
+
 // OverrideToolByName replaces all tools with the given name, keeping only the new one.
 // If no tool with that name exists, the new tool is appended.
 func (m *AiToolManager) OverrideToolByName(newTool *aitool.Tool) {

--- a/common/ai/aid/aitool/buildinaitools/tool_manager_restrict_test.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager_restrict_test.go
@@ -1,0 +1,44 @@
+package buildinaitools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+// RestrictToTools must confine the manager to exactly the named tools and turn
+// off the "enable all" shortcut plus both searchers, so a session-scoped MCP
+// mount cannot leak builtin/profile tools (e.g. the local "ssa-risk" yak tool).
+func TestRestrictToTools(t *testing.T) {
+	builtinA := aitool.NewWithoutCallback("builtin_a")
+	builtinB := aitool.NewWithoutCallback("builtin_b")
+	sessionTool := aitool.NewWithoutCallback("mcp_session_only")
+
+	mgr := NewToolManagerByToolGetter(func() []*aitool.Tool {
+		return []*aitool.Tool{builtinA, builtinB, sessionTool}
+	}, WithExtendTools([]*aitool.Tool{builtinA, builtinB, sessionTool}, true))
+
+	mgr.RestrictToTools("mcp_session_only")
+
+	tools, err := mgr.GetEnableTools()
+	require.NoError(t, err)
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+
+	assert.Equal(t, []string{"mcp_session_only"}, names, "only the restricted tool may remain")
+	assert.NotContains(t, names, "builtin_a")
+	assert.NotContains(t, names, "builtin_b")
+	assert.False(t, mgr.enableAllTools)
+	assert.False(t, mgr.enableSearchTool, "search tool must be disabled under restriction")
+	assert.False(t, mgr.enableForgeSearchTool, "forge search must be disabled under restriction")
+}
+
+// A nil receiver must be a safe no-op (defensive guard for loadExtraMCPServers).
+func TestRestrictToTools_NilReceiver(t *testing.T) {
+	var mgr *AiToolManager
+	assert.NotPanics(t, func() { mgr.RestrictToTools("anything") })
+}

--- a/common/ai/aid/aitool/buildinaitools/tool_manager_restrict_test.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager_restrict_test.go
@@ -37,6 +37,26 @@ func TestRestrictToTools(t *testing.T) {
 	assert.False(t, mgr.enableForgeSearchTool, "forge search must be disabled under restriction")
 }
 
+// RestrictToTools with no names must deny all (fail-closed), not fall back to
+// the builtin/search toolset. This guards the "restricted mount yielded zero
+// tools" path in loadExtraMCPServers.
+func TestRestrictToTools_EmptyDeniesAll(t *testing.T) {
+	builtinA := aitool.NewWithoutCallback("builtin_a")
+	builtinB := aitool.NewWithoutCallback("builtin_b")
+
+	mgr := NewToolManagerByToolGetter(func() []*aitool.Tool {
+		return []*aitool.Tool{builtinA, builtinB}
+	}, WithExtendTools([]*aitool.Tool{builtinA, builtinB}, true))
+
+	mgr.RestrictToTools()
+
+	tools, err := mgr.GetEnableTools()
+	require.NoError(t, err)
+	assert.Empty(t, tools, "restricting to no tools must enable nothing")
+	assert.False(t, mgr.enableSearchTool)
+	assert.False(t, mgr.enableForgeSearchTool)
+}
+
 // A nil receiver must be a safe no-op (defensive guard for loadExtraMCPServers).
 func TestRestrictToTools_NilReceiver(t *testing.T) {
 	var mgr *AiToolManager

--- a/common/ai/aid/aitool/mcp_server_loader.go
+++ b/common/ai/aid/aitool/mcp_server_loader.go
@@ -222,13 +222,26 @@ func LoadAIToolsFromMCPServer(ctx context.Context, server *schema.MCPServer, all
 	if server == nil {
 		return nil, utils.Errorf("mcp server is nil")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	mcpClient, err := createMCPClient(server)
 	if err != nil {
 		return nil, utils.Errorf("create mcp client failed: %v", err)
 	}
+	// createMCPClient already opened a live connection (sse) or spawned a
+	// subprocess (stdio). On any failure path below we must close it; only when
+	// tools are returned does ownership transfer to the caller (the returned
+	// tools' callbacks keep using the client), so we must NOT close it then.
+	success := false
+	defer func() {
+		if !success {
+			_ = mcpClient.Close()
+		}
+	}()
 
-	initCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	initCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	initRequest := mcp.InitializeRequest{}
@@ -266,6 +279,7 @@ func LoadAIToolsFromMCPServer(ctx context.Context, server *schema.MCPServer, all
 	if len(aiTools) == 0 {
 		return nil, utils.Errorf("no tools loaded from mcp server %s (allowlist=%v)", server.Name, allowedTools)
 	}
+	success = true
 	return aiTools, nil
 }
 

--- a/common/ai/aid/aitool/mcp_server_loader.go
+++ b/common/ai/aid/aitool/mcp_server_loader.go
@@ -20,6 +20,16 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 )
 
+// defaultMCPClientInfo is the implementation identity yaklang advertises during
+// the MCP initialize handshake (akin to a User-Agent). The version tracks the
+// running yaklang build so MCP servers can tell client versions apart.
+func defaultMCPClientInfo() mcp.Implementation {
+	return mcp.Implementation{
+		Name:    "yaklang-aitool-loader",
+		Version: consts.GetYakVersion(),
+	}
+}
+
 // mcpToolParamInfo is a lightweight representation of a tool parameter used for
 // JSON serialization into MCPServerToolConfig.ParamsJSON.
 type mcpToolParamInfo struct {
@@ -137,10 +147,7 @@ func LoadAIToolFromMCPServers(db *gorm.DB, ctx context.Context, name string, onT
 
 	initRequest := mcp.InitializeRequest{}
 	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-	initRequest.Params.ClientInfo = mcp.Implementation{
-		Name:    "yaklang-aitool-loader",
-		Version: "1.0.0",
-	}
+	initRequest.Params.ClientInfo = defaultMCPClientInfo()
 
 	var listChangedState *mcpToolsListChangedState
 	if listChangedHandler != nil {
@@ -226,10 +233,7 @@ func LoadAIToolsFromMCPServer(ctx context.Context, server *schema.MCPServer, all
 
 	initRequest := mcp.InitializeRequest{}
 	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-	initRequest.Params.ClientInfo = mcp.Implementation{
-		Name:    "yaklang-aitool-loader",
-		Version: "1.0.0",
-	}
+	initRequest.Params.ClientInfo = defaultMCPClientInfo()
 	if _, err = mcpClient.Initialize(initCtx, initRequest); err != nil {
 		return nil, utils.Errorf("initialize mcp client failed: %v", err)
 	}

--- a/common/ai/aid/aitool/mcp_server_loader.go
+++ b/common/ai/aid/aitool/mcp_server_loader.go
@@ -208,6 +208,63 @@ func LoadAIToolFromMCPServers(db *gorm.DB, ctx context.Context, name string, onT
 	return aiTools, nil
 }
 
+// LoadAIToolsFromMCPServer 从单个显式 MCP server（不查 DB）加载工具，用于会话级挂载。
+// allowedTools 非空时在 client 侧按裸工具名做白名单过滤，server 多暴露的工具一律丢弃，
+// 不依赖 server 自觉只暴露。客户端生命周期随返回的 Tool（Callback 持有 client）。
+func LoadAIToolsFromMCPServer(ctx context.Context, server *schema.MCPServer, allowedTools []string) ([]*Tool, error) {
+	if server == nil {
+		return nil, utils.Errorf("mcp server is nil")
+	}
+
+	mcpClient, err := createMCPClient(server)
+	if err != nil {
+		return nil, utils.Errorf("create mcp client failed: %v", err)
+	}
+
+	initCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "yaklang-aitool-loader",
+		Version: "1.0.0",
+	}
+	if _, err = mcpClient.Initialize(initCtx, initRequest); err != nil {
+		return nil, utils.Errorf("initialize mcp client failed: %v", err)
+	}
+
+	toolsResult, err := mcpClient.ListTools(initCtx, mcp.ListToolsRequest{})
+	if err != nil {
+		return nil, utils.Errorf("list tools failed: %v", err)
+	}
+
+	allow := make(map[string]bool, len(allowedTools))
+	for _, name := range allowedTools {
+		if name != "" {
+			allow[name] = true
+		}
+	}
+
+	var aiTools []*Tool
+	for _, mcpTool := range toolsResult.Tools {
+		if len(allow) > 0 && !allow[mcpTool.Name] {
+			continue
+		}
+		aiTool, err := convertMCPToolToAITool(mcpTool, server, mcpClient)
+		if err != nil {
+			log.Errorf("convert mcp tool to aitool failed: %v", err)
+			continue
+		}
+		aiTools = append(aiTools, aiTool)
+	}
+
+	if len(aiTools) == 0 {
+		return nil, utils.Errorf("no tools loaded from mcp server %s (allowlist=%v)", server.Name, allowedTools)
+	}
+	return aiTools, nil
+}
+
 // createMCPClient 根据 MCP 服务器配置创建客户端
 func createMCPClient(server *schema.MCPServer) (client.MCPClient, error) {
 	switch server.Type {

--- a/common/ai/aid/aitool/mcp_server_loader_session_test.go
+++ b/common/ai/aid/aitool/mcp_server_loader_session_test.go
@@ -1,0 +1,91 @@
+package aitool
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/server"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// startSessionTestMCPServer 启动一个暴露 toolCount 个工具的 SSE MCP server，返回其 sseURL。
+func startSessionTestMCPServer(t *testing.T, toolCount int) string {
+	t.Helper()
+	mcpServer := server.NewMCPServer("Session Test MCP Server", "1.0.0")
+	for i := 0; i < toolCount; i++ {
+		name := fmt.Sprintf("tool_%d", i)
+		tool := mcp.NewTool(name, mcp.WithDescription("session test tool "+name))
+		mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{Content: []any{mcp.TextContent{Type: "text", Text: "ok"}}}, nil
+		})
+	}
+
+	port := utils.GetRandomAvailableTCPPort()
+	hostPort := utils.HostPort("127.0.0.1", port)
+	baseURL := fmt.Sprintf("http://%s", hostPort)
+	sseServer := server.NewSSEServer(mcpServer, baseURL)
+
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		if err := sseServer.Start(hostPort); err != nil && err != http.ErrServerClosed {
+			log.Errorf("session test SSE server error: %v", err)
+		}
+	}()
+	<-started
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, utils.WaitConnect(hostPort, 5))
+	return baseURL + "/sse"
+}
+
+// TestLoadAIToolsFromMCPServer_Allowlist 验证 client 侧白名单过滤：
+// server 暴露 10 个工具，会话只允许 6 个，最终只能加载这 6 个。
+func TestLoadAIToolsFromMCPServer_Allowlist(t *testing.T) {
+	sseURL := startSessionTestMCPServer(t, 10)
+
+	srv := &schema.MCPServer{
+		Name:   "session-allowlist",
+		Type:   "sse",
+		URL:    sseURL,
+		Enable: true,
+	}
+	allowed := []string{"tool_0", "tool_1", "tool_2", "tool_3", "tool_4", "tool_5"}
+
+	tools, err := LoadAIToolsFromMCPServer(context.Background(), srv, allowed)
+	require.NoError(t, err)
+	require.Len(t, tools, 6, "only allowlisted tools should be loaded")
+
+	got := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		got[tool.Name] = true
+	}
+	for _, name := range allowed {
+		require.True(t, got[fmt.Sprintf("mcp_%s_%s", srv.Name, name)], "allowed tool %s missing", name)
+	}
+	// disallowed tools must not leak even though the server exposed them
+	for _, name := range []string{"tool_6", "tool_7", "tool_8", "tool_9"} {
+		require.False(t, got[fmt.Sprintf("mcp_%s_%s", srv.Name, name)], "disallowed tool %s leaked", name)
+	}
+}
+
+// TestLoadAIToolsFromMCPServer_NoAllowlist 验证白名单为空时加载全部工具。
+func TestLoadAIToolsFromMCPServer_NoAllowlist(t *testing.T) {
+	sseURL := startSessionTestMCPServer(t, 4)
+	srv := &schema.MCPServer{
+		Name:   "session-noallow",
+		Type:   "sse",
+		URL:    sseURL,
+		Enable: true,
+	}
+
+	tools, err := LoadAIToolsFromMCPServer(context.Background(), srv, nil)
+	require.NoError(t, err)
+	require.Len(t, tools, 4)
+}

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -519,6 +519,10 @@ func buildReActOptions(ctx context.Context, config *AIEngineConfig, outputChan c
 		options = append(options, aicommon.WithKeywords(config.Keywords...))
 	}
 
+	if config.RestrictToSessionMCP {
+		options = append(options, aicommon.WithRestrictToolsToExtraMCPServers(true))
+	}
+
 	// 交互配置
 	if !config.AllowUserInteract {
 		options = append(options, aicommon.WithAllowRequireForUserInteract(false))

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -519,6 +519,10 @@ func buildReActOptions(ctx context.Context, config *AIEngineConfig, outputChan c
 		options = append(options, aicommon.WithKeywords(config.Keywords...))
 	}
 
+	if len(config.ExtraMCPServers) > 0 {
+		options = append(options, aicommon.WithExtraMCPServers(config.ExtraMCPServers...))
+	}
+
 	if config.RestrictToSessionMCP {
 		options = append(options, aicommon.WithRestrictToolsToExtraMCPServers(true))
 	}

--- a/common/aiengine/config.go
+++ b/common/aiengine/config.go
@@ -47,8 +47,13 @@ type AIEngineConfig struct {
 	ExcludeToolNames      []string // 排除的工具名称
 	Keywords              []string // 关键词，用于工具搜索
 
+	// ExtraMCPServers 会话级显式挂载的 MCP server（内存态，不读 profile DB、
+	// 不进全局列表）。RestrictToSessionMCP 依赖此列表才能生效。
+	ExtraMCPServers []*aicommon.ExtraMCPServer
+
 	// RestrictToSessionMCP 为 true 时，工具集被钳制为仅会话注入的 MCP 工具，
 	// 禁用内置工具/搜索/forge，避免 agent 误用本地 yak 工具（如 ssa-risk）。
+	// 仅在配置了 ExtraMCPServers 时才有意义。
 	RestrictToSessionMCP bool
 
 	// 交互配置
@@ -71,7 +76,7 @@ type AIEngineConfig struct {
 	OnFinished           func(react aicommon.AIEngineOperator)                                                                  // 完成回调, 不返回结果
 	OnInputRequiredRaw   func(react aicommon.AIEngineOperator, event *schema.AiOutputEvent, question string) string             // 需要用户输入回调
 	OnInputRequired      func(react aicommon.AIEngineOperator, question string) string                                          // 需要用户输入回调
-	OnSessionID          func(sessionID string)                                                                               // 会话 ID 就绪回调
+	OnSessionID          func(sessionID string)                                                                                 // 会话 ID 就绪回调
 
 	// 高级配置
 	Focus    string // 焦点，用于聚焦某个任务，如 yaklang_code
@@ -202,6 +207,13 @@ func WithDisableAIForge(disable bool) AIEngineConfigOption {
 func WithDisableMCPServers(disable bool) AIEngineConfigOption {
 	return func(c *AIEngineConfig) {
 		c.DisableMCPServers = disable
+	}
+}
+
+// WithExtraMCPServers 注入会话级 MCP server（内存态，不读 profile DB）。
+func WithExtraMCPServers(servers ...*aicommon.ExtraMCPServer) AIEngineConfigOption {
+	return func(c *AIEngineConfig) {
+		c.ExtraMCPServers = append(c.ExtraMCPServers, servers...)
 	}
 }
 

--- a/common/aiengine/config.go
+++ b/common/aiengine/config.go
@@ -47,6 +47,10 @@ type AIEngineConfig struct {
 	ExcludeToolNames      []string // 排除的工具名称
 	Keywords              []string // 关键词，用于工具搜索
 
+	// RestrictToSessionMCP 为 true 时，工具集被钳制为仅会话注入的 MCP 工具，
+	// 禁用内置工具/搜索/forge，避免 agent 误用本地 yak 工具（如 ssa-risk）。
+	RestrictToSessionMCP bool
+
 	// 交互配置
 	AllowUserInteract bool   // 允许用户交互
 	ReviewPolicy      string // 审批策略: "yolo", "ai", "manual"
@@ -198,6 +202,13 @@ func WithDisableAIForge(disable bool) AIEngineConfigOption {
 func WithDisableMCPServers(disable bool) AIEngineConfigOption {
 	return func(c *AIEngineConfig) {
 		c.DisableMCPServers = disable
+	}
+}
+
+// WithRestrictToSessionMCP 将工具集钳制为仅会话注入的 MCP 工具（禁用内置工具/搜索/forge）。
+func WithRestrictToSessionMCP(restrict bool) AIEngineConfigOption {
+	return func(c *AIEngineConfig) {
+		c.RestrictToSessionMCP = restrict
 	}
 }
 


### PR DESCRIPTION
 ## 会话级 MCP 注入 + 工具白名单钳制（Session-scoped MCP）
  ### 背景 / 为什么
  IRify SaaS 的 AI 代码审计需要把 legion 侧的能力（风险/审计/数据流/文件内容等）
  以 MCP 工具形式**临时注入到单次研判会话**，并保证 agent **只能调用本次任务被授权的工具**，
  不能误用本地 yak 工具（如 `ssa-risk`）或其它 profile 工具——既是正确性要求，也是任务/会话级最小权限的安全边界。
  此前 `RestrictToSessionMCP` 实际是静默 no-op，且后台 MCP 加载会绕过白名单（fail-open）。
  本 PR 把「注入 → 钳制 → 生命周期」整条链路打通并收紧为 fail-closed。
  ### 改了什么
  **1. 会话级 MCP 注入（核心特性）**
  - `aireact`：新增 `loadExtraMCPServers`，构造期同步挂载会话注入的 MCP server（内存态，不读 profile DB、不进全局工具列表）。
  - `aitool.LoadAIToolsFromMCPServer`：从单个显式 server 加载工具，按 `AllowedTools` 在**客户端侧**做白名单过滤，server 多暴露的工具一律丢弃（不依赖 server 自觉）。
  - `aiengine`：新增 `ExtraMCPServers` 字段 + `WithExtraMCPServers` 选项，并在 `buildReActOptions` 接线，让注入与钳制可从 aiengine 端走通。
  **2. 工具钳制收紧为 fail-closed**
  - 受限模式下不再启动 profile/DB 的 MCP 后台加载（`preloadMCPStubsFromDB`/`loadMCPServers`），堵住其后台协程经 `OverrideToolByName` 在 `RestrictToTools` 之后重新放开 profile 工具的 fail-open 兼数据竞争。
  - 即便会话 MCP 挂载到 0 个工具，也无条件 `RestrictToTools`（deny-all），避免回退到全部内置/搜索工具。
  - 在 `applyEnabledImmediateCapabilities` 入口加 restrict 短路，使 `EnabledCapabilities` 热补丁无法在受限会话中重新启用工具（保持 restrict「粘性」）。
  **3. 资源与健壮性**
  - `LoadAIToolsFromMCPServer`：各错误路径关闭 MCP client，仅成功时把所有权转交给返回工具的 callback；init 超时改用调用方 `ctx`（带 nil 守卫）。
  - `loadExtraMCPServers` / `RestrictToTools` 增加 nil 守卫。
  - 统一 MCP client info 到 `defaultMCPClientInfo()`，版本取 `consts.GetYakVersion()`。
  ### 测试
  - 新增 `tool_manager_restrict_test.go`：`RestrictToTools` 钳制行为、deny-all（0 工具）、nil receiver。
  - 新增会话级 loader 测试（白名单 / 无白名单）。