### PR TITLE
fix(aibalance): dedup health checks + tighten request timeout to 150s

### DIFF
--- a/common/aibalance/latency_watcher.go
+++ b/common/aibalance/latency_watcher.go
@@ -17,6 +17,18 @@ type LatencyWatcher struct {
 	mutex            sync.RWMutex       // Protect concurrent access
 	problematicIDs   map[uint]time.Time // Track problematic provider IDs and when they were detected
 	running          bool               // Whether the watcher is running
+
+	// healthCheckInFlight tracks provider IDs for which a latency-triggered health
+	// check goroutine is currently running, implementing per-provider singleflight
+	// so repeated problematic ticks don't pile up duplicate checks.
+	// (incident 2026-06-22: same provider triggered immediate checks every 10s
+	// while already unhealthy, each spawning a new goroutine that timed out at 20s+.)
+	healthCheckInFlight map[uint]bool
+
+	// lastLatencyCheckAt records when a latency-triggered health check last started
+	// for a provider, used to enforce a cooldown so we don't re-check the same
+	// unhealthy provider on every fast-interval tick.
+	lastLatencyCheckAt map[uint]time.Time
 }
 
 var (
@@ -28,12 +40,14 @@ var (
 // NewLatencyWatcher creates a new latency watcher
 func NewLatencyWatcher() *LatencyWatcher {
 	return &LatencyWatcher{
-		normalInterval:   5 * time.Minute,
-		fastInterval:     10 * time.Second,
-		latencyThreshold: 10000, // 10 seconds
-		stopChan:         make(chan struct{}),
-		problematicIDs:   make(map[uint]time.Time),
-		running:          false,
+		normalInterval:      5 * time.Minute,
+		fastInterval:        10 * time.Second,
+		latencyThreshold:    10000, // 10 seconds
+		stopChan:            make(chan struct{}),
+		problematicIDs:      make(map[uint]time.Time),
+		healthCheckInFlight: make(map[uint]bool),
+		lastLatencyCheckAt:  make(map[uint]time.Time),
+		running:             false,
 	}
 }
 
@@ -149,13 +163,33 @@ func (w *LatencyWatcher) checkProviders(isNormalCheck bool) {
 					p.WrapperName, p.ID, p.LastLatency, p.IsHealthy)
 				w.problematicIDs[p.ID] = time.Now()
 			}
-			// Trigger health check for problematic provider (runs in fast mode)
-			go w.triggerHealthCheck(p.ID, p.WrapperName)
+			// Trigger health check for problematic provider (runs in fast mode),
+			// but only if one is not already running and the per-provider cooldown
+			// has elapsed. This singleflight + cooldown is what prevents the
+			// health-check storm seen in the incident, where the same unhealthy
+			// provider spawned a new 20s-timeout goroutine every fast tick.
+			// 关键词: LatencyWatcher singleflight cooldown, 健康检查放大修复
+			if w.shouldTriggerLatencyCheckLocked(p.ID) {
+				w.healthCheckInFlight[p.ID] = true
+				w.lastLatencyCheckAt[p.ID] = time.Now()
+				pid := p.ID
+				pname := p.WrapperName
+				go func() {
+					defer func() {
+						w.mutex.Lock()
+						w.healthCheckInFlight[pid] = false
+						w.mutex.Unlock()
+					}()
+					w.triggerHealthCheck(pid, pname)
+				}()
+			}
 		} else if wasTracked {
 			// Provider has recovered
 			log.Debugf("LatencyWatcher: provider %s (ID: %d) has recovered, latency: %dms, healthy: %v",
 				p.WrapperName, p.ID, p.LastLatency, p.IsHealthy)
 			delete(w.problematicIDs, p.ID)
+			delete(w.healthCheckInFlight, p.ID)
+			delete(w.lastLatencyCheckAt, p.ID)
 		}
 	}
 
@@ -182,6 +216,30 @@ func (w *LatencyWatcher) isProviderProblematic(p *AiProvider) bool {
 		p.LastLatency <= 0 ||
 		p.LastLatency >= w.latencyThreshold
 }
