### PR TITLE
refactor(yakdoc): testable webdoc package + Markdown structure & robustness overhaul

### DIFF
--- a/common/yak/yakdoc/generate_web_doc/generate_single_file_test.go
+++ b/common/yak/yakdoc/generate_web_doc/generate_single_file_test.go
@@ -7,7 +7,13 @@ import (
 	"testing"
 
 	"github.com/yaklang/yaklang/common/yak/yakdoc"
+	"github.com/yaklang/yaklang/common/yak/yakdoc/webdoc"
 )
+
+// 本文件聚焦"薄壳"生成器的端到端行为：GenerateSingleFile 写出的 .md 必须符合新结构、
+// 示例为 14 反引号块、且通过 webdoc.CheckMarkdownInvariants。纯渲染函数的细粒度测试在
+// common/yak/yakdoc/webdoc 包内。
+// 关键词: 文档生成端到端测试, 新结构, 示例 14 反引号, 产物不变量
 
 // makeLib 构造一个内存 ScriptLib 夹具，便于直接测试 GenerateSingleFile 的输出。
 func makeLib(name string, funcs ...*yakdoc.FuncDecl) *yakdoc.ScriptLib {
@@ -30,10 +36,15 @@ func genAndRead(t *testing.T, lib *yakdoc.ScriptLib) string {
 	if err != nil {
 		t.Fatalf("read generated file failed: %v", err)
 	}
-	return string(raw)
+	out := string(raw)
+	// 产物必须通过不变量校验（断锚/破表/裸URL/裸<等都会被拦截）
+	if err := webdoc.CheckMarkdownInvariants(out); err != nil {
+		t.Fatalf("generated markdown failed invariants: %v\n%s", err, out)
+	}
+	return out
 }
 
-// 关键词: 文档生成测试, 二次转义回归, 代码块漏表回归, 内联代码转义回归, 参数返回值解释列
+// 关键词: 二次转义回归, 代码块漏表回归, 签名代码块, 参数返回值解释列
 func TestGenerateSingleFile_NoDoubleEscapeAndRichTable(t *testing.T) {
 	doc := "Foo 演示函数，处理 \"input\" 与 <tag> & more。\n" +
 		"\n" +
@@ -67,7 +78,7 @@ func TestGenerateSingleFile_NoDoubleEscapeAndRichTable(t *testing.T) {
 
 	out := genAndRead(t, makeLib("demo", fn))
 
-	// 索引表格摘要：引号应只转义一次（&#34;），绝不出现二次转义（&amp;#34; / &amp;lt;）
+	// 索引摘要：引号应只转义一次（&#34;），绝不出现二次转义
 	if !strings.Contains(out, "&#34;") {
 		t.Errorf("expected single-escaped quote (&#34;) in summary, got:\n%s", out)
 	}
@@ -88,19 +99,16 @@ func TestGenerateSingleFile_NoDoubleEscapeAndRichTable(t *testing.T) {
 	if indexLine == "" {
 		t.Fatalf("index table row for demo.Foo not found:\n%s", out)
 	}
-	if strings.Contains(indexLine, "```") {
-		t.Errorf("code fence leaked into index table row: %q", indexLine)
-	}
-	if strings.Contains(indexLine, "Foo(\"x\")") || strings.Contains(indexLine, "example") {
-		t.Errorf("example content leaked into index table row: %q", indexLine)
+	if strings.Contains(indexLine, "```") || strings.Contains(indexLine, "Foo(\"x\")") {
+		t.Errorf("code/example leaked into index table row: %q", indexLine)
 	}
 
-	// 内联代码（定义/类型）不应被 HTML 转义：chan<- int 必须原样，不能出现 chan&lt;-
-	if !strings.Contains(out, "`Foo(a string, b chan<- int) (n int, err error)`") {
-		t.Errorf("expected raw inline decl with chan<- int, got:\n%s", out)
+	// 签名应放进 go 代码块且原样保留（chan<- int 不被 HTML 转义）
+	if !strings.Contains(out, "```go\nFoo(a string, b chan<- int) (n int, err error)\n```") {
+		t.Errorf("expected signature in go code block, got:\n%s", out)
 	}
 	if strings.Contains(out, "chan&lt;-") {
-		t.Errorf("inline code was HTML-escaped (chan&lt;-), regression:\n%s", out)
+		t.Errorf("signature/type was HTML-escaped (chan&lt;-), regression:\n%s", out)
 	}
 	if !strings.Contains(out, "`chan<- int`") {
 		t.Errorf("expected raw param type `chan<- int`, got:\n%s", out)
@@ -112,9 +120,16 @@ func TestGenerateSingleFile_NoDoubleEscapeAndRichTable(t *testing.T) {
 			t.Errorf("expected explanation %q filled into table, got:\n%s", want, out)
 		}
 	}
+
+	// 新结构标志
+	for _, want := range []string{"# demo {#library-demo}", "## 函数索引", "## 函数详情", "### Foo {#foo}", "**参数**", "**返回值**"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected new-structure marker %q, got:\n%s", want, out)
+		}
+	}
 }
 
-// 空文档应给详细描述加占位，避免标题下空白
+// 空文档应给描述加占位，避免标题下空白
 func TestGenerateSingleFile_EmptyDocPlaceholder(t *testing.T) {
 	fn := &yakdoc.FuncDecl{
 		LibName:    "demo",
@@ -129,57 +144,10 @@ func TestGenerateSingleFile_EmptyDocPlaceholder(t *testing.T) {
 	}
 }
 
-// 摘要辅助函数的纯逻辑校验
-func TestSummarizeDocument_StripsCodeAndExample(t *testing.T) {
-	raw := "hello world\n```yak\ncode()\n```\nexample：\nshould-drop"
-	got := summarizeDocument(raw)
-	if strings.Contains(got, "code()") {
-		t.Errorf("summary should strip fenced code, got %q", got)
-	}
-	if strings.Contains(got, "should-drop") || strings.Contains(got, "example") {
-		t.Errorf("summary should cut at example marker, got %q", got)
-	}
-	if !strings.Contains(got, "hello world") {
-		t.Errorf("summary should keep prose, got %q", got)
-	}
-}
-
-// renderDetailDoc：示例标记之后的内容（含缩进示例代码）应原样保留，不被 HTML 转义
-func TestRenderDetailDoc_KeepsExampleRaw(t *testing.T) {
-	doc := "prose <x> & \"y\"\n" +
-		"example:\n" +
-		"\thttp.Do(\"https://a\", []byte(`<link href=\"/x\">`))\n"
-	got := renderDetailDoc(doc)
-	// 标记前的 prose 应被转义
-	if !strings.Contains(got, "prose &lt;x&gt; &amp; &#34;y&#34;") {
-		t.Errorf("prose before example should be escaped, got:\n%s", got)
-	}
-	// 标记后的示例代码应原样保留
-	if !strings.Contains(got, "http.Do(\"https://a\", []byte(`<link href=\"/x\">`))") {
-		t.Errorf("example after marker should be kept raw, got:\n%s", got)
-	}
-	if strings.Contains(got, "&lt;link") || strings.Contains(got, "[]byte(`&#34;") {
-		t.Errorf("example code must not be HTML escaped, got:\n%s", got)
-	}
-}
-
-// escapeProseKeepCode 应保留围栏代码块内容、转义正文
-func TestEscapeProseKeepCode(t *testing.T) {
-	raw := "prose <x> & y\n```\nkeep <raw> &\n```"
-	got := escapeProseKeepCode(raw)
-	if !strings.Contains(got, "prose &lt;x&gt; &amp; y") {
-		t.Errorf("prose should be HTML escaped, got %q", got)
-	}
-	if !strings.Contains(got, "keep <raw> &") {
-		t.Errorf("fenced code should be kept raw, got %q", got)
-	}
-}
-
 // fence14 是 MANUAL_EXAMPLE_SPEC §2 的 14 反引号围栏，测试里独立定义一份避免依赖实现常量。
 const fence14 = "``````````````"
 
-// extractFence14Blocks 复刻 verify-manual-examples.py 抽取 14 反引号 yak 块的逻辑：
-// 开围栏行须严格等于 14 反引号+yak，闭围栏行须严格等于 14 反引号。
+// extractFence14Blocks 复刻 verify-manual-examples.py 抽取 14 反引号 yak 块的逻辑。
 func extractFence14Blocks(s string) []string {
 	var blocks []string
 	var cur []string
@@ -203,55 +171,7 @@ func extractFence14Blocks(s string) []string {
 	return blocks
 }
 
-// T1: extractExampleCode 应去标记、去围栏、去公共缩进
-func TestExtractExampleCode(t *testing.T) {
-	cases := []struct {
-		name string
-		doc  string
-		want string
-	}{
-		{
-			name: "fenced",
-			doc:  "desc\nexample：\n```yak\nfoo(\"x\")\nbar()\n```\n",
-			want: "foo(\"x\")\nbar()",
-		},
-		{
-			name: "indented-no-fence",
-			doc:  "desc\nExample:\n\thttp.Do(\"u\", []byte(`<a>`))\n\tprintln(1)\n",
-			want: "http.Do(\"u\", []byte(`<a>`))\nprintln(1)",
-		},
-		{
-			name: "no-example",
-			doc:  "desc only\n参数:\n- a: x\n",
-			want: "",
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := extractExampleCode(c.doc); got != c.want {
-				t.Errorf("extractExampleCode mismatch:\nwant: %q\ngot:  %q", c.want, got)
-			}
-		})
-	}
-}
-
-// T1: renderDetailDoc 的示例应输出为可被 verify-manual-examples.py 抽取的 14 反引号块
-func TestRenderDetailDoc_FenceExtractable(t *testing.T) {
-	doc := "prose desc\n" +
-		"example:\n" +
-		"\tassert 1+1 == 2\n" +
-		"\tprintln(\"ok\")\n"
-	got := renderDetailDoc(doc)
-	blocks := extractFence14Blocks(got)
-	if len(blocks) != 1 {
-		t.Fatalf("expected exactly 1 fenced block, got %d:\n%s", len(blocks), got)
-	}
-	if !strings.Contains(blocks[0], "assert 1+1 == 2") || !strings.Contains(blocks[0], "println(\"ok\")") {
-		t.Errorf("fenced block lost example content: %q", blocks[0])
-	}
-}
-
-// T1: GenerateSingleFile 产出的 .md 示例为 14 反引号块且原样保留代码
+// GenerateSingleFile 产出的 .md 示例为 14 反引号块且原样保留代码
 func TestGenerateSingleFile_ExampleFence14(t *testing.T) {
 	doc := "Demo func\n" +
 		"example:\n" +
@@ -277,9 +197,8 @@ func TestGenerateSingleFile_ExampleFence14(t *testing.T) {
 	}
 }
 
-// T2: collectDocCoverage 对夹具返回正确缺口集合
+// collectDocCoverage（迁移至 webdoc.CollectDocCoverage）对夹具返回正确缺口集合
 func TestCollectDocCoverage(t *testing.T) {
-	// full: 描述/参数解释/返回解释/示例齐全 -> 无缺口
 	full := &yakdoc.FuncDecl{
 		LibName:    "demo",
 		MethodName: "Full",
@@ -291,7 +210,6 @@ func TestCollectDocCoverage(t *testing.T) {
 		Params:  []*yakdoc.Field{{Name: "a", Type: "string"}},
 		Results: []*yakdoc.Field{{Name: "r", Type: "bool"}},
 	}
-	// gappy: 无描述/参数缺解释/返回缺解释/无示例
 	gappy := &yakdoc.FuncDecl{
 		LibName:    "demo",
 		MethodName: "Gappy",
@@ -304,7 +222,7 @@ func TestCollectDocCoverage(t *testing.T) {
 	libs := map[string]*yakdoc.ScriptLib{
 		"demo": makeLib("demo", full, gappy),
 	}
-	report := collectDocCoverage(libs)
+	report := webdoc.CollectDocCoverage(libs)
 
 	if report.Total != 2 {
 		t.Errorf("expected total 2, got %d", report.Total)
@@ -319,11 +237,8 @@ func TestCollectDocCoverage(t *testing.T) {
 	if g.Method != "Gappy" {
 		t.Errorf("expected gap on Gappy, got %s", g.Method)
 	}
-	if !g.MissingDesc {
-		t.Errorf("expected MissingDesc=true for Gappy")
-	}
-	if !g.MissingExample {
-		t.Errorf("expected MissingExample=true for Gappy")
+	if !g.MissingDesc || !g.MissingExample {
+		t.Errorf("expected MissingDesc and MissingExample for Gappy")
 	}
 	if len(g.ParamsNoExpl) != 1 || g.ParamsNoExpl[0] != "x" {
 		t.Errorf("expected param x missing explanation, got %v", g.ParamsNoExpl)

--- a/common/yak/yakdoc/generate_web_doc/generate_web_doc.go
+++ b/common/yak/yakdoc/generate_web_doc/generate_web_doc.go
@@ -3,40 +3,25 @@ package main
 import (
 	"flag"
 	"fmt"
-	"html"
 	"os"
 	"path"
-	"regexp"
 	"runtime/debug"
-	"sort"
 	"strings"
 
-	"github.com/samber/lo"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak"
-	"github.com/yaklang/yaklang/common/yak/antlr4yak"
 	"github.com/yaklang/yaklang/common/yak/yakdoc"
+	"github.com/yaklang/yaklang/common/yak/yakdoc/webdoc"
 	"github.com/yaklang/yaklang/common/yak/yaklang"
 )
 
-// YakDocParsed 用于存储解析后的注释字段
-type YakDocParsed struct {
-	Description     string
-	LongDescription string
-	Params          map[string]string // 参数名 -> 描述
-	Returns         []string          // 按顺序存储返回值描述
-	Example         string
-}
+// 本程序为 web 文档生成器的"薄壳"：负责从引擎取数(EngineToDocumentHelper)、写文件、跑
+// 覆盖率与产物不变量校验。所有纯渲染逻辑都在无引擎依赖的 common/yak/yakdoc/webdoc 包中，
+// 由该包的单元/边界/不变量测试在 essential-tests 里保证 Markdown 构建健壮。
+// 关键词: web 文档生成器薄壳, webdoc 渲染, 产物不变量自检
 
-func specialPatchValueStr(ins *yakdoc.LibInstance) string {
-	valueStr := ins.ValueStr
-	if ins.LibName == "os" && ins.InstanceName == "Args" {
-		valueStr = "Command line arguments"
-	}
-	return html.EscapeString(valueStr)
-}
-
+// CheckDocCodeBlockMatched 校验所有导出注释里的 ``` 围栏成对，不成对则 panic(早失败)。
 func CheckDocCodeBlockMatched() {
 	helper := yak.EngineToDocumentHelperWithVerboseInfo(yaklang.New())
 	failCount := 0
@@ -55,11 +40,9 @@ func CheckDocCodeBlockMatched() {
 			checkFunc(f)
 		}
 	}
-
 	for _, f := range helper.Functions {
 		checkFunc(f)
 	}
-
 	for _, lib := range helper.StructMethods {
 		for _, f := range lib.Functions {
 			checkFunc(f)
@@ -71,711 +54,28 @@ func CheckDocCodeBlockMatched() {
 	}
 }
 
-// stripFencedCodeBlocks 去除 ```...``` 围栏代码块（含围栏行），
-// 用于生成函数索引表格里的单行摘要，避免代码块漏进表格破坏渲染。
-func stripFencedCodeBlocks(s string) string {
-	lines := strings.Split(s, "\n")
-	out := make([]string, 0, len(lines))
-	inFence := false
-	for _, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
-			inFence = !inFence
-			continue
-		}
-		if inFence {
-			continue
-		}
-		out = append(out, line)
-	}
-	return strings.Join(out, "\n")
-}
-
-// indexOfExampleMarker 返回第一个示例标记的位置（覆盖 ASCII/全角冒号与中英文标记），
-// 找不到返回 -1。
-func indexOfExampleMarker(s string) int {
-	markers := []string{"Example:", "example:", "Example：", "example：", "示例:", "示例："}
-	idx := -1
-	for _, m := range markers {
-		if i := strings.Index(s, m); i != -1 && (idx == -1 || i < idx) {
-			idx = i
-		}
-	}
-	return idx
-}
-
-// cutAtExampleMarker 在第一个示例标记处截断，用于生成摘要时丢弃示例段落。
-func cutAtExampleMarker(s string) string {
-	if idx := indexOfExampleMarker(s); idx != -1 {
-		return s[:idx]
-	}
-	return s
-}
-
-// renderDetailDoc 渲染"详细描述"正文：示例标记之前的 prose 做 HTML 转义并保留围栏代码块，
-// 示例代码统一改为 14 反引号 yak 围栏输出（MANUAL_EXAMPLE_SPEC），既保证示例原样不被
-// 转义，又能被 verify-manual-examples.py 抽取验证。
-// 关键词: 详细描述渲染, 示例 14 反引号围栏, 正文转义
-func renderDetailDoc(doc string) string {
-	idx := indexOfExampleMarker(doc)
-	if idx == -1 {
-		return escapeProseKeepCode(doc)
-	}
-	prose := escapeProseKeepCode(doc[:idx])
-	code := extractExampleCode(doc)
-	if code == "" {
-		return prose
-	}
-	return prose + "\nExample:\n\n" + fenceExampleYak(code) + "\n"
-}
-
-// bareURLSchemeRe 匹配 URL 协议头 "http://" / "https://"。
-// 关键词: 裸URL autolink, MDX 构建崩溃, 协议分隔符转义
-var bareURLSchemeRe = regexp.MustCompile(`https?://`)
-
-// neutralizeBareURLAutolinks 把正文/表格里的"裸 URL"协议分隔符 "://" 替换为实体
-// "&#58;//"，阻断 gfm autolink。否则形如 "http://127.0.0.1:8080"） 的文本会被
-// gfm autolink 把后续的引号/全角标点一并并入 URL，生成 http://127.0.0.1:8080"）
-// 这种非法 URL，导致文档站 MDX 构建崩溃。
-//
-// 转义后浏览器仍会把实体还原显示为 http:// ，只是该 URL 不再被识别为可点击链接（对参数
-// 说明里的示例地址而言这正是期望行为）。唯一需要保留可点击的是 markdown 链接
-// "[text](http://...)"，因此这里跳过紧跟在 "](" 之后的 URL。
-// 注意：必须在 html.EscapeString 之后调用——此时字面引号已变为 "&#34;" 实体，无法再靠
-// "前导字符是引号" 来识别裸 URL，故改为"除 markdown 链接外一律转义"的稳健策略。
-// 关键词: neutralizeBareURLAutolinks, 阻断 autolink, 跳过 markdown 链接
-func neutralizeBareURLAutolinks(s string) string {
-	locs := bareURLSchemeRe.FindAllStringIndex(s, -1)
-	if len(locs) == 0 {
-		return s
-	}
-	var b strings.Builder
-	prev := 0
-	for _, loc := range locs {
-		start, end := loc[0], loc[1]
-		b.WriteString(s[prev:start])
-		if start >= 2 && s[start-2:start] == "](" {
-			// markdown 链接目标，保持可点击
-			b.WriteString(s[start:end])
-		} else {
-			b.WriteString(strings.Replace(s[start:end], "://", "&#58;//", 1))
-		}
-		prev = end
-	}
-	b.WriteString(s[prev:])
-	return b.String()
-}
-
-// summarizeDocument 从原始文档生成函数索引表格用的单行摘要：
-// 去除代码块与示例段、归一化空白、截断 150 runes、仅 HTML 转义一次并转义表格分隔符。
-// 关键词: 文档摘要, 避免二次转义, 避免代码块漏进表格
-func summarizeDocument(raw string) string {
-	s := stripFencedCodeBlocks(raw)
-	s = cutAtExampleMarker(s)
-	s = strings.ReplaceAll(s, "\r", "")
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.Join(strings.Fields(s), " ")
-	runes := []rune(s)
-	if len(runes) > 150 {
-		s = string(runes[:150]) + "..."
-	}
-	s = html.EscapeString(s)
-	s = neutralizeBareURLAutolinks(s)
-	s = strings.ReplaceAll(s, "|", "\\|")
-	return s
-}
-
-// escapeProseKeepCode 对正文按行 HTML 转义，但保留 ```...``` 围栏代码块原样，
-// 避免代码块内的 < 与 & 被转义成 &lt; / &amp; 字面量。
-func escapeProseKeepCode(s string) string {
-	lines := strings.Split(s, "\n")
-	inFence := false
-	for i, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
-			inFence = !inFence
-			continue
-		}
-		if inFence {
-			continue
-		}
-		lines[i] = neutralizeBareURLAutolinks(html.EscapeString(line))
-	}
-	return strings.Join(lines, "\n")
-}
-
-// escapeTableCell 处理表格普通文本单元：去换行、HTML 转义一次、转义表格分隔符。
-func escapeTableCell(s string) string {
-	s = strings.ReplaceAll(s, "\r", "")
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.TrimSpace(s)
-	s = html.EscapeString(s)
-	s = neutralizeBareURLAutolinks(s)
-	s = strings.ReplaceAll(s, "|", "\\|")
-	return s
-}
-
-// exampleFence 是 MANUAL_EXAMPLE_SPEC §2 规定的 14 个反引号围栏。
-// 采用超长围栏保证示例内部出现三反引号/Markdown 片段时整段仍是同一代码块。
-const exampleFence = "``````````````" // 14 backticks
-
-// dedent 去除多行文本的公共前导空白（按字节，适配制表符或空格统一缩进的示例）。
-func dedent(s string) string {
-	lines := strings.Split(s, "\n")
-	minIndent := -1
-	for _, l := range lines {
-		if strings.TrimSpace(l) == "" {
-			continue
-		}
-		indent := len(l) - len(strings.TrimLeft(l, " \t"))
-		if minIndent == -1 || indent < minIndent {
-			minIndent = indent
-		}
-	}
-	if minIndent <= 0 {
-		return s
-	}
-	for i, l := range lines {
-		if len(l) >= minIndent {
-			lines[i] = l[minIndent:]
-		}
-	}
-	return strings.Join(lines, "\n")
-}
-
-// extractExampleCode 从 doc 注释提取示例代码：去示例标记行、去已有 ``` 围栏、
-// 去公共缩进与首尾空行，得到可直接执行/包裹的纯代码。
-// 关键词: 示例提取, Example 段, 去围栏去缩进
-func extractExampleCode(doc string) string {
-	idx := indexOfExampleMarker(doc)
-	if idx == -1 {
-		return ""
-	}
-	rest := doc[idx:]
-	// 跳过示例标记所在行（如 "Example:" / "example："）
-	if nl := strings.Index(rest, "\n"); nl != -1 {
-		rest = rest[nl+1:]
-	} else {
-		return ""
-	}
-	// 去掉已有的三反引号围栏行，避免与外层 14 反引号围栏冲突
-	kept := make([]string, 0)
-	for _, line := range strings.Split(rest, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
-			continue
-		}
-		kept = append(kept, line)
-	}
-	return strings.TrimSpace(dedent(strings.Join(kept, "\n")))
-}
-
-// fenceExampleYak 用 14 反引号 yak 围栏包裹示例代码（MANUAL_EXAMPLE_SPEC §2），
-// 使 verify-manual-examples.py 能稳定抽取并执行。
-func fenceExampleYak(code string) string {
-	return exampleFence + "yak\n" + code + "\n" + exampleFence
-}
-
-// formatYakCode 格式化yak代码，使用 YaklangCompileAndFormat 接口
-// 如果格式化失败，则回退到原始代码
-func formatYakCode(originalCode string) string {
-	if originalCode == "" {
-		return originalCode
-	}
-
-	code := strings.TrimSpace(originalCode)
-
-	// 检查是否包含代码块标记
-	hasCodeBlock := false
-	codeBlockLang := ""
-	codeContent := code
-
-	if strings.HasPrefix(code, "```") {
-		hasCodeBlock = true
-		// 提取语言标识和代码内容
-		lines := strings.Split(code, "\n")
-		if len(lines) > 0 {
-			firstLine := lines[0]
-			codeBlockLang = strings.TrimPrefix(firstLine, "```")
-			codeBlockLang = strings.TrimSpace(codeBlockLang)
-
-			// 去除首尾的代码块标记
-			if len(lines) > 2 {
-				lastLineIdx := len(lines) - 1
-				if strings.HasPrefix(strings.TrimSpace(lines[lastLineIdx]), "```") {
-					codeContent = strings.Join(lines[1:lastLineIdx], "\n")
-				} else {
-					codeContent = strings.Join(lines[1:], "\n")
-				}
-			} else if len(lines) > 1 {
-				codeContent = strings.Join(lines[1:], "\n")
-			}
-		}
-	}
-
-	// 尝试使用 YaklangCompileAndFormat 格式化代码
-	engine := antlr4yak.New()
-	formatted, err := engine.FormattedAndSyntaxChecking(codeContent)
-
-	// 只有在格式化成功且返回非空结果时才使用格式化后的代码
-	if err == nil && formatted != "" {
-		codeContent = formatted
-	} else {
-		// 格式化失败，保持原始代码内容
-		log.Debugf("failed to format yak code: %v, using original code", err)
-	}
-
-	// 如果原本有代码块标记，重新添加
-	if hasCodeBlock {
-		if codeBlockLang != "" {
-			return fmt.Sprintf("```%s\n%s\n```", codeBlockLang, codeContent)
-		}
-		return fmt.Sprintf("```yak\n%s\n```", codeContent)
-	}
-
-	return codeContent
-}
-
-// 辅助函数：解析注释中的参数和返回值描述
-func parseCommentDetails(doc string) *YakDocParsed {
-	parsed := &YakDocParsed{
-		Params: make(map[string]string),
-	}
-
-	// 按行分割并清理
-	lines := strings.Split(doc, "\n")
-	var cleanLines []string
-	for _, line := range lines {
-		// 这里的 doc 假设已经去掉了 "//" 前缀，如果没有去掉，需要先在此处 strings.TrimPrefix(line, "//")
-		cleanLines = append(cleanLines, strings.TrimSpace(line))
-	}
-
-	var currentSection string // "", "long_desc", "params", "returns", "example"
-	var longDescLines []string
-	var exampleLines []string
-
-	// 正则匹配: - name(type): description 或 - name: description
-	listRegex := regexp.MustCompile(`^\s*-\s*([\w.]+)\s*(?:\(.*\))?\s*[:：]\s*(.*)$`)
-
-	for i := 0; i < len(cleanLines); i++ {
-		line := cleanLines[i]
-		lowerLine := strings.ToLower(line)
-
-		// 1. 检测状态切换 (关键字识别)
-		if strings.HasPrefix(line, "参数") {
-			currentSection = "params"
-			continue
-		} else if strings.HasPrefix(line, "返回值") {
-			currentSection = "returns"
-			continue
-		} else if strings.HasPrefix(lowerLine, "example") {
-			currentSection = "example"
-			continue
-		}
-
-		// 2. 处理内容提取
-		if line == "" && currentSection != "example" {
-			continue // 忽略非代码块中的空行
-		}
-
-		switch currentSection {
-		case "":
-			// 初始状态逻辑：第一行是 Description，之后到“参数”之前的内容是 LongDescription
-			if parsed.Description == "" {
-				parsed.Description = line
-			} else {
-				longDescLines = append(longDescLines, line)
-			}
-
-		case "params":
-			matches := listRegex.FindStringSubmatch(line)
-			if len(matches) > 2 {
-				parsed.Params[matches[1]] = matches[2]
-			}
-
-		case "returns":
-			matches := listRegex.FindStringSubmatch(line)
-			if len(matches) > 2 {
-				parsed.Returns = append(parsed.Returns, matches[2])
-			} else if strings.HasPrefix(line, "-") {
-				parsed.Returns = append(parsed.Returns, strings.TrimSpace(strings.TrimPrefix(line, "-")))
-			}
-
-		case "example":
-			// 保留原始格式（包括空格）
-			exampleLines = append(exampleLines, lines[i])
-		}
-	}
-
-	// 格式化输出
-	// LongDescription 处理：合并行，根据原逻辑使用了 Fields 处理（注意：Fields 会压缩所有空格）
-	if len(longDescLines) > 0 {
-		rawLongDesc := strings.Join(longDescLines, " ")
-		parsed.LongDescription = strings.Join(strings.Fields(rawLongDesc), "")
-	}
-
-	parsed.Example = strings.Join(exampleLines, "\n")
-
-	// 格式化example代码
-	if parsed.Example != "" {
-		parsed.Example = formatYakCode(parsed.Example)
-	}
-
-	return parsed
-}
-
+// GenerateSingleFile 渲染并写出一个库的 .md，写后跑 CheckMarkdownInvariants 做产物自检。
 func GenerateSingleFile(basepath string, lib *yakdoc.ScriptLib) {
-	file, err := os.Create(path.Join(basepath, lib.Name+".md"))
-	if err != nil {
+	// 示例代码不做格式化(保持注释原样)，传 nil。
+	md := webdoc.RenderLibMarkdown(lib, nil)
+	outPath := path.Join(basepath, lib.Name+".md")
+	if err := os.WriteFile(outPath, []byte(md), 0o644); err != nil {
 		log.Errorf("create file error: %v", err)
+		return
 	}
-	defer file.Close()
-	file.WriteString("# " + lib.Name + "\n\n")
-	if len(lib.Instances) > 0 {
-		file.WriteString("|实例名|实例描述|\n")
-		file.WriteString("|:------|:--------|\n")
-		keys := lo.Keys(lib.Instances)
-		sort.Strings(keys)
-		for _, key := range keys {
-			ins := lib.Instances[key]
-			file.WriteString(fmt.Sprintf("%s|(%s) %s|\n",
-				html.EscapeString(ins.InstanceName),
-				html.EscapeString(ins.Type),
-				specialPatchValueStr(ins),
-			))
-		}
-		file.WriteString("\n")
-	}
-
-	file.WriteString("|函数名|函数描述/介绍|\n")
-	file.WriteString("|:------|:--------|\n")
-
-	// 将Functions转成list
-	funcList := lo.MapToSlice(lib.Functions, func(key string, value *yakdoc.FuncDecl) *yakdoc.FuncDecl {
-		return value
-	})
-	sort.SliceStable(funcList, func(i, j int) bool {
-		return funcList[i].MethodName < funcList[j].MethodName
-	})
-	bufList := make([]strings.Builder, 0, len(funcList))
-
-	for _, fun := range funcList {
-		// 解析注释里的参数/返回值解释，用于填充表格第三列
-		parsed := parseCommentDetails(fun.Document)
-
-		// 函数索引表格用的单行摘要：从原始文档生成，仅转义一次，去除代码块/示例，避免破表
-		// 关键词: 函数索引摘要, 避免二次转义
-		simpleDocument := summarizeDocument(fun.Document)
-
-		// 详细描述正文：示例前转义 prose 并保留围栏代码块，示例后原样保留；空文档加占位
-		detailDoc := renderDetailDoc(fun.Document)
-		if strings.TrimSpace(detailDoc) == "" {
-			detailDoc = "暂无描述"
-		}
-
-		lowerMethodName := strings.ToLower(fun.MethodName)
-		file.WriteString(fmt.Sprintf("| [%s.%s](#%s) |%s|\n",
-			html.EscapeString(fun.LibName),
-			html.EscapeString(fun.MethodName),
-			html.EscapeString(lowerMethodName),
-			simpleDocument,
-		))
-		buf := strings.Builder{}
-		buf.WriteString(fmt.Sprintf("### %s\n\n", html.EscapeString(fun.MethodName)))
-		buf.WriteString(fmt.Sprintf("#### 详细描述\n%s\n\n", detailDoc))
-		// 定义放在行内代码块里，不能 HTML 转义，否则 < 与 & 会显示成 &lt; / &amp;
-		buf.WriteString(fmt.Sprintf("#### 定义\n\n`%s`\n\n", fun.Decl))
-		if len(fun.Params) > 0 {
-			buf.WriteString("#### 参数\n")
-			buf.WriteString("|参数名|参数类型|参数解释|\n")
-			buf.WriteString("|:-----------|:---------- |:-----------|\n")
-			for _, param := range fun.Params {
-				// 类型在行内代码块里，不转义；参数解释取自注释，无则留空
-				buf.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n", html.EscapeString(param.Name), param.Type, escapeTableCell(parsed.Params[param.Name])))
-			}
-			buf.WriteString("\n")
-		}
-		if len(fun.Results) > 0 {
-			buf.WriteString("#### 返回值\n")
-			buf.WriteString("|返回值(顺序)|返回值类型|返回值解释|\n")
-			buf.WriteString("|:-----------|:---------- |:-----------|\n")
-			for i, result := range fun.Results {
-				explanation := ""
-				if i < len(parsed.Returns) {
-					explanation = parsed.Returns[i]
-				}
-				buf.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n", html.EscapeString(result.Name), result.Type, escapeTableCell(explanation)))
-			}
-			buf.WriteString("\n")
-		}
-		buf.WriteString("\n")
-		bufList = append(bufList, buf)
-	}
-	file.WriteString("\n\n")
-	file.WriteString("## 函数定义\n")
-	for _, buf := range bufList {
-		file.WriteString(buf.String())
+	// 产物不变量自检：tag 期出文档时的二次兜底，违例打 error log(非阻断)。
+	if err := webdoc.CheckMarkdownInvariants(md); err != nil {
+		log.Errorf("markdown invariants check failed for lib %s: %v", lib.Name, err)
 	}
 }
 
+// GenerateSingleFileMDX 渲染并写出一个库的 .mdx(含 Tabs)。MDX 含 JSX，健壮性由文档站构建保证。
 func GenerateSingleFileMDX(basepath string, lib *yakdoc.ScriptLib, description string) {
-	file, err := os.Create(path.Join(basepath, lib.Name+".mdx"))
-	if err != nil {
+	mdx := webdoc.RenderLibMDX(lib, description, nil)
+	outPath := path.Join(basepath, lib.Name+".mdx")
+	if err := os.WriteFile(outPath, []byte(mdx), 0o644); err != nil {
 		log.Errorf("create file error: %v", err)
 	}
-	defer file.Close()
-	file.WriteString("---\n")
-	file.WriteString("sidebar_label: " + lib.Name + "\n")
-	file.WriteString("slug: /api/" + lib.Name + "\n")
-	file.WriteString("title: " + lib.Name + "\n")
-	file.WriteString("description: " + description + "\n")
-	file.WriteString("---\n")
-
-	file.WriteString("import Tabs from '@theme/Tabs';\n")
-	file.WriteString("import TabItem from '@theme/TabItem';\n")
-	file.WriteString("import CodeBlock from '@theme/CodeBlock';\n\n")
-
-	file.WriteString(":::info\n" + description + "\n:::\n\n")
-
-	// 预处理：解析所有函数并按分类分组
-	type FuncInfo struct {
-		Decl   *yakdoc.FuncDecl
-		Parsed *YakDocParsed
-	}
-
-	// 将Functions转成list
-	funcList := lo.MapToSlice(lib.Functions, func(key string, value *yakdoc.FuncDecl) FuncInfo {
-		return FuncInfo{Decl: value, Parsed: parseCommentDetails(value.Document)}
-	})
-	// 全局排序：按方法名排序
-	sort.SliceStable(funcList, func(i, j int) bool {
-		return funcList[i].Decl.MethodName < funcList[j].Decl.MethodName
-	})
-
-	file.WriteString("## 函数索引\n\n")
-	file.WriteString("|函数名|函数描述/介绍|\n")
-	file.WriteString("|:------|:--------|\n")
-
-	for _, f := range funcList {
-		lowerMethodName := strings.ToLower(f.Decl.MethodName)
-		file.WriteString(fmt.Sprintf("| [%s.%s](#%s) | %s |\n",
-			html.EscapeString(f.Decl.LibName),
-			html.EscapeString(f.Decl.MethodName),
-			html.EscapeString(lowerMethodName),
-			f.Parsed.Description,
-		))
-	}
-
-	file.WriteString("\n\n")
-
-	if len(lib.Instances) > 0 {
-		file.WriteString("## 实例索引\n\n")
-		file.WriteString("|实例名|实例描述|\n")
-		file.WriteString("|:------|:--------|\n")
-		keys := lo.Keys(lib.Instances)
-		sort.Strings(keys)
-		for _, key := range keys {
-			ins := lib.Instances[key]
-			file.WriteString(fmt.Sprintf("%s|(%s) %s|\n",
-				html.EscapeString(ins.InstanceName),
-				html.EscapeString(ins.Type),
-				specialPatchValueStr(ins),
-			))
-		}
-		file.WriteString("\n")
-	}
-
-	bufList := make([]strings.Builder, 0, len(funcList))
-	file.WriteString("## API 详情\n\n")
-
-	for _, f := range funcList {
-		fun := f.Decl
-		p := f.Parsed
-		buf := strings.Builder{}
-
-		buf.WriteString(fmt.Sprintf("### %s\n\n", fun.MethodName))
-		buf.WriteString(fmt.Sprintf("- 描述: %s\n\n", p.Description))
-		if p.LongDescription != "" {
-			buf.WriteString(fmt.Sprintf("- 详细描述: %s\n\n", p.LongDescription))
-		}
-		buf.WriteString("\n<Tabs>\n")
-		buf.WriteString(fmt.Sprintf("<TabItem value=\"%s-1\" label=\"定义\" default>\n\n", fun.MethodName))
-		buf.WriteString(fmt.Sprintf("```go\n%s\n```\n\n", html.EscapeString(fun.Decl)))
-
-		if len(fun.Params) > 0 {
-			buf.WriteString("**参数配置信息**\n")
-			buf.WriteString("\n|参数名|参数类型|参数解释|\n")
-			buf.WriteString("|:-----------|:---------- |:-----------|\n")
-			for _, param := range fun.Params {
-				explanation := p.Params[param.Name]
-				buf.WriteString(fmt.Sprintf("| %s | `%s` |  %s |\n", html.EscapeString(param.Name), html.EscapeString(param.Type), explanation))
-			}
-			buf.WriteString("\n")
-		}
-		if len(fun.Results) > 0 {
-			buf.WriteString("**返回值**\n")
-			buf.WriteString("\n|返回值(顺序)|返回值类型|返回值解释|\n")
-			buf.WriteString("|:-----------|:---------- |:-----------|\n")
-			for i, result := range fun.Results {
-				explanation := ""
-				if i < len(p.Returns) {
-					explanation = p.Returns[i]
-				}
-				buf.WriteString(fmt.Sprintf("| %s | `%s` |  %s |\n", html.EscapeString(result.Name), html.EscapeString(result.Type), explanation))
-			}
-			buf.WriteString("\n")
-		}
-		buf.WriteString("</TabItem>\n")
-		// 示例统一用 14 反引号 yak 围栏（MANUAL_EXAMPLE_SPEC），便于 verify-manual-examples.py 抽取验证
-		if exampleCode := extractExampleCode(fun.Document); exampleCode != "" {
-			buf.WriteString(fmt.Sprintf("<TabItem value=\"%s-2\" label=\"示例\">\n", fun.MethodName))
-			buf.WriteString(fmt.Sprintf("\n\n%s\n\n", fenceExampleYak(exampleCode)))
-			buf.WriteString("</TabItem>\n")
-		}
-		buf.WriteString("</Tabs>\n\n")
-		buf.WriteString("\n---\n\n")
-		bufList = append(bufList, buf)
-	}
-
-	file.WriteString("\n\n")
-	for _, buf := range bufList {
-		file.WriteString(buf.String())
-	}
-}
-
-// FuncCoverage 记录单个导出函数的文档缺口（缺描述/缺示例/缺参数解释/缺返回解释）。
-// 关键词: 文档覆盖率, 文档缺口
-type FuncCoverage struct {
-	Lib            string
-	Method         string
-	MissingDesc    bool     // 无描述（首行描述为空）
-	MissingExample bool     // 无 Example 段
-	ParamsNoExpl   []string // 缺解释的参数名
-	ResultsNoExpl  int      // 缺解释的返回值个数
-}
-
-// HasGap 该函数是否存在任一文档缺口。
-func (c *FuncCoverage) HasGap() bool {
-	return c.MissingDesc || c.MissingExample || len(c.ParamsNoExpl) > 0 || c.ResultsNoExpl > 0
-}
-
-// CoverageReport 全量文档覆盖率统计结果。
-type CoverageReport struct {
-	Total    int             // 导出函数总数
-	WithGap  int             // 存在缺口的函数数
-	Gaps     []*FuncCoverage // 仅包含有缺口的函数明细（按库名+方法名排序）
-	libCount map[string]int  // 每库缺口计数
-}
-
-// collectDocCoverage 遍历所有库的导出函数，统计文档缺口。该函数无副作用、可测试。
-// 关键词: collectDocCoverage, 文档覆盖率统计
-func collectDocCoverage(libs map[string]*yakdoc.ScriptLib) *CoverageReport {
-	report := &CoverageReport{libCount: make(map[string]int)}
-	// 库与函数都排序，保证输出稳定
-	libNames := lo.Keys(libs)
-	sort.Strings(libNames)
-
-	for _, libName := range libNames {
-		lib := libs[libName]
-		methodNames := lo.Keys(lib.Functions)
-		sort.Strings(methodNames)
-		for _, name := range methodNames {
-			fun := lib.Functions[name]
-			report.Total++
-
-			parsed := parseCommentDetails(fun.Document)
-			cov := &FuncCoverage{Lib: fun.LibName, Method: fun.MethodName}
-			cov.MissingDesc = strings.TrimSpace(parsed.Description) == ""
-			cov.MissingExample = extractExampleCode(fun.Document) == ""
-			for _, param := range fun.Params {
-				if strings.TrimSpace(parsed.Params[param.Name]) == "" {
-					cov.ParamsNoExpl = append(cov.ParamsNoExpl, param.Name)
-				}
-			}
-			for i := range fun.Results {
-				if i >= len(parsed.Returns) || strings.TrimSpace(parsed.Returns[i]) == "" {
-					cov.ResultsNoExpl++
-				}
-			}
-
-			if cov.HasGap() {
-				report.WithGap++
-				report.Gaps = append(report.Gaps, cov)
-				report.libCount[fun.LibName]++
-			}
-		}
-	}
-	return report
-}
-
-// LogSummary 以英文 log 打印覆盖率汇总（非阻断）。逐项 Warn 缺口、末尾打印每库与总计。
-func (r *CoverageReport) LogSummary() {
-	for _, g := range r.Gaps {
-		var missing []string
-		if g.MissingDesc {
-			missing = append(missing, "description")
-		}
-		if len(g.ParamsNoExpl) > 0 {
-			missing = append(missing, fmt.Sprintf("param-explanation(%s)", strings.Join(g.ParamsNoExpl, ",")))
-		}
-		if g.ResultsNoExpl > 0 {
-			missing = append(missing, fmt.Sprintf("return-explanation(%d)", g.ResultsNoExpl))
-		}
-		if g.MissingExample {
-			missing = append(missing, "example")
-		}
-		log.Warnf("doc coverage gap: %s.%s missing %s", g.Lib, g.Method, strings.Join(missing, ", "))
-	}
-
-	libs := lo.Keys(r.libCount)
-	sort.Strings(libs)
-	for _, name := range libs {
-		log.Warnf("doc coverage: lib %s has %d function(s) with gaps", name, r.libCount[name])
-	}
-	log.Infof("doc coverage summary: %d/%d functions have gaps (%d ok)", r.WithGap, r.Total, r.Total-r.WithGap)
-}
-
-// WriteMarkdown 把覆盖率明细写成 markdown 底单，用于驱动 backfill。该文件应写到 docs/api 之外。
-func (r *CoverageReport) WriteMarkdown(p string) error {
-	if dir := path.Dir(p); dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return err
-		}
-	}
-	buf := strings.Builder{}
-	buf.WriteString("# API Documentation Coverage Baseline\n\n")
-	buf.WriteString(fmt.Sprintf("Total functions: %d; functions with gaps: %d; ok: %d\n\n", r.Total, r.WithGap, r.Total-r.WithGap))
-
-	// 按库聚合
-	byLib := make(map[string][]*FuncCoverage)
-	for _, g := range r.Gaps {
-		byLib[g.Lib] = append(byLib[g.Lib], g)
-	}
-	libs := lo.Keys(byLib)
-	sort.Strings(libs)
-	for _, lib := range libs {
-		buf.WriteString(fmt.Sprintf("## %s (%d)\n\n", lib, len(byLib[lib])))
-		buf.WriteString("|function|missing description|missing param explanation|missing return explanation|missing example|\n")
-		buf.WriteString("|:--|:--|:--|:--|:--|\n")
-		for _, g := range byLib[lib] {
-			descMark := ""
-			if g.MissingDesc {
-				descMark = "yes"
-			}
-			paramMark := ""
-			if len(g.ParamsNoExpl) > 0 {
-				paramMark = strings.Join(g.ParamsNoExpl, ",")
-			}
-			retMark := ""
-			if g.ResultsNoExpl > 0 {
-				retMark = fmt.Sprintf("%d", g.ResultsNoExpl)
-			}
-			exMark := ""
-			if g.MissingExample {
-				exMark = "yes"
-			}
-			buf.WriteString(fmt.Sprintf("|%s|%s|%s|%s|%s|\n", g.Method, descMark, paramMark, retMark, exMark))
-		}
-		buf.WriteString("\n")
-	}
-	return os.WriteFile(p, []byte(buf.String()), 0o644)
 }
 
 func main() {
@@ -806,10 +106,9 @@ func main() {
 	}
 
 	CheckDocCodeBlockMatched()
-	// 列表维护需要生成 MDX 的库及对应描述
+	// 需要生成 MDX 的库及对应描述
 	mdxLibs := map[string]string{
 		"ai": "AI 模块提供了与多种大语言模型集成的能力，支持 OpenAI、ChatGLM、Moonshot 等主流 AI 服务。通过统一的接口调用不同的 AI 服务，支持对话、函数调用、流式输出等功能。",
-		// 可以继续添加其他库名和描述
 	}
 
 	helper := yak.EngineToDocumentHelperWithVerboseInfo(yaklang.New())
@@ -822,7 +121,7 @@ func main() {
 	}
 
 	// 文档覆盖率统计：非阻断，仅打印 warning 协助本地补全；CI 永不因此失败（除非显式 -strict）。
-	report := collectDocCoverage(helper.Libs)
+	report := webdoc.CollectDocCoverage(helper.Libs)
 	report.LogSummary()
 	if coverageReport != "" {
 		if err := report.WriteMarkdown(coverageReport); err != nil {

--- a/common/yak/yakdoc/webdoc/coverage.go
+++ b/common/yak/yakdoc/webdoc/coverage.go
@@ -1,0 +1,149 @@
+package webdoc
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/yak/yakdoc"
+)
+
+// FuncCoverage 记录单个导出函数的文档缺口（缺描述/缺示例/缺参数解释/缺返回解释）。
+// 关键词: 文档覆盖率, 文档缺口
+type FuncCoverage struct {
+	Lib            string
+	Method         string
+	MissingDesc    bool     // 无描述（首行描述为空）
+	MissingExample bool     // 无 Example 段
+	ParamsNoExpl   []string // 缺解释的参数名
+	ResultsNoExpl  int      // 缺解释的返回值个数
+}
+
+// HasGap 该函数是否存在任一文档缺口。
+func (c *FuncCoverage) HasGap() bool {
+	return c.MissingDesc || c.MissingExample || len(c.ParamsNoExpl) > 0 || c.ResultsNoExpl > 0
+}
+
+// CoverageReport 全量文档覆盖率统计结果。
+type CoverageReport struct {
+	Total    int             // 导出函数总数
+	WithGap  int             // 存在缺口的函数数
+	Gaps     []*FuncCoverage // 仅包含有缺口的函数明细（按库名+方法名排序）
+	libCount map[string]int  // 每库缺口计数
+}
+
+// CollectDocCoverage 遍历所有库的导出函数，统计文档缺口。该函数无副作用、可测试。
+// 关键词: CollectDocCoverage, 文档覆盖率统计
+func CollectDocCoverage(libs map[string]*yakdoc.ScriptLib) *CoverageReport {
+	report := &CoverageReport{libCount: make(map[string]int)}
+	libNames := lo.Keys(libs)
+	sort.Strings(libNames)
+
+	for _, libName := range libNames {
+		lib := libs[libName]
+		methodNames := lo.Keys(lib.Functions)
+		sort.Strings(methodNames)
+		for _, name := range methodNames {
+			fun := lib.Functions[name]
+			report.Total++
+
+			parsed := parseCommentDetails(fun.Document)
+			cov := &FuncCoverage{Lib: fun.LibName, Method: fun.MethodName}
+			cov.MissingDesc = strings.TrimSpace(parsed.Description) == ""
+			cov.MissingExample = extractExampleCode(fun.Document) == ""
+			for _, param := range fun.Params {
+				if strings.TrimSpace(parsed.Params[param.Name]) == "" {
+					cov.ParamsNoExpl = append(cov.ParamsNoExpl, param.Name)
+				}
+			}
+			for i := range fun.Results {
+				if i >= len(parsed.Returns) || strings.TrimSpace(parsed.Returns[i]) == "" {
+					cov.ResultsNoExpl++
+				}
+			}
+
+			if cov.HasGap() {
+				report.WithGap++
+				report.Gaps = append(report.Gaps, cov)
+				report.libCount[fun.LibName]++
+			}
+		}
+	}
+	return report
+}
+
+// LogSummary 以英文 log 打印覆盖率汇总（非阻断）。逐项 Warn 缺口、末尾打印每库与总计。
+func (r *CoverageReport) LogSummary() {
+	for _, g := range r.Gaps {
+		var missing []string
+		if g.MissingDesc {
+			missing = append(missing, "description")
+		}
+		if len(g.ParamsNoExpl) > 0 {
+			missing = append(missing, fmt.Sprintf("param-explanation(%s)", strings.Join(g.ParamsNoExpl, ",")))
+		}
+		if g.ResultsNoExpl > 0 {
+			missing = append(missing, fmt.Sprintf("return-explanation(%d)", g.ResultsNoExpl))
+		}
+		if g.MissingExample {
+			missing = append(missing, "example")
+		}
+		log.Warnf("doc coverage gap: %s.%s missing %s", g.Lib, g.Method, strings.Join(missing, ", "))
+	}
+
+	libs := lo.Keys(r.libCount)
+	sort.Strings(libs)
+	for _, name := range libs {
+		log.Warnf("doc coverage: lib %s has %d function(s) with gaps", name, r.libCount[name])
+	}
+	log.Infof("doc coverage summary: %d/%d functions have gaps (%d ok)", r.WithGap, r.Total, r.Total-r.WithGap)
+}
+
+// WriteMarkdown 把覆盖率明细写成 markdown 底单，用于驱动 backfill。该文件应写到 docs/api 之外。
+func (r *CoverageReport) WriteMarkdown(p string) error {
+	if dir := path.Dir(p); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	buf := strings.Builder{}
+	buf.WriteString("# API Documentation Coverage Baseline\n\n")
+	buf.WriteString(fmt.Sprintf("Total functions: %d; functions with gaps: %d; ok: %d\n\n", r.Total, r.WithGap, r.Total-r.WithGap))
+
+	byLib := make(map[string][]*FuncCoverage)
+	for _, g := range r.Gaps {
+		byLib[g.Lib] = append(byLib[g.Lib], g)
+	}
+	libs := lo.Keys(byLib)
+	sort.Strings(libs)
+	for _, lib := range libs {
+		buf.WriteString(fmt.Sprintf("## %s (%d)\n\n", lib, len(byLib[lib])))
+		buf.WriteString("|function|missing description|missing param explanation|missing return explanation|missing example|\n")
+		buf.WriteString("|:--|:--|:--|:--|:--|\n")
+		for _, g := range byLib[lib] {
+			descMark := ""
+			if g.MissingDesc {
+				descMark = "yes"
+			}
+			paramMark := ""
+			if len(g.ParamsNoExpl) > 0 {
+				paramMark = strings.Join(g.ParamsNoExpl, ",")
+			}
+			retMark := ""
+			if g.ResultsNoExpl > 0 {
+				retMark = fmt.Sprintf("%d", g.ResultsNoExpl)
+			}
+			exMark := ""
+			if g.MissingExample {
+				exMark = "yes"
+			}
+			buf.WriteString(fmt.Sprintf("|%s|%s|%s|%s|%s|\n", g.Method, descMark, paramMark, retMark, exMark))
+		}
+		buf.WriteString("\n")
+	}
+	return os.WriteFile(p, []byte(buf.String()), 0o644)
+}

--- a/common/yak/yakdoc/webdoc/invariants.go
+++ b/common/yak/yakdoc/webdoc/invariants.go
@@ -1,0 +1,158 @@
+package webdoc
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// 关键词: CheckMarkdownInvariants, Markdown 健壮性守卫, 锚点完整性, 围栏配对, 表格列一致
+//
+// CheckMarkdownInvariants 对一段(由本包生成的)Markdown 做结构不变量校验，复刻并守住
+// 那些会让文档站 MDX 构建崩溃或渲染错乱的失败模式。仅用于纯 Markdown(.md)，不适用 MDX。
+// 校验项:
+//   1. 代码围栏成对(``` 行数为偶数,无未闭合)。
+//   2. 仅一个 H1;无超过 3 级的标题。
+//   3. 显式 heading id 无重复;每个 (#id) 链接都有对应的 heading id(锚点完整)。
+//   4. 同一张表格各行的列数一致(忽略行内代码与转义管道)。
+//   5. 非代码处无未中和的裸 URL(避免 gfm autolink 崩溃)。
+//   6. 非代码处无裸 '<'(避免被 MDX 当作 JSX)。
+
+var (
+	mdHeadingRe = regexp.MustCompile(`^(#{1,6})\s+`)
+	mdIDRe      = regexp.MustCompile(`\{#([A-Za-z0-9_-]+)\}`)
+	mdLinkRe    = regexp.MustCompile(`\]\(#([A-Za-z0-9_-]+)\)`)
+	mdURLRe     = regexp.MustCompile(`https?://`)
+)
+
+type linkRef struct {
+	id   string
+	line int
+}
+
+// stripInlineCode 去掉一行里的行内代码 `...`(连同反引号),用于在不被代码内容干扰的前提下
+// 统计表格列、检测裸 URL 与裸 '<'。注意:仅处理单反引号行内代码,围栏代码块在调用方按行跳过。
+func stripInlineCode(line string) string {
+	var b strings.Builder
+	inCode := false
+	for _, r := range line {
+		if r == '`' {
+			inCode = !inCode
+			continue
+		}
+		if inCode {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// countTableColumns 统计去除行内代码后一行里的有效管道数(跳过被反斜杠转义的 \|)。
+func countTableColumns(stripped string) int {
+	cols := 0
+	runes := []rune(stripped)
+	for i, r := range runes {
+		if r == '|' {
+			if i > 0 && runes[i-1] == '\\' {
+				continue
+			}
+			cols++
+		}
+	}
+	return cols
+}
+
+// CheckMarkdownInvariants 校验 Markdown 结构不变量,违例时返回聚合后的错误(便于测试断言)。
+func CheckMarkdownInvariants(md string) error {
+	lines := strings.Split(md, "\n")
+	var violations []string
+	add := func(format string, args ...interface{}) {
+		violations = append(violations, fmt.Sprintf(format, args...))
+	}
+
+	fenceToggles := 0
+	inFence := false
+	h1 := 0
+	explicitIDs := map[string]int{}
+	var links []linkRef
+	tableCols := -1
+
+	for idx, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "```") {
+			fenceToggles++
+			inFence = !inFence
+			tableCols = -1
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		if m := mdHeadingRe.FindStringSubmatch(line); m != nil {
+			level := len(m[1])
+			if level == 1 {
+				h1++
+			}
+			if level > 3 {
+				add("line %d: heading level %d exceeds 3: %q", idx+1, level, trimmed)
+			}
+			for _, im := range mdIDRe.FindAllStringSubmatch(line, -1) {
+				explicitIDs[im[1]]++
+			}
+		}
+
+		stripped := stripInlineCode(line)
+
+		for _, lm := range mdLinkRe.FindAllStringSubmatch(stripped, -1) {
+			links = append(links, linkRef{id: lm[1], line: idx + 1})
+		}
+
+		if strings.Contains(stripped, "<") {
+			add("line %d: raw '<' outside code (MDX/JSX risk): %q", idx+1, trimmed)
+		}
+
+		for _, loc := range mdURLRe.FindAllStringIndex(stripped, -1) {
+			start := loc[0]
+			if !(start >= 2 && stripped[start-2:start] == "](") {
+				add("line %d: bare URL not neutralized (autolink crash risk): %q", idx+1, trimmed)
+				break
+			}
+		}
+
+		if strings.HasPrefix(trimmed, "|") {
+			cols := countTableColumns(stripInlineCode(trimmed))
+			if tableCols == -1 {
+				tableCols = cols
+			} else if cols != tableCols {
+				add("line %d: table column mismatch (got %d want %d): %q", idx+1, cols, tableCols, trimmed)
+			}
+		} else {
+			tableCols = -1
+		}
+	}
+
+	if inFence || fenceToggles%2 != 0 {
+		add("unbalanced code fence: %d fence lines", fenceToggles)
+	}
+	if h1 != 1 {
+		add("expected exactly 1 H1, got %d", h1)
+	}
+	for id, n := range explicitIDs {
+		if n > 1 {
+			add("duplicate heading id #%s (%d times)", id, n)
+		}
+	}
+	for _, lt := range links {
+		if explicitIDs[lt.id] == 0 {
+			add("line %d: link target #%s has no matching heading id", lt.line, lt.id)
+		}
+	}
+
+	if len(violations) > 0 {
+		return fmt.Errorf("markdown invariants failed:\n  - %s", strings.Join(violations, "\n  - "))
+	}
+	return nil
+}

--- a/common/yak/yakdoc/webdoc/invariants_test.go
+++ b/common/yak/yakdoc/webdoc/invariants_test.go
@@ -1,0 +1,53 @@
+package webdoc
+
+import (
+	"strings"
+	"testing"
+)
+
+// 关键词: CheckMarkdownInvariants 测试, 失败模式守卫
+
+func TestCheckMarkdownInvariantsValid(t *testing.T) {
+	valid := []string{
+		// 链接锚点齐全、行内代码里的 < 不算违例、围栏成对
+		"# t {#library-t}\n\n[x](#foo)\n\n## 函数详情\n\n### foo {#foo}\n\n```go\nfoo()\n```\n\ndesc with `a<b` inline\n\n---\n",
+		// markdown 链接里的 http:// 允许保留(可点击)
+		"# t {#library-t}\n\nsee [site](http://example.com)\n",
+		// 表格列一致，含行内代码管道
+		"# t {#library-t}\n\n|a|b|\n|:--|:--|\n| `x|y` | z |\n",
+	}
+	for i, md := range valid {
+		if err := CheckMarkdownInvariants(md); err != nil {
+			t.Fatalf("valid case %d should pass, got: %v\n%s", i, err, md)
+		}
+	}
+}
+
+func TestCheckMarkdownInvariantsCatches(t *testing.T) {
+	cases := []struct {
+		name string
+		md   string
+		want string
+	}{
+		{"duplicate id", "# a {#x}\n\n### b {#x}\n", "duplicate heading id"},
+		{"unbalanced fence", "# a {#a}\n\n```go\ncode\n", "unbalanced code fence"},
+		{"table mismatch", "# t {#t}\n\n|a|b|\n|:--|:--|\n|1|2|3|\n", "table column mismatch"},
+		{"bare url", "# t {#t}\n\nvisit http://x now\n", "bare URL not neutralized"},
+		{"raw lt", "# t {#t}\n\na < b here\n", "raw '<'"},
+		{"multiple h1", "# a {#a}\n\n# b {#b}\n", "expected exactly 1 H1"},
+		{"zero h1", "## a {#a}\n", "expected exactly 1 H1"},
+		{"deep heading", "# a {#a}\n\n#### deep {#d}\n", "exceeds 3"},
+		{"missing anchor", "# t {#t}\n\n[x](#missing)\n", "no matching heading id"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := CheckMarkdownInvariants(c.md)
+			if err == nil {
+				t.Fatalf("expected violation %q, got nil", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("expected error containing %q, got: %v", c.want, err)
+			}
+		})
+	}
+}

--- a/common/yak/yakdoc/webdoc/render.go
+++ b/common/yak/yakdoc/webdoc/render.go
@@ -1,0 +1,558 @@
+// Package webdoc 把 yaklang 导出库(yakdoc.ScriptLib)渲染为文档站(Docusaurus)使用的
+// Markdown / MDX 文本。本包只依赖 yakdoc 数据类型与标准库，不引入 yak 引擎，因此可被
+// 单元测试、边界测试与整文档不变量测试直接覆盖，保证 Markdown 构建健壮、不在文档站崩溃。
+// 关键词: web 文档渲染, RenderLibMarkdown, 可测渲染, Markdown 健壮性
+package webdoc
+
+import (
+	"fmt"
+	"html"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/yaklang/yaklang/common/yak/yakdoc"
+)
+
+// YakDocParsed 用于存储解析后的注释字段
+type YakDocParsed struct {
+	Description     string
+	LongDescription string
+	Params          map[string]string // 参数名 -> 描述
+	Returns         []string          // 按顺序存储返回值描述
+	Example         string
+}
+
+// instanceValueRaw 返回实例的原始展示值(未做任何转义),特殊实例做语义补丁。
+// 转义统一交给调用方的 escapeTableCell,避免二次转义。
+func instanceValueRaw(ins *yakdoc.LibInstance) string {
+	v := ins.ValueStr
+	if ins.LibName == "os" && ins.InstanceName == "Args" {
+		v = "Command line arguments"
+	}
+	return v
+}
+
+// stripFencedCodeBlocks 去除 ```...``` 围栏代码块（含围栏行），
+// 用于生成函数索引表格里的单行摘要，避免代码块漏进表格破坏渲染。
+func stripFencedCodeBlocks(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	inFence := false
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// indexOfExampleMarker 返回第一个示例标记的位置（覆盖 ASCII/全角冒号与中英文标记），
+// 找不到返回 -1。
+func indexOfExampleMarker(s string) int {
+	markers := []string{"Example:", "example:", "Example：", "example：", "示例:", "示例："}
+	idx := -1
+	for _, m := range markers {
+		if i := strings.Index(s, m); i != -1 && (idx == -1 || i < idx) {
+			idx = i
+		}
+	}
+	return idx
+}
+
+// cutAtExampleMarker 在第一个示例标记处截断，用于生成摘要时丢弃示例段落。
+func cutAtExampleMarker(s string) string {
+	if idx := indexOfExampleMarker(s); idx != -1 {
+		return s[:idx]
+	}
+	return s
+}
+
+// bareURLSchemeRe 匹配 URL 协议头 "http://" / "https://"。
+// 关键词: 裸URL autolink, MDX 构建崩溃, 协议分隔符转义
+var bareURLSchemeRe = regexp.MustCompile(`https?://`)
+
+// neutralizeBareURLAutolinks 把正文/表格里的"裸 URL"协议分隔符 "://" 替换为实体
+// "&#58;//"，阻断 gfm autolink。否则形如 "http://127.0.0.1:8080"） 的文本会被
+// gfm autolink 把后续的引号/全角标点一并并入 URL，生成 http://127.0.0.1:8080"）
+// 这种非法 URL，导致文档站 MDX 构建崩溃。
+//
+// 转义后浏览器仍会把实体还原显示为 http:// ，只是该 URL 不再被识别为可点击链接。
+// 唯一需要保留可点击的是 markdown 链接 "[text](http://...)"，因此跳过紧跟在 "](" 之后的 URL。
+// 关键词: neutralizeBareURLAutolinks, 阻断 autolink, 跳过 markdown 链接
+func neutralizeBareURLAutolinks(s string) string {
+	locs := bareURLSchemeRe.FindAllStringIndex(s, -1)
+	if len(locs) == 0 {
+		return s
+	}
+	var b strings.Builder
+	prev := 0
+	for _, loc := range locs {
+		start, end := loc[0], loc[1]
+		b.WriteString(s[prev:start])
+		if start >= 2 && s[start-2:start] == "](" {
+			b.WriteString(s[start:end])
+		} else {
+			b.WriteString(strings.Replace(s[start:end], "://", "&#58;//", 1))
+		}
+		prev = end
+	}
+	b.WriteString(s[prev:])
+	return b.String()
+}
+
+// summarizeDocument 从原始文档生成单行摘要：去代码块与示例段、归一化空白、截断 150 runes、
+// 仅 HTML 转义一次并转义表格分隔符。保留供向后兼容与潜在用途。
+// 关键词: 文档摘要, 避免二次转义
+func summarizeDocument(raw string) string {
+	s := stripFencedCodeBlocks(raw)
+	s = cutAtExampleMarker(s)
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.Join(strings.Fields(s), " ")
+	runes := []rune(s)
+	if len(runes) > 150 {
+		s = string(runes[:150]) + "..."
+	}
+	s = html.EscapeString(s)
+	s = neutralizeBareURLAutolinks(s)
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return s
+}
+
+// escapeProseKeepCode 对正文按行 HTML 转义，但保留 ```...``` 围栏代码块原样，
+// 避免代码块内的 < 与 & 被转义成 &lt; / &amp; 字面量。
+func escapeProseKeepCode(s string) string {
+	lines := strings.Split(s, "\n")
+	inFence := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		lines[i] = neutralizeBareURLAutolinks(html.EscapeString(line))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// escapeTableCell 处理表格普通文本单元：去换行、HTML 转义一次、转义表格分隔符。
+func escapeTableCell(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.TrimSpace(s)
+	s = html.EscapeString(s)
+	s = neutralizeBareURLAutolinks(s)
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return s
+}
+
+// exampleFence 是 MANUAL_EXAMPLE_SPEC §2 规定的 14 个反引号围栏。
+// 采用超长围栏保证示例内部出现三反引号/Markdown 片段时整段仍是同一代码块。
+const exampleFence = "``````````````" // 14 backticks
+
+// dedent 去除多行文本的公共前导空白（按字节，适配制表符或空格统一缩进的示例）。
+func dedent(s string) string {
+	lines := strings.Split(s, "\n")
+	minIndent := -1
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		indent := len(l) - len(strings.TrimLeft(l, " \t"))
+		if minIndent == -1 || indent < minIndent {
+			minIndent = indent
+		}
+	}
+	if minIndent <= 0 {
+		return s
+	}
+	for i, l := range lines {
+		if len(l) >= minIndent {
+			lines[i] = l[minIndent:]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// extractExampleCode 从 doc 注释提取示例代码：去示例标记行、去已有 ``` 围栏、
+// 去公共缩进与首尾空行，得到可直接执行/包裹的纯代码。
+// 关键词: 示例提取, Example 段, 去围栏去缩进
+func extractExampleCode(doc string) string {
+	idx := indexOfExampleMarker(doc)
+	if idx == -1 {
+		return ""
+	}
+	rest := doc[idx:]
+	if nl := strings.Index(rest, "\n"); nl != -1 {
+		rest = rest[nl+1:]
+	} else {
+		return ""
+	}
+	kept := make([]string, 0)
+	for _, line := range strings.Split(rest, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(dedent(strings.Join(kept, "\n")))
+}
+
+// fenceExampleYak 用 14 反引号 yak 围栏包裹示例代码（MANUAL_EXAMPLE_SPEC §2），
+// 使 verify-manual-examples.py 能稳定抽取并执行。
+func fenceExampleYak(code string) string {
+	return exampleFence + "yak\n" + code + "\n" + exampleFence
+}
+
+// parseCommentDetails 解析注释中的描述、参数与返回值说明。
+// 关键词: 注释解析, 参数/返回值说明
+func parseCommentDetails(doc string) *YakDocParsed {
+	parsed := &YakDocParsed{
+		Params: make(map[string]string),
+	}
+
+	lines := strings.Split(doc, "\n")
+	var cleanLines []string
+	for _, line := range lines {
+		cleanLines = append(cleanLines, strings.TrimSpace(line))
+	}
+
+	var currentSection string // "", "params", "returns", "example"
+	var longDescLines []string
+	var exampleLines []string
+
+	listRegex := regexp.MustCompile(`^\s*-\s*([\w.]+)\s*(?:\(.*\))?\s*[:：]\s*(.*)$`)
+
+	for i := 0; i < len(cleanLines); i++ {
+		line := cleanLines[i]
+		lowerLine := strings.ToLower(line)
+
+		if strings.HasPrefix(line, "参数") {
+			currentSection = "params"
+			continue
+		} else if strings.HasPrefix(line, "返回值") {
+			currentSection = "returns"
+			continue
+		} else if strings.HasPrefix(lowerLine, "example") {
+			currentSection = "example"
+			continue
+		}
+
+		if line == "" && currentSection != "example" {
+			continue
+		}
+
+		switch currentSection {
+		case "":
+			if parsed.Description == "" {
+				parsed.Description = line
+			} else {
+				longDescLines = append(longDescLines, line)
+			}
+		case "params":
+			matches := listRegex.FindStringSubmatch(line)
+			if len(matches) > 2 {
+				parsed.Params[matches[1]] = matches[2]
+			}
+		case "returns":
+			matches := listRegex.FindStringSubmatch(line)
+			if len(matches) > 2 {
+				parsed.Returns = append(parsed.Returns, matches[2])
+			} else if strings.HasPrefix(line, "-") {
+				parsed.Returns = append(parsed.Returns, strings.TrimSpace(strings.TrimPrefix(line, "-")))
+			}
+		case "example":
+			exampleLines = append(exampleLines, lines[i])
+		}
+	}
+
+	if len(longDescLines) > 0 {
+		rawLongDesc := strings.Join(longDescLines, " ")
+		parsed.LongDescription = strings.Join(strings.Fields(rawLongDesc), "")
+	}
+
+	parsed.Example = strings.Join(exampleLines, "\n")
+	return parsed
+}
+
+// firstStructuralMarker 返回原始 doc 中最早出现的"结构标记"字节偏移：示例标记、或行首
+// 以 参数/返回值/Returns/Return Values 开头的小节标题。找不到返回 -1。
+// 关键词: 描述去重, 结构标记定位
+func firstStructuralMarker(doc string) int {
+	best := -1
+	consider := func(i int) {
+		if i >= 0 && (best == -1 || i < best) {
+			best = i
+		}
+	}
+	consider(indexOfExampleMarker(doc))
+
+	offset := 0
+	for _, line := range strings.Split(doc, "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "参数") || strings.HasPrefix(t, "返回值") ||
+			strings.HasPrefix(t, "Returns") || strings.HasPrefix(t, "Return Values") {
+			consider(offset)
+			break
+		}
+		offset += len(line) + 1 // +1 还原被 Split 去掉的换行
+	}
+	return best
+}
+
+// leadingProse 取函数文档里"参数/返回值/示例"之前的描述正文，做 HTML 转义(保留代码块)、
+// 折叠多余空行并去首尾空白。用于"详细描述"区块，避免把参数/返回值列表重复 dump。
+// 关键词: leadingProse, 描述去重
+func leadingProse(doc string) string {
+	prose := doc
+	if idx := firstStructuralMarker(doc); idx >= 0 {
+		prose = doc[:idx]
+	}
+	return strings.TrimSpace(collapseBlankLines(escapeProseKeepCode(prose)))
+}
+
+// collapseBlankLines 把连续多个空行折叠为一个；围栏代码块内部原样保留(代码里的空行有意义)。
+// 关键词: collapseBlankLines, 空行折叠
+func collapseBlankLines(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	blank := false
+	inFence := false
+	for _, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), "```") {
+			inFence = !inFence
+			out = append(out, l)
+			blank = false
+			continue
+		}
+		if inFence {
+			out = append(out, l)
+			continue
+		}
+		isBlank := strings.TrimSpace(l) == ""
+		if isBlank && blank {
+			continue
+		}
+		out = append(out, l)
+		blank = isBlank
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+// isOptionFunc 判定一个函数是否为"配置选项"风格：恰好一个返回值且类型以 Option 结尾
+// (如 PocConfigOption / AIEngineConfigOption)。该启发式在全库普遍成立。
+// 关键词: 配置选项判定, 函数分组
+func isOptionFunc(fun *yakdoc.FuncDecl) bool {
+	return len(fun.Results) == 1 && strings.HasSuffix(fun.Results[0].Type, "Option")
+}
+
+// classifyFunctions 把函数分为"主要函数"与"配置选项"两组，组内保持入参顺序。
+// 关键词: classifyFunctions, 主要函数, 配置选项
+func classifyFunctions(funcs []*yakdoc.FuncDecl) (core, options []*yakdoc.FuncDecl) {
+	for _, f := range funcs {
+		if isOptionFunc(f) {
+			options = append(options, f)
+		} else {
+			core = append(core, f)
+		}
+	}
+	return
+}
+
+// sortedFuncs 把库的函数表转为按方法名稳定排序的切片。
+func sortedFuncs(lib *yakdoc.ScriptLib) []*yakdoc.FuncDecl {
+	funcList := lo.MapToSlice(lib.Functions, func(_ string, value *yakdoc.FuncDecl) *yakdoc.FuncDecl {
+		return value
+	})
+	sort.SliceStable(funcList, func(i, j int) bool {
+		return funcList[i].MethodName < funcList[j].MethodName
+	})
+	return funcList
+}
+
+// assignAnchors 给定最终展示顺序，为每个函数分配唯一锚点 id(默认方法名小写)。
+// 大小写冲突或重名时追加 -2/-3 序号，保证同页 id 唯一且索引链接与标题一致。
+// 关键词: 锚点分配, 唯一 id, 断锚修复
+func assignAnchors(order []*yakdoc.FuncDecl) map[*yakdoc.FuncDecl]string {
+	used := map[string]int{}
+	res := make(map[*yakdoc.FuncDecl]string, len(order))
+	for _, f := range order {
+		base := strings.ToLower(f.MethodName)
+		id := base
+		if n, ok := used[base]; ok {
+			id = fmt.Sprintf("%s-%d", base, n+1)
+			used[base] = n + 1
+		} else {
+			used[base] = 1
+		}
+		res[f] = id
+	}
+	return res
+}
+
+// RenderLibMarkdown 把一个库渲染为增强版 Markdown：分组索引 + 分组详情、签名代码块、
+// 加粗小节标签、去重描述、显式唯一锚点、函数间分隔线。formatExample 为示例代码格式化器，
+// 传 nil 表示不格式化(保持注释原样)。
+// 关键词: RenderLibMarkdown, 分组索引, 显式锚点, 签名代码块
+func RenderLibMarkdown(lib *yakdoc.ScriptLib, formatExample func(string) string) string {
+	if formatExample == nil {
+		formatExample = func(s string) string { return s }
+	}
+	var b strings.Builder
+
+	// 库 H1 用显式且不与函数锚点冲突的 id(library- 前缀),规避库名与同名函数抢 slug。
+	b.WriteString(fmt.Sprintf("# %s {#library-%s}\n\n", html.EscapeString(lib.Name), lib.Name))
+
+	funcList := sortedFuncs(lib)
+
+	// 事实性概览行(非杜撰)。
+	if len(funcList) > 0 || len(lib.Instances) > 0 {
+		parts := make([]string, 0, 2)
+		if len(funcList) > 0 {
+			parts = append(parts, fmt.Sprintf("%d 个函数", len(funcList)))
+		}
+		if len(lib.Instances) > 0 {
+			parts = append(parts, fmt.Sprintf("%d 个实例", len(lib.Instances)))
+		}
+		b.WriteString("> 共 " + strings.Join(parts, "、") + "\n\n")
+	}
+
+	// 实例区块
+	if len(lib.Instances) > 0 {
+		b.WriteString("## 实例\n\n")
+		b.WriteString("|实例名|类型|说明|\n")
+		b.WriteString("|:--|:--|:--|\n")
+		keys := lo.Keys(lib.Instances)
+		sort.Strings(keys)
+		for _, key := range keys {
+			ins := lib.Instances[key]
+			b.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n",
+				escapeTableCell(ins.InstanceName),
+				ins.Type,
+				escapeTableCell(instanceValueRaw(ins)),
+			))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(funcList) == 0 {
+		return b.String()
+	}
+
+	core, options := classifyFunctions(funcList)
+	grouped := len(core) > 0 && len(options) > 0
+
+	var order []*yakdoc.FuncDecl
+	if grouped {
+		order = append(order, core...)
+		order = append(order, options...)
+	} else {
+		order = funcList
+	}
+	anchors := assignAnchors(order)
+
+	// 函数索引
+	b.WriteString("## 函数索引\n\n")
+	writeIndex := func(funcs []*yakdoc.FuncDecl) {
+		b.WriteString("|函数|说明|\n")
+		b.WriteString("|:--|:--|\n")
+		for _, fun := range funcs {
+			parsed := parseCommentDetails(fun.Document)
+			b.WriteString(fmt.Sprintf("| [%s.%s](#%s) | %s |\n",
+				html.EscapeString(fun.LibName),
+				html.EscapeString(fun.MethodName),
+				anchors[fun],
+				escapeTableCell(parsed.Description),
+			))
+		}
+		b.WriteString("\n")
+	}
+	if grouped {
+		b.WriteString("**主要函数**\n\n")
+		writeIndex(core)
+		b.WriteString("**配置选项**\n\n")
+		writeIndex(options)
+	} else {
+		writeIndex(funcList)
+	}
+
+	// 函数详情
+	b.WriteString("## 函数详情\n\n")
+	writeDetails := func(funcs []*yakdoc.FuncDecl) {
+		for _, fun := range funcs {
+			b.WriteString(renderFuncDetail(fun, anchors[fun], formatExample))
+		}
+	}
+	if grouped {
+		b.WriteString("**主要函数**\n\n")
+		writeDetails(core)
+		b.WriteString("**配置选项**\n\n")
+		writeDetails(options)
+	} else {
+		writeDetails(funcList)
+	}
+
+	return b.String()
+}
+
+// renderFuncDetail 渲染单个函数的详情块：标题(显式锚点) + 签名代码块 + 去重描述 +
+// 参数表 + 返回值表 + 示例 + 分隔线。
+// 关键词: renderFuncDetail, 签名代码块, 加粗小节
+func renderFuncDetail(fun *yakdoc.FuncDecl, anchor string, formatExample func(string) string) string {
+	parsed := parseCommentDetails(fun.Document)
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("### %s {#%s}\n\n", html.EscapeString(fun.MethodName), anchor))
+
+	// 签名放进 go 代码块(围栏内原样,不转义,< & 安全)。
+	b.WriteString("```go\n" + fun.Decl + "\n```\n\n")
+
+	prose := leadingProse(fun.Document)
+	if strings.TrimSpace(prose) == "" {
+		prose = "暂无描述"
+	}
+	b.WriteString(prose + "\n\n")
+
+	if len(fun.Params) > 0 {
+		b.WriteString("**参数**\n\n")
+		b.WriteString("|参数名|类型|说明|\n")
+		b.WriteString("|:--|:--|:--|\n")
+		for _, param := range fun.Params {
+			b.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n",
+				html.EscapeString(param.Name), param.Type, escapeTableCell(parsed.Params[param.Name])))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(fun.Results) > 0 {
+		b.WriteString("**返回值**\n\n")
+		b.WriteString("|序号|类型|说明|\n")
+		b.WriteString("|:--|:--|:--|\n")
+		for i, result := range fun.Results {
+			explanation := ""
+			if i < len(parsed.Returns) {
+				explanation = parsed.Returns[i]
+			}
+			b.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n",
+				html.EscapeString(result.Name), result.Type, escapeTableCell(explanation)))
+		}
+		b.WriteString("\n")
+	}
+
+	if code := extractExampleCode(fun.Document); code != "" {
+		b.WriteString("**示例**\n\n")
+		b.WriteString(fenceExampleYak(formatExample(code)) + "\n\n")
+	}
+
+	b.WriteString("---\n\n")
+	return b.String()
+}

--- a/common/yak/yakdoc/webdoc/render_mdx.go
+++ b/common/yak/yakdoc/webdoc/render_mdx.go
@@ -1,0 +1,122 @@
+package webdoc
+
+import (
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/yaklang/yaklang/common/yak/yakdoc"
+)
+
+// RenderLibMDX 把一个库渲染为 MDX(带 Tabs 的富交互页),目前仅 ai 库使用。
+// 复用与 Markdown 路径相同的解析/示例/锚点逻辑;描述使用解析后的结构化字段(天然去重)。
+// 注意:MDX 含 JSX(<Tabs>),不适用 CheckMarkdownInvariants,其健壮性由文档站真实构建保证。
+// 关键词: RenderLibMDX, Tabs, ai 库
+func RenderLibMDX(lib *yakdoc.ScriptLib, description string, formatExample func(string) string) string {
+	if formatExample == nil {
+		formatExample = func(s string) string { return s }
+	}
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	b.WriteString("sidebar_label: " + lib.Name + "\n")
+	b.WriteString("slug: /api/" + lib.Name + "\n")
+	b.WriteString("title: " + lib.Name + "\n")
+	b.WriteString("description: " + description + "\n")
+	b.WriteString("---\n")
+
+	b.WriteString("import Tabs from '@theme/Tabs';\n")
+	b.WriteString("import TabItem from '@theme/TabItem';\n")
+	b.WriteString("import CodeBlock from '@theme/CodeBlock';\n\n")
+
+	b.WriteString(":::info\n" + description + "\n:::\n\n")
+
+	funcList := sortedFuncs(lib)
+	anchors := assignAnchors(funcList)
+
+	b.WriteString("## 函数索引\n\n")
+	b.WriteString("|函数名|函数描述/介绍|\n")
+	b.WriteString("|:------|:--------|\n")
+	for _, fun := range funcList {
+		parsed := parseCommentDetails(fun.Document)
+		b.WriteString(fmt.Sprintf("| [%s.%s](#%s) | %s |\n",
+			html.EscapeString(fun.LibName),
+			html.EscapeString(fun.MethodName),
+			anchors[fun],
+			escapeTableCell(parsed.Description),
+		))
+	}
+	b.WriteString("\n\n")
+
+	if len(lib.Instances) > 0 {
+		b.WriteString("## 实例索引\n\n")
+		b.WriteString("|实例名|类型|说明|\n")
+		b.WriteString("|:------|:------|:------|\n")
+		keys := lo.Keys(lib.Instances)
+		sort.Strings(keys)
+		for _, key := range keys {
+			ins := lib.Instances[key]
+			b.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n",
+				escapeTableCell(ins.InstanceName),
+				ins.Type,
+				escapeTableCell(instanceValueRaw(ins)),
+			))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## API 详情\n\n")
+	for _, fun := range funcList {
+		p := parseCommentDetails(fun.Document)
+
+		b.WriteString(fmt.Sprintf("### %s {#%s}\n\n", html.EscapeString(fun.MethodName), anchors[fun]))
+		if desc := strings.TrimSpace(p.Description); desc != "" {
+			b.WriteString(fmt.Sprintf("- 描述: %s\n\n", escapeTableCell(desc)))
+		}
+		if p.LongDescription != "" {
+			b.WriteString(fmt.Sprintf("- 详细描述: %s\n\n", escapeTableCell(p.LongDescription)))
+		}
+
+		b.WriteString("\n<Tabs>\n")
+		b.WriteString(fmt.Sprintf("<TabItem value=\"%s-1\" label=\"定义\" default>\n\n", fun.MethodName))
+		// 围栏内原样输出签名,不做 HTML 转义(否则 < & 会显示成实体字面量)。
+		b.WriteString(fmt.Sprintf("```go\n%s\n```\n\n", fun.Decl))
+
+		if len(fun.Params) > 0 {
+			b.WriteString("**参数配置信息**\n")
+			b.WriteString("\n|参数名|参数类型|参数解释|\n")
+			b.WriteString("|:-----------|:---------- |:-----------|\n")
+			for _, param := range fun.Params {
+				b.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n",
+					html.EscapeString(param.Name), param.Type, escapeTableCell(p.Params[param.Name])))
+			}
+			b.WriteString("\n")
+		}
+		if len(fun.Results) > 0 {
+			b.WriteString("**返回值**\n")
+			b.WriteString("\n|返回值(顺序)|返回值类型|返回值解释|\n")
+			b.WriteString("|:-----------|:---------- |:-----------|\n")
+			for i, result := range fun.Results {
+				explanation := ""
+				if i < len(p.Returns) {
+					explanation = p.Returns[i]
+				}
+				b.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n",
+					html.EscapeString(result.Name), result.Type, escapeTableCell(explanation)))
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("</TabItem>\n")
+		if exampleCode := extractExampleCode(fun.Document); exampleCode != "" {
+			b.WriteString(fmt.Sprintf("<TabItem value=\"%s-2\" label=\"示例\">\n", fun.MethodName))
+			b.WriteString(fmt.Sprintf("\n\n%s\n\n", fenceExampleYak(formatExample(exampleCode))))
+			b.WriteString("</TabItem>\n")
+		}
+		b.WriteString("</Tabs>\n\n")
+		b.WriteString("\n---\n\n")
+	}
+
+	return b.String()
+}

--- a/common/yak/yakdoc/webdoc/render_test.go
+++ b/common/yak/yakdoc/webdoc/render_test.go
@@ -1,0 +1,313 @@
+package webdoc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/yak/yakdoc"
+)
+
+// 关键词: webdoc 单元测试, 渲染纯函数测试
+
+func field(name, typ string) *yakdoc.Field {
+	return &yakdoc.Field{Name: name, Type: typ}
+}
+
+func fn(lib, name, decl, doc string, params, results []*yakdoc.Field) *yakdoc.FuncDecl {
+	return &yakdoc.FuncDecl{
+		LibName:    lib,
+		MethodName: name,
+		Decl:       decl,
+		Document:   doc,
+		Params:     params,
+		Results:    results,
+	}
+}
+
+func mkLib(name string, instances map[string]*yakdoc.LibInstance, funcs ...*yakdoc.FuncDecl) *yakdoc.ScriptLib {
+	m := make(map[string]*yakdoc.FuncDecl, len(funcs))
+	for _, f := range funcs {
+		m[f.MethodName] = f
+	}
+	if instances == nil {
+		instances = map[string]*yakdoc.LibInstance{}
+	}
+	return &yakdoc.ScriptLib{Name: name, Functions: m, Instances: instances}
+}
+
+func TestLeadingProse(t *testing.T) {
+	cases := []struct {
+		name       string
+		doc        string
+		wantHas    []string
+		wantHasNot []string
+	}{
+		{
+			name:       "cut at params",
+			doc:        "do something\nmore detail\n参数:\n- a: foo\n返回值:\n- bar",
+			wantHas:    []string{"do something", "more detail"},
+			wantHasNot: []string{"参数", "foo", "返回值", "bar"},
+		},
+		{
+			name:       "cut at example",
+			doc:        "desc line\nExample:\n```\ncode here\n```",
+			wantHas:    []string{"desc line"},
+			wantHasNot: []string{"code here", "Example"},
+		},
+		{
+			name:       "cut at returns first",
+			doc:        "only desc\n返回值:\n- r1",
+			wantHas:    []string{"only desc"},
+			wantHasNot: []string{"返回值", "r1"},
+		},
+		{
+			name:       "empty doc",
+			doc:        "",
+			wantHas:    nil,
+			wantHasNot: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := leadingProse(c.doc)
+			for _, s := range c.wantHas {
+				if !strings.Contains(got, s) {
+					t.Fatalf("leadingProse(%q)=%q, want contains %q", c.doc, got, s)
+				}
+			}
+			for _, s := range c.wantHasNot {
+				if strings.Contains(got, s) {
+					t.Fatalf("leadingProse(%q)=%q, want NOT contains %q", c.doc, got, s)
+				}
+			}
+		})
+	}
+}
+
+func TestClassifyFunctions(t *testing.T) {
+	opt := fn("demo", "WithTimeout", "WithTimeout(i float64) DemoOption", "", nil, []*yakdoc.Field{field("", "DemoOption")})
+	core := fn("demo", "Do", "Do() error", "", nil, []*yakdoc.Field{field("", "error")})
+	twoResults := fn("demo", "Pair", "Pair() (int, DemoOption)", "", nil, []*yakdoc.Field{field("", "int"), field("", "DemoOption")})
+	noResults := fn("demo", "Run", "Run()", "", nil, nil)
+
+	gotCore, gotOpts := classifyFunctions([]*yakdoc.FuncDecl{opt, core, twoResults, noResults})
+	if len(gotOpts) != 1 || gotOpts[0].MethodName != "WithTimeout" {
+		t.Fatalf("expected only WithTimeout as option, got %v", names(gotOpts))
+	}
+	if len(gotCore) != 3 {
+		t.Fatalf("expected 3 core funcs, got %v", names(gotCore))
+	}
+}
+
+func names(fs []*yakdoc.FuncDecl) []string {
+	out := make([]string, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, f.MethodName)
+	}
+	return out
+}
+
+func TestNeutralizeBareURLAutolinks(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`see http://127.0.0.1:8080 now`, `see http&#58;//127.0.0.1:8080 now`},
+		{`q &#34;https://a.com&#34;`, `q &#34;https&#58;//a.com&#34;`},
+		{`[link](http://a.com)`, `[link](http://a.com)`},
+		{`no url here`, `no url here`},
+		{`mixed [x](https://k) and http://bare`, `mixed [x](https://k) and http&#58;//bare`},
+	}
+	for _, c := range cases {
+		if got := neutralizeBareURLAutolinks(c.in); got != c.want {
+			t.Fatalf("neutralize(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEscapeTableCell(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"a|b", `a\|b`},
+		{"a<b>&c", "a&lt;b&gt;&amp;c"},
+		{"line1\nline2", "line1 line2"},
+		{"  trim  ", "trim"},
+		{`visit http://x"）`, `visit http&#58;//x&#34;）`},
+	}
+	for _, c := range cases {
+		if got := escapeTableCell(c.in); got != c.want {
+			t.Fatalf("escapeTableCell(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractExampleCodeAndDedent(t *testing.T) {
+	doc := "summary\nExample:\n    a = 1\n    b = 2\n"
+	got := extractExampleCode(doc)
+	if got != "a = 1\nb = 2" {
+		t.Fatalf("extractExampleCode=%q", got)
+	}
+
+	docFenced := "x\nExample:\n```\ncode = 1\n```\n"
+	if got := extractExampleCode(docFenced); got != "code = 1" {
+		t.Fatalf("extractExampleCode fenced=%q", got)
+	}
+
+	if got := extractExampleCode("no example"); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}
+
+func TestCollapseBlankLines(t *testing.T) {
+	if got := collapseBlankLines("a\n\n\n\nb"); got != "a\n\nb" {
+		t.Fatalf("collapse=%q", got)
+	}
+	// 围栏内空行保留
+	in := "p\n\n```\nx\n\n\ny\n```\n\nq"
+	got := collapseBlankLines(in)
+	if !strings.Contains(got, "x\n\n\ny") {
+		t.Fatalf("fence blank lines should be preserved, got %q", got)
+	}
+}
+
+func TestAssignAnchorsDedup(t *testing.T) {
+	a := fn("demo", "Foo", "", "", nil, nil)
+	b := fn("demo", "foo", "", "", nil, nil)
+	c := fn("demo", "FOO", "", "", nil, nil)
+	m := assignAnchors([]*yakdoc.FuncDecl{a, b, c})
+	seen := map[string]bool{}
+	for _, f := range []*yakdoc.FuncDecl{a, b, c} {
+		id := m[f]
+		if id == "" {
+			t.Fatalf("missing anchor for %s", f.MethodName)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate anchor id %q", id)
+		}
+		seen[id] = true
+	}
+	if m[a] != "foo" {
+		t.Fatalf("first should keep base id, got %q", m[a])
+	}
+}
+
+func TestStripInlineCodeAndColumns(t *testing.T) {
+	if got := stripInlineCode("| `a|b` | c |"); strings.Contains(got, "a|b") {
+		t.Fatalf("inline code should be stripped, got %q", got)
+	}
+	if cols := countTableColumns(stripInlineCode("| `a|b` | c |")); cols != 3 {
+		t.Fatalf("columns=%d want 3", cols)
+	}
+	if cols := countTableColumns(`| a \| b | c |`); cols != 3 {
+		t.Fatalf("escaped pipe columns=%d want 3", cols)
+	}
+}
+
+// TestRenderLibMarkdownInvariants 对一批"对抗性"合成库走真实渲染 + 不变量校验，
+// 这是 Markdown 构建健壮性的核心保障：任何渲染产物都必须通过 CheckMarkdownInvariants。
+func TestRenderLibMarkdownInvariants(t *testing.T) {
+	libs := []*yakdoc.ScriptLib{
+		// 混合库：核心函数 + 配置选项 + 实例，含裸 URL/全角标点/转义/示例围栏
+		mkLib("demo",
+			map[string]*yakdoc.LibInstance{
+				"Args": {LibName: "demo", InstanceName: "Args", Type: "[]string", ValueStr: `a|b<c>&d`},
+			},
+			fn("demo", "HTTP", "HTTP(raw string) (*Response, *Request, error)",
+				"send http request\nmore prose\n参数:\n- raw: the raw request, e.g. http://127.0.0.1:8080\"）\n返回值:\n- rsp: the response\nExample:\n```\nrsp = demo.HTTP(\"GET / HTTP/1.1\")\n```",
+				[]*yakdoc.Field{field("raw", "string")},
+				[]*yakdoc.Field{field("rsp", "*Response"), field("req", "*Request"), field("err", "error")}),
+			fn("demo", "timeout", "timeout(i float64) DemoOption", "set timeout\n参数:\n- i: seconds",
+				[]*yakdoc.Field{field("i", "float64")}, []*yakdoc.Field{field("", "DemoOption")}),
+			fn("demo", "proxy", "proxy(p ...string) DemoOption",
+				"set proxy 参数: - p: addr like \"http://127.0.0.1:8080\"（多个）",
+				[]*yakdoc.Field{field("p", "...string")}, []*yakdoc.Field{field("", "DemoOption")}),
+			fn("demo", "Map", "Map(c chan<- int) map[string]int", "build a map<k,v>",
+				[]*yakdoc.Field{field("c", "chan<- int")}, []*yakdoc.Field{field("", "map[string]int")}),
+		),
+		// 纯核心库（不应出现配置选项分组）
+		mkLib("core", nil,
+			fn("core", "A", "A()", "alpha", nil, nil),
+			fn("core", "B", "B() error", "beta", nil, []*yakdoc.Field{field("", "error")}),
+		),
+		// 纯配置选项库
+		mkLib("opts", nil,
+			fn("opts", "WithA", "WithA() OptsOption", "a", nil, []*yakdoc.Field{field("", "OptsOption")}),
+			fn("opts", "WithB", "WithB() OptsOption", "b", nil, []*yakdoc.Field{field("", "OptsOption")}),
+		),
+		// 库名 == 函数名（锚点冲突回归：cve/diff/ping）
+		mkLib("cve", nil,
+			fn("cve", "cve", "cve(q string) error", "query cve", []*yakdoc.Field{field("q", "string")}, []*yakdoc.Field{field("", "error")}),
+		),
+		// 大小写仅差的方法名（锚点去重）
+		mkLib("dup", nil,
+			fn("dup", "Parse", "Parse() error", "parse upper", nil, []*yakdoc.Field{field("", "error")}),
+			fn("dup", "parse", "parse() error", "parse lower", nil, []*yakdoc.Field{field("", "error")}),
+		),
+		// 空文档/无参无返回
+		mkLib("empty", nil,
+			fn("empty", "Nop", "Nop()", "", nil, nil),
+		),
+		// 仅实例无函数
+		mkLib("insonly",
+			map[string]*yakdoc.LibInstance{"X": {LibName: "insonly", InstanceName: "X", Type: "int", ValueStr: "1"}},
+		),
+		// 含三反引号与十四反引号片段的描述
+		mkLib("fences", nil,
+			fn("fences", "Tricky", "Tricky()", "desc with ```inline``` fence\n参数:\n- none", nil, nil),
+		),
+	}
+
+	for _, lib := range libs {
+		t.Run(lib.Name, func(t *testing.T) {
+			md := RenderLibMarkdown(lib, nil)
+			if err := CheckMarkdownInvariants(md); err != nil {
+				t.Fatalf("invariants failed for lib %s:\n%v\n---rendered---\n%s", lib.Name, err, md)
+			}
+		})
+	}
+}
+
+func TestRenderLibMarkdownGrouping(t *testing.T) {
+	mixed := mkLib("demo", nil,
+		fn("demo", "Do", "Do() error", "do", nil, []*yakdoc.Field{field("", "error")}),
+		fn("demo", "WithX", "WithX() DemoOption", "x", nil, []*yakdoc.Field{field("", "DemoOption")}),
+	)
+	md := RenderLibMarkdown(mixed, nil)
+	if !strings.Contains(md, "**主要函数**") || !strings.Contains(md, "**配置选项**") {
+		t.Fatalf("mixed lib should show both group labels:\n%s", md)
+	}
+
+	coreOnly := mkLib("core", nil,
+		fn("core", "Do", "Do() error", "do", nil, []*yakdoc.Field{field("", "error")}),
+	)
+	md2 := RenderLibMarkdown(coreOnly, nil)
+	if strings.Contains(md2, "**配置选项**") {
+		t.Fatalf("core-only lib should NOT show option group:\n%s", md2)
+	}
+}
+
+func TestRenderLibMarkdownStructure(t *testing.T) {
+	lib := mkLib("demo", nil,
+		fn("demo", "Do", "Do(a int) error", "do a thing\n参数:\n- a: the input\n返回值:\n- e: error",
+			[]*yakdoc.Field{field("a", "int")}, []*yakdoc.Field{field("e", "error")}),
+	)
+	md := RenderLibMarkdown(lib, nil)
+	wantContains := []string{
+		"# demo {#library-demo}",
+		"## 函数索引",
+		"## 函数详情",
+		"### Do {#do}",
+		"```go\nDo(a int) error\n```",
+		"[demo.Do](#do)",
+		"**参数**",
+		"**返回值**",
+		"---",
+	}
+	for _, s := range wantContains {
+		if !strings.Contains(md, s) {
+			t.Fatalf("rendered markdown missing %q:\n%s", s, md)
+		}
+	}
+	// 描述去重：参数说明 the input 只应出现在参数表，不应在描述正文重复 dump
+	if strings.Count(md, "the input") != 1 {
+		t.Fatalf("param explanation should appear exactly once, got %d:\n%s", strings.Count(md, "the input"), md)
+	}
+}


### PR DESCRIPTION
## 背景

承接已合并的 #4624（裸 URL autolink 防崩）。本 PR 在不改动任何源码注释（原材料）的前提下，重构 web 文档生成器：把所有纯渲染逻辑抽到无引擎依赖的新包 `common/yak/yakdoc/webdoc`，使 Markdown 构建过程可被单元/边界/整文档不变量测试覆盖，并优化 Markdown 的结构与阅读体验。

## 主要改动

### 可测性：渲染逻辑抽包
- 新增 `common/yak/yakdoc/webdoc`：迁移全部纯渲染/解析/覆盖率逻辑，仅依赖 `yakdoc` 类型与标准库（不拉引擎）。
- `generate_web_doc.go` 退化为薄壳：从引擎取数 → 调 `webdoc` 渲染 → 写文件 → 产物不变量自检。

### Markdown 结构与体验优化（原材料不变）
- 函数索引/详情按返回类型启发式分「主要函数 / 配置选项」。
- 函数签名由行内代码改为 ` ```go ` 代码块。
- `详细描述/参数/返回值` 由 `####` 标题降级为加粗标签，TOC 只保留 库 H1 / 区块 H2 / 函数 H3。
- 描述去重（`leadingProse`）：截断到 参数/返回值/示例 之前，不再把参数/返回值列表重复 dump。
- 显式唯一锚点：库 H1 用 `{#library-<name>}`，函数用 `{#methodname}`，修复 `cve/diff/ping` 断锚告警。
- 函数间加分隔线，空描述用占位。

### 健壮性：不变量校验 + 测试
- 新增 `CheckMarkdownInvariants`，生成器对每个产出 `.md` 自检（违例打英文 error log，非阻断）。校验项：围栏成对、单 H1、heading id 无重复、每个 `(#id)` 链接都有对应 heading、表格列一致、无未中和裸 URL、正文无裸 `<`。
- `webdoc` 单元 + 边界/对抗 + 整文档不变量测试；现有 `generate_web_doc` 测试改为端到端校验新结构。测试由 essential-tests 的 `./common/yak/yakdoc/...` 自动纳入，**无需新建 workflow/容器**。

### 保持不变
- 示例的 14 反引号 `yak` 围栏（被 `verify-manual-examples.py` 依赖）。
- `neutralizeBareURLAutolinks` 防崩语义、覆盖率统计逻辑（仅随包迁移）。

## 验证
- `go test ./common/yak/yakdoc/...` 全绿（含新不变量测试）。
- 本地运行生成器产出全部 127 个库文件，`CheckMarkdownInvariants` 零违例。
- 把重生成的 `docs/api` 灌入 `yaklang.github.io` 本地 `yarn build`：构建成功，无 MDX 报错、无断锚告警（仅遗留的 Sass @import 弃用警告，与本 PR 无关）。

## Test plan
- [ ] Essential Tests 跑通 `./common/yak/yakdoc/...`
- [ ] 合并后顺延打下一个 beta 触发文档归档，再手动 `sync-docs-from-oss` 指定该版本部署预览

Made with [Cursor](https://cursor.com)