### PR TITLE
feat(mitm): add tests for MITM request hijacking and upstream port mo…

### DIFF
--- a/common/crep/mitm_authority_hijack_test.go
+++ b/common/crep/mitm_authority_hijack_test.go
@@ -1,0 +1,134 @@
+package crep
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
+)
+
+func TestMITMRequestHijackAuthorityChangesUpstreamPort(t *testing.T) {
+	for _, isHTTPS := range []bool{false, true} {
+		isHTTPS := isHTTPS
+		t.Run(map[bool]string{false: "http", true: "https"}[isHTTPS], func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			var originalHits atomic.Int32
+			var modifiedHits atomic.Int32
+			response := func(body string) []byte {
+				return []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body))
+			}
+
+			originalHost, originalPort := utils.DebugMockHTTPServerWithContext(ctx, isHTTPS, false, false, false, false, func([]byte) []byte {
+				originalHits.Add(1)
+				return response("original")
+			})
+			modifiedHost, modifiedPort := utils.DebugMockHTTPServerWithContext(ctx, isHTTPS, false, false, false, false, func([]byte) []byte {
+				modifiedHits.Add(1)
+				return response("modified")
+			})
+
+			modifiedAddr := utils.HostPort(modifiedHost, modifiedPort)
+			proxy, err := NewMITMServer(
+				MITM_SetDisableSystemProxy(true),
+				MITM_SetHTTPRequestHijackRaw(func(_ bool, req *http.Request, raw []byte) []byte {
+					modified := lowhttp.ReplaceHTTPPacketHost(raw, modifiedAddr)
+					firstLine := strings.SplitN(string(modified), "\r\n", 2)[0]
+					parts := strings.SplitN(firstLine, " ", 3)
+					if len(parts) == 3 {
+						if requestURL, parseErr := url.Parse(parts[1]); parseErr == nil && requestURL.IsAbs() {
+							requestURL.Host = modifiedAddr
+							modified = lowhttp.ReplaceHTTPPacketFirstLine(modified, parts[0]+" "+requestURL.String()+" "+parts[2])
+						}
+					}
+					httpctx.SetRequestModified(req, "test manual hijack")
+					httpctx.SetHijackedRequestBytes(req, modified)
+					return modified
+				}),
+			)
+			require.NoError(t, err)
+
+			proxyAddr := utils.HostPort("127.0.0.1", utils.GetRandomAvailableTCPPort())
+			ready := make(chan struct{})
+			go func() {
+				_ = proxy.ServeWithListenedCallback(ctx, proxyAddr, func() { close(ready) })
+			}()
+			select {
+			case <-ready:
+			case <-ctx.Done():
+				t.Fatal("MITM proxy did not start")
+			}
+
+			originalAddr := utils.HostPort(originalHost, originalPort)
+			packet := []byte(fmt.Sprintf("GET /authority-port HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", originalAddr))
+			rsp, err := lowhttp.HTTPWithoutRedirect(
+				lowhttp.WithRequest(packet),
+				lowhttp.WithHttps(isHTTPS),
+				lowhttp.WithProxy("http://"+proxyAddr),
+				lowhttp.WithEnableSystemProxyFromEnv(false),
+				lowhttp.WithConnectTimeout(3*time.Second),
+				lowhttp.WithTimeout(5*time.Second),
+			)
+			require.NoError(t, err)
+			require.Contains(t, string(lowhttp.GetHTTPPacketBody(rsp.RawPacket)), "modified")
+			require.EqualValues(t, 0, originalHits.Load(), "the original upstream port must not receive the edited request")
+			require.EqualValues(t, 1, modifiedHits.Load(), "the edited upstream port should receive the request")
+		})
+	}
+}
+
+func TestMITMRequestHijackHostOnlyPreservesUpstream(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var receivedHost atomic.Value
+	originalHost, originalPort := utils.DebugMockHTTPServerWithContext(ctx, false, false, false, false, false, func(req []byte) []byte {
+		receivedHost.Store(lowhttp.GetHTTPPacketHeader(req, "Host"))
+		return []byte("HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\noriginal")
+	})
+
+	proxy, err := NewMITMServer(
+		MITM_SetDisableSystemProxy(true),
+		MITM_SetHTTPRequestHijackRaw(func(_ bool, req *http.Request, raw []byte) []byte {
+			modified := lowhttp.ReplaceHTTPPacketHost(raw, "virtual.example")
+			httpctx.SetRequestModified(req, "test host-only hijack")
+			httpctx.SetHijackedRequestBytes(req, modified)
+			return modified
+		}),
+	)
+	require.NoError(t, err)
+
+	proxyAddr := utils.HostPort("127.0.0.1", utils.GetRandomAvailableTCPPort())
+	ready := make(chan struct{})
+	go func() {
+		_ = proxy.ServeWithListenedCallback(ctx, proxyAddr, func() { close(ready) })
+	}()
+	select {
+	case <-ready:
+	case <-ctx.Done():
+		t.Fatal("MITM proxy did not start")
+	}
+
+	originalAddr := utils.HostPort(originalHost, originalPort)
+	packet := []byte(fmt.Sprintf("GET /host-only HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", originalAddr))
+	rsp, err := lowhttp.HTTPWithoutRedirect(
+		lowhttp.WithRequest(packet),
+		lowhttp.WithProxy("http://"+proxyAddr),
+		lowhttp.WithEnableSystemProxyFromEnv(false),
+		lowhttp.WithConnectTimeout(3*time.Second),
+		lowhttp.WithTimeout(5*time.Second),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(lowhttp.GetHTTPPacketBody(rsp.RawPacket)))
+	require.Equal(t, "virtual.example", receivedHost.Load())
+}

