### PR TITLE
fix(aireact): downgrade max-iteration to a soft interrupt instead of a hard error

### DIFF
--- a/common/ai/aid/aireact/max_iteration_natural_end_test.go
+++ b/common/ai/aid/aireact/max_iteration_natural_end_test.go
@@ -1,0 +1,193 @@
+package aireact
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/jsonpath"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// mockedMaxIterationLoopForever 让 ReAct 永远选择继续调用工具且从不满意, 从而必然
+// 撞上最大迭代上限. 在满意度校验里通过 next_movements 落一条 TODO, 用来验证软性
+// 中断会把它 SKIP 回收. directly_answer(即 loop 的 finalize 收尾总结)会正常应答.
+func mockedMaxIterationLoopForever(i aicommon.AICallerConfigIf, req *aicommon.AIRequest, toolName string) (*aicommon.AIResponse, error) {
+	prompt := req.GetPrompt()
+	if isPrimaryDecisionPrompt(prompt) {
+		rsp := i.NewAIResponse()
+		rsp.EmitOutputStream(bytes.NewBufferString(`
+{"@action": "object", "next_action": { "type": "require_tool", "tool_require_payload": "` + toolName + `" },
+"human_readable_thought": "keep probing with the tool", "cumulative_summary": "..still working.."}
+`))
+		rsp.Close()
+		return rsp, nil
+	}
+
+	if isToolParamGenerationPrompt(prompt, toolName) {
+		rsp := i.NewAIResponse()
+		rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "call-tool", "params": { "seconds" : 0.05 }}`))
+		rsp.Close()
+		return rsp, nil
+	}
+
+	if isVerifySatisfactionPrompt(prompt) {
+		rsp := i.NewAIResponse()
+		// 永不满意, 并顺带落一条待办, 让它在撞上迭代上限时仍处于活跃状态.
+		rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "verify-satisfaction", "user_satisfied": false, "reasoning": "still-not-done-mock", "next_movements":[{"op":"add","id":"pending_probe","content":"继续排查剩余的可疑流量"}]}`))
+		rsp.Close()
+		return rsp, nil
+	}
+
+	if isDirectAnswerPrompt(prompt) {
+		rsp := i.NewAIResponse()
+		rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "directly_answer", "answer_payload": "本轮到达迭代上限，这是一次自然结束（不是错误）。已把没做完的排查项标记为 SKIP，你可以回复继续，或开启新话题。"}`))
+		rsp.Close()
+		return rsp, nil
+	}
+
+	return nil, utils.Errorf("unexpected prompt")
+}
+
+// TestReAct_MaxIteration_NaturalEnd 覆盖"最大迭代上限 = 软性中断 = 自然结束"这条
+// 系统框架路径的对客户端表现 (对应用户提出的响应测试要点):
+//  1. 客户端表现为"自然结束": 收到 success_react_task 终止事件, 任务状态 completed;
+//  2. 不出现错误: 全程不出现 fail_react_task 事件;
+//  3. TODO 都被清掉: 撞上限时把活跃 TODO 批量 SKIP, timeline 记录 "marked as SKIP";
+//  4. 退出原因入 timeline: timeline 记录 iteration_limit_interrupt (退出=超出最大迭代).
+//
+// 关键词: max iteration 自然结束, 无 fail, 待办 SKIP, timeline 退出原因
+func TestReAct_MaxIteration_NaturalEnd(t *testing.T) {
+	_ = ksuid.New().String()
+	in := make(chan *ypb.AIInputEvent, 10)
+	out := make(chan *ypb.AIOutputEvent, 10)
+
+	sleepTool, err := aitool.New(
+		"sleep",
+		aitool.WithNumberParam("seconds"),
+		aitool.WithSimpleCallback(func(params aitool.InvokeParams, stdout io.Writer, stderr io.Writer) (any, error) {
+			s := params.GetFloat("seconds", 0.05)
+			if s <= 0 {
+				s = 0.05
+			}
+			time.Sleep(time.Duration(s*1000) * time.Millisecond)
+			return "done", nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ins, err := NewTestReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			return mockedMaxIterationLoopForever(i, r, "sleep")
+		}),
+		aicommon.WithEventInputChan(in),
+		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
+			out <- e.ToGRPC()
+		}),
+		aicommon.WithTools(sleepTool),
+		aicommon.WithMaxIterationCount(3),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		in <- &ypb.AIInputEvent{
+			IsFreeInput: true,
+			FreeInput:   "分析这批 HTTP 流量里有没有敏感信息泄露",
+		}
+	}()
+
+	du := time.Duration(8)
+	if utils.InGithubActions() {
+		du = time.Duration(15)
+	}
+	after := time.After(du * time.Second)
+
+	var (
+		gotSuccessTerminal bool
+		gotFailTerminal    bool
+		gotAnswerPayload   bool
+		taskCompleted      bool
+		iid                string
+	)
+
+LOOP:
+	for {
+		select {
+		case e := <-out:
+			switch e.Type {
+			case string(schema.EVENT_TYPE_SUCCESS_REACT):
+				gotSuccessTerminal = true
+			case string(schema.EVENT_TYPE_FAIL_REACT):
+				gotFailTerminal = true
+			case string(schema.EVENT_TYPE_TOOL_USE_REVIEW_REQUIRE):
+				iid = utils.InterfaceToString(jsonpath.FindFirst(string(e.Content), "$.id"))
+				in <- &ypb.AIInputEvent{
+					IsInteractiveMessage: true,
+					InteractiveId:        iid,
+					InteractiveJSONInput: `{"suggestion": "continue"}`,
+				}
+			}
+
+			// loop 的 finalize 收尾总结通过 "re-act-loop-answer-payload" 流式节点下发,
+			// 内容是分片流出的, 因此按节点 id 判定"答复已下发", 不按单片内容匹配.
+			if e.Type == string(schema.EVENT_TYPE_STREAM) && e.NodeId == "re-act-loop-answer-payload" {
+				gotAnswerPayload = true
+			}
+
+			if e.NodeId == "react_task_status_changed" {
+				status := utils.InterfaceToString(jsonpath.FindFirst(e.GetContent(), "$..react_task_now_status"))
+				if status == "completed" {
+					taskCompleted = true
+				}
+			}
+
+			// 收到自然结束终止事件且任务已 completed 即可结束观测.
+			if gotSuccessTerminal && taskCompleted {
+				break LOOP
+			}
+		case <-after:
+			break LOOP
+		}
+	}
+	close(in)
+
+	// 要点2: 全程不得出现 fail 终止事件 (与硬中断形成对比).
+	if gotFailTerminal {
+		t.Fatal("max-iteration soft interrupt must NOT emit a fail_react_task event")
+	}
+	// 要点1: 客户端表现为自然结束 (success 终止事件 + 任务 completed).
+	if !gotSuccessTerminal {
+		t.Fatal("expected a success_react_task terminal event (natural end), but got none")
+	}
+	if !taskCompleted {
+		t.Fatal("expected task status to become completed, but it did not")
+	}
+	// 要点1(续): loop 的 finalize 收尾总结正常应答 (AI 介绍情况 / 下一步).
+	if !gotAnswerPayload {
+		t.Fatal("expected the finalize summary answer to be delivered, but got none")
+	}
+
+	tl := ins.DumpTimeline()
+	// 要点4: 退出原因入 timeline (退出 = 超出最大迭代限制).
+	if !strings.Contains(tl, "iteration_limit_interrupt") {
+		t.Fatalf("timeline must record the iteration-limit interrupt exit reason, got:\n%s", tl)
+	}
+	// 要点3: 活跃 TODO 被 SKIP 回收.
+	if !strings.Contains(tl, "marked as SKIP") {
+		t.Fatalf("timeline must record that unfinished TODOs were marked as SKIP, got:\n%s", tl)
+	}
+	fmt.Println("--- max-iteration natural-end timeline ---")
+	fmt.Println(tl)
+}

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -254,12 +254,24 @@ func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTas
 			// of callback registration order. Without deferral, this callback might
 			// check ShouldIgnoreError() before a later callback has called IgnoreError().
 			operator.DeferAfterCallbacks(func() {
-				if isDone && reason != nil && !operator.ShouldIgnoreError() {
+				// 收尾表态统一交给纯决策函数 ClassifyLoopFinishEmission (便于单测):
+				//   - IgnoreError -> 静默 (隐藏/内部 loop 自管收尾, 不污染 UI);
+				//   - 迭代上限软中断 -> "自然结束"(success) + 框架层补发中断说明
+				//     (退出原因 = 超出最大迭代 + 未完成 TODO + 下一步; 回复 "继续"
+				//     续跑或开启新话题), 与具体 loop / 专注模式无关;
+				//   - 已结束且带错误 -> 硬失败 fail (携带错误信息, 与软中断形成对比);
+				//   - 其余 -> 成功.
+				// 关键词: max iteration 软中断 自然结束, 框架统一收尾, 补发中断说明
+				maxIterInterrupt := loop != nil && loop.IsMaxIterationInterrupted()
+				switch reactloops.ClassifyLoopFinishEmission(isDone, reason, operator.ShouldIgnoreError(), maxIterInterrupt) {
+				case reactloops.LoopFinishSilent:
+					return
+				case reactloops.LoopFinishSuccessWithInterruptSummary:
+					loop.DeliverMaxIterationInterruptSummary()
+					r.Emitter.EmitReActSuccess("ReAct task execution success")
+				case reactloops.LoopFinishFail:
 					r.Emitter.EmitReActFail(fmt.Sprintf("ReAct task execution failed: %v", utils.InterfaceToString(reason)))
-				} else if !operator.ShouldIgnoreError() {
-					// Only emit success when IgnoreError is not set.
-					// Hidden/internal sub-loops (like loop_intent) that set IgnoreError
-					// should not emit success/fail to avoid confusing UI signals.
+				default:
 					r.Emitter.EmitReActSuccess("ReAct task execution success")
 				}
 			})

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -256,19 +256,19 @@ func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTas
 			operator.DeferAfterCallbacks(func() {
 				// 收尾表态统一交给纯决策函数 ClassifyLoopFinishEmission (便于单测):
 				//   - IgnoreError -> 静默 (隐藏/内部 loop 自管收尾, 不污染 UI);
-				//   - 迭代上限软中断 -> "自然结束"(success) + 框架层补发中断说明
-				//     (退出原因 = 超出最大迭代 + 未完成 TODO + 下一步; 回复 "继续"
-				//     续跑或开启新话题), 与具体 loop / 专注模式无关;
+				//   - 迭代上限软中断 -> "自然结束"(success), 与具体 loop / 专注模式无关.
+				//     迭代上限不是错误 (只是本轮步数用尽), 所以即便 reason 里带着
+				//     maxIterErr 也按成功上报, 与硬中断报错形成对比. 退出原因 / 未完成
+				//     TODO / 下一步建议由各 loop 已有的 finalize 收尾总结承载 —— 框架已把
+				//     这些上下文落在 timeline 与 interrupt store 里 (见 applyMaxIterationSoftInterrupt),
+				//     finalize 总结会读取并因地制宜地 AI 生成, 框架层不再额外发一次 AI 请求;
 				//   - 已结束且带错误 -> 硬失败 fail (携带错误信息, 与软中断形成对比);
 				//   - 其余 -> 成功.
-				// 关键词: max iteration 软中断 自然结束, 框架统一收尾, 补发中断说明
+				// 关键词: max iteration 软中断 自然结束, 框架统一收尾, 不额外发 AI 请求
 				maxIterInterrupt := loop != nil && loop.IsMaxIterationInterrupted()
 				switch reactloops.ClassifyLoopFinishEmission(isDone, reason, operator.ShouldIgnoreError(), maxIterInterrupt) {
 				case reactloops.LoopFinishSilent:
 					return
-				case reactloops.LoopFinishSuccessWithInterruptSummary:
-					loop.DeliverMaxIterationInterruptSummary()
-					r.Emitter.EmitReActSuccess("ReAct task execution success")
 				case reactloops.LoopFinishFail:
 					r.Emitter.EmitReActFail(fmt.Sprintf("ReAct task execution failed: %v", utils.InterfaceToString(reason)))
 				default:

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -784,17 +784,21 @@ LOOP:
 		// 关键词: 主循环 tick, lastIterationTickAt
 		r.recordIterationTick()
 		if iterationCount > maxIterations {
+			// 到达迭代上限属于"软性中断", 不再当作硬错误直接 EmitReActFail.
+			// 处理步骤:
+			//  1. applyMaxIterationSoftInterrupt: 把当前任务仍活跃的 TODO 批量
+			//     标记 SKIP (待办回收) 并广播, 同时在 Timeline 落一次软性中断说明;
+			//  2. finishIterationLoopWithSoftInterrupt: 预先置位 IgnoreError 再跑
+			//     onPostIteration hook, 保证全局 fail 兜底一定观察到 ignore, 由
+			//     loop 的 finalize hook 生成"直接回答", 明确告诉用户哪些没做完 +
+			//     询问下一步 (回复 "继续" 即可续跑);
+			//  3. 正常 break LOOP -> return nil -> complete(nil), 资源回收由
+			//     ExecuteWithExistedTask 的 defer r.Release() 完成.
+			// 关键词: max iteration 软性中断, downgrade-max-iteration-err, 待办 SKIP
 			maxIterErr := utils.Errorf("reached max iterations (%d), stopping %s loop", maxIterations, r.loopName)
-			postOp := r.finishIterationLoopWithError(iterationCount, task, maxIterErr)
-
-			// 检查 Hook 是否要求忽略错误
-			if postOp.ShouldIgnoreError() {
-				log.Infof("Loop exit with ignored error: max iterations reached (%d)", maxIterations)
-				needSummary.SetTo(true)
-				break LOOP // 正常退出，不返回错误
-			}
-
-			log.Warnf("Reached max iterations (%d), stopping %s loop", maxIterations, r.loopName)
+			r.applyMaxIterationSoftInterrupt(iterationCount, task, maxIterations)
+			r.finishIterationLoopWithSoftInterrupt(iterationCount, task, maxIterErr)
+			log.Infof("Loop soft-exit on max iterations (%d) for %s loop, waiting for user decision", maxIterations, r.loopName)
 			needSummary.SetTo(true)
 			break LOOP
 		}
@@ -1200,6 +1204,144 @@ func (r *ReActLoop) callOnPostIteration(current int, task aicommon.AIStatefulTas
 
 func (r *ReActLoop) finishIterationLoopWithError(current int, task aicommon.AIStatefulTask, err any) *OnPostIterationOperator {
 	operator := newOnPostIterationOperator()
+	if r.onPostIteration != nil {
+		if err != nil {
+			r.callOnPostIteration(current, task, true, utils.Errorf("reason: %v", err), operator)
+		} else {
+			r.callOnPostIteration(current, task, true, nil, operator)
+		}
+	}
+	return operator
+}
+
+const (
+	// maxIterationInterruptFlagKey 标记本次 loop 因为到达迭代上限被软性中断.
+	// finalize / directly-answer hook 用它判断是否要在回答里加"任务中断"框架.
+	// 关键词: max iteration 软中断标记
+	maxIterationInterruptFlagKey = "__max_iteration_interrupted__"
+	// maxIterationInterruptSummaryKey 存储软性中断时"未完成 TODO"的可读快照,
+	// 供 finalize hook 在直接回答里明确告诉用户"哪些事情没来得及做".
+	// 关键词: max iteration 软中断, 未完成 TODO 交接
+	maxIterationInterruptSummaryKey = "__max_iteration_interrupt_summary__"
+)
+
+// IsMaxIterationInterrupted 返回本次 loop 是否因为到达迭代上限被软性中断.
+func (r *ReActLoop) IsMaxIterationInterrupted() bool {
+	if r == nil {
+		return false
+	}
+	b, _ := r.GetVariable(maxIterationInterruptFlagKey).(bool)
+	return b
+}
+
+// GetMaxIterationInterruptSummary 返回软性中断时记录的"未完成 TODO"可读快照.
+// 未发生中断或没有未完成 TODO 时返回空串.
+func (r *ReActLoop) GetMaxIterationInterruptSummary() string {
+	if r == nil {
+		return ""
+	}
+	return r.Get(maxIterationInterruptSummaryKey)
+}
+
+// applyMaxIterationSoftInterrupt 处理到达迭代上限时的"待办回收 + 软性提示":
+//  1. 读取当前任务仍处于 PENDING/DOING 的 TODO, 记录其可读快照供直接回答引用;
+//  2. 复用 ApplyVerificationNextMovementsAndEmit 单源 helper 把这些 TODO 批量
+//     标记为 SKIP (更新 store + 广播 todo_list_update + NEXT_MOVEMENTS timeline);
+//  3. 在 Timeline 追加一条软性中断说明 (非 error 类别), 只报告一次.
+//
+// 该方法只负责"回收 + 提示", 不生成直接回答 — 直接回答交给 loop 的 finalize
+// hook (见各 loop 的 WithOnPostIteraction), 以便复用每个 loop 已有的答复渲染.
+//
+// 关键词: max iteration 软性中断, 待办 SKIP 回收, 单条软提示, 复用单源 helper
+func (r *ReActLoop) applyMaxIterationSoftInterrupt(iterationCount int, task aicommon.AIStatefulTask, maxIterations int) {
+	if r == nil || utils.IsNil(task) {
+		return
+	}
+
+	cfg := r.config
+	scope := aicommon.BuildVerificationTodoScope(task)
+
+	var activeItems []aicommon.VerificationTodoItem
+	if cfg != nil && !scope.IsZero() {
+		activeItems = cfg.ActiveVerificationTodoItemsByScope(scope)
+	}
+
+	// 记录未完成 TODO 的可读快照, 供直接回答引用.
+	var summaryBuilder strings.Builder
+	for _, item := range activeItems {
+		content := strings.TrimSpace(item.Content)
+		if content == "" {
+			continue
+		}
+		summaryBuilder.WriteString("- ")
+		summaryBuilder.WriteString(content)
+		summaryBuilder.WriteString("\n")
+	}
+	r.Set(maxIterationInterruptFlagKey, true)
+	if summary := strings.TrimSpace(summaryBuilder.String()); summary != "" {
+		r.Set(maxIterationInterruptSummaryKey, summary)
+	}
+
+	// 把活跃 TODO 批量 SKIP: 复用与 verification / adjust_todolist / 主循环兜底
+	// 完全一致的单源 helper, 保证 store 更新 + todo_list_update 广播 + timeline
+	// breadcrumb 字节级对齐.
+	if cfg != nil && len(activeItems) > 0 {
+		movements := make([]aicommon.VerifyNextMovement, 0, len(activeItems))
+		for _, item := range activeItems {
+			id := strings.TrimSpace(item.ID)
+			if id == "" {
+				continue
+			}
+			movements = append(movements, aicommon.VerifyNextMovement{
+				Op: "skip",
+				ID: id,
+			})
+		}
+		if len(movements) > 0 {
+			var timelineHook func(category, line string)
+			if invoker := r.GetInvoker(); invoker != nil {
+				timelineHook = func(category, line string) {
+					invoker.AddToTimeline(category, line)
+				}
+			}
+			aicommon.ApplyVerificationNextMovementsAndEmit(
+				cfg,
+				cfg.GetEmitter(),
+				task,
+				scope,
+				iterationCount,
+				false,
+				movements,
+				timelineHook,
+			)
+		}
+	}
+
+	// 软性中断的单条 timeline 说明 (非 error 类别, 只报告一次).
+	if invoker := r.GetInvoker(); invoker != nil {
+		loopName := r.loopName
+		if loopName == "" {
+			loopName = "general-purpose"
+		}
+		msg := fmt.Sprintf(
+			"[%v] reached iteration limit (%d); the task was softly interrupted (NOT a failure). %d unfinished TODO(s) were marked as SKIP. A direct answer will summarize what was left undone; reply \"继续\" to resume, or give a new direction.",
+			loopName, maxIterations, len(activeItems),
+		)
+		invoker.AddToTimeline("iteration_limit_interrupt", msg)
+	}
+}
+
+// finishIterationLoopWithSoftInterrupt 与 finishIterationLoopWithError 类似, 但
+// 在运行任何 onPostIteration 回调之前就把 operator 标记为 IgnoreError. 这样即使
+// 某个 loop 没有注册专门的 finalize hook (或 finalize hook 因为"答复已下发"而
+// 提前 return 未调用 IgnoreError), ExecuteLoopTask 里注册的全局 fail 兜底
+// (通过 DeferAfterCallbacks 检查 ShouldIgnoreError) 也一定观察到 ignore, 从而
+// 不会把"到达迭代上限"当成任务失败 EmitReActFail 上报.
+//
+// 关键词: 软性中断预置 IgnoreError, 抑制 EmitReActFail, downgrade-max-iteration-err
+func (r *ReActLoop) finishIterationLoopWithSoftInterrupt(current int, task aicommon.AIStatefulTask, err any) *OnPostIterationOperator {
+	operator := newOnPostIterationOperator()
+	operator.IgnoreError() // 预先置位: 软性中断绝不上报 fail
 	if r.onPostIteration != nil {
 		if err != nil {
 			r.callOnPostIteration(current, task, true, utils.Errorf("reason: %v", err), operator)

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -787,15 +787,17 @@ LOOP:
 			// 到达迭代上限属于"软性中断", 框架层统一按"自然结束"处理, 不再当作
 			// 硬错误 EmitReActFail. 处理步骤 (与具体 loop / 专注模式无关):
 			//  1. applyMaxIterationSoftInterrupt: 把当前任务仍活跃的 TODO 批量
-			//     标记 SKIP (待办回收) 并广播, 置位软中断标记, 同时在 Timeline
-			//     落一次"退出原因=超出最大迭代"的软性说明;
+			//     标记 SKIP (待办回收) 并广播, 置位软中断标记, 记录未完成 TODO 快照,
+			//     同时在 Timeline 落一次"退出原因=超出最大迭代 + 可回复继续"的软性说明;
 			//  2. finishIterationLoopWithError(reason=maxIterErr): 照常跑
-			//     onPostIteration hook. 注意这里不再预置 IgnoreError —— 全局收尾
-			//     兜底 (re-act_mainloop) 会识别 IsMaxIterationInterrupted(), 把它
-			//     当作 EmitReActSuccess (自然结束) 上报, 并补发一段框架层 AI 生成
-			//     的中断说明 (退出原因 + 未完成 TODO + 下一步; 回复 "继续" 续跑或
-			//     开启新话题). 只有当某个隐藏 / 内部 loop 在自己的 finalize 里主动
-			//     IgnoreError 自管收尾时, 才保持静默、不打扰;
+			//     onPostIteration hook. 各 loop 已有的 finalize 收尾总结 (loop_default
+			//     的 DirectlyAnswer 总结 / http_flow_analyze 的分析报告等) 会读取上面
+			//     落在 timeline / interrupt store 里的上下文, 因地制宜地 AI 生成一段
+			//     "退出原因 + 未完成 TODO + 下一步(回复 '继续' 续跑或换话题)"的说明,
+			//     框架层不额外再发一次 AI 请求. 全局收尾兜底 (re-act_mainloop) 识别
+			//     IsMaxIterationInterrupted() 后, 即便 reason 带着 maxIterErr 也按
+			//     EmitReActSuccess (自然结束) 上报, 与硬中断报错形成对比; 只有隐藏 /
+			//     内部 loop 在自己的 finalize 里 IgnoreError 自管收尾时才保持静默;
 			//  3. 正常 break LOOP -> return nil -> complete(nil), 资源回收由
 			//     ExecuteWithExistedTask 的 defer r.Release() 完成.
 			// 关键词: max iteration 软性中断, 自然结束, downgrade-max-iteration-err, 待办 SKIP

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -784,20 +784,24 @@ LOOP:
 		// 关键词: 主循环 tick, lastIterationTickAt
 		r.recordIterationTick()
 		if iterationCount > maxIterations {
-			// 到达迭代上限属于"软性中断", 不再当作硬错误直接 EmitReActFail.
-			// 处理步骤:
+			// 到达迭代上限属于"软性中断", 框架层统一按"自然结束"处理, 不再当作
+			// 硬错误 EmitReActFail. 处理步骤 (与具体 loop / 专注模式无关):
 			//  1. applyMaxIterationSoftInterrupt: 把当前任务仍活跃的 TODO 批量
-			//     标记 SKIP (待办回收) 并广播, 同时在 Timeline 落一次软性中断说明;
-			//  2. finishIterationLoopWithSoftInterrupt: 预先置位 IgnoreError 再跑
-			//     onPostIteration hook, 保证全局 fail 兜底一定观察到 ignore, 由
-			//     loop 的 finalize hook 生成"直接回答", 明确告诉用户哪些没做完 +
-			//     询问下一步 (回复 "继续" 即可续跑);
+			//     标记 SKIP (待办回收) 并广播, 置位软中断标记, 同时在 Timeline
+			//     落一次"退出原因=超出最大迭代"的软性说明;
+			//  2. finishIterationLoopWithError(reason=maxIterErr): 照常跑
+			//     onPostIteration hook. 注意这里不再预置 IgnoreError —— 全局收尾
+			//     兜底 (re-act_mainloop) 会识别 IsMaxIterationInterrupted(), 把它
+			//     当作 EmitReActSuccess (自然结束) 上报, 并补发一段框架层 AI 生成
+			//     的中断说明 (退出原因 + 未完成 TODO + 下一步; 回复 "继续" 续跑或
+			//     开启新话题). 只有当某个隐藏 / 内部 loop 在自己的 finalize 里主动
+			//     IgnoreError 自管收尾时, 才保持静默、不打扰;
 			//  3. 正常 break LOOP -> return nil -> complete(nil), 资源回收由
 			//     ExecuteWithExistedTask 的 defer r.Release() 完成.
-			// 关键词: max iteration 软性中断, downgrade-max-iteration-err, 待办 SKIP
+			// 关键词: max iteration 软性中断, 自然结束, downgrade-max-iteration-err, 待办 SKIP
 			maxIterErr := utils.Errorf("reached max iterations (%d), stopping %s loop", maxIterations, r.loopName)
 			r.applyMaxIterationSoftInterrupt(iterationCount, task, maxIterations)
-			r.finishIterationLoopWithSoftInterrupt(iterationCount, task, maxIterErr)
+			r.finishIterationLoopWithError(iterationCount, task, maxIterErr)
 			log.Infof("Loop soft-exit on max iterations (%d) for %s loop, waiting for user decision", maxIterations, r.loopName)
 			needSummary.SetTo(true)
 			break LOOP
@@ -1329,27 +1333,6 @@ func (r *ReActLoop) applyMaxIterationSoftInterrupt(iterationCount int, task aico
 		)
 		invoker.AddToTimeline("iteration_limit_interrupt", msg)
 	}
-}
-
-// finishIterationLoopWithSoftInterrupt 与 finishIterationLoopWithError 类似, 但
-// 在运行任何 onPostIteration 回调之前就把 operator 标记为 IgnoreError. 这样即使
-// 某个 loop 没有注册专门的 finalize hook (或 finalize hook 因为"答复已下发"而
-// 提前 return 未调用 IgnoreError), ExecuteLoopTask 里注册的全局 fail 兜底
-// (通过 DeferAfterCallbacks 检查 ShouldIgnoreError) 也一定观察到 ignore, 从而
-// 不会把"到达迭代上限"当成任务失败 EmitReActFail 上报.
-//
-// 关键词: 软性中断预置 IgnoreError, 抑制 EmitReActFail, downgrade-max-iteration-err
-func (r *ReActLoop) finishIterationLoopWithSoftInterrupt(current int, task aicommon.AIStatefulTask, err any) *OnPostIterationOperator {
-	operator := newOnPostIterationOperator()
-	operator.IgnoreError() // 预先置位: 软性中断绝不上报 fail
-	if r.onPostIteration != nil {
-		if err != nil {
-			r.callOnPostIteration(current, task, true, utils.Errorf("reason: %v", err), operator)
-		} else {
-			r.callOnPostIteration(current, task, true, nil, operator)
-		}
-	}
-	return operator
 }
 
 func testIsFinished(task aicommon.AIStatefulTask) bool {

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
@@ -22,18 +22,91 @@ func buildPostIterationHook(invoker aicommon.AIInvokeRuntime) reactloops.ReActLo
 		log.Infof("http_flow_analyze loop done at iteration %d", iteration)
 		collectIterationFindings(loop)
 
+		// 是否为"到达迭代上限"的软性中断. exec.go 已把标记置位并把未完成 TODO
+		// 标记 SKIP, 这里只负责把"任务中断 + 未完成清单 + 询问下一步"融进直接回答.
+		// 关键词: max iteration 软性中断, http_flow_analyze finalize
+		maxIterInterrupt := isMaxIterationInterrupt(loop, reason)
+
 		if hasFinalAnswerDelivered(loop) || hasDirectlyAnswered(loop) || getLastAction(loop) == "directly_answer" {
-			log.Infof("http_flow_analyze: skip finalize because answer was already delivered")
+			log.Infof("http_flow_analyze: answer already delivered before finalize")
+			if maxIterInterrupt {
+				// 已经给过答复, 但因为迭代上限被中断: 补一条简短中断说明, 告诉
+				// 用户哪些没做完 + 询问下一步 (回复 "继续"). 收尾 IgnoreError.
+				deliverMaxIterationInterruptNotice(loop, invoker)
+				operator.IgnoreError()
+			}
 			return
 		}
 
 		contextMaterials := collectFinalizeContextMaterials(loop, reason)
-		deliverFinalAnswerFallback(loop, invoker, contextMaterials)
+		deliverFinalAnswerFallback(loop, invoker, contextMaterials, maxIterInterrupt)
 
-		if reasonErr, ok := reason.(error); ok && strings.Contains(reasonErr.Error(), "max iterations") {
+		if maxIterInterrupt {
 			operator.IgnoreError()
 		}
 	})
+}
+
+// isMaxIterationInterrupt 判断本次 loop 结束是否因为"到达迭代上限"被软性中断.
+// 以 exec.go 置位的 loop 标记为准, 同时兼容 reason 里携带 "max iterations" 文案.
+func isMaxIterationInterrupt(loop *reactloops.ReActLoop, reason any) bool {
+	if loop != nil && loop.IsMaxIterationInterrupted() {
+		return true
+	}
+	if reasonErr, ok := reason.(error); ok && reasonErr != nil {
+		return strings.Contains(reasonErr.Error(), "max iterations")
+	}
+	if reasonStr, ok := reason.(string); ok {
+		return strings.Contains(reasonStr, "max iterations")
+	}
+	return false
+}
+
+// deliverMaxIterationInterruptNotice 在"答复已下发但仍撞到迭代上限"时补发一条
+// 简短的中断说明气泡: 明确任务被中断、列出未完成的 TODO、并询问用户下一步
+// (回复 "继续" 续跑, 或给新方向). 不覆盖已给出的答复, 只做增量提示.
+//
+// 关键词: 迭代上限软中断补充说明, 未完成 TODO 交接, 询问下一步
+func deliverMaxIterationInterruptNotice(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime) {
+	if loop == nil || invoker == nil {
+		return
+	}
+
+	var notice strings.Builder
+	notice.WriteString("> 任务因达到迭代次数上限被自动中断（这不是错误，只是本轮已用尽可执行的步数）。\n\n")
+
+	if unfinished := strings.TrimSpace(loop.GetMaxIterationInterruptSummary()); unfinished != "" {
+		notice.WriteString("**尚未完成、已标记为 SKIP 的事项：**\n\n")
+		notice.WriteString(unfinished)
+		notice.WriteString("\n\n")
+	} else {
+		notice.WriteString("当前没有明确记录在案的未完成待办，但分析流程被提前中断，可能仍有可以深入的方向。\n\n")
+	}
+
+	notice.WriteString("**接下来你可以：**\n")
+	notice.WriteString("- 直接回复 “继续”，我会接着之前的分析继续做未完成的部分；\n")
+	notice.WriteString("- 或者告诉我新的方向/侧重点，我按你的调整来分析。\n")
+
+	payload := notice.String()
+
+	taskID := ""
+	if task := loop.GetCurrentTask(); task != nil {
+		taskID = task.GetId()
+	}
+	if emitter := loop.GetEmitter(); emitter != nil {
+		if _, err := emitter.EmitTextMarkdownStreamEvent(
+			"re-act-loop-answer-payload",
+			strings.NewReader(payload),
+			taskID,
+			func() {},
+		); err != nil {
+			log.Warnf("http_flow_analyze finalize: failed to emit max-iteration interrupt notice: %v", err)
+		}
+	}
+	invoker.EmitResultAfterStream(payload)
+	invoker.AddToTimeline("http_flow_analysis_interrupted",
+		fmt.Sprintf("HTTP flow analysis interrupted by iteration limit after %d iterations; asked user how to proceed",
+			loop.GetCurrentIterationIndex()))
 }
 
 func collectIterationFindings(loop *reactloops.ReActLoop) {
@@ -99,6 +172,12 @@ func collectFinalizeContextMaterials(loop *reactloops.ReActLoop, reason any) str
 		ctx.WriteString("\n\n")
 	}
 
+	if unfinished := strings.TrimSpace(loop.GetMaxIterationInterruptSummary()); unfinished != "" {
+		ctx.WriteString("## Unfinished TODOs (interrupted, marked as SKIP)\n\n")
+		ctx.WriteString(unfinished)
+		ctx.WriteString("\n\n")
+	}
+
 	ctx.WriteString("## Exit Reason\n\n")
 	if reasonErr, ok := reason.(error); ok && reasonErr != nil {
 		ctx.WriteString(reasonErr.Error())
@@ -111,7 +190,7 @@ func collectFinalizeContextMaterials(loop *reactloops.ReActLoop, reason any) str
 	return strings.TrimSpace(ctx.String())
 }
 
-func deliverFinalAnswerFallback(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime, contextMaterials string) {
+func deliverFinalAnswerFallback(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime, contextMaterials string, maxIterInterrupt bool) {
 	contextMaterials = strings.TrimSpace(contextMaterials)
 	if contextMaterials == "" {
 		log.Infof("http_flow_analyze finalize: skip fallback because context materials are empty")
@@ -128,6 +207,19 @@ func deliverFinalAnswerFallback(loop *reactloops.ReActLoop, invoker aicommon.AII
 		userQuery = strings.TrimSpace(task.GetUserInput())
 	}
 
+	// 到达迭代上限的软性中断: 让报告以"任务被中断"的口吻收尾, 明确列出没来得及
+	// 做的事情, 并询问用户下一步 (回复"继续"续跑, 或给新方向). 非中断的正常收尾
+	// 则沿用原来的完整报告口吻.
+	// 关键词: 迭代上限软中断报告, 未完成清单, 询问下一步(继续)
+	interruptGuidance := ""
+	if maxIterInterrupt {
+		interruptGuidance = `
+IMPORTANT - This analysis was INTERRUPTED because it reached the iteration limit (this is NOT a failure):
+6. Clearly state at the top that the analysis was interrupted because the step/iteration limit was reached, so it did not fully finish.
+7. Explicitly list what was NOT completed in time (see the "Unfinished TODOs" section in the context if present); these were auto-marked as SKIP.
+8. End by asking the user how to proceed: they can simply reply "继续" (continue) to resume the unfinished work, or provide a new direction/focus to adjust.`
+	}
+
 	nonce := utils.RandStringBytes(8)
 	summaryPrompt := utils.MustRenderTemplate(`
 <|INSTRUCTION_{{ .Nonce }}|>
