### PR TITLE
fix(mcp): remove oneOf from brute/payload tool schemas for OpenAI compat

### DIFF
--- a/common/mcp/brute.go
+++ b/common/mcp/brute.go
@@ -23,19 +23,12 @@ func init() {
 				mcp.EnumString(bruteutils.GetBuildinAvailableBruteType()...),
 				mcp.Required(),
 			),
-			mcp.WithOneOfStruct("target",
-				[]mcp.PropertyOption{
-					mcp.Required(),
-				},
-				[]mcp.ToolOption{
-					mcp.WithStringArray("targets",
-						mcp.Description("Targets for the brute force attack"),
-						mcp.Required(),
-					), mcp.WithString("targetFile",
-						mcp.Description("File containing targets for the brute force attack"),
-						mcp.Required(),
-					),
-				}),
+			mcp.WithStringArray("targets",
+				mcp.Description("Targets for the brute force attack"),
+			),
+			mcp.WithString("targetFile",
+				mcp.Description("File containing targets for the brute force attack"),
+			),
 			mcp.WithBool("replaceDefaultUsernameDict",
 				mcp.Description("If false, default username dictionary will be added"),
 				mcp.Required(),
@@ -46,30 +39,18 @@ func init() {
 				mcp.Required(),
 				mcp.Default(true),
 			),
-			mcp.WithOneOfStruct("user-dict",
-				[]mcp.PropertyOption{
-					mcp.Required(),
-				},
-				[]mcp.ToolOption{
-					mcp.WithStringArray("usernames",
-						mcp.Description("List of usernames to use in the brute force attack"),
-					),
-					mcp.WithString("usernameFile",
-						mcp.Description("File containing usernames for the brute force attack"),
-					),
-				}),
-			mcp.WithOneOfStruct("pass-dict",
-				[]mcp.PropertyOption{
-					mcp.Required(),
-				},
-				[]mcp.ToolOption{
-					mcp.WithStringArray("passwords",
-						mcp.Description("List of passwords to use in the brute force attack"),
-					),
-					mcp.WithString("passwordFile",
-						mcp.Description("File containing passwords for the brute force attack"),
-					),
-				}),
+			mcp.WithStringArray("usernames",
+				mcp.Description("List of usernames to use in the brute force attack"),
+			),
+			mcp.WithString("usernameFile",
+				mcp.Description("File containing usernames for the brute force attack"),
+			),
+			mcp.WithStringArray("passwords",
+				mcp.Description("List of passwords to use in the brute force attack"),
+			),
+			mcp.WithString("passwordFile",
+				mcp.Description("File containing passwords for the brute force attack"),
+			),
 			mcp.WithNumber("timeout",
 				mcp.Description("Timeout for the brute force attack"),
 			),
@@ -102,40 +83,39 @@ func handleBrute(s *MCPServer) server.ToolHandlerFunc {
 		ctx context.Context,
 		request mcp.CallToolRequest,
 	) (*mcp.CallToolResult, error) {
-		args := request.Params.Arguments
-		target := utils.MapGetRaw(args, "target")
-		targetMap, ok := target.(map[string]any)
-		if !ok {
-			return nil, utils.Error("invalid argument: target")
-		}
-		username := utils.MapGetRaw(args, "user-dict")
-		usernameMap, ok := username.(map[string]any)
-		if !ok {
-			return nil, utils.Error("invalid argument: user-dict")
-		}
-		password := utils.MapGetRaw(args, "pass-dict")
-		passwordMap, ok := password.(map[string]any)
-		if !ok {
-			return nil, utils.Error("invalid argument: pass-dict")
-		}
-		req := ypb.StartBruteParams{
-			Type:                       utils.MapGetString(args, "type"),
-			Targets:                    strings.Join(utils.MapGetStringSlice(targetMap, "targets"), "\n"),
-			TargetFile:                 utils.MapGetString(targetMap, "targetFile"),
-			Usernames:                  utils.MapGetStringSlice(usernameMap, "usernames"),
-			UsernameFile:               utils.MapGetString(usernameMap, "usernameFile"),
-			Passwords:                  utils.MapGetStringSlice(passwordMap, "passwords"),
-			PasswordFile:               utils.MapGetString(passwordMap, "passwordFile"),
-			ReplaceDefaultUsernameDict: utils.MapGetBool(args, "replaceDefaultUsernameDict"),
-			ReplaceDefaultPasswordDict: utils.MapGetBool(args, "replaceDefaultPasswordDict"),
-			Timeout:                    float32(utils.InterfaceToFloat64(utils.MapGetRaw(args, "timeout"))),
-			Concurrent:                 utils.MapGetInt64(args, "concurrent"),
-			Retry:                      utils.MapGetInt64(args, "retry"),
-			TargetTaskConcurrent:       utils.MapGetInt64(args, "targetTaskConcurrent"),
-			OkToStop:                   utils.MapGetBool(args, "okToStop"),
-			DelayMin:                   utils.MapGetInt64(args, "delayMin"),
-			DelayMax:                   utils.MapGetInt64(args, "delayMax"),
-		}
+	args := request.Params.Arguments
+	targets := utils.MapGetStringSlice(args, "targets")
+	targetFile := utils.MapGetString(args, "targetFile")
+	if len(targets) == 0 && targetFile == "" {
+		return nil, utils.Error("invalid argument: target is required (provide targets or targetFile)")
+	}
+	usernames := utils.MapGetStringSlice(args, "usernames")
+	usernameFile := utils.MapGetString(args, "usernameFile")
+	passwords := utils.MapGetStringSlice(args, "passwords")
+	passwordFile := utils.MapGetString(args, "passwordFile")
+	if (len(usernames) == 0 && usernameFile == "") || (len(passwords) == 0 && passwordFile == "") {
+		return nil, utils.Error("invalid argument: user-dict and pass-dict are required")
+	}
+
+	req := ypb.StartBruteParams{
+		Type:                       utils.MapGetString(args, "type"),
+		Targets:                    strings.Join(targets, "\n"),
+		TargetFile:                 targetFile,
+		Usernames:                  usernames,
+		UsernameFile:               usernameFile,
+		Passwords:                  passwords,
+		PasswordFile:               passwordFile,
+		ReplaceDefaultUsernameDict: utils.MapGetBool(args, "replaceDefaultUsernameDict"),
+		ReplaceDefaultPasswordDict: utils.MapGetBool(args, "replaceDefaultPasswordDict"),
+		Timeout:                    float32(utils.InterfaceToFloat64(utils.MapGetRaw(args, "timeout"))),
+		Concurrent:                 utils.MapGetInt64(args, "concurrent"),
+		Retry:                      utils.MapGetInt64(args, "retry"),
+		TargetTaskConcurrent:       utils.MapGetInt64(args, "targetTaskConcurrent"),
+		OkToStop:                   utils.MapGetBool(args, "okToStop"),
+		DelayMin:                   utils.MapGetInt64(args, "delayMin"),
+		DelayMax:                   utils.MapGetInt64(args, "delayMax"),
+	}
+
 
 		var progressToken mcp.ProgressToken
 		meta := request.Params.Meta

--- a/common/mcp/mcp_openai_compat_diagnostic_test.go
+++ b/common/mcp/mcp_openai_compat_diagnostic_test.go
@@ -1,0 +1,159 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+)
+
+// TestMCPSchemaOpenAICompatDiagnostic inspects every builtin legacy MCP tool
+// schema for patterns that are known to break OpenAI-style function calling /
+// tool providers (e.g. "invalid_request_error" / "Upstream request failed").
+//
+// It does NOT start a network server; it reads the registered tool definitions
+// directly so it stays fast and deterministic.
+func TestMCPSchemaOpenAICompatDiagnostic(t *testing.T) {
+	diag := newOpenAICompatDiagnostic()
+
+	for _, tw := range GlobalBuiltinTools() {
+		if tw == nil || tw.tool == nil {
+			continue
+		}
+		diag.checkTool(tw.tool)
+	}
+
+	diag.printReport(t)
+
+	// This is a diagnostic test: it prints the report but does not fail.
+	// Once we decide which compatibility rules are hard requirements we can
+	// convert the report into assertions.
+}
+
+// openAICompatDiagnostic collects schema compatibility issues.
+type openAICompatDiagnostic struct {
+	checked            int
+	rootNotObject      []string
+	missingType        []string
+	disallowedKeywords []string
+	emptyEnum          []string
+	mixedEnumTypes     []string
+	deeplyNested       []string
+	emptyDescription   []string
+	totalSchemaBytes   int
+}
+
+func newOpenAICompatDiagnostic() *openAICompatDiagnostic {
+	return &openAICompatDiagnostic{}
+}
+
+func (d *openAICompatDiagnostic) checkTool(tool *mcp.Tool) {
+	d.checked++
+
+	raw, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		return
+	}
+	d.totalSchemaBytes += len(raw)
+
+	var schema map[string]interface{}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return
+	}
+
+	if typ, _ := schema["type"].(string); typ != "object" {
+		d.rootNotObject = append(d.rootNotObject, tool.Name)
+	}
+
+	d.checkNode(tool.Name, "", schema, 0)
+}
+
+func (d *openAICompatDiagnostic) checkNode(toolName, path string, node map[string]interface{}, depth int) {
+	const maxDepth = 4 // OpenAI recommends shallow nesting
+	if depth > maxDepth {
+		d.deeplyNested = append(d.deeplyNested, fmt.Sprintf("%s.%s", toolName, path))
+		return
+	}
+
+	if node == nil {
+		return
+	}
+
+	if _, hasType := node["type"]; !hasType {
+		if _, hasOneOf := node["oneOf"]; !hasOneOf {
+			if _, hasAnyOf := node["anyOf"]; !hasAnyOf {
+				if _, hasAllOf := node["allOf"]; !hasAllOf {
+					d.missingType = append(d.missingType, fmt.Sprintf("%s.%s", toolName, path))
+				}
+			}
+		}
+	}
+
+	for _, kw := range []string{"oneOf", "anyOf", "allOf"} {
+		if _, ok := node[kw]; ok {
+			d.disallowedKeywords = append(d.disallowedKeywords, fmt.Sprintf("%s.%s: %s", toolName, path, kw))
+		}
+	}
+
+	if enum, ok := node["enum"].([]interface{}); ok {
+		if len(enum) == 0 {
+			d.emptyEnum = append(d.emptyEnum, fmt.Sprintf("%s.%s", toolName, path))
+		} else {
+			firstType := fmt.Sprintf("%T", enum[0])
+			for _, v := range enum[1:] {
+				if fmt.Sprintf("%T", v) != firstType {
+					d.mixedEnumTypes = append(d.mixedEnumTypes, fmt.Sprintf("%s.%s", toolName, path))
+					break
+				}
+			}
+		}
+	}
+
+	if desc, _ := node["description"].(string); desc == "" && path != "" {
+		typ, _ := node["type"].(string)
+		if typ == "object" || typ == "array" {
+			d.emptyDescription = append(d.emptyDescription, fmt.Sprintf("%s.%s", toolName, path))
+		}
+	}
+
+	if props, ok := node["properties"].(map[string]interface{}); ok {
+		for k, v := range props {
+			child, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			childPath := k
+			if path != "" {
+				childPath = path + "." + k
+			}
+			d.checkNode(toolName, childPath, child, depth+1)
+		}
+	}
+
+	if items, ok := node["items"].(map[string]interface{}); ok {
+		d.checkNode(toolName, path+".items", items, depth+1)
+	}
+}
+
+func (d *openAICompatDiagnostic) printReport(t *testing.T) {
+	fmt.Println("\n========== MCP Schema OpenAI-Compat Diagnostic ==========")
+	fmt.Printf("Tools checked: %d\n", d.checked)
+	fmt.Printf("Total inputSchema bytes: %d (%.1f KB)\n", d.totalSchemaBytes, float64(d.totalSchemaBytes)/1024)
+
+	printSection := func(title string, items []string) {
+		fmt.Printf("\n%s: %d\n", title, len(items))
+		for _, it := range items {
+			fmt.Printf("  - %s\n", it)
+		}
+	}
+
+	printSection("Root inputSchema.type != object", d.rootNotObject)
+	printSection("Properties missing type", d.missingType)
+	printSection("Disallowed keywords (oneOf/anyOf/allOf)", d.disallowedKeywords)
+	printSection("Empty enum", d.emptyEnum)
+	printSection("Mixed-type enum", d.mixedEnumTypes)
+	printSection("Nested deeper than 4 levels", d.deeplyNested)
+	printSection("Object/array properties with empty description", d.emptyDescription)
+	fmt.Println("========================================================")
+}

