### PR TITLE
fix(aispec): normalize responses input to array for packyapi compat

### DIFF
--- a/common/ai/aispec/base.go
+++ b/common/ai/aispec/base.go
@@ -885,6 +885,12 @@ func chatBaseResponses(url string, model string, msg string, ctx *ChatBaseContex
 	} else {
 		input = buildResponsesInput(msg, ctx.ImageUrls)
 	}
+	// 防御性规范化：部分 response-only 上游（如 packyapi）严格要求 input 为
+	// JSON 数组，拒绝字符串简写。当 input 因 ExtraBody 覆盖、调用链透传等
+	// 边缘路径落入字符串时，这里兜底包装成标准的 [{role,content}] 数组，
+	// 避免 "Input must be a list" 报错。
+	// 关键词: normalizeResponsesInput, input 必须为数组, packyapi 兼容
+	input = normalizeResponsesInput(input)
 	req := map[string]any{
 		"model":  model,
 		"input":  input,
@@ -1102,6 +1108,28 @@ func buildResponsesInput(msg string, images []*ImageDescription) []map[string]an
 			"role":    "user",
 			"content": content,
 		},
+	}
+}
+
+// normalizeResponsesInput 确保 input 始终为 JSON 数组格式。
+// OpenAI Responses API 同时接受字符串和数组，但部分上游网关（如 packyapi）
+// 严格要求 input 为数组，否则返回 "Input must be a list"。
+// 当 input 已经是切片类型时直接返回；当 input 为字符串时包装成
+// [{role:"user", content:[{type:"input_text", text:...}]}] 标准格式。
+// 关键词: normalizeResponsesInput, input 字符串转数组, packyapi 兼容
+func normalizeResponsesInput(input any) any {
+	if input == nil {
+		return buildResponsesInput("", nil)
+	}
+	switch v := input.(type) {
+	case []map[string]any:
+		return v
+	case []any:
+		return v
+	case string:
+		return buildResponsesInput(v, nil)
+	default:
+		return input
 	}
 }
 

--- a/common/ai/aispec/mirror_test.go
+++ b/common/ai/aispec/mirror_test.go
@@ -409,3 +409,52 @@ func TestConvertChatDetailsToResponsesInput(t *testing.T) {
 	assert.Equal(t, "input_text", c2[0]["type"])
 	assert.Equal(t, "12345", c2[0]["text"])
 }
+
+// TestNormalizeResponsesInput 确保 normalizeResponsesInput 把字符串/nil/数组
+// 全部规范化成 []map[string]any 格式，防止上游 response-only 网关（如 packyapi）
+// 拒绝字符串 input 报 "Input must be a list"。
+// 关键词: normalizeResponsesInput, input 字符串兜底, packyapi
+func TestNormalizeResponsesInput(t *testing.T) {
+	t.Run("string input wrapped into array", func(t *testing.T) {
+		result := normalizeResponsesInput("hello world")
+		arr, ok := result.([]map[string]any)
+		require.True(t, ok, "string input must be normalized to []map[string]any")
+		require.Len(t, arr, 1)
+		assert.Equal(t, "user", arr[0]["role"])
+		content := arr[0]["content"].([]map[string]any)
+		require.Len(t, content, 1)
+		assert.Equal(t, "input_text", content[0]["type"])
+		assert.Equal(t, "hello world", content[0]["text"])
+	})
+
+	t.Run("nil input produces default array", func(t *testing.T) {
+		result := normalizeResponsesInput(nil)
+		arr, ok := result.([]map[string]any)
+		require.True(t, ok, "nil input must be normalized to []map[string]any")
+		require.Len(t, arr, 1)
+	})
+
+	t.Run("existing []map[string]any passthrough", func(t *testing.T) {
+		original := []map[string]any{
+			{"role": "user", "content": []map[string]any{{"type": "input_text", "text": "hi"}}},
+		}
+		result := normalizeResponsesInput(original)
+		assert.Equal(t, original, result, "[]map[string]any should pass through unchanged")
+	})
+
+	t.Run("existing []any passthrough", func(t *testing.T) {
+		original := []any{
+			map[string]any{"role": "user", "content": "text"},
+		}
+		result := normalizeResponsesInput(original)
+		assert.Equal(t, original, result, "[]any should pass through unchanged")
+	})
+
+	t.Run("empty string produces default array", func(t *testing.T) {
+		result := normalizeResponsesInput("")
+		arr, ok := result.([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, arr, 1)
+		assert.Equal(t, "user", arr[0]["role"])
+	})
+}


### PR DESCRIPTION
Response-only upstreams (e.g. packyapi) strictly require the `input` field to be a JSON array and reject the string shorthand with "Input must be a list". Add normalizeResponsesInput() as a defensive guard in chatBaseResponses to wrap string/nil inputs into the standard [{role,content}] array format.