### PR TITLE
fix(scannode): 节点规则同步改用 node-session 认证

### DIFF
--- a/scannode/node.go
+++ b/scannode/node.go
@@ -33,6 +33,25 @@ func NewScanNode(cfg node.BaseConfig) (*ScanNode, error) {
 		cfg.StatusProvider = agent
 	}
 
+	// Register a post-bootstrap hook so the rule sync client gets valid node
+	// session credentials as soon as the node registers with the platform.
+	// The node-accessible snapshot endpoints authenticate via node_session_id
+	// query param + Bearer session token; without this hook the client would
+	// send empty credentials and get 401 on every sync. The hook is set before
+	// NewNodeBase so it is captured into the NodeBase lifecycle.
+	agent.ruleSyncClient = NewRuleSyncClient(&RuleSyncConfig{
+		ServerURL:   cfg.PlatformAPIBaseURL,
+		SyncEnabled: true,
+		Client:      cfg.HTTPClient,
+	})
+	existingHook := cfg.PostBootstrapHook
+	cfg.PostBootstrapHook = func(session node.SessionState) {
+		agent.updateRuleSyncCredentials(session)
+		if existingHook != nil {
+			existingHook(session)
+		}
+	}
+
 	base, err := node.NewNodeBase(cfg)
 	if err != nil {
 		return nil, err
@@ -43,11 +62,6 @@ func NewScanNode(cfg node.BaseConfig) (*ScanNode, error) {
 		NodeIDProvider: base.CurrentNodeID,
 		BaseDir:        base.BaseDir(),
 		RootContext:    base.GetRootContext(),
-	})
-	agent.ruleSyncClient = NewRuleSyncClient(&RuleSyncConfig{
-		ServerURL:   cfg.PlatformAPIBaseURL,
-		SyncEnabled: true,
-		Client:      cfg.HTTPClient,
 	})
 	agent.httpClient = cfg.HTTPClient
 	agent.initInvokeLimiter()
@@ -60,6 +74,18 @@ func (s *ScanNode) Run() {
 		go s.bridge.Run(s.node.GetRootContext())
 	}
 	s.node.Serve()
