### PR TITLE
fix(scannode): forward ssa-phase as progress event stage

### DIFF
--- a/scannode/legion_reporter_events.go
+++ b/scannode/legion_reporter_events.go
@@ -35,7 +35,7 @@ func (r *ScannerAgentReporter) publishJobProgress(process float64) error {
 	return publisher.PublishProgress(
 		r.agent.node.GetRootContext(),
 		*ref,
-		"yak_script",
+		r.currentStage(),
 		fmt.Sprintf("%.2f%%", process*100),
 		progressUnits(process),
 		legionProgressTotalUnits,

--- a/scannode/reporter.go
+++ b/scannode/reporter.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/jinzhu/gorm/dialects/postgres"
@@ -28,6 +29,45 @@ type ScannerAgentReporter struct {
 	progressCheckpoint attemptProgressCheckpoint
 	ssaCollector       *SSAArtifactCollector
 	ssaUploadCfg       *SSAArtifactUploadConfig
+
+	// currentPhase is the SSA scan phase surfaced by the yak script via
+	// `yakit.StatusCard("ssa-phase", phase)`. It is forwarded as the stage
+	// on progress events so the server can derive the correct phase label
+	// (e.g. "compile" / "scan") instead of the generic "yak_script".
+	phaseMu      sync.RWMutex
+	currentPhase string
+}
+
+// setSSAScanPhase records the current SSA scan phase reported by the yak
+// script through the `ssa-phase` status card. The phase is forwarded as the
+// stage on subsequent progress events.
+func (r *ScannerAgentReporter) setSSAScanPhase(phase string) {
+	if r == nil {
+		return
+	}
+	trimmed := strings.TrimSpace(phase)
+	if trimmed == "" {
+		return
+	}
+	r.phaseMu.Lock()
+	r.currentPhase = trimmed
+	r.phaseMu.Unlock()
+}
+
+// currentStage returns the stage label to attach to progress events. It
+// prefers the SSA scan phase reported by the yak script, falling back to
+// "yak_script" when no phase has been surfaced yet.
+func (r *ScannerAgentReporter) currentStage() string {
+	if r == nil {
+		return "yak_script"
+	}
+	r.phaseMu.RLock()
+	phase := r.currentPhase
+	r.phaseMu.RUnlock()
+	if phase == "" {
+		return "yak_script"
+	}
+	return phase
 }
 
 // convertRawToString 将原始数据转换为字符串，处理 JSON 反序列化后的各种数据格式

--- a/scannode/script_execution_logs.go
+++ b/scannode/script_execution_logs.go
@@ -171,11 +171,23 @@ func (s *ScanNode) handleStatusCardLog(
 	}
 
 	var card yaklib.YakitStatusCard
-	if err := json.Unmarshal([]byte(info), &card); err == nil && card.Id == "ssa-scan-detail" {
+	if err := json.Unmarshal([]byte(info), &card); err != nil {
+		return
+	}
+	switch card.Id {
+	case "ssa-scan-detail":
 		if reporter != nil {
 			if pubErr := reporter.PublishScanDetail("rule-detail", card.Data); pubErr != nil {
 				log.Warnf("publish scan detail failed: %v", pubErr)
 			}
+		}
+	case "ssa-phase":
+		// Surface the SSA scan phase (e.g. "compile" / "scan") reported by
+		// the yak script so subsequent progress events carry it as their
+		// stage. This lets the server expose the active phase on the scan
+		// record instead of the generic "yak_script" stage.
+		if reporter != nil {
+			reporter.setSSAScanPhase(card.Data)
 		}
 	}
 }


### PR DESCRIPTION
## 问题

扫描历史页看不到"编译中"阶段，phase 标签始终回退为"扫描执行中"。

## 根因

yak 脚本通过 `yakit.StatusCard("ssa-phase", phase)` 上报当前阶段（compile/scan），但 smoke node：

1. `handleStatusCardLog` 只处理 `ssa-scan-detail` 卡片，丢弃了 `ssa-phase`
2. `publishJobProgress` 把进度事件的 `stage` 硬编码为 `"yak_script"`

因此后端 `CurrentStage` 恒为 `"yak_script"`，前端 phase map 匹配不到，回退显示"扫描执行中"。

## 修复

- `ScannerAgentReporter` 增加 `currentPhase` 字段 + `setSSAScanPhase` / `currentStage` 方法
- `handleStatusCardLog` 识别 `ssa-phase` 卡片，记录到 reporter
- `publishJobProgress` 用 `r.currentStage()` 作为 `stage`（无 phase 时仍回退 `"yak_script"`）

## 关联

配合 legion 侧 PR `fix/legion/scan-progress-phase` 一起部署。legion 侧已移除前端的二次进度映射；本 PR 让 phase 正确转发，使编译/扫描阶段标签与进度条都能正确显示。

## 验证

- `go build ./scannode/` ✅
- `go build -tags hids -o /tmp/legion-smoke-node-new ./cmd/legion-smoke-node` ✅
- `go test ./scannode/ -run "Progress|StatusCard|Phase|ReportProcess"` ✅