### PR TITLE
fix(yaklib): EmitSSAResult enable DataflowDetailFull to fix empty dot_graph/paths

### DIFF
--- a/common/yak/ssaapi/sfreport/convert_single_stream_parts_test.go
+++ b/common/yak/ssaapi/sfreport/convert_single_stream_parts_test.go
@@ -1,10 +1,12 @@
 package sfreport
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/ssaapi"
 )
 
 func TestConvertSingleResultToSSAResultParts_NilResult(t *testing.T) {
@@ -49,3 +51,70 @@ func TestDedupStrings(t *testing.T) {
 	}
 }
 
+// TestNewStreamPartsOptions_DefaultDataflowDetailLevel verifies the default
+// detail level is minimal (the historical behavior EmitSSAResult relied on
+// before the fix).
+func TestNewStreamPartsOptions_DefaultDataflowDetailLevel(t *testing.T) {
+	opts := NewStreamPartsOptions()
+	assert.Equal(t, DataflowDetailMinimal, opts.DataflowDetailLevel)
+}
+
+// TestWithStreamDataflowDetailLevel verifies the option setter writes the
+// requested level into the options struct.
+func TestWithStreamDataflowDetailLevel(t *testing.T) {
+	opts := NewStreamPartsOptions(WithStreamDataflowDetailLevel(DataflowDetailFull))
+	assert.Equal(t, DataflowDetailFull, opts.DataflowDetailLevel)
+}
+
+// TestMarshalDataFlowPath_FullContainsDotGraph verifies that full mode
+// serialization preserves dot_graph, paths, and code_range — the fields that
+// EmitSSAResult must expose by passing WithStreamDataflowDetailLevel(Full).
+func TestMarshalDataFlowPath_FullContainsDotGraph(t *testing.T) {
+	path := &DataFlowPath{
+		Description: "taint flow",
+		DotGraph:    "digraph { n1 -> n2 }",
+		Paths:       [][]string{{"n1", "n2"}},
+		Nodes: []*NodeInfo{
+			{
+				NodeID:       "n1",
+				IRCode:       "source()",
+				IRSourceHash: "h1",
+				CodeRange:    &ssaapi.CodeRange{URL: "test.go", StartLine: 1, EndLine: 1},
+			},
+		},
+		Edges: []*EdgeInfo{
+			{EdgeID: "e1", FromNodeID: "n1", ToNodeID: "n2", EdgeType: "data-flow"},
+		},
+	}
+
+	t.Run("full preserves dot_graph/paths/code_range", func(t *testing.T) {
+		raw, err := MarshalDataFlowPath(path, DataflowDetailFull)
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+
+		var out DataFlowPath
+		require.NoError(t, json.Unmarshal(raw, &out))
+		assert.Equal(t, "digraph { n1 -> n2 }", out.DotGraph)
+		assert.Equal(t, [][]string{{"n1", "n2"}}, out.Paths)
+		require.Len(t, out.Nodes, 1)
+		assert.NotNil(t, out.Nodes[0].CodeRange)
+	})
+
+	t.Run("minimal strips dot_graph/paths/code_range", func(t *testing.T) {
+		raw, err := MarshalDataFlowPath(path, DataflowDetailMinimal)
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+
+		s := string(raw)
+		assert.NotContains(t, s, "dot_graph")
+		assert.NotContains(t, s, "paths")
+		assert.NotContains(t, s, "code_range")
+
+		var out DataFlowPath
+		require.NoError(t, json.Unmarshal(raw, &out))
+		assert.Empty(t, out.DotGraph)
+		assert.Nil(t, out.Paths)
+		require.Len(t, out.Nodes, 1)
+		assert.Nil(t, out.Nodes[0].CodeRange)
+	})
+}

--- a/common/yak/yaklib/yakit.go
+++ b/common/yak/yaklib/yakit.go
@@ -419,6 +419,7 @@ func (c *YakitClient) EmitSSAResult(result *ssaapi.SyntaxFlowResult) (int, int, 
 		sfreport.WithStreamShowDataflowPath(true),
 		sfreport.WithStreamShowFileContent(true),
 		sfreport.WithStreamWithFile(true),
+		sfreport.WithStreamDataflowDetailLevel(sfreport.DataflowDetailFull),
 	)
 	parts, err := sfreport.ConvertSingleResultToSSAResultParts(result, opts)
 	if err != nil {


### PR DESCRIPTION
## Problem

SSA scan results had empty dot_graph, paths, and node_code_ranges fields. The legion import side correctly extracts these keys, but they were absent from the NDJSON artifact payload.

## Root Cause

EmitSSAResult constructs StreamPartsOptions without DataflowDetailLevel. Default is DataflowDetailMinimal which strips DotGraph, CodeRange, Paths during serialization. The mechanism was introduced in commit 3c66c267c but EmitSSAResult never used Full mode.

## Fix

Add sfreport.WithStreamDataflowDetailLevel(sfreport.DataflowDetailFull) to EmitSSAResult.

### Tests

3 new sfreport tests: default-minimal invariant, setter, full-vs-minimal MarshalDataFlowPath.

### E2E

Verified with legion PR VillanCh/legion#163: dot_graph/paths/node_code_ranges all populated after scan.

## Related

- Companion legion PR: https://github.com/VillanCh/legion/pull/163
- Split-Branch: from go0p/refactor/scannode, scannode-layer only