### PR TITLE
feat(aispec): add Responses subset types and Chat↔Responses converts

### DIFF
--- a/common/ai/aispec/base.go
+++ b/common/ai/aispec/base.go
@@ -936,74 +936,140 @@ func chatBaseResponses(url string, model string, msg string, ctx *ChatBaseContex
 //
 // 字符串 content 渲染成 [{type:"input_text", text:...}]；[]*ChatContent
 // 类型按各自 type 字段分别映射为 input_text / input_image / input_video。
+// assistant.tool_calls → function_call；tool 角色 → function_call_output。
 //
 // 关键词: convertChatDetailsToResponsesInput, ChatDetail 转 responses input
 func convertChatDetailsToResponsesInput(msgs []ChatDetail) []map[string]any {
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		role := m.Role
+		role := strings.ToLower(strings.TrimSpace(m.Role))
 		if role == "" {
 			role = "user"
 		}
-		var content []map[string]any
-		switch v := m.Content.(type) {
-		case string:
-			content = append(content, map[string]any{
-				"type": "input_text",
-				"text": v,
+
+		// tool 结果 → Responses function_call_output
+		if role == "tool" || m.ToolCallID != "" {
+			var output string
+			switch v := m.Content.(type) {
+			case string:
+				output = v
+			case nil:
+				output = ""
+			default:
+				b, _ := json.Marshal(v)
+				output = string(b)
+			}
+			out = append(out, map[string]any{
+				"type":    "function_call_output",
+				"call_id": m.ToolCallID,
+				"output":  output,
 			})
-		case []*ChatContent:
-			for _, c := range v {
-				if c == nil {
+			continue
+		}
+
+		// assistant tool_calls → Responses function_call（可附带文本 message）
+		if len(m.ToolCalls) > 0 {
+			if hasNonEmptyChatContent(m.Content) {
+				out = append(out, buildResponsesMessageItem(role, m))
+			}
+			for _, tc := range m.ToolCalls {
+				if tc == nil {
 					continue
 				}
-				switch c.Type {
-				case "text":
+				out = append(out, map[string]any{
+					"type":      "function_call",
+					"call_id":   tc.ID,
+					"name":      tc.Function.Name,
+					"arguments": tc.Function.Arguments,
+				})
+			}
+			continue
+		}
+
+		out = append(out, buildResponsesMessageItem(role, m))
+	}
+	return out
+}
+
+func hasNonEmptyChatContent(content any) bool {
+	switch v := content.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(v) != ""
+	case []*ChatContent:
+		for _, c := range v {
+			if c == nil {
+				continue
+			}
+			if strings.TrimSpace(c.Text) != "" || c.ImageUrl != nil || c.VideoUrl != nil {
+				return true
+			}
+		}
+		return false
+	default:
+		return strings.TrimSpace(utils.InterfaceToString(v)) != ""
+	}
+}
+
+func buildResponsesMessageItem(role string, m ChatDetail) map[string]any {
+	var content []map[string]any
+	switch v := m.Content.(type) {
+	case string:
+		content = append(content, map[string]any{
+			"type": "input_text",
+			"text": v,
+		})
+	case []*ChatContent:
+		for _, c := range v {
+			if c == nil {
+				continue
+			}
+			switch c.Type {
+			case "text":
+				content = append(content, map[string]any{
+					"type": "input_text",
+					"text": c.Text,
+				})
+			case "image_url":
+				content = append(content, map[string]any{
+					"type":      "input_image",
+					"image_url": c.ImageUrl,
+				})
+			case "video_url":
+				content = append(content, map[string]any{
+					"type":      "input_video",
+					"video_url": c.VideoUrl,
+				})
+			default:
+				if c.Text != "" {
 					content = append(content, map[string]any{
 						"type": "input_text",
 						"text": c.Text,
 					})
-				case "image_url":
-					content = append(content, map[string]any{
-						"type":      "input_image",
-						"image_url": c.ImageUrl,
-					})
-				case "video_url":
-					content = append(content, map[string]any{
-						"type":      "input_video",
-						"video_url": c.VideoUrl,
-					})
-				default:
-					if c.Text != "" {
-						content = append(content, map[string]any{
-							"type": "input_text",
-							"text": c.Text,
-						})
-					}
 				}
 			}
-		default:
-			content = append(content, map[string]any{
-				"type": "input_text",
-				"text": utils.InterfaceToString(m.Content),
-			})
 		}
-		if len(content) == 0 {
-			content = append(content, map[string]any{
-				"type": "input_text",
-				"text": "",
-			})
-		}
-		item := map[string]any{
-			"role":    role,
-			"content": content,
-		}
-		if rc := strings.TrimSpace(m.ReasoningContent); rc != "" {
-			item["reasoning_content"] = rc
-		}
-		out = append(out, item)
+	default:
+		content = append(content, map[string]any{
+			"type": "input_text",
+			"text": utils.InterfaceToString(m.Content),
+		})
 	}
-	return out
+	if len(content) == 0 {
+		content = append(content, map[string]any{
+			"type": "input_text",
+			"text": "",
+		})
+	}
+	item := map[string]any{
+		"role":    role,
+		"content": content,
+	}
+	if rc := strings.TrimSpace(m.ReasoningContent); rc != "" {
+		item["reasoning_content"] = rc
+	}
+	return item
 }
 
 func buildResponsesInput(msg string, images []*ImageDescription) []map[string]any {

--- a/common/ai/aispec/responses.go
+++ b/common/ai/aispec/responses.go
@@ -1,0 +1,26 @@
+package aispec
+
+import "encoding/json"
+
+// ResponsesCreateRequest is the subset of OpenAI Responses API create body
+// that yaklang / aibalance support for Codex and OpenAI-compatible clients.
+// Full OpenAI SDK field surface is intentionally not mirrored.
+// 关键词: ResponsesCreateRequest, Responses 入站 subset, aispec
+type ResponsesCreateRequest struct {
+	Model           string          `json:"model"`
+	Input           json.RawMessage `json:"input"`
+	Stream          bool            `json:"stream"`
+	Tools           []any           `json:"tools,omitempty"`
+	ToolChoice      any             `json:"tool_choice,omitempty"`
+	MaxOutputTokens *int64          `json:"max_output_tokens,omitempty"`
+	Temperature     *float64        `json:"temperature,omitempty"`
+	TopP            *float64        `json:"top_p,omitempty"`
+	Reasoning       *ResponsesReasoning `json:"reasoning,omitempty"`
+	EnableThinking  bool            `json:"enable_thinking,omitempty"`
+}
+
+// ResponsesReasoning is the subset of Responses `reasoning` object.
+// 关键词: ResponsesReasoning
+type ResponsesReasoning struct {
+	Effort string `json:"effort,omitempty"`
+}

--- a/common/ai/aispec/responses_convert.go
+++ b/common/ai/aispec/responses_convert.go
@@ -1,0 +1,273 @@
+package aispec
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// ConvertChatDetailsToResponsesInput exports convertChatDetailsToResponsesInput
+// for gateways (aibalance) that need Chat → Responses request shaping.
+// 关键词: ConvertChatDetailsToResponsesInput, 导出 ChatDetail→responses input
+func ConvertChatDetailsToResponsesInput(msgs []ChatDetail) []map[string]any {
+	return convertChatDetailsToResponsesInput(msgs)
+}
+
+// ConvertToolsToResponses exports convertToolsToResponses.
+// 关键词: ConvertToolsToResponses
+func ConvertToolsToResponses(tools []Tool) []any {
+	return convertToolsToResponses(tools)
+}
+
+// ConvertToolChoiceToResponses exports convertToolChoiceToResponses.
+// 关键词: ConvertToolChoiceToResponses
+func ConvertToolChoiceToResponses(choice any) any {
+	return convertToolChoiceToResponses(choice)
+}
+
+// ConvertResponsesCreateRequestToChatMessage maps a Responses create body
+// (raw JSON) into the internal ChatMessage used by ChatBase / gateways.
+// 关键词: ConvertResponsesCreateRequestToChatMessage, Responses raw→ChatMessage
+func ConvertResponsesCreateRequestToChatMessage(raw []byte) (*ChatMessage, error) {
+	var req ResponsesCreateRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return nil, fmt.Errorf("invalid responses body: %w", err)
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	messages, err := ConvertResponsesInputToChatDetails(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("input is empty")
+	}
+	msg := &ChatMessage{
+		Model:          req.Model,
+		Messages:       messages,
+		Stream:         req.Stream,
+		EnableThinking: req.EnableThinking,
+		MaxTokens:      req.MaxOutputTokens,
+		Temperature:    req.Temperature,
+		TopP:           req.TopP,
+		Tools:          ConvertResponsesToolsToChat(req.Tools),
+		ToolChoice:     ConvertResponsesToolChoiceToChat(req.ToolChoice),
+	}
+	if req.Reasoning != nil && strings.TrimSpace(req.Reasoning.Effort) != "" {
+		msg.ReasoningEffort = strings.TrimSpace(req.Reasoning.Effort)
+	}
+	return msg, nil
+}
+
+// ConvertResponsesInputToChatDetails maps OpenAI Responses `input` (string or
+// item array JSON) into chat-completions style []ChatDetail.
+// Used by aibalance /v1/responses inbound path.
+// 关键词: ConvertResponsesInputToChatDetails, Responses→Chat 入站反向
+func ConvertResponsesInputToChatDetails(input json.RawMessage) ([]ChatDetail, error) {
+	if len(input) == 0 || string(input) == "null" {
+		return nil, fmt.Errorf("input is required")
+	}
+	var asString string
+	if err := json.Unmarshal(input, &asString); err == nil {
+		return []ChatDetail{{
+			Role:    "user",
+			Content: asString,
+		}}, nil
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(input, &items); err != nil {
+		return nil, fmt.Errorf("input must be string or array: %w", err)
+	}
+	out := make([]ChatDetail, 0, len(items))
+	for _, item := range items {
+		detail, ok := convertResponsesInputItemToChatDetail(item)
+		if !ok {
+			continue
+		}
+		out = append(out, detail)
+	}
+	return out, nil
+}
+
+func convertResponsesInputItemToChatDetail(item map[string]any) (ChatDetail, bool) {
+	typ := strings.ToLower(utils.MapGetString(item, "type"))
+	role := strings.ToLower(utils.MapGetString(item, "role"))
+	if typ == "" || typ == "message" {
+		if role == "" {
+			role = "user"
+		}
+		content := item["content"]
+		switch c := content.(type) {
+		case string:
+			return ChatDetail{Role: role, Content: c}, true
+		case nil:
+			return ChatDetail{Role: role, Content: ""}, true
+		default:
+			parts := convertResponsesContentPartsToChat(c)
+			if len(parts) == 1 && parts[0].Type == "text" {
+				return ChatDetail{Role: role, Content: parts[0].Text}, true
+			}
+			if len(parts) == 0 {
+				return ChatDetail{Role: role, Content: utils.InterfaceToString(c)}, true
+			}
+			return ChatDetail{Role: role, Content: parts}, true
+		}
+	}
+	if typ == "function_call" {
+		name := utils.MapGetString(item, "name")
+		callID := utils.MapGetString(item, "call_id")
+		if callID == "" {
+			callID = utils.MapGetString(item, "id")
+		}
+		args := utils.MapGetString(item, "arguments")
+		tc := &ToolCall{
+			Index: 0,
+			ID:    callID,
+			Type:  "function",
+			Function: FuncReturn{
+				Name:      name,
+				Arguments: args,
+			},
+		}
+		return ChatDetail{
+			Role:      "assistant",
+			Content:   "",
+			ToolCalls: []*ToolCall{tc},
+		}, true
+	}
+	if typ == "function_call_output" {
+		callID := utils.MapGetString(item, "call_id")
+		output := item["output"]
+		var content string
+		switch o := output.(type) {
+		case string:
+			content = o
+		default:
+			b, _ := json.Marshal(o)
+			content = string(b)
+		}
+		return ChatDetail{
+			Role:       "tool",
+			Content:    content,
+			ToolCallID: callID,
+		}, true
+	}
+	return ChatDetail{}, false
+}
+
+func convertResponsesContentPartsToChat(content any) []*ChatContent {
+	arr, ok := content.([]any)
+	if !ok {
+		raw, err := json.Marshal(content)
+		if err != nil {
+			return nil
+		}
+		_ = json.Unmarshal(raw, &arr)
+	}
+	parts := make([]*ChatContent, 0, len(arr))
+	for _, el := range arr {
+		m := utils.InterfaceToGeneralMap(el)
+		if m == nil {
+			continue
+		}
+		t := strings.ToLower(utils.MapGetString(m, "type"))
+		switch t {
+		case "input_text", "output_text", "text":
+			parts = append(parts, NewUserChatContentText(utils.MapGetString(m, "text")))
+		case "input_image", "image_url":
+			url := ""
+			if img := utils.MapGetMapRaw(m, "image_url"); img != nil {
+				url = utils.MapGetString(img, "url")
+			}
+			if url == "" {
+				url = utils.MapGetString(m, "image_url")
+			}
+			if url == "" {
+				url = utils.MapGetString(m, "url")
+			}
+			if url != "" {
+				parts = append(parts, NewUserChatContentImageUrl(url))
+			}
+		}
+	}
+	return parts
+}
+
+// ConvertResponsesToolsToChat maps Responses flat tools / nested chat tools
+// into []Tool for Chat Completions style clients.
+// 关键词: ConvertResponsesToolsToChat
+func ConvertResponsesToolsToChat(tools []any) []Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]Tool, 0, len(tools))
+	for _, t := range tools {
+		m := utils.InterfaceToGeneralMap(t)
+		if len(m) == 0 {
+			b, err := json.Marshal(t)
+			if err != nil {
+				continue
+			}
+			var mm map[string]any
+			if json.Unmarshal(b, &mm) != nil || len(mm) == 0 {
+				continue
+			}
+			m = mm
+		}
+		typ := utils.MapGetString(m, "type")
+		if typ == "" {
+			typ = "function"
+		}
+		if name := utils.MapGetString(m, "name"); name != "" {
+			out = append(out, Tool{
+				Type: typ,
+				Function: ToolFunction{
+					Name:        name,
+					Description: utils.MapGetString(m, "description"),
+					Parameters:  m["parameters"],
+				},
+			})
+			continue
+		}
+		if fn := utils.MapGetMapRaw(m, "function"); fn != nil {
+			out = append(out, Tool{
+				Type: typ,
+				Function: ToolFunction{
+					Name:        utils.MapGetString(fn, "name"),
+					Description: utils.MapGetString(fn, "description"),
+					Parameters:  fn["parameters"],
+				},
+			})
+		}
+	}
+	return out
+}
+
+// ConvertResponsesToolChoiceToChat maps Responses tool_choice into chat style.
+// 关键词: ConvertResponsesToolChoiceToChat
+func ConvertResponsesToolChoiceToChat(choice any) any {
+	if choice == nil {
+		return nil
+	}
+	if s, ok := choice.(string); ok {
+		return s
+	}
+	m := utils.InterfaceToGeneralMap(choice)
+	if m == nil {
+		return choice
+	}
+	if utils.MapGetString(m, "type") == "function" {
+		if name := utils.MapGetString(m, "name"); name != "" {
+			return map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": name,
+				},
+			}
+		}
+	}
+	return choice
+}

--- a/common/ai/aispec/responses_convert_test.go
+++ b/common/ai/aispec/responses_convert_test.go
@@ -1,0 +1,84 @@
+package aispec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertResponsesInputToChatDetails_String(t *testing.T) {
+	msgs, err := ConvertResponsesInputToChatDetails(json.RawMessage(`"hello"`))
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "user", msgs[0].Role)
+	assert.Equal(t, "hello", msgs[0].Content)
+}
+
+func TestConvertResponsesInputToChatDetails_RoundTripTools(t *testing.T) {
+	raw := json.RawMessage(`[
+  {"role":"user","content":"hi"},
+  {"type":"function_call","call_id":"c1","name":"fn","arguments":"{}"},
+  {"type":"function_call_output","call_id":"c1","output":"ok"}
+]`)
+	msgs, err := ConvertResponsesInputToChatDetails(raw)
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "assistant", msgs[1].Role)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "fn", msgs[1].ToolCalls[0].Function.Name)
+	assert.Equal(t, "tool", msgs[2].Role)
+
+	// outbound round-trip including tool history
+	out := ConvertChatDetailsToResponsesInput(msgs)
+	require.Len(t, out, 3)
+	assert.Equal(t, "user", out[0]["role"])
+	assert.Equal(t, "function_call", out[1]["type"])
+	assert.Equal(t, "c1", out[1]["call_id"])
+	assert.Equal(t, "fn", out[1]["name"])
+	assert.Equal(t, "function_call_output", out[2]["type"])
+	assert.Equal(t, "ok", out[2]["output"])
+}
+
+func TestConvertResponsesToolsToChat_Flat(t *testing.T) {
+	tools := ConvertResponsesToolsToChat([]any{
+		map[string]any{
+			"type":        "function",
+			"name":        "get_weather",
+			"description": "d",
+			"parameters":   map[string]any{"type": "object"},
+		},
+	})
+	require.Len(t, tools, 1)
+	assert.Equal(t, "get_weather", tools[0].Function.Name)
+}
+
+func TestConvertResponsesCreateRequestToChatMessage(t *testing.T) {
+	raw := []byte(`{
+  "model":"m",
+  "input":"hello",
+  "stream":true,
+  "max_output_tokens":128,
+  "reasoning":{"effort":"medium"},
+  "tools":[{"type":"function","name":"fn","parameters":{"type":"object"}}],
+  "tool_choice":{"type":"function","name":"fn"}
+}`)
+	msg, err := ConvertResponsesCreateRequestToChatMessage(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "m", msg.Model)
+	assert.True(t, msg.Stream)
+	require.NotNil(t, msg.MaxTokens)
+	assert.EqualValues(t, 128, *msg.MaxTokens)
+	assert.Equal(t, "medium", msg.ReasoningEffort)
+	require.Len(t, msg.Messages, 1)
+	require.Len(t, msg.Tools, 1)
+	assert.Equal(t, "fn", msg.Tools[0].Function.Name)
+}
+
+func TestConvertResponsesCreateRequestToChatMessage_RequiresModelAndInput(t *testing.T) {
+	_, err := ConvertResponsesCreateRequestToChatMessage([]byte(`{"input":"x"}`))
+	assert.Error(t, err)
+	_, err = ConvertResponsesCreateRequestToChatMessage([]byte(`{"model":"m"}`))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Expose ResponsesCreateRequest plus raw→ChatMessage and bidirectional input/tool converts so gateways can share one protocol adapter with ChatBase, including tool-call history on Chat→Responses.