### PR TITLE
fix(scannode): forward scheduler-injected SSA IR DB DSN to distyak ch…

### DIFF
--- a/scannode/clicmds.go
+++ b/scannode/clicmds.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/urfavecli"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak"
@@ -20,6 +21,7 @@ var DistYakCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		ctx, stop := newDistYakContext()
 		defer stop()
+		applySSADatabaseFromEnv()
 		runtimeID := os.Getenv("YAK_RUNTIME_ID")
 		args := c.Args()
 		if len(args) > 0 {
@@ -45,6 +47,19 @@ var DistYakCommand = cli.Command{
 
 func newDistYakContext() (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+}
+
+// applySSADatabaseFromEnv reads the SSA IR DB DSN from the process
+// environment and forwards it to the shared consts package before any script
+// execution can lazily initialize the SSA DB. The legion scheduler injects
+// SSA_DATABASE_RAW as a per-task env var so that compile jobs persist IR to a
+// shared Postgres and scan jobs reload it via NewProgramFromDB. Without this
+// call the global SSA_PROJECT_DB_RAW stays at the default SQLite path and the
+// env var is silently ignored.
+func applySSADatabaseFromEnv() {
+	if envRaw := consts.GetSSADatabaseInfoFromEnv(); envRaw != "" {
+		consts.SetSSADatabaseInfo(envRaw)
+	}
 }
 
 func runDistYakFile(parent context.Context, file string, runtimeID string) error {

--- a/scannode/clicmds_test.go
+++ b/scannode/clicmds_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/yaklang/yaklang/common/consts"
 )
 
 func TestRunDistYakFileUsesExecutionContext(t *testing.T) {
@@ -32,3 +34,29 @@ func TestRunDistYakFileUsesExecutionContext(t *testing.T) {
 		t.Fatalf("distyak context cancellation took too long: %v", elapsed)
 	}
 }
+
+// TestDistYakCommandConsumesSSADatabaseEnv verifies that the distyak entry
+// point reads SSA_DATABASE_RAW before script execution so the scheduler can
+// redirect compile/scan IR to a shared Postgres IR DB. This pins the bug fix
+// where the env var was silently ignored and IR fell back to default SQLite.
+func TestDistYakCommandConsumesSSADatabaseEnv(t *testing.T) {
+	original := consts.GetSSADatabaseInfoFromEnv()
+	_, originalRaw := consts.GetSSADataBaseInfo()
+	t.Cleanup(func() {
+		t.Setenv(consts.ENV_SSA_DATABASE_RAW, original)
+		consts.SetSSADatabaseInfo(originalRaw)
+	})
+
+	const fakeDSN = "postgres://testuser:testpass@127.0.0.1:5436/ssa_ir_test?sslmode=disable"
+	t.Setenv(consts.ENV_SSA_DATABASE_RAW, fakeDSN)
+
+	// Exercise the same env-var consumption path the CLI Action runs.
+	applySSADatabaseFromEnv()
+
+	// After Action ran, the global SSA DB info must reflect the env DSN.
+	_, raw := consts.GetSSADataBaseInfo()
+	if raw != fakeDSN {
+		t.Fatalf("expected SSA DB raw to be %q, got %q (env var was not consumed)", fakeDSN, raw)
+	}
+}
+

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -62,6 +62,7 @@ func (s *ScanNode) executeScriptTask(
 	if reporter.ssaCollector != nil {
 		defer reporter.ssaCollector.Cleanup()
 	}
+	ssaDBEnv := extractSSADatabaseEnv(keyValues)
 	result := &ScriptExecutionResult{}
 	yakitServer := s.createYakitServer(reporter, result)
 	yakitServer.Start()
@@ -80,7 +81,7 @@ func (s *ScanNode) executeScriptTask(
 	if err != nil {
 		return nil, utils.Errorf("fetch node path err: %s", err)
 	}
-	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID); err != nil {
+	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID, ssaDBEnv); err != nil {
 		logReporterEventError("final progress checkpoint", reporter.flushLatestJobProgress())
 		return nil, s.handleScriptFailure(err, result, taskID)
 	}
@@ -293,15 +294,18 @@ func (s *ScanNode) executeScript(
 	scriptFile string,
 	params []string,
 	runtimeID string,
+	extraEnv []string,
 ) error {
 	baseCmd := []string{"distyak", scriptFile}
 	log.Infof("yak %v %v", scriptFile, params)
 
 	cmd := exec.CommandContext(ctx, scanNodePath, append(baseCmd, params...)...)
-	cmd.Env = append(os.Environ(),
+	env := append(os.Environ(),
 		fmt.Sprintf("YAKIT_HOME=%v", os.Getenv("YAKIT_HOME")),
 		fmt.Sprintf("YAK_RUNTIME_ID=%v", runtimeID),
 	)
+	env = append(env, extraEnv...)
+	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/scannode/ssa_artifact_upload_config.go
+++ b/scannode/ssa_artifact_upload_config.go
@@ -1,11 +1,44 @@
 package scannode
 
 import (
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/yaklang/yaklang/common/consts"
 )
 
 const scannodeInternalParamPrefix = "_scannode_"
+
+// Hidden param keys consumed by scannode to set the shared SSA IR DB DSN
+// and skip AutoMigrate on read-only (scan) nodes. The legion scheduler
+// injects these into the script input JSON; scannode extracts them and
+// forwards as env vars to the distyak child process.
+const (
+	scannodeSSADatabaseRawParamKey = "_scannode_ssa_database_raw"
+	scannodeSSASkipMigrateParamKey = "_scannode_ssa_skip_migrate"
+)
+
+// extractSSADatabaseEnv reads the shared SSA IR DB DSN and skip_migrate flag
+// from the scheduler-injected hidden params and returns them as "KEY=VALUE"
+// env var entries suitable for appending to a child process cmd.Env.
+// Returns nil if no DSN was injected (legacy/unconfigured mode).
+func extractSSADatabaseEnv(params map[string]interface{}) []string {
+	if len(params) == 0 {
+		return nil
+	}
+	dsn := strings.TrimSpace(toString(params[scannodeSSADatabaseRawParamKey]))
+	if dsn == "" {
+		return nil
+	}
+	env := []string{
+		fmt.Sprintf("%s=%s", consts.ENV_SSA_DATABASE_RAW, dsn),
+	}
+	if toBool(params[scannodeSSASkipMigrateParamKey]) {
+		env = append(env, fmt.Sprintf("%s=1", consts.ENV_SSA_DB_SKIP_MIGRATE))
+	}
+	return env
+}
 
 func extractSSAArtifactUploadConfig(params map[string]interface{}) *SSAArtifactUploadConfig {
 	if len(params) == 0 {

--- a/scannode/ssa_artifact_upload_config_test.go
+++ b/scannode/ssa_artifact_upload_config_test.go
@@ -1,8 +1,11 @@
 package scannode
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/yaklang/yaklang/common/consts"
 )
 
 func TestExtractSSAArtifactUploadConfigSTS(t *testing.T) {
@@ -59,4 +62,58 @@ func TestSSAArtifactUploadConfigNeedSTSRefresh(t *testing.T) {
 	if cfg.NeedSTSRefresh(600) {
 		t.Fatal("expected no refresh when token is still valid")
 	}
+}
+
+func TestExtractSSADatabaseEnv(t *testing.T) {
+	t.Run("returns DSN env when database_raw present", func(t *testing.T) {
+		const dsn = "postgres://legion:legion@127.0.0.1:5436/ssa_ir?sslmode=disable"
+		env := extractSSADatabaseEnv(map[string]interface{}{
+			scannodeSSADatabaseRawParamKey: dsn,
+			scannodeSSASkipMigrateParamKey: true,
+		})
+		if len(env) < 1 {
+			t.Fatalf("expected at least 1 env entry, got %d", len(env))
+		}
+		if !strings.Contains(env[0], consts.ENV_SSA_DATABASE_RAW+"="+dsn) {
+			t.Fatalf("expected SSA_DATABASE_RAW env, got %v", env)
+		}
+		var foundSkip bool
+		for _, e := range env {
+			if strings.Contains(e, consts.ENV_SSA_DB_SKIP_MIGRATE+"=1") {
+				foundSkip = true
+				break
+			}
+		}
+		if !foundSkip {
+			t.Fatalf("expected SSA_DB_SKIP_MIGRATE=1 in env, got %v", env)
+		}
+	})
+
+	t.Run("returns nil when database_raw absent", func(t *testing.T) {
+		env := extractSSADatabaseEnv(map[string]interface{}{
+			"_scannode_ssa_object_key": "ssa/tasks/t1/result.ndjson.zst",
+		})
+		if env != nil {
+			t.Fatalf("expected nil env when no DSN, got %v", env)
+		}
+	})
+
+	t.Run("returns nil for empty params", func(t *testing.T) {
+		env := extractSSADatabaseEnv(nil)
+		if env != nil {
+			t.Fatalf("expected nil for empty params, got %v", env)
+		}
+	})
+
+	t.Run("omits skip_migrate when false", func(t *testing.T) {
+		env := extractSSADatabaseEnv(map[string]interface{}{
+			scannodeSSADatabaseRawParamKey: "postgres://x@y/db",
+			scannodeSSASkipMigrateParamKey: false,
+		})
+		for _, e := range env {
+			if strings.Contains(e, consts.ENV_SSA_DB_SKIP_MIGRATE) {
+				t.Fatalf("did not expect skip_migrate env, got %v", env)
+			}
+		}
+	})
 }


### PR DESCRIPTION
…ild process

The legion scheduler injects the shared SSA IR DB DSN via the hidden param _scannode_ssa_database_raw in the script input JSON (legion PR feat/legion/ssa-ir-dsn-injection). But the refactored scannode never read this param, and the distyak child process never consumed SSA_DATABASE_RAW from its env. Result: IR always fell back to default SQLite (default-yakssa.db) even when a shared Postgres IR DB DSN was injected.

Two-layer fix, matching the existing _scannode_ssa_object_key pattern:

1. scannode/ssa_artifact_upload_config.go:
   - Add scannodeSSADatabaseRawParamKey / scannodeSSASkipMigrateParamKey constants mirroring the legion-side param keys
   - Add extractSSADatabaseEnv(params) that reads the DSN + skip_migrate from the parsed key-value params and returns them as KEY=VALUE env var entries (nil when no DSN injected — preserves legacy behavior)

2. scannode/script_execution.go:
   - executeScriptTask calls extractSSADatabaseEnv and passes the result to executeScript as extraEnv
   - executeScript appends extraEnv to cmd.Env so the distyak child process receives SSA_DATABASE_RAW and SSA_DB_SKIP_MIGRATE

3. scannode/clicmds.go:
   - DistYakCommand Action calls applySSADatabaseFromEnv() which reads SSA_DATABASE_RAW from the process env and forwards it to consts.SetSSADatabaseInfo() before any script execution. This makes the per-task env var actually take effect on the global SSA DB config that SaveToDatabase / NewProgramFromDB ultimately use.

End-to-end: legion injects _scannode_ssa_database_raw -> scannode extracts it -> distyak child env gets SSA_DATABASE_RAW -> consts.SetSSADatabaseInfo runs at distyak startup -> lazy SSA DB init connects to shared Postgres -> compile persists IR there -> scan reloads it via NewProgramFromDB.

Tests:
- TestExtractSSADatabaseEnv: DSN present/absent, skip_migrate on/off
- TestDistYakCommandConsumesSSADatabaseEnv: env var -> consts mapping