### PR TITLE
fix(aid-loop): 不再语法干净即退出 + 空 old_snippet 重试；新增 codec 插件「提取同域名 PATH」

### DIFF
--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/tests/write_yaklang_code_err_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/tests/write_yaklang_code_err_test.go
@@ -78,7 +78,16 @@ println("c")`); ok {
 		return rsp, nil
 	}
 
+	// modify 不再自动退出循环：先 directly_answer 总结，再 finish 退出
+	if stat.modifyDone && stat.answerDone {
+		rsp := i.NewAIResponse()
+		rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish"}`))
+		rsp.Close()
+		return rsp, nil
+	}
+
 	if rsp, ok := mockYaklangFinalizeDirectlyAnswer(t, i, prompt); ok {
+		stat.answerDone = true
 		return rsp, nil
 	}
 

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/tests/write_yaklang_code_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/tests/write_yaklang_code_test.go
@@ -302,6 +302,7 @@ type mockStats_forWriteAndModify struct {
 	writeDone    bool
 	modifyDone   bool
 	verifyCalled bool
+	answerDone   bool
 }
 
 func mockedYaklangWritingAndModify(t *testing.T, i aicommon.AICallerConfigIf, req *aicommon.AIRequest, code string, stat *mockStats_forWriteAndModify) (*aicommon.AIResponse, error) {
@@ -364,7 +365,16 @@ func mockedYaklangWritingAndModify(t *testing.T, i aicommon.AICallerConfigIf, re
 		return rsp, nil
 	}
 
+	// modify 不再自动退出循环：先 directly_answer 总结，再 finish 退出
+	if stat.modifyDone && stat.answerDone {
+		rsp := i.NewAIResponse()
+		rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish"}`))
+		rsp.Close()
+		return rsp, nil
+	}
+
 	if rsp, ok := mockYaklangFinalizeDirectlyAnswer(t, i, prompt); ok {
+		stat.answerDone = true
 		return rsp, nil
 	}
 

--- a/common/ai/aid/aireact/reactloops/loopinfra/single_file_actions.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/single_file_actions.go
@@ -278,7 +278,8 @@ GEN_CODE 解析行号：[%d-%d]
 
 			// Call file changed callback
 			errMsg, hasBlockingErrors := f.OnFileChanged(fullCode, op)
-			runBlocked := f.applySyntaxLintResult(loop, op, hasBlockingErrors, f.ShouldExitWhenSyntaxClean())
+			// modify 操作不自动退出：AI 可能需要多次修改，由 AI 主动调用 finish 退出。
+			runBlocked := f.applySyntaxLintResult(loop, op, hasBlockingErrors, false)
 
 			// Check for spinning behavior
 			isSpinning, spinReason := f.DetectSpinning(loop, modifyStartLine, modifyEndLine)
@@ -409,7 +410,8 @@ func (f *SingleFileModificationSuiteFactory) buildInsertAction() reactloops.ReAc
 
 			// Call file changed callback
 			errMsg, hasBlockingErrors := f.OnFileChanged(fullCode, op)
-			runBlocked := f.applySyntaxLintResult(loop, op, hasBlockingErrors, f.ShouldExitWhenSyntaxClean())
+			// insert 操作不自动退出：AI 可能需要多次修改，由 AI 主动调用 finish 退出。
+			runBlocked := f.applySyntaxLintResult(loop, op, hasBlockingErrors, false)
 			msg = utils.ShrinkTextBlock(fmt.Sprintf("inserted at line[%v]:\n", insertLine)+partialCode, 256)
 			if errMsg != "" {
 				msg += "\n\n--[linter]--\nWriting Code Linter Check:\n" + utils.PrefixLines(utils.ShrinkTextBlock(errMsg, 2048), "  ")
@@ -547,7 +549,8 @@ func (f *SingleFileModificationSuiteFactory) buildDeleteAction() reactloops.ReAc
 
 			// Call file changed callback
 			errMsg, hasBlockingErrors := f.OnFileChanged(fullCode, op)
-			runBlocked := f.applySyntaxLintResult(loop, op, hasBlockingErrors, f.ShouldExitWhenSyntaxClean())
+			// delete 操作不自动退出：AI 可能需要多次修改，由 AI 主动调用 finish 退出。
+			runBlocked := f.applySyntaxLintResult(loop, op, hasBlockingErrors, false)
 
 			if deleteEndLine > 0 {
 				msg = fmt.Sprintf("deleted lines[%v-%v]", deleteStartLine, deleteEndLine)

--- a/common/ai/aid/aireact/reactloops/loopinfra/single_file_actions_test.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/single_file_actions_test.go
@@ -330,7 +330,7 @@ func TestModifyAction_Verifier_InvalidParams(t *testing.T) {
 	assert.Error(t, verifyErr)
 }
 
-func TestModifyAction_ExitWhenSyntaxClean(t *testing.T) {
+func TestModifyAction_ContinuesAfterSyntaxClean(t *testing.T) {
 	runtime := newTestRuntimeForSingleFile(t)
 	loop, factory, task := newLoopAndFactory(t, runtime,
 		WithActionSuffix("code"),
@@ -349,8 +349,9 @@ func TestModifyAction_ExitWhenSyntaxClean(t *testing.T) {
 		"modify_end_line":   2,
 	}), op)
 
+	// modify 操作不再自动退出：AI 需要通过 finish 主动退出循环
 	terminated, failErr := op.IsTerminated()
-	assert.True(t, terminated)
+	assert.False(t, terminated)
 	assert.NoError(t, failErr)
 	assert.Equal(t, "true", loop.Get(factory.GetLintStatusVariableName()))
 }
@@ -776,4 +777,150 @@ func TestModifyAction_OldSnippet_Ambiguous_Continue(t *testing.T) {
 
 	assert.True(t, op.IsContinued())
 	assert.True(t, runtime.timelineContains("modify_snippet_ambiguous"))
+}
+
+// TestModifyAction_OldSnippet_EmptyCode_SingleRetry verifies that a single empty
+// GEN_CODE block does NOT fail the task — it feeds back a correction hint (guiding
+// toward line-range mode) and continues, giving the AI a chance to retry.
+func TestModifyAction_OldSnippet_EmptyCode_SingleRetry(t *testing.T) {
+	runtime := newTestRuntimeForSingleFile(t)
+	loop, factory, task := newLoopAndFactory(t, runtime, WithActionSuffix("code"), WithExitAfterWrite(false))
+	filename := filepath.Join(runtime.tmpDir, "empty_snippet.yak")
+	loop.Set(factory.GetFilenameVariableName(), filename)
+	loop.Set(factory.GetFullCodeVariableName(), "a = 1\nb = 2\n")
+	loop.Set(factory.GetCodeVariableName(), "") // empty code
+
+	action := mustBuildAction(t, factory.GetActionName("modify"), map[string]any{
+		"old_snippet": "a = 1",
+	})
+	ac, _ := loop.GetActionHandler(factory.GetActionName("modify"))
+	op := reactloops.NewActionHandlerOperator(task)
+	ac.ActionHandler(loop, action, op)
+
+	terminated, failErr := op.IsTerminated()
+	assert.False(t, terminated, "single empty old_snippet modify should NOT abort")
+	assert.NoError(t, failErr)
+	assert.True(t, op.IsContinued(), "should continue for retry")
+	feedback := op.GetFeedback().String()
+	assert.Contains(t, feedback, "GEN_CODE")
+	assert.Contains(t, feedback, "modify_start_line", "feedback should suggest line-range alternative")
+	assert.True(t, runtime.timelineContains("error"))
+
+	// full_code must remain unchanged
+	assert.Equal(t, "a = 1\nb = 2\n", loop.Get(factory.GetFullCodeVariableName()))
+}
+
+// TestModifyAction_OldSnippet_EmptyCode_EscalatesToLineRangeHint verifies that
+// after 3+ consecutive empty GEN_CODE blocks, feedback escalates to a stronger
+// warning insisting the AI switch to line-range mode.
+func TestModifyAction_OldSnippet_EmptyCode_EscalatesToLineRangeHint(t *testing.T) {
+	runtime := newTestRuntimeForSingleFile(t)
+	loop, factory, task := newLoopAndFactory(t, runtime, WithActionSuffix("code"), WithExitAfterWrite(false))
+	filename := filepath.Join(runtime.tmpDir, "escalate.yak")
+	loop.Set(factory.GetFilenameVariableName(), filename)
+	loop.Set(factory.GetFullCodeVariableName(), "a = 1\nb = 2\n")
+
+	ac, _ := loop.GetActionHandler(factory.GetActionName("modify"))
+	actionName := factory.GetActionName("modify")
+
+	// Fire 3 consecutive empty old_snippet modifies
+	for i := 0; i < 3; i++ {
+		loop.Set(factory.GetCodeVariableName(), "")
+		op := reactloops.NewActionHandlerOperator(task)
+		ac.ActionHandler(loop, mustBuildAction(t, actionName, map[string]any{
+			"old_snippet": "a = 1",
+		}), op)
+		terminated, _ := op.IsTerminated()
+		assert.False(t, terminated, "attempt %d should not abort", i+1)
+		assert.True(t, op.IsContinued())
+	}
+
+	// 4th attempt should have escalated feedback
+	loop.Set(factory.GetCodeVariableName(), "")
+	op := reactloops.NewActionHandlerOperator(task)
+	ac.ActionHandler(loop, mustBuildAction(t, actionName, map[string]any{
+		"old_snippet": "a = 1",
+	}), op)
+	terminated, _ := op.IsTerminated()
+	assert.False(t, terminated, "4th attempt should still not abort")
+	feedback := op.GetFeedback().String()
+	assert.Contains(t, feedback, "改用行号模式", "escalated feedback should insist on line-range mode")
+}
+
+// TestModifyAction_OldSnippet_EmptyCode_EventuallyFails verifies that after
+// maxEmptySnippetRetry (5) consecutive empty attempts, the action does Fail
+// to prevent infinite loops.
+func TestModifyAction_OldSnippet_EmptyCode_EventuallyFails(t *testing.T) {
+	runtime := newTestRuntimeForSingleFile(t)
+	loop, factory, task := newLoopAndFactory(t, runtime, WithActionSuffix("code"), WithExitAfterWrite(false))
+	filename := filepath.Join(runtime.tmpDir, "fail.yak")
+	loop.Set(factory.GetFilenameVariableName(), filename)
+	loop.Set(factory.GetFullCodeVariableName(), "a = 1\nb = 2\n")
+
+	ac, _ := loop.GetActionHandler(factory.GetActionName("modify"))
+	actionName := factory.GetActionName("modify")
+
+	var lastOp *reactloops.LoopActionHandlerOperator
+	for i := 0; i < 10; i++ {
+		loop.Set(factory.GetCodeVariableName(), "")
+		lastOp = reactloops.NewActionHandlerOperator(task)
+		ac.ActionHandler(loop, mustBuildAction(t, actionName, map[string]any{
+			"old_snippet": "a = 1",
+		}), lastOp)
+		if done, _ := lastOp.IsTerminated(); done {
+			break
+		}
+	}
+
+	terminated, failErr := lastOp.IsTerminated()
+	assert.True(t, terminated, "should eventually fail after max retries")
+	assert.Error(t, failErr)
+	assert.Contains(t, failErr.Error(), "modify_start_line", "final error should suggest line-range alternative")
+}
+
+// TestModifyAction_OldSnippet_EmptyCode_ResetAfterSuccess verifies that a
+// successful old_snippet modify resets the empty-code retry counter, so
+// a later empty attempt gets a fresh set of retries.
+func TestModifyAction_OldSnippet_EmptyCode_ResetAfterSuccess(t *testing.T) {
+	runtime := newTestRuntimeForSingleFile(t)
+	loop, factory, task := newLoopAndFactory(t, runtime, WithActionSuffix("code"), WithExitAfterWrite(false))
+	filename := filepath.Join(runtime.tmpDir, "reset.yak")
+	loop.Set(factory.GetFilenameVariableName(), filename)
+	loop.Set(factory.GetFullCodeVariableName(), "a = 1\nb = 2\n")
+
+	ac, _ := loop.GetActionHandler(factory.GetActionName("modify"))
+	actionName := factory.GetActionName("modify")
+
+	// 2 consecutive empty attempts
+	for i := 0; i < 2; i++ {
+		loop.Set(factory.GetCodeVariableName(), "")
+		op := reactloops.NewActionHandlerOperator(task)
+		ac.ActionHandler(loop, mustBuildAction(t, actionName, map[string]any{
+			"old_snippet": "a = 1",
+		}), op)
+		terminated, _ := op.IsTerminated()
+		assert.False(t, terminated)
+	}
+
+	// Successful modify resets the counter
+	loop.Set(factory.GetCodeVariableName(), "a = 42")
+	successOp := reactloops.NewActionHandlerOperator(task)
+	ac.ActionHandler(loop, mustBuildAction(t, actionName, map[string]any{
+		"old_snippet": "a = 1",
+	}), successOp)
+	terminated, failErr := successOp.IsTerminated()
+	assert.False(t, terminated)
+	assert.NoError(t, failErr)
+	assert.Contains(t, loop.Get(factory.GetFullCodeVariableName()), "a = 42")
+
+	// After success, empty counter should be reset; next empty should not immediately fail
+	loop.Set(factory.GetCodeVariableName(), "")
+	retryOp := reactloops.NewActionHandlerOperator(task)
+	ac.ActionHandler(loop, mustBuildAction(t, actionName, map[string]any{
+		"old_snippet": "a = 42",
+	}), retryOp)
+	terminated, failErr = retryOp.IsTerminated()
+	assert.False(t, terminated, "after a successful modify, the counter should be reset")
+	assert.NoError(t, failErr)
+	assert.True(t, retryOp.IsContinued())
 }

--- a/common/ai/aid/aireact/reactloops/loopinfra/single_file_modification_suite.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/single_file_modification_suite.go
@@ -260,7 +260,9 @@ func (f *SingleFileModificationSuiteFactory) applySyntaxLintResult(
 	reactloops.EmitActionLog(loop, loopInfraNodeCodeVerify, "验证通过 / Code verification passed")
 	reactloops.EmitStatus(loop, "验证代码通过 / Code verification passed")
 
-	if exitOnClean && f.postSyntaxCleanHook != nil {
+	// postSyntaxCleanHook（如 YAK_MAIN 自测）与 exitOnClean 解耦：
+	// 语法通过时始终执行 hook，无论是否需要自动退出。
+	if f.postSyntaxCleanHook != nil {
 		feedback, blockExit := f.postSyntaxCleanHook(loop, op)
 		if blockExit {
 			if feedback != "" {
@@ -292,7 +294,8 @@ func (f *SingleFileModificationSuiteFactory) CommitAfterCodeEdit(
 	loop.Set(f.GetFullCodeVariableName(), fullCode)
 
 	errMsg, hasBlockingErrors := f.OnFileChanged(fullCode, op)
-	_ = f.applySyntaxLintResult(loop, op, hasBlockingErrors, f.ShouldExitWhenSyntaxClean())
+	// modify 操作不自动退出循环：AI 可能需要多次修改，由 AI 主动调用 finish 退出。
+	_ = f.applySyntaxLintResult(loop, op, hasBlockingErrors, false)
 
 	loop.GetEmitter().EmitPinFilename(filename)
 	_, _ = f.applyLoopYaklangCodeChange(loop, &loopYaklangCodeChange{
@@ -333,7 +336,33 @@ func (f *SingleFileModificationSuiteFactory) handleModifyByOldSnippet(
 	}
 
 	if strings.TrimSpace(newCode) == "" {
-		op.Fail("modify_code with old_snippet requires non-empty new code in GEN_CODE block")
+		const maxEmptySnippetRetry = 5
+		emptyCountVar := actionName + "_empty_modify_snippet_count"
+		emptyCount := loop.GetInt(emptyCountVar) + 1
+		loop.Set(emptyCountVar, fmt.Sprint(emptyCount))
+
+		failMsg := fmt.Sprintf("modify_code(old_snippet) GEN_CODE empty (attempt %d/%d)", emptyCount, maxEmptySnippetRetry)
+		runtime.AddToTimeline("error", failMsg)
+
+		if emptyCount >= maxEmptySnippetRetry {
+			op.Fail(fmt.Sprintf("%s — giving up. Switch to modify_start_line/modify_end_line line-range mode", failMsg))
+			return
+		}
+
+		var hint string
+		if emptyCount <= 2 {
+			hint = fmt.Sprintf("\n\nHINT: @action JSON 中指定了 old_snippet 但 %s 代码块为空。"+
+				"JSON 与代码块是同一条消息的一部分，不可分开。请在同一次回复中输出完整的代码块。"+
+				"\n如果无法生成代码块，请改用 modify_start_line/modify_end_line 行号模式："+
+				"只需在 @action JSON 中指定行号，将新代码写入 %s 代码块即可。", f.aiTagName, f.aiTagName)
+		} else {
+			hint = fmt.Sprintf("\n\n【警告】old_snippet 模式已连续 %d 次未能生成代码块（剩余 %d 次机会）。"+
+				"请立即改用行号模式: "+
+				`{"@action": "modify_code", "modify_start_line": <起始行>, "modify_end_line": <结束行>} `+
+				"+ %s 代码块。行号模式更可靠且不需要精确匹配旧代码。", emptyCount, maxEmptySnippetRetry-emptyCount, f.aiTagName)
+		}
+		op.Feedback(failMsg + hint)
+		op.Continue()
 		return
 	}
 
@@ -392,6 +421,10 @@ old_snippet 预览：
 	}
 
 	fullCode = editor.GetSourceCode()
+
+	// 成功修改后重置空代码计数器
+	emptyCountVar := actionName + "_empty_modify_snippet_count"
+	loop.Set(emptyCountVar, "0")
 
 	invoker.AddToTimeline("modify_code", fmt.Sprintf("replaced snippet (%d match(es), replace_all=%v)", len(matches), replaceAll))
 	if reason != "" {

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -5,7 +5,7 @@ package consts
 // ExistedCorePluginEmbedFSHash contains the SHA256 hash of the embedded core plugin filesystem.
 // This hash is used to verify the integrity of core plugins and detect changes in the plugin bundle.
 // The hash is automatically generated during the build process and should not be manually modified.
-const ExistedCorePluginEmbedFSHash string = "a563dd06c39595911855953bad5323813ceef155e4b599df150be76e2668e793"
+const ExistedCorePluginEmbedFSHash string = "23728f71dba1e3b68644fa71b24e43f9416a9f7c5a4d17b0604eb409d25eaa1d"
 
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -5,7 +5,7 @@ package consts
 // ExistedCorePluginEmbedFSHash contains the SHA256 hash of the embedded core plugin filesystem.
 // This hash is used to verify the integrity of core plugins and detect changes in the plugin bundle.
 // The hash is automatically generated during the build process and should not be manually modified.
-const ExistedCorePluginEmbedFSHash string = "eab4a2f8ddeed77e84033b48f6e73dd88cd02e455cd6859085b84bbcae5786dc"
+const ExistedCorePluginEmbedFSHash string = "a563dd06c39595911855953bad5323813ceef155e4b599df150be76e2668e793"
 
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.

--- a/common/coreplugin/base-yak-plugin/提取同域名下所有的PATH.yak
+++ b/common/coreplugin/base-yak-plugin/提取同域名下所有的PATH.yak
@@ -1,0 +1,205 @@
+/*
+插件名称: 提取同域名下所有的PATH
+插件类型: codec
+用途: 在 Yakit History 中右键（单选/多选）流量，输入为 flow id，
+      自动查询该流量的域名，然后从 History 中捞出该域名下所有唯一 PATH（去 query、去重）。
+标签: allow-custom-context-menu-execute, allow-custom-single-history-mutate, allow-custom-multiple-history-mutate
+验证: yak extract-same-domain-paths.yak                  # 自测纯逻辑
+      yak extract-same-domain-paths.yak --real 1         # 用真实 History 跑
+契约要点:
+  - History 右键时 input = flow id（多选为逗号拼接 id）
+  - handle(input) 返回提取结果字符串
+  - flow.Request 是 strconv-quote 后的字符串，需 codec.StrconvUnquote 还原
+  - PATH 去重前先剥掉 query，避免 ?page=1 / ?page=2 被当成不同路径
+*/
+
+__DESC__ = `
+# 提取同域名下所有的 PATH（codec 右键插件）
+
+## 功能
+在 Yakit History 表格中选中一条或多条流量，右键 → 插件扩展 → 提取同域名下所有的PATH，
+插件自动查询选中流量对应的域名，从 History 数据库中捞出该域名下的所有唯一 PATH
+（去掉 scheme 与 query，只保留 host+path），去重后输出。
+
+## 使用方式
+1. 在 Yakit 插件管理新建 codec 类型插件，粘贴本脚本
+2. 开启开关: "用于数据包右键" / "用于history右键(单选)" / "用于history右键(多选)"
+3. 在 History 表格选中流量 → 右键 → 插件扩展 → 提取同域名下所有的PATH
+`
+
+yakit.AutoInitYakit()
+
+status = (text) => {
+    yakit.StatusCard("Status", text)
+}
+
+// ---- 纯函数（可自测） ----
+// 解析 input 中的 flow id（单选 "1287"，多选 "1287,1290,1305"）
+parseIds = func(input) {
+
+    
+
+    ids = []
+    for part in str.Split(input, ",") {
+        p = str.TrimSpace(part)
+        if p == "" { continue }
+        n, err = atoi(p)
+        if err != nil { continue }
+        if n > 0 { ids = append(ids, int64(n)) }
+    }
+    return ids
+}
+
+// 从完整 URL 提取 host（去掉 scheme 与端口）
+hostOf = func(rawURL) {
+    rest = str.TrimPrefix(str.TrimPrefix(rawURL, "https://"), "http://")
+    hostPart = str.SplitN(rest, "/", 2)[0]
+    // 去掉端口部分
+    return str.SplitN(hostPart, ":", 2)[0]
+}
+
+// 从完整 URL 提取 path（去 scheme + host + query），根路径返回 "/"
+pathOf = func(rawURL) {
+    rest = str.TrimPrefix(str.TrimPrefix(rawURL, "https://"), "http://")
+    idx = str.Index(rest, "/")
+    if idx < 0 { return "/" }
+    return str.SplitN(rest[idx:], "?", 2)[0]
+}
+
+// ---- 生产入口 ----
+// 关键词: handle, codec 插件入口
+handle = func(input) {
+    status("准备解析参数")
+    ids = parseIds(input)
+    if len(ids) == 0 { 
+        msg = "未找到有效的流量 ID: " + input 
+        status("失败：" + msg)
+        return msg
+    }
+
+    // step 1: flow id → 收集所有涉及的域名（去重）
+    hostSeen = {}
+    hosts = []
+    status("开始提取主机")
+    for flow in db.QueryHTTPFlowsByID(ids...) {
+        h = hostOf(flow.Url)
+        if h != "" && !(h in hostSeen) {
+            hostSeen[h] = true
+            hosts = append(hosts, h)
+        }
+    }
+    if len(hosts) == 0 { return "未找到对应流量: " + input }
+
+    pathSeen = {}
+    allPaths = []
+    allUrls = []
+    total = len(hosts)
+    done = 0
+    flowCount = 0
+    startTime = time.Now()
+
+    // 每秒输出一次吞吐统计
+    go func() {
+        lastCount = 0
+        for {
+            time.Sleep(1)
+            currentCount = flowCount
+            rate = currentCount - lastCount
+            lastCount = currentCount
+            elapsed = time.Since(startTime).Seconds()
+            log.info("进度: 已分析 %d 条流量 | 每秒 %d 条 | 已耗时 %.0fs | 域名 %d/%d",
+                currentCount, rate, elapsed, done, total)
+        }
+    }()
+
+    for host in hosts {
+        yakit.SetProgress(float(done) / float(total))
+        status(f"开始数据库中搜索相关流量: ${host}")
+        for f in db.QueryHTTPFlowsByKeyword(host) {
+            p = pathOf(f.Url)
+            if p != "" && !(p in pathSeen) {
+                pathSeen[p] = true
+                allPaths = append(allPaths, p)
+                allUrls = append(allUrls, f.Url)
+            }
+            flowCount++
+            if flowCount % 100 == 0 {
+                status(f"已分析: ${flowCount} 条流量")
+            }
+        }
+        done++
+    }
+    yakit.SetProgress(1.0)
+    status(f"分析完成: 共 ${flowCount} 条流量, ${len(allPaths)} 条唯一 PATH")
+
+    // 输出摘要
+    yakit.EnableText("提取结果（路径）")
+    yakit.TextTabData("提取结果（路径）", str.Join(allPaths, "\n"))
+
+    yakit.EnableText("提取结果（URL）")
+    yakit.TextTabData("提取结果（URL）", str.Join(allUrls, "\n"))
+
+    // 表格输出 PATH 列表
+    tableName = "同域名PATH列表"
+    yakit.EnableTable(tableName, ["序号", "PATH"])
+    for i, p := range allPaths {
+        yakit.TableData(tableName, {
+            "序号": sprintf("%d", i+1),
+            "PATH": p,
+            "uuid": uuid(),
+        })
+    }
+
+    return sprintf("域名: %s\n共 %d 条唯一 PATH\n耗时 %.1fs\n\n%s",
+        str.Join(hosts, ", "),
+        len(allPaths),
+        time.Since(startTime).Seconds(),
+        str.Join(allPaths, "\n"),
+    )
+}
+
+func runSelfTest() {
+    log.info("start extract-same-domain-paths self test")
+
+    // parseIds
+    ids1 := parseIds("1287")
+    assert len(ids1) == 1 && ids1[0] == 1287, "单选 parseIds 失败"
+    ids2 := parseIds("1287, 1290, 1305")
+    assert len(ids2) == 3 && ids2[2] == 1305, "多选 parseIds 失败"
+    ids3 := parseIds("")
+    assert len(ids3) == 0, "空字符串应返回空"
+
+    // hostOf
+    assert hostOf("https://shop.example.com/api/list") == "shop.example.com", "hostOf https failed"
+    assert hostOf("http://a.b.c:8080/x/y") == "a.b.c", "hostOf with port failed"
+    assert hostOf("http://localhost/admin") == "localhost", "hostOf localhost failed"
+
+    // pathOf
+    assert pathOf("https://shop.example.com/api/list") == "/api/list", "pathOf simple failed"
+    assert pathOf("https://shop.example.com/api/list?page=1&size=10") == "/api/list", "pathOf query strip failed"
+    assert pathOf("https://shop.example.com") == "/", "pathOf root failed"
+    assert pathOf("https://shop.example.com/?q=1") == "/", "pathOf root with query failed"
+
+    log.info("extract-same-domain-paths self test PASSED")
+}
+
+func runReal() {
+    args = cli.Args()
+    id = "1"
+    n = len(args)
+    i = 0
+    for i < n {
+        if args[i] == "--real" && i+1 < n { id = args[i+1] }
+        i++
+    }
+    log.info("run real handle: id=%s", id)
+    log.info("result:\n" + handle(id))
+}
+
+if YAK_MAIN {
+    if "--real" in cli.Args() {
+        runReal()
+    } else {
+        runSelfTest()
+    }
+}

--- a/common/coreplugin/coreplugin.go
+++ b/common/coreplugin/coreplugin.go
@@ -499,6 +499,17 @@ func syncCorePluginEmbedInternal() error {
 		withPluginHelp("强制同步内置规则，包括 SyntaxFlow 规则、Core 插件、AI Forge"),
 		withPluginEnableGenerateParam(true),
 	)
+
+	registerBuildInPlugin(
+		"codec", "提取同域名下所有的PATH",
+		withPluginHelp("在 Yakit History 中右键选中流量，自动查询该流量域名并从 History 中提取该域名下所有唯一 PATH（去 query、去重）"),
+		withPluginAuthors("V1ll4n"),
+		withPluginTags([]string{
+			"web安全", "信息收集", "历史分析", "路径提取", "YakScript",
+			"allow-custom-single-history-mutate",
+			"allow-custom-multiple-history-mutate",
+		}),
+	)
 	return nil
 }
 

--- a/common/yak/yakscript/exec_param.go
+++ b/common/yak/yakscript/exec_param.go
@@ -75,7 +75,7 @@ func ExecScriptWithExecParam(script *schema.YakScript, input string, stream Stre
 	}
 	switch strings.ToLower(scriptType) {
 	case "codec":
-		tabName := "Codec结果"
+		tabName := "执行结果"
 		subEngine, err := engine.ExecuteExWithContext(streamCtx, script.Content, map[string]any{
 			"CTX":          streamCtx,
 			"PLUGIN_NAME":  scriptName,


### PR DESCRIPTION
## 背景

本 PR 包含两组相互独立的改动，按 commit 拆分，便于 review。

---

## 1. AI 代码编辑循环行为调整（`aid-loop`）

### 问题
单文件代码编辑循环此前只要语法检查通过（`ShouldExitWhenSyntaxClean`）就自动退出循环。这导致 AI 在一个任务里需要**多次修改**时被过早打断；而 `postSyntaxCleanHook`（如 `YAK_MAIN` 自测）也与退出逻辑耦合，语义不清。

另外，`modify_code(old_snippet)` 在 AI 输出空的 `GEN_CODE` 代码块时会直接 `op.Fail` 终止任务，没有给 AI 重试机会。

### 改动
**`common/ai/aid/aireact/reactloops/loopinfra/`**

- `single_file_actions.go` / `single_file_modification_suite.go`：`modify` / `insert` / `delete` / `CommitAfterCodeEdit` 一律传 `exitOnClean=false`。改为由 AI **主动调用 `finish`** 退出循环。
- `applySyntaxLintResult`：`postSyntaxCleanHook` 与 `exitOnClean` 解耦——语法通过时**始终执行** hook（不再受 `exitOnClean` 开关影响），只有 `blockExit` 才阻断退出。
- `handleModifyByOldSnippet`：空 `GEN_CODE` 不再立即 `Fail`：
  - 新增计数器 `*_empty_modify_snippet_count`，上限 5 次；
  - 1–2 次：温和提示，引导使用行号模式（`modify_start_line`/`modify_end_line`）；
  - 3+ 次：升级为强制警告，明确要求切换行号模式；
  - 达到 5 次：`Fail` 并在错误信息中指明行号模式，避免死循环；
  - 成功修改后**重置计数器**。

### 测试
- 更新已有用例：`TestModifyAction_ExitWhenSyntaxClean` → `TestModifyAction_ContinuesAfterSyntaxClean`（断言 modify 后**不再**自动终止）。
- `loop_yaklangcode/tests`：模拟 AI 在 modify 后先 `directly_answer` 再 `finish` 退出（新增 `answerDone` 状态）。
- 新增 4 个用例覆盖空 snippet 路径：
  - `TestModifyAction_OldSnippet_EmptyCode_SingleRetry`（单次空 → 重试 + 提示）
  - `TestModifyAction_OldSnippet_EmptyCode_EscalatesToLineRangeHint`（3+ 次升级警告）
  - `TestModifyAction_OldSnippet_EmptyCode_EventuallyFails`（达上限 Fail）
  - `TestModifyAction_OldSnippet_EmptyCode_ResetAfterSuccess`（成功后计数器重置）

### Review 重点
- `single_file_modification_suite.go` 中 `applySyntaxLintResult` 的解耦逻辑（`exitOnClean` 仅控制是否因语法干净退出，hook 照常跑）。
- `handleModifyByOldSnippet` 的重试计数 / 提示文案 / 失败兜底。
- ⚠️ **行为变更**：依赖「modify 后自动退出」的上层调用方需改为显式 `finish`。

---

## 2. 新增 codec 插件「提取同域名下所有的PATH」+ codec tab 改名

### 改动
- `common/coreplugin/coreplugin.go`：注册内置 codec 插件「提取同域名下所有的PATH」，标签含 `allow-custom-single-history-mutate` / `allow-custom-multiple-history-mutate`，用于 History 右键。
- `common/coreplugin/base-yak-plugin/提取同域名下所有的PATH.yak`：插件源码，包含纯函数 + `runSelfTest()`（纯逻辑自测）+ `--real` 真实 History 调试入口。
- `common/yak/yakscript/exec_param.go`：codec 执行 tab 名 `Codec结果` → `执行结果`（codec 插件现已服务于通用右键流程，不再局限于编解码）。

### Review 重点
- 插件逻辑：`flow id` → 域名去重 → `db.QueryHTTPFlowsByKeyword` 取流量 → `pathOf` 剥 scheme/host/query 去重。
- `exec_param.go` tab 名改动是否影响已有 codec 依赖方的 UI 定位。

### 🔗 关联前端 PR
> ⚠️ 本 PR 的 `exec_param.go` tab 名改动（`Codec结果` → `执行结果`）需与 yakit 前端 PR **同步发布**。
> - yakit 前端 PR：https://github.com/yaklang/yakit/pull/4003
> - 前端 `PluginExecuteResult` 中 codec 插件的 `defaultActiveKey` 已同步改为 `'执行结果'`，依赖后端下发的 `tab_name` 一致。
> - 两仓库若不同步发布，codec 插件执行后的默认激活 tab 会匹配失败。

---

## Checklist
- [x] 按 commit 拆分（行为修复 / 新增插件 各自独立）
- [x] 新增/更新测试
- [ ] CI 通过