### PR TITLE
fix(scannode): emit AISessionFailed when ReAct task aborts on empty r…

### DIFF
--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -192,6 +192,11 @@ func (e *AIEngine) SendMsg(input string, options ...AIEngineConfigOption) error 
 	return nil
 }
 
+// ErrAITaskAborted is returned by WaitTaskFinishByTaskName when the waited
+// ReAct task terminated in the Aborted state, so callers can distinguish an
+// abnormal termination from a successful completion.
+var ErrAITaskAborted = utils.Error("ai task aborted")
+
 // WaitTaskFinishByTaskName 等待指定任务完成
 // 传入任务ID，等待该任务状态变为 Completed 或 Aborted
 func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
@@ -204,7 +209,7 @@ func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 	status, exists := e.activeTasks[taskID]
 	if exists && (status == aicommon.AITaskState_Completed || status == aicommon.AITaskState_Aborted) {
 		e.tasksMutex.RUnlock()
-		return nil
+		return waitTaskFinishByTaskNameResult(status)
 	}
 	e.tasksMutex.RUnlock()
 
@@ -220,7 +225,36 @@ func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 
 	// 等待任务完成
 	taskEndpoint.WaitContext(e.ctx)
-	return e.ctx.Err()
+
+	// 引擎上下文取消优先报告，使调用方能区分"整体关闭"与"任务自身终止"。
+	if err := e.ctx.Err(); err != nil {
+		return err
+	}
+
+	// 唤醒后必须重新读取最新状态：任务可能在 fast-path 检查之后才被写入
+	// activeTasks，随后翻成终态并 release endpoint。复用进入等待前捕获的
+	// status/exists 会读到过时的非终态值，把成功完成的任务误判为失败。
+	e.tasksMutex.RLock()
+	finalStatus, finalExists := e.activeTasks[taskID]
+	e.tasksMutex.RUnlock()
+	if !finalExists {
+		// 任务条目缺失：未经过 react_task_* 事件序列即结束，视为成功。
+		return nil
+	}
+	return waitTaskFinishByTaskNameResult(finalStatus)
+}
+
+// waitTaskFinishByTaskNameResult 将终态映射为返回值：Completed -> nil，
+// Aborted -> ErrAITaskAborted，非终态（防御性，正常不应发生）-> error。
+func waitTaskFinishByTaskNameResult(status aicommon.AITaskState) error {
+	switch status {
+	case aicommon.AITaskState_Completed:
+		return nil
+	case aicommon.AITaskState_Aborted:
+		return ErrAITaskAborted
+	default:
+		return utils.Errorf("ai task ended in non-terminal state: %s", status)
+	}
 }
 
 // WaitTaskFinish 等待所有任务完成

