### PR TITLE
fix(ssa): handle token auth kind in parseAuth for SSA compilation

### DIFF
--- a/common/yak/ssaapi/ssa_compile_info.go
+++ b/common/yak/ssaapi/ssa_compile_info.go
@@ -133,7 +133,7 @@ func parseAuth(auth *ssaconfig.AuthConfigInfo) []yakgit.Option {
 	var opts []yakgit.Option
 
 	switch auth.Kind {
-	case "password":
+	case "password", "token":
 		opts = append(opts, yakgit.WithUsernamePassword(auth.UserName, auth.Password))
 	case "ssh_key":
 		if auth.KeyContent != "" {


### PR DESCRIPTION
The parseAuth function only handled 'password' and 'ssh_key' kinds, ignoring 'token'. Since token auth uses HTTP Basic Auth (same as password), add 'token' to the existing password case.