### PR TITLE
fix(crep): adapt MITM root cert install for legacy Windows (7/2008R2)

### DIFF
--- a/common/crep/enable_cert_windows.go
+++ b/common/crep/enable_cert_windows.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"unicode/utf8"
 
+	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/privileged"
 	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
+	"golang.org/x/sys/windows"
 )
 
 // AddMITMRootCertIntoSystem 将 MITM 根证书添加到 Windows 系统信任库
@@ -30,16 +32,24 @@ func AddMITMRootCertIntoSystem() error {
 		return utils.Errorf("failed to get MITM root certificate: %v", err)
 	}
 
-	// 创建临时文件保存证书
-	tmpFile := filepath.Join(os.TempDir(), "yaklang-mitm-ca.crt")
+	// 创建临时文件保存证书。
+	// 使用 Yakit 自己管理的基础临时目录而非 os.TempDir()：os.TempDir() 可能
+	// 指向含非 ASCII（如中文用户名）或被自定义过的路径，在中文 Win7 的 GBK
+	// 代码页下，把这些路径写进批处理脚本时会出现 UTF-8/GBK 编码错乱。
+	tmpFile := filepath.Join(consts.GetDefaultYakitBaseTempDir(), "yaklang-mitm-ca.crt")
 	err = os.WriteFile(tmpFile, ca, 0644)
 	if err != nil {
 		return utils.Errorf("failed to write certificate to temp file: %v", err)
 	}
 	defer os.Remove(tmpFile)
 
+	// 将证书路径转换为 8.3 短路径（纯 ASCII），避免批处理脚本里的非 ASCII 路径
+	// 在 cmd 的 OEM 代码页下被错误解码，导致 certutil 找不到证书文件。这是
+	// best-effort：若卷上禁用了 8.3 短文件名生成则回退到原始长路径。
+	certPathForScript := windowsShortPath(tmpFile)
+
 	// 构建安装脚本
