### PR TITLE
feat(aid): on-demand SKILL loading, forced/auto split, UserAIStats

### DIFF
--- a/common/ai/aid/aicommon/aiskillloader/aiskillloader_test.go
+++ b/common/ai/aid/aicommon/aiskillloader/aiskillloader_test.go
@@ -222,7 +222,7 @@ func TestSkillsContextManager_SearchSkills(t *testing.T) {
 	}
 }
 
-func TestSkillsContextManager_RenderStable_SortsAvailableSkills(t *testing.T) {
+func TestSkillsContextManager_RenderStable_CatalogHiddenByDefault(t *testing.T) {
 	vfs := buildTestVFS()
 	loader, err := NewFSSkillLoader(vfs)
 	if err != nil {
@@ -232,20 +232,46 @@ func TestSkillsContextManager_RenderStable_SortsAvailableSkills(t *testing.T) {
 	mgr := NewSkillsContextManager(loader)
 	rendered := mgr.RenderStable()
 
-	codeReviewIdx := strings.Index(rendered, "  - code-review:")
-	deployAppIdx := strings.Index(rendered, "  - deploy-app:")
-	if codeReviewIdx == -1 || deployAppIdx == -1 {
-		t.Fatalf("stable render should list both available skills. Got:\n%s", rendered)
+	// 改造后: 默认隐藏 SKILL 目录, 零加载 + 目录不可见 → 整段不渲染.
+	if rendered != "" {
+		t.Fatalf("default render with no loaded skills and hidden catalog should be empty. Got:\n%s", rendered)
 	}
-	if codeReviewIdx > deployAppIdx {
-		t.Fatalf("available skills should be rendered in stable alphabetical order. Got:\n%s", rendered)
+	if mgr.IsCatalogVisible() {
+		t.Fatalf("catalog should be hidden by default")
 	}
 }
 
-// TestSkillsContextManager_RenderStable_DualSectionStructure 验证 RenderStable
-// 输出始终为"Currently Loaded / Available Skills"双段结构, 即使零加载时也保留双段头。
-// 这是 Prompt 按稳定性分层路径下进入 AI_CACHE_FROZEN 块的字节稳定前置。
-// 关键词: SkillsContext renderWithTag, dual-section, 字节稳定
+// TestSkillsContextManager_RenderStable_CatalogVisibleWhenSet 验证意图识别写入
+// 目录后, catalog 段按 name 排序出现, 且截断到 MaxCatalogSkills.
+func TestSkillsContextManager_RenderStable_CatalogVisibleWhenSet(t *testing.T) {
+	vfs := buildTestVFS()
+	loader, err := NewFSSkillLoader(vfs)
+	if err != nil {
+		t.Fatalf("NewFSSkillLoader failed: %v", err)
+	}
+
+	mgr := NewSkillsContextManager(loader)
+	metas := loader.AllSkillMetas()
+	mgr.SetCatalogSkills(metas)
+	mgr.SetCatalogVisible(true)
+
+	rendered := mgr.RenderStable()
+	codeReviewIdx := strings.Index(rendered, "  - code-review:")
+	deployAppIdx := strings.Index(rendered, "  - deploy-app:")
+	if codeReviewIdx == -1 || deployAppIdx == -1 {
+		t.Fatalf("visible catalog should list both skills. Got:\n%s", rendered)
+	}
+	if codeReviewIdx > deployAppIdx {
+		t.Fatalf("catalog skills should be rendered in alphabetical order. Got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Relevant Skills") {
+		t.Fatalf("catalog section should use Relevant Skills header. Got:\n%s", rendered)
+	}
+}
+
+// TestSkillsContextManager_RenderStable_DualSectionStructure 验证当有 catalog 或
+// 加载时 RenderStable 输出 "Currently Loaded" + "Relevant Skills" 双段结构.
+// 改造后: 零加载 + 目录隐藏 → 整段为空 (节约 token); 有 catalog 时才出现双段.
 func TestSkillsContextManager_RenderStable_DualSectionStructure(t *testing.T) {
 	vfs := buildTestVFS()
 	loader, err := NewFSSkillLoader(vfs)
@@ -254,23 +280,23 @@ func TestSkillsContextManager_RenderStable_DualSectionStructure(t *testing.T) {
 	}
 
 	mgr := NewSkillsContextManager(loader)
+	mgr.SetCatalogSkills(loader.AllSkillMetas())
 
-	zeroLoadedRendered := mgr.RenderStable()
-	if !strings.Contains(zeroLoadedRendered, "== Currently Loaded Skills ==") {
-		t.Fatalf("zero-loaded render should contain 'Currently Loaded Skills' header. Got:\n%s", zeroLoadedRendered)
+	rendered := mgr.RenderStable()
+	if !strings.Contains(rendered, "== Currently Loaded Skills ==") {
+		t.Fatalf("render should contain 'Currently Loaded Skills' header. Got:\n%s", rendered)
 	}
-	if !strings.Contains(zeroLoadedRendered, "(none)") {
-		t.Fatalf("zero-loaded render should contain '(none)' under Currently Loaded. Got:\n%s", zeroLoadedRendered)
+	if !strings.Contains(rendered, "(none)") {
+		t.Fatalf("render should contain '(none)' under Currently Loaded. Got:\n%s", rendered)
 	}
-	if !strings.Contains(zeroLoadedRendered, "== Available Skills (use loading_skills action to load) ==") {
-		t.Fatalf("zero-loaded render should contain 'Available Skills' header. Got:\n%s", zeroLoadedRendered)
+	if !strings.Contains(rendered, "Relevant Skills") {
+		t.Fatalf("render should contain 'Relevant Skills' catalog header when visible. Got:\n%s", rendered)
 	}
 }
 
 // TestSkillsContextManager_RenderStable_AvailableSectionByteStable 验证 0->1
-// 加载技能时, "Available Skills"下半段保持字节稳定, 仅"Currently Loaded"上半段
-// 发生变化。这是前缀缓存命中率提升的关键: 零加载与有加载共享同一段 registry 字节。
-// 关键词: SkillsContext, 字节稳定, registry listing 不变
+// 加载技能时, catalog 下半段保持字节稳定 (意图识别写入的目录不变 → 输出不变).
+// 关键词: SkillsContext, 字节稳定, catalog 不变
 func TestSkillsContextManager_RenderStable_AvailableSectionByteStable(t *testing.T) {
 	vfs := buildTestVFS()
 	loader, err := NewFSSkillLoader(vfs)
@@ -279,6 +305,7 @@ func TestSkillsContextManager_RenderStable_AvailableSectionByteStable(t *testing
 	}
 
 	mgr := NewSkillsContextManager(loader)
+	mgr.SetCatalogSkills(loader.AllSkillMetas())
 	zeroLoaded := mgr.RenderStable()
 
 	if err := mgr.LoadSkill("deploy-app"); err != nil {
@@ -286,21 +313,20 @@ func TestSkillsContextManager_RenderStable_AvailableSectionByteStable(t *testing
 	}
 	withLoaded := mgr.RenderStable()
 
-	availableHeader := "== Available Skills (use loading_skills action to load) =="
-	zeroAvailableIdx := strings.Index(zeroLoaded, availableHeader)
-	withLoadedAvailableIdx := strings.Index(withLoaded, availableHeader)
-	if zeroAvailableIdx == -1 || withLoadedAvailableIdx == -1 {
-		t.Fatalf("both renders should contain Available Skills header. zero=%q with=%q",
-			zeroLoaded, withLoaded)
+	catalogHeader := "== Relevant Skills"
+	zeroCatalogIdx := strings.Index(zeroLoaded, catalogHeader)
+	withLoadedCatalogIdx := strings.Index(withLoaded, catalogHeader)
+	if zeroCatalogIdx == -1 || withLoadedCatalogIdx == -1 {
+		t.Fatalf("both renders should contain catalog header. zero=%q with=%q", zeroLoaded, withLoaded)
 	}
 
 	endTag := "<|SKILLS_CONTEXT_END_skills_context|>"
-	zeroAvailableSection := zeroLoaded[zeroAvailableIdx : strings.Index(zeroLoaded, endTag)]
-	withLoadedAvailableSection := withLoaded[withLoadedAvailableIdx : strings.Index(withLoaded, endTag)]
+	zeroCatalogSection := zeroLoaded[zeroCatalogIdx:strings.Index(zeroLoaded, endTag)]
+	withLoadedCatalogSection := withLoaded[withLoadedCatalogIdx:strings.Index(withLoaded, endTag)]
 
-	if zeroAvailableSection != withLoadedAvailableSection {
-		t.Fatalf("Available Skills section must be byte-stable across 0->1 load.\nzero:\n%s\nwith:\n%s",
-			zeroAvailableSection, withLoadedAvailableSection)
+	if zeroCatalogSection != withLoadedCatalogSection {
+		t.Fatalf("catalog section must be byte-stable across 0->1 load.\nzero:\n%s\nwith:\n%s",
+			zeroCatalogSection, withLoadedCatalogSection)
 	}
 }
 
@@ -670,13 +696,20 @@ func TestSkillsContextManager_LoadAndRender(t *testing.T) {
 		t.Fatal("manager should report skills available")
 	}
 
-	// Render before loading any skill - should show available skills hint
+	// Render before loading any skill - catalog hidden by default → empty (save tokens).
 	rendered := mgr.Render("test_nonce")
+	if rendered != "" {
+		t.Fatalf("default render with hidden catalog should be empty. Got:\n%s", rendered)
+	}
+
+	// Explicitly surface the catalog (simulating intent recognition).
+	mgr.SetCatalogSkills(loader.AllSkillMetas())
+	rendered = mgr.Render("test_nonce")
 	if !strings.Contains(rendered, "SKILLS_CONTEXT_test_nonce") {
-		t.Fatal("render should contain SKILLS_CONTEXT tags")
+		t.Fatal("render should contain SKILLS_CONTEXT tags when catalog visible")
 	}
 	if !strings.Contains(rendered, "deploy-app") {
-		t.Fatal("render should list available skills")
+		t.Fatal("render should list catalog skills when visible")
 	}
 
 	// Load a skill

--- a/common/ai/aid/aicommon/aiskillloader/forced_dup_render_test.go
+++ b/common/ai/aid/aicommon/aiskillloader/forced_dup_render_test.go
@@ -1,0 +1,107 @@
+package aiskillloader
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestForcedSkill_DuplicateRenderInSkillsContext 验证 forced skill 是否同时出现在
+// frozen_block (USER_FORCED_SKILL) 和 SKILLS_CONTEXT (Currently Loaded Skills) 两处。
+//
+// 预期行为: forced skill 满内容应只在 frozen_block 出现一次, 不应在 SKILLS_CONTEXT 中重复。
+// 若测试失败, 说明存在 prompt 内容重复问题。
+func TestForcedSkill_DuplicateRenderInSkillsContext(t *testing.T) {
+	vfs := buildTestVFS()
+	loader, err := NewFSSkillLoader(vfs)
+	if err != nil {
+		t.Fatalf("NewFSSkillLoader failed: %v", err)
+	}
+	mgr := NewSkillsContextManager(loader)
+
+	// 加载一个 forced skill
+	added, err := mgr.LoadForcedSkill("deploy-app")
+	if err != nil {
+		t.Fatalf("LoadForcedSkill failed: %v", err)
+	}
+	if !added {
+		t.Fatal("LoadForcedSkill should return added=true")
+	}
+
+	// 渲染 forced 段 (frozen_block)
+	forcedRender := mgr.RenderForcedSkills()
+	if forcedRender == "" {
+		t.Fatal("RenderForcedSkills should not be empty")
+	}
+
+	// 渲染 SKILLS_CONTEXT 段 (SemiDynamic 1)
+	skillsContext := mgr.RenderStable()
+
+	// 检查 SKILL.md body 是否在 SKILLS_CONTEXT 中出现
+	// body 是 "# Deploy App\n\nRun `scripts/deploy.sh`.\n"
+	skillMDBody := "Run `scripts/deploy.sh`"
+
+	forcedHasBody := strings.Contains(forcedRender, skillMDBody)
+	contextHasBody := strings.Contains(skillsContext, skillMDBody)
+
+	t.Logf("forcedRender:\n%s", forcedRender)
+	t.Logf("skillsContext:\n%s", skillsContext)
+	t.Logf("forcedHasBody=%v, contextHasBody=%v", forcedHasBody, contextHasBody)
+
+	if !forcedHasBody {
+		t.Fatal("forced render should contain the SKILL.md body")
+	}
+
+	if contextHasBody {
+		t.Fatal("BUG: SKILLS_CONTEXT also contains the SKILL.md body — forced skill content is duplicated in prompt (frozen_block + SKILLS_CONTEXT)")
+	}
+}
+
+// TestForcedAndAuto_NoCrossDuplicate 验证 forced skill 和 auto skill 同时存在时,
+// 不会互相重复渲染。
+func TestForcedAndAuto_NoCrossDuplicate(t *testing.T) {
+	vfs := buildTestVFS()
+	loader, err := NewFSSkillLoader(vfs)
+	if err != nil {
+		t.Fatalf("NewFSSkillLoader failed: %v", err)
+	}
+	mgr := NewSkillsContextManager(loader)
+
+	// deploy-app → forced (frozen_block)
+	if _, err := mgr.LoadForcedSkill("deploy-app"); err != nil {
+		t.Fatalf("LoadForcedSkill: %v", err)
+	}
+	// code-review → auto (SemiDynamic 2)
+	if _, err := mgr.LoadAutoSkill("code-review"); err != nil {
+		t.Fatalf("LoadAutoSkill: %v", err)
+	}
+
+	forced := mgr.RenderForcedSkills()
+	auto := mgr.RenderAutoLoadedSkills()
+	skillsContext := mgr.RenderStable()
+
+	// forced skill body 只应出现在 forced 段
+	forcedBody := "Run `scripts/deploy.sh`"
+	// auto skill body 只应出现在 auto 段
+	autoBody := "Use linters"
+
+	t.Logf("=== forced ===\n%s", forced)
+	t.Logf("=== auto ===\n%s", auto)
+	t.Logf("=== skillsContext ===\n%s", skillsContext)
+
+	// forced body 不应出现在 auto 段
+	if strings.Contains(auto, forcedBody) {
+		t.Fatal("BUG: forced skill body leaked into AUTO_LOADED_SKILLS section")
+	}
+	// auto body 不应出现在 forced 段
+	if strings.Contains(forced, autoBody) {
+		t.Fatal("BUG: auto skill body leaked into USER_FORCED_SKILL section")
+	}
+	// forced body 不应出现在 SKILLS_CONTEXT
+	if strings.Contains(skillsContext, forcedBody) {
+		t.Fatal("BUG: forced skill body duplicated in SKILLS_CONTEXT")
+	}
+	// auto body 不应出现在 SKILLS_CONTEXT (auto 进 SemiDynamic 2, 不进 SemiDynamic 1)
+	if strings.Contains(skillsContext, autoBody) {
+		t.Fatal("BUG: auto skill body duplicated in SKILLS_CONTEXT")
+	}
+}

--- a/common/ai/aid/aicommon/aiskillloader/forced_skills.go
+++ b/common/ai/aid/aicommon/aiskillloader/forced_skills.go
@@ -1,0 +1,170 @@
+package aiskillloader
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/yaklang/yaklang/common/utils/omap"
+)
+
+// forced_skills.go 实现「用户强制加载 SKILL」专用容器.
+//
+// 设计: 用户强制加载 (来源: load_skill sync 事件 / EnabledCapabilities) 的 SKILL
+// 拥有最高优先级 —— 满内容渲染 (无折叠), 进入 prompt 的 frozen_block 顶部 (比
+// SKILLS_CONTEXT 目录层级还高). 这与 AI 意图驱动的 LoadAutoSkill (进 SemiDynamic 2
+// 尾部, LRU 折叠) 形成职责清晰的分流.
+//
+// 关键词: ForcedSkillRegistry, 用户强制加载, frozen_block, 满内容, 最高优先级
+
+// forcedSkillBoundaryTagName / Nonce 是 forced skill 段的成对定界标记.
+// 强制 stable nonce, 让该段在内容不变时字节稳定, 利于 frozen_block 缓存命中.
+const (
+	forcedSkillBoundaryTagName = "USER_FORCED_SKILL"
+	forcedSkillBoundaryNonce   = "skills"
+)
+
+// ForcedSkillRegistry 维护用户强制加载的 SKILL (满内容, 进 frozen_block).
+type ForcedSkillRegistry struct {
+	mu       sync.RWMutex
+	skills   *omap.OrderedMap[string, *LoadedSkill]
+	loadedAt map[string]time.Time
+}
+
+// NewForcedSkillRegistry 创建空的 forced skill 注册表.
+func NewForcedSkillRegistry() *ForcedSkillRegistry {
+	return &ForcedSkillRegistry{
+		skills:   omap.NewOrderedMap[string, *LoadedSkill](map[string]*LoadedSkill{}),
+		loadedAt: make(map[string]time.Time),
+	}
+}
+
+// Add 写入一个满内容 skill. 覆盖同名旧条目. 返回 true 表示新增 (之前不存在).
+func (f *ForcedSkillRegistry) Add(name string, skill *LoadedSkill) bool {
+	if f == nil || strings.TrimSpace(name) == "" || skill == nil {
+		return false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, existed := f.skills.Get(name)
+	f.skills.Set(name, skill)
+	f.loadedAt[name] = time.Now()
+	return !existed
+}
+
+// Remove 移除一个 forced skill, 返回是否曾存在.
+func (f *ForcedSkillRegistry) Remove(name string) bool {
+	if f == nil {
+		return false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.skills.Have(name) {
+		return false
+	}
+	f.skills.Delete(name)
+	delete(f.loadedAt, name)
+	return true
+}
+
+// Has 返回是否包含指定 forced skill.
+func (f *ForcedSkillRegistry) Has(name string) bool {
+	if f == nil {
+		return false
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.skills.Have(name)
+}
+
+// IsEmpty 返回 forced skill 是否为空.
+func (f *ForcedSkillRegistry) IsEmpty() bool {
+	if f == nil {
+		return true
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.skills.Len() == 0
+}
+
+// Names 返回 (按名排序的) forced skill 名列表.
+func (f *ForcedSkillRegistry) Names() []string {
+	if f == nil {
+		return nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	names := make([]string, 0, f.skills.Len())
+	f.skills.ForEach(func(name string, _ *LoadedSkill) bool {
+		names = append(names, name)
+		return true
+	})
+	sort.Strings(names)
+	return names
+}
+
+// Render 渲染所有 forced skill 为 prompt 段落 (满内容, 无折叠).
+// 输出形如:
+//
+//	<|USER_FORCED_SKILL_skills|>
+//	# User Forced Skills
+//	The following skills were explicitly loaded by the user. Highest priority.
+//
+//	=== Skill: X ===
+//	<满内容 SKILL.md>
+//	=== Skill: Y ===
+//	<满内容 SKILL.md>
+//	<|USER_FORCED_SKILL_END_skills|>
+//
+// 空注册表返回空串 (段不渲染).
+func (f *ForcedSkillRegistry) Render() string {
+	if f == nil || f.IsEmpty() {
+		return ""
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	// 按名排序保证字节稳定 (利于 frozen_block 缓存).
+	type entry struct {
+		name  string
+		skill *LoadedSkill
+	}
+	items := make([]entry, 0, f.skills.Len())
+	f.skills.ForEach(func(name string, skill *LoadedSkill) bool {
+		items = append(items, entry{name: name, skill: skill})
+		return true
+	})
+	sort.Slice(items, func(i, j int) bool { return items[i].name < items[j].name })
+
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("<|%s_%s|>\n", forcedSkillBoundaryTagName, forcedSkillBoundaryNonce))
+	buf.WriteString("# User Forced Skills\n")
+	buf.WriteString("The following skills were explicitly loaded by the user and have the HIGHEST priority. They are always fully visible.\n\n")
+	for _, e := range items {
+		buf.WriteString(renderForcedSkillFull(e.name, e.skill))
+		buf.WriteString("\n")
+	}
+	buf.WriteString(fmt.Sprintf("<|%s_END_%s|>", forcedSkillBoundaryTagName, forcedSkillBoundaryNonce))
+	return buf.String()
+}
+
+// renderForcedSkillFull 渲染单个 forced skill 的满内容: 元信息 + 文件树 + SKILL.md 全文.
+func renderForcedSkillFull(name string, skill *LoadedSkill) string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("=== Skill: %s ===\n", name))
+	if skill != nil && skill.Meta != nil {
+		buf.WriteString(skill.Meta.BriefString())
+	}
+	if skill != nil && skill.FileSystem != nil {
+		buf.WriteString("\nFile Tree:\n")
+		buf.WriteString(RenderFileSystemTreeFull(skill.FileSystem))
+	}
+	if skill != nil && skill.SkillMDContent != "" {
+		buf.WriteString("\nSKILL.md:\n")
+		buf.WriteString(skill.SkillMDContent)
+	}
+	return buf.String()
+}

--- a/common/ai/aid/aicommon/aiskillloader/forced_skills_test.go
+++ b/common/ai/aid/aicommon/aiskillloader/forced_skills_test.go
@@ -1,0 +1,190 @@
+package aiskillloader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/utils/filesys"
+)
+
+// forced_skills_test.go 验证 ForcedSkillRegistry + 三态分离 (forced/catalog/auto).
+
+func TestForcedSkillRegistry_AddRemoveRender(t *testing.T) {
+	reg := NewForcedSkillRegistry()
+	if !reg.IsEmpty() {
+		t.Fatal("new registry should be empty")
+	}
+	if reg.Render() != "" {
+		t.Fatal("empty registry should render empty string")
+	}
+
+	// 构造一个 LoadedSkill.
+	vfs := filesys.NewVirtualFs()
+	vfs.AddFile("SKILL.md", "---\nname: test-skill\ndescription: a test\n---\n# Body\nHello")
+	loaded := &LoadedSkill{
+		Meta:           &SkillMeta{Name: "test-skill", Description: "a test"},
+		FileSystem:     vfs,
+		SkillMDContent: "# Body\nHello",
+	}
+
+	added := reg.Add("test-skill", loaded)
+	if !added {
+		t.Fatal("first Add should return true (new)")
+	}
+	if reg.IsEmpty() {
+		t.Fatal("registry should not be empty after add")
+	}
+	if !reg.Has("test-skill") {
+		t.Fatal("Has should return true")
+	}
+
+	// 重复 Add → false.
+	if reg.Add("test-skill", loaded) {
+		t.Fatal("second Add of same name should return false")
+	}
+
+	// Render 应包含满内容 + USER_FORCED_SKILL 边界.
+	rendered := reg.Render()
+	if !strings.Contains(rendered, "USER_FORCED_SKILL") {
+		t.Fatalf("render should contain USER_FORCED_SKILL boundary. Got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "=== Skill: test-skill ===") {
+		t.Fatalf("render should contain skill header. Got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "# Body") {
+		t.Fatalf("render should contain full SKILL.md body. Got:\n%s", rendered)
+	}
+
+	// Names.
+	names := reg.Names()
+	if len(names) != 1 || names[0] != "test-skill" {
+		t.Fatalf("Names should be [test-skill], got %v", names)
+	}
+
+	// Remove.
+	if !reg.Remove("test-skill") {
+		t.Fatal("Remove should return true")
+	}
+	if !reg.IsEmpty() {
+		t.Fatal("registry should be empty after remove")
+	}
+}
+
+// TestSkillsContextManager_ForcedSkill_LoadAndRender 验证 LoadForcedSkill 把满内容
+// 登记进 forced 容器, RenderForcedSkills 输出, 同时 loadedSkills 也登记.
+func TestSkillsContextManager_ForcedSkill_LoadAndRender(t *testing.T) {
+	vfs := buildTestVFS()
+	loader, err := NewFSSkillLoader(vfs)
+	if err != nil {
+		t.Fatalf("NewFSSkillLoader failed: %v", err)
+	}
+	mgr := NewSkillsContextManager(loader)
+
+	added, err := mgr.LoadForcedSkill("deploy-app")
+	if err != nil {
+		t.Fatalf("LoadForcedSkill failed: %v", err)
+	}
+	if !added {
+		t.Fatal("first LoadForcedSkill should return added=true")
+	}
+	if !mgr.HasForcedSkills() {
+		t.Fatal("HasForcedSkills should be true after load")
+	}
+	if !mgr.IsForcedSkill("deploy-app") {
+		t.Fatal("IsForcedSkill should be true")
+	}
+	// loadedSkills 也应登记 (IsSkillLoaded 一致性).
+	if !mgr.IsSkillLoaded("deploy-app") {
+		t.Fatal("forced skill should also register in loadedSkills for IsSkillLoaded consistency")
+	}
+
+	forced := mgr.RenderForcedSkills()
+	if !strings.Contains(forced, "USER_FORCED_SKILL") {
+		t.Fatalf("RenderForcedSkills should contain boundary. Got:\n%s", forced)
+	}
+	if !strings.Contains(forced, "deploy-app") {
+		t.Fatalf("RenderForcedSkills should contain skill name. Got:\n%s", forced)
+	}
+
+	// 重复 LoadForcedSkill → added=false (幂等).
+	added2, err := mgr.LoadForcedSkill("deploy-app")
+	if err != nil {
+		t.Fatalf("second LoadForcedSkill err: %v", err)
+	}
+	if added2 {
+		t.Fatal("second LoadForcedSkill should return added=false (idempotent)")
+	}
+
+	// UnloadForcedSkill.
+	if !mgr.UnloadForcedSkill("deploy-app") {
+		t.Fatal("UnloadForcedSkill should return true")
+	}
+	if mgr.HasForcedSkills() {
+		t.Fatal("HasForcedSkills should be false after unload")
+	}
+}
+
+// TestSkillsContextManager_AutoSkill_LoadAndRender 验证 LoadAutoSkill 进入 autoLoadedSkills,
+// RenderAutoLoadedSkills 输出 AUTO_LOADED_SKILLS 段; 且 forced 优先短路.
+func TestSkillsContextManager_AutoSkill_LoadAndRender(t *testing.T) {
+	vfs := buildTestVFS()
+	loader, err := NewFSSkillLoader(vfs)
+	if err != nil {
+		t.Fatalf("NewFSSkillLoader failed: %v", err)
+	}
+	mgr := NewSkillsContextManager(loader)
+
+	added, err := mgr.LoadAutoSkill("code-review")
+	if err != nil {
+		t.Fatalf("LoadAutoSkill failed: %v", err)
+	}
+	if !added {
+		t.Fatal("first LoadAutoSkill should return added=true")
+	}
+	if !mgr.HasAutoLoadedSkills() {
+		t.Fatal("HasAutoLoadedSkills should be true")
+	}
+	if !mgr.IsAutoSkillLoadedAndUnfolded("code-review") {
+		t.Fatal("IsAutoSkillLoadedAndUnfolded should be true")
+	}
+
+	auto := mgr.RenderAutoLoadedSkills()
+	if !strings.Contains(auto, "AUTO_LOADED_SKILLS") {
+		t.Fatalf("RenderAutoLoadedSkills should contain boundary. Got:\n%s", auto)
+	}
+	if !strings.Contains(auto, "code-review") {
+		t.Fatalf("RenderAutoLoadedSkills should contain skill name. Got:\n%s", auto)
+	}
+
+	// 重复 LoadAutoSkill → added=false.
+	added2, _ := mgr.LoadAutoSkill("code-review")
+	if added2 {
+		t.Fatal("second LoadAutoSkill should return added=false (idempotent)")
+	}
+}
+
+// TestSkillsContextManager_ForcePreemptsAuto 验证 forced skill 优先: 若已 forced,
+// LoadAutoSkill 短路 (added=false), IsAutoSkillLoadedAndUnfolded 也返回 true.
+func TestSkillsContextManager_ForcePreemptsAuto(t *testing.T) {
+	vfs := buildTestVFS()
+	loader, err := NewFSSkillLoader(vfs)
+	if err != nil {
+		t.Fatalf("NewFSSkillLoader failed: %v", err)
+	}
+	mgr := NewSkillsContextManager(loader)
+
+	if _, err := mgr.LoadForcedSkill("deploy-app"); err != nil {
+		t.Fatalf("LoadForcedSkill: %v", err)
+	}
+	// 对同名 skill 调 LoadAutoSkill 应短路.
+	added, err := mgr.LoadAutoSkill("deploy-app")
+	if err != nil {
+		t.Fatalf("LoadAutoSkill on forced skill err: %v", err)
+	}
+	if added {
+		t.Fatal("LoadAutoSkill on already-forced skill should short-circuit (added=false)")
+	}
+	if !mgr.IsAutoSkillLoadedAndUnfolded("deploy-app") {
+		t.Fatal("IsAutoSkillLoadedAndUnfolded should be true for forced skill (forced preempts)")
+	}
+}

--- a/common/ai/aid/aicommon/aiskillloader/skill_meta_list_budget.go
+++ b/common/ai/aid/aicommon/aiskillloader/skill_meta_list_budget.go
@@ -10,6 +10,15 @@ import (
 // AvailableSkillsRegistryHeader is the registry listing header in SKILLS_CONTEXT.
 const AvailableSkillsRegistryHeader = "== Available Skills (use loading_skills action to load) ==\n"
 
+// MaxCatalogSkills 是意图识别写入「最相关 SKILL 目录」(SKILLS_CONTEXT 下半段) 的最大条目数.
+// 目录默认隐藏, 仅当意图识别命中后由 SetCatalogVisible(true) 开启, 取最相关 top-N.
+// 关键词: MaxCatalogSkills, 意图识别目录 top-N, 默认隐藏 SKILL 目录
+const MaxCatalogSkills = 10
+
+// CatalogHeader 是意图识别驱动的「最相关 SKILL 目录」段头.
+// 与 AvailableSkillsRegistryHeader 区分开: 这是意图命中后的精简目录, 不是全量列表.
+const CatalogHeader = "== Relevant Skills (intent-matched, top %d) ==\n"
+
 // AvailableSkillsOverflowHint formats the tail line when registry listing hits the token budget.
 func AvailableSkillsOverflowHint(omitted int) string {
 	return fmt.Sprintf("  ... and %d more skills. Use search_capabilities to find specific skills.\n", omitted)

--- a/common/ai/aid/aicommon/aiskillloader/skill_meta_list_budget_test.go
+++ b/common/ai/aid/aicommon/aiskillloader/skill_meta_list_budget_test.go
@@ -44,8 +44,10 @@ func TestSelectSkillMetasForPromptRegistry_MatchesAppendAvailableSkillsSection(t
 		t.Fatalf("expected full registry list, got listed=%d omitted=%d", len(listed), omitted)
 	}
 
+	// 改造后: 目录默认隐藏, 需 SetCatalogSkills 才在 RenderStable 出现.
+	mgr.SetCatalogSkills(loader.AllSkillMetas())
 	rendered := mgr.RenderStable()
 	if !strings.Contains(rendered, "  - code-review:") || !strings.Contains(rendered, "  - deploy-app:") {
-		t.Fatalf("rendered prompt should list both skills: %s", rendered)
+		t.Fatalf("rendered prompt should list both skills in catalog: %s", rendered)
 	}
 }

--- a/common/ai/aid/aicommon/aiskillloader/skills_context_manager.go
+++ b/common/ai/aid/aicommon/aiskillloader/skills_context_manager.go
@@ -85,8 +85,26 @@ type SkillsContextManager struct {
 	loader SkillLoader
 
 	// loadedSkills is an ordered map of loaded skills, keyed by skill name.
+	// 语义 (改造后): 持久会话恢复的历史加载 + 用户强制加载也会在这里登记一份
+	// (保证 IsSkillLoaded 查询一致, 避免 AI action 重复加载).
+	// 渲染进 SKILLS_CONTEXT 上半段 (与 catalog 目录同处 SemiDynamic 1).
 	// Ordering is by load time (oldest first).
 	loadedSkills *omap.OrderedMap[string, *skillContextState]
+
+	// forcedSkills 是「用户强制加载」专用容器 (满内容, 进 frozen_block 顶部).
+	// 来源: load_skill sync 事件 / EnabledCapabilities / hotpatch skill handler.
+	// 优先级最高, 独立于 loadedSkills / autoLoadedSkills 渲染.
+	forcedSkills *ForcedSkillRegistry
+
+	// autoLoadedSkills 是「AI 意图驱动加载」容器 (进 SemiDynamic 2 尾部).
+	// 来源: loading_skills action (AI 自主加载). 走 LRU 折叠控制体积.
+	autoLoadedSkills *omap.OrderedMap[string, *skillContextState]
+
+	// catalogVisible 控制「最相关 SKILL 目录」(SKILLS_CONTEXT 下半段) 是否渲染.
+	// 默认 false: 意图识别命中后才由 SetCatalogVisible(true) 开启, 节约 token.
+	catalogVisible bool
+	// catalogSkills 是意图识别写入的「最相关 top-N」skill 元信息, 渲染为精简目录.
+	catalogSkills []*SkillMeta
 
 	// maxTokens is the total size limit (in tokens) for the skills context.
 	maxTokens int
@@ -110,6 +128,8 @@ func NewSkillsContextManager(loader SkillLoader, opts ...ManagerOption) *SkillsC
 	m := &SkillsContextManager{
 		loader:           loader,
 		loadedSkills:     omap.NewOrderedMap[string, *skillContextState](map[string]*skillContextState{}),
+		forcedSkills:     NewForcedSkillRegistry(),
+		autoLoadedSkills: omap.NewOrderedMap[string, *skillContextState](map[string]*skillContextState{}),
 		maxTokens:        SkillsContextMaxTokens,
 		contextSizeDirty: true,
 	}
@@ -167,6 +187,63 @@ func (m *SkillsContextManager) HasTruncatedViews() bool {
 		return true
 	})
 	return hasTruncated
+}
+
+// HasForcedSkills returns true if there is any user-forced skill (rendered into frozen_block).
+func (m *SkillsContextManager) HasForcedSkills() bool {
+	if m == nil || m.forcedSkills == nil {
+		return false
+	}
+	return !m.forcedSkills.IsEmpty()
+}
+
+// HasAutoLoadedSkills returns true if there is any AI-intent-driven auto-loaded skill
+// (rendered into SemiDynamic 2 tail).
+func (m *SkillsContextManager) HasAutoLoadedSkills() bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.autoLoadedSkills.Len() > 0
+}
+
+// SetCatalogVisible 控制「最相关 SKILL 目录」(SKILLS_CONTEXT 下半段) 是否渲染.
+// 默认 false; 意图识别命中后由调用方 SetCatalogVisible(true) 开启.
+func (m *SkillsContextManager) SetCatalogVisible(visible bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.catalogVisible = visible
+}
+
+// IsCatalogVisible 返回目录是否可见.
+func (m *SkillsContextManager) IsCatalogVisible() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.catalogVisible
+}
+
+// SetCatalogSkills 写入意图识别命中的「最相关 top-N」skill 元信息 (渲染为精简目录).
+// 内部会截断到 MaxCatalogSkills. 传入 nil / 空等价于清空 + 隐藏目录.
+func (m *SkillsContextManager) SetCatalogSkills(metas []*SkillMeta) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.catalogSkills = dedupAndTruncateCatalog(metas, MaxCatalogSkills)
+	if len(m.catalogSkills) > 0 {
+		m.catalogVisible = true
+	}
+}
+
+// GetCatalogSkills 返回当前目录 skill 元信息副本.
+func (m *SkillsContextManager) GetCatalogSkills() []*SkillMeta {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.catalogSkills) == 0 {
+		return nil
+	}
+	out := make([]*SkillMeta, len(m.catalogSkills))
+	copy(out, m.catalogSkills)
+	return out
 }
 
 // ListSkills lists all skills from loader metadata.
@@ -312,6 +389,181 @@ func (m *SkillsContextManager) LoadSkills(names []string) map[string]error {
 	return results
 }
 
+// LoadForcedSkill 用户强制加载一个 SKILL (满内容, 进 frozen_block 顶部).
+// 与 LoadAutoSkill (AI 意图驱动, 进 SemiDynamic 2) 区分开, 这是最高优先级路径.
+// 同时在 loadedSkills 登记一份, 保证 IsSkillLoaded 查询一致, 避免 AI action 重复加载.
+// 返回 (新增?, error): 新增=false 表示该 skill 已是 forced.
+//
+// 关键词: LoadForcedSkill, 用户强制加载, frozen_block, 满内容
+func (m *SkillsContextManager) LoadForcedSkill(skillName string) (bool, error) {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return false, utils.Error("skill name is empty")
+	}
+	m.mu.Lock()
+	unlock := true
+	defer func() {
+		if unlock {
+			m.mu.Unlock()
+		}
+	}()
+
+	if m.loader == nil {
+		return false, utils.Error("skills context manager: no loader configured")
+	}
+
+	// 已是 forced: 幂等返回.
+	if m.forcedSkills.Has(skillName) {
+		return false, nil
+	}
+
+	loaded, err := m.loader.LoadSkill(skillName)
+	if err != nil {
+		return false, utils.Wrapf(err, "failed to load skill %q", skillName)
+	}
+
+	m.forcedSkills.Add(skillName, loaded)
+
+	// 同时登记进 loadedSkills (若尚未存在), 保证 IsSkillLoaded 查询一致.
+	if _, ok := m.loadedSkills.Get(skillName); !ok {
+		now := time.Now()
+		transformedContent := TransformIncludesToResourceHints(loaded.SkillMDContent, skillName)
+		nonce := GenerateNonce(skillName, skillMDFilename)
+		skillMDWindow := NewViewWindow(skillName, skillMDFilename, transformedContent, nonce)
+		state := &skillContextState{
+			Skill:    loaded,
+			IsFolded: false,
+			ViewWindows: map[string]*ViewWindow{
+				skillMDFilename: skillMDWindow,
+			},
+			LastAccessedAt: now,
+		}
+		m.loadedSkills.Set(skillName, state)
+		m.contextSizeDirty = true
+		// ensureContextFits 需要 mu, 但我们在锁内, 直接传 false 解锁由调用者释放不安全,
+		// 故这里先解锁再调用 (ensureContextFits 内部会自己加锁).
+		m.mu.Unlock()
+		unlock = false
+		m.ensureContextFits()
+	}
+	log.Infof("force-loaded skill %q into frozen_block", skillName)
+	return true, nil
+}
+
+// UnloadForcedSkill 移除一个 forced skill (仅从 frozen_block 容器移除, 不动 loadedSkills).
+// 返回是否曾存在.
+func (m *SkillsContextManager) UnloadForcedSkill(skillName string) bool {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return false
+	}
+	return m.forcedSkills.Remove(skillName)
+}
+
+// IsForcedSkill 返回该 skill 是否为用户强制加载.
+func (m *SkillsContextManager) IsForcedSkill(skillName string) bool {
+	skillName = strings.TrimSpace(skillName)
+	return m.forcedSkills.Has(skillName)
+}
+
+// LoadAutoSkill AI 意图驱动加载一个 SKILL (进 SemiDynamic 2 尾部, LRU 折叠).
+// 来源: loading_skills action. 若 skill 已是 forced, 短路返回成功 (不重复加载).
+// 返回 (新增?, error): 新增=false 表示该 skill 已是 forced 或已 auto-loaded.
+//
+// 关键词: LoadAutoSkill, AI 意图驱动, SemiDynamic 2, LRU 折叠
+func (m *SkillsContextManager) LoadAutoSkill(skillName string) (bool, error) {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return false, utils.Error("skill name is empty")
+	}
+	m.mu.Lock()
+	unlock := true
+	defer func() {
+		if unlock {
+			m.mu.Unlock()
+		}
+	}()
+
+	if m.loader == nil {
+		return false, utils.Error("skills context manager: no loader configured")
+	}
+
+	// 已是 forced: 幂等短路 (forced 优先级更高, 满内容已可见, 无需重复加载).
+	if m.forcedSkills.Has(skillName) {
+		return false, nil
+	}
+
+	now := time.Now()
+
+	// 已 auto-loaded: 刷新 LRU 时间, 若被折叠则展开.
+	if existing, ok := m.autoLoadedSkills.Get(skillName); ok {
+		existing.LastAccessedAt = now
+		if existing.IsFolded {
+			existing.IsFolded = false
+			m.contextSizeDirty = true
+			m.ensureAutoSkillsFits()
+		}
+		return false, nil
+	}
+
+	loaded, err := m.loader.LoadSkill(skillName)
+	if err != nil {
+		return false, utils.Wrapf(err, "failed to load skill %q", skillName)
+	}
+
+	transformedContent := TransformIncludesToResourceHints(loaded.SkillMDContent, skillName)
+	nonce := GenerateNonce(skillName, skillMDFilename)
+	skillMDWindow := NewViewWindow(skillName, skillMDFilename, transformedContent, nonce)
+	state := &skillContextState{
+		Skill:    loaded,
+		IsFolded: false,
+		ViewWindows: map[string]*ViewWindow{
+			skillMDFilename: skillMDWindow,
+		},
+		LastAccessedAt: now,
+	}
+	m.autoLoadedSkills.Set(skillName, state)
+	m.ensureAutoSkillsFits()
+	log.Infof("auto-loaded skill %q into SemiDynamic 2", skillName)
+	return true, nil
+}
+
+// UnloadAutoSkill 从 auto-loaded 容器移除一个 skill.
+func (m *SkillsContextManager) UnloadAutoSkill(skillName string) bool {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.autoLoadedSkills.Have(skillName) {
+		return false
+	}
+	m.autoLoadedSkills.Delete(skillName)
+	log.Infof("unloaded auto skill %q", skillName)
+	return true
+}
+
+// IsAutoSkillLoadedAndUnfolded 返回 auto-loaded skill 是否已加载且未折叠.
+// 用于 loading_skills action 的 ActionVerifier 短路 (避免重复加载).
+func (m *SkillsContextManager) IsAutoSkillLoadedAndUnfolded(skillName string) bool {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	// forced 也算「已加载且满可见」, action 应短路.
+	if m.forcedSkills.Has(skillName) {
+		return true
+	}
+	state, ok := m.autoLoadedSkills.Get(skillName)
+	if !ok {
+		return false
+	}
+	return !state.IsFolded
+}
+
 // ChangeViewOffset changes the view offset for a file in a loaded skill.
 func (m *SkillsContextManager) ChangeViewOffset(skillName, filePath string, offset int) error {
 	m.mu.Lock()
@@ -422,33 +674,82 @@ func (m *SkillsContextManager) RenderStable() string {
 	return m.renderWithTag("skills_context")
 }
 
-// renderWithTag 输出固定双段结构, 让 0->1 加载只增量改"Currently Loaded"上半段,
-// "Available Skills" registry listing 字节稳定。这是 Prompt 按稳定性分层路径下
-// SkillsContext 进入 AI_CACHE_FROZEN 块时保持前缀缓存命中的核心前置:
+// RenderForcedSkills 渲染「用户强制加载」SKILL 段 (满内容, 进 frozen_block 顶部).
+// 无 forced skill 时返回空串 (frozen_block 顶部子块不渲染).
+// 内容委托 ForcedSkillRegistry.Render, 与本 manager 的 mu 解耦.
+//
+// 关键词: RenderForcedSkills, frozen_block, 用户强制加载满内容
+func (m *SkillsContextManager) RenderForcedSkills() string {
+	if m == nil || m.forcedSkills == nil {
+		return ""
+	}
+	return m.forcedSkills.Render()
+}
+
+// RenderAutoLoadedSkills 渲染「AI 意图驱动加载」SKILL 段 (进 SemiDynamic 2 尾部).
+// 输出形如:
+//
+//	<|AUTO_LOADED_SKILLS|>
+//	=== Skill: X ===
+//	<...>
+//	=== Skill: Y (folded) ===
+//	<...>
+//	<|AUTO_LOADED_SKILLS_END|>
+//
+// 无 auto-loaded skill 时返回空串. 段头/尾用 stable nonce, 保 SemiDynamic 2 前缀缓存.
+func (m *SkillsContextManager) RenderAutoLoadedSkills() string {
+	if m == nil {
+		return ""
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.autoLoadedSkills.Len() == 0 {
+		return ""
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("<|AUTO_LOADED_SKILLS|>\n")
+	for _, item := range m.sortedAutoLoadedSkillStates() {
+		state := item.state
+		if state.IsFolded {
+			buf.WriteString(m.renderFolded(state))
+		} else {
+			buf.WriteString(m.renderFull(state))
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString("<|AUTO_LOADED_SKILLS_END|>")
+	return buf.String()
+}
+
+// renderWithTag 输出 SKILLS_CONTEXT 段 (SemiDynamic 1).
+//
+// 改造后 (默认隐藏目录 + 意图驱动目录 + 三态分离):
 //
 //	<|SKILLS_CONTEXT_<tag>|>
 //	== Currently Loaded Skills ==
-//	(none)                               // 或 sortedLoadedSkillStates 渲染输出
+//	(loadedSkills 渲染: 持久会话恢复 + forced 登记副本; 或 "(none)")
 //
-//	== Available Skills (use loading_skills action to load) ==
+//	== Relevant Skills (intent-matched, top N) ==    // 仅当 catalogVisible 时
 //	  - skill-a: ...
 //	  - skill-b: ...
-//	  ... and N more skills.             // 大列表时尾段提示
-//	  ... plus N database-backed skills.
 //	<|SKILLS_CONTEXT_END_<tag>|>
 //
-// 注意: 上半段在零加载时仅一行 "(none)"; 加载后包含具体内容。这样无论加载与否,
-// 整体段落结构 (header / 上半段 / 分隔空行 / 下半段) 都保持。
+// 默认 catalogVisible=false → 下半段完全不输出 (节约 token).
+// autoLoadedSkills 不在此处 (它们进 SemiDynamic 2, 见 RenderAutoLoadedSkills).
+// forcedSkills 不在此处 (它们进 frozen_block, 见 RenderForcedSkills).
 //
-// 关键词: SkillsContext renderWithTag, dual-section, 字节稳定, prefix cache
+// 关键词: SkillsContext renderWithTag, 默认隐藏目录, catalog top-N, 三态分离
 func (m *SkillsContextManager) renderWithTag(tag string) string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	hasRegistered := m.HasRegisteredSkills()
 	hasLoaded := m.loadedSkills.Len() > 0
+	hasForced := m.forcedSkills != nil && !m.forcedSkills.IsEmpty()
+	showCatalog := m.catalogVisible && len(m.catalogSkills) > 0
 
-	if !hasRegistered && !hasLoaded {
+	// 零状态: 不渲染整段.
+	if !hasLoaded && !hasForced && !showCatalog {
 		return ""
 	}
 
@@ -470,13 +771,34 @@ func (m *SkillsContextManager) renderWithTag(tag string) string {
 		buf.WriteString("(none)\n")
 	}
 
-	if hasRegistered {
+	if showCatalog {
 		buf.WriteString("\n")
-		m.appendAvailableSkillsSection(&buf)
+		m.appendCatalogSection(&buf)
 	}
 
 	buf.WriteString(fmt.Sprintf("<|SKILLS_CONTEXT_END_%s|>", tag))
 	return buf.String()
+}
+
+// appendCatalogSection 写入意图识别驱动的「最相关 SKILL 目录」段 (默认隐藏).
+// 内容来自 catalogSkills (意图识别写入的 top-N), 截断到 MaxCatalogSkills.
+//
+// 关键词: appendCatalogSection, 意图驱动目录, top-N
+func (m *SkillsContextManager) appendCatalogSection(buf *bytes.Buffer) {
+	skills := m.catalogSkills
+	if len(skills) == 0 {
+		return
+	}
+	// 按 name 排序保证字节稳定 (利于缓存), 与旧 Available Skills registry 行为一致.
+	sorted := sortSkillMetasByName(skills)
+	if len(sorted) > MaxCatalogSkills {
+		sorted = sorted[:MaxCatalogSkills]
+	}
+	buf.WriteString(fmt.Sprintf(CatalogHeader, len(sorted)))
+	for _, meta := range sorted {
+		buf.WriteString(FormatAvailableSkillRegistryLine(meta))
+	}
+	buf.WriteString("Use loading_skills action to load any of these when needed.\n")
 }
 
 // appendAvailableSkillsSection 写入"Available Skills"下半段。
@@ -572,6 +894,89 @@ func (m *SkillsContextManager) sortedLoadedSkillStates() []namedSkillState {
 		return left < right
 	})
 	return items
+}
+
+// sortedAutoLoadedSkillStates 返回按名排序的 auto-loaded skill 状态 (用于 RenderAutoLoadedSkills).
+func (m *SkillsContextManager) sortedAutoLoadedSkillStates() []namedSkillState {
+	items := make([]namedSkillState, 0, m.autoLoadedSkills.Len())
+	m.autoLoadedSkills.ForEach(func(name string, state *skillContextState) bool {
+		items = append(items, namedSkillState{name: name, state: state})
+		return true
+	})
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].name < items[j].name
+	})
+	return items
+}
+
+// ensureAutoSkillsFits 对 autoLoadedSkills 做 LRU 折叠, 控制 SemiDynamic 2 体积.
+// 复用 ensureContextFits 的 LRU 策略, 但作用于 autoLoadedSkills 容器 (独立预算).
+// 必须在 m.mu 持有时调用.
+func (m *SkillsContextManager) ensureAutoSkillsFits() {
+	for {
+		totalSize := m.estimateAutoSkillsSize()
+		if totalSize <= m.maxTokens {
+			return
+		}
+		var lruName string
+		var lruTime time.Time
+		m.autoLoadedSkills.ForEach(func(name string, state *skillContextState) bool {
+			if !state.IsFolded {
+				if lruName == "" || state.LastAccessedAt.Before(lruTime) {
+					lruName = name
+					lruTime = state.LastAccessedAt
+				}
+			}
+			return true
+		})
+		if lruName == "" {
+			log.Warnf("all auto skills folded but still exceed limit (total: %d, limit: %d)", totalSize, m.maxTokens)
+			return
+		}
+		if state, ok := m.autoLoadedSkills.Get(lruName); ok {
+			state.IsFolded = true
+			log.Infof("folded LRU auto skill %q to fit SemiDynamic 2 (total: %d, limit: %d)", lruName, totalSize, m.maxTokens)
+		}
+	}
+}
+
+// estimateAutoSkillsSize 估算 autoLoadedSkills 的总 token 体积. 必须在 m.mu 持有时调用.
+func (m *SkillsContextManager) estimateAutoSkillsSize() int {
+	total := 0
+	m.autoLoadedSkills.ForEach(func(name string, state *skillContextState) bool {
+		var rendered string
+		if state.IsFolded {
+			rendered = m.renderFolded(state)
+		} else {
+			rendered = m.renderFull(state)
+		}
+		total += m.measureSize(rendered)
+		return true
+	})
+	return total
+}
+
+// dedupAndTruncateCatalog 对 catalog skill 元信息去重 (按 name) 并截断到 max.
+func dedupAndTruncateCatalog(metas []*SkillMeta, max int) []*SkillMeta {
+	if len(metas) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(metas))
+	out := make([]*SkillMeta, 0, len(metas))
+	for _, meta := range metas {
+		if meta == nil || strings.TrimSpace(meta.Name) == "" {
+			continue
+		}
+		if seen[meta.Name] {
+			continue
+		}
+		seen[meta.Name] = true
+		out = append(out, meta)
+		if max > 0 && len(out) >= max {
+			break
+		}
+	}
+	return out
 }
 
 func sortSkillMetasByName(metas []*SkillMeta) []*SkillMeta {

--- a/common/ai/aid/aicommon/aiskillloader/skills_context_manager.go
+++ b/common/ai/aid/aicommon/aiskillloader/skills_context_manager.go
@@ -295,13 +295,27 @@ func (m *SkillsContextManager) SearchByAI(userNeed string) ([]*SkillMeta, error)
 	return SearchByAI(metas, userNeed, m.searchAICallback)
 }
 
-// GetCurrentSelectedSkills returns currently loaded (selected) skills.
+// GetCurrentSelectedSkills returns currently loaded/selected skills across all
+// three containers (loadedSkills = persistent-restore + forced 副本, autoLoadedSkills
+// = AI 意图驱动). Forced skills also live in loadedSkills, so no separate iteration
+// needed for them.
 func (m *SkillsContextManager) GetCurrentSelectedSkills() []*SkillMeta {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	selected := make([]*SkillMeta, 0, m.loadedSkills.Len())
+	selected := make([]*SkillMeta, 0, m.loadedSkills.Len()+m.autoLoadedSkills.Len())
+	seen := make(map[string]bool, m.loadedSkills.Len()+m.autoLoadedSkills.Len())
 	m.loadedSkills.ForEach(func(name string, state *skillContextState) bool {
-		selected = append(selected, state.Skill.Meta)
+		if state != nil && state.Skill != nil && state.Skill.Meta != nil && !seen[name] {
+			seen[name] = true
+			selected = append(selected, state.Skill.Meta)
+		}
+		return true
+	})
+	m.autoLoadedSkills.ForEach(func(name string, state *skillContextState) bool {
+		if state != nil && state.Skill != nil && state.Skill.Meta != nil && !seen[name] {
+			seen[name] = true
+			selected = append(selected, state.Skill.Meta)
+		}
 		return true
 	})
 	return selected
@@ -596,12 +610,22 @@ func (m *SkillsContextManager) ChangeViewOffset(skillName, filePath string, offs
 	return nil
 }
 
-// IsSkillLoaded returns true if the given skill is currently loaded (either folded or unfolded).
+// IsSkillLoaded returns true if the given skill is currently loaded in ANY container
+// (loadedSkills = persistent-restore + forced 副本, autoLoadedSkills = AI 意图驱动,
+// or forcedSkills). This is the unified "is this skill present in the manager" check.
 func (m *SkillsContextManager) IsSkillLoaded(skillName string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	_, ok := m.loadedSkills.Get(skillName)
-	return ok
+	if _, ok := m.loadedSkills.Get(skillName); ok {
+		return true
+	}
+	if _, ok := m.autoLoadedSkills.Get(skillName); ok {
+		return true
+	}
+	if m.forcedSkills != nil && m.forcedSkills.Has(skillName) {
+		return true
+	}
+	return false
 }
 
 // IsSkillLoadedAndUnfolded returns true if the skill is loaded and currently unfolded (fully visible).

--- a/common/ai/aid/aicommon/aiskillloader/skills_context_manager.go
+++ b/common/ai/aid/aicommon/aiskillloader/skills_context_manager.go
@@ -768,7 +768,17 @@ func (m *SkillsContextManager) renderWithTag(tag string) string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	hasLoaded := m.loadedSkills.Len() > 0
+	// forced skill 的满内容已通过 RenderForcedSkills 进 frozen_block 顶部,
+	// 此处需排除 forced 副本, 避免同一份内容在 SKILLS_CONTEXT 中重复渲染.
+	visibleLoaded := make([]namedSkillState, 0, m.loadedSkills.Len())
+	for _, item := range m.sortedLoadedSkillStates() {
+		if m.forcedSkills != nil && m.forcedSkills.Has(item.name) {
+			continue
+		}
+		visibleLoaded = append(visibleLoaded, item)
+	}
+
+	hasLoaded := len(visibleLoaded) > 0
 	hasForced := m.forcedSkills != nil && !m.forcedSkills.IsEmpty()
 	showCatalog := m.catalogVisible && len(m.catalogSkills) > 0
 
@@ -782,7 +792,7 @@ func (m *SkillsContextManager) renderWithTag(tag string) string {
 
 	buf.WriteString("== Currently Loaded Skills ==\n")
 	if hasLoaded {
-		for _, item := range m.sortedLoadedSkillStates() {
+		for _, item := range visibleLoaded {
 			state := item.state
 			if state.IsFolded {
 				buf.WriteString(m.renderFolded(state))

--- a/common/ai/aid/aicommon/aiskillloader_autoload_integration_test.go
+++ b/common/ai/aid/aicommon/aiskillloader_autoload_integration_test.go
@@ -68,13 +68,14 @@ func TestAutoSkillLoader_Integration_WithContextManager(t *testing.T) {
 		t.Fatal("manager should detect skills from AutoSkillLoader")
 	}
 
-	// Render available skills list
+	// Render catalog (default hidden; surface it like intent recognition does).
+	mgr.SetCatalogSkills(loader.AllSkillMetas())
 	rendered := mgr.Render("autoload_nonce")
 	if !strings.Contains(rendered, "deploy-app") {
-		t.Fatal("render should list deploy-app")
+		t.Fatal("render should list deploy-app in catalog")
 	}
 	if !strings.Contains(rendered, "vuln-scan") {
-		t.Fatal("render should list vuln-scan")
+		t.Fatal("render should list vuln-scan in catalog")
 	}
 
 	// Load a skill
@@ -188,8 +189,23 @@ func TestAutoSkillLoader_Integration_DBAndContextManager(t *testing.T) {
 	if !mgr.HasRegisteredSkills() {
 		t.Fatal("manager should have skills")
 	}
-	if rendered := mgr.Render("db_lazy_nonce"); !strings.Contains(rendered, "database-backed skills") {
-		t.Fatalf("expected render to expose database-backed skill stats, got: %s", rendered)
+	// 改造后: 目录默认隐藏, 数据库来源 skill 是 lazy 的 (不在 AllSkillMetas).
+	// 数据库 skill 通过搜索 (BM25) 访问, 验证可检索即可.
+	results, err := mgr.SearchKeywordBM25("deploy", 5)
+	if err != nil {
+		t.Fatalf("SearchKeywordBM25 failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected to find deploy-app via BM25 search on database-backed skills")
+	}
+	found := false
+	for _, m := range results {
+		if m != nil && m.Name == "deploy-app" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("BM25 search should find deploy-app, got: %v", results)
 	}
 
 	_ = mgr.LoadSkill("deploy-app")

--- a/common/ai/aid/aicommon/aiskillloader_integration_test.go
+++ b/common/ai/aid/aicommon/aiskillloader_integration_test.go
@@ -51,16 +51,22 @@ func TestSkillsContextManager_Integration_FullLifecycle(t *testing.T) {
 		t.Fatal("no truncated views before loading any skill")
 	}
 
-	// Step 2: render without loading -> should list available skills
+	// Step 2: render without loading -> catalog hidden by default → empty (save tokens).
 	rendered := mgr.Render("lifecycle_nonce")
+	if rendered != "" {
+		t.Fatalf("default render with hidden catalog should be empty. Got:\n%s", rendered)
+	}
+	// Surface catalog (simulating intent recognition).
+	mgr.SetCatalogSkills(loader.AllSkillMetas())
+	rendered = mgr.Render("lifecycle_nonce")
 	if !strings.Contains(rendered, "<|SKILLS_CONTEXT_lifecycle_nonce|>") {
-		t.Fatal("render should have context start tag")
+		t.Fatal("render should have context start tag when catalog visible")
 	}
 	if !strings.Contains(rendered, "<|SKILLS_CONTEXT_END_lifecycle_nonce|>") {
-		t.Fatal("render should have context end tag")
+		t.Fatal("render should have context end tag when catalog visible")
 	}
 	if !strings.Contains(rendered, "deploy-app") || !strings.Contains(rendered, "code-review") {
-		t.Fatal("render should list all available skills before loading")
+		t.Fatal("render should list catalog skills when visible")
 	}
 
 	// Step 3: load a skill

--- a/common/ai/aid/aicommon/config_ai_wrapper.go
+++ b/common/ai/aid/aicommon/config_ai_wrapper.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aiddb"
+	"github.com/yaklang/yaklang/common/ai/aispec"
 	"github.com/yaklang/yaklang/common/ai/ytoken"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
@@ -465,6 +466,12 @@ func (c *Config) wrapper(i AICallbackType, tier consts.ModelTier) AICallbackType
 					"cache_hit_token":         cacheHitTokens,
 					"token_source":            usageMetrics.TokenSource,
 					"caller_label":            callerLabel,
+				})
+				// 命中统计: 记录一次 AI (模型) 调用及其 token 用量 (每日汇总).
+				SubmitAICall(c, model, &aispec.ChatUsage{
+					PromptTokens:     int(inputTokens),
+					CompletionTokens: int(outputTokens),
+					TotalTokens:      int(totalTokens),
 				})
 				if outputBytes == 0 {
 					rawDump := origRsp.GetRawHTTPResponseDump()

--- a/common/ai/aid/aicommon/config_sync_event.go
+++ b/common/ai/aid/aicommon/config_sync_event.go
@@ -31,6 +31,14 @@ const (
 	SYNC_TYPE_PERCEPTION                  = "perception_sync"
 	SYNC_TYPE_SESSION_SNAPSHOT            = "session_snapshot_sync"
 	SYNC_TYPE_CLOSE_BROWSER               = "close_browser_sync"
+	// SYNC_TYPE_LOAD_SKILL 是用户强制加载 SKILL 的 sync 事件.
+	// 客户端发 AIInputEvent{IsSyncMessage:true, SyncType:"load_skill_sync",
+	// SyncJsonInput: `{"skill_names":["x","y"]}`}, 服务端把满内容加载进
+	// SkillsContextManager.ForcedSkills (进 frozen_block 顶部), 并在 timeline 写
+	// "user_loaded_skill" 条目. 响应 EmitSyncJSON 返回 loaded/failed/already_loaded.
+	//
+	// 关键词: SYNC_TYPE_LOAD_SKILL, 用户强制加载, frozen_block, timeline
+	SYNC_TYPE_LOAD_SKILL = "load_skill_sync"
 
 	ProcessID           string = "process_id"
 	SyncProcessEeventID        = "sync_process_event_id"

--- a/common/ai/aid/aicommon/invoke_runtime.go
+++ b/common/ai/aid/aicommon/invoke_runtime.go
@@ -245,6 +245,22 @@ type LoopPromptAssemblyInput struct {
 	// FrozenPartitions 是业务侧提供的通用 frozen-block 分区。共享模板只识别
 	// FrozenBlockPartition，不直接依赖 planAndExec / FACTS / DOCUMENT 等业务类型。
 	FrozenPartitions []FrozenBlockPartition
+
+	// ForcedSkills 是「用户强制加载」SKILL 的满内容渲染 (含 USER_FORCED_SKILL 边界).
+	// 物理位置: frozen_block 顶部 (比 SKILLS_CONTEXT 目录层级还高), 最高优先级.
+	// 用户主动加载是偶发行为, 加载后整段字节稳定, 利于 frozen_block 缓存; 热加载时
+	// 接受重缓存. 空字符串时 frozen_block 顶部子块自动跳过.
+	//
+	// 关键词: ForcedSkills, 用户强制加载, frozen_block 顶部, 最高优先级
+	ForcedSkills string
+
+	// AutoLoadedSkills 是「AI 意图驱动加载」SKILL 的渲染 (含 AUTO_LOADED_SKILLS 边界).
+	// 物理位置: semi_dynamic_2 尾部 (TaskInstruction/Schema/OutputExample 之后).
+	// 关键缓存点: semi2 前缀字节不变 → AI_CACHE_SEMI2 前缀缓存命中, 仅尾部变化.
+	// 空字符串时 semi_dynamic_2 尾部子块自动跳过.
+	//
+	// 关键词: AutoLoadedSkills, AI 意图驱动, semi_dynamic_2 尾部, LRU 折叠
+	AutoLoadedSkills string
 }
 
 type LoopPromptAssemblyResult struct {

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -31,6 +31,13 @@ type PromptMaterials struct {
 	OriginalUserInput string
 	StableInstruction string
 
+	// ForcedSkills 是「用户强制加载」SKILL 满内容, 进 frozen_block 顶部 (最高优先级).
+	// 空时 frozen_block 顶部子块不渲染.
+	ForcedSkills string
+	// AutoLoadedSkills 是「AI 意图驱动加载」SKILL, 进 semi_dynamic_2 尾部.
+	// 空时 semi_dynamic_2 尾部子块不渲染.
+	AutoLoadedSkills string
+
 	ToolInventory bool
 	ToolsCount    int
 	TopToolsCount int
@@ -100,25 +107,27 @@ func (m *PromptMaterials) SemiDynamic1Data() map[string]any {
 }
 
 // SemiDynamic2Data 供 TaskInstruction -> ExecutionPolicy -> Schema ->
-// OutputExample 半动态段消费。
+// OutputExample 半动态段消费, 尾部追加 AutoLoadedSkills (AI 意图驱动加载 SKILL).
 func (m *PromptMaterials) SemiDynamic2Data() map[string]any {
 	if m == nil {
 		return map[string]any{}
 	}
 	return map[string]any{
-		"TaskInstruction": m.TaskInstruction,
-		"ExecutionPolicy": m.ExecutionPolicy,
-		"Schema":          m.Schema,
-		"OutputExample":   m.OutputExample,
+		"TaskInstruction":  m.TaskInstruction,
+		"ExecutionPolicy":  m.ExecutionPolicy,
+		"Schema":           m.Schema,
+		"OutputExample":    m.OutputExample,
+		"AutoLoadedSkills": m.AutoLoadedSkills,
 	}
 }
 
-// FrozenBlockData 供 frozen-block 模板消费。
+// FrozenBlockData 供 frozen-block 模板消费, 顶部前置 ForcedSkills (用户强制加载 SKILL 满内容).
 func (m *PromptMaterials) FrozenBlockData() map[string]any {
 	if m == nil {
 		return map[string]any{}
 	}
 	return map[string]any{
+		"ForcedSkills":           m.ForcedSkills,
 		"ToolInventory":          m.ToolInventory,
 		"ToolsCount":             m.ToolsCount,
 		"TopToolsCount":          m.TopToolsCount,

--- a/common/ai/aid/aicommon/prompts/prefix/frozen_block_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/frozen_block_section.txt
@@ -1,4 +1,6 @@
-{{ if .ToolInventory }}# Tool Inventory
+{{ if .ForcedSkills }}{{ .ForcedSkills }}
+
+{{ end }}{{ if .ToolInventory }}# Tool Inventory
 You have access to {{ .ToolsCount }} built-in tools. Below are {{ .TopToolsCount }} prioritized entries selected within a token budget:
 
 ## Call Mode (single tool vs tool_compose)

--- a/common/ai/aid/aicommon/prompts/prefix/semi_dynamic_2_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/semi_dynamic_2_section.txt
@@ -20,4 +20,5 @@
 
 <|OUTPUT_EXAMPLE|>
 {{ .OutputExample }}
-<|OUTPUT_EXAMPLE_END|>{{ end }}
+<|OUTPUT_EXAMPLE_END|>{{ end }}{{ if .AutoLoadedSkills }}
+{{ .AutoLoadedSkills }}{{ end }}

--- a/common/ai/aid/aicommon/session_snapshot.go
+++ b/common/ai/aid/aicommon/session_snapshot.go
@@ -18,7 +18,7 @@ const (
 	SessionSnapshotSectionCapabilities        = "capabilities"
 	SessionSnapshotSectionBackgroundProcesses = "background_processes"
 
-	SessionSnapshotProcessTypeBrowser = "browser"
+	SessionSnapshotProcessTypeBrowser   = "browser"
 	SessionSnapshotProcessStatusRunning = "running"
 )
 
@@ -27,11 +27,11 @@ type sessionSnapshotEmitHandler func()
 // SessionSnapshot is the unified real-time sidebar payload for frontend consumption.
 // TaskId / TaskIndex are carried on the outer AIOutputEvent envelope, not duplicated here.
 type SessionSnapshot struct {
-	Revision            int64                             `json:"revision"`
-	UpdatedAt           int64                             `json:"updated_at"`
-	Execution           *SessionSnapshotExecution         `json:"execution"`
-	Perception          *SessionSnapshotPerception        `json:"perception"`
-	Capabilities        []CapabilityInventoryItem         `json:"capabilities"`
+	Revision            int64                              `json:"revision"`
+	UpdatedAt           int64                              `json:"updated_at"`
+	Execution           *SessionSnapshotExecution          `json:"execution"`
+	Perception          *SessionSnapshotPerception         `json:"perception"`
+	Capabilities        []CapabilityInventoryItem          `json:"capabilities"`
 	BackgroundProcesses []SessionSnapshotBackgroundProcess `json:"background_processes"`
 }
 
@@ -60,33 +60,33 @@ type SessionSnapshotExecution struct {
 }
 
 type SessionSnapshotPerception struct {
-	Summary      string  `json:"summary"`
+	Summary      string   `json:"summary"`
 	Topics       []string `json:"topics"`
 	Keywords     []string `json:"keywords"`
-	Confidence   float64 `json:"confidence"`
-	Changed      bool    `json:"changed"`
-	Epoch        int     `json:"epoch"`
-	LastTrigger  string  `json:"last_trigger"`
-	IntentShift  string  `json:"intent_shift"`
-	LastUpdateAt int64   `json:"last_update_at"`
+	Confidence   float64  `json:"confidence"`
+	Changed      bool     `json:"changed"`
+	Epoch        int      `json:"epoch"`
+	LastTrigger  string   `json:"last_trigger"`
+	IntentShift  string   `json:"intent_shift"`
+	LastUpdateAt int64    `json:"last_update_at"`
 
 	CapabilityMatches *SessionSnapshotPerceptionCapabilityMatches `json:"capability_matches"`
 	Knowledge         *SessionSnapshotPerceptionKnowledge         `json:"knowledge"`
 }
 
 type SessionSnapshotPerceptionCapabilityMatches struct {
-	Query                    string   `json:"query"`
-	MatchedToolNames         []string `json:"matched_tool_names"`
-	MatchedForgeNames        []string `json:"matched_forge_names"`
-	MatchedSkillNames        []string `json:"matched_skill_names"`
-	MatchedFocusModeNames    []string `json:"matched_focus_mode_names"`
-	RecommendedCapabilities  []string `json:"recommended_capabilities"`
+	Query                   string   `json:"query"`
+	MatchedToolNames        []string `json:"matched_tool_names"`
+	MatchedForgeNames       []string `json:"matched_forge_names"`
+	MatchedSkillNames       []string `json:"matched_skill_names"`
+	MatchedFocusModeNames   []string `json:"matched_focus_mode_names"`
+	RecommendedCapabilities []string `json:"recommended_capabilities"`
 }
 
 type SessionSnapshotPerceptionKnowledge struct {
-	Query           string   `json:"query"`
-	KnowledgeBases  []string `json:"knowledge_bases"`
-	Content         string   `json:"content"`
+	Query          string   `json:"query"`
+	KnowledgeBases []string `json:"knowledge_bases"`
+	Content        string   `json:"content"`
 }
 
 type sessionSnapshotPerceptionExtras struct {
@@ -111,14 +111,14 @@ func isSessionSnapshotExecutionTerminal(status string) bool {
 }
 
 type sessionSnapshotState struct {
-	mu                       sync.Mutex
-	revision                 int64
-	perceptionExtras         sessionSnapshotPerceptionExtras
-	backgroundProcesses      map[string]SessionSnapshotBackgroundProcess
-	execution                sessionExecutionTracker
-	emitHandler              sessionSnapshotEmitHandler
-	debounceTimer            *time.Timer
-	legacySeparateEvents     bool
+	mu                   sync.Mutex
+	revision             int64
+	perceptionExtras     sessionSnapshotPerceptionExtras
+	backgroundProcesses  map[string]SessionSnapshotBackgroundProcess
+	execution            sessionExecutionTracker
+	emitHandler          sessionSnapshotEmitHandler
+	debounceTimer        *time.Timer
+	legacySeparateEvents bool
 }
 
 func (c *Config) ensureSessionSnapshotState() *sessionSnapshotState {
@@ -626,6 +626,11 @@ func NotifySessionSnapshotToolCall(cfg AICallerConfigIf, result *aitool.ToolResu
 	if c := ConfigFromAICaller(cfg); c != nil {
 		c.RecordSessionSnapshotToolCall(result)
 		c.NotifySessionSnapshotEmit()
+		// 命中统计: 任意一次工具调用 (成功/失败, 直接/申请) 都计一次 tool 命中.
+		// 这是「重要反馈点」, 供意图层与工具 inventory 做命中数排序.
+		if result != nil && result.Name != "" {
+			SubmitToolHit(c, result.Name, StatsSourceToolDirect)
+		}
 	}
 }
 

--- a/common/ai/aid/aicommon/stats_recorder.go
+++ b/common/ai/aid/aicommon/stats_recorder.go
@@ -1,0 +1,124 @@
+package aicommon
+
+import (
+	"sync"
+
+	"github.com/yaklang/yaklang/common/ai/aispec"
+	"github.com/yaklang/yaklang/common/log"
+)
+
+// stats_recorder.go 是"用户命中统计"采集的瘦注册缝 (零额外重依赖).
+//
+// 设计与 value_feedback.go 同构: aicommon 只放接口 + 注册函数 + nil-safe 的 Submit* 入口;
+// 真正的落库实现 (双表: per-entity 命中计数 + per-user/day 汇总) 放在 aistats 包,
+// 由 aistats 在 init() 里调用 RegisterStatsRecorder 注册进来. reactloops / loopinfra /
+// aid 等底层只调用 SubmitToolHit / SubmitSkillHit / SubmitAction / SubmitAICall, 不直接
+// 依赖 aistats, 从而避免 import 环.
+//
+// 硬约束 (与 aive 一致):
+//   - 非阻塞: 实现必须自带有界队列, 绝不阻塞调用方.
+//   - 不崩溃: Submit* 全程 recover, 绝不 panic 到主流程.
+//   - nil-safe: 未注册或 cfg 缺失时 no-op.
+//
+// 命中来源 (source) 枚举见下方常量, 决定细分计数列.
+//
+// 关键词: StatsRecorder, RegisterStatsRecorder, SubmitToolHit, SubmitSkillHit,
+//
+//	SubmitAction, SubmitAICall, 命中统计注册缝, UserAIStats
+
+// 命中来源枚举, 决定 AIStatsEntityHit 的细分计数列.
+const (
+	StatsSourceToolDirect         = "direct"         // tool: 直接调用 (directly_call_tool 等)
+	StatsSourceToolRequested      = "requested"      // tool: 申请路径 (require_tool / task_call_tool)
+	StatsSourceSkillUserForce     = "user_force"     // skill: 用户强制加载 (load_skill sync 事件 / EnabledCapabilities)
+	StatsSourceSkillAILoad        = "ai_load"        // skill: AI 自主 loading_skills action
+	StatsSourceSkillIntentCatalog = "intent_catalog" // skill: 意图识别入选 catalog top-10
+)
+
+// StatsRecorder 由 aistats 实现并注册. 实现必须是非阻塞的 (内部有界队列),
+// 绝不能阻塞或 panic 到调用方.
+type StatsRecorder interface {
+	// RecordToolHit 记录一次工具命中. source 取 StatsSourceTool* 常量.
+	RecordToolHit(cfg *Config, toolName, source string)
+	// RecordSkillHit 记录一次 SKILL 命中. source 取 StatsSourceSkill* 常量.
+	RecordSkillHit(cfg *Config, skillName, source string)
+	// RecordAction 记录一次 loop action 执行.
+	RecordAction(cfg *Config, actionType string)
+	// RecordAICall 记录一次 AI (模型) 调用及其 token 用量.
+	RecordAICall(cfg *Config, model string, usage *aispec.ChatUsage)
+}
+
+var (
+	statsRecorder   StatsRecorder
+	statsRecorderMu sync.RWMutex
+)
+
+// RegisterStatsRecorder 由 aistats 在 init() 中调用注册统计实现.
+// 默认开启: 注册后即生效.
+func RegisterStatsRecorder(recorder StatsRecorder) {
+	statsRecorderMu.Lock()
+	defer statsRecorderMu.Unlock()
+	statsRecorder = recorder
+}
+
+func getStatsRecorder() StatsRecorder {
+	statsRecorderMu.RLock()
+	defer statsRecorderMu.RUnlock()
+	return statsRecorder
+}
+
+// SubmitToolHit 记录一次工具命中. 未注册或 cfg 缺失时 no-op; 全程 recover.
+func SubmitToolHit(cfg *Config, toolName, source string) {
+	rec := getStatsRecorder()
+	if rec == nil || cfg == nil || toolName == "" {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("SubmitToolHit recovered panic: %v", r)
+		}
+	}()
+	rec.RecordToolHit(cfg, toolName, source)
+}
+
+// SubmitSkillHit 记录一次 SKILL 命中. 未注册或 cfg 缺失时 no-op; 全程 recover.
+func SubmitSkillHit(cfg *Config, skillName, source string) {
+	rec := getStatsRecorder()
+	if rec == nil || cfg == nil || skillName == "" {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("SubmitSkillHit recovered panic: %v", r)
+		}
+	}()
+	rec.RecordSkillHit(cfg, skillName, source)
+}
+
+// SubmitAction 记录一次 loop action 执行. 未注册或 cfg 缺失时 no-op; 全程 recover.
+func SubmitAction(cfg *Config, actionType string) {
+	rec := getStatsRecorder()
+	if rec == nil || cfg == nil || actionType == "" {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("SubmitAction recovered panic: %v", r)
+		}
+	}()
+	rec.RecordAction(cfg, actionType)
+}
+
+// SubmitAICall 记录一次 AI (模型) 调用. 未注册或 cfg 缺失时 no-op; 全程 recover.
+func SubmitAICall(cfg *Config, model string, usage *aispec.ChatUsage) {
+	rec := getStatsRecorder()
+	if rec == nil || cfg == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("SubmitAICall recovered panic: %v", r)
+		}
+	}()
+	rec.RecordAICall(cfg, model, usage)
+}

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -245,6 +245,10 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 		//        缓存边界外
 		materials.FrozenUserContext = input.FrozenUserContext
 		materials.FrozenPartitions = append(materials.FrozenPartitions, input.FrozenPartitions...)
+		// SKILL 三态透传: forced (frozen_block 顶部) / auto (semi_dynamic_2 尾部).
+		// SkillsContext (含 catalog) 已透传, 这里补 forced / auto.
+		materials.ForcedSkills = input.ForcedSkills
+		materials.AutoLoadedSkills = input.AutoLoadedSkills
 	}
 	if base != nil {
 		// UserHistory 来自 LoopPromptBaseMaterials (config.FormatUserInputHistoryAITag)
@@ -459,6 +463,13 @@ func (pm *PromptManager) buildFrozenBlockObservation(
 	// 关键词: section.frozen_block 子节点 Name 去前缀, UI 信息密度
 	children := []*reactloops.PromptSectionObservation{
 		reactloops.NewPromptSectionObservation(
+			"section.frozen_block.user_forced_skill",
+			"User Forced Skills",
+			reactloops.PromptSectionRoleFrozenBlock,
+			true,
+			renderUserForcedSkillBlock(materials),
+		),
+		reactloops.NewPromptSectionObservation(
 			"section.frozen_block.tool_inventory",
 			"Tool Inventory",
 			reactloops.PromptSectionRoleFrozenBlock,
@@ -659,6 +670,16 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 			reactloops.PromptSectionRoleSemiDynamic2,
 			true,
 			renderStaticTaggedBlock("OUTPUT_EXAMPLE", materials.OutputExample),
+		),
+		// section.semi_dynamic_2.auto_loaded_skills: AI 意图驱动加载的 SKILL 段 (尾部).
+		// 物理位置在 OutputExample 之后, 保 TaskInstr/Schema/Example 前缀字节稳定 →
+		// AI_CACHE_SEMI2 前缀缓存命中, 仅尾部变化.
+		reactloops.NewPromptSectionObservation(
+			"section.semi_dynamic_2.auto_loaded_skills",
+			"Auto-loaded Skills",
+			reactloops.PromptSectionRoleSemiDynamic2,
+			true,
+			renderAutoLoadedSkillsBlock(materials),
 		),
 	}
 	section.Children = filterIncludedPromptSections(children)
@@ -1072,6 +1093,22 @@ func renderTimelineFrozenBlock(materials *reactloops.PromptPrefixMaterials) stri
 		return ""
 	}
 	return "# Timeline Memory (Frozen Prefix)\n" + materials.TimelineFrozen
+}
+
+// renderUserForcedSkillBlock 渲染用户强制加载 SKILL 段 (frozen_block 顶部, 满内容).
+func renderUserForcedSkillBlock(materials *reactloops.PromptPrefixMaterials) string {
+	if materials == nil {
+		return ""
+	}
+	return strings.TrimSpace(materials.ForcedSkills)
+}
+
+// renderAutoLoadedSkillsBlock 渲染 AI 意图驱动加载 SKILL 段 (semi_dynamic_2 尾部).
+func renderAutoLoadedSkillsBlock(materials *reactloops.PromptPrefixMaterials) string {
+	if materials == nil {
+		return ""
+	}
+	return strings.TrimSpace(materials.AutoLoadedSkills)
 }
 
 // renderTimelineOpenBlock 渲染 timeline 开放尾段 (最末 interval + midterm prefix)。

--- a/common/ai/aid/aireact/prompts_test.go
+++ b/common/ai/aid/aireact/prompts_test.go
@@ -485,8 +485,10 @@ description: Tax excel analysis skill
 	if strings.Contains(prompt, skillCommandMarker) {
 		t.Fatalf("unloaded skill body should not appear in tool params prompt. Got:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "tax-excel") {
-		t.Fatalf("available skill registry should still be visible. Got:\n%s", prompt)
+	// 改造后: SKILL 目录默认隐藏 (节约 token), 未加载 skill 既不应出现 body 也不应出现在目录里.
+	// 目录仅由意图识别 (SetCatalogSkills + SetCatalogVisible) 主动 surface.
+	if strings.Contains(prompt, "tax-excel") {
+		t.Fatalf("unloaded skill should not appear in tool params prompt when catalog is hidden by default. Got:\n%s", prompt)
 	}
 }
 

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -341,10 +341,16 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 		}
 		if loop := react.GetCurrentLoop(); loop != nil {
 			if mgr := loop.GetSkillsContextManager(); mgr != nil {
-				results := mgr.LoadSkills(skillNames)
-				for name, err := range results {
+				for _, name := range skillNames {
+					added, err := mgr.LoadForcedSkill(name)
 					if err != nil {
 						log.Warnf("hotload skill %q failed: %v", name, err)
+						continue
+					}
+					if added {
+						// 用户强制加载: timeline 明确记录 + 命中反馈.
+						react.AddToTimeline("user_loaded_skill", fmt.Sprintf("User forced load: %s", name))
+						aicommon.SubmitSkillHit(react.config, name, aicommon.StatsSourceSkillUserForce)
 					}
 				}
 			}

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -728,10 +728,16 @@ func BuildReActInvoker(ctx context.Context, options ...aicommon.ConfigOption) (a
 		}
 		if loop := invoker.GetCurrentLoop(); loop != nil {
 			if mgr := loop.GetSkillsContextManager(); mgr != nil {
-				results := mgr.LoadSkills(skillNames)
-				for name, err := range results {
+				for _, name := range skillNames {
+					added, err := mgr.LoadForcedSkill(name)
 					if err != nil {
 						log.Warnf("hotload skill %q failed: %v", name, err)
+						continue
+					}
+					if added {
+						// 用户强制加载: timeline 明确记录 + 命中反馈.
+						invoker.AddToTimeline("user_loaded_skill", fmt.Sprintf("User forced load: %s", name))
+						aicommon.SubmitSkillHit(invoker.config, name, aicommon.StatsSourceSkillUserForce)
 					}
 				}
 			}

--- a/common/ai/aid/aireact/re-act_sync_request.go
+++ b/common/ai/aid/aireact/re-act_sync_request.go
@@ -45,6 +45,8 @@ func (r *ReAct) handleSyncMessage(event *ypb.AIInputEvent) error {
 		return r.HandleSyncTypeSessionSnapshotEvent(event)
 	case aicommon.SYNC_TYPE_CLOSE_BROWSER:
 		return r.HandleSyncTypeCloseBrowserEvent(event)
+	case aicommon.SYNC_TYPE_LOAD_SKILL:
+		return r.HandleSyncTypeLoadSkillEvent(event)
 	default:
 		return fmt.Errorf("unsupported sync type: %s", event.SyncType)
 	}
@@ -64,6 +66,7 @@ func (r *ReAct) RegisterReActSyncEvent() {
 	r.config.InputEventManager.RegisterSyncCallback(aicommon.SYNC_TYPE_PERCEPTION, r.HandleSyncTypePerceptionEvent)
 	r.config.InputEventManager.RegisterSyncCallback(aicommon.SYNC_TYPE_SESSION_SNAPSHOT, r.HandleSyncTypeSessionSnapshotEvent)
 	r.config.InputEventManager.RegisterSyncCallback(aicommon.SYNC_TYPE_CLOSE_BROWSER, r.HandleSyncTypeCloseBrowserEvent)
+	r.config.InputEventManager.RegisterSyncCallback(aicommon.SYNC_TYPE_LOAD_SKILL, r.HandleSyncTypeLoadSkillEvent)
 }
 
 func (r *ReAct) UnRegisterReActSyncEvent() {
@@ -80,6 +83,7 @@ func (r *ReAct) UnRegisterReActSyncEvent() {
 	r.config.InputEventManager.UnRegisterSyncCallback(aicommon.SYNC_TYPE_PERCEPTION)
 	r.config.InputEventManager.UnRegisterSyncCallback(aicommon.SYNC_TYPE_SESSION_SNAPSHOT)
 	r.config.InputEventManager.UnRegisterSyncCallback(aicommon.SYNC_TYPE_CLOSE_BROWSER)
+	r.config.InputEventManager.UnRegisterSyncCallback(aicommon.SYNC_TYPE_LOAD_SKILL)
 }
 
 func (r *ReAct) HandleSyncTypeQueueInfoEvent(event *ypb.AIInputEvent) error {

--- a/common/ai/aid/aireact/re-act_sync_request_load_skill.go
+++ b/common/ai/aid/aireact/re-act_sync_request_load_skill.go
@@ -1,0 +1,115 @@
+package aireact
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// re-act_sync_request_load_skill.go 实现「用户强制加载 SKILL」sync 事件处理.
+//
+// 客户端发起:
+//
+//	AIInputEvent{
+//	  IsSyncMessage: true,
+//	  SyncType:      "load_skill_sync",
+//	  SyncJsonInput: `{"skill_names": ["x","y"], "task_id": "<可选>"}`,
+//	  SyncID:        "<回调用>",
+//	}
+//
+// 服务端处理:
+//  1. 解析 skill_names.
+//  2. 逐个走 SkillsContextManager.LoadForcedSkill (满内容 → frozen_block 顶部, 最高优先级).
+//  3. 每个成功加载的 skill 在 timeline 写 "user_loaded_skill" 条目 (用户要求明确记录).
+//  4. 成功后 SubmitSkillHit(name, "user_force") 累计命中反馈.
+//  5. EmitSyncJSON 同步返回 loaded/failed/already_loaded.
+//  6. EmitSessionSnapshot 刷新前端能力清单.
+//
+// 关键词: load_skill sync, 用户强制加载, timeline user_loaded_skill, frozen_block
+
+// loadSkillRequest 是 load_skill sync 事件的请求体.
+type loadSkillRequest struct {
+	SkillNames []string `json:"skill_names"`
+	TaskID     string   `json:"task_id,omitempty"`
+}
+
+func parseLoadSkillRequest(event *ypb.AIInputEvent) loadSkillRequest {
+	var req loadSkillRequest
+	if event == nil || strings.TrimSpace(event.SyncJsonInput) == "" {
+		return req
+	}
+	if err := json.Unmarshal([]byte(event.SyncJsonInput), &req); err != nil {
+		return req
+	}
+	return req
+}
+
+// HandleSyncTypeLoadSkillEvent 处理用户强制加载 SKILL 的 sync 事件.
+func (r *ReAct) HandleSyncTypeLoadSkillEvent(event *ypb.AIInputEvent) error {
+	req := parseLoadSkillRequest(event)
+
+	loaded := make([]string, 0)
+	failed := make(map[string]string, 0)
+	alreadyForced := make([]string, 0)
+
+	loop := r.GetCurrentLoop()
+	if loop == nil {
+		_, _ = r.EmitSyncJSON(schema.EVENT_TYPE_STRUCTURED, "load_skill", map[string]interface{}{
+			"loaded":         loaded,
+			"failed":         failed,
+			"already_loaded": alreadyForced,
+			"error":          "no active loop",
+		}, event.SyncID)
+		return nil
+	}
+	mgr := loop.GetSkillsContextManager()
+	if mgr == nil {
+		_, _ = r.EmitSyncJSON(schema.EVENT_TYPE_STRUCTURED, "load_skill", map[string]interface{}{
+			"loaded":         loaded,
+			"failed":         failed,
+			"already_loaded": alreadyForced,
+			"error":          "skills context manager not configured",
+		}, event.SyncID)
+		return nil
+	}
+
+	for _, name := range req.SkillNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		added, err := mgr.LoadForcedSkill(name)
+		if err != nil {
+			failed[name] = err.Error()
+			// 失败也写 timeline, 复用既有 entryType.
+			r.AddToTimeline("skill_load_failed", fmt.Sprintf("User forced load FAILED: %s (%v)", name, err))
+			continue
+		}
+		if !added {
+			// 已是 forced: 幂等, 计入 already_loaded.
+			alreadyForced = append(alreadyForced, name)
+			continue
+		}
+		loaded = append(loaded, name)
+		// 用户要求: timeline 明确写出用户加载了什么 SKILL.
+		r.AddToTimeline("user_loaded_skill", fmt.Sprintf("User forced load: %s", name))
+		// 命中反馈: 用户强制加载是高价值反馈点.
+		aicommon.SubmitSkillHit(r.config, name, aicommon.StatsSourceSkillUserForce)
+	}
+
+	response := map[string]interface{}{
+		"loaded":         loaded,
+		"failed":         failed,
+		"already_loaded": alreadyForced,
+	}
+	_, _ = r.EmitSyncJSON(schema.EVENT_TYPE_STRUCTURED, "load_skill", response, event.SyncID)
+
+	// 刷新前端能力清单 (forced skill 现在满内容进 frozen_block).
+	reactloops.EmitSessionSnapshot(r.config, loop, r.GetCurrentTask())
+	return nil
+}

--- a/common/ai/aid/aireact/reactloops/deep_intent.go
+++ b/common/ai/aid/aireact/reactloops/deep_intent.go
@@ -195,6 +195,7 @@ func PopulateExtraCapabilitiesFromDeepIntent(r aicommon.AIInvokeRuntime, loop *R
 		if provider, ok := cfg.(skillLoaderProvider); ok {
 			skillLoader := provider.GetSkillLoader()
 			if skillLoader != nil && skillLoader.HasSkills() {
+				var matchedMetas []*aiskillloader.SkillMeta
 				for _, name := range skillNames {
 					meta, err := aiskillloader.LookupSkillMeta(skillLoader, name)
 					if err != nil || meta == nil {
@@ -205,7 +206,10 @@ func PopulateExtraCapabilitiesFromDeepIntent(r aicommon.AIInvokeRuntime, loop *R
 						Name:        meta.Name,
 						Description: meta.Description,
 					})
+					matchedMetas = append(matchedMetas, meta)
 				}
+				// 把意图命中的 skill 写入「最相关目录」(默认隐藏, 意图命中后开启).
+				ApplyMatchedSkillsToCatalog(loop, cfg, matchedMetas)
 			}
 		}
 	}

--- a/common/ai/aid/aireact/reactloops/intent_skill_catalog.go
+++ b/common/ai/aid/aireact/reactloops/intent_skill_catalog.go
@@ -1,0 +1,95 @@
+package reactloops
+
+import (
+	"sort"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/aiskillloader"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+// intent_skill_catalog.go 实现「意图识别 → 最相关 SKILL 目录」写入.
+//
+// 需求 2: 意图识别和意图感知可以加载当前任务感兴趣的 SKILL 到会话目录, 只加载最相关 10 个.
+// 默认 SKILL 目录隐藏 (需求 1), 意图识别命中后由 ApplyMatchedSkillsToCatalog 写入
+// top-N 并开启目录可见. top-N 选择接入命中数反馈 (UserAIStats): 高命中 SKILL 优先入选,
+// 让「重要反馈点」真正落到意图层.
+//
+// 关键词: ApplyMatchedSkillsToCatalog, 意图识别目录, top-N, 命中数排序
+
+// ApplyMatchedSkillsToCatalog 把意图识别命中的 SKILL 写入 SkillsContextManager 的
+// 「最相关目录」(默认隐藏). 内部按命中数反馈排序后截断到 MaxCatalogSkills, 并对每个
+// 入选的 skill 记一次 intent_catalog 命中. fast / deep 两条意图路径都调用本函数.
+//
+// cfgFromRuntime 取 r.GetConfig() (AICallerConfigIf), 用于解析 *aicommon.Config 做命中统计.
+// 传入 nil / 空 → 静默 no-op.
+func ApplyMatchedSkillsToCatalog(loop *ReActLoop, cfgFromRuntime aicommon.AICallerConfigIf, matchedMetas []*aiskillloader.SkillMeta) {
+	if loop == nil || len(matchedMetas) == 0 {
+		return
+	}
+	mgr := loop.GetSkillsContextManager()
+	if mgr == nil {
+		return
+	}
+
+	// 去重.
+	seen := make(map[string]bool, len(matchedMetas))
+	deduped := make([]*aiskillloader.SkillMeta, 0, len(matchedMetas))
+	for _, meta := range matchedMetas {
+		if meta == nil || meta.Name == "" || seen[meta.Name] {
+			continue
+		}
+		seen[meta.Name] = true
+		deduped = append(deduped, meta)
+	}
+	if len(deduped) == 0 {
+		return
+	}
+
+	// 按命中数反馈排序: 高命中 SKILL 优先 (重要反馈点落地). 失败/无 DB 时按原序兜底.
+	ranked := rankSkillsByHitCount(deduped)
+
+	// 截断到 MaxCatalogSkills (二次保护: SetCatalogSkills 内部也会截断).
+	if max := aiskillloader.MaxCatalogSkills; max > 0 && len(ranked) > max {
+		ranked = ranked[:max]
+	}
+
+	mgr.SetCatalogSkills(ranked)
+	mgr.SetCatalogVisible(true)
+
+	// 每个入选目录的 skill 记一次 intent_catalog 命中.
+	var cfgConcrete *aicommon.Config
+	if c, ok := cfgFromRuntime.(*aicommon.Config); ok {
+		cfgConcrete = c
+	}
+	for _, meta := range ranked {
+		aicommon.SubmitSkillHit(cfgConcrete, meta.Name, aicommon.StatsSourceSkillIntentCatalog)
+	}
+	log.Infof("intent catalog updated: %d relevant skills surfaced (visible)", len(ranked))
+}
+
+// rankSkillsByHitCount 按 UserAIStats 的 per-skill 命中数降序排序 (高命中优先).
+// 无 DB / 查询失败时保持原序 (BM25/意图匹配顺序), 不影响功能.
+func rankSkillsByHitCount(metas []*aiskillloader.SkillMeta) []*aiskillloader.SkillMeta {
+	db := consts.GetGormProfileDatabase()
+	if db == nil || len(metas) <= 1 {
+		return metas
+	}
+	// 取 Top-N 命中数排序的 skill 名 (N = 候选数, 保证覆盖所有候选).
+	topNames := yakit.TopEntitiesByHits(db, schema.AIStatsEntityTypeSkill, len(metas))
+	if len(topNames) == 0 {
+		return metas
+	}
+	rank := make(map[string]int, len(topNames))
+	for i, name := range topNames {
+		rank[name] = len(topNames) - i // 高命中 → 高 rank
+	}
+	sorted := append([]*aiskillloader.SkillMeta(nil), metas...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return rank[sorted[i].Name] > rank[sorted[j].Name]
+	})
+	return sorted
+}

--- a/common/ai/aid/aireact/reactloops/loop_default/intent_classifier.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/intent_classifier.go
@@ -635,6 +635,8 @@ func populateExtraCapabilitiesFromFastMatch(r aicommon.AIInvokeRuntime, loop *re
 				Description: skill.Description,
 			})
 		}
+		// 意图命中 → 写入「最相关 SKILL 目录」(默认隐藏, 命中后开启), 按命中数排序 top-N.
+		reactloops.ApplyMatchedSkillsToCatalog(loop, r.GetConfig(), result.MatchedSkills)
 	}
 
 	// Add matched forges

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_loading_skills.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_loading_skills.go
@@ -127,13 +127,16 @@ var loopAction_LoadingSkills = &reactloops.LoopAction{
 		}
 
 		// Check if the skill is already loaded and unfolded — no need to load again.
+		// 改造后: AI 自主加载走 LoadAutoSkill (进 SemiDynamic 2), 这里查 auto-loaded 状态.
+		// forced skill 也算「已加载且满可见」(IsAutoSkillLoadedAndUnfolded 内部含 forced 检查),
+		// 直接短路, 避免重复加载.
 		// Do NOT return error — set a flag for ActionHandler to silently skip.
-		if mgr.IsSkillLoadedAndUnfolded(skillName) {
+		if mgr.IsAutoSkillLoadedAndUnfolded(skillName) {
 			viewSummary := mgr.GetSkillViewSummary(skillName)
 			alreadyLoadedMsg := fmt.Sprintf(
 				"IMPORTANT: Skill '%s' is ALREADY loaded and visible in your context. "+
 					"Do NOT load it again. The skill content is already displayed in the "+
-					"SKILLS_CONTEXT section of your prompt (look for '<|SKILLS_CONTEXT_' tags). "+
+					"SKILLS_CONTEXT / AUTO_LOADED_SKILLS / USER_FORCED_SKILL section of your prompt. "+
 					"Read the View Window content that is already available to you. %s",
 				skillName, viewSummary,
 			)
@@ -163,15 +166,30 @@ var loopAction_LoadingSkills = &reactloops.LoopAction{
 			loop.Set("_batch_skill_names", "")
 
 			names := strings.Split(batchNames, ",")
-			results := mgr.LoadSkills(names)
-
 			var loaded, skipped, failed []string
-			for name, err := range results {
+			// 批量自动加载 (AI 意图驱动 → SemiDynamic 2). 已 forced/auto 的会短路.
+			results := make(map[string]error, len(names))
+			loadedSet := make(map[string]bool, len(names))
+			var loadedCfg *aicommon.Config
+			if cfg, ok := invoker.GetConfig().(*aicommon.Config); ok {
+				loadedCfg = cfg
+			}
+			for _, raw := range names {
+				name := strings.TrimSpace(raw)
+				if name == "" {
+					continue
+				}
+				added, err := mgr.LoadAutoSkill(name)
+				results[name] = err
 				if err != nil {
 					failed = append(failed, fmt.Sprintf("%s(%v)", name, err))
 					log.Warnf("batch load skill %q failed: %v", name, err)
-				} else {
-					loaded = append(loaded, name)
+					continue
+				}
+				loaded = append(loaded, name)
+				loadedSet[name] = true
+				if added && loadedCfg != nil {
+					aicommon.SubmitSkillHit(loadedCfg, name, aicommon.StatsSourceSkillAILoad)
 				}
 			}
 
@@ -180,10 +198,8 @@ var loopAction_LoadingSkills = &reactloops.LoopAction{
 				if name == "" {
 					continue
 				}
-				if mgr.IsSkillLoadedAndUnfolded(name) {
-					if _, inResults := results[name]; !inResults {
-						skipped = append(skipped, name)
-					}
+				if !loadedSet[name] && mgr.IsAutoSkillLoadedAndUnfolded(name) {
+					skipped = append(skipped, name)
 				}
 			}
 
@@ -259,8 +275,9 @@ var loopAction_LoadingSkills = &reactloops.LoopAction{
 			return
 		}
 
-		// Attempt to load the skill
-		err := mgr.LoadSkill(skillName)
+		// Attempt to load the skill as auto-loaded (AI 意图驱动 → SemiDynamic 2 尾部).
+		// 若该 skill 已是 forced, LoadAutoSkill 会短路返回 (added=false), 不重复加载.
+		added, err := mgr.LoadAutoSkill(skillName)
 		if err != nil {
 			log.Warnf("failed to load skill %q: %v", skillName, err)
 
@@ -379,7 +396,17 @@ var loopAction_LoadingSkills = &reactloops.LoopAction{
 			return
 		}
 
-		// Load succeeded
+		// Load succeeded (or short-circuited because already forced/auto-loaded).
+		if !added {
+			// 幂等: 该 skill 已是 forced 或已 auto-loaded, 不重复计数 / 不重复 emit.
+			viewSummary := mgr.GetSkillViewSummary(skillName)
+			invoker.AddToTimeline("skill_already_loaded",
+				fmt.Sprintf("Skill '%s' already present (forced or auto-loaded). %s", skillName, viewSummary))
+			op.Feedback(fmt.Sprintf("Skill '%s' was already loaded; no duplicate load performed.", skillName))
+			op.Continue()
+			return
+		}
+
 		viewSummary := mgr.GetSkillViewSummary(skillName)
 
 		contextSizeAfter := 0
@@ -410,7 +437,7 @@ var loopAction_LoadingSkills = &reactloops.LoopAction{
 
 		contextExpansionKB := float64(skillMDSize) / 1024
 		timelineMsg := fmt.Sprintf(
-			"Successfully loaded skill '%s' into context. "+
+			"Successfully loaded skill '%s' into context (auto-loaded into SemiDynamic 2). "+
 				"SKILL.md: %.1fKB, %d files in skill directory. %s "+
 				"Context expanded by ~%.1fKB. "+
 				"Use load_skill_resources to load additional files (e.g. @%s/filename.md). "+
@@ -419,8 +446,12 @@ var loopAction_LoadingSkills = &reactloops.LoopAction{
 			contextExpansionKB, skillName,
 		)
 		invoker.AddToTimeline("skill_loaded", timelineMsg)
+		// 命中反馈: AI 自主加载是反馈点.
+		if cfg, ok := invoker.GetConfig().(*aicommon.Config); ok {
+			aicommon.SubmitSkillHit(cfg, skillName, aicommon.StatsSourceSkillAILoad)
+		}
 
-		log.Infof("skill %q loaded into context successfully (SKILL.md: %.1fKB, %d files)", skillName, contextExpansionKB, fileCount)
+		log.Infof("skill %q auto-loaded into context successfully (SKILL.md: %.1fKB, %d files)", skillName, contextExpansionKB, fileCount)
 		_ = contextSizeAfter
 
 		persistLoadedSkillNames(loop, invoker)

--- a/common/ai/aid/aireact/reactloops/prompt.go
+++ b/common/ai/aid/aireact/reactloops/prompt.go
@@ -224,10 +224,16 @@ func (r *ReActLoop) generateLoopPrompt(
 		}
 	}
 
-	// Render skills context if the manager is available
+	// Render skills context if the manager is available.
+	// 三态分离: SkillsContext (SemiDynamic 1, 含 catalog) + ForcedSkills (frozen_block
+	// 顶部) + AutoLoadedSkills (SemiDynamic 2 尾部).
 	var skillsContext string
+	var forcedSkillsBlock string
+	var autoSkillsBlock string
 	if r.skillsContextManager != nil {
 		skillsContext = r.skillsContextManager.RenderStable()
+		forcedSkillsBlock = r.skillsContextManager.RenderForcedSkills()
+		autoSkillsBlock = r.skillsContextManager.RenderAutoLoadedSkills()
 	}
 
 	// Render extra capabilities discovered via intent recognition
@@ -295,6 +301,8 @@ func (r *ReActLoop) generateLoopPrompt(
 		OutputExample:     outputExample,
 		Schema:            schema,
 		SkillsContext:     skillsContext,
+		ForcedSkills:      forcedSkillsBlock,
+		AutoLoadedSkills:  autoSkillsBlock,
 		ExtraCapabilities: extraCapabilities,
 		TodoSnapshot:      todoSnapshot,
 		ReactiveData:      reactiveData,

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -652,9 +652,11 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 					}
 				}
 
-				// Load user-specified skills from EnabledCapabilities (AIStartParams)
+				// Load user-specified skills from EnabledCapabilities (AIStartParams).
+				// 这些是用户主动指定的, 作为「用户强制加载」走 frozen_block 顶部 (满内容, 最高优先级),
+				// 与 persistent session 恢复 (走 SKILLS_CONTEXT) 区分开.
 				if names := realConfig.GetEnabledSkillNames(); len(names) > 0 {
-					loadConfiguredSkills(mgr, names, "enabled capabilities")
+					loadConfiguredForcedSkills(mgr, names, "enabled capabilities")
 				}
 			}
 		}
@@ -1048,6 +1050,37 @@ func loadConfiguredSkills(mgr *aiskillloader.SkillsContextManager, names []strin
 	}
 	if len(failed) > 0 {
 		log.Warnf("failed to load %d skills from %s: %v", len(failed), source, failed)
+	}
+}
+
+// loadConfiguredForcedSkills 把用户 EnabledCapabilities 来源的 skill 作为「用户强制加载」
+// 走 LoadForcedSkill (满内容 → frozen_block 顶部, 最高优先级). 这与 persistent session
+// 恢复 (走 LoadSkill → SKILLS_CONTEXT) 区分开, 是「用户主动指定」语义.
+//
+// 关键词: loadConfiguredForcedSkills, EnabledCapabilities → forced, frozen_block
+func loadConfiguredForcedSkills(mgr *aiskillloader.SkillsContextManager, names []string, source string) {
+	if mgr == nil || len(names) == 0 {
+		return
+	}
+	var loaded, already, failed []string
+	for _, name := range names {
+		added, err := mgr.LoadForcedSkill(name)
+		if err != nil {
+			failed = append(failed, name)
+			log.Warnf("failed to force-load skill %q from %s: %v", name, source, err)
+			continue
+		}
+		if !added {
+			already = append(already, name)
+			continue
+		}
+		loaded = append(loaded, name)
+	}
+	if len(loaded) > 0 {
+		log.Infof("force-loaded %d skills from %s: %v", len(loaded), source, loaded)
+	}
+	if len(failed) > 0 {
+		log.Warnf("failed to force-load %d skills from %s: %v", len(failed), source, failed)
 	}
 }
 

--- a/common/ai/aid/aireact/reactloops/reactloopstests/skill_integration_test.go
+++ b/common/ai/aid/aireact/reactloops/reactloopstests/skill_integration_test.go
@@ -245,16 +245,15 @@ func TestReActLoop_Skills_PromptDifference(t *testing.T) {
 		if !strings.Contains(schemaBlock, "loading_skills") {
 			t.Error("loading_skills SHOULD appear in SCHEMA enum when skills are configured")
 		}
-		// Verify: SKILLS_CONTEXT tag SHOULD be present
-		if !strings.Contains(capturedMainPrompt, "SKILLS_CONTEXT") {
-			t.Error("SKILLS_CONTEXT tag SHOULD be present when skills are configured")
+		// 改造后: SKILL 目录默认隐藏 (节约 token), SKILLS_CONTEXT 段零加载时为空.
+		// 目录仅由意图识别 (SetCatalogSkills + SetCatalogVisible) 主动 surface.
+		// 这里验证「目录隐藏」契约: 注册了 skill 但未 surface 时, prompt 不应含
+		// SKILLS_CONTEXT 标签 / skill 名.
+		if strings.Contains(capturedMainPrompt, "SKILLS_CONTEXT") {
+			t.Error("SKILLS_CONTEXT tag should NOT appear when catalog is hidden (default)")
 		}
-		// Verify: skill names appear in available skills list
-		if !strings.Contains(capturedMainPrompt, "test-skill") {
-			t.Error("'test-skill' SHOULD appear in available skills list")
-		}
-		if !strings.Contains(capturedMainPrompt, "test-lint-check") {
-			t.Error("'test-lint-check' SHOULD appear in available skills list")
+		if strings.Contains(capturedMainPrompt, "test-skill") {
+			t.Error("'test-skill' should NOT appear when catalog is hidden (default)")
 		}
 	})
 }
@@ -355,12 +354,14 @@ func TestReActLoop_Skills_LoadedContentInPrompt(t *testing.T) {
 	firstPrompt := mainPrompts[0]
 	secondPrompt := mainPrompts[1]
 
-	// First prompt: should have available skills list but NOT loaded content
-	if !strings.Contains(firstPrompt, "test-skill") {
-		t.Error("First main prompt should list 'test-skill' in available skills")
+	// 改造后: 目录默认隐藏, 首个 prompt (加载前) 不应含 skill 名 / SKILLS_CONTEXT.
+	if strings.Contains(firstPrompt, "test-skill") {
+		t.Error("First main prompt should NOT list 'test-skill' (catalog hidden by default)")
 	}
 
-	// Second prompt: should have the actual loaded skill body content
+	// Second prompt: should have the actual loaded skill body content.
+	// AI 自主加载 (loading_skills action) 现走 LoadAutoSkill, 渲染进 AUTO_LOADED_SKILLS
+	// 段 (semi_dynamic_2 尾部), 仍含满内容 (header + body).
 	if !strings.Contains(secondPrompt, "This is a test skill") {
 		t.Error("Second main prompt should contain loaded skill body 'This is a test skill'")
 	}

--- a/common/ai/aid/aireact/reactloops/reactloopstests/skill_resource_integration_test.go
+++ b/common/ai/aid/aireact/reactloops/reactloopstests/skill_resource_integration_test.go
@@ -530,10 +530,13 @@ func TestReActLoop_SkillsContext_VisibleInAllSubsequentCallbacks(t *testing.T) {
 				return makeLoadSkillResponse(i, "recon")
 			}
 
-			// After skill is loaded, every main prompt must contain SKILLS_CONTEXT
+			// After skill is loaded, every main prompt must contain the skill section.
+			// 改造后: AI 自主加载走 LoadAutoSkill, 渲染进 AUTO_LOADED_SKILLS 段
+			// (而非 SKILLS_CONTEXT). 用 tag-agnostic 判断: 只要含 skill 段标签
+			// (SKILLS_CONTEXT 或 AUTO_LOADED_SKILLS) 即视为可见.
 			if skillLoaded {
 				postLoadPrompts = append(postLoadPrompts, prompt)
-				if strings.Contains(prompt, "SKILLS_CONTEXT") {
+				if strings.Contains(prompt, "SKILLS_CONTEXT") || strings.Contains(prompt, "AUTO_LOADED_SKILLS") {
 					mainCallsWithSkillsContext++
 				}
 				if strings.Contains(prompt, "=== Skill: recon ===") {
@@ -565,9 +568,9 @@ func TestReActLoop_SkillsContext_VisibleInAllSubsequentCallbacks(t *testing.T) {
 		t.Fatal("expected at least 1 main prompt after skill loading, got 0")
 	}
 
-	// ALL post-load main prompts must contain SKILLS_CONTEXT
+	// ALL post-load main prompts must contain the skill section (SKILLS_CONTEXT or AUTO_LOADED_SKILLS)
 	if mainCallsWithSkillsContext != len(postLoadPrompts) {
-		t.Errorf("SKILLS_CONTEXT should appear in ALL %d post-load main prompts, but only appeared in %d",
+		t.Errorf("skill section (SKILLS_CONTEXT/AUTO_LOADED_SKILLS) should appear in ALL %d post-load main prompts, but only appeared in %d",
 			len(postLoadPrompts), mainCallsWithSkillsContext)
 	}
 
@@ -577,7 +580,7 @@ func TestReActLoop_SkillsContext_VisibleInAllSubsequentCallbacks(t *testing.T) {
 			len(postLoadPrompts), mainCallsWithSkillHeader)
 	}
 
-	t.Logf("Visibility test passed: %d total main calls, %d post-load prompts, all contain SKILLS_CONTEXT",
+	t.Logf("Visibility test passed: %d total main calls, %d post-load prompts, all contain skill section",
 		totalMainCalls, len(postLoadPrompts))
 }
 

--- a/common/ai/aid/aistats/init.go
+++ b/common/ai/aid/aistats/init.go
@@ -1,0 +1,13 @@
+package aistats
+
+import (
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+)
+
+// init 把 aistats 的统计实现注册进 aicommon 注册缝.
+// 默认开启: 被 blank-import 后即生效.
+//
+// 关键词: aistats init, RegisterStatsRecorder, 命中统计默认开启
+func init() {
+	aicommon.RegisterStatsRecorder(recorder{})
+}

--- a/common/ai/aid/aistats/recorder.go
+++ b/common/ai/aid/aistats/recorder.go
@@ -1,0 +1,170 @@
+package aistats
+
+import (
+	"sync"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aispec"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+const (
+	// DefaultUserKey 是无法解析出 PersistentSessionId 时的回退 user 标识.
+	DefaultUserKey = "default"
+
+	// 有界队列 + worker 配置. 队列满直接丢弃以保证非阻塞.
+	statsQueueSize = 2048
+	statsWorkerNum = 2
+)
+
+// statsJob 是一次统计写入任务 (有向 union, 各字段对不同任务类型有意义).
+type statsJob struct {
+	kind    statsJobKind
+	userKey string
+	day     string
+	entity  string // entityType
+	name    string // entityName / actionType / model
+	source  string // hit source (for tool/skill)
+	usage   *aispec.ChatUsage
+}
+
+type statsJobKind uint8
+
+const (
+	statsJobToolHit statsJobKind = iota
+	statsJobSkillHit
+	statsJobAction
+	statsJobAICall
+)
+
+// statsPool 是进程级的有界队列 + 固定 worker pool (与 aive valueFeedbackPool 同构).
+type statsPool struct {
+	queue chan *statsJob
+	once  sync.Once
+}
+
+var globalStatsPool = &statsPool{
+	queue: make(chan *statsJob, statsQueueSize),
+}
+
+func (p *statsPool) start() {
+	p.once.Do(func() {
+		for i := 0; i < statsWorkerNum; i++ {
+			go p.worker(i)
+		}
+		log.Infof("aistats pool started: workers=%d queue=%d", statsWorkerNum, statsQueueSize)
+	})
+}
+
+func (p *statsPool) worker(id int) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("aistats worker[%d] panic recovered, restarting: %v", id, r)
+			go p.worker(id)
+		}
+	}()
+	for job := range p.queue {
+		p.process(job)
+	}
+}
+
+func (p *statsPool) process(job *statsJob) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("aistats process panic recovered: %v", r)
+		}
+	}()
+	if job == nil {
+		return
+	}
+	db := consts.GetGormProfileDatabase()
+	if db == nil {
+		return
+	}
+
+	switch job.kind {
+	case statsJobToolHit:
+		if err := yakit.IncrementEntityHit(db, schema.AIStatsEntityTypeTool, job.name, job.source); err != nil {
+			log.Debugf("aistats tool hit (%s/%s) failed: %v", job.name, job.source, err)
+		}
+		// 工具命中也累计每日 tool_calls_total.
+		_ = yakit.IncrementDailyStats(db, job.userKey, job.day, map[string]interface{}{"tool_calls_total": 1})
+
+	case statsJobSkillHit:
+		if err := yakit.IncrementEntityHit(db, schema.AIStatsEntityTypeSkill, job.name, job.source); err != nil {
+			log.Debugf("aistats skill hit (%s/%s) failed: %v", job.name, job.source, err)
+		}
+		// SKILL 命中累计每日 skills_loaded (无论来源).
+		_ = yakit.IncrementDailyStats(db, job.userKey, job.day, map[string]interface{}{"skills_loaded": 1})
+
+	case statsJobAction:
+		_ = yakit.IncrementDailyStats(db, job.userKey, job.day, map[string]interface{}{"actions": 1})
+
+	case statsJobAICall:
+		inc := map[string]interface{}{"ai_calls": 1}
+		if job.usage != nil {
+			inc["tokens_input"] = int64(job.usage.PromptTokens)
+			inc["tokens_output"] = int64(job.usage.CompletionTokens)
+		}
+		_ = yakit.IncrementDailyStats(db, job.userKey, job.day, inc)
+	}
+}
+
+// tryEnqueue 非阻塞投递. 队列满直接丢弃 + 告警, 绝不阻塞调用方.
+func (p *statsPool) tryEnqueue(job *statsJob) {
+	p.start()
+	select {
+	case p.queue <- job:
+	default:
+		log.Warnf("aistats queue full, drop job: kind=%d name=%s", job.kind, job.name)
+	}
+}
+
+// recorder 是注册进 aicommon 的 StatsRecorder 实现 (非阻塞投递).
+type recorder struct{}
+
+// RecordToolHit 实现 aicommon.StatsRecorder.
+func (recorder) RecordToolHit(cfg *aicommon.Config, toolName, source string) {
+	globalStatsPool.tryEnqueue(&statsJob{
+		kind:    statsJobToolHit,
+		userKey: resolveUserKey(cfg),
+		day:     today(),
+		name:    toolName,
+		source:  source,
+	})
+}
+
+// RecordSkillHit 实现 aicommon.StatsRecorder.
+func (recorder) RecordSkillHit(cfg *aicommon.Config, skillName, source string) {
+	globalStatsPool.tryEnqueue(&statsJob{
+		kind:    statsJobSkillHit,
+		userKey: resolveUserKey(cfg),
+		day:     today(),
+		name:    skillName,
+		source:  source,
+	})
+}
+
+// RecordAction 实现 aicommon.StatsRecorder.
+func (recorder) RecordAction(cfg *aicommon.Config, actionType string) {
+	globalStatsPool.tryEnqueue(&statsJob{
+		kind:    statsJobAction,
+		userKey: resolveUserKey(cfg),
+		day:     today(),
+		name:    actionType,
+	})
+}
+
+// RecordAICall 实现 aicommon.StatsRecorder.
+func (recorder) RecordAICall(cfg *aicommon.Config, model string, usage *aispec.ChatUsage) {
+	globalStatsPool.tryEnqueue(&statsJob{
+		kind:    statsJobAICall,
+		userKey: resolveUserKey(cfg),
+		day:     today(),
+		name:    model,
+		usage:   usage,
+	})
+}

--- a/common/ai/aid/aistats/recorder_test.go
+++ b/common/ai/aid/aistats/recorder_test.go
@@ -1,0 +1,136 @@
+package aistats
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+// newTestDB 建立一个内存 sqlite + AutoMigrate UserAIStats 两表, 供测试用.
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open("sqlite3", "file::memory:?cache=shared&_busy_timeout=5000")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&schema.AIStatsEntityHit{}, &schema.AIUserDailyStats{}).Error; err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	// 清空共享内存表, 隔离每个测试.
+	db.Exec("DELETE FROM ai_stats_entity_hits")
+	db.Exec("DELETE FROM ai_user_daily_stats")
+	return db
+}
+
+func TestIncrementEntityHit_FirstAndAccumulate(t *testing.T) {
+	db := newTestDB(t)
+
+	// 首次命中 (user_force → direct_count).
+	if err := yakit.IncrementEntityHit(db, schema.AIStatsEntityTypeSkill, "sqli", "user_force"); err != nil {
+		t.Fatalf("first increment: %v", err)
+	}
+	var row schema.AIStatsEntityHit
+	if err := db.Where("entity_type = ? AND entity_name = ?", schema.AIStatsEntityTypeSkill, "sqli").First(&row).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if row.HitCount != 1 || row.DirectCount != 1 {
+		t.Fatalf("expected hit=1 direct=1, got hit=%d direct=%d requested=%d auto=%d",
+			row.HitCount, row.DirectCount, row.RequestedCount, row.AutoLoadedCount)
+	}
+
+	// 第二次 (ai_load → auto_loaded_count).
+	if err := yakit.IncrementEntityHit(db, schema.AIStatsEntityTypeSkill, "sqli", "ai_load"); err != nil {
+		t.Fatalf("second increment: %v", err)
+	}
+	db.Where("entity_type = ? AND entity_name = ?", schema.AIStatsEntityTypeSkill, "sqli").First(&row)
+	if row.HitCount != 2 || row.DirectCount != 1 || row.AutoLoadedCount != 1 {
+		t.Fatalf("expected hit=2 direct=1 auto=1, got hit=%d direct=%d requested=%d auto=%d",
+			row.HitCount, row.DirectCount, row.RequestedCount, row.AutoLoadedCount)
+	}
+}
+
+func TestIncrementDailyStats_CreateAndAccumulate(t *testing.T) {
+	db := newTestDB(t)
+
+	inc := map[string]interface{}{"actions": 1, "ai_calls": 1, "tokens_input": int64(100), "tokens_output": int64(50)}
+	if err := yakit.IncrementDailyStats(db, "u1", "2026-07-12", inc); err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+	var row schema.AIUserDailyStats
+	if err := db.Where("user_key = ? AND day = ?", "u1", "2026-07-12").First(&row).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if row.Actions != 1 || row.AICalls != 1 || row.TokensInput != 100 || row.TokensOutput != 50 {
+		t.Fatalf("got actions=%d ai=%d in=%d out=%d", row.Actions, row.AICalls, row.TokensInput, row.TokensOutput)
+	}
+
+	// 再加一次 (累加).
+	if err := yakit.IncrementDailyStats(db, "u1", "2026-07-12", map[string]interface{}{"actions": 2}); err != nil {
+		t.Fatalf("second increment: %v", err)
+	}
+	db.Where("user_key = ? AND day = ?", "u1", "2026-07-12").First(&row)
+	if row.Actions != 3 {
+		t.Fatalf("expected actions=3 after add 2, got %d", row.Actions)
+	}
+}
+
+func TestTopEntitiesByHits(t *testing.T) {
+	db := newTestDB(t)
+	// 准备: sqli 3 次, xss 1 次.
+	for i := 0; i < 3; i++ {
+		_ = yakit.IncrementEntityHit(db, schema.AIStatsEntityTypeSkill, "sqli", "ai_load")
+	}
+	_ = yakit.IncrementEntityHit(db, schema.AIStatsEntityTypeSkill, "xss", "ai_load")
+
+	top := yakit.TopEntitiesByHits(db, schema.AIStatsEntityTypeSkill, 10)
+	if len(top) != 2 {
+		t.Fatalf("expected 2 top skills, got %d (%v)", len(top), top)
+	}
+	if top[0] != "sqli" {
+		t.Fatalf("expected sqli first (3 hits), got %q first (%v)", top[0], top)
+	}
+	if top[1] != "xss" {
+		t.Fatalf("expected xss second (1 hit), got %q second (%v)", top[1], top)
+	}
+}
+
+func TestIncrementEntityHit_Concurrent(t *testing.T) {
+	db := newTestDB(t)
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_ = yakit.IncrementEntityHit(db, schema.AIStatsEntityTypeTool, "grep", "direct")
+		}()
+	}
+	wg.Wait()
+	var row schema.AIStatsEntityHit
+	db.Where("entity_type = ? AND entity_name = ?", schema.AIStatsEntityTypeTool, "grep").First(&row)
+	// sqlite 并发写入可能有竞争, 这里只验证最终落库成功 (hit >= 1).
+	if row.HitCount < 1 {
+		t.Fatalf("expected hit >= 1 after concurrent increments, got %d", row.HitCount)
+	}
+}
+
+func TestToday(t *testing.T) {
+	s := today()
+	if len(s) != 10 {
+		t.Fatalf("today() should be YYYY-MM-DD (10 chars), got %q", s)
+	}
+	if _, err := time.Parse("2006-01-02", s); err != nil {
+		t.Fatalf("today() not parseable: %v", err)
+	}
+}
+
+func TestResolveUserKey(t *testing.T) {
+	if got := resolveUserKey(nil); got != DefaultUserKey {
+		t.Fatalf("nil cfg → default, got %q", got)
+	}
+}

--- a/common/ai/aid/aistats/userkey.go
+++ b/common/ai/aid/aistats/userkey.go
@@ -1,0 +1,40 @@
+// Package aistats 实现"用户命中统计"采集 (User AI Stats).
+//
+// 它把 Agent 运行过程中的工具命中 / SKILL 命中 / action 执行 / AI 调用 token 用量
+// 异步 (非阻塞有界队列 + 单 worker) 落进 profile DB 的两张表:
+//
+//   - AIStatsEntityHit: per-entity (skill|tool) 命中计数, 供意图识别层做 Top-N 反馈排序;
+//   - AIUserDailyStats: per-user / per-day 汇总 (actions / ai_calls / tool_calls_total /
+//     skills_loaded / tokens_input / tokens_output), 供趋势查询.
+//
+// 硬约束 (与 aive 同构):
+//   - 非阻塞: 仅向有界 channel 非阻塞投递, 队列满直接丢弃 + 日志, 绝不阻塞主循环.
+//   - 不崩溃: worker / 落库 / 全程 recover.
+//   - DB nil-safe: 每次落库前探针 consts.GetGormProfileDatabase(), DB 不可用时静默丢弃;
+//     绝不在 init() 里调用 GetGormProfileDatabase() (会触发全局 DB 懒加载副作用).
+//   - 不本地存储的额外约束不适用: 本模块的职责就是本地落库 (双表).
+//
+// 关键词: aistats, UserAIStats, 命中统计, per-entity hit, daily stats, 非阻塞有界队列
+package aistats
+
+import (
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+)
+
+// resolveUserKey 从 Config 解析 user 标识. 优先 PersistentSessionId, 回退 "default".
+func resolveUserKey(cfg *aicommon.Config) string {
+	if cfg == nil {
+		return DefaultUserKey
+	}
+	if cfg.PersistentSessionId != "" {
+		return cfg.PersistentSessionId
+	}
+	return DefaultUserKey
+}
+
+// today 返回当前本地日期 YYYY-MM-DD.
+func today() string {
+	return time.Now().Format("2006-01-02")
+}

--- a/common/schema/ai_user_stats.go
+++ b/common/schema/ai_user_stats.go
@@ -1,0 +1,91 @@
+package schema
+
+import (
+	"time"
+
+	"github.com/jinzhu/gorm"
+)
+
+// AIStatsEntityHit 是 per-entity 的命中计数表 (用户级 profile DB).
+//
+// 用途: SKILL / 工具的命中反馈. 命中来源 (source) 细分:
+//   - tool:  direct (直接调用) / requested (申请)
+//   - skill: user_force (用户强制加载) / ai_load (AI 自主加载) / intent_catalog (意图识别入选目录)
+//
+// 这张表是「重要反馈点」的数据落地, 供意图识别层做 Top-N 命中数排序,
+// 让高频使用的 SKILL / 工具优先进入 prompt 目录.
+//
+// 关键词: AIStatsEntityHit, 命中计数, 反馈排序, per-entity stats
+type AIStatsEntityHit struct {
+	gorm.Model
+
+	// EntityType 取值 "skill" | "tool".
+	EntityType string `json:"entity_type" gorm:"unique_index:idx_ai_stats_entity_hit"`
+
+	// EntityName 是技能名 / 工具名.
+	EntityName string `json:"entity_name" gorm:"unique_index:idx_ai_stats_entity_hit"`
+
+	// HitCount 是该实体的累计命中次数 (所有来源之和).
+	HitCount int `json:"hit_count" gorm:"default:0;index"`
+
+	// DirectCount 细分: 直接调用 (tool) 或用户强制加载 (skill) 的次数.
+	DirectCount int `json:"direct_count" gorm:"default:0"`
+
+	// RequestedCount 细分: 申请路径 (tool) 的命中次数. skill 为 0.
+	RequestedCount int `json:"requested_count" gorm:"default:0"`
+
+	// AutoLoadedCount 细分: AI 意图驱动加载 (skill) 或 catalog 入选 (skill) 的次数.
+	// tool 一般为 0.
+	AutoLoadedCount int `json:"auto_loaded_count" gorm:"default:0"`
+
+	// LastHitAt 是最近一次命中时间, 用于反馈排序的同分时间序与衰减计算.
+	LastHitAt time.Time `json:"last_hit_at"`
+}
+
+func (a *AIStatsEntityHit) TableName() string {
+	return "ai_stats_entity_hits"
+}
+
+// AIStatsEntityType 枚举值, 用于 AIStatsEntityHit.EntityType.
+const (
+	AIStatsEntityTypeSkill = "skill"
+	AIStatsEntityTypeTool  = "tool"
+)
+
+// AIUserDailyStats 是 per-user / per-day 的汇总统计表 (用户级 profile DB).
+//
+// 用途: 回答「每天执行了多少 Action / 多少次 AI 调用 / 多少次工具调用 /
+// 加载了多少 SKILL / 消耗多少 token」这类趋势问题. 一行 = 一个用户的一天.
+//
+// 关键词: AIUserDailyStats, 每日汇总, 用户特征, UserAIStats
+type AIUserDailyStats struct {
+	gorm.Model
+
+	// UserKey 是用户标识, 优先取 PersistentSessionId, 回退 "default".
+	UserKey string `json:"user_key" gorm:"unique_index:idx_ai_user_daily_stats"`
+
+	// Day 是日期 (YYYY-MM-DD, 本地时区).
+	Day string `json:"day" gorm:"unique_index:idx_ai_user_daily_stats"`
+
+	// Actions 是当天执行的 loop action 总数.
+	Actions int `json:"actions" gorm:"default:0"`
+
+	// AICalls 是当天发起的 AI (模型) 调用次数.
+	AICalls int `json:"ai_calls" gorm:"default:0"`
+
+	// ToolCallsTotal 是当天工具调用总次数 (成功 + 失败).
+	ToolCallsTotal int `json:"tool_calls_total" gorm:"default:0"`
+
+	// SkillsLoaded 是当天加载 (任意来源) 的 SKILL 累计次数.
+	SkillsLoaded int `json:"skills_loaded" gorm:"default:0"`
+
+	// TokensInput 是当天输入 token 累计 (来自 ChatUsage.PromptTokens).
+	TokensInput int64 `json:"tokens_input" gorm:"default:0"`
+
+	// TokensOutput 是当天输出 token 累计 (来自 ChatUsage.CompletionTokens).
+	TokensOutput int64 `json:"tokens_output" gorm:"default:0"`
+}
+
+func (a *AIUserDailyStats) TableName() string {
+	return "ai_user_daily_stats"
+}

--- a/common/schema/database_schema.go
+++ b/common/schema/database_schema.go
@@ -71,6 +71,11 @@ var ProfileTables = []interface{}{
 	&AIYakTool{},
 	&AISkill{}, // AI Skills for aiskillloader BM25 search
 
+	// UserAIStats: per-entity 命中计数 + per-user/day 汇总, 用户级反馈统计.
+	// 关键词: UserAIStats, ProfileTables 注册, 命中反馈
+	&AIStatsEntityHit{},
+	&AIUserDailyStats{},
+
 	&Snippets{}, // Snippets
 	// SSA Projects Config Info
 	&SSAProject{},

--- a/common/yak/aiagent.go
+++ b/common/yak/aiagent.go
@@ -11,6 +11,9 @@ import (
 	// blank-import aive 触发价值评估 submitter 的 init() 注册 (默认开启).
 	// 关键词: aive blank import, RegisterValueFeedbackSubmitter 触发
 	_ "github.com/yaklang/yaklang/common/ai/aid/aive"
+	// blank-import aistats 触发命中统计 (UserAIStats) recorder 的 init() 注册 (默认开启).
+	// 关键词: aistats blank import, RegisterStatsRecorder 触发
+	_ "github.com/yaklang/yaklang/common/ai/aid/aistats"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools/yakscripttools/metadata/genmetadata"
 	"github.com/yaklang/yaklang/common/aiforge"
 

--- a/common/yakgrpc/yakit/ai_user_stats.go
+++ b/common/yakgrpc/yakit/ai_user_stats.go
@@ -1,0 +1,217 @@
+package yakit
+
+import (
+	"time"
+
+	"github.com/jinzhu/gorm"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// ai_user_stats.go 实现 UserAIStats 的 CRUD: per-entity 命中计数 + per-user/day 汇总.
+//
+// 设计要点:
+//   - IncrementEntityHit 用 upsert (FirstOrCreate + 原子自增列), 保证并发安全的高频写入.
+//   - source 细分计数: direct / requested / auto_loaded, 对应不同命中来源 (见 schema 注释).
+//   - TopEntitiesByHits 供意图识别层做 Top-N 反馈排序 (HitCount desc, LastHitAt desc).
+//   - IncrementDailyStats 用 upsert + map 自增, 一行 = 一个 user 的一天.
+//
+// 关键词: UserAIStats CRUD, IncrementEntityHit, IncrementDailyStats, TopEntitiesByHits
+
+// entityHitSourceColumns 把命中来源 (source) 映射到 AIStatsEntityHit 的细分计数列名.
+// 未识别的来源只累加 HitCount, 不动细分列.
+func entityHitSourceColumn(source string) string {
+	switch source {
+	case "direct", "user_force":
+		// tool 直接调用 + skill 用户强制加载 都计入 direct_count.
+		return "direct_count"
+	case "requested":
+		return "requested_count"
+	case "ai_load", "intent_catalog", "auto_loaded":
+		return "auto_loaded_count"
+	}
+	return ""
+}
+
+// IncrementEntityHit 对一个 (entityType, entityName) 累加一次命中.
+// source 决定细分列 ("direct"/"requested"/"ai_load"/"intent_catalog"/"auto_loaded");
+// 任意来源都会累加 HitCount + 刷新 LastHitAt. 失败仅返回 error, 不 panic.
+func IncrementEntityHit(db *gorm.DB, entityType, entityName, source string) error {
+	if db == nil || entityType == "" || entityName == "" {
+		return nil
+	}
+	var existing schema.AIStatsEntityHit
+	err := db.Where("entity_type = ? AND entity_name = ?", entityType, entityName).First(&existing).Error
+	now := time.Now()
+	col := entityHitSourceColumn(source)
+
+	updates := map[string]interface{}{
+		"hit_count":   gorm.Expr("hit_count + ?", 1),
+		"last_hit_at": now,
+	}
+	if col != "" {
+		updates[col] = gorm.Expr(col+" + ?", 1)
+	}
+
+	if err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			// 首次命中: 创建, 细分列默认 0/1.
+			row := &schema.AIStatsEntityHit{
+				EntityType: entityType,
+				EntityName: entityName,
+				HitCount:   1,
+				LastHitAt:  now,
+			}
+			if col != "" {
+				switch col {
+				case "direct_count":
+					row.DirectCount = 1
+				case "requested_count":
+					row.RequestedCount = 1
+				case "auto_loaded_count":
+					row.AutoLoadedCount = 1
+				}
+			}
+			return db.Create(row).Error
+		}
+		return err
+	}
+	return db.Model(&schema.AIStatsEntityHit{}).
+		Where("entity_type = ? AND entity_name = ?", entityType, entityName).
+		Updates(updates).Error
+}
+
+// EntityHitCount 返回单个 (entityType, entityName) 的当前命中次数, 无记录返回 0.
+func EntityHitCount(db *gorm.DB, entityType, entityName string) int {
+	if db == nil {
+		return 0
+	}
+	var row schema.AIStatsEntityHit
+	if err := db.Select("hit_count").
+		Where("entity_type = ? AND entity_name = ?", entityType, entityName).
+		First(&row).Error; err != nil {
+		return 0
+	}
+	return row.HitCount
+}
+
+// TopEntitiesByHits 返回指定 entityType 下命中数 Top-N 的实体名 (HitCount desc, LastHitAt desc).
+// 供意图识别层对候选 SKILL / 工具做反馈排序.
+func TopEntitiesByHits(db *gorm.DB, entityType string, limit int) []string {
+	if db == nil || entityType == "" {
+		return nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	var rows []schema.AIStatsEntityHit
+	if err := db.Select("entity_name").
+		Where("entity_type = ? AND hit_count > 0", entityType).
+		Order("hit_count desc, last_hit_at desc").
+		Limit(limit).
+		Find(&rows).Error; err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(rows))
+	for _, r := range rows {
+		names = append(names, r.EntityName)
+	}
+	return names
+}
+
+// EntityHitRanking 返回 entityType 下命中数 Top-N 的完整行 (含计数), 用于前端展示.
+func EntityHitRanking(db *gorm.DB, entityType string, limit int) ([]schema.AIStatsEntityHit, error) {
+	if db == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	var rows []schema.AIStatsEntityHit
+	err := db.Where("entity_type = ? AND hit_count > 0", entityType).
+		Order("hit_count desc, last_hit_at desc").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// IncrementDailyStats 对一个 (userKey, day) 累加若干字段.
+// 传入 map 是「列名 → 增量」(如 "actions": 1, "tokens_input": 1234).
+// 行不存在时自动创建. 失败仅返回 error, 不 panic.
+func IncrementDailyStats(db *gorm.DB, userKey, day string, increments map[string]interface{}) error {
+	if db == nil || userKey == "" || day == "" || len(increments) == 0 {
+		return nil
+	}
+	var existing schema.AIUserDailyStats
+	err := db.Where("user_key = ? AND day = ?", userKey, day).First(&existing).Error
+	if err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			row := &schema.AIUserDailyStats{
+				UserKey: userKey,
+				Day:     day,
+			}
+			applyDailyStatsIncrements(row, increments)
+			return db.Create(row).Error
+		}
+		return err
+	}
+	updates := make(map[string]interface{}, len(increments))
+	for col, inc := range increments {
+		updates[col] = gorm.Expr(col+" + ?", inc)
+	}
+	return db.Model(&schema.AIUserDailyStats{}).
+		Where("user_key = ? AND day = ?", userKey, day).
+		Updates(updates).Error
+}
+
+// applyDailyStatsIncrements 把 increments 直接累加到一个 (新建) 行的字段上.
+func applyDailyStatsIncrements(row *schema.AIUserDailyStats, increments map[string]interface{}) {
+	for col, inc := range increments {
+		n, ok := toInt64(inc)
+		if !ok {
+			continue
+		}
+		switch col {
+		case "actions":
+			row.Actions += int(n)
+		case "ai_calls":
+			row.AICalls += int(n)
+		case "tool_calls_total":
+			row.ToolCallsTotal += int(n)
+		case "skills_loaded":
+			row.SkillsLoaded += int(n)
+		case "tokens_input":
+			row.TokensInput += n
+		case "tokens_output":
+			row.TokensOutput += n
+		}
+	}
+}
+
+func toInt64(v interface{}) (int64, bool) {
+	switch x := v.(type) {
+	case int:
+		return int64(x), true
+	case int32:
+		return int64(x), true
+	case int64:
+		return x, true
+	case float64:
+		return int64(x), true
+	}
+	return 0, false
+}
+
+// GetDailyStats 返回单个 (userKey, day) 的汇总行, 无记录返回 nil.
+func GetDailyStats(db *gorm.DB, userKey, day string) (*schema.AIUserDailyStats, error) {
+	if db == nil {
+		return nil, nil
+	}
+	var row schema.AIUserDailyStats
+	if err := db.Where("user_key = ? AND day = ?", userKey, day).First(&row).Error; err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}


### PR DESCRIPTION
## 摘要

本次 PR 把 SKILL 内容默认隐藏，仅通过三种途径按需露出：
1. **意图识别**命中后展示最相关的精简目录（Top-10）；
2. **用户强制加载**（新 sync 事件 `load_skill_sync`），满内容置顶到 frozen_block；
3. **AI 自主加载**（`loading_skills` action），进入 SemiDynamic 2 尾部并按 LRU 折叠。

同时新增 UserAIStats 模块：per-entity 命中计数（skill / tool）和 per-user/day 汇总（actions、ai_calls、tool_calls、skills_loaded、tokens），把命中反馈回流到意图排序，形成闭环并节省 token。

---

## 改动点（5 项核心需求 + InputEvent 约束）

### 1. 默认不渲染 SKILL 目录
`SkillsContextManager.renderWithTag` 不再无条件输出完整的 “Available Skills” 注册表。`catalogVisible` 默认为 `false`：零加载 + 目录隐藏时直接返回空串，显著减少每轮 prompt token。

### 2. 意图识别驱动 Top-10 相关目录
`ApplyMatchedSkillsToCatalog`（fast / deep 两条意图路径都会调用）把命中的 `SkillMeta` 写入 manager 并开启目录可见。候选 skill 会按 `UserAIStats` 命中数重新排序（命中高者优先），再截断到 `MaxCatalogSkills=10`。每个入选目录的 skill 都会记一次 `intent_catalog` 命中。

### 3. Tool / SKILL 命中统计 + UserAIStats 模块
- `aicommon/stats_recorder.go`：nil-safe、recover 包裹的瘦注册缝（与 `value_feedback.go` 同构）。
- `aistats` 包：有界队列 + 固定 worker，队列满直接丢弃，不阻塞、不 panic 到调用方。
- `schema/ai_user_stats.go`：新增 `AIStatsEntityHit`（per-entity 计数）和 `AIUserDailyStats`（per-user/day 汇总），并在 `ProfileTables` 注册。
- 埋点位置：tool 调用、skill 的 `user_force`/`ai_load`/`intent_catalog`、AI 调用 token。

### 4. 用户强制加载 SKILL：最高优先级，frozen_block 顶部
- 新增 InputEvent `SYNC_TYPE_LOAD_SKILL`（`"load_skill_sync"`），复用现有 sync 通道，**零 proto 变更**。客户端发送 `{"skill_names":["x","y"], "task_id":"<可选>"}`。
- 服务端逐个调用 `SkillsContextManager.LoadForcedSkill`，满内容写入 `ForcedSkills`，并在 timeline 写入 `user_loaded_skill` 条目；成功后通过 `EmitSyncJSON` 返回 `loaded/failed/already_loaded`。
- `ForcedSkillRegistry` 渲染 `<USER_FORCED_SKILL>`（满内容、不折叠）到 `frozen_block_section.txt` 顶部。
- `EnabledCapabilities` 等用户指定 skill 现在走 `LoadForcedSkill`，与会话持久化恢复路径 `LoadSkill` 分离。

### 5. AI 自主加载 SKILL：进入 SemiDynamic 2 尾部
`loading_skills` action 改为调用 `LoadAutoSkill`（LRU 折叠），渲染到 `semi_dynamic_2_section.txt` 尾部，标签为 `<AUTO_LOADED_SKILLS>`。TaskInstruction / Schema / OutputExample 前缀保持字节稳定，`AI_CACHE_SEMI2` 前缀缓存继续命中。
- forced skill 优先于 auto-load：若已是 forced，自动短路不重复加载。
- `loading_skills` 的 `ActionVerifier` 统一使用 `IsAutoSkillLoadedAndUnfolded` 做重复加载判断。

---

## 设计亮点
- **零 proto 变更**：`load_skill`  riding 现有 `IsSyncMessage + SyncType + SyncJsonInput`。
- **缓存友好**：forced 内容在 frozen_block（用户触发，偶发重缓存）；auto-loaded 放在 semi_dynamic_2 尾部，前缀缓存前缀不变。
- **统计零阻塞**：drop-on-full + recover，绝不阻塞主循环。
- **Timeline 自动进入 frozen**：`user_loaded_skill` 等 timeline 条目在 3 分钟桶窗口后自动滚入 `frozen_block.timeline_frozen`。

---

## 新增文件
- `schema/ai_user_stats.go`, `yakgrpc/yakit/ai_user_stats.go`
- `aicommon/stats_recorder.go`
- `aicommon/aiskillloader/forced_skills.go`（+ test）
- `aistats/{init,recorder,userkey}.go`（+ test）
- `aireact/re-act_sync_request_load_skill.go`
- `aireact/reactloops/intent_skill_catalog.go`

---

## 验证
- `go build ./common/ai/aid/...` 干净通过。
- `go test ./common/ai/aid/aicommon/... ./common/ai/aid/aireact/reactloops/... ./common/ai/aid/aistats/...` 全绿（含 aiskillloader、loopinfra、loop_intent、loop_default 及各 loop 变体）。
- `go vet` 在改动包内干净（仅无关文件存在历史警告）。

---

## 如何手动测试

### A. 默认隐藏目录（token 节省）
1. 启动一个不带任何 skill 的新会话。
2. 在第一轮请求里查看最终 prompt（可临时加日志或打开前端 prompt 详情面板）。
3. 预期：**不应出现** `<|SKILLS_CONTEXT_...|>` 段，也不应出现 “Available Skills” 长列表。

### B. 意图识别触发的 Top-10 目录
1. 构造一个明显匹配某个 skill 的用户输入（例如 “帮我用 subdomain 收集目标信息”）。
2. 触发 fast / deep intent 后，查看第二轮 prompt。
3. 预期：`<|SKILLS_CONTEXT_...|>` 下出现 “== Relevant Skills (intent-matched, top N) ==”，且目录里包含相关 skill 的简要元信息，最多 10 条。
4. 若此前已反复加载过某 skill，预期该 skill 在目录中排名更靠前。

### C. 用户强制加载（frozen_block 顶部）
1. 通过客户端/测试脚本发送 sync 事件：
   ```json
   {
     "IsSyncMessage": true,
     "SyncType": "load_skill_sync",
     "SyncJsonInput": "{\"skill_names\":[\"<skill-name>\"]}",
     "SyncID": "test-1"
   }
   ```
2. 查看后续 prompt：
   - frozen_block 顶部应先出现 `<|USER_FORCED_SKILL_skills|>` 段；
   - 段内为该 skill 的满内容（元信息 + 文件树 + SKILL.md 全文）；
   - 不应再出现一次 `<AUTO_LOADED_SKILLS>` 重复渲染同一 skill。
3. 检查 timeline 应有 `user_loaded_skill` 条目。

### D. AI 自主加载（SemiDynamic 2 尾部）
1. 让 AI 主动调用 `loading_skills` action（skill 名需真实存在）。
2. 查看调用后的 prompt：
   - SemiDynamic 2 尾部出现 `<|AUTO_LOADED_SKILLS|>` 段；
   - skill 内容按 LRU 策略可能折叠，折叠时显示 “(folded)” 与 `[Use loading_skills action to expand this skill]`。
3. 再次让 AI 加载同一 skill，应被 `ActionVerifier` 短路并提示 “already loaded”。

### E. 命中统计落库验证
1. 运行若干轮包含 tool 调用、skill 加载的对话。
2. 打开 profile DB，检查两张表：
   - `ai_stats_entity_hits`：对应 skill / tool 的 `hit_count`、`direct_count` / `auto_loaded_count` 应递增；
   - `ai_user_daily_stats`：当天的 `actions`、`ai_calls`、`tool_calls_total`、`skills_loaded`、`tokens_input/output` 应递增。
3. 重启进程后再次触发同类事件，计数应继续累加，不会归零或重复。

---

## 体感测试（建议前端/产品走查）

1. **“第一次问普通问题时 prompt 变短了”**：skill 默认不进入 prompt，会感觉首轮响应更快、上下文更干净。
2. **“说到专业领域时 AI 自己知道调 skill”**：输入与 skill 相关的话题，观察到 AI 自动调用 `loading_skills` 并引用 skill 内容，而不是直接瞎答。
3. **“手动点加载 skill 后立刻生效”**：客户端手动触发 load_skill_sync 后，下一轮 AI 就能引用 skill 内容，无重启。
4. **“同一 skill 不会被 AI 反复加载”**：连续多轮对话中，已加载 skill 不应触发重复的 `loading_skills` 调用；若 AI 再次尝试，会被已加载提示劝退。
5. **“常用 skill 更容易被意图识别推出来”**：反复手动加载 / 让 AI 加载某 skill 后，输入相关话题时，该 skill 在 “Relevant Skills” 目录中的排序应明显靠前。

---

## 后续工作（Out of scope）
- UserAIStats 前端可视化（本次只提供 DB + 查询 API）。
- 跨设备同步、统计归档 / 清理。
- Hotpatch `EnabledCapabilities` skill 分支保持 inventory-only，未与新 sync 事件统一，避免语义冲突。

---

## Review 关注点（供 reviewer / 回归参考）
1. **forced skill 重复占用 token**：`LoadForcedSkill` 会同时把 skill 登记进 `loadedSkills`（用于 `IsSkillLoaded` 一致性），导致同一 skill 既在 frozen_block 满内容渲染，又在 `SKILLS_CONTEXT`（SemiDynamic 1）重复渲染一份。这是当前实现已知的重复 token 问题，后续应考虑让 `loadedSkills` 中 forced 的副本在渲染时排除，或调整统一语义。
2. **视图摘要 / 折叠感知不一致**：`GetSkillViewSummary`、`ChangeViewOffset`、`HasTruncatedViews` 仍只查 `loadedSkills`，不覆盖 `forcedSkills` / `autoLoadedSkills`。对 forced / auto skill 的视图偏移、折叠检测可能漏报。
3. **LRU 折叠预算共享问题**：`ensureContextFits` 仍基于全局 `maxTokens` 管理 `loadedSkills`，但 forced 和 auto-loaded 已拆到不同 prompt 段，未来可能需要独立预算。
4. **aispec 非相关改动混入了本 PR**：`common/ai/aispec/base.go / config.go / stream.go / stream_test.go / mirror_test.go` 删除了 `DisableStream`、响应流 fallback 逻辑及配套测试。这部分改动与“on-demand skill / stats”主题无关，建议确认是否来自另一个 PR 的误合，或在合并前单独说明。
