### PR TITLE
ci(essential-tests): fix duplicate test execution in yakgrpc shards

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -265,7 +265,7 @@ jobs:
         run: |
           cat > "${{ runner.temp }}/prepare_yakgrpc_test_config.json" <<'CONFIGEOF'
           [
-            {"package": "./common/yakgrpc/...", "timeout": "10m"}
+            {"package": "./common/yakgrpc/...", "timeout": "10m", "exclude_packages": ["./common/yakgrpc/airaghttp/...", "./common/yakgrpc/aihttp/tests/..."]}
           ]
           CONFIGEOF
 
@@ -730,7 +730,8 @@ jobs:
               [
                 {"package": "./common/yakgrpc/yakit", "timeout": "2m", "run": "^TestMUSTPASS_(UpdateMCPServer|SyncAndCache|McpServerEndpoint|MCPServerToolFullName|MigrateMCPServer|MigrateMCPClientBridge|DeleteMCPServer|MCPServerUserJourney|GetMCPServerToolConfigByFullName).*$"},
                 {"package": "./common/yakgrpc/...", "timeout": "4m", "run": "^TestGRPCMUSTPASS_StartMcpServer_.*$"},
-                {"package": "./common/yakgrpc/...", "timeout": "10m", "skip": "^(TestGRPCMUSTPASS_PluginTrace.*|TestGRPCMUSTPASS_AnalyzeHTTPFlow.*|TestGRPCMUSTPASS_Fingerprint.*|TestGRPCMUSTPASS_HTTP_.*|TestGRPCMUSTPASS_HTTPFUZZER.*|TestGRPCMUSTPASS_HTTPFuzzer.*|TestAITaskWith.*|TestGRPCMUSTPASS_MITM.*|TestGRPCMUSTPASS_MITMV2.*|TestGRPCMUSTPASS_LANGUAGE.*|TestGRPCMUSTPASS_COMMON.*|TestLARGEGRPCMUSTPASS.*|TestGRPCMUSTPASS_SyntaxFlow.*|TestGRPCMUSTPASS_SSA.*|TestGRPCMUSTPASS_FuzzerConfig|TestGRPCMUSTPASS_MaxSize|TestPBTest|TestLargePayload|TestGRPCMUSTPASS_AIForge.*|TestGRPCMUSTPASS_RequestYakURL.*|TestGRPCMUSTPASS_StartMcpServer_.*)$"}
+                {"package": "./common/yakgrpc/yakit", "timeout": "10m", "skip": "^TestMUSTPASS.*$"},
+                {"package": "./common/yakgrpc/...", "timeout": "10m", "exclude_packages": ["./common/yakgrpc/yakit/...", "./common/yakgrpc/airaghttp/...", "./common/yakgrpc/aihttp/tests/..."], "skip": "^(TestGRPCMUSTPASS_PluginTrace.*|TestGRPCMUSTPASS_AnalyzeHTTPFlow.*|TestGRPCMUSTPASS_Fingerprint.*|TestGRPCMUSTPASS_HTTP_.*|TestGRPCMUSTPASS_HTTPFlowSlowSQL|TestGRPCMUSTPASS_HTTPFUZZER.*|TestGRPCMUSTPASS_HTTPFuzzer.*|TestAITaskWith.*|TestGRPCMUSTPASS_MITM.*|TestGRPCMUSTPASS_MITMV2.*|TestGRPCMUSTPASS_LANGUAGE.*|TestGRPCMUSTPASS_COMMON.*|TestGRPCMUSTPASS_HybridScan.*|TestLARGEGRPCMUSTPASS.*|TestGRPCMUSTPASS_SyntaxFlow.*|TestGRPCMUSTPASS_SSA.*|TestGRPCMUSTPASS_FuzzerConfig|TestGRPCMUSTPASS_MaxSize|TestPBTest|TestLargePayload|TestGRPCMUSTPASS_AIForge.*|TestGRPCMUSTPASS_RequestYakURL.*|TestGRPCMUSTPASS_StartMcpServer_.*)$"}
               ]
     steps:
       - name: Checkout


### PR DESCRIPTION
The test-prepared-yakgrpc job's catch-all shard re-ran tests that sibling shards (with `run` filters) already executed, because its manual `skip` regex drifted from the `run` patterns. test-run.sh has no intra-suite dedup, so any skip-list gap silently causes real re-execution.

Three confirmed duplicates, ~60 cases total:

- common/yakgrpc/airaghttp/* (incl. TestE2E_SearchReturnsResults): re-compiled into the prepared suite and re-run by the catch-all, even though test-local already runs them. Exclude the package from both prepare-yakgrpc compile and the catch-all.

- TestGRPCMUSTPASS_HybridScan_* (6): run by the Scan shard, but missing from the catch-all skip list.

- TestGRPCMUSTPASS_HTTPFlowSlowSQL (1): run by the MITMV2/Slow shard; the catch-all's `HTTP_.*` (underscore) never matched `HTTPFlowSlowSQL`.

- yakit TestMUSTPASS_* (~47): covered by the MITM shard (all MUSTPASS) and the Other shard's MCP subset, but the catch-all matched yakgit with no `TestMUSTPASS` skip, running them again. Split the catch-all into a yakit-only rule (skip TestMUSTPASS.*) plus a yakgrpc/... rule that excludes yakit, preserving the 13 non-yakit MUSTPASS tests that rely on the catch-all.