+// shouldTriggerLatencyCheckLocked returns true if a latency-triggered health
+// check may be started now for the given provider. It enforces:
+//   - singleflight: no check is currently in flight for this provider
+//   - cooldown: at least latencyCheckCooldown has passed since the last check
+//
+// MUST be called with w.mutex held. 关键词: shouldTriggerLatencyCheckLocked
+func (w *LatencyWatcher) shouldTriggerLatencyCheckLocked(providerID uint) bool {
+	if w.healthCheckInFlight[providerID] {
+		return false
+	}
+	last, ok := w.lastLatencyCheckAt[providerID]
+	if ok && time.Since(last) < latencyCheckCooldown {
+		return false
+	}
+	return true
+}
+
+// latencyCheckCooldown is the minimum spacing between latency-triggered health
+// checks for the SAME provider. It is deliberately larger than fastInterval so
+// that even in fast mode a single unhealthy provider can produce at most one
+// check per cooldown window, breaking the amplification loop.
+// 关键词: latencyCheckCooldown, 健康检查去重冷却
+const latencyCheckCooldown = 60 * time.Second
+
 
 // triggerHealthCheck triggers a health check for a specific provider
 func (w *LatencyWatcher) triggerHealthCheck(providerID uint, providerName string) {
@@ -198,7 +256,13 @@ func (w *LatencyWatcher) triggerHealthCheck(providerID uint, providerName string
 	}
 }
 