-	script := buildWindowsInstallCertScript(tmpFile)
+	script := buildWindowsInstallCertScript(certPathForScript)
 
 	log.Info("installing MITM root certificate into Windows system trust store")
 	output, err := executor.Execute(ctx, script,
@@ -82,9 +92,7 @@ func WithdrawMITMRootCertFromSystem() error {
 // buildWindowsInstallCertScript 构建 Windows 证书安装脚本
 // 使用 certutil 和 PowerShell 来操作证书
 func buildWindowsInstallCertScript(certPath string) string {
-	// Windows 路径需要反斜杠
-	certPath = filepath.ToSlash(certPath)
-
+	// certPath 已是 8.3 短路径（纯 ASCII），保留 Windows 原生反斜杠直接使用。
 	script := fmt.Sprintf(`@echo off
 REM MITM Root Certificate Installation Script for Windows
 setlocal enabledelayedexpansion
@@ -210,4 +218,38 @@ func decodeWindowsConsoleOutput(output []byte) string {
 		return string(output)
 	}
 	return string(decoded)
+}
+
+// windowsShortPath returns the 8.3 short path form of path. Short paths are
+// pure ASCII, which sidesteps the UTF-8/GBK codepage mismatch between Go's
+// UTF-8 file paths and cmd.exe's OEM codepage on localized (e.g. Chinese)
+// Windows 7: non-ASCII bytes embedded in a batch file (user profile dir, temp
+// dir, ...) get mis-decoded by cmd and break certutil.
+//
+// It is best-effort: if 8.3 name generation is disabled on the volume (via
+// fsutil / NtfsDisable8dot3NameCreation) the original long path is returned
+// unchanged. The caller must ensure the path exists, since GetShortPathName
+// resolves an existing path.
+func windowsShortPath(path string) string {
+	if path == "" {
+		return path
+	}
+	long, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return path
+	}
+	n, err := windows.GetShortPathName(long, nil, 0)
+	if err != nil || n == 0 {
+		return path
+	}
+	buf := make([]uint16, n)
+	n, err = windows.GetShortPathName(long, &buf[0], uint32(len(buf)))
+	if err != nil || n == 0 {
+		return path
+	}
+	short := windows.UTF16ToString(buf[:n])
+	if short == "" {
+		return path
+	}
+	return short
 }

--- a/common/crep/legacy_windows_compat_other.go
+++ b/common/crep/legacy_windows_compat_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package crep
+
+// isLegacyWindowsWithoutSHA256RootSupport is always false on non-Windows
+// platforms; the SHA-256 root fallback is a Windows-only concern.
+func isLegacyWindowsWithoutSHA256RootSupport() bool {
+	return false
+}

--- a/common/crep/legacy_windows_compat_windows.go
+++ b/common/crep/legacy_windows_compat_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package crep
+
+import "golang.org/x/sys/windows"
+
+// isLegacyWindowsWithoutSHA256RootSupport reports whether the current Windows
+// version cannot reliably validate SHA-256 signed root certificates in the
+// system trust store.
+//
+// Native SHA-256 root certificate support landed in Windows 8 (NT 6.2).
+// Windows 7 / Server 2008 R2 (NT 6.1) and earlier require KB3033929, which is
+// frequently absent on long-unpatched installs (exactly the old machines this
+// tool tends to run on). On such systems a SHA-256 MITM root installs without
+// error but is silently rejected by browsers/crypto, making MITM unusable. We
+// detect these versions so callers can fall back to a SHA-1 signed root.
+//
+// RtlGetVersion is used instead of GetVersion/GetVersionEx because the latter
+// is manifest-gated and lies on modern Windows; RtlGetVersion reports the true
+// OS version regardless of the calling process's manifest.
+func isLegacyWindowsWithoutSHA256RootSupport() bool {
+	info := windows.RtlGetVersion()
+	if info == nil {
+		// Cannot determine version; assume modern to avoid degrading security.
+		return false
+	}
+	// Anything older than Windows 8 (NT 6.2) lacks native SHA-256 root support.
+	if info.MajorVersion < 6 {
+		return true
+	}
+	if info.MajorVersion == 6 && info.MinorVersion < 2 {
+		return true
+	}
+	return false
+}

--- a/common/crep/mitm.go
+++ b/common/crep/mitm.go
@@ -136,6 +136,28 @@ func GetDefaultMITMCAAndPrivForGM() (*gmx509.Certificate, *sm2.PrivateKey, error
 	return caCert, privKey, nil
 }
 
+// generateDefaultMITMRootCA generates the MITM root CA certificate/key bytes,
+// picking a signature algorithm appropriate for the current OS.
+//
+// On legacy Windows (7 / Server 2008 R2 and older) the system crypto stack
+// cannot reliably validate SHA-256 signed root certificates unless KB3033929 is
+// installed, which is often missing on the old machines this tool runs on. To
+// keep MITM usable there we deliberately downgrade the root signature to SHA-1
+// and log a warning. Everywhere else the modern SHA-256 default is kept.
+//
+// Note: this only governs fresh generation. An already-persisted CA loaded from
+// disk is reused as-is, so existing installs are never silently re-keyed.
+func generateDefaultMITMRootCA() ([]byte, []byte, error) {
+	if isLegacyWindowsWithoutSHA256RootSupport() {
+		log.Warn("detected legacy Windows (7 or older) without reliable SHA-256 root certificate support; generating MITM root CA with SHA-1 signature for compatibility (install KB3033929 to enable stronger hashing)")
+		return tlsutils.GenerateSelfSignedCertKeyWithSignatureAlgorithm(
+			"Yakit MITM Root CA", "Yakit MITM Root CA", "mitmserver",
+			nil, nil, nil, false, x509.SHA1WithRSA,
+		)
+	}
+	return tlsutils.GenerateSelfSignedCertKey("mitmserver", nil, nil)
+}
+
 func InitMITMCert() {
 	defaultCA, _ = ioutil.ReadFile(defaultCAFile)
 	defaultKey, _ = ioutil.ReadFile(defaultKeyFile)
@@ -162,7 +184,7 @@ func InitMITMCert() {
 
 	if defaultCA == nil || defaultKey == nil {
 		var err error
-		defaultCA, defaultKey, err = tlsutils.GenerateSelfSignedCertKey("mitmserver", nil, nil)
+		defaultCA, defaultKey, err = generateDefaultMITMRootCA()
 		if err != nil {
 			log.Errorf("generate default ca/key failed: %s", err)
 			return

--- a/common/utils/tlsutils/sign.go
+++ b/common/utils/tlsutils/sign.go
@@ -22,6 +22,13 @@ type SelfSignConfig struct {
 	AlternativeDNS []string
 	AlternativeIP  []string
 	Org            string
+	// SignatureAlgorithm forces a specific signature algorithm on the generated
+	// certificate. Leave as the zero value (x509.UnknownSignatureAlgorithm) to
+	// let Go pick the default (SHA-256 for RSA keys). Set to x509.SHA1WithRSA to
+	// mint a SHA-1 signed root for legacy Windows (7/2008R2) compatibility, where
+	// the system crypto stack cannot reliably validate SHA-256 roots without
+	// KB3033929.
+	SignatureAlgorithm x509.SignatureAlgorithm
 }
 
 type SelfSignConfigOpt func(*SelfSignConfig)
@@ -58,6 +65,16 @@ func WithSelfSign_Organization(s string) SelfSignConfigOpt {
 func WithSelfSign_EnableAuth(b bool) SelfSignConfigOpt {
 	return func(c *SelfSignConfig) {
 		c.EnableAuth = b
+	}
+}
+
+// WithSelfSign_SignatureAlgorithm forces a specific signature algorithm on the
+// generated certificate. Pass x509.UnknownSignatureAlgorithm (0) to keep the Go
+// default. This is used to emit SHA-1 signed roots for legacy Windows
+// (7/2008R2) compatibility where SHA-256 roots are not validated reliably.
+func WithSelfSign_SignatureAlgorithm(algo x509.SignatureAlgorithm) SelfSignConfigOpt {
+	return func(c *SelfSignConfig) {
+		c.SignatureAlgorithm = algo
 	}
 }
 
@@ -108,7 +125,8 @@ func SelfSignCACertificateAndPrivateKey(common string, opts ...SelfSignConfigOpt
 
 	var notBeforeYear = time.Now().Add(-20 * 24 * time.Hour)
 	template := x509.Certificate{
-		SerialNumber: sid,
+		SerialNumber:       sid,
+		SignatureAlgorithm: config.SignatureAlgorithm,
 		Subject: pkix.Name{
 			Country:            []string{config.Org},
 			Province:           []string{config.Org},

--- a/common/utils/tlsutils/tls.go
+++ b/common/utils/tlsutils/tls.go
@@ -255,6 +255,37 @@ func GenerateSelfSignedCertKeyWithCommonNameEx(commonName, org, host string, alt
 	return SelfSignCACertificateAndPrivateKey(commonName, WithSelfSign_SignTo(hosts...), WithSelfSign_EnableAuth(auth), WithSelfSign_PrivateKey(priv), WithSelfSign_Organization(org))
 }
 
+// GenerateSelfSignedCertKeyWithSignatureAlgorithm is like
+// GenerateSelfSignedCertKeyWithCommonNameEx but forces a specific signature
+// algorithm on the generated self-signed CA certificate. Pass
+// x509.UnknownSignatureAlgorithm (0) to keep the Go default. It exists
+// primarily to mint SHA-1 signed root certificates for legacy Windows
+// versions (7 / Server 2008 R2 and older) that cannot reliably validate
+// SHA-256 roots in the system trust store without KB3033929.
+func GenerateSelfSignedCertKeyWithSignatureAlgorithm(commonName, org, host string, alternateIPs []net.IP, alternateDNS []string, priv *rsa.PrivateKey, auth bool, sigAlgo x509.SignatureAlgorithm) ([]byte, []byte, error) {
+	var hosts []string
+	if host != "" {
+		hosts = append(hosts, host)
+	}
+	for _, i := range alternateDNS {
+		if i != "" {
+			hosts = append(hosts, i)
+		}
+	}
+	for _, i := range alternateIPs {
+		if i != nil {
+			hosts = append(hosts, i.String())
+		}
+	}
+	return SelfSignCACertificateAndPrivateKey(commonName,
+		WithSelfSign_SignTo(hosts...),
+		WithSelfSign_EnableAuth(auth),
+		WithSelfSign_PrivateKey(priv),
+		WithSelfSign_Organization(org),
+		WithSelfSign_SignatureAlgorithm(sigAlgo),
+	)
+}
+
 // SignX509ServerCertAndKey 根据给定的 CA 证书和私钥，生成带客户端认证的服务器证书和密钥
 // 参数:
 //   - ca: PEM 格式的 CA 证书


### PR DESCRIPTION
Two Windows-specific issues broke the MITM root certificate install path on old/Chinese Win7 machines:

1. SHA-256 signed root certificates are not reliably validated by the system crypto stack on Windows 7 / Server 2008 R2 and older without KB3033929 (often missing on the long-unpatched boxes this tool runs on). The root installs without error but is silently rejected, making MITM unusable. Detect NT < 6.2 via RtlGetVersion (manifest-gate-safe) and, only for fresh CA generation on those versions, fall back to a SHA-1 signed root with a warning log. Already-persisted CAs are reused as-is, so existing installs are never silently re-keyed. Added an optional SignatureAlgorithm knob to tlsutils.SelfSignConfig.

2. The cert temp file lived under os.TempDir(), which on Chinese Win7 resolves to a path containing a non-ASCII username. Embedded into the batch script, that UTF-8 path gets mis-decoded by cmd's OEM/GBK codepage and breaks certutil. Move the temp file to Yakit's own base temp dir and convert the path to an 8.3 short path (pure ASCII) via GetShortPathName before injecting it into the script. Also drop a bogus filepath.ToSlash that contradicted its own "need backslashes" comment.