### PR TITLE
fix(ssa): flush dbcache close during large project compile

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -439,6 +439,7 @@ jobs:
                 {"package": "./common/yak/cartesian", "timeout": "20s"},
                 {"package": "./common/utils/omap/...", "timeout": "30s", "race": true},
                 {"package": "./common/utils", "timeout": "1m"},
+                {"package": "./common/utils/dbcache", "timeout": "1m"},
                 {"package": "./common/utils/imageutils/...", "timeout": "20s"},
                 {"package": "./common/utils/xml2", "timeout": "10s"},
                 {"package": "./common/utils/tlsutils/...", "timeout": "20s"},

--- a/common/utils/dbcache/cache.go
+++ b/common/utils/dbcache/cache.go
@@ -436,18 +436,23 @@ func (c *ResidencyCacheWithKey[K, T]) ForEach(f func(K, T) bool) {
 	}
 }
 
-func (c *ResidencyCacheWithKey[K, T]) Close() {
+func (c *ResidencyCacheWithKey[K, T]) Close() error {
 	if c == nil {
-		return
+		return nil
 	}
 	c.closed.Store(true)
 	c.EnableSave()
 	c.QueueAll(utils.EvictionReasonDeleted)
 	c.Wait()
+	remaining := c.Count()
 	c.DisableSave()
 	if c.evictionCache != nil {
 		c.evictionCache.Close()
 	}
+	if remaining > 0 {
+		return utils.Errorf("dbcache: %d resident items were not persisted on close", remaining)
+	}
+	return nil
 }
 
 func (c *ResidencyCacheWithKey[K, T]) CloseWithoutSave() {

--- a/common/utils/dbcache/cache_test.go
+++ b/common/utils/dbcache/cache_test.go
@@ -368,6 +368,27 @@ func TestResidencyCache_SkipEvictionKeepsHotItemsResidentUntilClose(t *testing.T
 	require.Equal(t, "hot", value)
 }
 
+func TestResidencyCacheCloseReportsUnpersistedItems(t *testing.T) {
+	var cache *dbcache.ResidencyCacheWithKey[int, string]
+	cache = dbcache.NewResidencyCacheWithKey[int, string](
+		0,
+		0,
+		func(key int, generation uint64, reason utils.EvictionReason) bool {
+			cache.FinishPersist(key, generation, false)
+			return true
+		},
+		func(key int) (string, error) {
+			return "", utils.Errorf("missing key")
+		},
+	)
+
+	cache.Set(1, "keep")
+
+	err := cache.Close()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dbcache: 1 resident items were not persisted on close")
+}
+
 func TestCacheCloseFlushesWithoutTimeout(t *testing.T) {
 	saved := 0
 	cache := dbcache.NewCache[*closeFlushItem, int](
@@ -391,6 +412,28 @@ func TestCacheCloseFlushesWithoutTimeout(t *testing.T) {
 	require.NoError(t, cache.Close())
 	require.Less(t, time.Since(start), time.Second)
 	require.Equal(t, 2, saved)
+}
+
+func TestCacheCloseReportsMarshalError(t *testing.T) {
+	cache := dbcache.NewCache[*closeFlushItem, int](
+		10*time.Second,
+		0,
+		func(item *closeFlushItem, _ utils.EvictionReason) (int, error) {
+			return 0, utils.Errorf("marshal failed for %d", item.id)
+		},
+		func(items []int) error {
+			return nil
+		},
+		nil,
+		dbcache.WithSaveTimeout(5*time.Second),
+	)
+
+	cache.Set(&closeFlushItem{id: 7})
+
+	err := cache.Close()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "marshal failed for 7")
+	require.Contains(t, err.Error(), "dbcache: 1 resident items were not persisted on close")
 }
 
 func TestCacheCloseFlushesRejectingLateSet(t *testing.T) {
@@ -449,7 +492,7 @@ func TestCacheCloseFlushesAllItemsWithPersistLimit(t *testing.T) {
 			return nil
 		},
 		nil,
-		dbcache.WithSaveTimeout(5*time.Second),
+		dbcache.WithSaveTimeout(20*time.Millisecond),
 		dbcache.WithSaveSize(2),
 		dbcache.WithPersistLimit(3),
 	)
@@ -461,6 +504,60 @@ func TestCacheCloseFlushesAllItemsWithPersistLimit(t *testing.T) {
 	require.NoError(t, cache.Close())
 
 	require.Len(t, saved, total, "close should flush every resident item even when persistLimit forces batching")
+}
+
+func TestCacheCloseFlushesWhilePersistLimitAlreadyReached(t *testing.T) {
+	var saved atomic.Int32
+	saveStarted := make(chan struct{})
+	releaseSave := make(chan struct{})
+	var started atomic.Bool
+
+	cache := dbcache.NewCache[*closeFlushItem, int](
+		10*time.Millisecond,
+		0,
+		func(item *closeFlushItem, _ utils.EvictionReason) (int, error) {
+			return int(item.id), nil
+		},
+		func(items []int) error {
+			if started.CompareAndSwap(false, true) {
+				close(saveStarted)
+			}
+			<-releaseSave
+			saved.Add(int32(len(items)))
+			return nil
+		},
+		nil,
+		dbcache.WithSaveTimeout(10*time.Millisecond),
+		dbcache.WithPersistLimit(1),
+	)
+
+	cache.Set(&closeFlushItem{id: 1})
+	require.Eventually(t, func() bool {
+		select {
+		case <-saveStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	cache.Set(&closeFlushItem{id: 2})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cache.Close()
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	close(releaseSave)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cache.Close hung while flushing with a full persist limit")
+	}
+	require.Equal(t, int32(2), saved.Load())
 }
 
 func TestResidencyCache_RejectingPersistLeavesItemResident(t *testing.T) {

--- a/common/utils/dbcache/databasex.go
+++ b/common/utils/dbcache/databasex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/yaklang/yaklang/common/log"
@@ -42,8 +43,9 @@ type Cache[T MemoryItem, D any] struct {
 	save         SaveFunc[D]
 	persistLimit int64
 
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	closing atomic.Bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 }
 
 func NewCache[T MemoryItem, D any](
@@ -72,7 +74,7 @@ func NewCache[T MemoryItem, D any](
 			resident.FinishPersist(key, generation, true)
 			return true
 		}
-		if cache.persistLimit > 0 && resident.PendingCount() > cache.persistLimit {
+		if !cache.closing.Load() && cache.persistLimit > 0 && resident.PendingCount() > cache.persistLimit {
 			return false
 		}
 		cache.marshalPipe.Feed(evictionRequest{
@@ -234,15 +236,18 @@ func (c *Cache[T, D]) Close() error {
 	if c == nil {
 		return nil
 	}
+	var closeErr error
 
 	if c.resident != nil {
 		c.resident.MarkClosed()
 		c.resident.DisableSave()
 	}
+	c.closing.Store(true)
 
 	if c.marshalPipe != nil {
 		c.enqueueCloseRequests()
 		c.marshalPipe.Close()
+		closeErr = utils.JoinErrors(closeErr, c.marshalPipe.Error())
 	}
 	c.wg.Wait()
 	if c.saver != nil {
@@ -258,9 +263,9 @@ func (c *Cache[T, D]) Close() error {
 		c.cancel()
 	}
 	if remaining > 0 {
-		return utils.Errorf("dbcache: %d resident items were not persisted on close", remaining)
+		closeErr = utils.JoinErrors(closeErr, utils.Errorf("dbcache: %d resident items were not persisted on close", remaining))
 	}
-	return nil
+	return closeErr
 }
 
 func (c *Cache[T, D]) enqueueCloseRequests() {

--- a/common/utils/dbcache/persist_bug_test.go
+++ b/common/utils/dbcache/persist_bug_test.go
@@ -1,0 +1,89 @@
+package dbcache
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+type bugItem struct{ id int64 }
+
+func (i *bugItem) GetId() int64   { return i.id }
+func (i *bugItem) SetId(id int64) { i.id = id }
+
+// TestPersistLimitCloseWithExistingPending reproduces the large-project bug:
+// items evicted by TTL during compile create pending backlog that exceeds
+// persistLimit. When close arrives, enqueueCloseRequests batches interact
+// with the existing pending count → exceed persistLimit → rejection.
+//
+// On main: FAILS — Close returns "resident items were not persisted"
+// With closing flag fix: PASSES — all items flush correctly
+func TestPersistLimitCloseWithExistingPending(t *testing.T) {
+	const total = 30
+	var savedCount atomic.Int32
+	saveStarted := make(chan struct{})
+	releaseSave := make(chan struct{})
+	var started atomic.Bool
+
+	cache := NewCache[*bugItem, int](
+		5*time.Millisecond,  // short TTL — trigger evictions quickly
+		0,
+		func(item *bugItem, _ utils.EvictionReason) (int, error) {
+			return int(item.id), nil
+		},
+		func(items []int) error {
+			if started.CompareAndSwap(false, true) {
+				close(saveStarted)
+			}
+			<-releaseSave // block save — items stay pending
+			savedCount.Add(int32(len(items)))
+			return nil
+		},
+		nil,
+		WithSaveTimeout(10*time.Millisecond),
+		WithSaveSize(1),
+		WithPersistLimit(2), // very low persist limit
+	)
+
+	// Insert items — TTL evictions will start quickly
+	for i := 1; i <= total; i++ {
+		cache.Set(&bugItem{id: int64(i)})
+	}
+
+	// Wait for at least one save to be triggered (items are pending)
+	select {
+	case <-saveStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("save never started")
+	}
+
+	// Now many items are in the pending queue (save is blocked).
+	// pendingCount >> persistLimit(2).
+	// Close the cache while items are still pending.
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- cache.Close()
+	}()
+
+	// Give enqueueCloseRequests time to try processing
+	time.Sleep(100 * time.Millisecond)
+
+	// Release the save — allow everything to drain
+	close(releaseSave)
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close() error (bug on main): %v", err)
+		}
+		t.Logf("all items persisted correctly — fix verified")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() hung")
+	}
+
+	if int(savedCount.Load()) != total {
+		t.Fatalf("not all items saved: %d of %d", savedCount.Load(), total)
+	}
+}

--- a/common/utils/pipeline/pipe.go
+++ b/common/utils/pipeline/pipe.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"sync"
 
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
@@ -12,6 +13,9 @@ type Pipe[T, U any] struct {
 	ctx        context.Context
 	in         *chanx.UnlimitedChan[T]
 	out        *chanx.UnlimitedChan[U]
+	boundedIn  chan T
+	boundedOut chan U
+	errMu      sync.Mutex
 	err        error
 	swg        *utils.SizedWaitGroup
 	handler    func(item T, store *utils.SafeMap[any]) (U, error)
@@ -195,7 +199,9 @@ func (p *Pipe[T, U]) worker() {
 			if err == nil {
 				p.out.SafeFeed(result)
 			} else {
+				p.errMu.Lock()
 				p.err = utils.JoinErrors(p.err, err)
+				p.errMu.Unlock()
 			}
 		}
 	}
@@ -208,5 +214,7 @@ func (p *Pipe[T, U]) Close() {
 }
 
 func (p *Pipe[T, U]) Error() error {
+	p.errMu.Lock()
+	defer p.errMu.Unlock()
 	return p.err
 }


### PR DESCRIPTION
Drain deferred builds registered during deferred execution and make dbcache close report and complete pending persistence. Add dbcache CI coverage and update exclude expectations for default test/testdata skips.