### PR TITLE
fix(ssa): protect OffsetMap from concurrent writes via offsetStore

### DIFF
--- a/common/yak/ssa/offset_item.go
+++ b/common/yak/ssa/offset_item.go
@@ -1,7 +1,6 @@
 package ssa
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/yaklang/yaklang/common/utils/memedit"
@@ -40,57 +39,21 @@ func InsertSortedIntSlice(ts []int, t int) []int {
 }
 
 func (prog *Program) ShowOffsetMap() {
-	for i := 0; i < len(prog.OffsetSortedSlice); i++ {
-		offset := prog.OffsetSortedSlice[i]
-		value := prog.OffsetMap[offset].GetValue()
-		if value == nil {
-		}
-		fmt.Printf("%d: %s\n", offset, value.String())
-	}
+	prog.offsets.showAll()
 }
 
 func (prog *Program) SetOffsetVariable(v *Variable, r *memedit.Range) {
-	if r == nil {
-		return
-	}
-	endOffset := r.GetEndOffset()
-
-	// If it already exists, then the trust range is smaller
-	if item, ok := prog.OffsetMap[endOffset]; ok && item.rangeLength <= r.Len() {
-		return
-	}
-
-	prog.OffsetSortedSlice = InsertSortedIntSlice(prog.OffsetSortedSlice, endOffset)
-	prog.OffsetMap[endOffset] = &OffsetItem{
-		variable:    v,
-		value:       v.GetValue(),
-		rangeLength: r.Len(),
-	}
+	prog.offsets.setVariable(v, r)
 }
 
 func (prog *Program) ForceSetOffsetValue(v Value, r *memedit.Range) {
-	prog.SetOffsetValueEx(v, r, true)
+	prog.offsets.setValue(v, r, true)
 }
 
 func (prog *Program) SetOffsetValue(v Value, r *memedit.Range) {
-	prog.SetOffsetValueEx(v, r, false)
+	prog.offsets.setValue(v, r, false)
 }
 
 func (prog *Program) SetOffsetValueEx(v Value, r *memedit.Range, force bool) {
-	if r == nil {
-		return
-	}
-	endOffset := r.GetEndOffset()
-
-	// If it already exists, then the trust range is smaller
-	if item, ok := prog.OffsetMap[endOffset]; !force && ok && item.rangeLength <= r.Len() {
-		return
-	}
-
-	prog.OffsetSortedSlice = InsertSortedIntSlice(prog.OffsetSortedSlice, endOffset)
-	prog.OffsetMap[endOffset] = &OffsetItem{
-		variable:    nil,
-		value:       v,
-		rangeLength: r.Len(),
-	}
+	prog.offsets.setValue(v, r, force)
 }

