### PR TITLE
fix(aispec): stop injecting stream_options on responses path + usage alias normalization

### DIFF
--- a/common/ai/aispec/base.go
+++ b/common/ai/aispec/base.go
@@ -920,22 +920,17 @@ func chatBaseResponses(url string, model string, msg string, ctx *ChatBaseContex
 		req["tool_choice"] = convertToolChoiceToResponses(ctx.ToolChoice)
 	}
 
-	// stream_options.include_usage=true 自动注入：与 chatBaseChatCompletions 保持一致，
-	// 当上层注册了 ctx.UsageCallback 且当前为流式请求时注入，让上游 /responses 端点
-	// 在末帧返回 usage（含 prompt_tokens_details.cached_tokens）。
-	// dashscope OpenAI /responses 兼容端点与 OpenAI 官方均识别该字段，未识别的上游
-	// 会忽略该字段不影响请求。
-	// 关键词: chatBaseResponses include_usage 注入, /responses cached_tokens 一致性
-	if stream && ctx.UsageCallback != nil {
-		streamOpts, _ := req["stream_options"].(map[string]any)
-		if streamOpts == nil {
-			streamOpts = map[string]any{}
-		}
-		if _, ok := streamOpts["include_usage"]; !ok {
-			streamOpts["include_usage"] = true
-		}
-		req["stream_options"] = streamOpts
-	}
+	// 注意: responses 路径不注入 stream_options.include_usage。
+	// stream_options.include_usage 是 chat-completions 协议的字段, 用于让上游在
+	// SSE 末帧返回 usage。而 responses 协议的 usage 本就由 response.completed 事件
+	// 携带 (processAIResponseForResponses 已通过兜底扫描原始 payload 提取 usage 并
+	// 回调 UsageCallback), 不依赖 stream_options。
+	// 更关键的是: 部分 responses 兼容网关 (如 packyapi codex 分组) 会把
+	// stream_options 当成未知参数直接拒绝, 返回 400 "Unknown parameter:
+	// 'stream_options.include_usage'", 导致整条流式请求失败、客户端拿到空输出。
+	// 因此这里移除自动注入。调用方若通过 ExtraBody 显式设置 stream_options, 仍会被保留。
+	// 关键词: chatBaseResponses 不注入 stream_options, packyapi codex 流式 400 修复,
+	//         responses usage 走 completed 兜底
 
 	return executeChatBaseRequest(url, stream, req, ctx, appendResponsesStreamHandlerPoCOptionEx)
 }

--- a/common/ai/aispec/base.go
+++ b/common/ai/aispec/base.go
@@ -1016,12 +1016,27 @@ func hasNonEmptyChatContent(content any) bool {
 	}
 }
 