--- a/common/aiengine/aiengine_terminate_test.go
+++ b/common/aiengine/aiengine_terminate_test.go
@@ -1,0 +1,123 @@
+package aiengine
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+)
+
+// newEngineForTerminalTest builds a minimal AIEngine with its task state maps
+// initialized and a live context, so the terminal-state mapping of
+// WaitTaskFinishByTaskName can be driven without spinning up a ReAct loop.
+func newEngineForTerminalTest(t *testing.T) *AIEngine {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &AIEngine{
+		ctx:           ctx,
+		cancel:        cancel,
+		activeTasks:   make(map[string]aicommon.AITaskState),
+		taskEndpoints: make(map[string]*aicommon.Endpoint),
+	}
+}
+
+// TestWaitTaskFinishByTaskNameFastPath verifies the fast-path terminal-state
+// mapping: a task already in a terminal state returns immediately without
+// blocking, with the state mapped to the correct return value.
+func TestWaitTaskFinishByTaskNameFastPath(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	e.activeTasks["task-aborted"] = aicommon.AITaskState_Aborted
+
+	cases := []struct {
+		name    string
+		taskID  string
+		wantErr error // nil means expect a non-nil error (guards), only checked when set
+	}{
+		{"aborted returns ErrAITaskAborted", "task-aborted", ErrAITaskAborted},
+		{"empty taskID errors", "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := e.WaitTaskFinishByTaskName(tc.taskID)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestWaitTaskFinishByTaskNameAbortedReleasesEndpoint verifies that when the
+// endpoint is created and the task is then flipped to Aborted (which calls
+// Release()), WaitTaskFinishByTaskName unblocks and returns ErrAITaskAborted.
+// This mirrors the real runtime: the waiter blocks, the status-changed event
+// releases the endpoint, then we read the final state fresh.
+func TestWaitTaskFinishByTaskNameAbortedReleasesEndpoint(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	taskID := "task-late-abort"
+	e.activeTasks[taskID] = aicommon.AITaskState_Processing
+
+	// Pre-create the endpoint so the waiter does not race with creation.
+	epm := aicommon.NewEndpointManagerContext(e.ctx)
+	endpoint := epm.CreateEndpoint()
+	e.taskEndpoints[taskID] = endpoint
+
+	errCh := make(chan error, 1)
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		errCh <- e.WaitTaskFinishByTaskName(taskID)
+	}()
+	<-ready
+	time.Sleep(20 * time.Millisecond) // let the goroutine enter WaitContext
+
+	// Flip to Aborted and release, mimicking the status-changed handler.
+	e.tasksMutex.Lock()
+	e.activeTasks[taskID] = aicommon.AITaskState_Aborted
+	e.tasksMutex.Unlock()
+	endpoint.Release()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrAITaskAborted) {
+			t.Fatalf("expected ErrAITaskAborted after late abort, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not unblock after endpoint release")
+	}
+}
+
+// TestWaitTaskFinishByTaskNameContextCancelledPrecedence verifies that a
+// cancelled engine context is reported in preference to the task state, so
+// callers can distinguish "engine torn down" from "task aborted on its own".
+func TestWaitTaskFinishByTaskNameContextCancelledPrecedence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	e := &AIEngine{
+		ctx:           ctx,
+		cancel:        cancel,
+		activeTasks:   map[string]aicommon.AITaskState{"task-x": aicommon.AITaskState_Processing},
+		taskEndpoints: make(map[string]*aicommon.Endpoint),
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- e.WaitTaskFinishByTaskName("task-x") }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not unblock after context cancel")
+	}
+}

