### PR TITLE
fix(ci): generate and upload sha256 for yak-slim builds

### DIFF
--- a/.github/workflows/reuse-build.yml
+++ b/.github/workflows/reuse-build.yml
@@ -284,8 +284,28 @@ jobs:
         if: startsWith(inputs.os, 'linux')
         run: bash .github/scripts/verify-glibc-baseline.sh "./${{ env.OUTPUT_NAME }}"
 
+      - name: Generate Checksums
+        shell: bash
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          if command -v yak >/dev/null 2>&1; then
+            YAK=yak
+          else
+            CGO_ENABLED="${CGO_ENABLED:-1}" go build -o ./yak_cli -v common/yak/cmd/yak.go
+            YAK=./yak_cli
+            [ -f ./yak_cli.exe ] && YAK=./yak_cli.exe
+          fi
+          "$YAK" sha256 -f ${{ env.OUTPUT_NAME }}
+          echo "SHA256=${{ env.OUTPUT_NAME }}.sha256.txt" >> "$GITHUB_ENV"
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.OUTPUT_NAME }}
           path: ./${{ env.OUTPUT_NAME }}
+
+      - name: Upload sha256 checksums artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SHA256 }}
+          path: ./${{ env.SHA256 }}


### PR DESCRIPTION
## Problem

yak-slim 发布的二进制缺少 sha256 校验文件。

## Root Cause

 yak-slim 通过 `exp-cross-build.yml` 的 `build_slim_binaries` job 构建，实际走的是 `reuse-build.yml`（`build_type=yakslim`）。

对比两条构建路径：

| | 标准版 (`exp-cross-build.yml` `build_and_upload_to_oss`) | slim (`reuse-build.yml`) |
|---|---|---|
| Generate Checksums | ✅ (line 510-522) | ❌ 缺失 |
| Upload sha256 artifact | ✅ (line 570-574) | ❌ 缺失 |

`reuse-build.yml` 只上传了二进制本身（`Upload Artifact`），没有生成 sha256，也没有上传 sha256 artifact。

而 release job (`check_version_and_github_release`):
- 它的 `needs` 只包含 `build_slim_binaries`（不包含 `upload_slim_binaries_to_oss`，line 681）
- 它的 release 文件列表里列出了 `yak-slim_*.sha256.txt`（line 742-748）
- `upload_slim_binaries_to_oss` 虽然在下载汇总时会用 `yak sha256 -f` 生成 sha256 并打进 `yak-slim-release-bundle`，但该 job 不在 release job 的依赖链上，release 时这些 sha256 artifact 可能拿不到

最终结果：GitHub Release 缺少 `yak-slim_*.sha256.txt` 校验文件。

## Fix

在 `reuse-build.yml` 补上和标准版一致的 `Generate Checksums` + `Upload sha256 checksums artifacts` 两步。

- 使用项目自有工具 `yak sha256 -f` 生成校验文件（与标准版一致，无 ``yak`` 时 fallback 到本地编译 `yak_cli`）
- 校验文件作为独立 artifact 上传，artifact 名为 `yak-slim_<os>_<arch>.sha256.txt`
- `build_slim_binaries`（已在 release job 的 `needs` 中）会产出这些 artifact，release 时即可稳定获取

这样修复后，slim 与标准版在 sha256 产物上的行为完全一致，`upload_slim_binaries_to_oss` 里那段临时生成 sha256 的逻辑可作为兜底保留，不冲突。

## Test

- [ ] `exp-cross-build.yml` 在 PR 上触发 `build_slim_binaries` → `reuse-build.yml`，确认每个 slim 平台都产出 `yak-slim_*` 和 `yak-slim_*.sha256.txt` 两个 artifact
- [ ] 确认 `check_version_and_github_release` 的 release 资产里包含 slim 的 sha256

> 等 review 后合并即可，不急于自动合并。