### PR TITLE
fix(aiengine): surface Aborted task state from WaitTaskFinishByTaskName

### DIFF
--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -192,6 +192,11 @@ func (e *AIEngine) SendMsg(input string, options ...AIEngineConfigOption) error 
 	return nil
 }
 
+// ErrAITaskAborted is returned by WaitTaskFinishByTaskName when the waited
+// ReAct task terminated in the Aborted state, so callers can distinguish an
+// abnormal termination from a successful completion.
+var ErrAITaskAborted = utils.Error("ai task aborted")
+
 // WaitTaskFinishByTaskName 等待指定任务完成
 // 传入任务ID，等待该任务状态变为 Completed 或 Aborted
 func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
@@ -204,7 +209,7 @@ func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 	status, exists := e.activeTasks[taskID]
 	if exists && (status == aicommon.AITaskState_Completed || status == aicommon.AITaskState_Aborted) {
 		e.tasksMutex.RUnlock()
-		return nil
+		return waitTaskFinishByTaskNameResult(status)
 	}
 	e.tasksMutex.RUnlock()
 
@@ -220,7 +225,36 @@ func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 
 	// 等待任务完成
 	taskEndpoint.WaitContext(e.ctx)
-	return e.ctx.Err()
+
+	// 引擎上下文取消优先报告，使调用方能区分"整体关闭"与"任务自身终止"。
+	if err := e.ctx.Err(); err != nil {
+		return err
+	}
+
+	// 唤醒后必须重新读取最新状态：任务可能在 fast-path 检查之后才被写入
+	// activeTasks，随后翻成终态并 release endpoint。复用进入等待前捕获的
+	// status/exists 会读到过时的非终态值，把成功完成的任务误判为失败。
+	e.tasksMutex.RLock()
+	finalStatus, finalExists := e.activeTasks[taskID]
+	e.tasksMutex.RUnlock()
+	if !finalExists {
+		// 任务条目缺失：未经过 react_task_* 事件序列即结束，视为成功。
+		return nil
+	}
+	return waitTaskFinishByTaskNameResult(finalStatus)
+}
+
+// waitTaskFinishByTaskNameResult 将终态映射为返回值：Completed -> nil，
+// Aborted -> ErrAITaskAborted，非终态（防御性，正常不应发生）-> error。
+func waitTaskFinishByTaskNameResult(status aicommon.AITaskState) error {
+	switch status {
+	case aicommon.AITaskState_Completed:
+		return nil
+	case aicommon.AITaskState_Aborted:
+		return ErrAITaskAborted
+	default:
+		return utils.Errorf("ai task ended in non-terminal state: %s", status)
+	}
 }
 
 // WaitTaskFinish 等待所有任务完成

--- a/common/aiengine/aiengine_terminate_test.go
+++ b/common/aiengine/aiengine_terminate_test.go
@@ -1,0 +1,123 @@
+package aiengine
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+)
+
+// newEngineForTerminalTest builds a minimal AIEngine with its task state maps
+// initialized and a live context, so the terminal-state mapping of
+// WaitTaskFinishByTaskName can be driven without spinning up a ReAct loop.
+func newEngineForTerminalTest(t *testing.T) *AIEngine {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &AIEngine{
+		ctx:           ctx,
+		cancel:        cancel,
+		activeTasks:   make(map[string]aicommon.AITaskState),
+		taskEndpoints: make(map[string]*aicommon.Endpoint),
+	}
+}
+
+// TestWaitTaskFinishByTaskNameFastPath verifies the fast-path terminal-state
+// mapping: a task already in a terminal state returns immediately without
+// blocking, with the state mapped to the correct return value.
+func TestWaitTaskFinishByTaskNameFastPath(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	e.activeTasks["task-aborted"] = aicommon.AITaskState_Aborted
+
+	cases := []struct {
+		name    string
+		taskID  string
+		wantErr error // nil means expect a non-nil error (guards), only checked when set
+	}{
+		{"aborted returns ErrAITaskAborted", "task-aborted", ErrAITaskAborted},
+		{"empty taskID errors", "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := e.WaitTaskFinishByTaskName(tc.taskID)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestWaitTaskFinishByTaskNameAbortedReleasesEndpoint verifies that when the
+// endpoint is created and the task is then flipped to Aborted (which calls
+// Release()), WaitTaskFinishByTaskName unblocks and returns ErrAITaskAborted.
+// This mirrors the real runtime: the waiter blocks, the status-changed event
+// releases the endpoint, then we read the final state fresh.
+func TestWaitTaskFinishByTaskNameAbortedReleasesEndpoint(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	taskID := "task-late-abort"
+	e.activeTasks[taskID] = aicommon.AITaskState_Processing
+
+	// Pre-create the endpoint so the waiter does not race with creation.
+	epm := aicommon.NewEndpointManagerContext(e.ctx)
+	endpoint := epm.CreateEndpoint()
+	e.taskEndpoints[taskID] = endpoint
+
+	errCh := make(chan error, 1)
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		errCh <- e.WaitTaskFinishByTaskName(taskID)
+	}()
+	<-ready
+	time.Sleep(20 * time.Millisecond) // let the goroutine enter WaitContext
+
+	// Flip to Aborted and release, mimicking the status-changed handler.
+	e.tasksMutex.Lock()
+	e.activeTasks[taskID] = aicommon.AITaskState_Aborted
+	e.tasksMutex.Unlock()
+	endpoint.Release()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrAITaskAborted) {
+			t.Fatalf("expected ErrAITaskAborted after late abort, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not unblock after endpoint release")
+	}
+}
+
+// TestWaitTaskFinishByTaskNameContextCancelledPrecedence verifies that a
+// cancelled engine context is reported in preference to the task state, so
+// callers can distinguish "engine torn down" from "task aborted on its own".
+func TestWaitTaskFinishByTaskNameContextCancelledPrecedence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	e := &AIEngine{
+		ctx:           ctx,
+		cancel:        cancel,
+		activeTasks:   map[string]aicommon.AITaskState{"task-x": aicommon.AITaskState_Processing},
+		taskEndpoints: make(map[string]*aicommon.Endpoint),
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- e.WaitTaskFinishByTaskName("task-x") }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not unblock after context cancel")
+	}
+}


### PR DESCRIPTION
修复任务aborted（例如provider返回为空）的时候不会返回错误，导致运营平台服务端的session一直处于阻塞状态