--- a/common/yak/ssa/offset_store.go
+++ b/common/yak/ssa/offset_store.go
@@ -1,0 +1,144 @@
+package ssa
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/yaklang/yaklang/common/utils/memedit"
+)
+
+// offsetStore wraps OffsetMap and OffsetSortedSlice with a RWMutex to
+// protect concurrent access during syntaxflow scan parallelism.
+//
+// LazyInstruction materialization from multiple goroutines (triggered by
+// concurrent syntaxflow scan rules) can invoke setValue/setVariable
+// simultaneously on the same Program. Without locking, this triggers
+// "fatal error: concurrent map writes".
+type offsetStore struct {
+	mu            sync.RWMutex
+	offsetMap     map[int]*OffsetItem
+	sortedOffsets []int
+}
+
+func newOffsetStore() *offsetStore {
+	return &offsetStore{
+		offsetMap:     make(map[int]*OffsetItem),
+		sortedOffsets: make([]int, 0),
+	}
+}
+
+func (s *offsetStore) setVariable(v *Variable, r *memedit.Range) {
+	if r == nil {
+		return
+	}
+	endOffset := r.GetEndOffset()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if item, ok := s.offsetMap[endOffset]; ok && item.rangeLength <= r.Len() {
+		return
+	}
+	s.sortedOffsets = InsertSortedIntSlice(s.sortedOffsets, endOffset)
+	s.offsetMap[endOffset] = &OffsetItem{
+		variable:    v,
+		value:       v.GetValue(),
+		rangeLength: r.Len(),
+	}
+}
+
+func (s *offsetStore) setValue(v Value, r *memedit.Range, force bool) {
+	if r == nil {
+		return
+	}
+	endOffset := r.GetEndOffset()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if item, ok := s.offsetMap[endOffset]; !force && ok && item.rangeLength <= r.Len() {
+		return
+	}
+	s.sortedOffsets = InsertSortedIntSlice(s.sortedOffsets, endOffset)
+	s.offsetMap[endOffset] = &OffsetItem{
+		variable:    nil,
+		value:       v,
+		rangeLength: r.Len(),
+	}
+}
+
+func (s *offsetStore) get(offset int) (*OffsetItem, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, ok := s.offsetMap[offset]
+	return item, ok
+}
+
+func (s *offsetStore) count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.offsetMap)
+}
+
+func (s *offsetStore) searchIndexAndOffset(searchOffset int) (index int, offset int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	index = sort.Search(len(s.sortedOffsets), func(i int) bool {
+		return s.sortedOffsets[i] >= searchOffset
+	})
+	if index >= len(s.sortedOffsets) && len(s.sortedOffsets) > 0 {
+		index = len(s.sortedOffsets) - 1
+	}
+	if len(s.sortedOffsets) > 0 {
+		offset = s.sortedOffsets[index]
+	}
+	return
+}
+
+func (s *offsetStore) getFrontValue(searchOffset int) (offset int, value Value) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	index := sort.Search(len(s.sortedOffsets), func(i int) bool {
+		return s.sortedOffsets[i] >= searchOffset
+	})
+	if index >= len(s.sortedOffsets) && len(s.sortedOffsets) > 0 {
+		index = len(s.sortedOffsets) - 1
+	}
+	if len(s.sortedOffsets) > 0 {
+		offset = s.sortedOffsets[index]
+	}
+	if offset > searchOffset {
+		if index > 0 {
+			index -= 1
+		}
+		offset = s.sortedOffsets[index]
+	}
+	if item, ok := s.offsetMap[offset]; ok {
+		value = item.GetValue()
+	}
+	return
+}
+
+func (s *offsetStore) showAll() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := 0; i < len(s.sortedOffsets); i++ {
+		offset := s.sortedOffsets[i]
+		value := s.offsetMap[offset].GetValue()
+		fmt.Printf("%d: %s\n", offset, value.String())
+	}
+}
+
+func (s *offsetStore) getAllOffsetItemsBefore(offset int) []*OffsetItem {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	index := sort.SearchInts(s.sortedOffsets, offset)
+	if index < len(s.sortedOffsets) && s.sortedOffsets[index] > offset && index > 0 {
+		index--
+	}
+	beforeSlice := s.sortedOffsets[:index]
+	result := make([]*OffsetItem, 0, len(beforeSlice))
+	for _, off := range beforeSlice {
+		if item := s.offsetMap[off]; item != nil && item.GetVariable() != nil {
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/common/yak/ssa/offset_store_test.go
+++ b/common/yak/ssa/offset_store_test.go
@@ -1,0 +1,149 @@
+package ssa
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils/memedit"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+// newOffsetTestProgram creates a minimal Program with a mem editor for offset tests.
+func newOffsetTestProgram(t *testing.T) (*Program, *memedit.MemEditor) {
+	t.Helper()
+	cfg, _ := ssaconfig.New(ssaconfig.ModeSSACompile, ssaconfig.WithSetProgramName(t.Name()))
+	prog := NewProgram(cfg, ProgramCacheMemory, Application, nil, "", 0)
+	// 300-byte content so offsets 0..99 each map to a unique endOffset
+	content := make([]byte, 300)
+	for i := range content {
+		content[i] = 'x'
+	}
+	editor := memedit.NewMemEditor(string(content))
+	editor.SetFileName("test.yak")
+	prog.PushEditor(editor)
+	return prog, editor
+}
+
+// TestProgramSetOffsetValueConcurrent verifies that concurrent calls to
+// SetOffsetValue on the same Program do not trigger
+// "fatal error: concurrent map writes".
+//
+// Before the offsetStore fix, this test panics because OffsetMap and
+// OffsetSortedSlice are unprotected plain map/slice. Values and ranges
+// are pre-created (single-threaded) to isolate the test to offsetStore's
+// locking correctness.
+func TestProgramSetOffsetValueConcurrent(t *testing.T) {
+	prog, editor := newOffsetTestProgram(t)
+
+	builder := prog.GetAndCreateFunctionBuilder("", string(MainFunctionName))
+	require.NotNil(t, builder)
+
+	// Pre-create values and ranges (single-threaded) — builder.EmitConstInst
+	// is not goroutine-safe, so we must not call it concurrently.
+	type item struct {
+		val Value
+		r   *memedit.Range
+	}
+	items := make([]item, 100)
+	for i := 0; i < 100; i++ {
+		val := builder.EmitConstInst(i)
+		r := memedit.NewRangeFromOffsets(editor, i, i+1)
+		items[i] = item{val: val, r: r}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			prog.SetOffsetValue(items[n].val, items[n].r)
+		}(i)
+	}
+	wg.Wait()
+	// If we reach here without panic, the concurrent map writes bug is fixed.
+}
+
+// TestProgramSetOffsetValueAndReadConcurrent verifies no race between
+// concurrent writes (SetOffsetValue) and reads (GetFrontValueByOffset /
+// SearchIndexAndOffsetByOffset) on the same Program.
+func TestProgramSetOffsetValueAndReadConcurrent(t *testing.T) {
+	prog, editor := newOffsetTestProgram(t)
+
+	builder := prog.GetAndCreateFunctionBuilder("", string(MainFunctionName))
+	require.NotNil(t, builder)
+
+	// Pre-create values and ranges (single-threaded)
+	type item struct {
+		val Value
+		r   *memedit.Range
+	}
+	items := make([]item, 70)
+	for i := 0; i < 70; i++ {
+		val := builder.EmitConstInst(i)
+		r := memedit.NewRangeFromOffsets(editor, i, i+1)
+		items[i] = item{val: val, r: r}
+	}
+
+	// Seed some offsets first so readers have data
+	for i := 0; i < 20; i++ {
+		prog.SetOffsetValue(items[i].val, items[i].r)
+	}
+
+	var wg sync.WaitGroup
+	// Concurrent writers (use pre-created items[20..69])
+	for i := 20; i < 70; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			prog.SetOffsetValue(items[n].val, items[n].r)
+		}(i)
+	}
+	// Concurrent readers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			prog.GetFrontValueByOffset(n)
+			prog.SearchIndexAndOffsetByOffset(n)
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestOffsetStoreConcurrentSetIsAtomic verifies the offsetStore directly:
+// concurrent setValue calls with distinct endOffsets must all be preserved
+// (no lost writes due to race).
+func TestOffsetStoreConcurrentSetIsAtomic(t *testing.T) {
+	store := newOffsetStore()
+	content := make([]byte, 300)
+	for i := range content {
+		content[i] = 'x'
+	}
+	editor := memedit.NewMemEditor(string(content))
+
+	// Pre-create all ranges (single-threaded) to isolate offsetStore locking
+	ranges := make([]*memedit.Range, 100)
+	for i := 0; i < 100; i++ {
+		ranges[i] = memedit.NewRangeFromOffsets(editor, i, i+1)
+	}
+
+	// Verify all endOffsets are unique (sanity check)
+	endOffsets := make(map[int]bool, 100)
+	for _, r := range ranges {
+		endOffsets[r.GetEndOffset()] = true
+	}
+	require.Equal(t, 100, len(endOffsets), "precondition: all 100 ranges must have unique endOffsets")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			store.setValue(nil, ranges[n], false)
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, 100, store.count(), "all 100 concurrent writes should be preserved")
+}

