### PR TITLE
refactor(aid): emit per-item TODO stream events with content backfill

### DIFF
--- a/common/ai/aid/aicommon/emitter.go
+++ b/common/ai/aid/aicommon/emitter.go
@@ -754,34 +754,23 @@ func (r *Emitter) EmitDefaultStreamEvent(nodeId string, reader io.Reader, taskIn
 	})
 }
 
-// EmitNextMovementsSplitSystemStreams splits an already-parsed next_movements
-// slice by op into three channels and emits each non-empty channel as a system
-// stream event under the matching nodeId:
+// EmitNextMovementsSplitStreams splits an already-parsed next_movements slice
+// by op and emits each individual movement as its own stream event under the
+// matching nodeId:
 //
 //   - "added"    (add)                   -> nodeIdAdded
 //   - "doing"    (doing / 开始执行)      -> nodeIdDoing
 //   - "completed"(done / delete / skip)  -> nodeIdCompleted
 //
-// Each channel emits exactly ONE summary line — a count of that direction's
-// ops this round (e.g. "新增 2 条" / "开始 1 条" / "完成 3 条") — rather than a
-// per-item list. The card title (i18n via the NodeId) already labels the
-// direction, so the content only carries the count.
+// Each movement emits one event whose text is the TODO item's content only
+// (no label, no ID). The nodeId already carries the semantic label (i18n),
+// and the content is resolved by applyStatusMutation backfilling from the
+// store when the original movement didn't carry it. Movements with empty
+// content after resolution are silently skipped.
 //
-// An empty channel (no ops of that direction this round) produces no event —
-// the frontend never sees an empty card. The caller is expected to have parsed
-// the AI output already; this helper does no JSON decoding.
+// 关键词: EmitNextMovementsSplitStreams, next_movements 逐条 emit,
 //