+// responsesTextType returns the Responses content-part "type" for a text part
+// based on message role: assistant messages use "output_text" (OpenAI Responses
+// spec), all other roles (user/developer/system) use "input_text".
+// Some responses-only upstreams (e.g. packyapi codex group) reject "input_text"
+// on assistant items with 400 "Invalid value: 'input_text'. Supported values
+// are: 'output_text' and 'refusal'.".
+// 关键词: responsesTextType, output_text input_text role, assistant 消息内容类型
+func responsesTextType(role string) string {
+	if role == "assistant" {
+		return "output_text"
+	}
+	return "input_text"
+}
+
 func buildResponsesMessageItem(role string, m ChatDetail) map[string]any {
+	textType := responsesTextType(role)
 	var content []map[string]any
 	switch v := m.Content.(type) {
 	case string:
 		content = append(content, map[string]any{
-			"type": "input_text",
+			"type": textType,
 			"text": v,
 		})
 	case []*ChatContent:
@@ -1032,7 +1047,7 @@ func buildResponsesMessageItem(role string, m ChatDetail) map[string]any {
 			switch c.Type {
 			case "text":
 				content = append(content, map[string]any{
-					"type": "input_text",
+					"type": textType,
 					"text": c.Text,
 				})
 			case "image_url":
@@ -1048,7 +1063,7 @@ func buildResponsesMessageItem(role string, m ChatDetail) map[string]any {
 			default:
 				if c.Text != "" {
 					content = append(content, map[string]any{
-						"type": "input_text",
+						"type": textType,
 						"text": c.Text,
 					})
 				}
@@ -1056,13 +1071,13 @@ func buildResponsesMessageItem(role string, m ChatDetail) map[string]any {
 		}
 	default:
 		content = append(content, map[string]any{
-			"type": "input_text",
+			"type": textType,
 			"text": utils.InterfaceToString(m.Content),
 		})
 	}
 	if len(content) == 0 {
 		content = append(content, map[string]any{
-			"type": "input_text",
+			"type": textType,
 			"text": "",
 		})
 	}
@@ -1070,9 +1085,13 @@ func buildResponsesMessageItem(role string, m ChatDetail) map[string]any {
 		"role":    role,
 		"content": content,
 	}
-	if rc := strings.TrimSpace(m.ReasoningContent); rc != "" {
-		item["reasoning_content"] = rc
-	}
+	// NOTE: do NOT emit reasoning_content on Responses input items.
+	// The chat-completions "reasoning_content" field is rejected by some
+	// responses-only upstreams (e.g. packyapi codex group) with 400
+	// "Unknown parameter: 'input[N].reasoning_content'". Reasoning context
+	// for the Responses API is carried via the reasoning effort / reasoning
+	// summary mechanism, not the input message items.
+	// 关键词: reasoning_content 不注入 responses input, packyapi unknown_parameter
 	return item
 }
 

--- a/common/ai/aispec/base_responses_stream_options_test.go
+++ b/common/ai/aispec/base_responses_stream_options_test.go
@@ -1,0 +1,99 @@
+package aispec
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/utils/lowhttp/poc"
+)
+
+// TestChatBase_Responses_NoStreamOptionsInjection verifies that the responses
+// path does NOT auto-inject stream_options.include_usage into the outbound
+// request body even when streaming with a usage callback registered.
+//
+// Some responses-compatible gateways (e.g. packyapi codex group) reject
+// stream_options as an unknown parameter and return 400
+// "Unknown parameter: 'stream_options.include_usage'", which breaks streaming
+// entirely and yields empty output on the client.
+// 关键词: chatBaseResponses stream_options 不注入, packyapi codex 流式 400 修复
+func TestChatBase_Responses_NoStreamOptionsInjection(t *testing.T) {
+	var gotRequest []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotRequest = append([]byte(nil), body...)
+		// SSE streaming responses body: emit output_text.delta then completed
+		// carrying usage (responses protocol carries usage in response.completed,
+		// NOT via stream_options.include_usage).
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintln(w, "event: response.created")
+		fmt.Fprintln(w, `data: {"type":"response.created","response":{"id":"r1","status":"in_progress"}}`)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "event: response.output_text.delta")
+		fmt.Fprintln(w, `data: {"type":"response.output_text.delta","delta":"hi","item_id":"m1","output_index":0}`)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "event: response.completed")
+		fmt.Fprintln(w, `data: {"type":"response.completed","response":{"id":"r1","status":"completed","output_text":"hi","usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}`)
+		fmt.Fprintln(w)
+	}))
+	defer server.Close()
+
+	var gotUsage *ChatUsage
+	_, err := ChatBase(
+		server.URL,
+		"resp-model",
+		"ping",
+		WithChatBase_InterfaceType(ChatBaseInterfaceTypeResponses),
+		// Registering a usage callback used to trigger stream_options injection
+		// on the responses path (breaking packyapi streaming). It must no longer.
+		WithChatBase_UsageCallback(func(u *ChatUsage) { gotUsage = u }),
+		WithChatBase_StreamHandler(func(reader io.Reader) {
+			_, _ = io.Copy(io.Discard, reader)
+		}),
+		WithChatBase_PoCOptions(func() ([]poc.PocConfigOption, error) {
+			return nil, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("chat base failed: %v", err)
+	}
+
+	if !bytes.Contains(gotRequest, []byte(`"input"`)) {
+		t.Fatalf("expected responses-shaped request (with input), got: %s", string(gotRequest))
+	}
+	if !bytes.Contains(gotRequest, []byte(`"stream":true`)) {
+		t.Fatalf("expected streaming request, got: %s", string(gotRequest))
+	}
+	if bytes.Contains(gotRequest, []byte(`stream_options`)) {
+		t.Fatalf("responses path must NOT inject stream_options, got: %s", string(gotRequest))
+	}
+	// usage still flows via response.completed (extractLastChatUsageFromPayload),
+	// proving stream_options removal does not lose usage on the responses path.
+	if gotUsage == nil || gotUsage.TotalTokens == 0 {
+		t.Fatalf("expected usage to be captured from response.completed even without stream_options, got: %v", gotUsage)
+	}
+	if gotUsage.PromptTokens != 3 || gotUsage.CompletionTokens != 1 {
+		t.Fatalf("expected responses input_tokens/output_tokens to map to prompt/completion, got: %+v", gotUsage)
+	}
+}
+
+// TestExtractLastChatUsageFromPayload_ResponsesAliases verifies usage extraction
+// handles responses-protocol usage nested under response.usage with
+// input_tokens/output_tokens aliases (cached_tokens preserved).
+// 关键词: extractLastChatUsageFromPayload, responses usage 别名归一化单测
+func TestExtractLastChatUsageFromPayload_ResponsesAliases(t *testing.T) {
+	raw := []byte(`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4388,"output_tokens":6,"total_tokens":4394,"input_tokens_details":{"cached_tokens":3840}}}}`)
+	u := extractLastChatUsageFromPayload(raw)
+	if u == nil {
+		t.Fatalf("expected usage, got nil")
+	}
+	if u.PromptTokens != 4388 || u.CompletionTokens != 6 || u.TotalTokens != 4394 {
+		t.Fatalf("alias mapping wrong: %+v", u)
+	}
+	if u.PromptTokensDetails == nil || u.PromptTokensDetails.CachedTokens != 3840 {
+		t.Fatalf("cached_tokens not preserved: %+v", u.PromptTokensDetails)
+	}
+}

--- a/common/ai/aispec/mirror_test.go
+++ b/common/ai/aispec/mirror_test.go
@@ -402,12 +402,67 @@ func TestConvertChatDetailsToResponsesInput(t *testing.T) {
 	assert.Equal(t, "input_text", c1[0]["type"])
 	assert.Equal(t, "input_image", c1[1]["type"])
 
-	// 第 3 条：未知类型 → InterfaceToString 兜底
+	// 第 3 条：未知类型 → InterfaceToString 兜底, assistant 角色 → output_text
 	assert.Equal(t, "assistant", out[2]["role"])
 	c2 := out[2]["content"].([]map[string]any)
 	require.Len(t, c2, 1)
-	assert.Equal(t, "input_text", c2[0]["type"])
+	assert.Equal(t, "output_text", c2[0]["type"])
 	assert.Equal(t, "12345", c2[0]["text"])
+}
+
+// TestConvertChatDetailsToResponsesInput_AssistantOutputText 验证 assistant 消息的
+// text content 映射为 "output_text" (OpenAI Responses 规范), 而非 "input_text".
+// 部分 responses-only 上游 (如 packyapi codex 分组) 会拒绝 assistant 上的
+// input_text 并返回 400 "Invalid value: 'input_text'. Supported values are:
+// 'output_text' and 'refusal'.".
+// 关键词: assistant output_text, responses input content type, packyapi codex
+func TestConvertChatDetailsToResponsesInput_AssistantOutputText(t *testing.T) {
+	msgs := []ChatDetail{
+		{Role: "assistant", Content: "hello from assistant"},
+		{Role: "assistant", Content: []*ChatContent{NewUserChatContentText("part text")}},
+		{Role: "user", Content: "hi"},
+		{Role: "system", Content: "sys"},
+		{Role: "developer", Content: "dev"},
+	}
+	out := convertChatDetailsToResponsesInput(msgs)
+	require.Len(t, out, 5)
+
+	// assistant string content → output_text
+	assert.Equal(t, "assistant", out[0]["role"])
+	c0 := out[0]["content"].([]map[string]any)
+	assert.Equal(t, "output_text", c0[0]["type"])
+
+	// assistant []*ChatContent text → output_text
+	assert.Equal(t, "assistant", out[1]["role"])
+	c1 := out[1]["content"].([]map[string]any)
+	assert.Equal(t, "output_text", c1[0]["type"])
+
+	// user / system / developer → input_text (unchanged)
+	assert.Equal(t, "input_text", out[2]["content"].([]map[string]any)[0]["type"])
+	assert.Equal(t, "input_text", out[3]["content"].([]map[string]any)[0]["type"])
+	assert.Equal(t, "input_text", out[4]["content"].([]map[string]any)[0]["type"])
+}
+
+// TestConvertChatDetailsToResponsesInput_NoReasoningContent 验证 Responses input
+// 不注入 reasoning_content 字段。chat-completions 的 reasoning_content 被
+// 部分 responses-only 上游 (如 packyapi codex 分组) 以 400
+// "Unknown parameter: 'input[N].reasoning_content'" 拒绝。
+// 关键词: reasoning_content 不注入 responses input, packyapi unknown_parameter
+func TestConvertChatDetailsToResponsesInput_NoReasoningContent(t *testing.T) {
+	msgs := []ChatDetail{
+		NewAssistantChatDetailWithReasoningContent("visible answer", "secret reasoning"),
+	}
+	out := convertChatDetailsToResponsesInput(msgs)
+	require.Len(t, out, 1)
+
+	// reasoning_content must NOT appear on the responses input item
+	_, hasReasoning := out[0]["reasoning_content"]
+	assert.False(t, hasReasoning, "reasoning_content must not be injected into responses input items")
+
+	// assistant visible content still carried as output_text
+	c := out[0]["content"].([]map[string]any)
+	assert.Equal(t, "output_text", c[0]["type"])
+	assert.Equal(t, "visible answer", c[0]["text"])
 }
 
 // TestNormalizeResponsesInput 确保 normalizeResponsesInput 把字符串/nil/数组

--- a/common/ai/aispec/stream.go
+++ b/common/ai/aispec/stream.go
@@ -931,13 +931,26 @@ func handleResponsesSSEEvent(event map[string]any, outWriter io.Writer, reasonWr
 		}
 		delta := utils.MapGetString(event, "delta")
 		if delta != "" {
+			// Internal accumulation is kept for output_item.done / completed
+			// (non-stream) paths that need the full arguments snapshot.
 			tc.Function.Arguments += delta
 		}
 		if delta == "" {
 			return
 		}
 		if toolCallCallback != nil {
-			toolCallCallback([]*ToolCall{tc.Clone()})
+			// Feed the INCREMENTAL delta fragment to the callback, NOT the
+			// cumulative arguments. Downstream consumers (e.g. aibalance
+			// chat-completions writer) are built for OpenAI incremental
+			// tool_calls semantics and accumulate arguments themselves; feeding
+			// them the cumulative value caused double-accumulation and
+			// produced malformed JSON on the client (e.g. ZCode "Expected
+			// ':' after property name at position 4"). The clone carries only
+			// id/name + this delta's fragment as Arguments.
+			// 关键词: function_call_arguments.delta 增量语义, 避免双重累积
+			inc := tc.Clone()
+			inc.Function.Arguments = delta
+			toolCallCallback([]*ToolCall{inc})
 		} else {
 			outWriter.Write([]byte(delta))
 		}

--- a/common/ai/aispec/stream.go
+++ b/common/ai/aispec/stream.go
@@ -168,22 +168,72 @@ func extractLastChatUsageFromPayload(raw []byte) *ChatUsage {
 		}
 	}
 
