### PR TITLE
fix(ssadb): 修复 PostgreSQL NUL byte 导致扫描在编译阶段失败

### DIFF
--- a/common/yak/ssa/ssadb/sanitize_for_pg.go
+++ b/common/yak/ssa/ssadb/sanitize_for_pg.go
@@ -1,0 +1,130 @@
+package ssadb
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+)
+
+// sanitizeStringForPG removes NUL bytes (\x00) from a string.
+//
+// PostgreSQL rejects NUL bytes at the wire-protocol level — they never reach
+// column validation, triggers, or CHECK constraints. Any Go string that
+// contains a NUL byte and is sent through libpq (e.g. via GORM tx.Save) will
+// fail with: "pq: invalid byte sequence for encoding \"UTF8\": 0x00".
+//
+// MySQL (utf8mb4) and SQLite tolerate NUL bytes, so this is a PostgreSQL-only
+// concern. SSA string constants derived from source code (e.g. binary resource
+// files parsed as constants) can carry NUL bytes; without stripping, the
+// entire batch write aborts and the scan fails at the compile phase.
+//
+// NUL bytes have no semantic value in SSA IR (they are never part of valid
+// source identifiers, type names, or instruction strings), so stripping is
+// lossless from the perspective of vulnerability detection.
+func sanitizeStringForPG(s string) string {
+	if !strings.ContainsRune(s, 0) {
+		return s
+	}
+	return strings.ReplaceAll(s, "\x00", "")
+}
+
+// sanitizeStructStringsForPG uses reflection to strip NUL bytes from every
+// string field (and every element of []string fields) on a struct. This
+// automatically covers newly added string fields without manual maintenance.
+//
+// It handles:
+//   - Top-level string fields
+//   - string fields inside embedded structs (e.g. gorm.Model is NOT embedded
+//     in IrNamePool, but IrCode embeds gorm.Model — gorm.Model has no string
+//     fields, so it is a no-op there)
+//   - Custom types whose underlying type is []string (e.g. StringSlice)
+//
+// It is called from BeforeSave GORM hooks on each SSA DB model.
+func sanitizeStructStringsForPG(v any) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr {
+		return
+	}
+	rv = rv.Elem()
+	if rv.Kind() != reflect.Struct {
+		return
+	}
+	sanitizeStructFieldsForPG(rv)
+}
+
+// sanitizeStructFieldsForPG walks the struct's fields recursively.
+func sanitizeStructFieldsForPG(rv reflect.Value) {
+	t := rv.Type()
+	for i := 0; i < rv.NumField(); i++ {
+		field := rv.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		switch field.Kind() {
+		case reflect.String:
+			s := field.String()
+			if strings.ContainsRune(s, 0) {
+				field.SetString(sanitizeStringForPG(s))
+			}
+		case reflect.Slice:
+			// Handle []string (including StringSlice which is []string)
+			if field.Type().Elem().Kind() == reflect.String {
+				sanitizeStringSliceForPG(field)
+			}
+		case reflect.Struct:
+			// Recurse into embedded/anonymous structs only (avoid touching
+			// non-embedded value structs that we don't own).
+			if t.Field(i).Anonymous {
+				sanitizeStructFieldsForPG(field)
+			}
+		case reflect.Ptr:
+			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+				sanitizeStructFieldsForPG(field.Elem())
+			}
+		}
+	}
+}
+
+// sanitizeStringSliceForPG strips NUL bytes from every element of a []string
+// slice (including the StringSlice custom type).
+func sanitizeStringSliceForPG(field reflect.Value) {
+	if field.Type().Elem().Kind() != reflect.String {
+		return
+	}
+	n := field.Len()
+	for i := 0; i < n; i++ {
+		elem := field.Index(i)
+		s := elem.String()
+		if strings.ContainsRune(s, 0) {
+			elem.SetString(sanitizeStringForPG(s))
+		}
+	}
+}
+
+// BeforeSave hooks for SSA DB models.
+//
+// These hooks fire on every GORM write path: tx.Save, db.Save, db.Create,
+// and db.Where().Assign().FirstOrCreate() (used by UpsertIrCode). They run
+// before the row is sent to PostgreSQL, stripping NUL bytes that PG would
+// reject at the protocol level.
+
+func (r *IrCode) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(r)
+	return nil
+}
+
+func (t *IrType) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(t)
+	return nil
+}
+
+func (i *IrNamePool) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(i)
+	return nil
+}
+
+func (r *IrOffset) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(r)
+	return nil
+}