-// MarkProviderAsProblematic marks a provider as problematic and triggers immediate monitoring
+// MarkProviderAsProblematic marks a provider as problematic and triggers immediate monitoring.
+//
+// It also enforces the same per-provider singleflight + cooldown used by checkProviders,
+// because this method is called from the request hot path (PeekOrderedProvidersWithAffinity)
+// when no low-latency provider is available — without dedup, a burst of requests for a
+// model whose providers are all high-latency would each spawn a health-check goroutine.
+// 关键词: MarkProviderAsProblematic singleflight, 请求热路径健康检查去重
 func (w *LatencyWatcher) MarkProviderAsProblematic(providerID uint, providerName string) {
 	w.mutex.Lock()
 	if _, exists := w.problematicIDs[providerID]; !exists {
@@ -206,10 +270,24 @@ func (w *LatencyWatcher) MarkProviderAsProblematic(providerID uint, providerName
 		log.Infof("LatencyWatcher: provider %s (ID: %d) marked as problematic, will monitor with fast interval",
 			providerName, providerID)
 	}
+	// Respect singleflight + cooldown before spawning a check from the hot path.
+	if !w.shouldTriggerLatencyCheckLocked(providerID) {
+		w.mutex.Unlock()
+		return
+	}
+	w.healthCheckInFlight[providerID] = true
+	w.lastLatencyCheckAt[providerID] = time.Now()
 	w.mutex.Unlock()
 
-	// Trigger immediate health check
-	go w.triggerHealthCheck(providerID, providerName)
+	// Trigger immediate health check (only one in flight per provider at a time).
+	go func() {
+		defer func() {
+			w.mutex.Lock()
+			w.healthCheckInFlight[providerID] = false
+			w.mutex.Unlock()
+		}()
+		w.triggerHealthCheck(providerID, providerName)
+	}()
 }
 
 // GetProblematicProviderCount returns the number of currently tracked problematic providers

--- a/common/aibalance/latency_watcher_singleflight_test.go
+++ b/common/aibalance/latency_watcher_singleflight_test.go
@@ -1,0 +1,56 @@
+
+package aibalance
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLatencyWatcher_SingleflightCooldown verifies that the
+// shouldTriggerLatencyCheckLocked gate blocks when a check is already in flight
+// (singleflight) and until the cooldown elapses after the last check. This is
+// the core fix for the health-check amplification that piled up duplicate
+// 20s-timeout goroutines for the same unhealthy provider every fast tick.
+func TestLatencyWatcher_SingleflightCooldown(t *testing.T) {
+	w := NewLatencyWatcher()
+
+	// Initially allowed.
+	if !w.shouldTriggerLatencyCheckLocked(42) {
+		t.Fatalf("first check for a provider should be allowed")
+	}
+
+	// Mark a check in flight -> singleflight blocks.
+	w.healthCheckInFlight[42] = true
+	if w.shouldTriggerLatencyCheckLocked(42) {
+		t.Fatalf("check in flight should block a new check (singleflight)")
+	}
+	// Different provider unaffected.
+	if !w.shouldTriggerLatencyCheckLocked(99) {
+		t.Fatalf("singleflight on one provider must not block a different provider")
+	}
+
+	// Check completes; cooldown now applies.
+	w.healthCheckInFlight[42] = false
+	w.lastLatencyCheckAt[42] = time.Now()
+	if w.shouldTriggerLatencyCheckLocked(42) {
+		t.Fatalf("cooldown should block an immediate re-check")
+	}
+
+	// After cooldown elapses, allowed again.
+	w.lastLatencyCheckAt[42] = time.Now().Add(-(latencyCheckCooldown + time.Second))
+	if !w.shouldTriggerLatencyCheckLocked(42) {
+		t.Fatalf("check should be allowed after cooldown elapses")
+	}
+}
+
+// TestLatencyWatcher_NewInstanceMapsInit verifies the new tracking maps are
+// initialized (non-nil) so the background loop doesn't panic on a fresh watcher.
+func TestLatencyWatcher_NewInstanceMapsInit(t *testing.T) {
+	w := NewLatencyWatcher()
+	if w.healthCheckInFlight == nil {
+		t.Fatalf("healthCheckInFlight must be initialized")
+	}
+	if w.lastLatencyCheckAt == nil {
+		t.Fatalf("lastLatencyCheckAt must be initialized")
+	}
+}

--- a/common/aibalance/server.go
+++ b/common/aibalance/server.go
@@ -1428,8 +1428,10 @@ func (c *ServerConfig) serveChatCompletions(conn net.Conn, rawPacket []byte) {
 		// but wg.Wait() depends on pipes being closed (which happens in stream handlers)
 		// If stream handlers never complete, wg.Wait() blocks forever
 
-		// Request timeout to prevent infinite blocking
-		const requestTimeout = 5 * time.Minute
+		// Request timeout to prevent infinite blocking. Tightened from 5m to 150s:
+		// upstream providers respond (or time out) well within this window, and a
+		// 5m cap let stuck goroutines pile up under load (incident 2026-06-22).
+		const requestTimeout = 150 * time.Second
 
 		var chatErr error
 		select {


### PR DESCRIPTION
## 背景

2026-06-22 aibalance 出现资源耗尽 / 崩溃,goroutine 飙到 ~2300、堆内存超过 3GB,最终 systemd 只能 SIGKILL 重启。本次只保留两处针对性修复,不改变任何已通过请求的行为与响应格式。

## 改动

### 1. 健康检查去重 (`latency_watcher.go`)

LatencyWatcher 每 10s(fastInterval)一轮,原来对每个「problematic」provider 都 `go w.triggerHealthCheck`,**没有 singleflight、没有 cooldown**。同一个 unhealthy provider 在每个 tick 都会 spawn 一个新的会超时 20s 的 goroutine,形成健康检查风暴,在过载时进一步加剧资源压力。

修复:
- 新增 `healthCheckInFlight`(per-provider 单飞)+ `lastLatencyCheckAt`(per-provider 60s 冷却)。
- `checkProviders`(后台循环)和 `MarkProviderAsProblematic`(请求热路径)都走同一个 `shouldTriggerLatencyCheckLocked` 判定,杜绝重复 spawn。

### 2. 请求超时收紧 (`server.go`)

`serveChatCompletions` 的请求超时从硬编码 `5 * time.Minute` 收紧到 `150 * time.Second`。上游 provider 正常响应或自身超时都远在 150s 内,5min 的上限让卡住的 goroutine 长时间占着资源不释放。

## 测试

- 新增 `TestLatencyWatcher_SingleflightCooldown` / `TestLatencyWatcher_NewInstanceMapsInit`,验证单飞 + 冷却逻辑。
- 现有 latency watcher 测试(`TestLatencyWatcherSingleton` / `TestLatencyWatcherStartStop`)无回归。
- `go build` + `go vet` 干净。