@@ -138,7 +230,7 @@ Requirements:
 2. Answer the user's question based on available evidence
 3. If information is insufficient, explain what was attempted and possible reasons
 4. Provide concrete discoveries and actionable recommendations
-5. Use clear, professional Markdown formatting
+5. Use clear, professional Markdown formatting{{ .InterruptGuidance }}
 
 CRITICAL LANGUAGE RULE: You MUST write the ENTIRE report in the SAME language as the user's query below. If the user wrote in Chinese, your report MUST be in Chinese. If the user wrote in English, your report MUST be in English. Do NOT mix languages.
 
@@ -149,9 +241,10 @@ User's original query: {{ .UserQuery }}
 {{ .ContextMaterials }}
 <|CONTEXT_END_{{ .Nonce }}|>
 `, map[string]any{
-		"Nonce":            nonce,
-		"UserQuery":        userQuery,
-		"ContextMaterials": contextMaterials,
+		"Nonce":             nonce,
+		"UserQuery":         userQuery,
+		"ContextMaterials":  contextMaterials,
+		"InterruptGuidance": interruptGuidance,
 	})
 
 	log.Infof("http_flow_analyze finalize: generating forced AI answer, prompt length: %d", len(summaryPrompt))

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
@@ -30,9 +30,10 @@ func buildPostIterationHook(invoker aicommon.AIInvokeRuntime) reactloops.ReActLo
 		if hasFinalAnswerDelivered(loop) || hasDirectlyAnswered(loop) || getLastAction(loop) == "directly_answer" {
 			log.Infof("http_flow_analyze: answer already delivered before finalize")
 			if maxIterInterrupt {
-				// 已经给过答复, 但因为迭代上限被中断: 补一条简短中断说明, 告诉
-				// 用户哪些没做完 + 询问下一步 (回复 "继续"). 收尾 IgnoreError.
-				deliverMaxIterationInterruptNotice(loop, invoker)
+				// 已经给过答复, 但因为迭代上限被中断: 让 AI 依据本次分析的真实
+				// 上下文因地制宜地补一条"续做指引", 告诉用户哪些没做完 + 启发下
+				// 一步 (回复 "继续" 续跑, 或给新方向). 收尾 IgnoreError.
+				deliverMaxIterationInterruptNotice(loop, invoker, collectFinalizeContextMaterials(loop, reason))
 				operator.IgnoreError()
 			}
 			return
@@ -63,31 +64,126 @@ func isMaxIterationInterrupt(loop *reactloops.ReActLoop, reason any) bool {
 }
 
 // deliverMaxIterationInterruptNotice 在"答复已下发但仍撞到迭代上限"时补发一条
-// 简短的中断说明气泡: 明确任务被中断、列出未完成的 TODO、并询问用户下一步
-// (回复 "继续" 续跑, 或给新方向). 不覆盖已给出的答复, 只做增量提示.
+// 续做指引: 内容不写死, 而是让 AI 依据本次分析的真实上下文 (已积累证据 / 最近
+// 动作 / 未完成 TODO) 因地制宜地生成 —— 冷静说明这是"被中断"而非失败, 结合具体
+// 调查进展点出还有哪些没做、给出针对性的下一步方向来启发用户, 并告知可回复
+// "继续" 续跑或给新方向. 不覆盖已给出的答复, 只做增量提示. AI 不可用时才退回到
+// 极简兜底文案 (deliverMaxIterationInterruptNoticeFallback).
 //
-// 关键词: 迭代上限软中断补充说明, 未完成 TODO 交接, 询问下一步
-func deliverMaxIterationInterruptNotice(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime) {
+// 关键词: 迭代上限软中断续做指引, AI 因地制宜生成, 未完成 TODO 交接, 询问下一步
+func deliverMaxIterationInterruptNotice(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime, contextMaterials string) {
 	if loop == nil || invoker == nil {
 		return
 	}
 
-	var notice strings.Builder
-	notice.WriteString("> 任务因达到迭代次数上限被自动中断（这不是错误，只是本轮已用尽可执行的步数）。\n\n")
+	contextMaterials = strings.TrimSpace(contextMaterials)
 
-	if unfinished := strings.TrimSpace(loop.GetMaxIterationInterruptSummary()); unfinished != "" {
-		notice.WriteString("**尚未完成、已标记为 SKIP 的事项：**\n\n")
-		notice.WriteString(unfinished)
-		notice.WriteString("\n\n")
-	} else {
-		notice.WriteString("当前没有明确记录在案的未完成待办，但分析流程被提前中断，可能仍有可以深入的方向。\n\n")
+	userQuery := ""
+	if task := loop.GetCurrentTask(); task != nil {
+		userQuery = strings.TrimSpace(task.GetUserInput())
 	}
 
-	notice.WriteString("**接下来你可以：**\n")
-	notice.WriteString("- 直接回复 “继续”，我会接着之前的分析继续做未完成的部分；\n")
-	notice.WriteString("- 或者告诉我新的方向/侧重点，我按你的调整来分析。\n")
+	nonce := utils.RandStringBytes(8)
+	noticePrompt := utils.MustRenderTemplate(`
+<|INSTRUCTION_{{ .Nonce }}|>
+You are an HTTP traffic analysis expert. An analysis answer has ALREADY been delivered to the user, but the analysis loop was then INTERRUPTED because it reached the iteration/step limit. This is NOT an error or a failure.
 
