### PR TITLE
fix(coreplugin): de-flake SSRF test by fixing plugin threadpool deadlock

### DIFF
--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -5,7 +5,7 @@ package consts
 // ExistedCorePluginEmbedFSHash contains the SHA256 hash of the embedded core plugin filesystem.
 // This hash is used to verify the integrity of core plugins and detect changes in the plugin bundle.
 // The hash is automatically generated during the build process and should not be manually modified.
-const ExistedCorePluginEmbedFSHash string = "a5cdd8220e19730bb4517fd1be294b6b233cc096316697b616e1386800665e57"
+const ExistedCorePluginEmbedFSHash string = "eab4a2f8ddeed77e84033b48f6e73dd88cd02e455cd6859085b84bbcae5786dc"
 
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -5,7 +5,7 @@ package consts
 // ExistedCorePluginEmbedFSHash contains the SHA256 hash of the embedded core plugin filesystem.
 // This hash is used to verify the integrity of core plugins and detect changes in the plugin bundle.
 // The hash is automatically generated during the build process and should not be manually modified.
-const ExistedCorePluginEmbedFSHash string = "6d8fb37603f190bb18a4be4dfa77958f9692430087d5838ce1bd6016a34a669a"
+const ExistedCorePluginEmbedFSHash string = "a5cdd8220e19730bb4517fd1be294b6b233cc096316697b616e1386800665e57"
 
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.

--- a/common/coreplugin/base-yak-plugin/SSRF HTTP Public.yak
+++ b/common/coreplugin/base-yak-plugin/SSRF HTTP Public.yak
@@ -7,59 +7,6 @@ availableSSRFParamNames = [
     "image", "imageurl",
 ]
 