--- a/common/mcp/payload.go
+++ b/common/mcp/payload.go
@@ -45,21 +45,11 @@ var savePayloadToolOptions = []mcp.ToolOption{
 	mcp.WithBool("saveAsFile",
 		mcp.Description("Whether to save the payload as a file"),
 	),
-	mcp.WithOneOfStruct("source", []mcp.PropertyOption{
-		mcp.Description("source from content or file"),
-		mcp.Required(),
-	}, []mcp.ToolOption{
-		mcp.WithString("content",
-			mcp.Description("The raw content of the payload. Can be multiple lines of content, with one payload per line."),
-			mcp.Required(),
-		),
-	},
-		[]mcp.ToolOption{
-			mcp.WithStringArray("filename",
-				mcp.Description("The filename(s) of the payload that want to import"),
-				mcp.Required(),
-			),
-		},
+	mcp.WithString("content",
+		mcp.Description("The raw content of the payload. Can be multiple lines of content, with one payload per line."),
+	),
+	mcp.WithStringArray("filename",
+		mcp.Description("The filename(s) of the payload that want to import"),
 	),
 }
 
@@ -274,26 +264,25 @@ func handleSavePayload(s *MCPServer) server.ToolHandlerFunc {
 		ctx context.Context,
 		request mcp.CallToolRequest,
 	) (*mcp.CallToolResult, error) {
-		args := request.Params.Arguments
-		group, folder := utils.MapGetString(args, "group"), utils.MapGetString(args, "folder")
-		isNew, saveAsFile := utils.MapGetBool(args, "isNew"), utils.MapGetBool(args, "saveAsFile")
-		source := utils.MapGetRaw(args, "source")
-		sourceMap, ok := source.(map[string]any)
-		if !ok {
-			return nil, utils.Error("invalid argument: source")
-		}
-		content, fileName := utils.MapGetString(sourceMap, "content"), utils.MapGetStringSlice(sourceMap, "filename")
-		req := ypb.SavePayloadRequest{
-			Group:  group,
-			Folder: folder,
-			IsNew:  isNew,
-		}
-		if content != "" {
-			req.Content = content
-		} else if len(fileName) > 0 {
-			req.FileName = fileName
-			req.IsFile = true
-		}
+	args := request.Params.Arguments
+	group, folder := utils.MapGetString(args, "group"), utils.MapGetString(args, "folder")
+	isNew, saveAsFile := utils.MapGetBool(args, "isNew"), utils.MapGetBool(args, "saveAsFile")
+	content, fileName := utils.MapGetString(args, "content"), utils.MapGetStringSlice(args, "filename")
+	if content == "" && len(fileName) == 0 {
+		return nil, utils.Error("invalid argument: source is required (provide content or filename)")
+	}
+	req := ypb.SavePayloadRequest{
+		Group:  group,
+		Folder: folder,
+		IsNew:  isNew,
+	}
+	if content != "" {
+		req.Content = content
+	} else {
+		req.FileName = fileName
+		req.IsFile = true
+	}
+
 
 		var progressToken mcp.ProgressToken
 		meta := request.Params.Meta


### PR DESCRIPTION
Claude / Opencode / Pi reported 400 invalid_request_error when forwarding Yakit MCP tools to their LLM provider. Root cause: brute.* and save_payload used WithOneOfStruct, which emits JSON Schema 'oneOf' — a keyword that OpenAI function calling strict mode rejects.

Changes:
- brute: replace oneOf target/user-dict/pass-dict wrappers with flat optional fields (targets/targetFile, usernames/usernameFile, passwords/passwordFile). Handler validates that at least one of each pair is provided.
- save_payload: replace oneOf source wrapper with flat optional content and filename fields. Handler validates that at least one is provided.
- Add mcp_openai_compat_diagnostic_test.go to scan all builtin tool schemas for OpenAI-incompatible keywords (oneOf/anyOf/allOf), missing types, empty enums, etc.

After fix: diagnostic reports 0 disallowed keywords.