### PR TITLE
fix(aispec): handle responses completed/done events to prevent content loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.zcode/
 .cursor
 *.yakc
 *.test

--- a/common/ai/aispec/base.go
+++ b/common/ai/aispec/base.go
@@ -330,6 +330,9 @@ func WithChatBase_AISamplingFromConfig(cfg *AIConfig) ChatBaseOption {
 		if s := strings.TrimSpace(cfg.ReasoningEffort); s != "" {
 			c.ReasoningEffort = s
 		}
+		if cfg.DisableStream {
+			c.DisableStream = true
+		}
 	}
 }
 

--- a/common/ai/aispec/config.go
+++ b/common/ai/aispec/config.go
@@ -53,7 +53,12 @@ type AIConfig struct {
 	Type                    string `json:"Type"`
 	PreferredTier           consts.ModelTier
 	DisableProviderFallback bool
-	Context                 context.Context
+	// DisableStream forces the upstream request to use non-streaming mode
+	// even if the caller originally requested streaming. The response
+	// callbacks (StreamHandler etc.) still fire with the full payload,
+	// allowing the caller to re-chunk it to the downstream client.
+	DisableStream bool
+	Context       context.Context
 
 	FunctionCallRetryTimes int
 
@@ -884,6 +889,12 @@ func WithProxy(p string) AIConfigOption {
 func WithAPIType(apiType string) AIConfigOption {
 	return func(c *AIConfig) {
 		c.APIType = strings.TrimSpace(apiType)
+	}
+}
+
+func WithDisableStream(b bool) AIConfigOption {
+	return func(c *AIConfig) {
+		c.DisableStream = b
 	}
 }
 

--- a/common/ai/aispec/stream.go
+++ b/common/ai/aispec/stream.go
@@ -721,6 +721,8 @@ func processAIResponseForResponses(r []byte, closer io.ReadCloser, outWriter io.
 type responsesToolCallState struct {
 	byItemID          map[string]*ToolCall
 	streamedMessageID map[string]struct{}
+	anyTextStreamed    bool
+	anyReasonStreamed  bool
 }
 
 func newResponsesToolCallState() *responsesToolCallState {
@@ -841,13 +843,31 @@ func handleResponsesSSEEvent(event map[string]any, outWriter io.Writer, reasonWr
 		itemID := utils.MapGetString(event, "item_id")
 		delta := utils.MapGetString(event, "delta")
 		if delta != "" {
+			toolState.anyTextStreamed = true
 			toolState.markMessageStreamed(itemID, outputIndex)
 			outWriter.Write([]byte(delta))
+		}
+	case "response.output_text.done":
+		if !toolState.anyTextStreamed {
+			text := utils.MapGetString(event, "text")
+			if text != "" {
+				toolState.anyTextStreamed = true
+				outWriter.Write([]byte(text))
+			}
 		}
 	case "response.reasoning_text.delta", "response.reasoning_summary_text.delta":
 		delta := utils.MapGetString(event, "delta")
 		if delta != "" {
+			toolState.anyReasonStreamed = true
 			reasonWriter.Write([]byte(delta))
+		}
+	case "response.reasoning_text.done", "response.reasoning_summary_text.done":
+		if !toolState.anyReasonStreamed {
+			text := utils.MapGetString(event, "text")
+			if text != "" {
+				toolState.anyReasonStreamed = true
+				reasonWriter.Write([]byte(text))
+			}
 		}
 	case "response.function_call_arguments.delta":
 		outputIndex := utils.InterfaceToInt(event["output_index"])
@@ -879,7 +899,12 @@ func handleResponsesSSEEvent(event map[string]any, outWriter io.Writer, reasonWr
 		outputIndex := utils.InterfaceToInt(event["output_index"])
 		handleResponsesOutputItem(item, outputIndex, eventType, outWriter, reasonWriter, toolCallCallback, toolState)
 	case "response.completed":
-		// Ignore completed event in streaming mode to avoid duplicate output/tool-calls.
+		if !toolState.anyTextStreamed {
+			resp := utils.MapGetMapRaw(event, "response")
+			if len(resp) > 0 {
+				extractResponsesOutputFromObject(resp, outWriter, reasonWriter, toolCallCallback)
+			}
+		}
 	default:
 		if strings.Contains(eventType, "reasoning") {
 			delta := utils.MapGetString(event, "delta")

--- a/common/ai/aispec/stream_test.go
+++ b/common/ai/aispec/stream_test.go
@@ -351,3 +351,158 @@ data: [DONE]`
 		t.Errorf("content mismatch, got %q", outBuffer.String())
 	}
 }
+
+// TestHandleResponsesSSEEvent_CompletedFallback 验证当上游不发 output_text.delta、
+// 只在 response.completed 里给 output_text 时（packyapi codex 风格），
+// handleResponsesSSEEvent 仍能通过 completed 事件补吐文本。
+// 关键词: response.completed 补吐, packyapi codex 风格, 流式内容不丢
+func TestHandleResponsesSSEEvent_CompletedFallback(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	reasonBuf := &bytes.Buffer{}
+	state := newResponsesToolCallState()
+
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.output_item.added",
+		"item": map[string]any{"type": "message", "id": "msg_1", "role": "assistant",
+			"content": []any{map[string]any{"type": "output_text", "text": ""}}},
+		"output_index": 0,
+	}, outBuf, reasonBuf, nil, state)
+
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.output_item.done",
+		"item": map[string]any{"type": "message", "id": "msg_1", "role": "assistant",
+			"content": []any{map[string]any{"type": "output_text", "text": ""}}},
+		"output_index": 0,
+	}, outBuf, reasonBuf, nil, state)
+
+	if outBuf.Len() != 0 {
+		t.Fatalf("expected empty output before completed, got %q", outBuf.String())
+	}
+
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"output_text": "PONG",
+			"output": []any{map[string]any{
+				"type": "message", "role": "assistant",
+				"content": []any{map[string]any{"type": "output_text", "text": "PONG"}},
+			}},
+		},
+	}, outBuf, reasonBuf, nil, state)
+
+	if outBuf.String() != "PONG" {
+		t.Errorf("expected output %q from completed fallback, got %q", "PONG", outBuf.String())
+	}
+}
+
+// TestHandleResponsesSSEEvent_DeltaSuppressCompleted 验证已有 delta 事件后
+// completed 不会重复吐出内容（防重复逻辑不回退）。
+// 关键词: response.completed 防重复, anyTextStreamed
+func TestHandleResponsesSSEEvent_DeltaSuppressCompleted(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	reasonBuf := &bytes.Buffer{}
+	state := newResponsesToolCallState()
+
+	handleResponsesSSEEvent(map[string]any{
+		"type":         "response.output_text.delta",
+		"delta":        "Hello",
+		"output_index": 0,
+		"item_id":      "msg_1",
+	}, outBuf, reasonBuf, nil, state)
+
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"output_text": "Hello",
+			"output": []any{map[string]any{
+				"type": "message", "role": "assistant",
+				"content": []any{map[string]any{"type": "output_text", "text": "Hello"}},
+			}},
+		},
+	}, outBuf, reasonBuf, nil, state)
+
+	if outBuf.String() != "Hello" {
+		t.Errorf("expected exactly one %q, got %q", "Hello", outBuf.String())
+	}
+}
+
+// TestHandleResponsesSSEEvent_OutputTextDone 验证 response.output_text.done 事件
+// 在没有 delta 的情况下能补吐文本。
+// 关键词: response.output_text.done, 流式补吐
+func TestHandleResponsesSSEEvent_OutputTextDone(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	reasonBuf := &bytes.Buffer{}
+	state := newResponsesToolCallState()
+
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.output_text.done",
+		"text": "done-text",
+	}, outBuf, reasonBuf, nil, state)
+
+	if outBuf.String() != "done-text" {
+		t.Errorf("expected %q, got %q", "done-text", outBuf.String())
+	}
+	if !state.anyTextStreamed {
+		t.Error("anyTextStreamed should be true after output_text.done")
+	}
+}
+
+// TestHandleResponsesSSEEvent_ReasoningTextDone 验证 response.reasoning_text.done
+// 在没有 reasoning delta 的情况下能补吐推理文本。
+// 关键词: response.reasoning_text.done, 推理补吐
+func TestHandleResponsesSSEEvent_ReasoningTextDone(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	reasonBuf := &bytes.Buffer{}
+	state := newResponsesToolCallState()
+
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.reasoning_text.done",
+		"text": "reason-done",
+	}, outBuf, reasonBuf, nil, state)
+
+	if reasonBuf.String() != "reason-done" {
+		t.Errorf("expected %q, got %q", "reason-done", reasonBuf.String())
+	}
+	if !state.anyReasonStreamed {
+		t.Error("anyReasonStreamed should be true after reasoning_text.done")
+	}
+}
+
+// TestHandleResponsesSSEEvent_CompletedWithToolCalls 验证 completed 事件含
+// function_call output 时 tool_call 不丢。
+// 关键词: response.completed tool_calls, function_call 不丢
+func TestHandleResponsesSSEEvent_CompletedWithToolCalls(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	reasonBuf := &bytes.Buffer{}
+	state := newResponsesToolCallState()
+	var receivedCalls []*ToolCall
+	tcCallback := func(calls []*ToolCall) {
+		receivedCalls = append(receivedCalls, calls...)
+	}
+
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"output_text": "",
+			"output": []any{
+				map[string]any{
+					"type":      "function_call",
+					"id":        "fc_1",
+					"call_id":   "call_abc",
+					"name":      "get_weather",
+					"arguments": `{"city":"Tokyo"}`,
+				},
+			},
+		},
+	}, outBuf, reasonBuf, tcCallback, state)
+
+	if len(receivedCalls) == 0 {
+		t.Fatal("expected tool call from completed event, got none")
+	}
+	if receivedCalls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", receivedCalls[0].Function.Name)
+	}
+	if receivedCalls[0].Function.Arguments != `{"city":"Tokyo"}` {
+		t.Errorf("expected arguments %q, got %q", `{"city":"Tokyo"}`, receivedCalls[0].Function.Arguments)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix BUG2 (P0): `handleResponsesSSEEvent` silently discarded output when upstream (packyapi codex-style) sends no `output_text.delta` events and only provides final text in `response.completed`
- Add `anyTextStreamed` / `anyReasonStreamed` tracking to `responsesToolCallState` for conditional completed-event fallback
- Add `response.output_text.done` / `response.reasoning_text.done` / `response.reasoning_summary_text.done` event handlers
- Add `AIConfig.DisableStream` field + `WithDisableStream` option for callers to force non-streaming upstream (used by aibalance for responses-mode providers as BUG2 fallback)
- Propagate `DisableStream` through `WithChatBase_AISamplingFromConfig`

## Test plan

- [x] `TestHandleResponsesSSEEvent_CompletedFallback` — completed-only upstream produces output
- [x] `TestHandleResponsesSSEEvent_DeltaSuppressCompleted` — delta + completed does not duplicate
- [x] `TestHandleResponsesSSEEvent_OutputTextDone` — output_text.done fallback works
- [x] `TestHandleResponsesSSEEvent_ReasoningTextDone` — reasoning_text.done fallback works
- [x] `TestHandleResponsesSSEEvent_CompletedWithToolCalls` — tool_calls from completed not lost
- [x] All existing `aispec` tests pass (54/54)


Made with [Cursor](https://cursor.com)