### PR TITLE
fix(ai): make cachebench attribution exact and stabilize cache prefix

### DIFF
--- a/common/ai/aid/aicache/cachebench/lib.yak
+++ b/common/ai/aid/aicache/cachebench/lib.yak
@@ -502,10 +502,11 @@ func classifyReason(tag) {
 //      ChatUsage.MirrorCorrelationID, aicache.Observe 把本次 SeqId 写到上面,
 //      ChatBase 透传到 SSE 末帧 callback. dump 文件名 (000XXX.txt) 同名 SeqId,
 //      所以 dump.seqId.toString() 就能直接 join.
-//   2. 没 ID 的 usage (老 yak 二进制 / 异常 callback) 退化成"按 usages 列表
-//      顺序消费 + 跳过已被 ID 命中的"兜底, 兼容性安全.
-//   3. 这样即便中途漏 callback, 也不会让后续 dump 与 usage 累计错位
-//      (这是上一轮 hostscan 长跑里 28% 记录归因错位的根因).
+//   2. 只有真正没有 correlationID 的 usage (老 yak 二进制 / 非 mirror 路径)
+//      才允许按顺序兜底. 带 ID 但 ID 不等于当前 dump.seqId 的 usage 绝不能
+//      被兜底消费, 否则一次漏 callback 会把后续所有记录整体左移.
+//   3. 每条 record 写入 alignment 字段, 让报告明确区分 correlation_id / legacy_order /
+//      missing / in_flight_cancelled / usage_without_dump, 并计算精确关联覆盖率.
 //
 // maxPromptsTriggered 透传"末尾 trailing dumps 是否 ctx cancel 飞行中"语义,
 // 标 inFlightCancelled 避免误判 missing.
@@ -516,12 +517,14 @@ func alignDumpsAndUsages(dumps, usages, maxPromptsTriggered) {
     nDumps = len(dumps)
     nUsages = len(usages)
 
-    // 第一遍: 建 correlationID -> usage 索引, 同时统计带/不带 ID 的 usage 数,
+    // 第一遍: 建 correlationID -> usage 索引, 同时单独保存无 ID usage.
     // 让上层一眼看出新旧二进制的部署状态 (启动期就能分辨"还在跑老 binary").
     // 关键词: cachebench correlationID stats, ID 部署可观测
     usageByID = {}
+    usagesWithoutID = []
     usagesWithID = 0
     usagesNoID = 0
+    maxUsageSeqID = 0
     j = 0
     for j < nUsages {
         u = usages[j]
@@ -532,23 +535,29 @@ func alignDumpsAndUsages(dumps, usages, maxPromptsTriggered) {
         if cid != "" {
             usageByID[cid] = u
             usagesWithID++
+            cidInt = ccbAsInt(cid)
+            if cidInt > maxUsageSeqID {
+                maxUsageSeqID = cidInt
+            }
         } else {
             usagesNoID++
+            usagesWithoutID = append(usagesWithoutID, u)
         }
         j++
     }
     log.info("cachebench align: nDumps=%d nUsages=%d usagesWithID=%d usagesNoID=%d",
         nDumps, nUsages, usagesWithID, usagesNoID)
 
-    // 第二遍: 按 dump 顺序产 records. 优先 ID 匹配, 否则下标兜底游标取下一条
-    // 还没被 ID 路径消费掉的 usage.
+    // 第二遍: 按 dump 顺序产 records. 优先 ID 匹配; 不匹配时只允许消费
+    // usagesWithoutID, 永远不跨 correlationID 错配.
     consumedByID = {}
-    nextUsagePtr = 0
+    nextNoIDPtr = 0
 
     i = 0
     for i < nDumps {
         rec = dumps[i]
         usage = nil
+        alignment = "missing"
         seqStr = ""
         if !ccbIsNil(rec) {
             seqStr = sprintf("%d", ccbAsInt(rec["seqId"]))
@@ -556,22 +565,12 @@ func alignDumpsAndUsages(dumps, usages, maxPromptsTriggered) {
         if seqStr != "" && seqStr != "0" && !ccbIsNil(usageByID[seqStr]) && consumedByID[seqStr] != true {
             usage = usageByID[seqStr]
             consumedByID[seqStr] = true
+            alignment = "correlation_id"
         } else {
-            for nextUsagePtr < nUsages {
-                u = usages[nextUsagePtr]
-                nextUsagePtr++
-                cid = ""
-                if !ccbIsNil(u) {
-                    cid = ccbToString(u["correlationID"])
-                }
-                if cid != "" && consumedByID[cid] == true {
-                    continue
-                }
-                usage = u
-                if cid != "" {
-                    consumedByID[cid] = true
-                }
-                break
+            if nextNoIDPtr < len(usagesWithoutID) {
+                usage = usagesWithoutID[nextNoIDPtr]
+                nextNoIDPtr++
+                alignment = "legacy_order"
             }
         }
 
@@ -594,12 +593,18 @@ func alignDumpsAndUsages(dumps, usages, maxPromptsTriggered) {
         }
         // max-prompts 触发后, 没 usage 的 trailing dump 视为 in-flight cancelled
         // 而非真实 missing (chat 被 ctx cancel 抛错, callback 没机会触发).
-        if ccbIsNil(usage) && maxPromptsTriggered && i >= nUsages {
+        seqID = ccbAsInt(rec["seqId"])
+        trailingCancelled = usagesWithID > 0 && seqID > maxUsageSeqID
+        if usagesWithID == 0 {
+            trailingCancelled = i >= nUsages
+        }
+        if ccbIsNil(usage) && maxPromptsTriggered && trailingCancelled {
             usage = {
                 "seq":               i + 1,
                 "missing":           false,
                 "inFlightCancelled": true,
             }
+            alignment = "in_flight_cancelled"
         }
 
         tag = TAG_UNKNOWN
@@ -615,6 +620,7 @@ func alignDumpsAndUsages(dumps, usages, maxPromptsTriggered) {
             "usage":  usage,
             "tag":    tag,
             "reason": classifyReason(tag),
+            "alignment": alignment,
         }
         records = append(records, item)
         i++
@@ -623,16 +629,45 @@ func alignDumpsAndUsages(dumps, usages, maxPromptsTriggered) {
     // 第三遍: 兜底处理 trailing usages (dump 落盘失败但 callback 跑过的边界场景),
     // 用 placeholder dump 反映真实情况, 不让任何 usage 被静默吞掉.
     // 关键词: alignDumpsAndUsages trailing usages placeholder
-    for nextUsagePtr < nUsages {
-        u = usages[nextUsagePtr]
-        nextUsagePtr++
-        cid = ""
-        if !ccbIsNil(u) {
-            cid = ccbToString(u["correlationID"])
-        }
-        if cid != "" && consumedByID[cid] == true {
+    // 先补带 ID 但没有对应 dump 的 usage.
+    for cid, u in usageByID {
+        if consumedByID[cid] == true {
             continue
         }
+        idx = len(records)
+        rec = {
+            "seqId":            ccbAsInt(cid),
+            "missing":          true,
+            "sections":         [],
+            "advices":          [],
+            "sectionHashCount": {},
+            "sectionTotalUses": {},
+            "totalRequests":    0,
+            "totalChunks":      0,
+            "prefixHitChunks":  0,
+            "prefixHitRatio":   0.0,
+            "totalBytes":       0,
+            "prefixHitBytes":   0,
+            "rawText":          "",
+        }
+        tag = TAG_UNKNOWN
+        item = {
+            "seq":       ccbAsInt(cid),
+            "dump":      rec,
+            "usage":     u,
+            "tag":       tag,
+            "reason":    classifyReason(tag),
+            "alignment": "usage_without_dump",
+        }
+        records = append(records, item)
+        consumedByID[cid] = true
+    }
+
+    // 再补无 ID 且顺序兜底没有消费完的 legacy usage.
+    for nextNoIDPtr < len(usagesWithoutID) {
+        u = usagesWithoutID[nextNoIDPtr]
+        nextNoIDPtr++
+        cid = ""
         idx = len(records)
         rec = {
             "seqId":            idx + 1,
@@ -662,6 +697,7 @@ func alignDumpsAndUsages(dumps, usages, maxPromptsTriggered) {
             "usage":  u,
             "tag":    tag,
             "reason": classifyReason(tag),
+            "alignment": "usage_without_dump",
         }
         records = append(records, item)
     }
@@ -678,6 +714,11 @@ func summarize(records) {
         "cacheHitCount":         0,
         "missingUsageCount":     0,
         "inFlightCancelledCount": 0,
+        "exactCorrelationCount": 0,
+        "legacyOrderCount":      0,
+        "unalignedDumpCount":    0,
+        "usageWithoutDumpCount": 0,
+        "alignmentCoverage":     0.0,
         "tagCount":              {},
         "sumPromptTokens":       0,
         "sumCachedTokens":       0,
@@ -693,6 +734,17 @@ func summarize(records) {
     }
 
     for item in records {
+        alignment = ccbToString(item["alignment"])
+        if alignment == "correlation_id" {
+            summary["exactCorrelationCount"]++
+        } else if alignment == "legacy_order" {
+            summary["legacyOrderCount"]++
+        } else if alignment == "usage_without_dump" {
+            summary["usageWithoutDumpCount"]++
+        } else if alignment == "missing" {
+            summary["unalignedDumpCount"]++
+        }
+
         tag = item["tag"]
         tagCount = summary["tagCount"]
         if ccbIsNil(tagCount[tag]) {
@@ -770,6 +822,8 @@ func summarize(records) {
     summary["hitRatioTokenReal"] = ccbSafeRatio(summary["sumCachedTokens"], summary["sumPromptTokens"])
     summary["hitRatioLcpClient"] = ccbSafeRatio(summary["sumPrefixHitBytes"], summary["sumRequestBytes"])
     summary["upstreamCreationCost"] = float(summary["sumCacheCreation"]) * 1.25
+    alignedDen = summary["exactCorrelationCount"] + summary["legacyOrderCount"] + summary["unalignedDumpCount"]
+    summary["alignmentCoverage"] = ccbSafeRatio(summary["exactCorrelationCount"], alignedDen)
 
     return summary
 }
@@ -907,7 +961,7 @@ func renderMarkdown(benchReport) {
     intelOnly = summary["intelligentOnly"]
     if !ccbIsNil(intelOnly) {
         md += "## intelligent-only summary (主指标, 验收基线)\n\n"
-        md += "_仅统计 modelTier == intelligent 的高推理成本调用, 排除 lightweight (verification / quick judge) 干扰._\n\n"
+        md += "_仅统计 modelTier == intelligent 且 correlationID 精确关联的高推理成本调用, 排除 lightweight 与顺序兜底污染._\n\n"
         md += sprintf("- intelligent calls:                 %d\n", intelOnly["totalCalls"])
         md += sprintf("- intelligent prompt_tokens:         %d\n", intelOnly["sumPromptTokens"])
         md += sprintf("- intelligent cached_tokens:         %d\n", intelOnly["sumCachedTokens"])
@@ -916,6 +970,7 @@ func renderMarkdown(benchReport) {
         md += sprintf("- intelligent lcp_hit_ratio:         %.2f%% (in-proc)\n", intelOnly["hitRatioLcpClient"]*100.0)
         md += sprintf("- intelligent cache_hit_count:       %d\n", intelOnly["cacheHitCount"])
         md += sprintf("- intelligent cache_create_count:    %d\n", intelOnly["cacheCreateCount"])
+        md += sprintf("- excluded unaligned records:        %d\n", intelOnly["excludedUnalignedCount"])
         md += sprintf("- intelligent upstream_creation_cost (1.25x): %.0f tokens\n", intelOnly["upstreamCreationCost"])
         hsDistinct = ccbAsInt(intelOnly["highStaticDistinct"])
         passLine = "PASS"
@@ -933,6 +988,11 @@ func renderMarkdown(benchReport) {
     md += sprintf("- cache_hit_count    (cached>0):    %d\n", summary["cacheHitCount"])
     md += sprintf("- missing usage callbacks:          %d\n", summary["missingUsageCount"])
     md += sprintf("- in_flight cancelled (max-prompts): %d\n", summary["inFlightCancelledCount"])
+    md += sprintf("- exact correlation joins:           %d\n", summary["exactCorrelationCount"])
+    md += sprintf("- legacy order joins:                %d\n", summary["legacyOrderCount"])
+    md += sprintf("- unaligned dumps:                   %d\n", summary["unalignedDumpCount"])
+    md += sprintf("- usages without dump:               %d\n", summary["usageWithoutDumpCount"])
+    md += sprintf("- exact alignment coverage:          %.2f%%\n", summary["alignmentCoverage"]*100.0)
     md += sprintf("- sum prompt_tokens:                %d\n", summary["sumPromptTokens"])
     md += sprintf("- sum cached_tokens:                %d\n", summary["sumCachedTokens"])
     md += sprintf("- sum cache_creation_input_tokens:  %d\n", summary["sumCacheCreation"])
@@ -1215,8 +1275,8 @@ func analyzeBenchmark(sessionDir, usageList, events, invokeErr, inputText, maxPr
 // 之前按 ts 就近匹配 modelName 在 hostscan 长跑里被 stream-finished 漏 callback
 // 引发的累计错位污染, 出现"242KB prompt 配 830 tokens"等离谱 join, 是 cachebench
 // 归因 bug 的根因之一. 切到 dump.model 后, per-tier 命中率才真实可信.
-// modelTier 仍来自 record["modelTier"] (analyzeBenchmarkWithModels 按 ts 匹配
-// ai_first_byte_cost_ms 事件), tier 信息只用于展示, 不再决定 group key.
+// modelTier 来自 analyzeBenchmarkWithModels 建立的 modelName -> tier 元数据表,
+// 不再逐请求按时间猜测, 避免漏 first-byte / usage callback 后跨模型串线.
 //
 // 关键词: cachebench summarizeByModel 直读 dump.model, 修复跨记录归因错位
 func summarizeByModel(records) {
@@ -1330,9 +1390,17 @@ func summarizeIntelligentOnly(records) {
 		"sectionTotalMax":      {},
 		"sectionReuseRateMin":  {},
 		"modelNames":           {},
+		"excludedUnalignedCount": 0,
 	}
 
     for item in records {
+        // intelligent-only 是验收主指标, 只接受 correlationID 精确 join.
+        // legacy 顺序关联仍保留在全量报告中用于兼容旧 binary, 但不能作为
+        // 高成本模型缓存优化的验收依据.
+        if ccbToString(item["alignment"]) != "correlation_id" {
+            view["excludedUnalignedCount"]++
+            continue
+        }
         tier = ccbToString(item["modelTier"])
         if tier != "intelligent" {
             continue
@@ -1420,92 +1488,61 @@ func summarizeIntelligentOnly(records) {
 
 // analyzeBenchmarkWithModels 在 analyzeBenchmark 基础上额外接受 modelList,
 // 为每条 record 注入 modelName / modelTier, 并在 summary 中产出 byModel 子表.
-// modelList 来自 captureEvent 解析 ai_first_byte_cost_ms 事件, 与 usageList
-// 同源 (一次 chat 先 first-byte 后 SSE 末帧 usageCallback).
 //
-// 对齐策略: 不能简单按 index 对齐, 因为某些 LiteForge/RAG 路径不发 first_byte
-// (走 TeeAIResponse wrapper 路径才 emit), 导致 modelList 数量可能 < usageList.
-// 这里按时间戳就近匹配: 对每个 usage[i], 在 modelList 里找 ts <= usage.ts 且
-// 时间差最小的未消费 entry, 匹配上就标记已消费, 没匹配上就标 (unknown).
-// 关键词: cachebench analyzeBenchmarkWithModels, ts 就近对齐, modelList 短缺兜底
+// 模型归因策略:
+//   1. modelName 永远优先取 dump.model, 它与 prompt dump 在 ChatBase 入口同步落盘.
+//   2. modelList 只用来建立 modelName -> (tier, provider) 元数据表; 不再按时间
+//      或顺序逐请求匹配. 同一实际模型的 tier/provider 是稳定属性.
+//   3. 没有 dump.model 的记录保留 unknown, 不把猜测结果混入 intelligent-only.
+//
+// 关键词: cachebench analyzeBenchmarkWithModels, dump model 真值, model 元数据表
 func analyzeBenchmarkWithModels(sessionDir, usageList, modelList, events, invokeErr, inputText, maxPromptsTriggered) {
     benchReport = analyzeBenchmark(sessionDir, usageList, events, invokeErr, inputText, maxPromptsTriggered)
     records = benchReport["records"]
-    n = len(records)
     nModel = len(modelList)
-
-    // 准备 modelList 的可消费拷贝, 加入 consumed 标志
-    pool = []
-    j = 0
-    for j < nModel {
-        entry = modelList[j]
-        ts = ccbAsInt(entry["ts"])
-        pool = append(pool, {
-            "modelName": ccbToString(entry["modelName"]),
-            "modelTier": ccbToString(entry["modelTier"]),
-            "ts":        ts,
-            "consumed":  false,
-        })
-        j++
+    modelMeta = {}
+    for entry in modelList {
+        name = ccbToString(entry["modelName"])
+        if name == "" {
+            continue
+        }
+        tier = ccbToString(entry["modelTier"])
+        provider = ccbToString(entry["providerName"])
+        old = modelMeta[name]
+        if ccbIsNil(old) {
+            modelMeta[name] = {"modelTier": tier, "providerName": provider}
+            continue
+        }
+        if ccbToString(old["modelTier"]) == "" && tier != "" {
+            old["modelTier"] = tier
+        }
+        if ccbToString(old["providerName"]) == "" && provider != "" {
+            old["providerName"] = provider
+        }
+        modelMeta[name] = old
     }
 
-    // 第一轮: 严格按 ts <= usage.ts 就近匹配
     i = 0
-    for i < n {
+    for i < len(records) {
         rec = records[i]
-        usage = rec["usage"]
-        usageTs = 0
-        if !ccbIsNil(usage) {
-            usageTs = ccbAsInt(usage["ts"])
+        modelName = ""
+        dumpRec = rec["dump"]
+        if !ccbIsNil(dumpRec) && dumpRec["missing"] != true {
+            modelName = ccbToString(dumpRec["model"])
         }
-        bestIdx = -1
-        bestDelta = 99999999
-        if usageTs > 0 {
-            k = 0
-            for k < len(pool) {
-                p = pool[k]
-                if p["consumed"] != true && p["ts"] <= usageTs {
-                    delta = usageTs - p["ts"]
-                    if delta < bestDelta {
-                        bestDelta = delta
-                        bestIdx = k
-                    }
-                }
-                k++
+        rec["modelName"] = modelName
+        rec["modelTier"] = ""
+        rec["providerName"] = ""
+        rec["modelAttribution"] = "unknown"
+        if modelName != "" {
+            rec["modelAttribution"] = "dump_model"
+            meta = modelMeta[modelName]
+            if !ccbIsNil(meta) {
+                rec["modelTier"] = ccbToString(meta["modelTier"])
+                rec["providerName"] = ccbToString(meta["providerName"])
             }
-        }
-        if bestIdx >= 0 {
-            picked = pool[bestIdx]
-            rec["modelName"] = picked["modelName"]
-            rec["modelTier"] = picked["modelTier"]
-            picked["consumed"] = true
-            pool[bestIdx] = picked
-        } else {
-            rec["modelName"] = ""
-            rec["modelTier"] = ""
         }
         records[i] = rec
-        i++
-    }
-
-    // 第二轮: 给仍未匹配的 record 顺序填补未消费 entry (兜底)
-    fillIdx = 0
-    i = 0
-    for i < n {
-        rec = records[i]
-        if rec["modelName"] == "" {
-            for fillIdx < len(pool) && pool[fillIdx]["consumed"] == true {
-                fillIdx++
-            }
-            if fillIdx < len(pool) {
-                p = pool[fillIdx]
-                rec["modelName"] = p["modelName"]
-                rec["modelTier"] = p["modelTier"]
-                p["consumed"] = true
-                pool[fillIdx] = p
-                records[i] = rec
-            }
-        }
         i++
     }
     benchReport["records"] = records
@@ -1520,5 +1557,6 @@ func analyzeBenchmarkWithModels(sessionDir, usageList, modelList, events, invoke
     benchReport["summary"] = summary
 
     benchReport["modelEventCount"] = nModel
+    benchReport["modelMetadata"] = modelMeta
     return benchReport
 }

--- a/common/ai/aid/aicache/cachebench/selftest.yak
+++ b/common/ai/aid/aicache/cachebench/selftest.yak
@@ -1,0 +1,91 @@
+// cachebench deterministic attribution self-test
+//
+// 用法:
+//   go run common/yak/cmd/yak.go common/ai/aid/aicache/cachebench/selftest.yak
+//
+// 该脚本不访问模型或数据库, 专门防止 correlationID 漏 callback 后的顺序串线
+// 以及 intelligent-only 混入非精确记录。
+
+include "common/ai/aid/aicache/cachebench/lib.yak"
+
+func must(cond, message) {
+    if !cond {
+        die("cachebench selftest failed: " + message)
+    }
+}
+
+func fakeDump(seq, model) {
+    return {
+        "seqId":            seq,
+        "model":            model,
+        "missing":          false,
+        "sections":         [],
+        "advices":          [],
+        "sectionHashCount": {"high-static": 1},
+        "sectionTotalUses": {"high-static": 1},
+        "sectionReuseRate": {"high-static": 1.0},
+        "totalRequests":    1,
+        "totalChunks":      1,
+        "prefixHitChunks":  0,
+        "prefixHitRatio":   0.0,
+        "totalBytes":       100,
+        "prefixHitBytes":   0,
+        "rawText":          "",
+    }
+}
+
+dumps = [
+    fakeDump(1, "memfit-standard-free"),
+    fakeDump(2, "memfit-light-free"),
+    fakeDump(3, "memfit-standard-free"),
+]
+usages = [
+    {"correlationID": "1", "missing": false, "promptTokens": 100, "cachedTokens": 80},
+    // seq=2 故意漏 callback. seq=3 绝不能被顺序兜底错配给 dump 2.
+    {"correlationID": "3", "missing": false, "promptTokens": 300, "cachedTokens": 240},
+]
+
+records = alignDumpsAndUsages(dumps, usages, false)
+must(len(records) == 3, "expected three dump records")
+must(records[0]["alignment"] == "correlation_id", "seq1 must use exact correlation")
+must(records[1]["alignment"] == "missing", "seq2 missing callback must remain missing")
+must(records[1]["usage"] == nil, "seq2 must not steal seq3 usage")
+must(records[2]["alignment"] == "correlation_id", "seq3 must use exact correlation")
+must(records[2]["usage"]["correlationID"] == "3", "seq3 correlation must be preserved")
+
+records[0]["modelName"] = "memfit-standard-free"
+records[0]["modelTier"] = "intelligent"
+records[1]["modelName"] = "memfit-light-free"
+records[1]["modelTier"] = "lightweight"
+records[2]["modelName"] = "memfit-standard-free"
+records[2]["modelTier"] = "intelligent"
+
+intel = summarizeIntelligentOnly(records)
+must(intel["totalCalls"] == 2, "intelligent-only must contain two exact standard calls")
+must(intel["sumPromptTokens"] == 400, "intelligent prompt token total must be exact")
+must(intel["sumCachedTokens"] == 320, "intelligent cached token total must be exact")
+must(intel["hitRatioTokenReal"] == 0.8, "intelligent hit ratio must be 80 percent")
+must(intel["excludedUnalignedCount"] == 1, "missing record must be excluded explicitly")
+
+legacy = alignDumpsAndUsages([fakeDump(1, "legacy-model")], [
+    {"correlationID": "", "missing": false, "promptTokens": 10, "cachedTokens": 5},
+], false)
+must(legacy[0]["alignment"] == "legacy_order", "usage without ID may use legacy order fallback")
+
+orphanUsage = alignDumpsAndUsages([fakeDump(1, "memfit-standard-free")], [
+    {"correlationID": "1", "missing": false, "promptTokens": 10, "cachedTokens": 5},
+    {"correlationID": "9", "missing": false, "promptTokens": 90, "cachedTokens": 45},
+], false)
+must(len(orphanUsage) == 2, "usage without matching dump must remain visible")
+must(orphanUsage[1]["alignment"] == "usage_without_dump", "orphan usage must be classified")
+must(orphanUsage[1]["usage"]["correlationID"] == "9", "orphan usage ID must be preserved")
+
+cancelled = alignDumpsAndUsages([
+    fakeDump(1, "memfit-standard-free"),
+    fakeDump(2, "memfit-standard-free"),
+], [
+    {"correlationID": "1", "missing": false, "promptTokens": 10, "cachedTokens": 5},
+], true)
+must(cancelled[1]["alignment"] == "in_flight_cancelled", "trailing cancelled dump must not count as missing")
+
+println("cachebench selftest passed")

--- a/common/ai/aid/aicache/hijacker.go
+++ b/common/ai/aid/aicache/hijacker.go
@@ -516,7 +516,7 @@ func splitBySemiBoundary(res *aitag.SplitResult) (user1, user2, user3 string, ok
 //	<Tool/Forge/Timeline-Frozen>
 //	<|AI_CACHE_FROZEN_END_semi-dynamic|>
 //	<|AI_CACHE_SEMI_semi|>
-//	<Skills + RecentToolsCache>
+//	<Stable Skills Context>
 //	<|AI_CACHE_SEMI_END_semi|>
 //	<|AI_CACHE_SEMI2_semi|>
 //	<Persistent + Schema + OutputExample>

--- a/common/ai/aid/aicache/types.go
+++ b/common/ai/aid/aicache/types.go
@@ -17,7 +17,7 @@ import "time"
 //     的单一 semi-dynamic 段。
 //   - SectionSemiDynamic1 ("semi-dynamic-1") / SectionSemiDynamic2 ("semi-dynamic-2"):
 //     aireact 新路径 "按稳定性分层 + UI 信息密度" 拆分后的两块 semi 段, 分别
-//     承载 SkillsContext + RecentToolsCache 与 TaskInstruction + Schema +
+//     承载 SkillsContext 与 TaskInstruction + Schema +
 //     OutputExample, 由 hijacker 切成两条 user message (semi-1 不打 cc /
 //     semi-2 打 cc, 合并算 prefix cache).
 //

--- a/common/ai/aid/aicommon/invoke_runtime.go
+++ b/common/ai/aid/aicommon/invoke_runtime.go
@@ -208,12 +208,12 @@ type LoopPromptAssemblyInput struct {
 	InjectedMemory string
 
 	// RecentToolsCache 是 CACHE_TOOL_CALL 块的渲染输出 (含 directly_call_tool
-	// routing hint + 最近工具的 schema/footer), 用稳定 nonce 渲染, 字节级跨 turn
-	// 稳定. 物理位置在 semi-dynamic 段, 让其与 Skills + Schema 一起被
-	// AI_CACHE_SEMI 边界包裹进入 prefix cache. 空字符串时模板自动跳过.
+	// routing hint + 最近工具的 schema/footer). 标签 nonce 稳定, 但工具集合正文
+	// 会随任务推进变化, 因此物理位置在 timeline-open 段、最后 cache boundary
+	// 之后, 避免一次工具集合变化击穿 Skills + Schema 的大前缀缓存.
 	//
-	// 关键词: LoopPromptAssemblyInput, RecentToolsCache, semi-dynamic 段,
-	//        AI_CACHE_SEMI prefix cache
+	// 关键词: LoopPromptAssemblyInput, RecentToolsCache, timeline-open 易变尾段,
+	//        cache boundary 之后
 	RecentToolsCache string
 
 	// FrozenUserContext 用于承载 PE-TASK 等场景下"PLAN 阶段产出 + 用户原始

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -22,10 +22,12 @@ type PromptMaterials struct {
 	OutputExample   string
 
 	// SemiDynamic 提示材料:
-	//   - aireact: SkillsContext + RecentToolsCache
+	//   - aireact: SkillsContext
 	//   - aid: PlanHelp / OriginalUserInput / StableInstruction 等 prompt-specific
 	//     但仍属可缓存半动态前缀的内容
-	SkillsContext     string
+	SkillsContext string
+	// RecentToolsCache 的标签 nonce 稳定, 但正文会随着最近使用工具集合变化。
+	// 因此它属于 timeline-open 易变尾段, 不能放在 semi-2 cache boundary 之前。
 	RecentToolsCache  string
 	PlanHelp          string
 	OriginalUserInput string
@@ -94,7 +96,6 @@ func (m *PromptMaterials) SemiDynamicData() map[string]any {
 	}
 	return map[string]any{
 		"SkillsContext":     m.SkillsContext,
-		"RecentToolsCache":  m.RecentToolsCache,
 		"PlanHelp":          m.PlanHelp,
 		"OriginalUserInput": m.OriginalUserInput,
 		"StableInstruction": m.StableInstruction,
@@ -146,7 +147,7 @@ func (m *PromptMaterials) FrozenBlockData() map[string]any {
 
 // TimelineOpenData 供 timeline-open 模板消费, 模板字段渲染顺序 (P1-C3):
 //
-//	Timeline (Open Tail) -> SessionEvidence -> TodoSnapshot -> Workspace ->
+//	Timeline (Open Tail) -> SessionEvidence -> TodoSnapshot -> RecentToolsCache -> Workspace ->
 //	SessionArtifactsOpen -> UserHistory -> Current Time -> PlanContext (末尾)
 //
 // 段内排序原则:
@@ -189,6 +190,7 @@ func (m *PromptMaterials) TimelineOpenData() map[string]any {
 		"TimelineFrozenTimeUnix": m.TimelineFrozenTimeUnix,
 		"SessionEvidence":        sessionEvidenceOpen,
 		"TodoSnapshot":           m.TodoSnapshot,
+		"RecentToolsCache":       m.RecentToolsCache,
 		"Workspace":              m.Workspace,
 		"OSArch":                 m.OSArch,
 		"WorkingDir":             m.WorkingDir,

--- a/common/ai/aid/aicommon/prompts/prefix/semi_dynamic_1_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/semi_dynamic_1_section.txt
@@ -1,3 +1,1 @@
 {{ if .SkillsContext }}{{ .SkillsContext }}{{ end }}
-{{ if .RecentToolsCache }}
-{{ .RecentToolsCache }}{{ end }}

--- a/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
@@ -19,6 +19,11 @@
 {{ .TodoSnapshot }}
 {{ end }}
 
+{{ if .RecentToolsCache }}
+
+{{ .RecentToolsCache }}
+{{ end }}
+
 {{ if .Workspace }}# Workspace Context
 
 工作区上下文给出 Agent 当前运行环境的"物理坐标"：操作系统 / 架构、当前工作目录的绝对路径、该目录顶层结构概览。

--- a/common/ai/aid/aicommon/timeline_groups_render.go
+++ b/common/ai/aid/aicommon/timeline_groups_render.go
@@ -861,7 +861,7 @@ const (
 // <|AI_CACHE_SEMI2_semi|>...<|AI_CACHE_SEMI2_END_semi|>.
 //
 // 设计意图 (P1.1: 把 SEMI 段拆成两条 user message):
-//   - AI_CACHE_SEMI  (semi-1) -> 无 cc, user2 (Skills + RecentToolsCache)
+//   - AI_CACHE_SEMI  (semi-1) -> 无 cc, user2 (Stable Skills Context)
 //   - AI_CACHE_SEMI2 (semi-2) -> ephemeral cc, user3 (Persistent + Schema + OutputExample)
 //
 // dashscope 命中点: system / system+frozen / system+frozen+semi1+semi2.

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -233,8 +233,9 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 		// prompt 任何一次 iteration 都能看到当前 TODO 全貌.
 		// 关键词: TodoSnapshot 透传, timeline-open, SessionEvidence 之后
 		materials.TodoSnapshot = input.TodoSnapshot
-		// CACHE_TOOL_CALL 块从 dynamic/REFLECTION 迁到 semi-dynamic 段
-		// 关键词: RecentToolsCache 透传, semi-dynamic 段
+		// CACHE_TOOL_CALL 正文会随最近工具集合变化, 放到 timeline-open 尾段,
+		// 保护其前面的 semi-2 cache boundary 不被工具变化击穿。
+		// 关键词: RecentToolsCache 透传, timeline-open, cache boundary 之后
 		materials.RecentToolsCache = input.RecentToolsCache
 		// PE-TASK PLAN 产物 (PARENT_TASK + CURRENT_TASK + INSTRUCTION) 通过
 		// FrozenUserContext 字段透传, 渲染时位于 timeline-open 段最末尾
@@ -260,7 +261,7 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 }
 
 // AssemblePromptPrefix 按"稳定性分层"路径输出 5 段: HighStatic | FrozenBlock |
-// SemiDynamic1 (Skills + CacheToolCall) | SemiDynamic2 (TaskInstruction + Schema +
+// SemiDynamic1 (Skills) | SemiDynamic2 (TaskInstruction + Schema +
 // OutputExample) | TimelineOpen。Prompt 字段是 5 段拼接结果, 调用方拼上 Dynamic
 // 段后形成完整 prompt。
 //
@@ -564,7 +565,7 @@ func renderPlanContextBlock(materials *reactloops.PromptPrefixMaterials) string 
 }
 
 // buildSemiDynamic1Observation 给"PROMPT_SECTION_semi-dynamic-1 段"做观测树:
-// Skills Context + Cache Tool Call. 物理上对应 hijacker 5 段切分中的 user2
+// Skills Context. 物理上对应 hijacker 5 段切分中的 user2
 // (string content, 不打 cc), 与 buildSemiDynamic2Observation 一起被 dashscope
 // 视作合并 prefix cache 计算.
 //
@@ -592,15 +593,6 @@ func (pm *PromptManager) buildSemiDynamic1Observation(
 			reactloops.PromptSectionRoleSemiDynamic1,
 			true,
 			materials.SkillsContext,
-		),
-		// CACHE_TOOL_CALL 块从 dynamic/REFLECTION 迁到此处, 用稳定 nonce 渲染.
-		// 关键词: Semi Dynamic 1 / Cache Tool Call, RecentToolsCache 观测节点
-		reactloops.NewPromptSectionObservation(
-			"section.semi_dynamic_1.cache_tool_call",
-			"Cache Tool Call",
-			reactloops.PromptSectionRoleSemiDynamic1,
-			true,
-			materials.RecentToolsCache,
 		),
 	}
 	section.Children = filterIncludedPromptSections(children)
@@ -690,7 +682,7 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 }
 
 // buildTimelineOpenObservation 给"PROMPT_SECTION_timeline-open 段"做观测树:
-// Timeline 末桶 (+ midterm 检索结果) + SessionEvidence + TodoSnapshot + Workspace +
+// Timeline 末桶 (+ midterm 检索结果) + SessionEvidence + TodoSnapshot + RecentToolsCache + Workspace +
 // SessionArtifactsOpen + UserHistory + Current Time + PlanContext (末尾)。
 //
 // 段内排序原则 (P1-C3 调整):
@@ -733,7 +725,7 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 	// "Timeline Open & Workspace" 已经表达层级.
 	// 关键词: section.timeline_open 子节点 Name 去前缀, UI 信息密度
 	//
-	// 子节点排列顺序: timeline_open -> session_evidence -> todo_list -> workspace ->
+	// 子节点排列顺序: timeline_open -> session_evidence -> todo_list -> cache_tool_call -> workspace ->
 	// session_artifacts_open -> user_history -> current_time -> plan_context. 该顺序与 timeline_open_section.txt
 	// 模板渲染顺序严格一致, 让"上下文成分"面板看到的层级与实际 prompt 字节
 	// 流顺序保持同步.
@@ -766,6 +758,15 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 			reactloops.PromptSectionRoleTimelineOpen,
 			true,
 			materials.TodoSnapshot,
+		),
+		// RecentToolsCache 标签使用稳定 nonce, 但正文随最近使用工具集合变化。
+		// 放在最后 cache boundary 之后, 避免工具集合变化导致 semi-2 前缀冷启动。
+		reactloops.NewPromptSectionObservation(
+			"section.timeline_open.cache_tool_call",
+			"Recent Tool Routing",
+			reactloops.PromptSectionRoleTimelineOpen,
+			true,
+			materials.RecentToolsCache,
 		),
 		reactloops.NewPromptSectionObservation(
 			"section.timeline_open.workspace",
@@ -1150,7 +1151,7 @@ func (pm *PromptManager) renderLoopHighStaticSection(materials *reactloops.Promp
 }
 
 // renderLoopSemiDynamic1Section 渲染 P1.1 拆分后的 semi-dynamic 第一块:
-// SkillsContext + RecentToolsCache. 物理上对应 hijacker 5 段切分中的 user2
+// SkillsContext. 物理上对应 hijacker 5 段切分中的 user2
 // (string content, 不打 cc), 由 wrapAICacheSemi 包一层 AI_CACHE_SEMI 边界.
 //
 // 关键词: renderLoopSemiDynamic1Section, semi_dynamic_section_1.txt, P1.1

--- a/common/ai/aid/aireact/prompt_loop_materials_test.go
+++ b/common/ai/aid/aireact/prompt_loop_materials_test.go
@@ -26,7 +26,7 @@ func mustLoopPromptSections(t *testing.T, raw any) []*reactloops.PromptSectionOb
 }
 
 // TestPromptManager_AssembleLoopPrompt_SectionOrder 验证"按稳定性分层"路径
-// 下 6 段顺序: high_static -> frozen_block -> semi_dynamic_1 (Skills + CacheToolCall)
+// 下 6 段顺序: high_static -> frozen_block -> semi_dynamic_1 (Skills)
 // -> semi_dynamic_2 (ExecutionPolicy + TaskInstruction + Schema + OutputExample) -> timeline_open ->
 // dynamic; 以及 frozen_block 段被 AI_CACHE_FROZEN_semi-dynamic 标签包裹,
 // semi_dynamic_1 / semi_dynamic_2 段分别被 AI_CACHE_SEMI / AI_CACHE_SEMI2 包裹.
@@ -125,7 +125,7 @@ func TestPromptManager_AssembleLoopPrompt_SectionOrder(t *testing.T) {
 
 	// 段顺序 (P1-C3 timeline-open 段内子项重排后): TRAITS -> AI_CACHE_FROZEN(START) ->
 	// Tool/Forge/Timeline-frozen -> AI_CACHE_FROZEN(END) ->
-	// PROMPT_SECTION_semi-dynamic-1 (Skills + CacheToolCall) ->
+	// PROMPT_SECTION_semi-dynamic-1 (Skills) ->
 	// PROMPT_SECTION_semi-dynamic-2 (ExecutionPolicy + Persistent + Schema + OutputExample) ->
 	// PROMPT_SECTION_timeline-open (Timeline open + SessionEvidence +
 	// Workspace + PREV_USER_INPUT + Current Time + PlanContext) ->
@@ -234,7 +234,7 @@ func TestPromptManager_AssembleLoopPrompt_SectionOrder(t *testing.T) {
 }
 
 // TestPromptManager_RenderLoopSemiDynamic1Section_Order 验证 SEMI-1 段
-// (semi_dynamic_section_1.txt) 仅包含 SkillsContext + RecentToolsCache, 不含
+// (semi_dynamic_section_1.txt) 仅包含 SkillsContext, 不含 RecentToolsCache /
 // Schema / Persistent / OutputExample / Tool / Forge.
 //
 // 关键词: renderLoopSemiDynamic1Section, semi_dynamic_section_1 内容范围, P1.1
@@ -266,10 +266,8 @@ func TestPromptManager_RenderLoopSemiDynamic1Section_Order(t *testing.T) {
 	require.NoError(t, err)
 
 	skillsIdx := strings.Index(rendered, "<|SKILLS_CONTEXT_demo|>")
-	cacheIdx := strings.Index(rendered, "<|CACHE_TOOL_CALL_[current-nonce]|>")
 	require.NotEqual(t, -1, skillsIdx)
-	require.NotEqual(t, -1, cacheIdx)
-	require.Less(t, skillsIdx, cacheIdx)
+	require.NotContains(t, rendered, "<|CACHE_TOOL_CALL_[current-nonce]|>")
 	// SEMI-1 段绝对不能含 Schema / Persistent / OutputExample / Tool / Forge.
 	require.NotContains(t, rendered, "<|SCHEMA|>")
 	require.NotContains(t, rendered, "<|PERSISTENT|>")
@@ -730,13 +728,13 @@ func requireMessageHasNoCacheControl(t *testing.T, detail aispec.ChatDetail, lab
 	}
 }
 
-// TestPromptManager_AssembleLoopPrompt_RecentToolsCacheInSemiSegment 验证
+// TestPromptManager_AssembleLoopPrompt_RecentToolsCacheAfterCacheBoundary 验证
 // CACHE_TOOL_CALL 块 (经 LoopPromptAssemblyInput.RecentToolsCache 透传) 物理位置
-// 在 semi-dynamic-1 段 (而不再在 dynamic 段, 也不在 semi-dynamic-2 段),
-// 经 hijacker 切割后位于 user2.
+// 在 timeline-open 段, 经 hijacker 切割后位于最后一个 cache boundary 之后的
+// user4, 避免最近工具集合变化击穿 semi-2 prefix cache.
 //
 // 关键词: TestPromptManager, CACHE_TOOL_CALL 物理迁移, semi-dynamic-1 段, P1.1 主路径
-func TestPromptManager_AssembleLoopPrompt_RecentToolsCacheInSemiSegment(t *testing.T) {
+func TestPromptManager_AssembleLoopPrompt_RecentToolsCacheAfterCacheBoundary(t *testing.T) {
 	react, err := NewTestReAct(
 		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
 			rsp := i.NewAIResponse()
@@ -783,14 +781,19 @@ func TestPromptManager_AssembleLoopPrompt_RecentToolsCacheInSemiSegment(t *testi
 	require.NotEqual(t, -1, cacheStartIdx, "CACHE_TOOL_CALL must appear in prompt")
 	require.NotEqual(t, -1, cacheEndIdx)
 
-	// 2. 必须位于 PROMPT_SECTION_semi-dynamic-1 段内 (P1.1: CACHE_TOOL_CALL 落在
-	//    semi 第一块, 不在 semi-2 / dynamic 段).
+	// 2. 必须位于 timeline-open 段, 不得再污染 semi-1 / semi-2 cache prefix.
 	semi1Start := strings.Index(prompt, "<|PROMPT_SECTION_semi-dynamic-1|>")
 	semi1End := strings.Index(prompt, "<|PROMPT_SECTION_END_semi-dynamic-1|>")
 	require.NotEqual(t, -1, semi1Start)
 	require.NotEqual(t, -1, semi1End)
-	require.Greater(t, cacheStartIdx, semi1Start, "CACHE_TOOL_CALL must start AFTER semi-dynamic-1 START")
-	require.Less(t, cacheEndIdx, semi1End, "CACHE_TOOL_CALL must end BEFORE semi-dynamic-1 END")
+	semi1Body := prompt[semi1Start:semi1End]
+	require.NotContains(t, semi1Body, "<|CACHE_TOOL_CALL_[current-nonce]|>")
+	timelineStart := strings.Index(prompt, "<|PROMPT_SECTION_timeline-open|>")
+	timelineEnd := strings.Index(prompt, "<|PROMPT_SECTION_END_timeline-open|>")
+	require.NotEqual(t, -1, timelineStart)
+	require.NotEqual(t, -1, timelineEnd)
+	require.Greater(t, cacheStartIdx, timelineStart)
+	require.Less(t, cacheEndIdx, timelineEnd)
 
 	// 3. semi-dynamic-2 段绝对不能含 CACHE_TOOL_CALL (P1.1 拆分边界)
 	semi2Start := strings.Index(prompt, "<|PROMPT_SECTION_semi-dynamic-2|>")
@@ -799,9 +802,9 @@ func TestPromptManager_AssembleLoopPrompt_RecentToolsCacheInSemiSegment(t *testi
 	require.NotEqual(t, -1, semi2End)
 	semi2Body := prompt[semi2Start:semi2End]
 	require.NotContains(t, semi2Body, "<|CACHE_TOOL_CALL_[current-nonce]|>",
-		"CACHE_TOOL_CALL must NOT appear in semi-dynamic-2 (belongs to semi-dynamic-1)")
+		"CACHE_TOOL_CALL must NOT appear before the final cache boundary")
 
-	// 4. dynamic 段不应该再含 CACHE_TOOL_CALL (历史位置)
+	// 4. dynamic 段不含 CACHE_TOOL_CALL; 它现在属于 timeline-open 观测段.
 	dynamicStart := strings.Index(prompt, "<|PROMPT_SECTION_dynamic_turnA|>")
 	require.NotEqual(t, -1, dynamicStart)
 	dynamicTail := prompt[dynamicStart:]
@@ -831,8 +834,8 @@ func TestPromptManager_AssembleLoopPrompt_RecentToolsCacheInSemiSegment(t *testi
 
 // TestPromptManager_AssembleLoopPrompt_SemiSegmentByteStableAcrossTurns 验证
 // 在 turn nonce 不同的两次 AssembleLoopPrompt 调用中, semi-dynamic-1 与
-// semi-dynamic-2 段都跨 turn 字节稳定 (因为 CACHE_TOOL_CALL 已用稳定字面量 nonce
-// 渲染, Schema / Persistent / OutputExample 不依赖 turn nonce).
+// semi-dynamic-2 段都跨 turn 字节稳定。RecentToolsCache 已位于最后 cache
+// boundary 之后, Schema / Persistent / OutputExample 也不依赖 turn nonce.
 //
 // 这是 P1.1 三 cache 边界生效的前提: hijacker 切到 user2 (semi-1) 与 user3
 // (semi-2) 的字节流必须跨 turn 一致, 才能命中 dashscope prefix cache.
@@ -887,7 +890,7 @@ func TestPromptManager_AssembleLoopPrompt_SemiSegmentByteStableAcrossTurns(t *te
 		return p[startIdx : endIdx+len(endTag)]
 	}
 
-	// SEMI-1 段跨 turn 字节稳定 (Skills + CacheToolCall, [current-nonce] 占位).
+	// SEMI-1 段跨 turn 字节稳定, 且不再包含随最近工具集合变化的 CacheToolCall.
 	semi1Round1 := extractSegment(t, prompt1, "<|AI_CACHE_SEMI_semi|>", "<|AI_CACHE_SEMI_END_semi|>")
 	semi1Round2 := extractSegment(t, prompt2, "<|AI_CACHE_SEMI_semi|>", "<|AI_CACHE_SEMI_END_semi|>")
 	require.Equal(t, semi1Round1, semi1Round2,
@@ -895,8 +898,8 @@ func TestPromptManager_AssembleLoopPrompt_SemiSegmentByteStableAcrossTurns(t *te
 	require.NotContains(t, semi1Round1, "nonce_round1",
 		"semi-1 segment must NOT contain turn nonce (would break byte stability)")
 	require.NotContains(t, semi1Round1, "nonce_round2_completely_different")
-	require.Contains(t, semi1Round1, "[current-nonce]",
-		"semi-1 segment must use placeholder stable nonce '[current-nonce]'")
+	require.NotContains(t, semi1Round1, "CACHE_TOOL_CALL",
+		"recent tool routing must stay after the final cache boundary")
 
 	// SEMI-2 段跨 turn 字节稳定 (ExecutionPolicy + Persistent + Schema + OutputExample, 无 turn nonce).
 	semi2Round1 := extractSegment(t, prompt1, "<|AI_CACHE_SEMI2_semi|>", "<|AI_CACHE_SEMI2_END_semi|>")

--- a/common/ai/aid/aireact/reactloops/prompt.go
+++ b/common/ai/aid/aireact/reactloops/prompt.go
@@ -261,12 +261,11 @@ func (r *ReActLoop) generateLoopPrompt(
 		}
 	}
 
-	// CACHE_TOOL_CALL 块的渲染. 整段都用稳定 nonce
-	// aicommon.RecentToolCacheStableNonce, 让该段跨 turn 字节稳定; 物理位置从
-	// dynamic/REFLECTION 迁到 semi-dynamic 段 (经 LoopPromptAssemblyInput.
-	// RecentToolsCache 字段透传, 由 semi_dynamic_section.txt 模板渲染).
+	// CACHE_TOOL_CALL 块的标签使用稳定 nonce, 但 Summary 正文会随最近工具集合
+	// 变化。物理位置放在 timeline-open 段、最后 cache boundary 之后, 避免正文
+	// 变化击穿前面的 Skills + Schema prefix cache.
 	//
-	// 关键词: CACHE_TOOL_CALL 物理迁移, semi-dynamic 段, 稳定 nonce 渲染
+	// 关键词: CACHE_TOOL_CALL 物理位置, timeline-open, cache boundary 之后
 	var recentToolsCacheBlock string
 	if tm := r.config.GetAiToolManager(); tm != nil && tm.HasRecentlyUsedTools() {
 		r.syncRecentToolParamAITagFields(tm.GetRecentToolParamNames())

--- a/common/ai/aid/aireact/reactloops/prompt_materials.go
+++ b/common/ai/aid/aireact/reactloops/prompt_materials.go
@@ -64,7 +64,7 @@ type PromptPrefixMaterials = aicommon.PromptMaterials
 //
 // HighStatic / SemiDynamic1 / SemiDynamic2 是兼容字段 (用于老路径与单元测试):
 //   - SemiDynamic1 = semi_dynamic_section_1.txt 完整渲染串
-//     (SkillsContext + RecentToolsCache),
+//     (SkillsContext),
 //     被 wrapAICacheSemi 包一层 AI_CACHE_SEMI 边界, 物理上对应 hijacker 5 段切分
 //     中的 user2 (不打 cc).
 //   - SemiDynamic2 = semi_dynamic_section_2.txt 完整渲染串

--- a/common/ai/aid/aireact/reactloops/reflection_prompt.go
+++ b/common/ai/aid/aireact/reactloops/reflection_prompt.go
@@ -68,7 +68,7 @@ func (r *ReActLoop) buildReflectionPrompt(
 	prompt := aicommon.BuildTaggedPromptSections(
 		highStatic,
 		frozenBlock,
-		"", // semi-dynamic-1 (反思不需要 SkillsContext / RecentToolsCache)
+		"", // semi-dynamic-1 (反思不需要 SkillsContext)
 		"", // semi-dynamic-2 (反思不需要主循环的 TaskInstruction / Schema)
 		timelineOpen,
 		dynamic,
@@ -186,4 +186,3 @@ func buildReflectionSchema() string {
 	)
 	return schema
 }
-

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -385,15 +385,18 @@ func (e *AIEngine) processOutputEvent(event *schema.AiOutputEvent) {
 			e.handleStreamFinishedEvent(event)
 		}
 		if event.NodeId == "react_task_created" {
-			taskInfo := map[string]string{}
+			// Structured task events can carry non-string metadata (for example,
+			// boolean flags). Decode them as mixed JSON values so an unrelated
+			// field cannot make us drop the task lifecycle event entirely.
+			taskInfo := map[string]any{}
 			err := json.Unmarshal(event.Content, &taskInfo)
 			if err != nil {
 				log.Errorf("failed to unmarshal task info: %v", err)
 				return
 			}
 			// {"react_task_id":"re-act-task-355VUaVpMxVpglfOyMuuacTWGcV","react_task_status":"created","react_user_input":"你好"}
-			taskID := taskInfo["react_task_id"]
-			taskStatus := aicommon.AITaskState(taskInfo["react_task_status"])
+			taskID := utils.InterfaceToString(taskInfo["react_task_id"])
+			taskStatus := aicommon.AITaskState(utils.InterfaceToString(taskInfo["react_task_status"]))
 
 			// 记录新任务
 			e.tasksMutex.Lock()
@@ -410,7 +413,7 @@ func (e *AIEngine) processOutputEvent(event *schema.AiOutputEvent) {
 		}
 		// {"react_task_id":"re-act-task-355VUaVpMxVpglfOyMuuacTWGcV","react_task_now_status":"completed","react_task_old_status":"processing"}
 		if event.NodeId == "react_task_status_changed" {
-			taskInfo := map[string]string{}
+			taskInfo := map[string]any{}
 			err := json.Unmarshal(event.Content, &taskInfo)
 			if err != nil {
 				log.Errorf("failed to unmarshal task info: %v", err)
@@ -418,8 +421,8 @@ func (e *AIEngine) processOutputEvent(event *schema.AiOutputEvent) {
 			}
 
 			// 更新任务状态
-			taskID := taskInfo["react_task_id"]
-			nowStatus := aicommon.AITaskState(taskInfo["react_task_now_status"])
+			taskID := utils.InterfaceToString(taskInfo["react_task_id"])
+			nowStatus := aicommon.AITaskState(utils.InterfaceToString(taskInfo["react_task_now_status"]))
 
 			e.tasksMutex.Lock()
 			e.activeTasks[taskID] = nowStatus

--- a/common/aiengine/aiengine_terminate_test.go
+++ b/common/aiengine/aiengine_terminate_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/schema"
 )
 
 // newEngineForTerminalTest builds a minimal AIEngine with its task state maps
@@ -22,6 +23,43 @@ func newEngineForTerminalTest(t *testing.T) *AIEngine {
 		activeTasks:   make(map[string]aicommon.AITaskState),
 		taskEndpoints: make(map[string]*aicommon.Endpoint),
 	}
+}
+
+func TestProcessOutputEventAcceptsMixedTaskMetadata(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	e.processOutputEvent(&schema.AiOutputEvent{
+		Type:   schema.EVENT_TYPE_STRUCTURED,
+		NodeId: "react_task_created",
+		Content: []byte(`{
+			"react_task_id":"task-with-flags",
+			"react_task_status":"created",
+			"react_user_input":"进行主机体检",
+			"is_root_task":true,
+			"iteration":1
+		}`),
+	})
+
+	requireTaskState := func(want aicommon.AITaskState) {
+		t.Helper()
+		e.tasksMutex.Lock()
+		defer e.tasksMutex.Unlock()
+		if got := e.activeTasks["task-with-flags"]; got != want {
+			t.Fatalf("unexpected task state: got %q want %q", got, want)
+		}
+	}
+	requireTaskState(aicommon.AITaskState_Created)
+
+	e.processOutputEvent(&schema.AiOutputEvent{
+		Type:   schema.EVENT_TYPE_STRUCTURED,
+		NodeId: "react_task_status_changed",
+		Content: []byte(`{
+			"react_task_id":"task-with-flags",
+			"react_task_now_status":"processing",
+			"react_task_old_status":"created",
+			"success":true
+		}`),
+	})
+	requireTaskState(aicommon.AITaskState_Processing)
 }
 
 // TestWaitTaskFinishByTaskNameFastPath verifies the fast-path terminal-state

--- a/common/yak/antlr4yak/engine_compile_to_bytes.go
+++ b/common/yak/antlr4yak/engine_compile_to_bytes.go
@@ -8,11 +8,15 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
+	parser "github.com/yaklang/yaklang/common/yak/antlr4yak/parser"
 	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
 	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 
@@ -36,11 +40,87 @@ func HaveYakcCache(code string) ([]byte, bool) {
 }
 
 func calcHash(code string, key []byte) string {
-	codeHashBasic := codec.Sha256(code + consts.GetYakVersion())
+	// `include` is compiled into the parent program, so hashing only the parent
+	// source can silently execute stale bytecode after an included file changes.
+	// Add the resolved dependency graph (path + contents) to the cache key. The
+	// absolute path also separates identical parent scripts executed from
+	// different working directories, matching include's cwd-relative semantics.
+	codeHashBasic := codec.Sha256(code + consts.GetYakVersion() + includeCacheMaterial(code, make(map[string]struct{})))
 	if key != nil {
 		return codec.Sha256(codeHashBasic + string(key))
 	}
 	return codeHashBasic
+}
+
+func includeCacheMaterial(code string, visited map[string]struct{}) string {
+	if !strings.Contains(code, "include") {
+		return ""
+	}
+
+	lexer := parser.NewYaklangLexer(antlr.NewInputStream(code))
+	var material strings.Builder
+	for {
+		token := lexer.NextToken()
+		if token.GetTokenType() == antlr.TokenEOF {
+			break
+		}
+		if token.GetTokenType() != parser.YaklangLexerInclude {
+			continue
+		}
+
+		var literal antlr.Token
+		for {
+			candidate := lexer.NextToken()
+			if candidate.GetTokenType() == antlr.TokenEOF {
+				break
+			}
+			if candidate.GetChannel() != antlr.TokenDefaultChannel {
+				continue
+			}
+			if candidate.GetTokenType() == parser.YaklangLexerStringLiteral {
+				literal = candidate
+			}
+			break
+		}
+		if literal == nil {
+			continue
+		}
+
+		includePath, err := strconv.Unquote(literal.GetText())
+		if err != nil {
+			continue
+		}
+		resolvedPath, err := utils.GetFirstExistedFileE(includePath)
+		if err != nil {
+			// A missing dependency cannot have produced a valid new cache entry,
+			// but the marker keeps it distinct from a source with no include.
+			material.WriteString("\x00missing-include\x00")
+			material.WriteString(includePath)
+			continue
+		}
+		absolutePath, err := filepath.Abs(resolvedPath)
+		if err != nil {
+			absolutePath = filepath.Clean(resolvedPath)
+		}
+		material.WriteString("\x00include-path\x00")
+		material.WriteString(absolutePath)
+		if _, ok := visited[absolutePath]; ok {
+			material.WriteString("\x00include-cycle\x00")
+			continue
+		}
+
+		includedCode, err := os.ReadFile(resolvedPath)
+		if err != nil {
+			material.WriteString("\x00unreadable-include\x00")
+			material.WriteString(err.Error())
+			continue
+		}
+		visited[absolutePath] = struct{}{}
+		material.WriteString("\x00include-code\x00")
+		material.Write(includedCode)
+		material.WriteString(includeCacheMaterial(string(includedCode), visited))
+	}
+	return material.String()
 }
 
 func HaveYakcCacheWithKey(code string, key []byte) ([]byte, bool) {

--- a/common/yak/antlr4yak/engine_compile_to_bytes_test.go
+++ b/common/yak/antlr4yak/engine_compile_to_bytes_test.go
@@ -1,0 +1,27 @@
+package antlr4yak
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalcHashTracksIncludedSource(t *testing.T) {
+	includePath := filepath.Join(t.TempDir(), "dependency.yak")
+	require.NoError(t, os.WriteFile(includePath, []byte(`value = "first"`), 0o600))
+	code := fmt.Sprintf("include %q\nprintln(value)", includePath)
+
+	first := calcHash(code, nil)
+	require.NoError(t, os.WriteFile(includePath, []byte(`value = "second"`), 0o600))
+	second := calcHash(code, nil)
+
+	require.NotEqual(t, first, second, "changing an included file must invalidate the parent yakc cache")
+}
+
+func TestCalcHashIgnoresIncludeTextOutsideStatements(t *testing.T) {
+	code := `println("include") // include "missing.yak"`
+	require.Empty(t, includeCacheMaterial(code, make(map[string]struct{})))
+}


### PR DESCRIPTION
## Summary

- make cachebench join dumps and usage by correlation ID without allowing a missing callback to shift every later sample
- attribute model tier from the model recorded in each dump and expose exact/legacy/missing/cancelled coverage in JSON and Markdown
- add a deterministic cachebench self-test for dropped callbacks, legacy fallback, orphan usage, cancellation, and high-quality aggregation
- fix structured ReAct task lifecycle events containing boolean or numeric metadata being rejected by map[string]string decoding
- make YAKC cache keys include the resolved transitive include graph so changed benchmark libraries cannot silently execute stale bytecode
- move the changing RecentToolsCache block after the final cache boundary so Skills and Schema remain reusable

## Measurement

Ran aim.InvokeReAct with 进行主机体检 for the full 1200-second window on aibalance and evaluated only memfit-standard-free records joined by exact correlation ID.

- post-change: 80 calls, 3,831,814 prompt tokens, 2,197,408 cached tokens, 57.35% exact token hit
- baseline reconstructed with the same exact join and dump-model truth: 64 calls, 3,126,472 prompt tokens, 1,958,272 cached tokens, 62.64%
- semi-dynamic-1 variants fell from 4 to 2; the stable variant covered 76/80 high-quality calls
- cold calls fell proportionally from 25.00% to 23.75%, and their share of misses fell from 56.11% to 47.27%
- 14 of 19 post-change cold calls occurred after the same semi-dynamic-2 hash had already been seen, indicating that upstream cache namespace/routing affinity is now a larger bottleneck than prompt byte drift

The total hit rate did not improve in this longer and different task trajectory, so this PR does not claim the 90% target. It makes the metric trustworthy, removes one early-prefix invalidator, and identifies sticky upstream routing/cache namespace plus timeline-tail growth as the next optimization targets.

A short post-fix smoke run verified that the report now emits alignment, modelAttribution, modelMetadata, and exact coverage; cancelled/nil-usage calls were excluded instead of shifting later records.

## Verification

- go test ./common/aiengine ./common/yak/antlr4yak ./common/ai/aid/aicache
- go test ./common/ai/aid/aireact -count=1
- targeted prompt boundary tests after the final template adjustment
- go run common/yak/cmd/yak.go common/ai/aid/aicache/cachebench/selftest.yak
- git diff --check
- full 1200-second aim.InvokeReAct benchmark plus a post-fix short smoke run