-	payload := notice.String()
+Write a SHORT continuation note (do NOT repeat the full report). Requirements:
+1. Calmly state that the analysis was interrupted because the step limit was reached, and make clear this is NOT a failure.
+2. Ground everything in the SPECIFIC context below (accumulated evidence, recent actions, unfinished TODOs). Point out concretely what was left undone, then give 2-4 tailored, inspiring next-step directions for THIS particular investigation. Do NOT give generic advice; refer to the actual endpoints/params/findings seen so far.
+3. End by telling the user they can simply reply "继续" (continue) to resume the unfinished work, or give a new direction/focus to adjust.
+
+Keep it concise: a few short paragraphs or a short bullet list. Use clear Markdown.
+
+CRITICAL LANGUAGE RULE: Write the ENTIRE note in the SAME language as the user's query below. If the user wrote in Chinese, write in Chinese; if in English, write in English. Do NOT mix languages.
+
+User's original query: {{ .UserQuery }}
+<|INSTRUCTION_END_{{ .Nonce }}|>
+
+<|CONTEXT_{{ .Nonce }}|>
+{{ .ContextMaterials }}
+<|CONTEXT_END_{{ .Nonce }}|>
+`, map[string]any{
+		"Nonce":            nonce,
+		"UserQuery":        userQuery,
+		"ContextMaterials": contextMaterials,
+	})
+
+	reactloops.EmitStatus(loop, "生成续做指引 / Generating Continuation Guidance...")
+
+	taskID := ""
+	if task := loop.GetCurrentTask(); task != nil {
+		taskID = task.GetId()
+	}
+
+	action, err := invoker.InvokeSpeedPriorityLiteForge(
+		loop.GetConfig().GetContext(),
+		"http_flow_analyze_interrupt_notice",
+		noticePrompt,
+		[]aitool.ToolOption{
+			aitool.WithStringParam("continuation_note",
+				aitool.WithParam_Description("Short, context-aware continuation note in Markdown that explains the interruption and inspires the user on what to do next"),
+				aitool.WithParam_Required(true),
+			),
+		},
+		aicommon.WithGeneralConfigStreamableFieldEmitterCallback([]string{
+			"continuation_note",
+		}, func(key string, r io.Reader, emitter *aicommon.Emitter) {
+			if emitter == nil {
+				io.Copy(io.Discard, r)
+				return
+			}
+			if event, _ := emitter.EmitStreamEventWithContentType(
+				"re-act-loop-answer-payload",
+				utils.JSONStringReader(r),
+				taskID,
+				aicommon.TypeTextMarkdown,
+				func() {},
+			); event != nil && contextMaterials != "" {
+				emitter.EmitTextReferenceMaterial(event.GetStreamEventWriterId(), contextMaterials)
+			}
+		}),
+	)
+
+	if err != nil {
+		log.Errorf("http_flow_analyze finalize: AI interrupt notice generation failed: %v", err)
+		deliverMaxIterationInterruptNoticeFallback(loop, invoker)
+		return
+	}
+
+	note := strings.TrimSpace(action.GetString("continuation_note"))
+	if note == "" {
+		log.Warnf("http_flow_analyze finalize: AI generated empty interrupt notice, using fallback")
+		deliverMaxIterationInterruptNoticeFallback(loop, invoker)
+		return
+	}
+
+	invoker.EmitResultAfterStream(note)
+	recordMetaAction(loop, "interrupt_notice",
+		"iteration limit continuation guidance",
+		utils.ShrinkTextBlock(note, 240))
+	invoker.AddToTimeline("http_flow_analysis_interrupted",
+		fmt.Sprintf("HTTP flow analysis interrupted by iteration limit after %d iterations; AI generated continuation guidance",
+			loop.GetCurrentIterationIndex()))
+}
+
+// deliverMaxIterationInterruptNoticeFallback 是 AI 生成续做指引失败时的极简兜底:
+// 只在无法调用 AI 时使用, 尽量少写死内容, 仅陈述被中断 + 罗列未完成 TODO + 提示
+// 用户可回复 "继续" 或给新方向. 与 deliverRawContextFallback 的降级定位一致.
+func deliverMaxIterationInterruptNoticeFallback(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime) {
+	if loop == nil || invoker == nil {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("> 分析因达到迭代次数上限被中断（这不是错误，只是本轮已用尽可执行的步数）。\n\n")
+	if unfinished := strings.TrimSpace(loop.GetMaxIterationInterruptSummary()); unfinished != "" {
+		b.WriteString("尚未完成、已标记为 SKIP 的事项：\n\n")
+		b.WriteString(unfinished)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("你可以回复 “继续” 让我接着做，或告诉我新的方向/侧重点。\n")
+	payload := b.String()
 
 	taskID := ""
 	if task := loop.GetCurrentTask(); task != nil {
@@ -100,12 +196,12 @@ func deliverMaxIterationInterruptNotice(loop *reactloops.ReActLoop, invoker aico
 			taskID,
 			func() {},
 		); err != nil {
-			log.Warnf("http_flow_analyze finalize: failed to emit max-iteration interrupt notice: %v", err)
+			log.Warnf("http_flow_analyze finalize: failed to emit interrupt notice fallback: %v", err)
 		}
 	}
 	invoker.EmitResultAfterStream(payload)
 	invoker.AddToTimeline("http_flow_analysis_interrupted",
-		fmt.Sprintf("HTTP flow analysis interrupted by iteration limit after %d iterations; asked user how to proceed",
+		fmt.Sprintf("HTTP flow analysis interrupted by iteration limit after %d iterations (fallback notice)",
 			loop.GetCurrentIterationIndex()))
 }
 

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
@@ -22,187 +22,19 @@ func buildPostIterationHook(invoker aicommon.AIInvokeRuntime) reactloops.ReActLo
 		log.Infof("http_flow_analyze loop done at iteration %d", iteration)
 		collectIterationFindings(loop)
 
-		// 是否为"到达迭代上限"的软性中断. exec.go 已把标记置位并把未完成 TODO
-		// 标记 SKIP, 这里只负责把"任务中断 + 未完成清单 + 询问下一步"融进直接回答.
-		// 关键词: max iteration 软性中断, http_flow_analyze finalize
-		maxIterInterrupt := isMaxIterationInterrupt(loop, reason)
-
+		// 迭代上限的软性中断收尾 (自然结束 + 未完成 TODO 清单 + 询问下一步) 已经
+		// 统一上移到框架层处理 (见 reactloops.(*ReActLoop).DeliverMaxIterationInterruptSummary),
+		// 不再与任何具体 loop 的专注模式绑定. 这里只保留本 loop 常规的"最终分析
+		// 报告"输出, 不再耦合任何中断专用逻辑.
+		// 关键词: http_flow_analyze finalize 常规收尾, 迭代上限交给框架
 		if hasFinalAnswerDelivered(loop) || hasDirectlyAnswered(loop) || getLastAction(loop) == "directly_answer" {
 			log.Infof("http_flow_analyze: answer already delivered before finalize")
-			if maxIterInterrupt {
-				// 已经给过答复, 但因为迭代上限被中断: 让 AI 依据本次分析的真实
-				// 上下文因地制宜地补一条"续做指引", 告诉用户哪些没做完 + 启发下
-				// 一步 (回复 "继续" 续跑, 或给新方向). 收尾 IgnoreError.
-				deliverMaxIterationInterruptNotice(loop, invoker, collectFinalizeContextMaterials(loop, reason))
-				operator.IgnoreError()
-			}
 			return
 		}
 
 		contextMaterials := collectFinalizeContextMaterials(loop, reason)
-		deliverFinalAnswerFallback(loop, invoker, contextMaterials, maxIterInterrupt)
-
-		if maxIterInterrupt {
-			operator.IgnoreError()
-		}
+		deliverFinalAnswerFallback(loop, invoker, contextMaterials)
 	})
-}
-
-// isMaxIterationInterrupt 判断本次 loop 结束是否因为"到达迭代上限"被软性中断.
-// 以 exec.go 置位的 loop 标记为准, 同时兼容 reason 里携带 "max iterations" 文案.
-func isMaxIterationInterrupt(loop *reactloops.ReActLoop, reason any) bool {
-	if loop != nil && loop.IsMaxIterationInterrupted() {
-		return true
-	}
-	if reasonErr, ok := reason.(error); ok && reasonErr != nil {
-		return strings.Contains(reasonErr.Error(), "max iterations")
-	}
-	if reasonStr, ok := reason.(string); ok {
-		return strings.Contains(reasonStr, "max iterations")
-	}
-	return false
-}
-
-// deliverMaxIterationInterruptNotice 在"答复已下发但仍撞到迭代上限"时补发一条
-// 续做指引: 内容不写死, 而是让 AI 依据本次分析的真实上下文 (已积累证据 / 最近
-// 动作 / 未完成 TODO) 因地制宜地生成 —— 冷静说明这是"被中断"而非失败, 结合具体
-// 调查进展点出还有哪些没做、给出针对性的下一步方向来启发用户, 并告知可回复
-// "继续" 续跑或给新方向. 不覆盖已给出的答复, 只做增量提示. AI 不可用时才退回到
-// 极简兜底文案 (deliverMaxIterationInterruptNoticeFallback).
-//
-// 关键词: 迭代上限软中断续做指引, AI 因地制宜生成, 未完成 TODO 交接, 询问下一步
-func deliverMaxIterationInterruptNotice(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime, contextMaterials string) {
-	if loop == nil || invoker == nil {
-		return
-	}
-
-	contextMaterials = strings.TrimSpace(contextMaterials)
-
-	userQuery := ""
-	if task := loop.GetCurrentTask(); task != nil {
-		userQuery = strings.TrimSpace(task.GetUserInput())
-	}
-
-	nonce := utils.RandStringBytes(8)
-	noticePrompt := utils.MustRenderTemplate(`
-<|INSTRUCTION_{{ .Nonce }}|>
-You are an HTTP traffic analysis expert. An analysis answer has ALREADY been delivered to the user, but the analysis loop was then INTERRUPTED because it reached the iteration/step limit. This is NOT an error or a failure.
-
-Write a SHORT continuation note (do NOT repeat the full report). Requirements:
-1. Calmly state that the analysis was interrupted because the step limit was reached, and make clear this is NOT a failure.
-2. Ground everything in the SPECIFIC context below (accumulated evidence, recent actions, unfinished TODOs). Point out concretely what was left undone, then give 2-4 tailored, inspiring next-step directions for THIS particular investigation. Do NOT give generic advice; refer to the actual endpoints/params/findings seen so far.
-3. End by telling the user they can simply reply "继续" (continue) to resume the unfinished work, or give a new direction/focus to adjust.
-
-Keep it concise: a few short paragraphs or a short bullet list. Use clear Markdown.
-
-CRITICAL LANGUAGE RULE: Write the ENTIRE note in the SAME language as the user's query below. If the user wrote in Chinese, write in Chinese; if in English, write in English. Do NOT mix languages.
-
-User's original query: {{ .UserQuery }}
-<|INSTRUCTION_END_{{ .Nonce }}|>
-
-<|CONTEXT_{{ .Nonce }}|>
-{{ .ContextMaterials }}
-<|CONTEXT_END_{{ .Nonce }}|>
-`, map[string]any{
-		"Nonce":            nonce,
-		"UserQuery":        userQuery,
-		"ContextMaterials": contextMaterials,
-	})
-
-	reactloops.EmitStatus(loop, "生成续做指引 / Generating Continuation Guidance...")
-
-	taskID := ""
-	if task := loop.GetCurrentTask(); task != nil {
-		taskID = task.GetId()
-	}
-
-	action, err := invoker.InvokeSpeedPriorityLiteForge(
-		loop.GetConfig().GetContext(),
-		"http_flow_analyze_interrupt_notice",
-		noticePrompt,
-		[]aitool.ToolOption{
-			aitool.WithStringParam("continuation_note",
-				aitool.WithParam_Description("Short, context-aware continuation note in Markdown that explains the interruption and inspires the user on what to do next"),
-				aitool.WithParam_Required(true),
-			),
-		},
-		aicommon.WithGeneralConfigStreamableFieldEmitterCallback([]string{
-			"continuation_note",
-		}, func(key string, r io.Reader, emitter *aicommon.Emitter) {
-			if emitter == nil {
-				io.Copy(io.Discard, r)
-				return
-			}
-			if event, _ := emitter.EmitStreamEventWithContentType(
-				"re-act-loop-answer-payload",
-				utils.JSONStringReader(r),
-				taskID,
-				aicommon.TypeTextMarkdown,
-				func() {},
-			); event != nil && contextMaterials != "" {
-				emitter.EmitTextReferenceMaterial(event.GetStreamEventWriterId(), contextMaterials)
-			}
-		}),
-	)
-
-	if err != nil {
-		log.Errorf("http_flow_analyze finalize: AI interrupt notice generation failed: %v", err)
-		deliverMaxIterationInterruptNoticeFallback(loop, invoker)
-		return
-	}
-
-	note := strings.TrimSpace(action.GetString("continuation_note"))
-	if note == "" {
-		log.Warnf("http_flow_analyze finalize: AI generated empty interrupt notice, using fallback")
-		deliverMaxIterationInterruptNoticeFallback(loop, invoker)
-		return
-	}
-
-	invoker.EmitResultAfterStream(note)
-	recordMetaAction(loop, "interrupt_notice",
-		"iteration limit continuation guidance",
-		utils.ShrinkTextBlock(note, 240))
-	invoker.AddToTimeline("http_flow_analysis_interrupted",
-		fmt.Sprintf("HTTP flow analysis interrupted by iteration limit after %d iterations; AI generated continuation guidance",
-			loop.GetCurrentIterationIndex()))
-}
-
-// deliverMaxIterationInterruptNoticeFallback 是 AI 生成续做指引失败时的极简兜底:
-// 只在无法调用 AI 时使用, 尽量少写死内容, 仅陈述被中断 + 罗列未完成 TODO + 提示
-// 用户可回复 "继续" 或给新方向. 与 deliverRawContextFallback 的降级定位一致.
-func deliverMaxIterationInterruptNoticeFallback(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime) {
-	if loop == nil || invoker == nil {
-		return
-	}
-
-	var b strings.Builder
-	b.WriteString("> 分析因达到迭代次数上限被中断（这不是错误，只是本轮已用尽可执行的步数）。\n\n")
-	if unfinished := strings.TrimSpace(loop.GetMaxIterationInterruptSummary()); unfinished != "" {
-		b.WriteString("尚未完成、已标记为 SKIP 的事项：\n\n")
-		b.WriteString(unfinished)
-		b.WriteString("\n\n")
-	}
-	b.WriteString("你可以回复 “继续” 让我接着做，或告诉我新的方向/侧重点。\n")
-	payload := b.String()
-
-	taskID := ""
-	if task := loop.GetCurrentTask(); task != nil {
-		taskID = task.GetId()
-	}
-	if emitter := loop.GetEmitter(); emitter != nil {
-		if _, err := emitter.EmitTextMarkdownStreamEvent(
-			"re-act-loop-answer-payload",
-			strings.NewReader(payload),
-			taskID,
-			func() {},
-		); err != nil {
-			log.Warnf("http_flow_analyze finalize: failed to emit interrupt notice fallback: %v", err)
-		}
-	}
-	invoker.EmitResultAfterStream(payload)
-	invoker.AddToTimeline("http_flow_analysis_interrupted",
-		fmt.Sprintf("HTTP flow analysis interrupted by iteration limit after %d iterations (fallback notice)",
-			loop.GetCurrentIterationIndex()))
 }
 
 func collectIterationFindings(loop *reactloops.ReActLoop) {
@@ -286,7 +118,7 @@ func collectFinalizeContextMaterials(loop *reactloops.ReActLoop, reason any) str
 	return strings.TrimSpace(ctx.String())
 }
 
-func deliverFinalAnswerFallback(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime, contextMaterials string, maxIterInterrupt bool) {
+func deliverFinalAnswerFallback(loop *reactloops.ReActLoop, invoker aicommon.AIInvokeRuntime, contextMaterials string) {
 	contextMaterials = strings.TrimSpace(contextMaterials)
 	if contextMaterials == "" {
 		log.Infof("http_flow_analyze finalize: skip fallback because context materials are empty")
@@ -303,19 +135,6 @@ func deliverFinalAnswerFallback(loop *reactloops.ReActLoop, invoker aicommon.AII
 		userQuery = strings.TrimSpace(task.GetUserInput())
 	}
 
-	// 到达迭代上限的软性中断: 让报告以"任务被中断"的口吻收尾, 明确列出没来得及
-	// 做的事情, 并询问用户下一步 (回复"继续"续跑, 或给新方向). 非中断的正常收尾
-	// 则沿用原来的完整报告口吻.
-	// 关键词: 迭代上限软中断报告, 未完成清单, 询问下一步(继续)
-	interruptGuidance := ""
-	if maxIterInterrupt {
-		interruptGuidance = `
-IMPORTANT - This analysis was INTERRUPTED because it reached the iteration limit (this is NOT a failure):
-6. Clearly state at the top that the analysis was interrupted because the step/iteration limit was reached, so it did not fully finish.
-7. Explicitly list what was NOT completed in time (see the "Unfinished TODOs" section in the context if present); these were auto-marked as SKIP.
-8. End by asking the user how to proceed: they can simply reply "继续" (continue) to resume the unfinished work, or provide a new direction/focus to adjust.`
-	}
-
 	nonce := utils.RandStringBytes(8)
 	summaryPrompt := utils.MustRenderTemplate(`
 <|INSTRUCTION_{{ .Nonce }}|>
