### PR TITLE
fix(grpc_cve): ensure QueryCVE response always carries non-nil pagina…

### DIFF
--- a/common/yakgrpc/grpc_cve.go
+++ b/common/yakgrpc/grpc_cve.go
@@ -20,6 +20,15 @@ import (
 )
 
 func (s *Server) QueryCVE(ctx context.Context, req *ypb.QueryCVERequest) (*ypb.QueryCVEResponse, error) {
+	// Ensure response pagination is non-nil so callers (MCP/GUI) always get
+	// the effective paging parameters. QueryCVE fills in defaults for empty
+	// OrderBy / Order, but a nil Pagination in the request would otherwise
+	// produce a nil Pagination in the response.
+	params := req.GetPagination()
+	if params == nil {
+		params = &ypb.Paging{}
+	}
+
 	paging, data, err := cveresources.QueryCVE(consts.GetGormCVEDatabase(), req)
 	if err != nil {
 		return nil, err
@@ -29,7 +38,7 @@ func (s *Server) QueryCVE(ctx context.Context, req *ypb.QueryCVERequest) (*ypb.Q
 		results = append(results, c.ToGPRCModel())
 	}
 	return &ypb.QueryCVEResponse{
-		Pagination: req.GetPagination(),
+		Pagination: params,
 		Total:      int64(paging.TotalRecord),
 		Data:       results,
 	}, nil


### PR DESCRIPTION
…tion

MCP/GUI callers may omit Pagination in QueryCVERequest. Although cveresources.QueryCVE already nil-checks the pagination internally, the gRPC response previously returned req.GetPagination() directly, which could leave Pagination nil in the response.

Fill in an empty ypb.Paging{} when the request does not provide one so that callers always receive the effective paging parameters.