--- a/common/crep/mitm_hijack_handler.go
+++ b/common/crep/mitm_hijack_handler.go
@@ -22,6 +22,24 @@ import (
 	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
 )
 
+func getRequestUpstreamPort(req *http.Request, isHTTPS bool) (int, bool, bool) {
+	if req == nil {
+		return 0, false, false
+	}
+
+	reqCopy := req.Clone(req.Context())
+	targetURL, err := lowhttp.ExtractURLFromHTTPRequest(reqCopy, isHTTPS)
+	if err != nil || targetURL == nil {
+		return 0, false, false
+	}
+
+	host, port, err := utils.ParseStringToHostPort(targetURL.String())
+	if err != nil || host == "" || port <= 0 {
+		return 0, false, false
+	}
+	return port, targetURL.Port() != "", true
+}
+
 func (m *MITMServer) setHijackHandler(rootCtx context.Context) {
 	group := fifo.NewGroup()
 
@@ -135,6 +153,7 @@ func (m *MITMServer) hijackRequestHandler(rootCtx context.Context, wsModifier *W
 	httpctx.SetRequestHTTPS(req, isHttps)
 
 	if m.requestHijackHandler != nil {
+		originalPort, _, originalPortOK := getRequestUpstreamPort(req, isHttps)
 		hijackedRaw := httpctx.GetBareRequestBytes(req)
 		if hijackedRaw == nil || len(hijackedRaw) == 0 {
 			hijackedRaw, err := utils.DumpHTTPRequest(req, true)
@@ -179,6 +198,8 @@ func (m *MITMServer) hijackRequestHandler(rootCtx context.Context, wsModifier *W
 			if isHttps {
 				hijackedReq.TLS = req.TLS
 			}
+			hijackedPort, hijackedPortExplicit, hijackedPortOK := getRequestUpstreamPort(hijackedReq, isHttps)
+			httpctx.SetUpstreamPortModified(req, originalPortOK && hijackedPortOK && hijackedPortExplicit && originalPort != hijackedPort)
 			hijackedReq.RemoteAddr = req.RemoteAddr
 			if req.ProtoMajor != 2 {
 				hijackedReq.Proto = "HTTP/1.1"

--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -92,6 +92,7 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 
 	// In strong host mode, disable connection pool
 	// Strong host connections must not be reused from pool
+	upstreamPortModified := httpctx.GetUpstreamPortIsModified(req)
 	opts := append(
 		p.lowhttpConfig,
 		lowhttp.WithRequest(reqBytes),
@@ -142,20 +143,21 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 	//	}
 	//}
 
-	connectedPort := httpctx.GetContextIntInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToPort)
-	if connectedPort > 0 {
-		opts = append(opts, lowhttp.WithPort(connectedPort))
+	connectedHost := httpctx.GetContextStringInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToHost)
+	if isStrongHostMode || !upstreamPortModified {
+		connectedPort := httpctx.GetContextIntInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToPort)
+		if connectedPort > 0 {
+			opts = append(opts, lowhttp.WithPort(connectedPort))
+		}
 	}
 
-	connectedHost := httpctx.GetContextStringInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToHost)
-
-	// Determine the hostname to use for connection target
+	// Preserve the original connection host so Host-header rewriting continues to support
+	// virtual-host testing. Only an explicitly edited port changes the socket target.
 	if connectedHost != "" {
 		opts = append(opts, lowhttp.WithHost(connectedHost))
 	}
 
-	// Set TLS SNI if available and different from connection host
-	// This is important when connectedHost is an IP but we need a domain for SNI
+	// Host-header rewriting must not implicitly change TLS SNI.
 	tlsSNI := httpctx.GetContextStringInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_TLS_SNI)
 	if isHttps && tlsSNI != "" && tlsSNI != connectedHost {
 		opts = append(opts, lowhttp.WithSNI(tlsSNI))

--- a/common/utils/lowhttp/httpctx/base.go
+++ b/common/utils/lowhttp/httpctx/base.go
@@ -310,6 +310,7 @@ const (
 	RESPONSE_CONTEXT_KEY_ReaderOffset                = "rsp_reader_offset"
 	RESPONSE_CONTEXT_KEY_Timestamp                   = "timestamp_response"
 	REQUEST_CONTEXT_KEY_RequestIsModified            = "requestIsModified"
+	REQUEST_CONTEXT_KEY_UpstreamPortIsModified       = "upstreamPortIsModified"
 	REQUEST_CONTEXT_KEY_ResponseIsModified           = "responseIsModified"
 	REQUEST_CONTEXT_KEY_RequestModifiedBy            = "requestIsModifiedBy"
 	REQUEST_CONTEXT_KEY_ResponseModifiedBy           = "responseIsModifiedBy"
@@ -656,6 +657,14 @@ func SetRequestModified(req *http.Request, by ...string) {
 
 func GetRequestIsModified(req *http.Request) bool {
 	return GetContextBoolInfoFromRequest(req, REQUEST_CONTEXT_KEY_RequestIsModified)
+}
+
+func SetUpstreamPortModified(req *http.Request, modified bool) {
+	SetContextValueInfoFromRequest(req, REQUEST_CONTEXT_KEY_UpstreamPortIsModified, modified)
+}
+
+func GetUpstreamPortIsModified(req *http.Request) bool {
+	return GetContextBoolInfoFromRequest(req, REQUEST_CONTEXT_KEY_UpstreamPortIsModified)
 }
 
 func SetResponseModified(req *http.Request, by ...string) {


### PR DESCRIPTION
…difications

- Introduced `mitm_authority_hijack_test.go` to validate the behavior of MITM request hijacking for both HTTP and HTTPS.
- Implemented tests to ensure that the original upstream port is not hit when a request is modified and that the modified request is correctly routed.
- Enhanced the MITM server to track upstream port modifications and added context handling for hijacked requests.
- Updated `mitm_hijack_handler.go` and `lowhttp_exec.go` to support new functionality for upstream port tracking.