### PR TITLE
feat(ollama): support API Key auth and Ollama reasoning field fallback

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -556,6 +556,7 @@ jobs:
                 {"package": "./common/ai/rag/ragtests/...", "timeout": "1m", "run": "^TestMUSTPASS.*$"},
                 {"package": "./common/ai/tests/...", "timeout": "2m", "parallel": 1},
                 {"package": "./common/ai/aispec/...", "timeout": "60s", "parallel": 1},
+                {"package": "./common/ai/ollama/...", "timeout": "60s", "parallel": 1},
                 {"package": "./common/aireducer/...", "timeout": "60s", "parallel": 1},
                 {"package": "./common/aiforge/aibp", "timeout": "2m30s", "parallel": 1, "run": "^(TestBuildForgeFromYak|TestNewForgeExecutor)$"},
                 {"package": "./common/aiforge", "timeout": "3m", "parallel": 1},

--- a/common/ai/aispec/stream.go
+++ b/common/ai/aispec/stream.go
@@ -318,10 +318,13 @@ func processAIResponse(r []byte, closer io.ReadCloser, outWriter io.Writer, reas
 					if key != "message" {
 						return
 					}
-					result := utils.InterfaceToGeneralMap(data)
-					reasonContent := utils.InterfaceToString(utils.MapGetString(result, "reasoning_content"))
-					content := utils.InterfaceToString(utils.MapGetString(result, "content"))
-					reasonWriter.Write([]byte(reasonContent))
+				result := utils.InterfaceToGeneralMap(data)
+				reasonContent := utils.InterfaceToString(utils.MapGetString(result, "reasoning_content"))
+				if reasonContent == "" {
+					reasonContent = utils.InterfaceToString(utils.MapGetString(result, "reasoning"))
+				}
+				content := utils.InterfaceToString(utils.MapGetString(result, "content"))
+				reasonWriter.Write([]byte(reasonContent))
 					outWriter.Write([]byte(content))
 					if toolcallRaw, ok := result["tool_calls"]; ok {
 						toolcallList := utils.InterfaceToSliceInterface(toolcallRaw)
@@ -422,6 +425,17 @@ func processAIResponse(r []byte, closer io.ReadCloser, outWriter io.Writer, reas
 					return fmt.Sprint(reason)
 				})
 				reasonDelta = strings.Join(reasonStrs, "")
+				// Ollama 的 /v1/chat/completions 用 "reasoning" 而非 "reasoning_content"
+				if reasonDelta == "" {
+					reasonContent = jsonpath.Find(j, `$..choices[*].delta.reasoning`)
+					reasonStrs = lo.Map(utils.InterfaceToSliceInterface(reasonContent), func(reason any, idx int) string {
+						if utils.IsNil(reason) {
+							return ""
+						}
+						return fmt.Sprint(reason)
+					})
+					reasonDelta = strings.Join(reasonStrs, "")
+				}
 			}
 
 			handled := false

--- a/common/ai/aispec/stream_test.go
+++ b/common/ai/aispec/stream_test.go
@@ -245,3 +245,109 @@ func (r *errAfterReadReader) Read(p []byte) (int, error) {
 }
 
 func (r *errAfterReadReader) Close() error { return nil }
