### PR TITLE
fix(lowhttp): prevent POST→GET mutate from splitting request-line on …

### DIFF
--- a/common/utils/lowhttp/modifier.go
+++ b/common/utils/lowhttp/modifier.go
@@ -1861,8 +1861,11 @@ func GetParamsFromBody(contentType string, body []byte) (params *OrderedParams, 
 	}
 
 	// try post values
+	// 请求体在 header 分隔后可能带前导空行（例如用户多打了一个空行），
+	// 直接 ParseQueryParams 会把 \nsql 当成 key，进而在 POST→GET 变形时污染请求行。
 	if len(params.Items) == 0 {
-		queryParams := ParseQueryParams(string(body))
+		bodyForQuery := strings.TrimLeft(string(body), "\r\n \t")
+		queryParams := ParseQueryParams(bodyForQuery)
 		if len(queryParams.Items) > 0 {
 			for _, item := range queryParams.Items {
 				if len(item.Key) == 0 {

--- a/common/utils/lowhttp/modifier_test.go
+++ b/common/utils/lowhttp/modifier_test.go
@@ -3002,6 +3002,26 @@ Content-Disposition: form-data; name="b"
 				err:    nil,
 			},
 		},
+		{
+			name:        "form-urlencoded-leading-blank-lines",
+			contentType: "application/x-www-form-urlencoded",
+			body:        "\n\nsql=1",
+			expected: &Excepted{
+				params: map[string][]string{"sql": {"1"}},
+				useRaw: false,
+				err:    nil,
+			},
+		},
+		{
+			name:        "form-urlencoded-leading-crlf",
+			contentType: "application/x-www-form-urlencoded",
+			body:        "\r\n\r\nsql=1&a=2",
+			expected: &Excepted{
+				params: map[string][]string{"sql": {"1"}, "a": {"2"}},
+				useRaw: false,
+				err:    nil,
+			},
+		},
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/common/utils/lowhttp/query.go
+++ b/common/utils/lowhttp/query.go
@@ -57,11 +57,32 @@ type QueryParamItem struct {
 	Position        HttpParamPositionType
 }
 
+// escapeQueryStructuralChars keeps NoAutoEncode semantics for most characters,
+// but always percent-encodes CR/LF so they cannot break the HTTP request-line.
+func escapeQueryStructuralChars(s string) string {
+	if !strings.ContainsAny(s, "\r\n") {
+		return s
+	}
+	var buf bytes.Buffer
+	buf.Grow(len(s) + 8)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\r':
+			buf.WriteString("%0D")
+		case '\n':
+			buf.WriteString("%0A")
+		default:
+			buf.WriteByte(s[i])
+		}
+	}
+	return buf.String()
+}
+
 func (item *QueryParamItem) Encode() string {
 	var buf bytes.Buffer
 	if item.Key == "" && item.Value == "" {
 		if item.NoAutoEncode {
-			buf.WriteString(item.Raw)
+			buf.WriteString(escapeQueryStructuralChars(item.Raw))
 		} else {
 			buf.WriteString(codec.QueryEscape(item.Raw))
 		}
@@ -69,13 +90,13 @@ func (item *QueryParamItem) Encode() string {
 	}
 
 	if item.NoAutoEncode {
-		buf.WriteString(item.Key)
+		buf.WriteString(escapeQueryStructuralChars(item.Key))
 	} else {
 		buf.WriteString(codec.QueryEscape(item.Key))
 	}
 	buf.WriteByte('=')
 	if item.NoAutoEncode {
-		buf.WriteString(item.Value)
+		buf.WriteString(escapeQueryStructuralChars(item.Value))
 	} else {
 		buf.WriteString(codec.QueryEscape(item.Value))
 	}

--- a/common/utils/lowhttp/query_test.go
+++ b/common/utils/lowhttp/query_test.go
@@ -46,3 +46,13 @@ func TestQueryParams1(t *testing.T) {
 	params.Set("ddd", "cc31==+&")
 	test.Equal("a=22&c=3&c=5&ac2224*(&*&&*&*((&*&ccc=&&&&ddd=cc31%3D%3D%2B%26", params.Encode())
 }
+
+func TestQueryParamsNoAutoEncodeEscapesCRLF(t *testing.T) {
+	params := NewQueryParams().DisableAutoEncode(true)
+	params.Add("\nsql", "1")
+	params.Add("a", "b\nc")
+	encoded := params.Encode()
+	assert.Equal(t, "%0Asql=1&a=b%0Ac", encoded)
+	assert.NotContains(t, encoded, "\n")
+	assert.NotContains(t, encoded, "\r")
+}

--- a/common/yak/yaklib/codec/codegrpc/codec_grpc_methods_test.go
+++ b/common/yak/yaklib/codec/codegrpc/codec_grpc_methods_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/authhack"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
 	"github.com/yaklang/yaklang/common/utils/tlsutils"
 	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 )
@@ -309,4 +311,22 @@ func TestSM2PrivateKeyTryDecode(t *testing.T) {
 	err = flow.SM2Decrypt(codec.EncodeBase64(priKey), "C1C2C3")
 	require.NoError(t, err)
 	require.Equal(t, plaintext, flow.Text)
+}
+
+func TestHTTPRequestMutate_PostToGetWithLeadingBlankLinesInBody(t *testing.T) {
+	// 用户反馈：body 前多一个空行时，POST→GET 会污染请求行：
+	// GET /path? HTTP/1.1
+	// sql=1 HTTP/1.1
+	raw := []byte("POST /WebServiceEx.asmx/GetDataTableBySql HTTP/1.1\nHost: \nContent-Type: application/x-www-form-urlencoded\n\n\nsql=1")
+	flow := NewCodecExecFlow(raw, nil)
+	err := flow.HTTPRequestMutate("GET")
+	require.NoError(t, err)
+
+	result := string(flow.Text)
+	// 请求行必须完整：?sql=1 在同一行，不能被拆成第二行 "sql=1 HTTP/1.1"
+	require.True(t, strings.HasPrefix(result, "GET /WebServiceEx.asmx/GetDataTableBySql?sql=1 HTTP/1.1"), "got: %q", result)
+	require.False(t, strings.Contains(result, "?\r\nsql=") || strings.Contains(result, "?\nsql="), "request-line should not be split by query CR/LF, got: %q", result)
+	require.Equal(t, "GET", lowhttp.GetHTTPRequestMethod(flow.Text))
+	require.Equal(t, map[string][]string{"sql": {"1"}}, lowhttp.GetFullHTTPRequestQueryParams(flow.Text))
+	require.Empty(t, strings.TrimSpace(string(lowhttp.GetHTTPPacketBody(flow.Text))))
 }


### PR DESCRIPTION
…blank body lines

When form body had leading blank lines, GetParamsFromBody parsed keys like "\nsql", and NoAutoEncode wrote CR/LF into the query string, breaking the HTTP request-line. Trim leading whitespace before form parsing and always percent-encode CR/LF in query encode.