### PR TITLE
fix(cybertunnel): improve error handling in HoldingCreateTunnelClient…

### DIFF
--- a/common/cybertunnel/client_tunnel.go
+++ b/common/cybertunnel/client_tunnel.go
@@ -198,6 +198,7 @@ func HoldingCreateTunnelClient(
 
 	go func() {
 		defer func() {
+			cancel()
 			if err := recover(); err != nil {
 				log.Errorf(
 					"panic from main loop mirror tunnel: %s => %v, reason: %s",
@@ -210,7 +211,12 @@ func HoldingCreateTunnelClient(
 		for {
 			output, err := client.Recv()
 			if err != nil {
-				panic(err)
+				log.Errorf(
+					"recv from mirror tunnel failed: %s => %v, reason: %s",
+					fmt.Sprintf("%v - %v", id, utils.HostPort(localhost, localport)),
+					remoteport, err,
+				)
+				return
 			}
 			dispatchOutput(
 				ctx, output, idToLocalHost[output.GetFromId()], idToLocalPort[output.GetFromId()],

--- a/common/cybertunnel/server_create_tunnel.go
+++ b/common/cybertunnel/server_create_tunnel.go
@@ -31,6 +31,51 @@ type connectionDesc struct {
 	Reader     chan *tpb.TunnelInput
 }
 
+func dispatchTunnelInputToTCPConnection(ctx context.Context, desc *tunnelDesc, rsp *tpb.TunnelInput) (handled bool) {
+	if desc == nil || desc.Connections == nil || rsp == nil {
+		return false
+	}
+
+	remoteAddr := rsp.GetToRemoteAddr()
+	connRaw, ok := desc.Connections.Load(remoteAddr)
+	if !ok {
+		return false
+	}
+
+	conn, ok := connRaw.(*connectionDesc)
+	if !ok || conn == nil {
+		desc.Connections.Delete(remoteAddr)
+		return false
+	}
+
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warnf("drop tunnel input for closed tcp conn %s: %v", remoteAddr, err)
+			if conn.Connection != nil {
+				_ = conn.Connection.Close()
+			}
+			desc.Connections.Delete(remoteAddr)
+			handled = false
+		}
+	}()
+
+	if rsp.GetClose() {
+		close(conn.Reader)
+		if conn.Connection != nil {
+			_ = conn.Connection.Close()
+		}
+		desc.Connections.Delete(remoteAddr)
+		return true
+	}
+
+	select {
+	case conn.Reader <- rsp:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 func (t *tunnelDesc) Close() {
 	if t.Listener != nil {
 		t.Listener.Close()
@@ -168,22 +213,7 @@ func (s *TunnelServer) CreateTunnel(server tpb.Tunnel_CreateTunnelServer) error 
 
 			switch desc.Network {
 			case "tcp":
-				connRaw, ok := desc.Connections.Load(rsp.GetToRemoteAddr())
-				if !ok {
-					continue
-				}
-				conn := connRaw.(*connectionDesc)
-
-				if rsp.GetClose() {
-					close(conn.Reader)
-					conn.Connection.Close()
-					desc.Connections.Delete(rsp.GetToRemoteAddr())
-					continue
-				}
-
-				select {
-				case conn.Reader <- rsp:
-				case <-server.Context().Done():
+				if !dispatchTunnelInputToTCPConnection(server.Context(), desc, rsp) && server.Context().Err() != nil {
 					return
 				}
 			case "udp":

--- a/common/cybertunnel/server_create_tunnel_test.go
+++ b/common/cybertunnel/server_create_tunnel_test.go
@@ -1,0 +1,118 @@
+package cybertunnel
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/cybertunnel/tpb"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestMUSTPASS_DispatchTunnelInputSkipsClosedReaderAndKeepsTunnelAlive(t *testing.T) {
+	desc := &tunnelDesc{
+		Network:     "tcp",
+		Connections: new(sync.Map),
+	}
+
+	closedLocal, closedPeer := net.Pipe()
+	defer closedPeer.Close()
+	closedReader := make(chan *tpb.TunnelInput)
+	close(closedReader)
+	desc.Connections.Store("closed-remote", &connectionDesc{
+		Connection: closedLocal,
+		RemoteAddr: "closed-remote",
+		Reader:     closedReader,
+	})
+
+	if dispatchTunnelInputToTCPConnection(context.Background(), desc, &tpb.TunnelInput{
+		ToRemoteAddr: "closed-remote",
+		Data:         []byte("late packet"),
+	}) {
+		t.Fatal("closed connection should not be handled")
+	}
+	if _, ok := desc.Connections.Load("closed-remote"); ok {
+		t.Fatal("closed connection should be removed after a late packet")
+	}
+
+	openLocal, openPeer := net.Pipe()
+	defer openLocal.Close()
+	defer openPeer.Close()
+	openReader := make(chan *tpb.TunnelInput, 1)
+	desc.Connections.Store("open-remote", &connectionDesc{
+		Connection: openLocal,
+		RemoteAddr: "open-remote",
+		Reader:     openReader,
+	})
+
+	if !dispatchTunnelInputToTCPConnection(context.Background(), desc, &tpb.TunnelInput{
+		ToRemoteAddr: "open-remote",
+		Data:         []byte("next packet"),
+	}) {
+		t.Fatal("open connection should be handled after a closed connection is skipped")
+	}
+
+	select {
+	case got := <-openReader:
+		if string(got.GetData()) != "next packet" {
+			t.Fatalf("unexpected forwarded data: %q", got.GetData())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("open connection did not receive forwarded packet")
+	}
+}
+
+type failingCreateTunnelClient struct {
+	ctx context.Context
+}
+
+func (f *failingCreateTunnelClient) Send(*tpb.TunnelInput) error {
+	return nil
+}
+
+func (f *failingCreateTunnelClient) Recv() (*tpb.TunnelOutput, error) {
+	return nil, errors.New("recv failed")
+}
+
+func (f *failingCreateTunnelClient) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (f *failingCreateTunnelClient) Trailer() metadata.MD {
+	return nil
+}
+
+func (f *failingCreateTunnelClient) CloseSend() error {
+	return nil
+}
+
+func (f *failingCreateTunnelClient) Context() context.Context {
+	return f.ctx
+}
+
+func (f *failingCreateTunnelClient) SendMsg(any) error {
+	return nil
+}
+
+func (f *failingCreateTunnelClient) RecvMsg(any) error {
+	return nil
+}
+
+func TestMUSTPASS_HoldingCreateTunnelClientReturnsWhenRecvLoopFails(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- HoldingCreateTunnelClient(&failingCreateTunnelClient{ctx: ctx}, "127.0.0.1", 1, 2, "test-tunnel")
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("HoldingCreateTunnelClient should return when the recv loop exits")
+	}
+}


### PR DESCRIPTION
… and add tests for tunnel input dispatch

- Added a cancel call in the goroutine to ensure proper cleanup.
- Replaced panic with a structured error log when receiving from the mirror tunnel fails.
- Introduced a new function, dispatchTunnelInputToTCPConnection, to handle TCP connection input more robustly.
- Added tests for HoldingCreateTunnelClient to verify behavior when the receive loop fails and to ensure closed connections are handled correctly.