--- a/common/yak/ssa/ssadb/sanitize_for_pg_test.go
+++ b/common/yak/ssa/ssadb/sanitize_for_pg_test.go
@@ -1,0 +1,175 @@
+package ssadb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeStringForPG(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"clean string", "hello world", "hello world"},
+		{"single NUL", "hello\x00world", "helloworld"},
+		{"leading NUL", "\x00start", "start"},
+		{"trailing NUL", "end\x00", "end"},
+		{"multiple NUL", "a\x00b\x00c\x00", "abc"},
+		{"only NUL", "\x00\x00\x00", ""},
+		{"empty", "", ""},
+		{"tab is preserved", "hello\tworld", "hello\tworld"},
+		{"newline is preserved", "hello\nworld", "hello\nworld"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeStringForPG(tt.input)
+			assert.Equal(t, tt.expected, result)
+			assert.False(t, strings.ContainsRune(result, 0), "result must not contain NUL byte")
+		})
+	}
+
+	// Fast path: strings without NUL should be returned as-is (same pointer)
+	clean := "no nulls here"
+	result := sanitizeStringForPG(clean)
+	assert.Equal(t, clean, result)
+}
+
+func TestSanitizeStructStringsForPG_IrCode(t *testing.T) {
+	ir := &IrCode{
+		ProgramName:       "test\x00program",
+		Name:              "func\x00name",
+		VerboseName:       "verbose\x00name",
+		ShortVerboseName:  "short\x00name",
+		String:            "const\x00value",
+		OpcodeName:        "opcode",
+		SourceCodeHash:    "hash\x00abc",
+		ProgramCompileHash: "compile\x00hash",
+		ConstType:         "normal",
+		Variable:          StringSlice{"var\x001", "var2", "var\x003"},
+	}
+
+	sanitizeStructStringsForPG(ir)
+
+	assert.NotContains(t, ir.ProgramName, "\x00")
+	assert.Equal(t, "testprogram", ir.ProgramName)
+	assert.Equal(t, "funcname", ir.Name)
+	assert.Equal(t, "verbosename", ir.VerboseName)
+	assert.Equal(t, "shortname", ir.ShortVerboseName)
+	assert.Equal(t, "constvalue", ir.String)
+	assert.Equal(t, "hashabc", ir.SourceCodeHash)
+	assert.Equal(t, "compilehash", ir.ProgramCompileHash)
+	// Non-NUL fields unchanged
+	assert.Equal(t, "opcode", ir.OpcodeName)
+	assert.Equal(t, "normal", ir.ConstType)
+	// StringSlice elements
+	assert.Equal(t, StringSlice{"var1", "var2", "var3"}, ir.Variable)
+}
+
+func TestSanitizeStructStringsForPG_IrType(t *testing.T) {
+	ir := &IrType{
+		ProgramName: "test\x00prog",
+		String:      "type\x00name",
+	}
+	sanitizeStructStringsForPG(ir)
+	assert.Equal(t, "testprog", ir.ProgramName)
+	assert.Equal(t, "typename", ir.String)
+}
+
+func TestSanitizeStructStringsForPG_IrNamePool(t *testing.T) {
+	pool := &IrNamePool{
+		ProgramName: "prog\x00name",
+		Name:        "var\x00iable",
+	}
+	sanitizeStructStringsForPG(pool)
+	assert.Equal(t, "progname", pool.ProgramName)
+	assert.Equal(t, "variable", pool.Name)
+}
+
+func TestSanitizeStructStringsForPG_IrOffset(t *testing.T) {
+	offset := &IrOffset{
+		ProgramName:  "test\x00prog",
+		VariableName: "var\x00name",
+		FileHash:     "hash\x00123",
+	}
+	sanitizeStructStringsForPG(offset)
+	assert.Equal(t, "testprog", offset.ProgramName)
+	assert.Equal(t, "varname", offset.VariableName)
+	assert.Equal(t, "hash123", offset.FileHash)
+}
+
+func TestBeforeSaveHookStripsNUL_IrCode(t *testing.T) {
+	// Use SQLite to test the BeforeSave hook fires and strips NUL.
+	// SQLite tolerates NUL bytes, so without the hook the value would be
+	// stored as-is. With the hook, NUL bytes should be stripped before save.
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&IrCode{}).Error)
+
+	ir := &IrCode{
+		ProgramName: "test\x00program",
+		Name:        "func\x00name",
+		String:      "hello\x00world",
+	}
+	require.NoError(t, db.Save(ir).Error)
+
+	// Read back
+	var result IrCode
+	require.NoError(t, db.First(&result, ir.ID).Error)
+
+	assert.NotContains(t, result.ProgramName, "\x00", "ProgramName should have NUL stripped")
+	assert.NotContains(t, result.Name, "\x00", "Name should have NUL stripped")
+	assert.NotContains(t, result.String, "\x00", "String should have NUL stripped")
+	assert.Equal(t, "testprogram", result.ProgramName)
+	assert.Equal(t, "funcname", result.Name)
+	assert.Equal(t, "helloworld", result.String)
+}
+
+func TestBeforeSaveHookStripsNUL_IrNamePool(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&IrNamePool{}).Error)
+
+	pool := &IrNamePool{
+		ProgramName: "test\x00prog",
+		Name:        "var\x00name",
+	}
+	require.NoError(t, db.Save(pool).Error)
+
+	var result IrNamePool
+	require.NoError(t, db.First(&result, pool.NameID).Error)
+	assert.Equal(t, "testprog", result.ProgramName)
+	assert.Equal(t, "varname", result.Name)
+}
+
+func TestBeforeSaveHookStripsNUL_UpsertIrCode(t *testing.T) {
+	// UpsertIrCode uses db.Where().Assign().FirstOrCreate() which also
+	// triggers BeforeSave. Verify the hook covers this path.
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&IrCode{}).Error)
+
+	ir := &IrCode{
+		ProgramName: "test\x00upsert",
+		CodeID:      1,
+		Name:        "func\x00x",
+	}
+	require.NoError(t, UpsertIrCode(db, ir))
+
+	var result IrCode
+	require.NoError(t, db.Where("program_name = ?", "testupsert").First(&result).Error)
+	assert.Equal(t, "testupsert", result.ProgramName)
+	assert.Equal(t, "funcx", result.Name)
+}