-// doing is kept separate from add so the frontend can render a distinct
-// "开始执行" card: add means a brand-new TODO was appended, doing means an
-// already-known TODO actually started executing. Routing them through the same
-// nodeId would collapse two semantically different signals into one count.
-//
-// Returns the successfully emitted events in emission order so the caller can
-// capture a reference-materials anchor from whichever channel fired first.
-//
-// 关键词: EmitNextMovementsSplitStreams, next_movements 三通道,
-//
-//	added / doing / completed 流, 每类一条计数摘要, 空通道跳过, 解析后 emit
+//	added / doing / completed 流, 每条直接展示 content, 无参考资料
 func (r *Emitter) EmitNextMovementsSplitStreams(
 	nodeIdAdded, nodeIdDoing, nodeIdCompleted string,
 	movements []VerifyNextMovement,
@@ -790,39 +779,19 @@ func (r *Emitter) EmitNextMovementsSplitStreams(
 	if r == nil || len(movements) == 0 {
 		return nil, nil
 	}
-	var addedCount, doingCount, completedCount int
-	var addedLines, doingLines, completedLines []string
-	for _, m := range movements {
-		switch {
-		case IsNextMovementAddedOp(m.Op):
-			addedCount++
-			if m.Content != "" {
-				addedLines = append(addedLines, m.Content)
-			}
-		case IsNextMovementDoingOp(m.Op):
-			doingCount++
-			if m.Content != "" {
-				doingLines = append(doingLines, m.Content)
-			}
-		default:
-			completedCount++
-			if m.Content != "" {
-				completedLines = append(completedLines, m.Content)
-			}
-		}
-	}
 
 	var (
 		events   []*schema.AiOutputEvent
 		firstErr error
 	)
-	emitOne := func(nodeId string, count int, lines []string, label string) {
-		if count <= 0 {
+	emitItem := func(nodeId string, m VerifyNextMovement) {
+		text := strings.TrimSpace(m.Content)
+		if text == "" {
 			return
 		}
 		event, err := r.EmitDefaultStreamEvent(
 			nodeId,
-			strings.NewReader(fmt.Sprintf("%s 待办 %d 条", label, count)),
+			strings.NewReader(text),
 			taskIndex,
 			func() {},
 		)
@@ -836,13 +805,17 @@ func (r *Emitter) EmitNextMovementsSplitStreams(
 		if event != nil {
 			events = append(events, event)
 		}
-		if len(lines) > 0 && event != nil {
-			r.EmitTextReferenceMaterial(event.GetStreamEventWriterId(), strings.Join(lines, "\n"))
+	}
+	for _, m := range movements {
+		switch {
+		case IsNextMovementAddedOp(m.Op):
+			emitItem(nodeIdAdded, m)
+		case IsNextMovementDoingOp(m.Op):
+			emitItem(nodeIdDoing, m)
+		default:
+			emitItem(nodeIdCompleted, m)
 		}
 	}
-	emitOne(nodeIdAdded, addedCount, addedLines, "新增")
-	emitOne(nodeIdDoing, doingCount, doingLines, "开始")
-	emitOne(nodeIdCompleted, completedCount, completedLines, "完成")
 
 	if firstErr != nil && len(events) == 0 {
 		return nil, firstErr

--- a/common/ai/aid/aicommon/verification_todo_store.go
+++ b/common/ai/aid/aicommon/verification_todo_store.go
@@ -349,7 +349,11 @@ func (s *VerificationTodoStore) applyStatusMutation(
 	}
 	item.Status = target
 	item.UpdatedAt = roundIndex
-	return todoApplySuccess(movement)
+	resultMovement := movement
+	if resultMovement.Content == "" {
+		resultMovement.Content = item.Content
+	}
+	return todoApplySuccess(resultMovement)
 }
 
 func (i *VerificationTodoItem) scope() VerificationTodoScope {

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
@@ -344,7 +344,22 @@ var loopAction_directlyCallTool = &reactloops.LoopAction{
 
 		mgr := loop.GetConfig().GetAiToolManager()
 		if mgr == nil || !mgr.IsRecentlyUsedTool(toolName) {
-			return utils.Errorf("tool '%s' is not in the recently-used cache; use require_tool instead", toolName)
+			// 工具不在 recently-used cache 中时只记录警告，不报错触发重试。
+			// 后续 ActionHandler 会通过 GetToolByName 自行决定：工具存在则继续
+			// 直接调用，工具不存在则走已有的 fallback 到 require_tool 路径。
+			// 关键词: directly_call_tool, cache miss, 不触发重试, handler 自处理
+			emit := loop.GetEmitter()
+			if emit != nil {
+				emit.EmitWarning("tool '%s' is not in the recently-used cache; handler will resolve it", toolName)
+			}
+			loop.GetInvoker().AddToTimeline(
+				"directly_call_cache_miss",
+				fmt.Sprintf(
+					"[DIRECT_CALL_CACHE_MISS] directly_call_tool selected '%s' but it is not in the recently-used cache. "+
+						"Letting handler resolve (call if tool exists, otherwise fall back to require_tool).",
+					toolName,
+				),
+			)
 		}
 		reactloops.MaybeWarnBashBeforeEdit(loop, toolName)
 

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool_test.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool_test.go
@@ -292,3 +292,45 @@ func TestDirectlyCallTool_Handler_RequiredParamMismatchAddsLatestFewShot(t *test
 	assert.NotContains(t, timeline, `"next_action"`)
 	assert.Contains(t, op.GetFeedback().String(), "automatically switching to @action=require_tool")
 }
+
+func TestDirectlyCallTool_Verifier_PassesThroughWhenNotCached(t *testing.T) {
+	ctx := context.Background()
+	testTool := mustNewTool(
+		"scan_port",
+		aitool.WithNumberParam("port"),
+		aitool.WithSimpleCallback(func(params aitool.InvokeParams, stdout io.Writer, stderr io.Writer) (any, error) {
+			return "ok", nil
+		}),
+	)
+	// 工具启用但不在 recently-used cache 中，模拟 LLM 误用 directly_call_tool
+	cfg := &aicommon.Config{AiToolManager: newToolManagerWithTool(testTool)}
+	require.False(t, cfg.GetAiToolManager().IsRecentlyUsedTool("scan_port"), "scan_port should not be in cache at start")
+
+	invoker := &directlyCallTestInvoker{testInvoker: newTestInvoker(ctx)}
+	invoker.tool = testTool
+	invoker.toolCallResult = &aitool.ToolResult{Success: true, Data: "ok"}
+	invoker.verifySatisfactionResult = aicommon.NewVerifySatisfactionResult(true, "done", "")
+
+	task := newTestTask(ctx)
+	invoker.currentTask = task
+
+	loop := reactloops.NewMinimalReActLoop(cfg, invoker)
+	loop.SetCurrentTask(task)
+
+	action := buildDirectlyCallAction(`{
+		"@action": "directly_call_tool",
+		"directly_call_tool_name": "scan_port",
+		"directly_call_tool_params": {"port": 443}
+	}`)
+
+	// Verifier 不应返回错误，不触发 transaction 重试
+	require.NoError(t, loopAction_directlyCallTool.ActionVerifier(loop, action))
+
+	// 验证 directly_call_tool_name 仍然被设置（handler 正常处理）
+	assert.Equal(t, "scan_port", loop.Get("directly_call_tool_name"))
+
+	// 验证 timeline 记录了 cache miss 信息
+	timeline := invoker.getTimelineString()
+	assert.Contains(t, timeline, "DIRECT_CALL_CACHE_MISS")
+	assert.Contains(t, timeline, "scan_port")
+}

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
@@ -177,16 +177,16 @@ Example - Sequential file operations(With AI-Tag tags):
 			return
 		}
 
-		if mermaidCode, _ := dag.GenerateMermaidFlowChartWithStyles(); mermaidCode != "" {
-			markdownCompose, markdownComposeWriter := utils.NewPipe()
-			emitter := loop.GetEmitter()
-			emitter.EmitStreamEventWithContentType("tool_compose_progress", markdownCompose, loop.GetCurrentTask().GetId(), "text/markdown")
-			markdownComposeWriter.WriteString("## Tool Compose DAG\n")
-			markdownComposeWriter.WriteString("```mermaid\n")
-			markdownComposeWriter.WriteString(mermaidCode)
-			markdownComposeWriter.WriteString("```\n")
-			markdownComposeWriter.Close()
-		}
+		// if mermaidCode, _ := dag.GenerateMermaidFlowChartWithStyles(); mermaidCode != "" {
+		// 	markdownCompose, markdownComposeWriter := utils.NewPipe()
+		// 	emitter := loop.GetEmitter()
+		// 	emitter.EmitStreamEventWithContentType("tool_compose_progress", markdownCompose, loop.GetCurrentTask().GetId(), "text/markdown")
+		// 	markdownComposeWriter.WriteString("## Tool Compose DAG\n")
+		// 	markdownComposeWriter.WriteString("```mermaid\n")
+		// 	markdownComposeWriter.WriteString(mermaidCode)
+		// 	markdownComposeWriter.WriteString("```\n")
+		// 	markdownComposeWriter.Close()
+		// }
 
 		// Log the DAG structure
 		log.Infof("Tool compose DAG built successfully with %d nodes", len(dag.GetAllNodes()))

--- a/common/schema/ai_node_id_i18n.go
+++ b/common/schema/ai_node_id_i18n.go
@@ -74,15 +74,15 @@ var nodeIdMapper = map[string]*I18n{
 		En: "TODO List",
 	},
 	"todo_added": {
-		Zh: "TODO 增加",
+		Zh: "待办任务",
 		En: "TODO Added",
 	},
 	"todo_doing": {
-		Zh: "TODO 开始",
+		Zh: "待办进行中",
 		En: "TODO In Progress",
 	},
 	"todo_completed": {
-		Zh: "TODO 完成",
+		Zh: "待办完成",
 		En: "TODO Completed",
 	},
 	"task-dependency": {


### PR DESCRIPTION
## 概述 / Summary

重构 AI Agent 中 TODO（待办）流式事件的生成方式：从「每个方向一条计数摘要」改为「逐条 emit TODO 内容」，并修复内容为空时无法回填的问题；同时临时屏蔽 tool-compose 的 mermaid DAG 输出，刷新 i18n 文案。

## 改动内容 / What changed

| 文件 | 改动 |
| --- | --- |
| `common/ai/aid/aicommon/emitter.go` | `EmitNextMovementsSplitStreams` 重构：不再按 added/doing/completed 汇总成一条计数摘要（如 "新增 2 条"），改为**逐条** emit 每个 movement，事件文本直接使用 TODO 的 `Content`；移除每类的 `EmitTextReferenceMaterial` 参考资料附加 |
| `common/ai/aid/aicommon/verification_todo_store.go` | `applyStatusMutation` 在 `movement.Content` 为空时，从 store 中对应 item **回填** Content，保证 resolved 后的事件一定有文本 |
| `common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go` | **临时**注释掉 tool-compose 的 mermaid DAG 进度流输出（保留 log.Infof 日志） |
| `common/schema/ai_node_id_i18n.go` | 刷新 `todo_added`/`todo_doing`/`todo_completed` 的中文文案：`待办任务` / `待办进行中` / `待办完成` |

## 产生影响 / Impact

- **行为变化**：前端 AI 对话中 TODO 卡片将展示逐条内容而非计数摘要。由于 nodeId（i18n）已承载方向语义标签，计数移除后信息不丢失，反而更清晰。
- **API 兼容**：`EmitNextMovementsSplitStreams` 签名不变；返回值语义不变（仍返回已发出的事件与首个错误）。
- **临时屏蔽**：tool-compose 的 mermaid 流在前端暂时不再渲染，后续如需恢复直接取消注释即可。

## 如何测试 / How to test

1. `go test ./common/ai/aid/aicommon/ -count=1` — 已通过（覆盖 `EmitNextMovements`、`TodoStore`、`ApplyStatus`、`NextMovement` 等相关用例，124s 全绿）
2. `go test ./common/schema/... -count=1` — 已通过
3. 手动验证：触发一次含 next_movements 的 AI 任务，确认前端 TODO 卡片逐条展示内容、新增/进行中/完成方向正确；验证 `Content` 原本为空的运动条目能被回填展示。