--- a/common/yak/ssa/program.go
+++ b/common/yak/ssa/program.go
@@ -2,7 +2,6 @@ package ssa
 
 import (
 	"path/filepath"
-	"sort"
 	"strings"
 
 	tl "github.com/yaklang/yaklang/common/yak/templateLanguage"
@@ -36,8 +35,7 @@ func NewProgram(
 		UpStream:                omap.NewEmptyOrderedMap[string, *Program](),
 		DownStream:              make(map[string]*Program),
 		errors:                  make([]*SSAError, 0),
-		OffsetMap:               make(map[int]*OffsetItem),
-		OffsetSortedSlice:       make([]int, 0),
+		offsets:                 newOffsetStore(),
 		Funcs:                   omap.NewEmptyOrderedMap[string, *Function](),
 		Blueprint:               omap.NewEmptyOrderedMap[string, *Blueprint](),
 		BlueprintStack:          utils.NewStack[*Blueprint](),
@@ -85,8 +83,7 @@ func NewTmpProgram(ProgramName string) *Program {
 		UpStream:                omap.NewEmptyOrderedMap[string, *Program](),
 		DownStream:              make(map[string]*Program),
 		errors:                  make([]*SSAError, 0),
-		OffsetMap:               make(map[int]*OffsetItem),
-		OffsetSortedSlice:       make([]int, 0),
+		offsets:                 newOffsetStore(),
 		Funcs:                   omap.NewEmptyOrderedMap[string, *Function](),
 		Blueprint:               omap.NewEmptyOrderedMap[string, *Blueprint](),
 		BlueprintStack:          utils.NewStack[*Blueprint](),
@@ -369,31 +366,17 @@ func (prog *Program) Finish() {
 }
 
 func (prog *Program) SearchIndexAndOffsetByOffset(searchOffset int) (index int, offset int) {
-	index = sort.Search(len(prog.OffsetSortedSlice), func(i int) bool {
-		return prog.OffsetSortedSlice[i] >= searchOffset
-	})
-	if index >= len(prog.OffsetSortedSlice) && len(prog.OffsetSortedSlice) > 0 {
-		index = len(prog.OffsetSortedSlice) - 1
-	}
-	if len(prog.OffsetSortedSlice) > 0 {
-		offset = prog.OffsetSortedSlice[index]
-	}
-	return
+	return prog.offsets.searchIndexAndOffset(searchOffset)
 }
 
 func (prog *Program) GetFrontValueByOffset(searchOffset int) (offset int, value Value) {
-	index, offset := prog.SearchIndexAndOffsetByOffset(searchOffset)
-	// 如果二分查找的结果是大于目标值的，那么就需要回退一个
-	if offset > searchOffset {
-		if index > 0 {
-			index -= 1
-		}
-		offset = prog.OffsetSortedSlice[index]
-	}
-	if item, ok := prog.OffsetMap[offset]; ok {
-		value = item.GetValue()
-	}
-	return offset, value
+	return prog.offsets.getFrontValue(searchOffset)
+}
+
+// GetAllOffsetItemsBefore returns all OffsetItems with a variable set
+// at offsets before the given offset. Used by ssaapi for variable matching.
+func (prog *Program) GetAllOffsetItemsBefore(offset int) []*OffsetItem {
+	return prog.offsets.getAllOffsetItemsBefore(offset)
 }
 
 func (p *Program) ShouldVisit(path string) bool {

--- a/common/yak/ssa/ssa.go
+++ b/common/yak/ssa/ssa.go
@@ -308,8 +308,7 @@ type Program struct {
 	importDeclares *omap.OrderedMap[string, *importDeclareItem]
 
 	// offset
-	OffsetMap         map[int]*OffsetItem
-	OffsetSortedSlice []int
+	offsets *offsetStore
 
 	// package Loader
 	Loader      *ssautil.PackageFileLoader

--- a/common/yak/ssaapi/program.go
+++ b/common/yak/ssaapi/program.go
@@ -3,7 +3,6 @@ package ssaapi
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"go.uber.org/atomic"
@@ -241,21 +240,7 @@ func (p *Program) refWithExcludeFiles(name string, excludeFiles []string) Values
 }
 
 func (p *Program) GetAllOffsetItemsBefore(offset int) []*ssa.OffsetItem {
-	offsetSortedSlice := p.Program.OffsetSortedSlice
-	index := sort.SearchInts(offsetSortedSlice, offset)
-	if index < len(offsetSortedSlice) && offsetSortedSlice[index] > offset && index > 0 {
-		index--
-	}
-	beforeSlice := offsetSortedSlice[:index]
-
-	return lo.Filter(
-		lo.Map(beforeSlice, func(offset int, _ int) *ssa.OffsetItem {
-			return p.Program.OffsetMap[offset]
-		}),
-		func(v *ssa.OffsetItem, _ int) bool {
-			return v.GetVariable() != nil
-		},
-	)
+	return p.Program.GetAllOffsetItemsBefore(offset)
 }
 
 func (v *Value) NewConstValue(i any, rng ...*memedit.Range) *Value {


### PR DESCRIPTION
## Problem

Program.OffsetMap and OffsetSortedSlice were unprotected plain map/slice. During syntaxflow scan, multiple goroutines materialize LazyInstructions concurrently via Variable.Assign -> SetOffsetValueEx, writing the same shared Program-level map. This triggers 'fatal error: concurrent map writes', killing the scan process.

The per-LazyInstruction sync.Once only serializes individual instruction materialization; it cannot prevent different instructions from racing on the shared Program map.

## Fix

Encapsulate OffsetMap + OffsetSortedSlice in a new offsetStore type with sync.RWMutex:
- Write operations (setValue/setVariable) hold the write lock across check-then-write
- Read operations (getFrontValue/searchIndexAndOffset/getAllOffsetItemsBefore) hold the read lock
- Program methods delegate to offsetStore

### TDD

- RED: TestOffsetStoreConcurrentSetIsAtomic fails with lost writes (33/100) before fix
- GREEN: All concurrent tests pass with offsetStore locking
- Race detector clean: go test -race passes

### E2E Verification

JavaSecLab scan (105K lines, 338 rules) completes without panic:
- 2033 dataflows, 5956 risks
- All dot_graph fields populated
- Compile + scan jobs share same task_id (scan_batch_id aggregation works)

## Related

- Branch: go0p/refactor/scannode (scannode track, self-contained)
- Depends on NUL byte fix (PR #4770) for JavaSecLab compile to succeed on PostgreSQL