### PR TITLE
fix(ssadb): strip NUL bytes for PostgreSQL on scannode baseline

### DIFF
--- a/common/yak/ssa/ssadb/sanitize_for_pg.go
+++ b/common/yak/ssa/ssadb/sanitize_for_pg.go
@@ -1,0 +1,130 @@
+package ssadb
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+)
+
+// sanitizeStringForPG removes NUL bytes (\x00) from a string.
+//
+// PostgreSQL rejects NUL bytes at the wire-protocol level — they never reach
+// column validation, triggers, or CHECK constraints. Any Go string that
+// contains a NUL byte and is sent through libpq (e.g. via GORM tx.Save) will
+// fail with: "pq: invalid byte sequence for encoding \"UTF8\": 0x00".
+//
+// MySQL (utf8mb4) and SQLite tolerate NUL bytes, so this is a PostgreSQL-only
+// concern. SSA string constants derived from source code (e.g. binary resource
+// files parsed as constants) can carry NUL bytes; without stripping, the
+// entire batch write aborts and the scan fails at the compile phase.
+//
+// NUL bytes have no semantic value in SSA IR (they are never part of valid
+// source identifiers, type names, or instruction strings), so stripping is
+// lossless from the perspective of vulnerability detection.
+func sanitizeStringForPG(s string) string {
+	if !strings.ContainsRune(s, 0) {
+		return s
+	}
+	return strings.ReplaceAll(s, "\x00", "")
+}
+
+// sanitizeStructStringsForPG uses reflection to strip NUL bytes from every
+// string field (and every element of []string fields) on a struct. This
+// automatically covers newly added string fields without manual maintenance.
+//
+// It handles:
+//   - Top-level string fields
+//   - string fields inside embedded structs (e.g. gorm.Model is NOT embedded
+//     in IrNamePool, but IrCode embeds gorm.Model — gorm.Model has no string
+//     fields, so it is a no-op there)
+//   - Custom types whose underlying type is []string (e.g. StringSlice)
+//
+// It is called from BeforeSave GORM hooks on each SSA DB model.
+func sanitizeStructStringsForPG(v any) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr {
+		return
+	}
+	rv = rv.Elem()
+	if rv.Kind() != reflect.Struct {
+		return
+	}
+	sanitizeStructFieldsForPG(rv)
+}
+
+// sanitizeStructFieldsForPG walks the struct's fields recursively.
+func sanitizeStructFieldsForPG(rv reflect.Value) {
+	t := rv.Type()
+	for i := 0; i < rv.NumField(); i++ {
+		field := rv.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		switch field.Kind() {
+		case reflect.String:
+			s := field.String()
+			if strings.ContainsRune(s, 0) {
+				field.SetString(sanitizeStringForPG(s))
+			}
+		case reflect.Slice:
+			// Handle []string (including StringSlice which is []string)
+			if field.Type().Elem().Kind() == reflect.String {
+				sanitizeStringSliceForPG(field)
+			}
+		case reflect.Struct:
+			// Recurse into embedded/anonymous structs only (avoid touching
+			// non-embedded value structs that we don't own).
+			if t.Field(i).Anonymous {
+				sanitizeStructFieldsForPG(field)
+			}
+		case reflect.Ptr:
+			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+				sanitizeStructFieldsForPG(field.Elem())
+			}
+		}
+	}
+}
+
+// sanitizeStringSliceForPG strips NUL bytes from every element of a []string
+// slice (including the StringSlice custom type).
+func sanitizeStringSliceForPG(field reflect.Value) {
+	if field.Type().Elem().Kind() != reflect.String {
+		return
+	}
+	n := field.Len()
+	for i := 0; i < n; i++ {
+		elem := field.Index(i)
+		s := elem.String()
+		if strings.ContainsRune(s, 0) {
+			elem.SetString(sanitizeStringForPG(s))
+		}
+	}
+}
+
+// BeforeSave hooks for SSA DB models.
+//
+// These hooks fire on every GORM write path: tx.Save, db.Save, db.Create,
+// and db.Where().Assign().FirstOrCreate() (used by UpsertIrCode). They run
+// before the row is sent to PostgreSQL, stripping NUL bytes that PG would
+// reject at the protocol level.
+
+func (r *IrCode) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(r)
+	return nil
+}
+
+func (t *IrType) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(t)
+	return nil
+}
+
+func (i *IrNamePool) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(i)
+	return nil
+}
+
+func (r *IrOffset) BeforeSave(tx *gorm.DB) error {
+	sanitizeStructStringsForPG(r)
+	return nil
+}