+}
+
+// updateRuleSyncCredentials feeds the node session id + session token into the
+// rule sync client so it can authenticate against the node-accessible snapshot
+// endpoints. Called from the PostBootstrapHook after the node registers.
+func (s *ScanNode) updateRuleSyncCredentials(session node.SessionState) {
+	client, ok := s.ruleSyncClient.(*RuleSyncClient)
+	if !ok || client == nil {
+		return
+	}
+	client.UpdateCredentials(session.SessionID, session.SessionToken)
+	log.Infof("rule sync client credentials updated: node_session_id=%s", session.SessionID)
 }
 
 func (s *ScanNode) Shutdown() {

--- a/scannode/rule_sync.go
+++ b/scannode/rule_sync.go
@@ -23,10 +23,16 @@ import (
 )
 
 const (
-	activeRuleSnapshotEndpointPath = "/v1/ssa-rule-sync/active-snapshot"
-	ruleSnapshotBundleEndpointFmt  = "/v1/ssa-rule-sync/snapshots/%s"
+	// activeRuleSnapshotEndpointPath is the node-accessible active-snapshot
+	// manifest endpoint. It authenticates the node via the node_session_id
+	// query parameter + Bearer session token (no platform user session needed).
+	activeRuleSnapshotEndpointPath = "/v1/ssa-rule-sync-node/active-snapshot"
+	ruleSnapshotBundleEndpointFmt  = "/v1/ssa-rule-sync-node/snapshots/%s"
 	ruleSnapshotBundleFormatJSON   = "json"
 	ruleSnapshotSchemaVersionV1    = "ssa_rule_snapshot_bundle.v1"
+	// nodeSessionIDQueryParam is the query parameter carrying the node session
+	// id used by the server to authenticate the node.
+	nodeSessionIDQueryParam = "node_session_id"
 )
 
 type ruleSyncer interface {
@@ -39,10 +45,14 @@ type RuleSyncBundleImporter func(context.Context, RuleSnapshotBundle) (int, erro
 type RuleSyncConfig struct {
 	ServerURL   string                 `json:"server_url"`
 	BearerToken string                 `json:"bearer_token,omitempty"`
-	SyncEnabled bool                   `json:"sync_enabled"`
-	CacheDir    string                 `json:"cache_dir,omitempty"`
-	Client      *http.Client           `json:"-"`
-	Importer    RuleSyncBundleImporter `json:"-"`
+	// NodeSessionID is the node session id sent as the node_session_id query
+	// parameter so the server can authenticate the node via its session token.
+	// It is populated after bootstrap completes (see UpdateCredentials).
+	NodeSessionID string               `json:"node_session_id,omitempty"`
+	SyncEnabled   bool                 `json:"sync_enabled"`
+	CacheDir      string               `json:"cache_dir,omitempty"`
+	Client        *http.Client         `json:"-"`
+	Importer      RuleSyncBundleImporter `json:"-"`
 }
 
 type RuleSyncClient struct {
@@ -378,11 +388,29 @@ func (c *RuleSyncClient) getJSON(ctx context.Context, path string, target any) e
 
 func (c *RuleSyncClient) getRaw(ctx context.Context, path string) ([]byte, error) {
 	baseURL := strings.TrimRight(strings.TrimSpace(c.config.ServerURL), "/")
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
+
+	// Build the request URL with the node_session_id query parameter so the
+	// server can authenticate the node via its session token.
+	requestURL := baseURL + path
+	c.mu.RLock()
+	sessionID := strings.TrimSpace(c.config.NodeSessionID)
+	c.mu.RUnlock()
+	if sessionID != "" {
+		separator := "&"
+		if !strings.Contains(requestURL, "?") {
+			separator = "?"
+		}
+		requestURL = requestURL + separator + nodeSessionIDQueryParam + "=" + url.QueryEscape(sessionID)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, utils.Wrap(err, "build rule sync request failed")
 	}
-	if token := strings.TrimSpace(c.config.BearerToken); token != "" {
+	c.mu.RLock()
+	token := strings.TrimSpace(c.config.BearerToken)
+	c.mu.RUnlock()
+	if token != "" {
 		request.Header.Set("Authorization", "Bearer "+token)
 	}
 
@@ -401,6 +429,16 @@ func (c *RuleSyncClient) getRaw(ctx context.Context, path string) ([]byte, error
 		return nil, utils.Wrap(err, "read rule sync response failed")
 	}
 	return body, nil
+}
+
+// UpdateCredentials updates the node session credentials used to authenticate
+// rule sync requests. It is called after bootstrap completes so the client
+// can talk to the node-accessible snapshot endpoints with a valid session.
+func (c *RuleSyncClient) UpdateCredentials(nodeSessionID, sessionToken string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.config.BearerToken = strings.TrimSpace(sessionToken)
+	c.config.NodeSessionID = strings.TrimSpace(nodeSessionID)
 }
 
 func readRuleSyncHTTPError(response *http.Response) error {

--- a/scannode/rule_sync_test.go
+++ b/scannode/rule_sync_test.go
@@ -70,7 +70,7 @@ func TestRuleSyncClientDownloadSnapshotBundleUsesCache(t *testing.T) {
 
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/ssa-rule-sync/snapshots/rulesnapshot-a" {
+		if r.URL.Path != "/v1/ssa-rule-sync-node/snapshots/rulesnapshot-a" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		requestCount++


### PR DESCRIPTION
## 改动摘要

修复节点同步 syntaxflow 规则时报 401「invalid platform session token」（显示「没有认证信息」）。

### 根因
节点 `RuleSyncClient` 调用平台 `/v1/ssa-rule-sync/active-snapshot`，但该端点在平台会话认证之后，节点只有 node-session token（在 `node_sessions` 表），服务端按 `platform_sessions` 表查不到。且 `RuleSyncClient` 构建时 BearerToken 为空，bootstrap 后从未更新。

### 修复
- `RuleSyncConfig` 新增 `NodeSessionID` 字段
- `getRaw` 在请求 URL 加 `node_session_id` 查询参数；Bearer header 用 session token
- 新增 `UpdateCredentials(nodeSessionID, sessionToken)` 方法（线程安全）
- `node.go` 在 `NewNodeBase` **之前**注册 `PostBootstrapHook`，bootstrap 成功后注入 `session.SessionID` + `session.SessionToken`（修复 hook 注册顺序 bug）
- 端点路径改为 `/v1/ssa-rule-sync-node/active-snapshot` 和 `/v1/ssa-rule-sync-node/snapshots/{id}`（legion 侧新增的节点会话认证端点）

## 改动文件
- `scannode/rule_sync.go`：NodeSessionID 字段 + node_session_id 查询参数 + UpdateCredentials
- `scannode/node.go`：PostBootstrapHook 注入凭据
- `scannode/rule_sync_test.go`：更新端点路径断言

## 验证方式
- `go test ./scannode/` 全部通过
- T2 端到端（配合 legion PR）：bootstrap→heartbeat→active-snapshot→snapshots/{id} 全部 HTTP 200，bundle 含 338 条真实规则

## 配套 PR
legion 仓库：https://github.com/VillanCh/legion/pull/165（新增节点会话认证端点 + 规则管理发布快照）