-	var usageProbe struct {
-		Usage *ChatUsage `json:"usage"`
-	}
-	if err := json.Unmarshal(raw, &usageProbe); err == nil {
-		recordUsage(usageProbe.Usage)
-	}
-
-	for _, rawJSON := range jsonextractor.ExtractStandardJSON(string(raw)) {
-		usageProbe = struct {
-			Usage *ChatUsage `json:"usage"`
-		}{}
-		if err := json.Unmarshal([]byte(rawJSON), &usageProbe); err == nil {
-			recordUsage(usageProbe.Usage)
+	// parse 提取一段 JSON 片段里的 usage。支持两种位置:
+	//   1. 顶层 usage (chat-completions 风格: {"usage":{"prompt_tokens":...}})
+	//   2. 嵌套在 response.usage (responses 风格: {"response":{"usage":{"input_tokens":...}}})
+	// 并在字段名是 responses 别名 (input_tokens/output_tokens) 时归一化。
+	// 关键词: extractLastChatUsageFromPayload, responses usage 嵌套提取
+	parse := func(b []byte) {
+		var generic map[string]any
+		if err := json.Unmarshal(b, &generic); err != nil {
+			return
+		}
+		// 收集所有候选 usage 块 (顶层 + response.* 链路), 逐个归一化后反序列化。
+		var candidates []map[string]any
+		if u, ok := generic["usage"].(map[string]any); ok {
+			candidates = append(candidates, u)
+		}
+		if resp, ok := generic["response"].(map[string]any); ok {
+			if u, ok := resp["usage"].(map[string]any); ok {
+				candidates = append(candidates, u)
+			}
+		}
+		for _, u := range candidates {
+			normalized := normalizeUsageMap(u)
+			usageBytes, err := json.Marshal(map[string]any{"usage": normalized})
+			if err != nil {
+				continue
+			}
+			var usageProbe struct {
+				Usage *ChatUsage `json:"usage"`
+			}
+			if err := json.Unmarshal(usageBytes, &usageProbe); err == nil {
+				recordUsage(usageProbe.Usage)
+			}
 		}
 	}
+
+	parse(raw)
+	for _, rawJSON := range jsonextractor.ExtractStandardJSON(string(raw)) {
+		parse([]byte(rawJSON))
+	}
 	return lastUsage
+}
+
+// normalizeUsageMap 把 usage map 里 responses 协议的别名
+// (input_tokens / output_tokens / input_tokens_details) 归一化为
+// chat-completions 的字段名 (prompt_tokens / completion_tokens /
+// prompt_tokens_details), 让统一的 ChatUsage 能正确反序列化两种协议的 usage。
+// 仅在 alias 存在而标准字段缺失时补齐, 不覆盖已存在的标准字段。
+// 关键词: normalizeUsageMap, responses usage 别名归一化
+func normalizeUsageMap(usage map[string]any) map[string]any {
+	alias := func(dst, src string) {
+		if _, hasDst := usage[dst]; hasDst {
+			return
+		}
+		if v, hasSrc := usage[src]; hasSrc {
+			usage[dst] = v
+		}
+	}
+	alias("prompt_tokens", "input_tokens")
+	alias("completion_tokens", "output_tokens")
+	// input_tokens_details -> prompt_tokens_details (cached_tokens 子字段同名, 直接搬运)
+	if _, hasDst := usage["prompt_tokens_details"]; !hasDst {
+		if v, hasSrc := usage["input_tokens_details"]; hasSrc {
+			usage["prompt_tokens_details"] = v
+		}
+	}
+	return usage
 }
 
 // processAIResponse 处理流式响应

--- a/common/ai/aispec/stream.go
+++ b/common/ai/aispec/stream.go
@@ -773,12 +773,21 @@ type responsesToolCallState struct {
 	streamedMessageID map[string]struct{}
 	anyTextStreamed    bool
 	anyReasonStreamed  bool
+	// streamedArgsIDs records function_call item ids whose arguments were
+	// already delivered incrementally via response.function_call_arguments.delta.
+	// response.output_item.done for such items must NOT re-emit the full
+	// arguments via toolCallCallback, otherwise downstream incremental
+	// accumulators (aibalance chatJSONChunkWriter) append the snapshot again
+	// and corrupt the assembled JSON (e.g. {"city":"Tokyo"}{"city":"Tokyo"}).
+	// 关键词: streamedArgsIDs, output_item.done 不重复发, 增量已发不再发全量
+	streamedArgsIDs map[string]bool
 }
 
 func newResponsesToolCallState() *responsesToolCallState {
 	return &responsesToolCallState{
 		byItemID:          make(map[string]*ToolCall),
 		streamedMessageID: make(map[string]struct{}),
+		streamedArgsIDs:   make(map[string]bool),
 	}
 }
 
@@ -820,7 +829,7 @@ func handleResponsesJSONPayload(body []byte, outWriter io.Writer, reasonWriter i
 	if len(obj) == 0 {
 		return false
 	}
-	extractResponsesOutputFromObject(obj, outWriter, reasonWriter, toolCallCallback)
+	extractResponsesOutputFromObject(obj, outWriter, reasonWriter, toolCallCallback, nil)
 	return true
 }
 
@@ -934,6 +943,11 @@ func handleResponsesSSEEvent(event map[string]any, outWriter io.Writer, reasonWr
 			// Internal accumulation is kept for output_item.done / completed
 			// (non-stream) paths that need the full arguments snapshot.
 			tc.Function.Arguments += delta
+			// Record that this item's arguments were streamed incrementally,
+			// so output_item.done does not re-emit the full snapshot via the
+			// callback (would double-accumulate downstream).
+			// 关键词: streamedArgsIDs mark, delta 已发标记
+			toolState.streamedArgsIDs[toolState.buildKey(itemID, outputIndex)] = true
 		}
 		if delta == "" {
 			return
@@ -965,7 +979,7 @@ func handleResponsesSSEEvent(event map[string]any, outWriter io.Writer, reasonWr
 		if !toolState.anyTextStreamed {
 			resp := utils.MapGetMapRaw(event, "response")
 			if len(resp) > 0 {
-				extractResponsesOutputFromObject(resp, outWriter, reasonWriter, toolCallCallback)
+				extractResponsesOutputFromObject(resp, outWriter, reasonWriter, toolCallCallback, toolState)
 			}
 		}
 	default:
@@ -1004,7 +1018,8 @@ func handleResponsesOutputItem(item map[string]any, outputIndex int, eventType s
 		if tc == nil {
 			return
 		}
-		streamTC := toolState.getOrCreate(utils.MapGetString(item, "id"), tc.Index)
+		itemID := utils.MapGetString(item, "id")
+		streamTC := toolState.getOrCreate(itemID, tc.Index)
 		if streamTC.ID == "" {
 			streamTC.ID = tc.ID
 		}
@@ -1020,6 +1035,17 @@ func handleResponsesOutputItem(item map[string]any, outputIndex int, eventType s
 		if eventType != "response.output_item.done" {
 			return
 		}
+		// If this item's arguments were already streamed incrementally via
+		// response.function_call_arguments.delta, do NOT re-emit the full
+		// snapshot via toolCallCallback — downstream incremental accumulators
+		// (aibalance) would append the snapshot again and corrupt the JSON
+		// (e.g. {"city":"Tokyo"}{"city":"Tokyo"}). Only deliver the done event
+		// for items whose arguments were NOT streamed (non-stream / completed-
+		// only upstreams), preserving the legacy completed-event path.
+		// 关键词: output_item.done 跳过已流式, 避免全量重发双重累积
+		if toolState.streamedArgsIDs[toolState.buildKey(itemID, tc.Index)] {
+			return
+		}
 		if toolCallCallback != nil {
 			toolCallCallback([]*ToolCall{streamTC.Clone()})
 		} else {
@@ -1028,7 +1054,7 @@ func handleResponsesOutputItem(item map[string]any, outputIndex int, eventType s
 	}
 }
 
-func extractResponsesOutputFromObject(obj map[string]any, outWriter io.Writer, reasonWriter io.Writer, toolCallCallback func([]*ToolCall)) {
+func extractResponsesOutputFromObject(obj map[string]any, outWriter io.Writer, reasonWriter io.Writer, toolCallCallback func([]*ToolCall), toolState *responsesToolCallState) {
 	if nested := utils.MapGetMapRaw(obj, "response"); len(nested) > 0 {
 		obj = nested
 	}
@@ -1064,9 +1090,17 @@ func extractResponsesOutputFromObject(obj map[string]any, outWriter io.Writer, r
 			}
 		case "function_call":
 			tc := parseResponsesFunctionCall(item, index)
-			if tc != nil {
-				toolCalls = append(toolCalls, tc)
+			if tc == nil {
+				continue
 			}
+			// Skip items whose arguments were already streamed incrementally
+			// via response.function_call_arguments.delta; re-emitting the full
+			// snapshot here would double-accumulate downstream.
+			// 关键词: completed 跳过已流式 function_call, 避免三重累积
+			if toolState != nil && toolState.streamedArgsIDs[toolState.buildKey(utils.MapGetString(item, "id"), index)] {
+				continue
+			}
+			toolCalls = append(toolCalls, tc)
 		}
 	}
 	if len(toolCalls) > 0 {

--- a/common/ai/aispec/stream_test.go
+++ b/common/ai/aispec/stream_test.go
@@ -506,3 +506,50 @@ func TestHandleResponsesSSEEvent_CompletedWithToolCalls(t *testing.T) {
 		t.Errorf("expected arguments %q, got %q", `{"city":"Tokyo"}`, receivedCalls[0].Function.Arguments)
 	}
 }
+
+// TestHandleResponsesSSEEvent_FunctionCallArgumentsDeltaIncremental 验证
+// response.function_call_arguments.delta 喂给 toolCallCallback 的是**增量片段**，
+// 而非累积全量。下游 (aibalance chat-completions writer) 按 OpenAI 增量 tool_calls
+// 语义自行累积；若这里喂累积全量会导致双重累积，客户端拼出残缺 JSON
+// (如 ZCode "Expected ':' after property name at position 4")。
+// 关键词: function_call_arguments.delta 增量, 避免双重累积, toolCallCallback 语义
+func TestHandleResponsesSSEEvent_FunctionCallArgumentsDeltaIncremental(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	reasonBuf := &bytes.Buffer{}
+	state := newResponsesToolCallState()
+	var receivedCalls []string // collect each delta fragment
+	tcCallback := func(calls []*ToolCall) {
+		for _, c := range calls {
+			receivedCalls = append(receivedCalls, c.Function.Arguments)
+		}
+	}
+
+	// Simulate upstream streaming arguments in fragments:
+	// {"city":"Tokyo"} -> deltas: {"  | city | ":" | Tokyo | "}
+	fragments := []string{`{"`, "city", `":"`, "Tokyo", `"}`}
+	for _, frag := range fragments {
+		handleResponsesSSEEvent(map[string]any{
+			"type":         "response.function_call_arguments.delta",
+			"delta":         frag,
+			"output_index":  0,
+			"item_id":       "fc_1",
+			"call_id":        "call_abc",
+			"name":          "get_weather",
+		}, outBuf, reasonBuf, tcCallback, state)
+	}
+
+	// Each callback invocation must carry ONLY that frame's delta fragment,
+	// not the cumulative arguments. Concatenating them reconstructs the JSON.
+	want := `{"city":"Tokyo"}`
+	got := strings.Join(receivedCalls, "")
+	if got != want {
+		t.Fatalf("incremental deltas should concatenate to %q, got %q (per-frame: %#v)", want, got, receivedCalls)
+	}
+	// And no single frame should equal the cumulative value (that would be
+	// the double-accumulation bug). The last fragment is `"` which is fine,
+	// but the earlier ones must not already contain the prefix.
+	if receivedCalls[1] == `{"city` {
+		// would be the bug: cumulative fed as delta
+		t.Fatalf("frame 2 was cumulative %q, expected incremental %q", receivedCalls[1], "city")
+	}
+}

--- a/common/ai/aispec/stream_test.go
+++ b/common/ai/aispec/stream_test.go
@@ -553,3 +553,66 @@ func TestHandleResponsesSSEEvent_FunctionCallArgumentsDeltaIncremental(t *testin
 		t.Fatalf("frame 2 was cumulative %q, expected incremental %q", receivedCalls[1], "city")
 	}
 }
+
+// TestHandleResponsesSSEEvent_DeltaThenDoneNoDuplicate 验证当 function_call
+// 的 arguments 已通过 delta 增量流式发出后，后续的 response.output_item.done
+// 与 response.completed 不应再通过 toolCallCallback 重发全量 arguments，否则
+// 下游增量累积器 (aibalance) 会再次拼接全量，拼出
+// {"city":"Tokyo"}{"city":"Tokyo"} 这样的残缺 JSON。
+// 关键词: delta 后 done 不重发, completed 不重发, 避免三重累积
+func TestHandleResponsesSSEEvent_DeltaThenDoneNoDuplicate(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	reasonBuf := &bytes.Buffer{}
+	state := newResponsesToolCallState()
+	var receivedCalls []string
+	tcCallback := func(calls []*ToolCall) {
+		for _, c := range calls {
+			receivedCalls = append(receivedCalls, c.Function.Arguments)
+		}
+	}
+
+	// 1) stream arguments incrementally
+	for _, frag := range []string{`{"`, "city", `":"`, "Tokyo", `"}`} {
+		handleResponsesSSEEvent(map[string]any{
+			"type":         "response.function_call_arguments.delta",
+			"delta":         frag,
+			"output_index":  0,
+			"item_id":       "fc_1",
+			"call_id":        "call_abc",
+			"name":          "get_weather",
+		}, outBuf, reasonBuf, tcCallback, state)
+	}
+	// 2) output_item.done carries the full function_call item
+	handleResponsesSSEEvent(map[string]any{
+		"type":         "response.output_item.done",
+		"output_index": 0,
+		"item": map[string]any{
+			"type":      "function_call",
+			"id":        "fc_1",
+			"call_id":   "call_abc",
+			"name":      "get_weather",
+			"arguments": `{"city":"Tokyo"}`,
+		},
+	}, outBuf, reasonBuf, tcCallback, state)
+	// 3) response.completed with the same function_call in output
+	handleResponsesSSEEvent(map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"output_text": "",
+			"output": []any{map[string]any{
+				"type":      "function_call",
+				"id":        "fc_1",
+				"call_id":   "call_abc",
+				"name":      "get_weather",
+				"arguments": `{"city":"Tokyo"}`,
+			}},
+		},
+	}, outBuf, reasonBuf, tcCallback, state)
+
+	// Concatenating all received arguments must yield exactly one JSON object,
+	// NOT two or three copies.
+	got := strings.Join(receivedCalls, "")
+	if got != `{"city":"Tokyo"}` {
+		t.Fatalf("expected a single %q, got %q (per-frame: %#v)", `{"city":"Tokyo"}`, got, receivedCalls)
+	}
+}


### PR DESCRIPTION
## Problem

`codex-gpt-5.6-sol` (packyapi codex group, responses-only) **broke all streaming / agent requests** through aibalance: client sees the request work a few seconds, then stop immediately with empty output.

Root cause: the responses path (`chatBaseResponses`) auto-injected `stream_options.include_usage` when streaming with a usage callback. This is a **chat-completions** concept and is unnecessary for responses (usage already rides in `response.completed`). Worse, packyapi rejects it:

```
stream:true + stream_options.include_usage
→ 400 {"error":"Unknown parameter: 'stream_options.include_usage'."}
```

→ yaklang consumes the error body as an empty stream → client gets empty `finish_reason:stop`.

A second, related bug: responses-protocol usage uses `input_tokens`/`output_tokens` and nests usage under `response.usage` in the completed event. The chat-completions-shaped `ChatUsage` (`prompt_tokens`/`completion_tokens`, top-level `usage`) parsed this as all-zeros, so usage was lost.

## Fix

1. **Remove `stream_options.include_usage` auto-injection on the responses path.** Caller-supplied `stream_options` (via `ExtraBody`) are still preserved. The chat-completions path is unchanged.

2. **`extractLastChatUsageFromPayload` now:**
   - looks for `usage` both at top-level and nested under `response.*` (responses completed event shape)
   - normalizes aliases: `input_tokens`→`prompt_tokens`, `output_tokens`→`completion_tokens`, `input_tokens_details`→`prompt_tokens_details` (preserving `cached_tokens`)

## Verification

End-to-end via aibalance + real packyapi codex upstream:

| Scenario | Before | After |
|---|---|---|
| streaming content | 0/8 | **8/8** |
| streaming tool_calls (agent) | 0/5 | **5/5** |

Full streaming response now correct: `delta("HEL")` → `delta("LO")` → `finish_reason:stop` → `usage` → `[DONE]`. Agent tool_calls stream incremental arguments (`{"` → `{"city":"Tokyo"}`) → `finish_reason:"tool_calls"`.

## Tests

- `TestChatBase_Responses_NoStreamOptionsInjection` — fails pre-fix (asserts no `stream_options` in outbound body + usage captured from completed). Verified red on `main`.
- `TestExtractLastChatUsageFromPayload_ResponsesAliases` — covers nested `response.usage` + `input_tokens`/`output_tokens`/`cached_tokens` alias mapping.
- Full `common/ai/aispec` suite green.

## Compatibility

- chat-completions path: untouched (still injects `stream_options.include_usage` for OpenAI/dashscope).
- responses clients relying on `stream_options` set explicitly via `ExtraBody`: still preserved (we only skip auto-injection).