--- a/scannode/legion_ai_runtime_yak.go
+++ b/scannode/legion_ai_runtime_yak.go
@@ -3,6 +3,7 @@ package scannode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -163,13 +164,23 @@ func (h *yakAIEngineRuntimeHandle) sendMessage(ctx context.Context, content stri
 
 	if err := h.engine.SendMsg(content, options...); err != nil {
 		if ctx.Err() != nil {
+			// 上下文已取消（关闭/关停），不报失败事件。
 			return
 		}
-		detail := mustJSON(map[string]string{
+		// 任务异常终止时上报失败事件，使绑定任务能即时收敛。
+		h.emitter.Failed(yakAISendFailureCode(err), err.Error(), mustJSON(map[string]string{
 			"runtime": "yak_ai_engine",
-		})
-		h.emitter.Failed("yak_ai_send_failed", err.Error(), detail)
+		}))
 	}
+}
+
+// yakAISendFailureCode 将 SendMsg 错误映射为失败事件错误码：任务中止用
+// yak_ai_task_aborted，其他发送/传输失败用 yak_ai_send_failed。
+func yakAISendFailureCode(err error) string {
+	if errors.Is(err, aiengine.ErrAITaskAborted) {
+		return "yak_ai_task_aborted"
+	}
+	return "yak_ai_send_failed"
 }
 
 type yakRuntimeOptions struct {

--- a/scannode/legion_ai_runtime_yak_terminal_test.go
+++ b/scannode/legion_ai_runtime_yak_terminal_test.go
@@ -1,0 +1,83 @@
+package scannode
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/aiengine"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// TestYakAISendFailureCode verifies the breakpoint A-2 mapping: a ReAct task
+// that terminated in the Aborted state (surfaced by aiengine as
+// ErrAITaskAborted, e.g. the loop ended on an empty provider response) is
+// reported to the platform with the distinct "yak_ai_task_aborted" code, while
+// genuine send/transport failures keep the generic "yak_ai_send_failed" code.
+//
+// The scan node previously swallowed Aborted (SendMsg returned nil) and never
+// emitted an AISessionFailed event, so the platform had to fall back to the
+// 15-minute timeout sweeper to converge the session. With the aiengine fix
+// (ErrAITaskAborted) plus this mapping, the failure is now reported promptly
+// with a code that lets consumers distinguish aborts from transport errors.
+func TestYakAISendFailureCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "aborted task surfaces distinct code",
+			err:  aiengine.ErrAITaskAborted,
+			want: "yak_ai_task_aborted",
+		},
+		{
+			name: "wrapped aborted task still classified as abort",
+			err:  errors.New("react loop failed: " + aiengine.ErrAITaskAborted.Error()),
+			// errors.Is unwraps; a plain wrap via fmt.Errorf("%w", ...) would match.
+			// Here we pass a sentinel that matches via errors.Is when wrapped with %w.
+			want: "yak_ai_send_failed", // not wrapped with %w, so not matched
+		},
+		{
+			name: "generic send failure keeps generic code",
+			err:  utils.Error("failed to send input event: connection reset"),
+			want: "yak_ai_send_failed",
+		},
+		{
+			name: "nil-adjacent plain error keeps generic code",
+			err:  errors.New("some other failure"),
+			want: "yak_ai_send_failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := yakAISendFailureCode(tc.err)
+			if got != tc.want {
+				t.Fatalf("yakAISendFailureCode(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestYakAISendFailureCodeWrappedAbort confirms that a properly wrapped
+// (%w) ErrAITaskAborted is still classified as an abort.
+func TestYakAISendFailureCodeWrappedAbort(t *testing.T) {
+	t.Parallel()
+	wrapped := errors.New("react loop ended: empty response")
+	combined := combinedAbortErr{inner: aiengine.ErrAITaskAborted, msg: wrapped.Error()}
+	if got := yakAISendFailureCode(combined); got != "yak_ai_task_aborted" {
+		t.Fatalf("wrapped abort classified as %q, want yak_ai_task_aborted", got)
+	}
+}
+
+type combinedAbortErr struct {
+	inner error
+	msg   string
+}
+
+func (e combinedAbortErr) Error() string { return e.msg }
+func (e combinedAbortErr) Is(target error) bool {
+	return target == e.inner || errors.Is(e.inner, target)
+}


### PR DESCRIPTION
…esponse

When a scan node AI session's ReAct loop terminated abnormally (e.g. the loop ended on an empty provider response), the node never published an AISessionFailed event: aiengine's WaitTaskFinishByTaskName returned e.ctx.Err() (nil while the engine context was alive), discarding the Aborted state, so SendMsg returned nil and sendMessage skipped the emitter.Failed branch. The platform projector therefore received no terminal event and the bound MCP task stayed running until the 15-minute timeout sweeper reaped it — leaving the frontend placeholder spinning.

This commit fixes both halves of breakpoint A on the scannode baseline:

1. common/aiengine/aiengine.go: WaitTaskFinishByTaskName now reads the final task state fresh from activeTasks after the endpoint releases (instead of returning e.ctx.Err() / a stale captured status) and maps it: Completed -> nil, Aborted -> ErrAITaskAborted, ctx error reported first. This mirrors the origin/main fix; the scannode baseline shares the same aiengine.go source so the same change applies here so the branch is self-contained and verifiable.

2. scannode/legion_ai_runtime_yak.go: sendMessage now maps SendMsg errors to an AISessionFailed error code (yak_ai_task_aborted for ErrAITaskAborted, yak_ai_send_failed otherwise) and emits emitter.Failed, so the platform projector (with its SessionTerminalHook) converges the bound MCP task immediately. Context cancellation still suppresses the event (platform drives terminal state via the close command path).

Tests:
- common/aiengine/aiengine_terminate_test.go: aborted/completed, endpoint release after late abort, context-cancel precedence, empty taskID.
- scannode/legion_ai_runtime_yak_terminal_test.go: yakAISendFailureCode classification (abort vs transport error, wrapped abort).