### PR TITLE
fix(yakgrpc): refresh builtin AI provider keys by type in GetApiKeyBy…

### DIFF
--- a/common/yakgrpc/grpc_ai_config.go
+++ b/common/yakgrpc/grpc_ai_config.go
@@ -3,7 +3,6 @@ package yakgrpc
 import (
 	"context"
 	"github.com/yaklang/yaklang/common/consts"
-	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/yak/yaklib"
 
 	"github.com/yaklang/yaklang/common/utils"
@@ -124,23 +123,26 @@ func (s *Server) GetApiKeyByOnline(ctx context.Context, req *ypb.GetApiKeyByOnli
 		return nil, err
 	}
 
-	var (
-		aiThirdPartyConfig schema.AIThirdPartyConfig
-		oldKey             string
-	)
-	err = consts.GetGormProfileDatabase().First(&aiThirdPartyConfig).Error
+	cfg, err := s.GetAIGlobalConfig(ctx, &ypb.Empty{})
 	if err != nil {
-		oldKey = "free-user"
-	} else {
-		oldKey = aiThirdPartyConfig.APIKey
-		aiThirdPartyConfig.APIKey = apiKey
-		if err := consts.GetGormProfileDatabase().Save(&aiThirdPartyConfig).Error; err != nil {
-			return nil, utils.Errorf("update apiKey failed: %v", err)
-		}
+		return nil, err
 	}
-
-	if err := yakit.ReplaceAPIKeys(s.GetProfileDatabase(), oldKey, apiKey); err != nil {
-		return nil, utils.Errorf("ReplaceAPIKeys failed: %v", err)
+	if cfg != nil {
+		for _, models := range [][]*ypb.AIModelConfig{
+			cfg.IntelligentModels,
+			cfg.LightweightModels,
+			cfg.VisionModels,
+		} {
+			for _, model := range models {
+				if yakit.IsBuiltinAIProvider(model) {
+					model.Provider.APIKey = apiKey
+				}
+			}
+		}
+		// SetAIGlobalConfig 会写入并手动 Apply 到运行时缓存
+		if _, err := s.SetAIGlobalConfig(ctx, cfg); err != nil {
+			return nil, utils.Errorf("update AIGlobalConfig failed: %v", err)
+		}
 	}
 
 	return &ypb.GetApiKeyByOnlineResponse{ApiKey: apiKey}, nil

--- a/common/yakgrpc/grpc_ai_config_local_test.go
+++ b/common/yakgrpc/grpc_ai_config_local_test.go
@@ -205,7 +205,7 @@ func TestGetApiKey_ReplaceAPIKeys(t *testing.T) {
 				ModelName: "model-vision",
 				Provider: &ypb.ThirdPartyApplicationConfig{
 					Type:    "aibalance",
-					APIKey:  "not-free-user", // 不会替换
+					APIKey:  "not-free-user", // 同为 aibalance，会被替换为新 onlinekey
 					BaseURL: "https://aibalance.yaklang.com/v1",
 				},
 			},
@@ -247,7 +247,7 @@ func TestGetApiKey_ReplaceAPIKeys(t *testing.T) {
 			assert.Equal(t, newAPIKey, m.Provider.APIKey)
 		}
 		for _, m := range updatedCfg.VisionModels {
-			assert.Equal(t, "not-free-user", m.Provider.APIKey) // 未被替换
+			assert.Equal(t, newAPIKey, m.Provider.APIKey) // aibalance 类型一并被替换为 onlinekey
 		}
 
 	})

--- a/common/yakgrpc/yakit/ai_provider.go
+++ b/common/yakgrpc/yakit/ai_provider.go
@@ -1,9 +1,7 @@
 package yakit
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/yaklang/yaklang/common/consts"
 	"hash/fnv"
 	"math"
 	"sort"
@@ -28,6 +26,21 @@ func DefaultAIBalanceProviderConfig() *ypb.ThirdPartyApplicationConfig {
 		APIKey: aiProviderDefaultAPIKey,
 		Domain: aiProviderDefaultDomain,
 	}
+}
+
+// builtinAIProviderTypes 记录所有内置 AI 服务类型，新增内置服务时只需在此追加。
+var builtinAIProviderTypes = map[string]struct{}{
+	aiProviderTypeAIBalance: {},
+}
+
+// IsBuiltinAIProvider 判断该模型配置是否指向内置 AI 服务（目前仅 aibalance）。
+// 新增内置服务时往 builtinAIProviderTypes 增加对应类型即可，无需改动调用方。
+func IsBuiltinAIProvider(model *ypb.AIModelConfig) bool {
+	if model == nil || model.Provider == nil {
+		return false
+	}
+	_, ok := builtinAIProviderTypes[strings.ToLower(strings.TrimSpace(model.Provider.Type))]
+	return ok
 }
 
 func ListAIProviders(db *gorm.DB) ([]*ypb.AIProvider, error) {
@@ -401,32 +414,4 @@ func providerIDFromHash(hash string) int64 {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(hash))
 	return int64(h.Sum64() & math.MaxInt64)
-}
-
-func ReplaceAPIKeys(db *gorm.DB, oldKey, newKey string) error {
-	cfg, err := GetAIGlobalConfig(db)
-	if err != nil {
-		return err
-	}
-	if cfg == nil {
-		return nil
-	}
-
-	for _, models := range [][]*ypb.AIModelConfig{
-		cfg.IntelligentModels,
-		cfg.LightweightModels,
-		cfg.VisionModels,
-	} {
-		for _, model := range models {
-			if model != nil && model.Provider != nil && model.Provider.APIKey == oldKey {
-				model.Provider.APIKey = newKey
-			}
-		}
-	}
-
-	data, err := json.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-	return SetKey(db, consts.AI_GLOBAL_CONFIG_KEY, string(data))
 }


### PR DESCRIPTION
…Online

GetApiKeyByOnline 之前依赖 oldKey 精确匹配来刷新 provider key, 无法更新那些 key 与旧值不一致的内置服务配置。改为通过
GetAIGlobalConfig 取出全局配置, 筛选所有内置服务(目前为 aibalance)
替换为 onlinekey 后用 SetAIGlobalConfig 写回并手动 Apply。

同时抽取 yakit.IsBuiltinAIProvider 判断内置服务类型, 便于后续扩展。
移除不再使用的 ReplaceAPIKeys 及相关导入。