--- a/common/yak/ssa/ssadb/source.go
+++ b/common/yak/ssa/ssadb/source.go
@@ -198,5 +198,7 @@ func (irSource *IrSource) BeforeSave(tx *gorm.DB) error {
 	if irSource.FolderPath == "" {
 		irSource.FolderPath = "/"
 	}
+	// Strip NUL bytes from string fields (PostgreSQL rejects them at protocol level)
+	sanitizeStructStringsForPG(irSource)
 	return nil
 }


### PR DESCRIPTION
## 改动摘要

PostgreSQL 在 wire-protocol 层拒绝 NUL byte (`0x00`)，数据根本到不了列验证、触发器或 CHECK 约束。当 SSA 编译器将源码中含 NUL byte 的字符串常量（如二进制资源文件被解析为常量）持久化到 PG `text` 列时，整个 batch 写入中止，报错 `pq: invalid byte sequence for encoding "UTF8": 0x00`，导致扫描在编译阶段失败，零漏洞产出。

## 修复方案

新增反射驱动的 `sanitizeStructStringsForPG` 工具函数，通过反射自动遍历 struct 的所有 string 字段和 `[]string` 切片字段，strip NUL byte。在 `IrCode`、`IrType`、`IrNamePool`、`IrOffset`、`IrSource` 的 `BeforeSave` GORM hook 中调用。

- **新增字段自动覆盖**：反射遍历所有 string 字段，不需要手动维护列名列表
- **MySQL/SQLite 不受影响**：PG 专有问题，strip 对 SSA IR 语义无损
- **覆盖所有写入路径**：`tx.Save`、`db.Save`、`db.Create`、`UpsertIrCode` (`FirstOrCreate`) 全部触发 GORM hook
- **幂等**：`strings.ReplaceAll` 对不含 NUL 的字符串直接返回原值（fast path）

## 改动文件

| 文件 | 变更 |
|------|------|
| `common/yak/ssa/ssadb/sanitize_for_pg.go` | 新增：反射工具 + 5 个 BeforeSave hooks |
| `common/yak/ssa/ssadb/sanitize_for_pg_test.go` | 新增：8 个单元测试 |
| `common/yak/ssa/ssadb/source.go` | 修改：在现有 `IrSource.BeforeSave` 中追加 sanitize 调用 |

## 验证方式

### 单元测试
```bash
go test ./common/yak/ssa/ssadb/ -run "TestSanitize|TestBeforeSave" -v
# 全部 PASS（8 个测试）
```

### 端到端验证

靶场：JavaSecLab（Gitea 私有仓库），数据库：PostgreSQL

| 指标 | 修前 | 修后 |
|------|------|------|
| scan status | `failed` | `succeeded` |
| completed_units | 9691/10000 | 10000/10000 |
| error | `persist IR to database failed: pq: invalid byte sequence` | `null` |
| NUL byte 错误次数 | 14 | 0 |
| ir_codes 写入 | 1339（中断） | 189868 |
| ir_types | 1196（中断） | 128814 |
| **ssa_risks（漏洞）** | **0** | **93** |
| audit_results | 0 | 1251 |

修前扫描在编译阶段 9691/10000 处失败，零漏洞。修后扫描 10000/10000 完成，检出 93 条漏洞（含命令注入、XSS、命令执行等）。