+
+// TestProcessAIResponse_OllamaReasoningField_Stream 验证 Ollama /v1/chat/completions
+// 使用 "reasoning" 字段（而非标准 "reasoning_content"）时，SSE 流式思考内容
+// 能被正确提取到 reasonBuffer。
+func TestProcessAIResponse_OllamaReasoningField_Stream(t *testing.T) {
+	streamData := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"We need"}}]}
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"content":"","reasoning":" to answer"}}]}
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"content":"","reasoning":" 1+1."}}]}
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"content":"2"}}]}
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}
+data: [DONE]`
+
+	mockResponse := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n")
+	mockCloser := io.NopCloser(strings.NewReader(streamData))
+
+	outBuffer := &bytes.Buffer{}
+	reasonBuffer := &bytes.Buffer{}
+
+	err := processAIResponse(mockResponse, mockCloser, outBuffer, reasonBuffer, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if reasonBuffer.String() != "We need to answer 1+1." {
+		t.Errorf("reason mismatch, want %q, got %q", "We need to answer 1+1.", reasonBuffer.String())
+	}
+	if outBuffer.String() != "2" {
+		t.Errorf("content mismatch, want %q, got %q", "2", outBuffer.String())
+	}
+}
+
+// TestProcessAIResponse_OllamaReasoningField_NonStream 验证 Ollama /v1/chat/completions
+// 使用 "reasoning" 字段的非流式 JSON 响应能被正确提取。
+func TestProcessAIResponse_OllamaReasoningField_NonStream(t *testing.T) {
+	nonStreamData := `{"id":"chatcmpl-1","object":"chat.completion","model":"kimi-k2.7-code","choices":[{"index":0,"message":{"role":"assistant","content":"1 + 1 = 2","reasoning":"We need answer simple math. 1+1=2."},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":25,"total_tokens":37}}`
+
+	mockResponse := []byte("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n")
+	mockCloser := io.NopCloser(strings.NewReader(nonStreamData))
+
+	outBuffer := &bytes.Buffer{}
+	reasonBuffer := &bytes.Buffer{}
+
+	err := processAIResponse(mockResponse, mockCloser, outBuffer, reasonBuffer, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if outBuffer.String() != "1 + 1 = 2" {
+		t.Errorf("content mismatch, want %q, got %q", "1 + 1 = 2", outBuffer.String())
+	}
+	if reasonBuffer.String() != "We need answer simple math. 1+1=2." {
+		t.Errorf("reason mismatch, want %q, got %q", "We need answer simple math. 1+1=2.", reasonBuffer.String())
+	}
+}
+
+// TestProcessAIResponse_StandardReasoningContent_StillWorks 确保标准的 reasoning_content
+// 字段（deepseek/kimi API 等）不受 Ollama fallback 影响。
+func TestProcessAIResponse_StandardReasoningContent_StillWorks(t *testing.T) {
+	streamData := `data: {"choices":[{"delta":{"reasoning_content":"standard thinking"}}]}
+data: {"choices":[{"delta":{"content":"answer"}}]}
+data: [DONE]`
+
+	mockResponse := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n")
+	mockCloser := io.NopCloser(strings.NewReader(streamData))
+
+	outBuffer := &bytes.Buffer{}
+	reasonBuffer := &bytes.Buffer{}
+
+	err := processAIResponse(mockResponse, mockCloser, outBuffer, reasonBuffer, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if reasonBuffer.String() != "standard thinking" {
+		t.Errorf("reason mismatch, want %q, got %q", "standard thinking", reasonBuffer.String())
+	}
+	if outBuffer.String() != "answer" {
+		t.Errorf("content mismatch, want %q, got %q", "answer", outBuffer.String())
+	}
+}
+
+// TestProcessAIResponse_ReasoningContentTakesPrecedence 确保当同一响应同时包含
+// reasoning_content 和 reasoning 时，reasoning_content 优先。
+func TestProcessAIResponse_ReasoningContentTakesPrecedence(t *testing.T) {
+	streamData := `data: {"choices":[{"delta":{"reasoning_content":"from reasoning_content","reasoning":"from reasoning"}}]}
+data: {"choices":[{"delta":{"content":"done"}}]}
+data: [DONE]`
+
+	mockResponse := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n")
+	mockCloser := io.NopCloser(strings.NewReader(streamData))
+
+	outBuffer := &bytes.Buffer{}
+	reasonBuffer := &bytes.Buffer{}
+
+	err := processAIResponse(mockResponse, mockCloser, outBuffer, reasonBuffer, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if reasonBuffer.String() != "from reasoning_content" {
+		t.Errorf("reason should prefer reasoning_content, got %q", reasonBuffer.String())
+	}
+	if outBuffer.String() != "done" {
+		t.Errorf("content mismatch, got %q", outBuffer.String())
+	}
+}

--- a/common/ai/ollama/gateway.go
+++ b/common/ai/ollama/gateway.go
@@ -74,6 +74,13 @@ func (g *GatewayClient) LoadOption(opt ...aispec.AIConfigOption) {
 		g.config.Model = "qwen"
 	}
 
+	// Ollama 本地默认走 HTTP；仅当用户显式配置了 domain（如 ollama.com）
+	// 且没有手动设置 NoHttps 时，才走 HTTPS（由 GetBaseURLFromConfig 处理）。
+	// 对于纯本地场景（无 domain / 无 baseURL），强制 NoHttps=true 确保用 HTTP。
+	if config.Domain == "" && config.BaseURL == "" {
+		config.NoHttps = true
+	}
+
 	// 默认使用 OpenAI 兼容 API
 	g.useOpenAIFormat = true
 
@@ -110,11 +117,15 @@ func (g *GatewayClient) LoadOption(opt ...aispec.AIConfigOption) {
 }
 
 func (g *GatewayClient) BuildHTTPOptions() ([]poc.PocConfigOption, error) {
+	headers := map[string]string{
+		"Content-Type": "application/json; charset=UTF-8",
+		"Accept":       "application/json",
+	}
+	if g.config.APIKey != "" {
+		headers["Authorization"] = "Bearer " + g.config.APIKey
+	}
 	opts := []poc.PocConfigOption{
-		poc.WithReplaceAllHttpPacketHeaders(map[string]string{
-			"Content-Type": "application/json; charset=UTF-8",
-			"Accept":       "application/json",
-		}),
+		poc.WithReplaceAllHttpPacketHeaders(headers),
 	}
 	opts = aispec.AppendCustomHeadersToPocOptions(opts, aispec.ExtraHeadersToMap(g.config.Headers))
 	opts = append(opts, poc.WithTimeout(g.config.Timeout))
@@ -138,7 +149,18 @@ func (g *GatewayClient) BuildHTTPOptions() ([]poc.PocConfigOption, error) {
 	return opts, nil
 }
 
+func (g *GatewayClient) isCloudTarget() bool {
+	return strings.Contains(g.targetUrl, "ollama.com")
+}
+
 func (g *GatewayClient) CheckValid() error {
+	if g.isCloudTarget() {
+		if g.config.APIKey == "" {
+			return errors.New("ollama cloud requires an API key")
+		}
+		return nil
+	}
+
 	host, port, err := utils.ParseStringToHostPort(g.targetUrl)
 	if err != nil {
 		return err

--- a/common/ai/ollama/gateway_test.go
+++ b/common/ai/ollama/gateway_test.go
@@ -1,0 +1,122 @@
+package ollama
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aispec"
+)
+
+func TestOllamaLoadOption_LocalDefaultHTTP(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(aispec.WithModel("qwen"))
+
+	assert.Contains(t, g.targetUrl, "http://")
+	assert.Contains(t, g.targetUrl, "127.0.0.1:11434")
+	assert.Contains(t, g.targetUrl, "/v1/chat/completions")
+}
+
+func TestOllamaLoadOption_CloudURL(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(
+		aispec.WithModel("kimi-k2.7-code:cloud"),
+		aispec.WithDomain("ollama.com"),
+		aispec.WithAPIKey("test-key"),
+	)
+
+	assert.True(t, strings.HasPrefix(g.targetUrl, "https://"), "cloud URL should use HTTPS, got: %s", g.targetUrl)
+	assert.Contains(t, g.targetUrl, "ollama.com")
+	assert.Contains(t, g.targetUrl, "/v1/chat/completions")
+}
+
+func TestOllamaLoadOption_ExplicitBaseURL(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(
+		aispec.WithModel("kimi-k2.7-code:cloud"),
+		aispec.WithBaseURL("https://ollama.com/v1/chat/completions"),
+		aispec.WithAPIKey("test-key"),
+	)
+
+	assert.Equal(t, "https://ollama.com/v1/chat/completions", g.targetUrl)
+}
+
+func TestOllamaCheckValid_CloudWithAPIKey(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(
+		aispec.WithModel("kimi-k2.7-code:cloud"),
+		aispec.WithDomain("ollama.com"),
+		aispec.WithAPIKey("test-api-key"),
+	)
+
+	err := g.CheckValid()
+	assert.NoError(t, err)
+}
+
+func TestOllamaCheckValid_CloudWithoutAPIKey(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(
+		aispec.WithModel("kimi-k2.7-code:cloud"),
+		aispec.WithDomain("ollama.com"),
+	)
+
+	err := g.CheckValid()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API key")
+}
+
+func TestOllamaBuildHTTPOptions_WithAPIKey(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(
+		aispec.WithModel("kimi-k2.7-code:cloud"),
+		aispec.WithDomain("ollama.com"),
+		aispec.WithAPIKey("my-secret-key"),
+	)
+
+	assert.Equal(t, "my-secret-key", g.config.APIKey)
+
+	opts, err := g.BuildHTTPOptions()
+	require.NoError(t, err)
+	assert.NotEmpty(t, opts)
+}
+
+func TestOllamaBuildHTTPOptions_WithoutAPIKey(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(aispec.WithModel("qwen"))
+
+	assert.Empty(t, g.config.APIKey)
+
+	opts, err := g.BuildHTTPOptions()
+	require.NoError(t, err)
+	assert.NotEmpty(t, opts)
+}
+
+func TestOllamaIsCloudTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{"cloud domain", "https://ollama.com/v1/chat/completions", true},
+		{"local default", "http://127.0.0.1:11434/v1/chat/completions", false},
+		{"local custom port", "http://localhost:11434/v1/chat/completions", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GatewayClient{targetUrl: tt.url}
+			assert.Equal(t, tt.expected, g.isCloudTarget())
+		})
+	}
+}
+
+func TestOllamaLoadOption_NativeAPI(t *testing.T) {
+	g := &GatewayClient{}
+	g.LoadOption(aispec.WithModel("qwen_native_api"))
+
+	assert.Contains(t, g.targetUrl, "/api/chat")
+	assert.NotContains(t, g.targetUrl, "/v1/chat/completions")
+	assert.Equal(t, "qwen", g.config.Model)
+	assert.False(t, g.useOpenAIFormat)
+}

--- a/common/ai/tests/chatbase_test.go
+++ b/common/ai/tests/chatbase_test.go
@@ -2548,6 +2548,145 @@ func TestChatBase_ResponsesAPI_StreamHandlerWaitsForContinueSignal(t *testing.T)
 	}
 }
 
+// ==================== Ollama Reasoning Format Tests ====================
+
+// mockOllamaReasoningStreamRsp 模拟 Ollama /v1/chat/completions 流式响应
+// Ollama 的思考内容使用 "reasoning" 字段而非标准 "reasoning_content"
+const mockOllamaReasoningStreamRsp = `HTTP/1.1 200 OK
+Connection: close
+Content-Type: text/event-stream
+
+data: {"id":"chatcmpl-ollama-1","object":"chat.completion.chunk","created":1753329315,"model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"Let me think about this..."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ollama-2","object":"chat.completion.chunk","created":1753329316,"model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"content":"","reasoning":" The answer should be 2."},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ollama-3","object":"chat.completion.chunk","created":1753329317,"model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"content":"1 + 1 = 2"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-ollama-4","object":"chat.completion.chunk","created":1753329318,"model":"kimi-k2.7-code","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}
+
+data: [DONE]
+`
+
+// mockOllamaReasoningNonStreamRsp 模拟 Ollama /v1/chat/completions 非流式响应
+const mockOllamaReasoningNonStreamRsp = `HTTP/1.1 200 OK
+Connection: close
+Content-Type: application/json; charset=utf-8
+
+{
+  "id": "chatcmpl-ollama-nonstream",
+  "object": "chat.completion",
+  "created": 1753327376,
+  "model": "kimi-k2.7-code",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "1 + 1 = 2",
+        "reasoning": "The user is asking a simple arithmetic question. 1 + 1 equals 2."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": { "prompt_tokens": 10, "completion_tokens": 25, "total_tokens": 35 }
+}
+`
+
+// TestChatBase_OllamaReasoningStream 测试 Ollama 流式响应中 "reasoning" 字段的处理
+func TestChatBase_OllamaReasoningStream(t *testing.T) {
+	host, port := utils.DebugMockHTTP([]byte(mockOllamaReasoningStreamRsp))
+
+	var streamContent strings.Builder
+	var reasonContent strings.Builder
+
+	res, err := aispec.ChatBase(
+		"http://example.com/v1/chat/completions",
+		"kimi-k2.7-code",
+		"1+1=?",
+		aispec.WithChatBase_PoCOptions(func() ([]poc.PocConfigOption, error) {
+			return []poc.PocConfigOption{
+				poc.WithHost(host),
+				poc.WithPort(port),
+				poc.WithForceHTTPS(false),
+				poc.WithTimeout(5),
+			}, nil
+		}),
+		aispec.WithChatBase_StreamHandler(func(reader io.Reader) {
+			data, _ := io.ReadAll(reader)
+			streamContent.Write(data)
+		}),
+		aispec.WithChatBase_ReasonStreamHandler(func(reader io.Reader) {
+			data, _ := io.ReadAll(reader)
+			reasonContent.Write(data)
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "1 + 1 = 2", res, "content should match")
+	assert.Contains(t, reasonContent.String(), "Let me think about this...", "reasoning should be captured from Ollama 'reasoning' field")
+	assert.Contains(t, reasonContent.String(), "The answer should be 2.", "reasoning continuation should be captured")
+	t.Logf("Ollama reasoning stream: content=%q, reason=%q", res, reasonContent.String())
+}
+
+// TestChatBase_OllamaReasoningNonStream 测试 Ollama 非流式响应中 "reasoning" 字段的处理
+func TestChatBase_OllamaReasoningNonStream(t *testing.T) {
+	host, port := utils.DebugMockHTTP([]byte(mockOllamaReasoningNonStreamRsp))
+
+	var reasonContent strings.Builder
+
+	res, err := aispec.ChatBase(
+		"http://example.com/v1/chat/completions",
+		"kimi-k2.7-code",
+		"1+1=?",
+		aispec.WithChatBase_PoCOptions(func() ([]poc.PocConfigOption, error) {
+			return []poc.PocConfigOption{
+				poc.WithHost(host),
+				poc.WithPort(port),
+				poc.WithForceHTTPS(false),
+				poc.WithTimeout(5),
+			}, nil
+		}),
+		aispec.WithChatBase_ReasonStreamHandler(func(reader io.Reader) {
+			data, _ := io.ReadAll(reader)
+			reasonContent.Write(data)
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "1 + 1 = 2", res)
+	assert.Contains(t, reasonContent.String(), "simple arithmetic", "reasoning should be extracted from Ollama 'reasoning' field")
+	t.Logf("Ollama reasoning non-stream: content=%q, reason=%q", res, reasonContent.String())
+}
+
+// TestChatBase_StandardReasoningContentNotBroken 确保标准 reasoning_content 仍然正常工作
+func TestChatBase_StandardReasoningContentNotBroken(t *testing.T) {
+	host, port := utils.DebugMockHTTP([]byte(mockAiReasoningRsp))
+
+	var reasonContent strings.Builder
+
+	res, err := aispec.ChatBase(
+		"http://example.com/v1/chat/completions",
+		"deepseek-r1",
+		"生命的终极答案",
+		aispec.WithChatBase_PoCOptions(func() ([]poc.PocConfigOption, error) {
+			return []poc.PocConfigOption{
+				poc.WithHost(host),
+				poc.WithPort(port),
+				poc.WithForceHTTPS(false),
+				poc.WithTimeout(5),
+			}, nil
+		}),
+		aispec.WithChatBase_ReasonStreamHandler(func(reader io.Reader) {
+			data, _ := io.ReadAll(reader)
+			reasonContent.Write(data)
+		}),
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "基于我的分析，答案是42。", res)
+	assert.Contains(t, reasonContent.String(), "银河系漫游指南")
+}
+
 func TestChatBase_InfersResponsesInterfaceFromURL(t *testing.T) {
 	var capturedRequest []byte
 	host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {


### PR DESCRIPTION
## Summary

- Ollama 客户端支持 API Key 认证（注入 `Authorization: Bearer`），适配云端（ollama.com）调用
- `CheckValid` 区分云端/本地：云端只校验 API Key，本地做 TCP 连通性检查
- 纯本地场景强制 HTTP，避免错误使用 HTTPS
- 修复 `kimi-k2.7-code` 等思考模型经 Ollama `/v1/chat/completions` 返回的 `reasoning` 字段无法被提取的问题（标准 `reasoning_content` 优先，为空时 fallback 到 `reasoning`）

## Changes

- `common/ai/ollama/gateway.go`: BuildHTTPOptions 注入 Bearer / CheckValid 区分云端 / LoadOption 强制本地 HTTP
- `common/ai/aispec/stream.go`: SSE 流式 + 非流式 JSON 中 fallback 提取 `reasoning`
- 新增 mock 与集成测试（aispec / ollama / ai/tests）
- `essential-tests.yml` 增加 `common/ai/ollama/...` 覆盖

## Test plan

- [x] `go test ./common/ai/aispec/...` 全部通过
- [x] `go test ./common/ai/ollama/...` 全部通过
- [x] `go test ./common/ai/tests/...` 全部通过
- [x] Essential Tests CI 通过


Made with [Cursor](https://cursor.com)