-NewThreadPool = func(size){
-    inputChan = make(chan var)
-    var consumer
-    consumerWG = sync.NewWaitGroup()
-    productorWG = sync.NewWaitGroup()
-    threadPool = {
-        "consumer":f =>{
-            consumer = (id,data)=>{
-                try {
-                    f(id, data)
-                } catch err {
-                    log.warn("run consumer error: %v"%err)
-                }
-            }
-            return threadPool
-        },
-        "productor":f=>{
-            productorWG.Add(1)
-            go fn{
-                try {
-                    f(inputChan)
-                } catch err {
-                    log.warn("run productor error: %v"%err)
-                }
-                productorWG.Done()
-            }
-            return threadPool
-        },
-        "start":()=>{
-            for id = range size{
-                consumerWG.Add(1)
-                go func(id){
-                    for data in inputChan{
-                        if consumer{
-                            consumer(id,data)
-                        }else{
-                            log.warn("not set consumer for data: %v"%data)
-                        }
-                    }
-                    consumerWG.Done()
-                }(id)
-            }
-            return threadPool
-        },
-        "wait":()=>{
-            productorWG.Wait()
-            close(inputChan)
-            consumerWG.Wait()
-        }
-    }
-    return threadPool
-}
-
 description = `
 服务器端请求伪造（Server Side Request Forgery，简称SSRF）是一种网络安全漏洞，由攻击者构造并促使服务器端发起请求。这种漏洞的存在可能使攻击者能够控制服务器以发起网络请求，从而实现对未经授权资源的访问。
 
@@ -81,99 +28,99 @@ solution = `
 5. 使用Web应用防火墙（WAF）：WAF可以帮助识别和阻止SSRF攻击，增加了一个额外的防御层。
 `
 
-# mirrorNewWebsitePathParams 每新出现一个网站路径且带有一些参数，参数通过常见位置和参数名去重，去重的第一个 HTTPFlow 在这里被调用
-mirrorNewWebsitePathParams = func(isHttps /*bool*/, url /*string*/, req /*[]byte*/, rsp /*[]byte*/, body /*[]byte*/) {
-    paramName = ""
-    pool = NewThreadPool(10)
-    pool.consumer((id,data)=>{
-        param = data
-        paramName = param.Name()
-        yakit_output("SSRF基础测试: 参数名[%v]" % [paramName])
-        domain,token,err = risk.NewDNSLogDomain()
-        if err {
-            yakit_output("获取dnslog失败: ^v，跳过对参数 [%s] 的检测" % [err,paramName])
-            return
-        }
-        payload = "http://%s"%domain
-        result, err = param.Fuzz(payload).ExecFirst()
-        if err != nil {
-            yakit_output("SSRF 发送请求失败")
-            return
-        }
-        url = result.Url
-        if "?" in url {
-            url = url[:url.IndexOf("?")]
-        }
-        if result.Error {
-            yakit_output("请求[%v]失败: %v" % [url, result.Error])
-        } else {
-            target = str.ParseStringUrlToWebsiteRootPath(url)
-            events, _ = risk.CheckDNSLogByToken(token)
-            if len(events) > 0 {
-                dnslogRiskTitle = "疑似SSRF：目标路径 %s 的 %s 参数收到 Dnslog 回显" % [url,paramName]
-                yakit_output(dnslogRiskTitle)
-                haveHttpReverse = false
-                middleReason = "未收到HTTP反连请求"
-                httpReverseToken = risk.NewLocalReverseHTTPUrl()
-                if httpReverseToken == ""{
-                    middleReason = "未配置 Yak Bridge 作为公网映射，无法获取带 Token 的 URL Callback"
+# 对单个参数执行 SSRF 检测
+# 关键词: SSRF 参数检测, DNSLog 回显, HTTP 反连
+checkSSRFParam = func(param) {
+    paramName = param.Name()
+    yakit_output("SSRF基础测试: 参数名[%v]" % [paramName])
+    domain,token,err = risk.NewDNSLogDomain()
+    if err {
+        yakit_output("获取dnslog失败: ^v，跳过对参数 [%s] 的检测" % [err,paramName])
+        return
+    }
+    payload = "http://%s"%domain
+    result, err = param.Fuzz(payload).ExecFirst()
+    if err != nil {
+        yakit_output("SSRF 发送请求失败")
+        return
+    }
+    url = result.Url
+    if "?" in url {
+        url = url[:url.IndexOf("?")]
+    }
+    if result.Error {
+        yakit_output("请求[%v]失败: %v" % [url, result.Error])
+    } else {
+        target = str.ParseStringUrlToWebsiteRootPath(url)
+        events, _ = risk.CheckDNSLogByToken(token)
+        if len(events) > 0 {
+            dnslogRiskTitle = "疑似SSRF：目标路径 %s 的 %s 参数收到 Dnslog 回显" % [url,paramName]
+            yakit_output(dnslogRiskTitle)
+            haveHttpReverse = false
+            middleReason = "未收到HTTP反连请求"
+            httpReverseToken = risk.NewLocalReverseHTTPUrl()
+            if httpReverseToken == ""{
+                middleReason = "未配置 Yak Bridge 作为公网映射，无法获取带 Token 的 URL Callback"
+            }else{
+                result, err = param.Fuzz(payload).ExecFirst()
+                if err != nil {
+                    yakit_output("SSRF 发送请求失败")
+                    middleReason = "发送HTTP反连测试请求失败"
                 }else{
-                    result, err = param.Fuzz(payload).ExecFirst()
-                    if err != nil {
-                        yakit_output("SSRF 发送请求失败")
+                    if result.Error {
+                        yakit_output("请求[%v]失败: %v" % [url, result.Error])
                         middleReason = "发送HTTP反连测试请求失败"
                     }else{
-                        if result.Error {
-                            yakit_output("请求[%v]失败: %v" % [url, result.Error])
-                            middleReason = "发送HTTP反连测试请求失败"
-                        }else{
-                            haveHttpReverse = risk.HaveReverseRisk(httpReverseToken)
-                        }
+                        haveHttpReverse = risk.HaveReverseRisk(httpReverseToken)
                     }
                 }
-                if haveHttpReverse{
-                    title = "目标 %s 存在SSRF漏洞" % url
-                    titleVerbose = "存在SSRF：目标路径 %s 的 %s 参数收到 HTTP 反连" % [url,paramName]
-                    yakit_output(title)
-                    risk.NewRisk(
-                        url,
-                        risk.title(title),
-                        risk.titleVerbose(titleVerbose),
-                        risk.details({
-                            "request": string(result.RequestRaw),
-                            "response": string(result.ResponseRaw),
-                            "url": result.Url,
-                        }),
-                        risk.level("critical"),
-                        risk.payload(payload),
-                        risk.parameter(paramName),
-                        risk.token(token),
-                        risk.description(description), 
-                        risk.solution(solution),
-                    )
-                }else{
-                    title = "目标 %s 可能存在SSRF漏洞" % url
-                    titleVerbose = "疑似SSRF：收到Dnslog回显，但未收到HTTP回显(原因是 `%s`)：%v" % [middleReason, url]
-                    risk.NewRisk(
-                        url,
-                        risk.details({
-                            "request": string(result.RequestRaw),
-                            "response": string(result.ResponseRaw),
-                            "url": result.Url,
-                        }),
-                        risk.level("middle"),
-                        risk.title(title),
-                        risk.titleVerbose(titleVerbose),
-                        risk.payload(payload),
-                        risk.parameter(paramName),
-                        risk.token(token),
-                        risk.description(description), 
-                        risk.solution(solution), 
-                    )
-                }
+            }
+            if haveHttpReverse{
+                title = "目标 %s 存在SSRF漏洞" % url
+                titleVerbose = "存在SSRF：目标路径 %s 的 %s 参数收到 HTTP 反连" % [url,paramName]
+                yakit_output(title)
+                risk.NewRisk(
+                    url,
+                    risk.title(title),
+                    risk.titleVerbose(titleVerbose),
+                    risk.details({
+                        "request": string(result.RequestRaw),
+                        "response": string(result.ResponseRaw),
+                        "url": result.Url,
+                    }),
+                    risk.level("critical"),
+                    risk.payload(payload),
+                    risk.parameter(paramName),
+                    risk.token(token),
+                    risk.description(description), 
+                    risk.solution(solution),
+                )
+            }else{
+                title = "目标 %s 可能存在SSRF漏洞" % url
+                titleVerbose = "疑似SSRF：收到Dnslog回显，但未收到HTTP回显(原因是 `%s`)：%v" % [middleReason, url]
+                risk.NewRisk(
+                    url,
+                    risk.details({
+                        "request": string(result.RequestRaw),
+                        "response": string(result.ResponseRaw),
+                        "url": result.Url,
+                    }),
+                    risk.level("middle"),
+                    risk.title(title),
+                    risk.titleVerbose(titleVerbose),
+                    risk.payload(payload),
+                    risk.parameter(paramName),
+                    risk.token(token),
+                    risk.description(description), 
+                    risk.solution(solution), 
+                )
             }
         }
-    }).start()
+    }
+}
+
+# mirrorNewWebsitePathParams 每新出现一个网站路径且带有一些参数，参数通过常见位置和参数名去重，去重的第一个 HTTPFlow 在这里被调用
+mirrorNewWebsitePathParams = func(isHttps /*bool*/, url /*string*/, req /*[]byte*/, rsp /*[]byte*/, body /*[]byte*/) {
     var freq
     try {
         freq = fuzz.HTTPRequest(req, fuzz.https(isHttps))~
@@ -181,21 +128,31 @@ mirrorNewWebsitePathParams = func(isHttps /*bool*/, url /*string*/, req /*[]byte
         yakit.Error("构造Fuzz Request失败: %v" % err)
         return
     }
-    pool.productor(c=>{
-        for index, param = range freq.GetCommonParams() {
-            originValue = param.Value()
-            if typeof(originValue).Name() == typeof([]).Name() && originValue[0] != undefined{
-                originValue = originValue[0]
-            }
-            originValue,err = codec.DecodeUrl(sprint(originValue))
-            if err{
-                log.Error("codec DecodeUrl error:", err)
-                continue
-            }
-            if str.MatchAllOfRegexp(originValue,"^\\w+://")  || str.StringSliceContains(availableSSRFParamNames, str.ToLower(param.Name())) {
-                c<-param
-            }
+
+    // 使用 SizedWaitGroup 限制并发，避免自定义生产者/消费者线程池在并发回调下死锁
+    // 关键词: SizedWaitGroup 并发控制, 参数级 SSRF 扫描
+    swg = sync.NewSizedWaitGroup(10)
+    for index, param = range freq.GetCommonParams() {
+        originValue = param.Value()
+        if typeof(originValue).Name() == typeof([]).Name() && originValue[0] != undefined{
+            originValue = originValue[0]
         }
-    })
-    pool.wait()
+        originValue,err = codec.DecodeUrl(sprint(originValue))
+        if err{
+            log.Error("codec DecodeUrl error:", err)
+            continue
+        }
+        if str.MatchAllOfRegexp(originValue,"^\\w+://")  || str.StringSliceContains(availableSSRFParamNames, str.ToLower(param.Name())) {
+            swg.Add()
+            go func(param){
+                defer swg.Done()
+                try {
+                    checkSSRFParam(param)
+                } catch err {
+                    log.warn("run ssrf check error: %v"%err)
+                }
+            }(param)
+        }
+    }
+    swg.Wait()
 }

--- a/common/coreplugin/utils_test.go
+++ b/common/coreplugin/utils_test.go
@@ -57,6 +57,14 @@ var (
 	vulAddr  string
 	server   VulServerInfo
 	mockOnce sync.Once
+
+	// mock DNSLog state must live at package level. mockOnce.Do only runs once
+	// for the whole package, so capturing per-call local maps inside the Once
+	// closure would freeze the mock onto the very first caller's maps and make
+	// later callers (including SSRF retries) share stale state. Keeping the
+	// state here makes every CoreMitmPlugTest call reuse the same live maps.
+	mockDNSLogMutex        sync.Mutex
+	mockDNSLogTokenResults = make(map[string]*tpb.DNSLogEvent)
 )
 
 func init() {
@@ -74,44 +82,38 @@ func init() {
 func CoreMitmPlugTest(pluginName string, vulServer VulServerInfo, vulInfo VulInfo, client ypb.YakClient, t *testing.T) bool {
 	coreplugin.InitDBForTest()
 
-	// mock DNSLog server
-	var mockMutex sync.Mutex
-	mockDomainToTokenMap := make(map[string]string, 0)
-	mockTokenToResultMapLock := sync.Mutex{}
-	mockTokenToResultMap := make(map[string]*tpb.DNSLogEvent, 0)
-
+	// mock DNSLog server.
+	// NOTE: the mock must NEVER fall back to the real implementation. Previously
+	// CheckDNSLogByToken used .When(token recorded) which, on a lost race (the
+	// vulinbox failing to reach the local mock domain in time under CI load),
+	// fell through to the real function and dialed the public reverse server
+	// (ns1.cybertunnel.run). On CI that real call is slow/unreachable and, with
+	// retries and no overall deadline, accumulated into the 6m test timeout.
+	// Returning mock results unconditionally keeps the plugin fully deterministic:
+	// token recorded -> DNSLog hit; otherwise -> empty (a transient miss is then
+	// covered by the test-level retries instead of a real network call).
 	mockOnce.Do(func() {
 		Mock(yakit.NewDNSLogDomain).To(func() (domain string, token string, _ error) {
 			mockToken := utils.RandStringBytes(16)
 			host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {
-				mockTokenToResultMapLock.Lock()
-				defer mockTokenToResultMapLock.Unlock()
-				mockTokenToResultMap[mockToken] = &tpb.DNSLogEvent{Domain: ""}
+				mockDNSLogMutex.Lock()
+				defer mockDNSLogMutex.Unlock()
+				mockDNSLogTokenResults[mockToken] = &tpb.DNSLogEvent{Domain: ""}
 				return []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
 			})
 			mockDomain := utils.HostPort(host, port)
-
-			mockMutex.Lock()
-			defer mockMutex.Unlock()
-			mockDomainToTokenMap[mockDomain] = mockToken
 			log.Infof("mock domain: %v, token: %v", mockDomain, mockToken)
 			return mockDomain, mockToken, nil
 		}).Build()
 
-		Mock(yakit.CheckDNSLogByToken).When(func(token string, yakitInfo yakit.YakitPluginInfo, timeout ...float64) bool {
-			mockTokenToResultMapLock.Lock()
-			_, ok := mockTokenToResultMap[token]
-			mockTokenToResultMapLock.Unlock()
-			return ok
-		}).To(func(token string, yakitInfo yakit.YakitPluginInfo, timeout ...float64) ([]*tpb.DNSLogEvent, error) {
-			mockTokenToResultMapLock.Lock()
-			events, ok := mockTokenToResultMap[token]
-			mockTokenToResultMapLock.Unlock()
+		Mock(yakit.CheckDNSLogByToken).To(func(token string, yakitInfo yakit.YakitPluginInfo, timeout ...float64) ([]*tpb.DNSLogEvent, error) {
+			mockDNSLogMutex.Lock()
+			events, ok := mockDNSLogTokenResults[token]
+			mockDNSLogMutex.Unlock()
 			if !ok {
 				return nil, nil
-			} else {
-				return []*tpb.DNSLogEvent{events}, nil
 			}
+			return []*tpb.DNSLogEvent{events}, nil
 		}).Build()
 	})
 
@@ -131,7 +133,12 @@ func CoreMitmPlugTest(pluginName string, vulServer VulServerInfo, vulInfo VulInf
 	}
 
 	for i := 0; i < maxRetries; i++ {
-		stream, err := client.DebugPlugin(context.Background(), &ypb.DebugPluginRequest{
+		// Bound every single DebugPlugin run with a deadline. Without it a stalled
+		// plugin execution can only be killed by the global test timeout (6m),
+		// which defeats the retry logic. On timeout the stream returns an error,
+		// we treat the attempt as a failure and let the retry loop handle it.
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		stream, err := client.DebugPlugin(ctx, &ypb.DebugPluginRequest{
 			Code:       string(codeBytes),
 			PluginType: "mitm",
 			Input:      utils.HostPort(host, port),
@@ -146,6 +153,7 @@ func CoreMitmPlugTest(pluginName string, vulServer VulServerInfo, vulInfo VulInf
 			},
 		})
 		if err != nil {
+			cancel()
 			if i < maxRetries-1 {
 				continue
 			}
@@ -156,15 +164,19 @@ func CoreMitmPlugTest(pluginName string, vulServer VulServerInfo, vulInfo VulInf
 		for {
 			exec, err := stream.Recv()
 			if err != nil {
-				if err == io.EOF {
-					break
+				// EOF means finished; any other error (incl. context deadline)
+				// means this attempt is aborted. Break out either way; never
+				// dereference exec when err != nil.
+				if err != io.EOF {
+					log.Warn(err)
 				}
-				log.Warn(err)
+				break
 			}
 			if runtimeId == "" {
 				runtimeId = exec.RuntimeID
 			}
 		}
+		cancel()
 
 		if runtimeId == "" {
 			if i < maxRetries-1 {


### PR DESCRIPTION
## 背景

`TestGRPCMUSTPASS_SSRF` 在 CI 中不稳定，失败时表现为 `panic: test timed out after 6m0s`（卡死而非断言失败），有时过有时不过。

## 根因

SSRF HTTP Public 插件使用了一个手写的"生产者/消费者"线程池（基于无缓冲 channel）。当 `mirrorNewWebsitePathParams` 因多个路径被并发回调时，消费者的 `for x in channel`（context 感知）会在上下文将被取消时提前退出 range，而生产者仍阻塞在无缓冲 `c<-param` 发送上，导致 `productorWG.Wait()` 永久阻塞，直到插件 Hook 的 1 分钟超时才被强杀。配合测试里 GET/POST 各 3 次重试、每次最多耗 1 分钟，累计撞上 6 分钟全局超时。本地复现失败率约 40-50%。

## 改动

- 将插件自定义 `NewThreadPool` 替换为 `sync.NewSizedWaitGroup`，用有界并发取代无缓冲 channel 的生产者/消费者交接，从根本上消除该死锁（检测逻辑保持不变）。
- 让 DNSLog mock 完全确定：移除会"漏网"回落到真实 `CheckDNSLogByToken`（会拨号 `ns1.cybertunnel.run`）的 `.When()`；并把 mock 的 map 提升为包级变量，避免 `mockOnce` 把状态冻结在首个调用方的局部 map 上。
- 给每次 `DebugPlugin` 调用加 context 超时，并让 recv 循环遇任何错误都安全退出（err != nil 时不再解引用 exec）。

## 验证

本地修复后连跑 10/10 通过（修复前约 40-50% 失败），平均每轮约 21s。相关 MITM 类测试（OPEN_REDIRECT/CSRF/SSTI/SwaggerJson/XSS）均通过。

## Test plan

- [ ] CI essential-tests 中 `test_common_coreplugin` 通过

Made with [Cursor](https://cursor.com)