@@ -326,7 +145,7 @@ Requirements:
 2. Answer the user's question based on available evidence
 3. If information is insufficient, explain what was attempted and possible reasons
 4. Provide concrete discoveries and actionable recommendations
-5. Use clear, professional Markdown formatting{{ .InterruptGuidance }}
+5. Use clear, professional Markdown formatting
 
 CRITICAL LANGUAGE RULE: You MUST write the ENTIRE report in the SAME language as the user's query below. If the user wrote in Chinese, your report MUST be in Chinese. If the user wrote in English, your report MUST be in English. Do NOT mix languages.
 
@@ -337,10 +156,9 @@ User's original query: {{ .UserQuery }}
 {{ .ContextMaterials }}
 <|CONTEXT_END_{{ .Nonce }}|>
 `, map[string]any{
-		"Nonce":             nonce,
-		"UserQuery":         userQuery,
-		"ContextMaterials":  contextMaterials,
-		"InterruptGuidance": interruptGuidance,
+		"Nonce":            nonce,
+		"UserQuery":        userQuery,
+		"ContextMaterials": contextMaterials,
 	})
 
 	log.Infof("http_flow_analyze finalize: generating forced AI answer, prompt length: %d", len(summaryPrompt))

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/init.go
@@ -32,7 +32,7 @@ func init() {
 				reactloops.WithAllowToolCall(true),
 				reactloops.WithAllowAIForge(false),
 				reactloops.WithAllowPlanAndExec(false),
-				reactloops.WithMaxIterations(10),
+				reactloops.WithMaxIterations(20),
 				reactloops.WithAllowUserInteract(r.GetConfig().GetAllowUserInteraction()),
 				reactloops.WithPersistentInstruction(persistentInstruction),
 				reactloops.WithReflectionOutputExample(outputExample),

--- a/common/ai/aid/aireact/reactloops/max_iteration_interrupt.go
+++ b/common/ai/aid/aireact/reactloops/max_iteration_interrupt.go
@@ -1,0 +1,270 @@
+package reactloops
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// LoopFinishEmission 描述一次 loop 收尾时, 全局兜底应当如何对客户端表态.
+type LoopFinishEmission int
+
+const (
+	// LoopFinishSilent: 保持静默 (loop 通过 IgnoreError 自管收尾, 常见于隐藏/内部 loop).
+	LoopFinishSilent LoopFinishEmission = iota
+	// LoopFinishSuccess: 普通成功收尾, EmitReActSuccess.
+	LoopFinishSuccess
+	// LoopFinishFail: 硬错误收尾, EmitReActFail (携带错误信息).
+	LoopFinishFail
+	// LoopFinishSuccessWithInterruptSummary: 到达迭代上限的软性中断. 客户端表现为
+	// "自然结束"(EmitReActSuccess), 并额外补发一段框架层 AI 生成的中断说明.
+	LoopFinishSuccessWithInterruptSummary
+)
+
+// ClassifyLoopFinishEmission 是全局收尾兜底的纯决策逻辑, 抽成独立函数以便单测覆盖:
+//   - IgnoreError 优先 -> 静默 (隐藏/内部 loop 自管收尾);
+//   - 到达迭代上限的软性中断 -> 自然结束(success) + 补发中断说明 (对比硬中断: 不报错);
+//   - 其余"已结束且带 reason(错误)" -> 硬失败(fail, 携带错误信息);
+//   - 其余 -> 成功.
+//
+// 关键词: 全局收尾决策, max iteration 软中断 自然结束, 对比硬中断报错
+func ClassifyLoopFinishEmission(isDone bool, reason any, ignoreError bool, maxIterationInterrupted bool) LoopFinishEmission {
+	if ignoreError {
+		return LoopFinishSilent
+	}
+	if isDone && maxIterationInterrupted {
+		return LoopFinishSuccessWithInterruptSummary
+	}
+	if isDone && reason != nil {
+		return LoopFinishFail
+	}
+	return LoopFinishSuccess
+}
+
+// DeliverMaxIterationInterruptSummary 是"到达迭代上限软性中断"的框架层统一收尾,
+// 与具体 loop / 专注模式完全解耦. 它让 AI 依据当前会话的真实上下文 (用户诉求 /
+// 未完成 TODO / 最近动作) 因地制宜地生成一段简短说明:
+//   - 明确本轮是因为"达到最大迭代次数"而自然结束的, 这不是错误;
+//   - 列出还没来得及做完 (已被 SKIP) 的 TODO;
+//   - 启发用户下一步可以做什么;
+//   - 告知用户可以直接回复 "继续" 续跑未完成的部分, 或直接开启一个新话题.
+//
+// AI 不可用 (调用失败或返回空) 时退回极简兜底文案. 内容不写死, 交由 AI 生成.
+//
+// 该方法由 re-act 主循环的全局收尾兜底在"软性中断 且 未被 IgnoreError"时调用且仅
+// 调用一次. 隐藏 / 内部 loop (在自己的 finalize 里 IgnoreError 自管收尾) 不会触发
+// 它, 因此不会被打扰.
+//
+// 关键词: 迭代上限软中断框架收尾, 自然结束, 未完成 TODO 交接, 询问下一步(继续)
+func (r *ReActLoop) DeliverMaxIterationInterruptSummary() {
+	if r == nil {
+		return
+	}
+	invoker := r.GetInvoker()
+	if utils.IsNil(invoker) {
+		return
+	}
+
+	task := r.GetCurrentTask()
+	userQuery := ""
+	if !utils.IsNil(task) {
+		userQuery = strings.TrimSpace(task.GetUserInput())
+	}
+	contextMaterials := r.buildMaxIterationInterruptContext(task)
+
+	taskID := ""
+	if !utils.IsNil(task) {
+		taskID = task.GetId()
+	}
+
+	nonce := utils.RandStringBytes(8)
+	prompt := utils.MustRenderTemplate(`
+<|INSTRUCTION_{{ .Nonce }}|>
+The assistant loop just STOPPED because it reached its maximum iteration/step limit. This is a NATURAL, EXPECTED stop, NOT an error and NOT a failure.
+
+Write a SHORT closing note for the user (do NOT redo the whole task). Requirements:
+1. Calmly state that work stopped because the step/iteration limit was reached (make clear this is NOT an error, the run simply ran out of allowed steps this round).
+2. Based on the SPECIFIC context below (the user's request, the unfinished TODOs, and recent actions), point out concretely what was NOT finished in time (these unfinished items were auto-marked as SKIP), and give 2-4 tailored, inspiring suggestions for what to do next about THIS particular task. Do NOT give generic filler; refer to the actual work seen so far.
+3. End by telling the user they can simply reply "继续" (continue) to resume the unfinished work, or start a brand new topic / give a new direction.
+
+Keep it concise: a few short sentences or a short bullet list. Use clear Markdown.
+
+CRITICAL LANGUAGE RULE: Write the ENTIRE note in the SAME language as the user's request below. If the user wrote in Chinese, write in Chinese; if in English, write in English. Do NOT mix languages.
+
+User's original request: {{ .UserQuery }}
+<|INSTRUCTION_END_{{ .Nonce }}|>
+
+<|CONTEXT_{{ .Nonce }}|>
+{{ .ContextMaterials }}
+<|CONTEXT_END_{{ .Nonce }}|>
+`, map[string]any{
+		"Nonce":            nonce,
+		"UserQuery":        userQuery,
+		"ContextMaterials": contextMaterials,
+	})
+
+	r.loadingStatus("生成中断说明 / Generating interruption summary...")
+
+	action, err := invoker.InvokeSpeedPriorityLiteForge(
+		r.GetConfig().GetContext(),
+		"max_iteration_interrupt_summary",
+		prompt,
+		[]aitool.ToolOption{
+			aitool.WithStringParam("continuation_note",
+				aitool.WithParam_Description("Short, context-aware closing note in Markdown that explains the iteration-limit stop and inspires the user on what to do next"),
+				aitool.WithParam_Required(true),
+			),
+		},
+		aicommon.WithGeneralConfigStreamableFieldEmitterCallback([]string{
+			"continuation_note",
+		}, func(key string, rd io.Reader, emitter *aicommon.Emitter) {
+			if emitter == nil {
+				io.Copy(io.Discard, rd)
+				return
+			}
+			if event, _ := emitter.EmitStreamEventWithContentType(
+				"re-act-loop-answer-payload",
+				utils.JSONStringReader(rd),
+				taskID,
+				aicommon.TypeTextMarkdown,
+				func() {},
+			); event != nil && contextMaterials != "" {
+				emitter.EmitTextReferenceMaterial(event.GetStreamEventWriterId(), contextMaterials)
+			}
+		}),
+	)
+	if err != nil {
+		log.Errorf("react loop[%s] max-iteration interrupt summary generation failed: %v", r.loopNameOrDefault(), err)
+		r.deliverMaxIterationInterruptSummaryFallback(invoker, taskID)
+		return
+	}
+
+	note := strings.TrimSpace(action.GetString("continuation_note"))
+	if note == "" {
+		log.Warnf("react loop[%s] max-iteration interrupt summary is empty, using fallback", r.loopNameOrDefault())
+		r.deliverMaxIterationInterruptSummaryFallback(invoker, taskID)
+		return
+	}
+
+	invoker.EmitResultAfterStream(note)
+	invoker.AddToTimeline("iteration_limit_interrupt_summary",
+		fmt.Sprintf("[%s] delivered AI continuation guidance after iteration-limit soft interrupt at iteration %d",
+			r.loopNameOrDefault(), r.GetCurrentIterationIndex()))
+}
+
+// deliverMaxIterationInterruptSummaryFallback 只在 AI 不可用时使用: 尽量少写死内容,
+// 仅陈述"因迭代上限自然结束(非错误)" + 罗列未完成 TODO + 提示可回复"继续"或换话题.
+func (r *ReActLoop) deliverMaxIterationInterruptSummaryFallback(invoker aicommon.AIInvokeRuntime, taskID string) {
+	if r == nil || utils.IsNil(invoker) {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("> 本轮已到达最大迭代次数上限，任务在此自然结束（这不是错误，只是本轮可执行的步数已经用尽）。\n\n")
+	if unfinished := strings.TrimSpace(r.GetMaxIterationInterruptSummary()); unfinished != "" {
+		b.WriteString("尚未完成、已标记为 SKIP 的事项：\n\n")
+		b.WriteString(unfinished)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("接下来你可以直接回复 “继续”，我会接着把没做完的部分做完；或者告诉我新的方向，也可以直接开启一个新话题。\n")
+	payload := b.String()
+
+	if emitter := r.GetEmitter(); emitter != nil {
+		if _, err := emitter.EmitTextMarkdownStreamEvent(
+			"re-act-loop-answer-payload",
+			strings.NewReader(payload),
+			taskID,
+			func() {},
+		); err != nil {
+			log.Warnf("react loop[%s] failed to emit max-iteration interrupt fallback: %v", r.loopNameOrDefault(), err)
+		}
+	}
+	invoker.EmitResultAfterStream(payload)
+	invoker.AddToTimeline("iteration_limit_interrupt_summary",
+		fmt.Sprintf("[%s] delivered fallback continuation guidance after iteration-limit soft interrupt at iteration %d",
+			r.loopNameOrDefault(), r.GetCurrentIterationIndex()))
+}
+
+// buildMaxIterationInterruptContext 汇总一份与 loop 无关的通用上下文, 供 AI 生成
+// 中断说明: 专注模式名 / 迭代上限 / 用户诉求 / 未完成 TODO / 最近动作.
+func (r *ReActLoop) buildMaxIterationInterruptContext(task aicommon.AIStatefulTask) string {
+	var ctx strings.Builder
+	ctx.WriteString("# Iteration-Limit Soft Interrupt Context\n\n")
+	ctx.WriteString(fmt.Sprintf("- Focus mode / loop: %s\n", r.loopNameOrDefault()))
+	ctx.WriteString(fmt.Sprintf("- Stopped at iteration: %d\n\n", r.GetCurrentIterationIndex()))
+
+	if !utils.IsNil(task) {
+		if userInput := strings.TrimSpace(task.GetUserInput()); userInput != "" {
+			ctx.WriteString("## User Request\n\n")
+			ctx.WriteString(userInput)
+			ctx.WriteString("\n\n")
+		}
+	}
+
+	if unfinished := strings.TrimSpace(r.GetMaxIterationInterruptSummary()); unfinished != "" {
+		ctx.WriteString("## Unfinished TODOs (auto-marked SKIP)\n\n")
+		ctx.WriteString(unfinished)
+		ctx.WriteString("\n\n")
+	}
+
+	if recent := strings.TrimSpace(r.buildRecentActionsForInterrupt()); recent != "" {
+		ctx.WriteString("## Recent Actions\n\n")
+		ctx.WriteString(recent)
+		ctx.WriteString("\n\n")
+	}
+
+	return strings.TrimSpace(ctx.String())
+}
+
+// buildRecentActionsForInterrupt 从 actionHistory 里取最近若干条动作, 拼成通用摘要.
+func (r *ReActLoop) buildRecentActionsForInterrupt() string {
+	r.actionHistoryMutex.Lock()
+	defer r.actionHistoryMutex.Unlock()
+
+	if len(r.actionHistory) == 0 {
+		return ""
+	}
+
+	const maxShow = 8
+	start := 0
+	if len(r.actionHistory) > maxShow {
+		start = len(r.actionHistory) - maxShow
+	}
+
+	var b strings.Builder
+	for _, rec := range r.actionHistory[start:] {
+		if rec == nil {
+			continue
+		}
+		name := strings.TrimSpace(rec.ActionName)
+		if name == "" {
+			name = strings.TrimSpace(rec.ActionType)
+		}
+		if name == "" {
+			continue
+		}
+		line := fmt.Sprintf("- iter %d: %s", rec.IterationIndex, name)
+		if tool := strings.TrimSpace(rec.ToolName); tool != "" {
+			line += fmt.Sprintf(" (tool: %s)", tool)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// loopNameOrDefault 返回 loop 名, 空时给一个稳定占位, 便于日志 / timeline 阅读.
+func (r *ReActLoop) loopNameOrDefault() string {
+	if r == nil {
+		return "general-purpose"
+	}
+	if name := strings.TrimSpace(r.loopName); name != "" {
+		return name
+	}
+	return "general-purpose"
+}

--- a/common/ai/aid/aireact/reactloops/max_iteration_interrupt.go
+++ b/common/ai/aid/aireact/reactloops/max_iteration_interrupt.go
@@ -1,34 +1,24 @@
 package reactloops
 
-import (
-	"fmt"
-	"io"
-	"strings"
-
-	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
-	"github.com/yaklang/yaklang/common/ai/aid/aitool"
-	"github.com/yaklang/yaklang/common/log"
-	"github.com/yaklang/yaklang/common/utils"
-)
-
 // LoopFinishEmission 描述一次 loop 收尾时, 全局兜底应当如何对客户端表态.
 type LoopFinishEmission int
 
 const (
 	// LoopFinishSilent: 保持静默 (loop 通过 IgnoreError 自管收尾, 常见于隐藏/内部 loop).
 	LoopFinishSilent LoopFinishEmission = iota
-	// LoopFinishSuccess: 普通成功收尾, EmitReActSuccess.
+	// LoopFinishSuccess: 自然结束, EmitReActSuccess. 普通成功收尾与"到达迭代上限的
+	// 软性中断"都归到这里 —— 迭代上限不是错误, 客户端一律表现为自然结束.
 	LoopFinishSuccess
 	// LoopFinishFail: 硬错误收尾, EmitReActFail (携带错误信息).
 	LoopFinishFail
-	// LoopFinishSuccessWithInterruptSummary: 到达迭代上限的软性中断. 客户端表现为
-	// "自然结束"(EmitReActSuccess), 并额外补发一段框架层 AI 生成的中断说明.
-	LoopFinishSuccessWithInterruptSummary
 )
 
 // ClassifyLoopFinishEmission 是全局收尾兜底的纯决策逻辑, 抽成独立函数以便单测覆盖:
 //   - IgnoreError 优先 -> 静默 (隐藏/内部 loop 自管收尾);
-//   - 到达迭代上限的软性中断 -> 自然结束(success) + 补发中断说明 (对比硬中断: 不报错);
+//   - 到达迭代上限的软性中断 -> 自然结束(success). 迭代上限属于"步数用尽"而非错误,
+//     虽然 reason 里带着 maxIterErr, 也不当作硬失败上报 (对比硬中断: 不报错). 中断
+//     原因 / 未完成 TODO / 下一步建议由各 loop 已有的 finalize 收尾总结承载 (它会读
+//     取框架落在 timeline / interrupt store 里的上下文), 框架层不再额外发一次 AI 请求;
 //   - 其余"已结束且带 reason(错误)" -> 硬失败(fail, 携带错误信息);
 //   - 其余 -> 成功.
 //
@@ -38,233 +28,10 @@ func ClassifyLoopFinishEmission(isDone bool, reason any, ignoreError bool, maxIt
 		return LoopFinishSilent
 	}
 	if isDone && maxIterationInterrupted {
-		return LoopFinishSuccessWithInterruptSummary
+		return LoopFinishSuccess
 	}
 	if isDone && reason != nil {
 		return LoopFinishFail
 	}
 	return LoopFinishSuccess
-}
-
-// DeliverMaxIterationInterruptSummary 是"到达迭代上限软性中断"的框架层统一收尾,
-// 与具体 loop / 专注模式完全解耦. 它让 AI 依据当前会话的真实上下文 (用户诉求 /
-// 未完成 TODO / 最近动作) 因地制宜地生成一段简短说明:
-//   - 明确本轮是因为"达到最大迭代次数"而自然结束的, 这不是错误;
-//   - 列出还没来得及做完 (已被 SKIP) 的 TODO;
-//   - 启发用户下一步可以做什么;
-//   - 告知用户可以直接回复 "继续" 续跑未完成的部分, 或直接开启一个新话题.
-//
-// AI 不可用 (调用失败或返回空) 时退回极简兜底文案. 内容不写死, 交由 AI 生成.
-//
-// 该方法由 re-act 主循环的全局收尾兜底在"软性中断 且 未被 IgnoreError"时调用且仅
-// 调用一次. 隐藏 / 内部 loop (在自己的 finalize 里 IgnoreError 自管收尾) 不会触发
-// 它, 因此不会被打扰.
-//
-// 关键词: 迭代上限软中断框架收尾, 自然结束, 未完成 TODO 交接, 询问下一步(继续)
-func (r *ReActLoop) DeliverMaxIterationInterruptSummary() {
-	if r == nil {
-		return
-	}
-	invoker := r.GetInvoker()
-	if utils.IsNil(invoker) {
-		return
-	}
-
-	task := r.GetCurrentTask()
-	userQuery := ""
-	if !utils.IsNil(task) {
-		userQuery = strings.TrimSpace(task.GetUserInput())
-	}
-	contextMaterials := r.buildMaxIterationInterruptContext(task)
-
-	taskID := ""
-	if !utils.IsNil(task) {
-		taskID = task.GetId()
-	}
-
-	nonce := utils.RandStringBytes(8)
-	prompt := utils.MustRenderTemplate(`
-<|INSTRUCTION_{{ .Nonce }}|>
-The assistant loop just STOPPED because it reached its maximum iteration/step limit. This is a NATURAL, EXPECTED stop, NOT an error and NOT a failure.
-
-Write a SHORT closing note for the user (do NOT redo the whole task). Requirements:
-1. Calmly state that work stopped because the step/iteration limit was reached (make clear this is NOT an error, the run simply ran out of allowed steps this round).
-2. Based on the SPECIFIC context below (the user's request, the unfinished TODOs, and recent actions), point out concretely what was NOT finished in time (these unfinished items were auto-marked as SKIP), and give 2-4 tailored, inspiring suggestions for what to do next about THIS particular task. Do NOT give generic filler; refer to the actual work seen so far.
-3. End by telling the user they can simply reply "继续" (continue) to resume the unfinished work, or start a brand new topic / give a new direction.
-
-Keep it concise: a few short sentences or a short bullet list. Use clear Markdown.
-
-CRITICAL LANGUAGE RULE: Write the ENTIRE note in the SAME language as the user's request below. If the user wrote in Chinese, write in Chinese; if in English, write in English. Do NOT mix languages.
-
-User's original request: {{ .UserQuery }}
-<|INSTRUCTION_END_{{ .Nonce }}|>
-
-<|CONTEXT_{{ .Nonce }}|>
-{{ .ContextMaterials }}
-<|CONTEXT_END_{{ .Nonce }}|>
-`, map[string]any{
-		"Nonce":            nonce,
-		"UserQuery":        userQuery,
-		"ContextMaterials": contextMaterials,
-	})
-
-	r.loadingStatus("生成中断说明 / Generating interruption summary...")
-
-	action, err := invoker.InvokeSpeedPriorityLiteForge(
-		r.GetConfig().GetContext(),
-		"max_iteration_interrupt_summary",
-		prompt,
-		[]aitool.ToolOption{
-			aitool.WithStringParam("continuation_note",
-				aitool.WithParam_Description("Short, context-aware closing note in Markdown that explains the iteration-limit stop and inspires the user on what to do next"),
-				aitool.WithParam_Required(true),
-			),
-		},
-		aicommon.WithGeneralConfigStreamableFieldEmitterCallback([]string{
-			"continuation_note",
-		}, func(key string, rd io.Reader, emitter *aicommon.Emitter) {
-			if emitter == nil {
-				io.Copy(io.Discard, rd)
-				return
-			}
-			if event, _ := emitter.EmitStreamEventWithContentType(
-				"re-act-loop-answer-payload",
-				utils.JSONStringReader(rd),
-				taskID,
-				aicommon.TypeTextMarkdown,
-				func() {},
-			); event != nil && contextMaterials != "" {
-				emitter.EmitTextReferenceMaterial(event.GetStreamEventWriterId(), contextMaterials)
-			}
-		}),
-	)
-	if err != nil {
-		log.Errorf("react loop[%s] max-iteration interrupt summary generation failed: %v", r.loopNameOrDefault(), err)
-		r.deliverMaxIterationInterruptSummaryFallback(invoker, taskID)
-		return
-	}
-
-	note := strings.TrimSpace(action.GetString("continuation_note"))
-	if note == "" {
-		log.Warnf("react loop[%s] max-iteration interrupt summary is empty, using fallback", r.loopNameOrDefault())
-		r.deliverMaxIterationInterruptSummaryFallback(invoker, taskID)
-		return
-	}
-
-	invoker.EmitResultAfterStream(note)
-	invoker.AddToTimeline("iteration_limit_interrupt_summary",
-		fmt.Sprintf("[%s] delivered AI continuation guidance after iteration-limit soft interrupt at iteration %d",
-			r.loopNameOrDefault(), r.GetCurrentIterationIndex()))
-}
-
-// deliverMaxIterationInterruptSummaryFallback 只在 AI 不可用时使用: 尽量少写死内容,
-// 仅陈述"因迭代上限自然结束(非错误)" + 罗列未完成 TODO + 提示可回复"继续"或换话题.
-func (r *ReActLoop) deliverMaxIterationInterruptSummaryFallback(invoker aicommon.AIInvokeRuntime, taskID string) {
-	if r == nil || utils.IsNil(invoker) {
-		return
-	}
-
-	var b strings.Builder
-	b.WriteString("> 本轮已到达最大迭代次数上限，任务在此自然结束（这不是错误，只是本轮可执行的步数已经用尽）。\n\n")
-	if unfinished := strings.TrimSpace(r.GetMaxIterationInterruptSummary()); unfinished != "" {
-		b.WriteString("尚未完成、已标记为 SKIP 的事项：\n\n")
-		b.WriteString(unfinished)
-		b.WriteString("\n\n")
-	}
-	b.WriteString("接下来你可以直接回复 “继续”，我会接着把没做完的部分做完；或者告诉我新的方向，也可以直接开启一个新话题。\n")
-	payload := b.String()
-
-	if emitter := r.GetEmitter(); emitter != nil {
-		if _, err := emitter.EmitTextMarkdownStreamEvent(
-			"re-act-loop-answer-payload",
-			strings.NewReader(payload),
-			taskID,
-			func() {},
-		); err != nil {
-			log.Warnf("react loop[%s] failed to emit max-iteration interrupt fallback: %v", r.loopNameOrDefault(), err)
-		}
-	}
-	invoker.EmitResultAfterStream(payload)
-	invoker.AddToTimeline("iteration_limit_interrupt_summary",
-		fmt.Sprintf("[%s] delivered fallback continuation guidance after iteration-limit soft interrupt at iteration %d",
-			r.loopNameOrDefault(), r.GetCurrentIterationIndex()))
-}
-
-// buildMaxIterationInterruptContext 汇总一份与 loop 无关的通用上下文, 供 AI 生成
-// 中断说明: 专注模式名 / 迭代上限 / 用户诉求 / 未完成 TODO / 最近动作.
-func (r *ReActLoop) buildMaxIterationInterruptContext(task aicommon.AIStatefulTask) string {
-	var ctx strings.Builder
-	ctx.WriteString("# Iteration-Limit Soft Interrupt Context\n\n")
-	ctx.WriteString(fmt.Sprintf("- Focus mode / loop: %s\n", r.loopNameOrDefault()))
-	ctx.WriteString(fmt.Sprintf("- Stopped at iteration: %d\n\n", r.GetCurrentIterationIndex()))
-
-	if !utils.IsNil(task) {
-		if userInput := strings.TrimSpace(task.GetUserInput()); userInput != "" {
-			ctx.WriteString("## User Request\n\n")
-			ctx.WriteString(userInput)
-			ctx.WriteString("\n\n")
-		}
-	}
-
-	if unfinished := strings.TrimSpace(r.GetMaxIterationInterruptSummary()); unfinished != "" {
-		ctx.WriteString("## Unfinished TODOs (auto-marked SKIP)\n\n")
-		ctx.WriteString(unfinished)
-		ctx.WriteString("\n\n")
-	}
-
-	if recent := strings.TrimSpace(r.buildRecentActionsForInterrupt()); recent != "" {
-		ctx.WriteString("## Recent Actions\n\n")
-		ctx.WriteString(recent)
-		ctx.WriteString("\n\n")
-	}
-
-	return strings.TrimSpace(ctx.String())
-}
-
-// buildRecentActionsForInterrupt 从 actionHistory 里取最近若干条动作, 拼成通用摘要.
-func (r *ReActLoop) buildRecentActionsForInterrupt() string {
-	r.actionHistoryMutex.Lock()
-	defer r.actionHistoryMutex.Unlock()
-
-	if len(r.actionHistory) == 0 {
-		return ""
-	}
-
-	const maxShow = 8
-	start := 0
-	if len(r.actionHistory) > maxShow {
-		start = len(r.actionHistory) - maxShow
-	}
-
-	var b strings.Builder
-	for _, rec := range r.actionHistory[start:] {
-		if rec == nil {
-			continue
-		}
-		name := strings.TrimSpace(rec.ActionName)
-		if name == "" {
-			name = strings.TrimSpace(rec.ActionType)
-		}
-		if name == "" {
-			continue
-		}
-		line := fmt.Sprintf("- iter %d: %s", rec.IterationIndex, name)
-		if tool := strings.TrimSpace(rec.ToolName); tool != "" {
-			line += fmt.Sprintf(" (tool: %s)", tool)
-		}
-		b.WriteString(line)
-		b.WriteString("\n")
-	}
-	return b.String()
-}
-
-// loopNameOrDefault 返回 loop 名, 空时给一个稳定占位, 便于日志 / timeline 阅读.
-func (r *ReActLoop) loopNameOrDefault() string {
-	if r == nil {
-		return "general-purpose"
-	}
-	if name := strings.TrimSpace(r.loopName); name != "" {
-		return name
-	}
-	return "general-purpose"
 }

--- a/common/ai/aid/aireact/reactloops/max_iteration_soft_interrupt_test.go
+++ b/common/ai/aid/aireact/reactloops/max_iteration_soft_interrupt_test.go
@@ -56,8 +56,9 @@ type maxIterTestInvoker struct {
 	cfg         *maxIterTestConfig
 	currentTask aicommon.AIStatefulTask
 
-	mu       sync.Mutex
-	timeline []string
+	mu          sync.Mutex
+	timeline    []string
+	emitResults []string
 }
 
 func (i *maxIterTestInvoker) GetConfig() aicommon.AICallerConfigIf { return i.cfg }
@@ -83,6 +84,18 @@ func (i *maxIterTestInvoker) timelineString() string {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	return strings.Join(i.timeline, "\n")
+}
+
+func (i *maxIterTestInvoker) EmitResultAfterStream(result any) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.emitResults = append(i.emitResults, utils.InterfaceToString(result))
+}
+
+func (i *maxIterTestInvoker) emitResultString() string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return strings.Join(i.emitResults, "\n")
 }
 
 func newMaxIterTestLoop(t *testing.T, active []aicommon.VerificationTodoItem) (*ReActLoop, *maxIterTestInvoker, *maxIterTestConfig, aicommon.AIStatefulTask) {
@@ -148,46 +161,57 @@ func TestMaxIterationSoftInterrupt_NoActiveTodos(t *testing.T) {
 	assert.Contains(t, invoker.timelineString(), "iteration_limit_interrupt")
 }
 
-// TestFinishIterationLoopWithSoftInterrupt_SuppressesFail 验证软性中断收尾会预置
-// IgnoreError: 即便某个 loop 没有 finalize hook 主动 IgnoreError, ExecuteLoopTask
-// 里"reason != nil 且未 IgnoreError -> EmitReActFail"的全局兜底也一定观察到 ignore,
-// 从而不会把"到达迭代上限"当成任务失败上报.
-// 关键词: 软性中断预置 IgnoreError, 抑制 EmitReActFail
-func TestFinishIterationLoopWithSoftInterrupt_SuppressesFail(t *testing.T) {
-	loop, _, _, task := newMaxIterTestLoop(t, nil)
+// TestClassifyLoopFinishEmission_SoftInterruptIsNaturalEnd 覆盖框架层全局收尾的核心
+// 决策 (测试要点 1/2/4):
+//   - 到达迭代上限的软性中断 -> "自然结束"(success) + 补发中断说明, 不报错;
+//   - 对比硬中断 (已结束且带错误、非软中断) -> 硬失败 fail (携带错误信息);
+//   - IgnoreError (隐藏/内部 loop 自管收尾) -> 静默.
+//
+// 关键词: max iteration 软中断 自然结束, 不报错, 对比硬中断报错
+func TestClassifyLoopFinishEmission_SoftInterruptIsNaturalEnd(t *testing.T) {
+	maxIterErr := utils.Errorf("reached max iterations (10), stopping test loop")
 
-	var wouldFail bool
-	// 模拟 ExecuteLoopTask 里注册的全局 fail 兜底: 用 DeferAfterCallbacks 在所有
-	// 回调跑完后再判定, 与线上时序一致.
-	WithOnPostIteraction(func(_ *ReActLoop, _ int, _ aicommon.AIStatefulTask, isDone bool, reason any, operator *OnPostIterationOperator) {
-		operator.DeferAfterCallbacks(func() {
-			if isDone && reason != nil && !operator.ShouldIgnoreError() {
-				wouldFail = true
-			}
-		})
-	})(loop)
+	// 要点1: 软性中断 -> 自然结束(success) + 补发中断说明, 不是 fail
+	got := ClassifyLoopFinishEmission(true, maxIterErr, false, true)
+	require.Equal(t, LoopFinishSuccessWithInterruptSummary, got,
+		"max-iteration soft interrupt must be a natural success with an interrupt summary, not a failure")
 
-	loop.finishIterationLoopWithSoftInterrupt(11, task, utils.Errorf("reached max iterations (10), stopping test loop"))
+	// 要点2: 软性中断不产生 fail
+	require.NotEqual(t, LoopFinishFail, got, "soft interrupt must not be reported as failure")
 
-	require.False(t, wouldFail, "soft interrupt must not trigger EmitReActFail")
+	// 要点4: 对比硬中断 (真实错误, 未标记软中断) -> 携带错误信息的 fail
+	hard := ClassifyLoopFinishEmission(true, utils.Errorf("boom: unexpected transaction error"), false, false)
+	require.Equal(t, LoopFinishFail, hard, "a genuine hard interrupt/error must still be reported as failure")
+
+	// 隐藏/内部 loop 自管收尾 (IgnoreError) -> 静默, 即便标记了软中断也不打扰
+	silent := ClassifyLoopFinishEmission(true, maxIterErr, true, true)
+	require.Equal(t, LoopFinishSilent, silent, "IgnoreError loops must stay silent")
+
+	// 正常完成 (无错误) -> 成功
+	ok := ClassifyLoopFinishEmission(true, nil, false, false)
+	require.Equal(t, LoopFinishSuccess, ok)
 }
 
-// TestFinishIterationLoopWithError_WouldFailWithoutIgnore 作为对照: 老的
-// finishIterationLoopWithError 在没有任何 hook 主动 IgnoreError 时, 全局兜底会判定
-// 为失败. 这正是软性中断路径要修掉的坏体验.
-func TestFinishIterationLoopWithError_WouldFailWithoutIgnore(t *testing.T) {
-	loop, _, _, task := newMaxIterTestLoop(t, nil)
+// TestDeliverMaxIterationInterruptSummary_FallbackExplainsAndAsksNext 验证框架层补发
+// 的中断说明 (测试要点 1): 即便 AI 不可用走兜底, 也会明确"因迭代上限自然结束(非错误)"、
+// 列出未完成 TODO、并提示用户可回复 "继续" 或开启新话题; 同时落一条 timeline.
+// 关键词: 框架中断说明, 自然结束, 未完成 TODO, 询问下一步(继续)
+func TestDeliverMaxIterationInterruptSummary_FallbackExplainsAndAsksNext(t *testing.T) {
+	loop, invoker, _, task := newMaxIterTestLoop(t, []aicommon.VerificationTodoItem{
+		{ID: "check_sensitive", Content: "检查响应体里是否有身份证/手机号", Status: aicommon.VerificationTodoStatusDoing},
+	})
 
-	var wouldFail bool
-	WithOnPostIteraction(func(_ *ReActLoop, _ int, _ aicommon.AIStatefulTask, isDone bool, reason any, operator *OnPostIterationOperator) {
-		operator.DeferAfterCallbacks(func() {
-			if isDone && reason != nil && !operator.ShouldIgnoreError() {
-				wouldFail = true
-			}
-		})
-	})(loop)
+	// 先触发软性中断以记录"未完成 TODO"快照
+	loop.applyMaxIterationSoftInterrupt(21, task, 20)
 
-	loop.finishIterationLoopWithError(11, task, utils.Errorf("reached max iterations (10), stopping test loop"))
+	// mock 的 InvokeSpeedPriorityLiteForge 不会返回可用的 continuation_note,
+	// 因此会走极简兜底文案 —— 兜底同样承担"解释中断 + 询问下一步"的职责.
+	loop.DeliverMaxIterationInterruptSummary()
 
-	require.True(t, wouldFail, "legacy error path would emit fail without an IgnoreError hook")
+	result := invoker.emitResultString()
+	assert.Contains(t, result, "迭代次数上限")
+	assert.Contains(t, result, "继续")
+	assert.Contains(t, result, "检查响应体里是否有身份证/手机号")
+
+	assert.Contains(t, invoker.timelineString(), "iteration_limit_interrupt_summary")
 }

--- a/common/ai/aid/aireact/reactloops/max_iteration_soft_interrupt_test.go
+++ b/common/ai/aid/aireact/reactloops/max_iteration_soft_interrupt_test.go
@@ -1,0 +1,193 @@
+package reactloops
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// maxIterTestConfig 记录 ApplyVerificationTodoOps 调用, 并按 scope 返回活跃 TODO,
+// 用来验证"到达迭代上限"时的软性中断是否把活跃 TODO 批量标记为 SKIP.
+type maxIterTestConfig struct {
+	*mock.MockedAIConfig
+
+	mu           sync.Mutex
+	activeByTask map[string][]aicommon.VerificationTodoItem
+	appliedOps   []aicommon.VerifyNextMovement
+	appliedScope aicommon.VerificationTodoScope
+}
+
+func (c *maxIterTestConfig) ActiveVerificationTodoItemsByScope(scope aicommon.VerificationTodoScope) []aicommon.VerificationTodoItem {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]aicommon.VerificationTodoItem(nil), c.activeByTask[scope.TaskID]...)
+}
+
+func (c *maxIterTestConfig) ApplyVerificationTodoOps(scope aicommon.VerificationTodoScope, satisfied bool, movements []aicommon.VerifyNextMovement) []aicommon.VerificationTodoApplyError {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.appliedScope = scope
+	c.appliedOps = append(c.appliedOps, movements...)
+	return nil
+}
+
+func (c *maxIterTestConfig) appliedSkipIDs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ids := make([]string, 0, len(c.appliedOps))
+	for _, m := range c.appliedOps {
+		if strings.EqualFold(strings.TrimSpace(m.Op), "skip") {
+			ids = append(ids, m.ID)
+		}
+	}
+	return ids
+}
+
+type maxIterTestInvoker struct {
+	*mock.MockInvoker
+	cfg         *maxIterTestConfig
+	currentTask aicommon.AIStatefulTask
+
+	mu       sync.Mutex
+	timeline []string
+}
+
+func (i *maxIterTestInvoker) GetConfig() aicommon.AICallerConfigIf { return i.cfg }
+
+func (i *maxIterTestInvoker) SetCurrentTask(task aicommon.AIStatefulTask) { i.currentTask = task }
+
+func (i *maxIterTestInvoker) GetCurrentTask() aicommon.AIStatefulTask { return i.currentTask }
+
+func (i *maxIterTestInvoker) GetCurrentTaskId() string {
+	if i.currentTask == nil {
+		return ""
+	}
+	return i.currentTask.GetId()
+}
+
+func (i *maxIterTestInvoker) AddToTimeline(entry, content string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.timeline = append(i.timeline, entry+": "+content)
+}
+
+func (i *maxIterTestInvoker) timelineString() string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return strings.Join(i.timeline, "\n")
+}
+
+func newMaxIterTestLoop(t *testing.T, active []aicommon.VerificationTodoItem) (*ReActLoop, *maxIterTestInvoker, *maxIterTestConfig, aicommon.AIStatefulTask) {
+	t.Helper()
+	ctx := context.Background()
+	baseInvoker := mock.NewMockInvoker(ctx)
+	mockCfg, ok := baseInvoker.GetConfig().(*mock.MockedAIConfig)
+	require.True(t, ok)
+
+	cfg := &maxIterTestConfig{
+		MockedAIConfig: mockCfg,
+		activeByTask: map[string][]aicommon.VerificationTodoItem{
+			"test-task": active,
+		},
+	}
+	invoker := &maxIterTestInvoker{
+		MockInvoker: baseInvoker,
+		cfg:         cfg,
+	}
+	loop := NewMinimalReActLoop(cfg, invoker)
+	task := aicommon.NewStatefulTaskBase("test-task", "分析这批 HTTP 流量里有没有敏感信息泄露", ctx, cfg.GetEmitter(), true)
+	invoker.SetCurrentTask(task)
+	loop.SetCurrentTask(task)
+	return loop, invoker, cfg, task
+}
+
+// TestMaxIterationSoftInterrupt_MarksActiveTodosSkip 验证到达迭代上限的软性中断:
+// 当前任务仍活跃的 TODO 会被批量标记为 SKIP, 未完成快照被记录, 且 Timeline 落一
+// 条软性中断说明 (非 error), 供直接回答引用. 关键词: max iteration 软中断, 待办 SKIP
+func TestMaxIterationSoftInterrupt_MarksActiveTodosSkip(t *testing.T) {
+	loop, invoker, cfg, task := newMaxIterTestLoop(t, []aicommon.VerificationTodoItem{
+		{ID: "check_sensitive", Content: "检查响应体里是否有身份证/手机号", Status: aicommon.VerificationTodoStatusDoing},
+		{ID: "check_token", Content: "确认是否有明文 token 泄露", Status: aicommon.VerificationTodoStatusPending},
+	})
+
+	loop.applyMaxIterationSoftInterrupt(11, task, 10)
+
+	// 两条活跃 TODO 都应被标记为 SKIP
+	skipIDs := cfg.appliedSkipIDs()
+	require.ElementsMatch(t, []string{"check_sensitive", "check_token"}, skipIDs)
+	require.Equal(t, "test-task", cfg.appliedScope.TaskID)
+
+	// 软中断标记与未完成快照
+	require.True(t, loop.IsMaxIterationInterrupted())
+	summary := loop.GetMaxIterationInterruptSummary()
+	assert.Contains(t, summary, "检查响应体里是否有身份证/手机号")
+	assert.Contains(t, summary, "确认是否有明文 token 泄露")
+
+	// 单条软性中断 timeline 说明
+	assert.Contains(t, invoker.timelineString(), "iteration_limit_interrupt")
+}
+
+// TestMaxIterationSoftInterrupt_NoActiveTodos 验证没有活跃 TODO 时也能安全走软性
+// 中断: 不产生 skip op, 但仍置位中断标记并落一条软性说明.
+func TestMaxIterationSoftInterrupt_NoActiveTodos(t *testing.T) {
+	loop, invoker, cfg, task := newMaxIterTestLoop(t, nil)
+
+	loop.applyMaxIterationSoftInterrupt(11, task, 10)
+
+	require.Empty(t, cfg.appliedSkipIDs())
+	require.True(t, loop.IsMaxIterationInterrupted())
+	assert.Empty(t, loop.GetMaxIterationInterruptSummary())
+	assert.Contains(t, invoker.timelineString(), "iteration_limit_interrupt")
+}
+
+// TestFinishIterationLoopWithSoftInterrupt_SuppressesFail 验证软性中断收尾会预置
+// IgnoreError: 即便某个 loop 没有 finalize hook 主动 IgnoreError, ExecuteLoopTask
+// 里"reason != nil 且未 IgnoreError -> EmitReActFail"的全局兜底也一定观察到 ignore,
+// 从而不会把"到达迭代上限"当成任务失败上报.
+// 关键词: 软性中断预置 IgnoreError, 抑制 EmitReActFail
+func TestFinishIterationLoopWithSoftInterrupt_SuppressesFail(t *testing.T) {
+	loop, _, _, task := newMaxIterTestLoop(t, nil)
+
+	var wouldFail bool
+	// 模拟 ExecuteLoopTask 里注册的全局 fail 兜底: 用 DeferAfterCallbacks 在所有
+	// 回调跑完后再判定, 与线上时序一致.
+	WithOnPostIteraction(func(_ *ReActLoop, _ int, _ aicommon.AIStatefulTask, isDone bool, reason any, operator *OnPostIterationOperator) {
+		operator.DeferAfterCallbacks(func() {
+			if isDone && reason != nil && !operator.ShouldIgnoreError() {
+				wouldFail = true
+			}
+		})
+	})(loop)
+
+	loop.finishIterationLoopWithSoftInterrupt(11, task, utils.Errorf("reached max iterations (10), stopping test loop"))
+
+	require.False(t, wouldFail, "soft interrupt must not trigger EmitReActFail")
+}
+
+// TestFinishIterationLoopWithError_WouldFailWithoutIgnore 作为对照: 老的
+// finishIterationLoopWithError 在没有任何 hook 主动 IgnoreError 时, 全局兜底会判定
+// 为失败. 这正是软性中断路径要修掉的坏体验.
+func TestFinishIterationLoopWithError_WouldFailWithoutIgnore(t *testing.T) {
+	loop, _, _, task := newMaxIterTestLoop(t, nil)
+
+	var wouldFail bool
+	WithOnPostIteraction(func(_ *ReActLoop, _ int, _ aicommon.AIStatefulTask, isDone bool, reason any, operator *OnPostIterationOperator) {
+		operator.DeferAfterCallbacks(func() {
+			if isDone && reason != nil && !operator.ShouldIgnoreError() {
+				wouldFail = true
+			}
+		})
+	})(loop)
+
+	loop.finishIterationLoopWithError(11, task, utils.Errorf("reached max iterations (10), stopping test loop"))
+
+	require.True(t, wouldFail, "legacy error path would emit fail without an IgnoreError hook")
+}

--- a/common/ai/aid/aireact/reactloops/max_iteration_soft_interrupt_test.go
+++ b/common/ai/aid/aireact/reactloops/max_iteration_soft_interrupt_test.go
@@ -56,9 +56,8 @@ type maxIterTestInvoker struct {
 	cfg         *maxIterTestConfig
 	currentTask aicommon.AIStatefulTask
 
-	mu          sync.Mutex
-	timeline    []string
-	emitResults []string
+	mu       sync.Mutex
+	timeline []string
 }
 
 func (i *maxIterTestInvoker) GetConfig() aicommon.AICallerConfigIf { return i.cfg }
@@ -84,18 +83,6 @@ func (i *maxIterTestInvoker) timelineString() string {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	return strings.Join(i.timeline, "\n")
-}
-
-func (i *maxIterTestInvoker) EmitResultAfterStream(result any) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.emitResults = append(i.emitResults, utils.InterfaceToString(result))
-}
-
-func (i *maxIterTestInvoker) emitResultString() string {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	return strings.Join(i.emitResults, "\n")
 }
 
 func newMaxIterTestLoop(t *testing.T, active []aicommon.VerificationTodoItem) (*ReActLoop, *maxIterTestInvoker, *maxIterTestConfig, aicommon.AIStatefulTask) {
@@ -163,7 +150,8 @@ func TestMaxIterationSoftInterrupt_NoActiveTodos(t *testing.T) {
 
 // TestClassifyLoopFinishEmission_SoftInterruptIsNaturalEnd 覆盖框架层全局收尾的核心
 // 决策 (测试要点 1/2/4):
-//   - 到达迭代上限的软性中断 -> "自然结束"(success) + 补发中断说明, 不报错;
+//   - 到达迭代上限的软性中断 -> "自然结束"(success), 不报错 (中断原因/未完成 TODO/
+//     下一步建议由各 loop 已有的 finalize 收尾总结承载, 框架不额外发 AI 请求);
 //   - 对比硬中断 (已结束且带错误、非软中断) -> 硬失败 fail (携带错误信息);
 //   - IgnoreError (隐藏/内部 loop 自管收尾) -> 静默.
 //
@@ -171,12 +159,10 @@ func TestMaxIterationSoftInterrupt_NoActiveTodos(t *testing.T) {
 func TestClassifyLoopFinishEmission_SoftInterruptIsNaturalEnd(t *testing.T) {
 	maxIterErr := utils.Errorf("reached max iterations (10), stopping test loop")
 
-	// 要点1: 软性中断 -> 自然结束(success) + 补发中断说明, 不是 fail
+	// 要点1&2: 软性中断 -> 自然结束(success), 即便 reason 带着 maxIterErr 也不报 fail
 	got := ClassifyLoopFinishEmission(true, maxIterErr, false, true)
-	require.Equal(t, LoopFinishSuccessWithInterruptSummary, got,
-		"max-iteration soft interrupt must be a natural success with an interrupt summary, not a failure")
-
-	// 要点2: 软性中断不产生 fail
+	require.Equal(t, LoopFinishSuccess, got,
+		"max-iteration soft interrupt must be a natural success, not a failure")
 	require.NotEqual(t, LoopFinishFail, got, "soft interrupt must not be reported as failure")
 
 	// 要点4: 对比硬中断 (真实错误, 未标记软中断) -> 携带错误信息的 fail
@@ -190,28 +176,4 @@ func TestClassifyLoopFinishEmission_SoftInterruptIsNaturalEnd(t *testing.T) {
 	// 正常完成 (无错误) -> 成功
 	ok := ClassifyLoopFinishEmission(true, nil, false, false)
 	require.Equal(t, LoopFinishSuccess, ok)
-}
-
-// TestDeliverMaxIterationInterruptSummary_FallbackExplainsAndAsksNext 验证框架层补发
-// 的中断说明 (测试要点 1): 即便 AI 不可用走兜底, 也会明确"因迭代上限自然结束(非错误)"、
-// 列出未完成 TODO、并提示用户可回复 "继续" 或开启新话题; 同时落一条 timeline.
-// 关键词: 框架中断说明, 自然结束, 未完成 TODO, 询问下一步(继续)
-func TestDeliverMaxIterationInterruptSummary_FallbackExplainsAndAsksNext(t *testing.T) {
-	loop, invoker, _, task := newMaxIterTestLoop(t, []aicommon.VerificationTodoItem{
-		{ID: "check_sensitive", Content: "检查响应体里是否有身份证/手机号", Status: aicommon.VerificationTodoStatusDoing},
-	})
-
-	// 先触发软性中断以记录"未完成 TODO"快照
-	loop.applyMaxIterationSoftInterrupt(21, task, 20)
-
-	// mock 的 InvokeSpeedPriorityLiteForge 不会返回可用的 continuation_note,
-	// 因此会走极简兜底文案 —— 兜底同样承担"解释中断 + 询问下一步"的职责.
-	loop.DeliverMaxIterationInterruptSummary()
-
-	result := invoker.emitResultString()
-	assert.Contains(t, result, "迭代次数上限")
-	assert.Contains(t, result, "继续")
-	assert.Contains(t, result, "检查响应体里是否有身份证/手机号")
-
-	assert.Contains(t, invoker.timelineString(), "iteration_limit_interrupt_summary")
 }


### PR DESCRIPTION
Reaching the ReAct iteration limit (e.g. HTTP History AI / http_flow_analyze, default 10) used to surface a ReAct fail, which was a poor experience.

Now the limit is handled as a soft interrupt in the shared loop core:
- active TODOs of the current task are batch-marked SKIP via the single-source ApplyVerificationNextMovementsAndEmit helper (store + todo_list_update);
- a single non-error timeline breadcrumb reports the interruption once;
- IgnoreError is pre-set before running post-iteration hooks so the global EmitReActFail fallback is always suppressed on max-iteration, regardless of whether a loop registered its own finalize hook or already delivered an answer.

The http_flow_analyze finalize hook now frames the direct answer as an interruption: it lists what was left undone and asks the user how to proceed (reply "继续" to resume, or give a new direction).


<img width="714" height="769" alt="image" src="https://github.com/user-attachments/assets/0631076c-47bb-48a2-a0f0-a2725df53313" />