--- a/common/yak/ssa/ssadb/sanitize_for_pg_test.go
+++ b/common/yak/ssa/ssadb/sanitize_for_pg_test.go
@@ -1,0 +1,175 @@
+package ssadb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeStringForPG(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"clean string", "hello world", "hello world"},
+		{"single NUL", "hello\x00world", "helloworld"},
+		{"leading NUL", "\x00start", "start"},
+		{"trailing NUL", "end\x00", "end"},
+		{"multiple NUL", "a\x00b\x00c\x00", "abc"},
+		{"only NUL", "\x00\x00\x00", ""},
+		{"empty", "", ""},
+		{"tab is preserved", "hello\tworld", "hello\tworld"},
+		{"newline is preserved", "hello\nworld", "hello\nworld"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeStringForPG(tt.input)
+			assert.Equal(t, tt.expected, result)
+			assert.False(t, strings.ContainsRune(result, 0), "result must not contain NUL byte")
+		})
+	}
+
+	// Fast path: strings without NUL should be returned as-is (same pointer)
+	clean := "no nulls here"
+	result := sanitizeStringForPG(clean)
+	assert.Equal(t, clean, result)
+}
+
+func TestSanitizeStructStringsForPG_IrCode(t *testing.T) {
+	ir := &IrCode{
+		ProgramName:       "test\x00program",
+		Name:              "func\x00name",
+		VerboseName:       "verbose\x00name",
+		ShortVerboseName:  "short\x00name",
+		String:            "const\x00value",
+		OpcodeName:        "opcode",
+		SourceCodeHash:    "hash\x00abc",
+		ProgramCompileHash: "compile\x00hash",
+		ConstType:         "normal",
+		Variable:          StringSlice{"var\x001", "var2", "var\x003"},
+	}
+
+	sanitizeStructStringsForPG(ir)
+
+	assert.NotContains(t, ir.ProgramName, "\x00")
+	assert.Equal(t, "testprogram", ir.ProgramName)
+	assert.Equal(t, "funcname", ir.Name)
+	assert.Equal(t, "verbosename", ir.VerboseName)
+	assert.Equal(t, "shortname", ir.ShortVerboseName)
+	assert.Equal(t, "constvalue", ir.String)
+	assert.Equal(t, "hashabc", ir.SourceCodeHash)
+	assert.Equal(t, "compilehash", ir.ProgramCompileHash)
+	// Non-NUL fields unchanged
+	assert.Equal(t, "opcode", ir.OpcodeName)
+	assert.Equal(t, "normal", ir.ConstType)
+	// StringSlice elements
+	assert.Equal(t, StringSlice{"var1", "var2", "var3"}, ir.Variable)
+}
+
+func TestSanitizeStructStringsForPG_IrType(t *testing.T) {
+	ir := &IrType{
+		ProgramName: "test\x00prog",
+		String:      "type\x00name",
+	}
+	sanitizeStructStringsForPG(ir)
+	assert.Equal(t, "testprog", ir.ProgramName)
+	assert.Equal(t, "typename", ir.String)
+}
+
+func TestSanitizeStructStringsForPG_IrNamePool(t *testing.T) {
+	pool := &IrNamePool{
+		ProgramName: "prog\x00name",
+		Name:        "var\x00iable",
+	}
+	sanitizeStructStringsForPG(pool)
+	assert.Equal(t, "progname", pool.ProgramName)
+	assert.Equal(t, "variable", pool.Name)
+}
+
+func TestSanitizeStructStringsForPG_IrOffset(t *testing.T) {
+	offset := &IrOffset{
+		ProgramName:  "test\x00prog",
+		VariableName: "var\x00name",
+		FileHash:     "hash\x00123",
+	}
+	sanitizeStructStringsForPG(offset)
+	assert.Equal(t, "testprog", offset.ProgramName)
+	assert.Equal(t, "varname", offset.VariableName)
+	assert.Equal(t, "hash123", offset.FileHash)
+}
+
+func TestBeforeSaveHookStripsNUL_IrCode(t *testing.T) {
+	// Use SQLite to test the BeforeSave hook fires and strips NUL.
+	// SQLite tolerates NUL bytes, so without the hook the value would be
+	// stored as-is. With the hook, NUL bytes should be stripped before save.
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&IrCode{}).Error)
+
+	ir := &IrCode{
+		ProgramName: "test\x00program",
+		Name:        "func\x00name",
+		String:      "hello\x00world",
+	}
+	require.NoError(t, db.Save(ir).Error)
+
+	// Read back
+	var result IrCode
+	require.NoError(t, db.First(&result, ir.ID).Error)
+
+	assert.NotContains(t, result.ProgramName, "\x00", "ProgramName should have NUL stripped")
+	assert.NotContains(t, result.Name, "\x00", "Name should have NUL stripped")
+	assert.NotContains(t, result.String, "\x00", "String should have NUL stripped")
+	assert.Equal(t, "testprogram", result.ProgramName)
+	assert.Equal(t, "funcname", result.Name)
+	assert.Equal(t, "helloworld", result.String)
+}
+
+func TestBeforeSaveHookStripsNUL_IrNamePool(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&IrNamePool{}).Error)
+
+	pool := &IrNamePool{
+		ProgramName: "test\x00prog",
+		Name:        "var\x00name",
+	}
+	require.NoError(t, db.Save(pool).Error)
+
+	var result IrNamePool
+	require.NoError(t, db.First(&result, pool.NameID).Error)
+	assert.Equal(t, "testprog", result.ProgramName)
+	assert.Equal(t, "varname", result.Name)
+}
+
+func TestBeforeSaveHookStripsNUL_UpsertIrCode(t *testing.T) {
+	// UpsertIrCode uses db.Where().Assign().FirstOrCreate() which also
+	// triggers BeforeSave. Verify the hook covers this path.
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&IrCode{}).Error)
+
+	ir := &IrCode{
+		ProgramName: "test\x00upsert",
+		CodeID:      1,
+		Name:        "func\x00x",
+	}
+	require.NoError(t, UpsertIrCode(db, ir))
+
+	var result IrCode
+	require.NoError(t, db.Where("program_name = ?", "testupsert").First(&result).Error)
+	assert.Equal(t, "testupsert", result.ProgramName)
+	assert.Equal(t, "funcx", result.Name)
+}

--- a/common/yak/ssa/ssadb/source.go
+++ b/common/yak/ssa/ssadb/source.go
@@ -198,5 +198,7 @@ func (irSource *IrSource) BeforeSave(tx *gorm.DB) error {
 	if irSource.FolderPath == "" {
 		irSource.FolderPath = "/"
 	}
+	// Strip NUL bytes from string fields (PostgreSQL rejects them at protocol level)
+	sanitizeStructStringsForPG(irSource)
 	return nil
 }


### PR DESCRIPTION
## Problem

PostgreSQL rejects NUL bytes (0x00) at the wire-protocol level. When the SSA compiler persists string constants from source code containing NUL bytes (e.g. binary resources in JavaSecLab), the entire batch write aborts with 'pq: invalid byte sequence for encoding UTF8: 0x00', causing scan failure at compile phase with zero findings.

## Fix

Cherry-pick of commit 303197d87 (originally targeting main via PR #4767) onto the go0p/refactor/scannode baseline, so scannode-track development is not blocked waiting for the main-track PR to merge.

Adds a reflection-driven sanitizeStructStringsForPG utility that strips NUL bytes from all string fields on a struct. Wired into BeforeSave GORM hooks on IrCode, IrType, IrNamePool, IrOffset, and IrSource.

## Verification

- JavaSecLab scan on PostgreSQL: compile phase 105383 lines succeeded (previously failed at persist IR with 0 findings)
- All ssadb tests pass

## Related

- Main-track PR (same fix, targets main): https://github.com/yaklang/yaklang/pull/4767
- This PR targets go0p/refactor/scannode per Split-Branch Strategy so the refactor track is not blocked
- At final main rebase, the owner reconciles the duplicate (drop the scannode copy if the main version landed first)