### PR TITLE
feat(ai): deterministic completion and main-loop direct answers

### DIFF
--- a/common/ai/aid/aicache/cachebench/lib.yak
+++ b/common/ai/aid/aicache/cachebench/lib.yak
@@ -952,6 +952,9 @@ func renderMarkdown(benchReport) {
     if !ccbIsNil(benchReport["disableAIVerification"]) {
         md += sprintf("- AI verification disabled: %v\n", benchReport["disableAIVerification"])
     }
+    if !ccbIsNil(benchReport["directlyAnswerViaMainLoop"]) {
+        md += sprintf("- DirectlyAnswer via main loop: %v\n", benchReport["directlyAnswerViaMainLoop"])
+    }
     if invokeError != "" {
         md += sprintf("- invoke error: %s\n", invokeError)
     }

--- a/common/ai/aid/aicache/cachebench/lib.yak
+++ b/common/ai/aid/aicache/cachebench/lib.yak
@@ -949,6 +949,9 @@ func renderMarkdown(benchReport) {
     md += sprintf("- generated:    %s\n", benchReport["generatedAt"])
     md += sprintf("- input:        %s\n", ccbTruncate(inputText, 200))
     md += sprintf("- session dir:  %s\n", sessionDir)
+    if !ccbIsNil(benchReport["disableAIVerification"]) {
+        md += sprintf("- AI verification disabled: %v\n", benchReport["disableAIVerification"])
+    }
     if invokeError != "" {
         md += sprintf("- invoke error: %s\n", invokeError)
     }

--- a/common/ai/aid/aicache/cachebench/run_react.yak
+++ b/common/ai/aid/aicache/cachebench/run_react.yak
@@ -72,6 +72,8 @@ sessionID = cli.String("session-id", cli.setDefault(""),
     cli.setHelp("传给 aim.sessionID 的会话 ID, 留空 = 自动生成独立 cachebench session 避免污染默认 session"))
 disableAIVerification = cli.Bool("disable-ai-verification",
     cli.setHelp("禁用所有 AI satisfaction verification；仅允许 finish 在当前任务 TODO 全部关闭后结束循环"))
+directlyAnswerViaMainLoop = cli.Bool("directly-answer-via-main-loop",
+    cli.setHelp("把运行中独立 DirectlyAnswer 请求写入 Timeline，并交回主循环的 directly_answer Action"))
 
 // =============================================================================
 // 失速 / 限流 / 错误的"立即退出"开关 (P3-A1: fast-fail switches)
@@ -100,8 +102,8 @@ if sessionID == "" {
     sessionID = sprintf("cachebench-%d-%d", time.Now().Unix(), os.Getpid())
 }
 
-log.info("aicache cachebench - input=%s ai-type=%s session-id=%s max-iteration=%d max-prompts=%d max-intelligent-prompts=%d max-duration=%ds stall-timeout=%ds max-throttle-events=%d abort-on-fatal-error=%v fatal-error-threshold=%d disable-ai-verification=%v",
-    inputText, aiType, sessionID, maxIter, maxPrompts, maxIntelligentPrompts, maxDuration, stallTimeout, maxThrottleEvents, abortOnFatalError, fatalErrorThreshold, disableAIVerification)
+log.info("aicache cachebench - input=%s ai-type=%s session-id=%s max-iteration=%d max-prompts=%d max-intelligent-prompts=%d max-duration=%ds stall-timeout=%ds max-throttle-events=%d abort-on-fatal-error=%v fatal-error-threshold=%d disable-ai-verification=%v directly-answer-via-main-loop=%v",
+    inputText, aiType, sessionID, maxIter, maxPrompts, maxIntelligentPrompts, maxDuration, stallTimeout, maxThrottleEvents, abortOnFatalError, fatalErrorThreshold, disableAIVerification, directlyAnswerViaMainLoop)
 
 // =============================================================================
 // 取消上下文 (用于 max-prompts 限流 / max-duration 时间硬截断)
@@ -502,6 +504,7 @@ err = aim.InvokeReAct(
     aim.yoloMode(),
     aim.allowUserInteract(false),
     aim.disableAIVerification(disableAIVerification),
+    aim.directlyAnswerViaMainLoop(directlyAnswerViaMainLoop),
     aim.onEvent(captureEvent),
 )
 
@@ -569,6 +572,7 @@ benchReport["durationSec"] = durationSec
 benchReport["aiType"] = aiType
 benchReport["aiModel"] = aiModel
 benchReport["disableAIVerification"] = disableAIVerification
+benchReport["directlyAnswerViaMainLoop"] = directlyAnswerViaMainLoop
 benchReport["maxIteration"] = maxIter
 benchReport["maxPrompts"] = maxPrompts
 benchReport["maxPromptsTriggered"] = maxPromptsTriggered

--- a/common/ai/aid/aicache/cachebench/run_react.yak
+++ b/common/ai/aid/aicache/cachebench/run_react.yak
@@ -70,6 +70,8 @@ outputDir  = cli.String("output-dir",
 // reload + reassign 所有条目, 造成多分钟"卡顿"假象 (见 P3-X2 排障).
 sessionID = cli.String("session-id", cli.setDefault(""),
     cli.setHelp("传给 aim.sessionID 的会话 ID, 留空 = 自动生成独立 cachebench session 避免污染默认 session"))
+disableAIVerification = cli.Bool("disable-ai-verification",
+    cli.setHelp("禁用所有 AI satisfaction verification；仅允许 finish 在当前任务 TODO 全部关闭后结束循环"))
 
 // =============================================================================
 // 失速 / 限流 / 错误的"立即退出"开关 (P3-A1: fast-fail switches)
@@ -98,8 +100,8 @@ if sessionID == "" {
     sessionID = sprintf("cachebench-%d-%d", time.Now().Unix(), os.Getpid())
 }
 
-log.info("aicache cachebench - input=%s ai-type=%s session-id=%s max-iteration=%d max-prompts=%d max-intelligent-prompts=%d max-duration=%ds stall-timeout=%ds max-throttle-events=%d abort-on-fatal-error=%v fatal-error-threshold=%d",
-    inputText, aiType, sessionID, maxIter, maxPrompts, maxIntelligentPrompts, maxDuration, stallTimeout, maxThrottleEvents, abortOnFatalError, fatalErrorThreshold)
+log.info("aicache cachebench - input=%s ai-type=%s session-id=%s max-iteration=%d max-prompts=%d max-intelligent-prompts=%d max-duration=%ds stall-timeout=%ds max-throttle-events=%d abort-on-fatal-error=%v fatal-error-threshold=%d disable-ai-verification=%v",
+    inputText, aiType, sessionID, maxIter, maxPrompts, maxIntelligentPrompts, maxDuration, stallTimeout, maxThrottleEvents, abortOnFatalError, fatalErrorThreshold, disableAIVerification)
 
 // =============================================================================
 // 取消上下文 (用于 max-prompts 限流 / max-duration 时间硬截断)
@@ -499,6 +501,7 @@ err = aim.InvokeReAct(
     aim.language(language),
     aim.yoloMode(),
     aim.allowUserInteract(false),
+    aim.disableAIVerification(disableAIVerification),
     aim.onEvent(captureEvent),
 )
 
@@ -565,6 +568,7 @@ benchReport = analyzeBenchmarkWithModels(sessionDir, usageList, modelList, event
 benchReport["durationSec"] = durationSec
 benchReport["aiType"] = aiType
 benchReport["aiModel"] = aiModel
+benchReport["disableAIVerification"] = disableAIVerification
 benchReport["maxIteration"] = maxIter
 benchReport["maxPrompts"] = maxPrompts
 benchReport["maxPromptsTriggered"] = maxPromptsTriggered

--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -38,6 +38,32 @@ import (
 // reactloops/docs/16-verification-frequency-experiment.md.
 // 关键词: DefaultPeriodicVerificationInterval 6, iter 门基础节拍, verification 节流
 const DefaultPeriodicVerificationInterval = 6
+
+// ConfigKeyDisableAIVerification controls the deterministic-completion
+// experiment. When enabled, no verification prompt may be sent to an AI model;
+// task completion is decided only by the finish action and the current TODO
+// state.
+const ConfigKeyDisableAIVerification = "disable_ai_verification"
+
+// IsAIVerificationDisabled is deliberately defined on KeyValueConfigIf so loop
+// and action implementations can honor the switch without widening the large
+// AICallerConfigIf interface (and breaking lightweight test invokers).
+func IsAIVerificationDisabled(config KeyValueConfigIf) (disabled bool) {
+	if utils.IsNil(config) {
+		return false
+	}
+	// Some minimal/test invokers satisfy KeyValueConfigIf by embedding a nil
+	// *KeyValueConfig. The interface itself is non-nil, but invoking the promoted
+	// method would panic. Treat missing backing config as the default (enabled)
+	// behavior so the experimental switch never destabilizes existing callers.
+	defer func() {
+		if recover() != nil {
+			disabled = false
+		}
+	}()
+	return config.GetConfigBool(ConfigKeyDisableAIVerification, false)
+}
+
 const DefaultGoalMinIterations = 6
 const GoalModeIterationBuffer = 2
 
@@ -1650,6 +1676,16 @@ func WithDisableToolUse(disable bool) ConfigOption {
 		c.m.Lock()
 		c.DisableToolUse = disable
 		c.m.Unlock()
+		return nil
+	}
+}
+
+// WithDisableAIVerification disables every AI-backed satisfaction check. The
+// ReAct loop must then terminate through finish, whose handler deterministically
+// rejects completion while the current task owns active TODO items.
+func WithDisableAIVerification(disable bool) ConfigOption {
+	return func(c *Config) error {
+		c.SetConfig(ConfigKeyDisableAIVerification, disable)
 		return nil
 	}
 }
@@ -3939,6 +3975,9 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 
 	// Disable tool use flag
 	opts = append(opts, WithDisableToolUse(i.DisableToolUse))
+	// Deterministic completion is session-wide. Child ReAct/plan/forge configs
+	// must inherit it or nested loops can silently re-enable verification AI.
+	opts = append(opts, WithDisableAIVerification(IsAIVerificationDisabled(i)))
 
 	// Capability managers: child configs reuse parent instances when present.
 	if i.AiToolManager != nil {

--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -45,6 +45,12 @@ const DefaultPeriodicVerificationInterval = 6
 // state.
 const ConfigKeyDisableAIVerification = "disable_ai_verification"
 
+// ConfigKeyDirectlyAnswerViaMainLoop controls the experiment that collapses
+// standalone DirectlyAnswer AI calls into the currently running ReAct loop.
+// The request is written to Timeline and the normal directly_answer action is
+// selected by the next main-loop decision instead of using a separate prompt.
+const ConfigKeyDirectlyAnswerViaMainLoop = "directly_answer_via_main_loop"
+
 // IsAIVerificationDisabled is deliberately defined on KeyValueConfigIf so loop
 // and action implementations can honor the switch without widening the large
 // AICallerConfigIf interface (and breaking lightweight test invokers).
@@ -62,6 +68,18 @@ func IsAIVerificationDisabled(config KeyValueConfigIf) (disabled bool) {
 		}
 	}()
 	return config.GetConfigBool(ConfigKeyDisableAIVerification, false)
+}
+
+func IsDirectlyAnswerViaMainLoopEnabled(config KeyValueConfigIf) (enabled bool) {
+	if utils.IsNil(config) {
+		return false
+	}
+	defer func() {
+		if recover() != nil {
+			enabled = false
+		}
+	}()
+	return config.GetConfigBool(ConfigKeyDirectlyAnswerViaMainLoop, false)
 }
 
 const DefaultGoalMinIterations = 6
@@ -1686,6 +1704,16 @@ func WithDisableToolUse(disable bool) ConfigOption {
 func WithDisableAIVerification(disable bool) ConfigOption {
 	return func(c *Config) error {
 		c.SetConfig(ConfigKeyDisableAIVerification, disable)
+		return nil
+	}
+}
+
+// WithDirectlyAnswerViaMainLoop makes standalone DirectlyAnswer requests join
+// the active ReAct loop. It is intentionally opt-in while cache and completion
+// behavior are being measured.
+func WithDirectlyAnswerViaMainLoop(enable bool) ConfigOption {
+	return func(c *Config) error {
+		c.SetConfig(ConfigKeyDirectlyAnswerViaMainLoop, enable)
 		return nil
 	}
 }
@@ -3978,6 +4006,9 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 	// Deterministic completion is session-wide. Child ReAct/plan/forge configs
 	// must inherit it or nested loops can silently re-enable verification AI.
 	opts = append(opts, WithDisableAIVerification(IsAIVerificationDisabled(i)))
+	// Keep the answer-routing experiment consistent across plan/forge/sub-loop
+	// configs; otherwise child loops silently recreate standalone answer calls.
+	opts = append(opts, WithDirectlyAnswerViaMainLoop(IsDirectlyAnswerViaMainLoopEnabled(i)))
 
 	// Capability managers: child configs reuse parent instances when present.
 	if i.AiToolManager != nil {

--- a/common/ai/aid/aicommon/directly_answer_delegation.go
+++ b/common/ai/aid/aicommon/directly_answer_delegation.go
@@ -1,0 +1,12 @@
+package aicommon
+
+import "errors"
+
+// ErrDirectlyAnswerDelegatedToMainLoop means no standalone AI request was
+// issued. The active loop received a Timeline stage-summary request and will
+// make the next decision through its normal action schema.
+var ErrDirectlyAnswerDelegatedToMainLoop = errors.New("directly answer delegated to active main loop")
+
+func IsDirectlyAnswerDelegatedToMainLoop(err error) bool {
+	return errors.Is(err, ErrDirectlyAnswerDelegatedToMainLoop)
+}

--- a/common/ai/aid/aicommon/disable_ai_verification_test.go
+++ b/common/ai/aid/aicommon/disable_ai_verification_test.go
@@ -15,3 +15,12 @@ func TestDisableAIVerificationIsInheritedByChildConfig(t *testing.T) {
 	require.True(t, IsAIVerificationDisabled(child),
 		"nested ReAct/plan/forge configs must not silently re-enable verification AI")
 }
+
+func TestDirectlyAnswerViaMainLoopIsInheritedByChildConfig(t *testing.T) {
+	parent := NewConfig(context.Background(), WithDirectlyAnswerViaMainLoop(true))
+	require.True(t, IsDirectlyAnswerViaMainLoopEnabled(parent))
+
+	child := NewConfig(context.Background(), ConvertConfigToOptions(parent)...)
+	require.True(t, IsDirectlyAnswerViaMainLoopEnabled(child),
+		"nested ReAct/plan/forge configs must preserve main-loop answer routing")
+}

--- a/common/ai/aid/aicommon/disable_ai_verification_test.go
+++ b/common/ai/aid/aicommon/disable_ai_verification_test.go
@@ -1,0 +1,17 @@
+package aicommon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisableAIVerificationIsInheritedByChildConfig(t *testing.T) {
+	parent := NewConfig(context.Background(), WithDisableAIVerification(true))
+	require.True(t, IsAIVerificationDisabled(parent))
+
+	child := NewConfig(context.Background(), ConvertConfigToOptions(parent)...)
+	require.True(t, IsAIVerificationDisabled(child),
+		"nested ReAct/plan/forge configs must not silently re-enable verification AI")
+}

--- a/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
@@ -14,7 +14,7 @@
 
 {{ if .TodoSnapshot }}
 
-全局待办清单（TODO LIST）由历轮 Verify 阶段累积维护，跨整段会话保持可见，是当前最权威的"应做、正在做、已关闭"事项集合。在选择下一步动作前请先对照此清单：优先沿 [DOING] 项继续推进、不要重复创建已存在的 [ ] 项、[DELETED] / [SKIPPED] 已显式放弃不应再尝试。任何新增 / 完成 / 删除都只能通过 verify-satisfaction 的 next_movements 走，正常 loop 动作不直接写入。
+全局待办清单（TODO LIST）由所有动作的 `next_movements` 与 `adjust_todolist` 共同维护，跨整段会话保持可见，是当前最权威的"应做、正在做、已关闭"事项集合。在选择下一步动作前请先对照此清单：优先沿 [DOING] 项继续推进、不要重复创建已存在的 [ ] 项、[DELETED] / [SKIPPED] 已显式放弃不应再尝试。任何正常 loop 动作都可以携带 `next_movements` 来新增、推进或关闭当前任务的 TODO；需要单独调整时使用 `adjust_todolist`。只有当前任务的 TODO 全部显式关闭后，`finish` 才能结束循环。
 
 {{ .TodoSnapshot }}
 {{ end }}

--- a/common/ai/aid/aicommon/verification_todo_store.go
+++ b/common/ai/aid/aicommon/verification_todo_store.go
@@ -695,7 +695,7 @@ func (s *VerificationTodoStore) RenderWithCurrentScope(currentScope Verification
 	if len(currentItems) == 0 {
 		lines = append(lines, "- (no TODO items tracked for the current task yet)")
 	} else {
-		lines = append(lines, "- You MUST advance or close ONLY the TODOs in this section via adjust_todolist / verification next_movements.")
+		lines = append(lines, "- You MUST advance or close ONLY the TODOs in this section via adjust_todolist or an action next_movements delta.")
 		lines = append(lines, renderVerificationTodoItemLines(currentItems)...)
 	}
 

--- a/common/ai/aid/aireact/invoke_directly_answer.go
+++ b/common/ai/aid/aireact/invoke_directly_answer.go
@@ -46,6 +46,23 @@ func (r *ReAct) DirectlyAnswer(ctx context.Context, query string, tools []*aitoo
 		return "", ctx.Err()
 	default:
 	}
+
+	// Experimental convergence path: while a ReAct loop is actively deciding or
+	// normally finalizing, do not build the standalone directly-answer prompt.
+	// Put the request/evidence into Timeline so the next ordinary main-loop call
+	// selects the directly_answer action using the same stable prompt family.
+	if aicommon.IsDirectlyAnswerViaMainLoopEnabled(r.config) {
+		if task := r.GetCurrentTask(); task != nil &&
+			task.GetStatus() == aicommon.AITaskState_Processing &&
+			!task.IsAsyncMode() {
+			if loop := r.GetCurrentLoop(); loop != nil &&
+				loop.IsDirectlyAnswerDelegationAllowed() &&
+				!loop.IsMaxIterationInterrupted() &&
+				loop.RequestStageSummary(query, config.ReferenceMaterial) {
+				return "", aicommon.ErrDirectlyAnswerDelegatedToMainLoop
+			}
+		}
+	}
 	prompt, nonceStr, err := r.promptManager.GenerateDirectlyAnswerPrompt(
 		query,
 		tools,

--- a/common/ai/aid/aireact/invoke_directly_answer_delegation_test.go
+++ b/common/ai/aid/aireact/invoke_directly_answer_delegation_test.go
@@ -1,0 +1,65 @@
+package aireact
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+)
+
+func TestReAct_DirectlyAnswer_DelegatesToActiveMainLoop(t *testing.T) {
+	var aiCalls atomic.Int32
+	ins, err := NewTestReAct(
+		aicommon.WithDirectlyAnswerViaMainLoop(true),
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			aiCalls.Add(1)
+			return nil, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	loop := reactloops.NewMinimalReActLoop(ins.config, ins)
+	task := aicommon.NewStatefulTaskBase("delegated-answer-task", "检查主机", context.Background(), ins.Emitter, true)
+	task.SetStatus(aicommon.AITaskState_Processing)
+	loop.SetCurrentTask(task)
+	loop.SetDirectlyAnswerDelegationAllowed(true)
+
+	answer, err := ins.DirectlyAnswer(
+		context.Background(),
+		"总结当前证据并标注已完成任务",
+		nil,
+		aicommon.WithDirectlyAnswerReferenceMaterial("evidence: host is reachable", 0),
+	)
+	require.Empty(t, answer)
+	require.ErrorIs(t, err, aicommon.ErrDirectlyAnswerDelegatedToMainLoop)
+	require.Zero(t, aiCalls.Load(), "delegation must not issue a standalone AI request")
+	require.True(t, loop.HasPendingStageSummaryRequest())
+}
+
+func TestReAct_DirectlyAnswer_AsyncTaskKeepsStandaloneFallback(t *testing.T) {
+	var aiCalls atomic.Int32
+	ins, err := NewTestReAct(
+		aicommon.WithDirectlyAnswerViaMainLoop(true),
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			aiCalls.Add(1)
+			return mockedLoopDirectlyAnswerOutput(i, `{"@action":"directly_answer","answer_payload":"async fallback"}`)
+		}),
+	)
+	require.NoError(t, err)
+
+	loop := reactloops.NewMinimalReActLoop(ins.config, ins)
+	task := aicommon.NewStatefulTaskBase("async-answer-task", "异步检查", context.Background(), ins.Emitter, true)
+	task.SetStatus(aicommon.AITaskState_Processing)
+	task.SetAsyncMode(true)
+	loop.SetCurrentTask(task)
+	loop.SetDirectlyAnswerDelegationAllowed(true)
+
+	answer, err := ins.DirectlyAnswer(context.Background(), "总结异步结果", nil)
+	require.NoError(t, err)
+	require.Equal(t, "async fallback", answer)
+	require.EqualValues(t, 1, aiCalls.Load())
+	require.False(t, loop.HasPendingStageSummaryRequest())
+}

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -254,6 +254,9 @@ func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTas
 			// of callback registration order. Without deferral, this callback might
 			// check ShouldIgnoreError() before a later callback has called IgnoreError().
 			operator.DeferAfterCallbacks(func() {
+				if operator.ShouldResumeLoop() {
+					return
+				}
 				// 收尾表态统一交给纯决策函数 ClassifyLoopFinishEmission (便于单测):
 				//   - IgnoreError -> 静默 (隐藏/内部 loop 自管收尾, 不污染 UI);
 				//   - 迭代上限软中断 -> "自然结束"(success), 与具体 loop / 专注模式无关.
@@ -276,6 +279,9 @@ func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTas
 				}
 			})
 			operator.DeferAfterCallbacks(func() {
+				if operator.ShouldResumeLoop() {
+					return
+				}
 				if r.memoryTriage == nil {
 					return
 				}

--- a/common/ai/aid/aireact/reactloops/action_buildin.go
+++ b/common/ai/aid/aireact/reactloops/action_buildin.go
@@ -18,7 +18,7 @@ func buildExitBlockedByTodoMessage(actionName string, items []aicommon.Verificat
 		lines = append(lines, aicommon.FormatVerificationTodoLine(item))
 	}
 	return fmt.Sprintf(
-		"current task still has %d active TODO item(s); %s cannot exit until each one is explicitly closed via adjust_todolist or verification next_movements with op=done / op=delete / op=skip.\nRemaining TODOs:\n%s",
+		"current task still has %d active TODO item(s); %s cannot exit until each one is explicitly closed via adjust_todolist or an action next_movements delta with op=done / op=delete / op=skip.\nRemaining TODOs:\n%s",
 		len(items),
 		actionName,
 		strings.Join(lines, "\n"),

--- a/common/ai/aid/aireact/reactloops/action_from_tool.go
+++ b/common/ai/aid/aireact/reactloops/action_from_tool.go
@@ -169,6 +169,10 @@ func ConvertAIToolToLoopAction(tool *aitool.Tool) *LoopAction {
 			if directly {
 				answer, err := invoker.DirectlyAnswer(ctx, "在上一次工具调用中，用户中断了工具执行，要求直接回答一些问题", nil)
 				if err != nil {
+					if aicommon.IsDirectlyAnswerDelegatedToMainLoop(err) {
+						operator.Continue()
+						return
+					}
 					operator.Fail(utils.Errorf("DirectlyAnswer failed: %v", err))
 					return
 				}

--- a/common/ai/aid/aireact/reactloops/action_operator.go
+++ b/common/ai/aid/aireact/reactloops/action_operator.go
@@ -156,6 +156,7 @@ type OnPostIterationOperator struct {
 	shouldEndIteration bool
 	endReason          any
 	ignoreError        bool     // 忽略错误，静默退出
+	resumeLoop         bool     // 阶段总结请求接管正常收尾，恢复同一个主循环
 	deferredFuncs      []func() // 在所有回调完成后执行的延迟函数
 }
 
@@ -198,6 +199,17 @@ func (o *OnPostIterationOperator) IgnoreError() {
 // ShouldIgnoreError 返回是否应该忽略错误
 func (o *OnPostIterationOperator) ShouldIgnoreError() bool {
 	return o.ignoreError
+}
+
+// ResumeLoop asks ExecuteWithExistedTask to resume after a normal action Exit.
+// It is used when a legacy standalone DirectlyAnswer finalizer is converted to
+// a Timeline stage-summary request for the ordinary main-loop action schema.
+func (o *OnPostIterationOperator) ResumeLoop() {
+	o.resumeLoop = true
+}
+
+func (o *OnPostIterationOperator) ShouldResumeLoop() bool {
+	return o.resumeLoop
 }
 
 // DeferAfterCallbacks registers a function to run after ALL OnPostIteration

--- a/common/ai/aid/aireact/reactloops/directly_answer_helper.go
+++ b/common/ai/aid/aireact/reactloops/directly_answer_helper.go
@@ -74,6 +74,7 @@ func DirectlyAnswerContinue(loop *ReActLoop, action *aicommon.Action, operator *
 		operator.Continue()
 		return
 	}
+	loop.MarkStageSummaryDelivered()
 	invoker := loop.GetInvoker()
 	if len(aicommon.NormalizeVerifyNextMovements(action)) > 0 {
 		if !utils.IsNil(invoker) {

--- a/common/ai/aid/aireact/reactloops/directly_answer_helper.go
+++ b/common/ai/aid/aireact/reactloops/directly_answer_helper.go
@@ -47,6 +47,9 @@ func ShouldAutoFinishAfterSimpleQueryDirectlyAnswer(loop *ReActLoop, action *aic
 	if loop == nil || action == nil {
 		return false
 	}
+	if aicommon.IsAIVerificationDisabled(loop.GetConfig()) {
+		return false
+	}
 	if strings.TrimSpace(loop.Get("intent_hint")) != loopIntentHintSimpleQuery {
 		return false
 	}

--- a/common/ai/aid/aireact/reactloops/directly_answer_helper_test.go
+++ b/common/ai/aid/aireact/reactloops/directly_answer_helper_test.go
@@ -187,6 +187,22 @@ func TestDirectlyAnswerContinue_DisabledVerificationRequiresFinish(t *testing.T)
 	require.True(t, op.IsContinued())
 }
 
+func TestDirectlyAnswerContinue_ClosesPendingStageSummaryRequest(t *testing.T) {
+	loop, _, _, task := newTodoGateTestLoop(t, nil)
+	require.True(t, loop.RequestStageSummary("总结当前结果", "evidence"))
+	require.True(t, loop.HasPendingStageSummaryRequest())
+
+	action, err := aicommon.ExtractAction(`{"@action":"directly_answer","answer_payload":"阶段总结"}`, "directly_answer")
+	require.NoError(t, err)
+	require.NoError(t, loopAction_DirectlyAnswer.ActionVerifier(loop, action))
+
+	op := NewActionHandlerOperator(task)
+	loopAction_DirectlyAnswer.ActionHandler(loop, action, op)
+
+	require.True(t, op.IsContinued())
+	require.False(t, loop.HasPendingStageSummaryRequest())
+}
+
 func TestDirectlyAnswerContinue_AutoFinishesSimpleQuery(t *testing.T) {
 	loop, invoker, _, task := newTodoGateTestLoop(t, nil)
 	loop.Set("intent_hint", loopIntentHintSimpleQuery)

--- a/common/ai/aid/aireact/reactloops/directly_answer_helper_test.go
+++ b/common/ai/aid/aireact/reactloops/directly_answer_helper_test.go
@@ -164,6 +164,27 @@ func TestShouldAutoFinishAfterSimpleQueryDirectlyAnswer(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.False(t, ShouldAutoFinishAfterSimpleQueryDirectlyAnswer(loop, actionWithNM))
+
+	loop.GetConfig().SetConfig(aicommon.ConfigKeyDisableAIVerification, true)
+	assert.False(t, ShouldAutoFinishAfterSimpleQueryDirectlyAnswer(loop, action),
+		"deterministic completion mode requires the explicit finish action")
+}
+
+func TestDirectlyAnswerContinue_DisabledVerificationRequiresFinish(t *testing.T) {
+	loop, _, _, task := newTodoGateTestLoop(t, nil)
+	loop.GetConfig().SetConfig(aicommon.ConfigKeyDisableAIVerification, true)
+	loop.Set("intent_hint", loopIntentHintSimpleQuery)
+	action, err := aicommon.ExtractAction(`{"@action":"directly_answer","answer_payload":"你好"}`, "directly_answer")
+	require.NoError(t, err)
+	require.NoError(t, loopAction_DirectlyAnswer.ActionVerifier(loop, action))
+
+	op := NewActionHandlerOperator(task)
+	loopAction_DirectlyAnswer.ActionHandler(loop, action, op)
+
+	terminated, termErr := op.IsTerminated()
+	require.False(t, terminated)
+	require.NoError(t, termErr)
+	require.True(t, op.IsContinued())
 }
 
 func TestDirectlyAnswerContinue_AutoFinishesSimpleQuery(t *testing.T) {

--- a/common/ai/aid/aireact/reactloops/docs/17-disable-ai-verification-experiment.md
+++ b/common/ai/aid/aireact/reactloops/docs/17-disable-ai-verification-experiment.md
@@ -1,0 +1,128 @@
+# Disable AI verification experiment
+
+## Question
+
+Measure whether removing AI-backed satisfaction verification improves cache
+behavior and task execution, while retaining deterministic completion:
+
+- `finish` is the only explicit action that terminates a ReAct loop;
+- `finish` is rejected while the current task owns an active TODO;
+- TODO state is updated by `next_movements` on any action or by
+  `adjust_todolist`;
+- no automatic, explicit, watchdog, or specialized action path may issue a
+  verification prompt.
+
+## Reproduction
+
+Both runs used the repository engine directly:
+
+```bash
+go run common/yak/cmd/yak.go \
+  common/ai/aid/aicache/cachebench/run_react.yak \
+  --input '进行主机体检' \
+  --ai-type aibalance \
+  --max-iteration 15 \
+  --max-duration 1200 \
+  --stall-timeout 180 \
+  --fatal-error-threshold 0 \
+  --output-dir <output>
+```
+
+The experiment run additionally used `--disable-ai-verification`. Each run had
+an isolated persistent session. No prompt-count cutoff was configured.
+
+Baseline report: `/tmp/yaklang-noverify-experiment/baseline/cachebench-20260718-140055.json`.
+Experiment report: `/tmp/yaklang-noverify-experiment/after-fixed/cachebench-20260718-143239.json`.
+
+## Verification attribution
+
+Exact prompt-schema attribution found six baseline prompts whose schema had
+`"const": "verify-satisfaction"`, at request sequences 31, 69, 95, 129, 168,
+and 198. All six were routed to the intelligent model.
+
+| metric | baseline verification | disabled |
+| --- | ---: | ---: |
+| calls | 6 | 0 |
+| prompt tokens | 319,325 | 0 |
+| cached tokens | 169,695 | 0 |
+| uncached prompt tokens | 149,630 | 0 |
+| upstream token hit | 53.14% | n/a |
+
+Verification represented 14.63% of baseline intelligent calls and 19.42% of
+baseline intelligent prompt tokens.
+
+## Equal-call comparison
+
+The complete runs reached different execution depths, so the primary causal
+comparison uses the first 206 calls from each run. This is the complete baseline
+sample size.
+
+| metric, first 206 calls | baseline | disabled | change |
+| --- | ---: | ---: | ---: |
+| intelligent calls | 41 | 43 | +2 |
+| all prompt tokens | 4,402,305 | 4,130,241 | -6.18% |
+| intelligent prompt tokens | 1,644,573 | 1,431,068 | -12.98% |
+| upstream token hit, all | 29.17% | 26.56% | -2.60 pp |
+| upstream token hit, intelligent | 49.97% | 48.90% | -1.07 pp |
+| client LCP hit, all | 33.39% | 43.75% | +10.36 pp |
+| client LCP hit, intelligent | 29.45% | 32.44% | +2.99 pp |
+| dynamic distinct hashes | 166 | 159 | -7 |
+| timeline-open distinct hashes | 52 | 49 | -3 |
+| semi-dynamic-2 distinct hashes | 11 | 9 | -2 |
+
+Disabling verification therefore reduced high-cost prompt volume and structural
+prefix drift. It did not improve the upstream token-hit ratio in the equal-call
+window. The provider cache result is affected by request/model mix and cannot be
+inferred from client LCP alone.
+
+## Complete-run outcome
+
+The baseline stopped after 645 seconds because no usage callback arrived for
+180 seconds. It captured 206 calls, six task result summaries, 16 tool-call
+artifacts, one direct answer, and one explicit finish.
+
+The disabled run reached the 1200-second hard cap with 376 calls and no
+verification prompt. It produced all six task result summaries, 38 tool-call
+artifacts, five direct answers, and six explicit finishes. Its final metrics
+were:
+
+- intelligent calls: 76;
+- intelligent upstream token hit: 55.74%;
+- intelligent client LCP hit: 26.85%;
+- all-tier upstream token hit: 30.30%;
+- all-tier client LCP hit: 33.59%.
+
+The disabled run progressed through Timeline archival that had stalled the
+baseline and emitted the final child-task answer. It still did not terminate
+naturally: Timeline fork/embedding cleanup encountered an upstream 502 and the
+outer invocation remained alive until the hard cap.
+
+## Findings
+
+1. AI verification is removable without losing the deterministic TODO safety
+   gate. Real child tasks closed TODOs through ordinary action
+   `next_movements`, then used `finish`.
+2. The switch must be inherited by every child Config. Without propagation in
+   `ConvertConfigToOptions`, nested blueprint loops silently re-enable
+   verification.
+3. The old Timeline Open prompt incorrectly said that only verification could
+   mutate TODO state. That conflicts with the global `next_movements` runtime
+   and makes verification-free completion unreliable.
+4. Removing verification alone does not produce a 90% upstream cache hit rate.
+   The remaining dominant drift is in `dynamic` and `timeline-open`, and the
+   remaining tail-latency risk is Timeline archive/embedding cleanup.
+5. Verification-free subtasks emitted more user-visible `directly_answer`
+   actions before `finish`. A follow-up experiment should suppress child-task
+   chat emission and let the coordinator synthesize one final answer.
+
+## Next experiments
+
+1. Make child-task completion use `finish` directly when its result summary is
+   already persisted; reserve `directly_answer` for the root task.
+2. Decouple Timeline archive/embedding cleanup from the synchronous task exit
+   path and bound it with its own timeout.
+3. Compare equal-task-stage checkpoints in addition to equal-call windows, so
+   extra useful progress is separated from extra overhead.
+4. Continue moving stable task/instruction material ahead of volatile Timeline
+   content; removing verification reduces one behavior family but does not fix
+   dynamic-section growth.

--- a/common/ai/aid/aireact/reactloops/docs/19-directly-answer-main-loop-experiment.md
+++ b/common/ai/aid/aireact/reactloops/docs/19-directly-answer-main-loop-experiment.md
@@ -1,0 +1,147 @@
+# DirectlyAnswer main-loop convergence experiment
+
+## Question
+
+Can every answer emitted while ReAct is running use the ordinary
+`directly_answer` action instead of starting a second, standalone AI call with
+the `# Direct Answer Decision` prompt family?
+
+The desired lifecycle is:
+
+1. a legacy caller requests `DirectlyAnswer` while a synchronous loop is live;
+2. the request and bounded reference material are appended to Timeline as
+   `stage_summary_request`;
+3. the current finalizer resumes the same main loop;
+4. the next ordinary decision emits `directly_answer`, including evidence and
+   `next_movements` for completed TODOs;
+5. `directly_answer` emits the stage summary and continues; only an explicit
+   `finish` may terminate the task.
+
+This keeps one action schema and one prompt family in the hot path. It also
+preserves the existing rule that a user-visible answer is not equivalent to
+task completion.
+
+## Implementation boundary
+
+The behavior is opt-in through `aim.directlyAnswerViaMainLoop(true)` or
+`aicommon.WithDirectlyAnswerViaMainLoop(true)`. The option is inherited by
+child configs.
+
+| situation | behavior |
+| --- | --- |
+| synchronous task, live decision/action phase | write one Timeline request and return a typed delegation sentinel |
+| normal finalization with a pending request | skip terminal callbacks and resume the same main loop |
+| main-loop `directly_answer` | emit answer, close the pending request, continue execution |
+| second request while one is pending | keep the standalone fallback to avoid a resume loop |
+| initialization failure, hard error, max-iteration exit | keep the standalone fallback because the main loop cannot safely resume |
+| asynchronous plan/blueprint handoff | do not summarize the parent; the downstream runner owns the result |
+
+The async rule is important. An early version delegated the parent summary to
+Timeline after `require_ai_blueprint`, but that parent loop had already handed
+off control and could never consume the request. The final implementation skips
+that premature summary instead of either delegating it or starting a standalone
+answer call.
+
+## Reproduction
+
+Runs used the repository engine directly and disabled AI verification:
+
+```bash
+go run common/yak/cmd/yak.go \
+  common/ai/aid/aicache/cachebench/run_react.yak \
+  --input '进行主机体检' \
+  --ai-type aibalance \
+  --max-iteration 15 \
+  --max-duration 1200 \
+  --stall-timeout 600 \
+  --fatal-error-threshold 0 \
+  --disable-ai-verification \
+  --directly-answer-via-main-loop \
+  --output-dir <output>
+```
+
+No prompt-count cutoff was configured for the complete runs. The corrected run
+was allowed to reach the full 1200-second cap and captured 416 calls.
+
+Reports:
+
+- verification-disabled baseline:
+  `/tmp/yaklang-noverify-experiment/after-fixed/cachebench-20260718-143239.json`;
+- first convergence run, containing the stale async Timeline request:
+  `/tmp/yaklang-noverify-experiment/directly-main-loop/cachebench-20260718-152700.json`;
+- corrected complete run:
+  `/tmp/yaklang-noverify-experiment/directly-main-loop-fixed/cachebench-20260718-154820.json`;
+- final-code 40-prompt lifecycle smoke test:
+  `/tmp/yaklang-noverify-experiment/directly-main-loop-final-smoke/cachebench-20260718-155013.json`.
+
+## Results
+
+| complete-run metric | standalone baseline | corrected convergence |
+| --- | ---: | ---: |
+| duration limit | 1200 s | 1200 s |
+| total calls | 376 | 416 |
+| intelligent calls | 76 | 74 |
+| intelligent prompt tokens | 3,875,533 | 4,557,643 |
+| intelligent upstream token hit | 55.74% | 55.06% |
+| intelligent client LCP hit | 26.85% | 24.00% |
+| all-tier upstream token hit | 30.30% | 30.19% |
+| all-tier client LCP hit | 33.59% | 29.10% |
+| high-static distinct hashes | 2 | 2 |
+| timeline-open distinct hashes | 83 | 83 |
+| dynamic distinct hashes | 291 | 323 |
+| standalone `# Direct Answer Decision` prompts | 1 | 1 |
+| delegated stage-summary requests | 0 | 0 |
+
+The single remaining standalone answer in the corrected complete run was the
+outer asynchronous blueprint handoff. That executable included the synchronous
+delegation guard but predated the final “skip async post-summary” fix. A smoke
+test compiled from the final code captured 41 calls and contained zero
+standalone Direct Answer Decision prompts and zero stale stage-summary requests.
+
+The first convergence run reached 213 calls before its 180-second stall guard
+fired. It measured 57.37% intelligent upstream hit, but the sample is not a
+valid improvement claim: it stopped at a different task depth and contained an
+unconsumable stage-summary request created by the async-parent bug.
+
+## Interpretation
+
+The control-flow convergence is valid, but this host-health task does not
+exercise it often. Its user-visible direct answers were already ordinary
+main-loop `directly_answer` actions. Only one call used the standalone prompt,
+and that call belonged to an async handoff that should not have summarized at
+all. Eliminating one call cannot materially change a 4.6-million-token
+intelligent sample, and the observed 55.74% to 55.06% difference is run-path
+noise rather than evidence of a regression or gain.
+
+This experiment therefore supports keeping the bridge as a guarded compatibility
+path for tool interruptions and specialized synchronous finalizers. It does not
+support enabling it as a cache-rate headline optimization until a workload with
+frequent programmatic `DirectlyAnswer` calls demonstrates a causal gain.
+
+## Actual bottleneck exposed by the run
+
+The late run spent substantial wall time synchronously compressing Timeline and
+expanding a single archive operation to nearly 200 indexed chunks. Prompt sizes
+then reached roughly 790-899 KB while only about 7 KB remained aligned in many
+lightweight calls. The corrected report shows:
+
+- `dynamic`: 323 distinct hashes over 413 uses, minimum reuse 6%;
+- `timeline-open`: 83 distinct hashes over 413 uses, minimum reuse 14%;
+- 17 `lcp_hit_but_upstream_miss` records late in the run;
+- intelligent upstream hit remained about 55%, far from 90%.
+
+The next cache work should prioritize bounding and asynchronously persisting
+Timeline archives, preventing raw tool output from multiplying archive chunks,
+and moving stable task/TODO facts ahead of volatile Timeline Open content. Those
+changes affect hundreds of calls; DirectlyAnswer convergence affected one call
+in this workload.
+
+## Follow-up experiment
+
+Use a synthetic workload that deliberately triggers programmatic direct answers
+from synchronous tool interruption and specialized-loop finalization. Compare
+equal action checkpoints with the flag off and on, and assert all three:
+
+1. standalone Direct Answer Decision prompt count decreases to zero;
+2. the same evidence and TODO transitions appear in the main-loop answer;
+3. total main-loop iterations do not increase enough to offset the removed call.

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -694,7 +694,9 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 
 	taskStartProcessing := func() {
 		task.SetStatus(aicommon.AITaskState_Processing)
+		r.SetDirectlyAnswerDelegationAllowed(true)
 	}
+	defer r.SetDirectlyAnswerDelegationAllowed(false)
 
 	defer func() {
 		if err := recover(); err != nil {
@@ -1073,7 +1075,11 @@ LOOP:
 				fmt.Printf("[IsTerminated-Early] action executed[%v]: \n%v\npreparing for end iteration\n", actionParams.ActionType(), actionParams.GetParams().Dump())
 				fmt.Println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
 			})
-			r.finishIterationLoopWithError(iterationCount, task, nil)
+			postOp := r.finishIterationLoopWithError(iterationCount, task, nil)
+			if postOp.ShouldResumeLoop() {
+				operator = newLoopActionHandlerOperator(task)
+				continue LOOP
+			}
 			return nil
 		}
 
@@ -1144,7 +1150,11 @@ LOOP:
 				fmt.Printf("[IsTerminated] action executed[%v]: \n%v\npreparing for end iteration\n", actionParams.ActionType(), actionParams.GetParams().Dump())
 				fmt.Println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
 			})
-			r.finishIterationLoopWithError(iterationCount, task, nil)
+			postOp := r.finishIterationLoopWithError(iterationCount, task, nil)
+			if postOp.ShouldResumeLoop() {
+				operator = newLoopActionHandlerOperator(task)
+				continue LOOP
+			}
 			return nil
 		}
 
@@ -1241,6 +1251,12 @@ func (r *ReActLoop) callOnPostIteration(current int, task aicommon.AIStatefulTas
 	for _, fn := range r.onPostIteration {
 		fn(r, current, task, isDone, reason, operator)
 	}
+	// A normal finalizer may have converted a legacy standalone DirectlyAnswer
+	// into a Timeline request. Set this before deferred callbacks so success and
+	// memory-finalization hooks do not publish a false terminal event.
+	if isDone && r.HasPendingStageSummaryRequest() && r.IsDirectlyAnswerDelegationAllowed() {
+		operator.ResumeLoop()
+	}
 	// Phase 2: Run deferred functions after ALL callbacks have completed.
 	// This ensures deferred logic can safely check the final operator state
 	// (e.g. ShouldIgnoreError()) regardless of callback registration order.
@@ -1250,6 +1266,11 @@ func (r *ReActLoop) callOnPostIteration(current int, task aicommon.AIStatefulTas
 func (r *ReActLoop) finishIterationLoopWithError(current int, task aicommon.AIStatefulTask, err any) *OnPostIterationOperator {
 	operator := newOnPostIterationOperator()
 	if r.onPostIteration != nil {
+		previousDelegationState := r.IsDirectlyAnswerDelegationAllowed()
+		if err != nil || r.IsMaxIterationInterrupted() {
+			r.SetDirectlyAnswerDelegationAllowed(false)
+		}
+		defer r.SetDirectlyAnswerDelegationAllowed(previousDelegationState)
 		if err != nil {
 			r.callOnPostIteration(current, task, true, utils.Errorf("reason: %v", err), operator)
 		} else {

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -641,7 +641,7 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 		}
 	}
 
-	if !r.DisablePeriodicVerification {
+	if !r.DisablePeriodicVerification && !aicommon.IsAIVerificationDisabled(r.GetConfig()) {
 		r.startVerificationWatchdog(task)
 		var clearWatchdogToolHooks func()
 		if inv := r.GetInvoker(); inv != nil {

--- a/common/ai/aid/aireact/reactloops/loop_default/base.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/base.go
@@ -73,6 +73,10 @@ func buildDefaultReactiveDataBuilder() reactloops.ReActLoopOption {
 	})
 }
 
+func shouldSkipPostIterationSummaryForAsync(task aicommon.AIStatefulTask) bool {
+	return task != nil && task.IsAsyncMode()
+}
+
 func init() {
 	err := reactloops.RegisterLoopFactory(
 		schema.AI_REACT_LOOP_NAME_DEFAULT,
@@ -93,7 +97,16 @@ func init() {
 					if !isDone {
 						return
 					}
-					if loop.GetLastValidAction().ActionType == schema.AI_REACT_LOOP_ACTION_DIRECTLY_ANSWER {
+					// Async actions (require_ai_blueprint/request_plan) are handoffs,
+					// not completed conversations. Their downstream runner owns the
+					// eventual user-facing result; generating a summary here either
+					// creates a premature standalone DirectlyAnswer call or leaves an
+					// unconsumable main-loop delegation request behind.
+					if shouldSkipPostIterationSummaryForAsync(task) {
+						log.Infof("iteration %d: async handoff, skip premature post-iteration summary", iteration)
+						return
+					}
+					if last := loop.GetLastValidAction(); last != nil && last.ActionType == schema.AI_REACT_LOOP_ACTION_DIRECTLY_ANSWER {
 						log.Infof("iteration %d: action is directly answer, exiting loop and returning final answer", iteration)
 						return
 					}
@@ -102,9 +115,16 @@ func init() {
 						return
 					}
 
-					directlySummary, _ := loop.GetInvoker().DirectlyAnswer(
+					directlySummary, directlyErr := loop.GetInvoker().DirectlyAnswer(
 						task.GetContext(), reActPostSummary, nil, nil,
 					)
+					if aicommon.IsDirectlyAnswerDelegatedToMainLoop(directlyErr) {
+						log.Infof("iteration %d: final summary delegated to the main-loop directly_answer action", iteration)
+						return
+					}
+					if directlyErr != nil {
+						log.Warnf("iteration %d: final summary DirectlyAnswer failed: %v", iteration, directlyErr)
+					}
 					if directlySummary != "" {
 						loop.GetInvoker().AddToTimeline("final_summary", directlySummary)
 					}

--- a/common/ai/aid/aireact/reactloops/loop_default/base_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/base_test.go
@@ -20,6 +20,14 @@ func TestResolveMaxIterations_GoalModeRaisesSmallLimit(t *testing.T) {
 	require.Equal(t, 8, resolveMaxIterations(cfg))
 }
 
+func TestShouldSkipPostIterationSummaryForAsync(t *testing.T) {
+	require.False(t, shouldSkipPostIterationSummaryForAsync(nil))
+	task := aicommon.NewStatefulTaskBase("async-handoff", "运行蓝图", context.Background(), nil, true)
+	require.False(t, shouldSkipPostIterationSummaryForAsync(task))
+	task.SetAsyncMode(true)
+	require.True(t, shouldSkipPostIterationSummaryForAsync(task))
+}
+
 func TestConfigExecutionPolicy(t *testing.T) {
 	cfg := aicommon.NewConfig(
 		context.Background(),

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/finalize.go
@@ -80,6 +80,10 @@ func tryDeliverLoopHTTPFuzzFinalizeViaAI(loop *reactloops.ReActLoop, invoker aic
 		aicommon.WithDirectlyAnswerReferenceMaterial(referenceMaterial, 0),
 	)
 	if err != nil {
+		if aicommon.IsDirectlyAnswerDelegatedToMainLoop(err) {
+			log.Infof("http_fuzztest finalize: delegated stage summary to main loop")
+			return true
+		}
 		log.Warnf("http_fuzztest finalize: DirectlyAnswer failed, falling back to lite summary: %v", err)
 		return false
 	}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
@@ -1210,6 +1210,9 @@ func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, a
 	if invoker == nil || task == nil {
 		return nil, "", nil
 	}
+	if aicommon.IsAIVerificationDisabled(loop.GetConfig()) {
+		return nil, "", nil
+	}
 
 	reactloops.EmitStatus(loop, "验证测试目标中 / Verifying Test Goal...")
 	verifyResult, err := invoker.VerifyUserSatisfaction(taskCtx, task.GetUserInput(), true, verificationPayload)

--- a/common/ai/aid/aireact/reactloops/loop_internet_research/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_internet_research/finalize.go
@@ -76,6 +76,10 @@ func emitFinalResearchReport(loop *reactloops.ReActLoop, invoker aicommon.AIInvo
 			return true
 		}
 		if err != nil {
+			if aicommon.IsDirectlyAnswerDelegatedToMainLoop(err) {
+				log.Infof("internet research finalize: delegated stage summary to main loop")
+				return true
+			}
 			log.Warnf("internet research finalize: DirectlyAnswer failed, falling back to raw report: %v", err)
 		} else {
 			log.Warnf("internet research finalize: DirectlyAnswer returned empty answer, falling back to raw report")

--- a/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/finalize.go
@@ -75,6 +75,10 @@ func deliverFinalAnswerFallback(loop *reactloops.ReActLoop, invoker aicommon.AII
 			return
 		}
 		if err != nil {
+			if aicommon.IsDirectlyAnswerDelegatedToMainLoop(err) {
+				log.Infof("knowledge enhance finalize: delegated stage summary to main loop")
+				return
+			}
 			log.Warnf("knowledge enhance finalize: DirectlyAnswer failed, falling back to raw report: %v", err)
 		} else {
 			log.Warnf("knowledge enhance finalize: DirectlyAnswer returned empty answer, falling back to raw report")

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/finalize.go
@@ -80,6 +80,10 @@ func tryDeliverYaklangFinalizeViaAI(loop *reactloops.ReActLoop, invoker aicommon
 		aicommon.WithDirectlyAnswerReferenceMaterial(reference, 0),
 	)
 	if err != nil {
+		if aicommon.IsDirectlyAnswerDelegatedToMainLoop(err) {
+			log.Infof("write_yaklang_code finalize: delegated stage summary to main loop")
+			return true
+		}
 		log.Warnf("write_yaklang_code finalize: DirectlyAnswer failed, falling back to lite summary: %v", err)
 		return false
 	}

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_enhance_knowledge_answer.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_enhance_knowledge_answer.go
@@ -108,6 +108,10 @@ var loopAction_EnhanceKnowledgeAnswer = &reactloops.LoopAction{
 
 		directlyAnswerResult, err := invoker.DirectlyAnswer(ctx, rewriteQuery, nil)
 		if err != nil {
+			if aicommon.IsDirectlyAnswerDelegatedToMainLoop(err) {
+				op.Continue()
+				return
+			}
 			log.Warnf("DirectlyAnswer failed after knowledge enhancement: %v", err)
 			invoker.EmitFileArtifactWithExt("directly_answer", ".md", enhancedAnswer)
 			invoker.EmitResultAfterStream(enhancedAnswer)

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_enhance_knowledge_answer.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_enhance_knowledge_answer.go
@@ -114,6 +114,15 @@ var loopAction_EnhanceKnowledgeAnswer = &reactloops.LoopAction{
 			directlyAnswerResult = enhancedAnswer
 		}
 
+		if aicommon.IsAIVerificationDisabled(loop.GetConfig()) {
+			invoker.AddToTimeline(
+				"knowledge_enhance_verification_skipped",
+				"AI verification is disabled; use finish after explicitly closing the current task TODOs.",
+			)
+			op.Continue()
+			return
+		}
+
 		verifyResult, err := invoker.VerifyUserSatisfaction(
 			ctx,
 			rewriteQuery,

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
@@ -280,9 +280,9 @@ Example - Sequential file operations(With AI-Tag tags):
 			fmt.Sprintf("工具编排完成: %d nodes / Tool Compose Complete: %d nodes", len(resultSummary), len(resultSummary)),
 			strings.Join(resultSummary, "\n"))
 
-		// Verify user satisfaction
+		// Verify user satisfaction unless deterministic-completion mode is active.
 		task := loop.GetCurrentTask()
-		if task != nil {
+		if task != nil && !aicommon.IsAIVerificationDisabled(loop.GetConfig()) {
 			verifyResult, err := invoker.VerifyUserSatisfaction(ctx, task.GetUserInput(), true, payload)
 			if err != nil {
 				operator.Fail(err)

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
@@ -72,6 +72,10 @@ func handleToolCallResult(
 		answer, answerErr := invoker.DirectlyAnswer(ctx,
 			"在上一次工具调用中，用户中断了工具执行，要求直接回答一些问题。一般这种情况出现在用户认为这个任务不应该使用工具或者工具无法满足需求的情况下。", nil)
 		if answerErr != nil {
+			if aicommon.IsDirectlyAnswerDelegatedToMainLoop(answerErr) {
+				operator.Continue()
+				return
+			}
 			operator.Fail(utils.Error("DirectlyAnswer fail, reason: " + answerErr.Error()))
 			return
 		}

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -704,9 +704,11 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 		}
 	}
 
-	if _, ok := r.actions.Get(schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION); !ok {
-		if verifyNow, ok := GetLoopAction(schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION); ok {
-			r.actions.Set(verifyNow.ActionType, verifyNow)
+	if !aicommon.IsAIVerificationDisabled(r.GetConfig()) {
+		if _, ok := r.actions.Get(schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION); !ok {
+			if verifyNow, ok := GetLoopAction(schema.AI_REACT_LOOP_ACTION_REQUEST_VERIFICATION); ok {
+				r.actions.Set(verifyNow.ActionType, verifyNow)
+			}
 		}
 	}
 

--- a/common/ai/aid/aireact/reactloops/stage_summary.go
+++ b/common/ai/aid/aireact/reactloops/stage_summary.go
@@ -1,0 +1,80 @@
+package reactloops
+
+import (
+	"strings"
+
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+const (
+	stageSummaryRequestPendingKey      = "__stage_summary_request_pending__"
+	directAnswerDelegationAllowedKey   = "__direct_answer_delegation_allowed__"
+	TimelineEntryStageSummaryRequest   = "stage_summary_request"
+	TimelineEntryStageSummaryDelivered = "stage_summary_delivered"
+)
+
+// SetDirectlyAnswerDelegationAllowed limits the compatibility bridge to the
+// live decision/action phase and normal finish finalization. Hard-error and
+// initialization finalizers continue to use the standalone fallback.
+func (r *ReActLoop) SetDirectlyAnswerDelegationAllowed(allowed bool) {
+	if r == nil {
+		return
+	}
+	r.Set(directAnswerDelegationAllowedKey, allowed)
+}
+
+func (r *ReActLoop) IsDirectlyAnswerDelegationAllowed() bool {
+	if r == nil {
+		return false
+	}
+	return utils.InterfaceToBoolean(r.GetVariable(directAnswerDelegationAllowedKey))
+}
+
+func (r *ReActLoop) HasPendingStageSummaryRequest() bool {
+	if r == nil {
+		return false
+	}
+	return utils.InterfaceToBoolean(r.GetVariable(stageSummaryRequestPendingKey))
+}
+
+// RequestStageSummary records one bounded, action-oriented request in Timeline.
+// Returning false means an earlier request is still pending; callers should use
+// their compatibility fallback instead of repeatedly resuming the loop.
+func (r *ReActLoop) RequestStageSummary(query, referenceMaterial string) bool {
+	if r == nil || r.HasPendingStageSummaryRequest() {
+		return false
+	}
+	r.Set(stageSummaryRequestPendingKey, true)
+
+	var body strings.Builder
+	body.WriteString("当前进行阶段性小总结。请回到主循环，根据 Timeline 中已经存在的事实和工具结果执行下一步：\n")
+	body.WriteString("1. 使用主循环的 directly_answer Action 向用户输出当前结论，不要启动独立回答调用；\n")
+	body.WriteString("2. 明确列出关键证据及其来源，不要把推测写成已验证事实；\n")
+	body.WriteString("3. 标注哪些 TODO/子任务已经完成，并通过 next_movements 更新对应状态；\n")
+	body.WriteString("4. 若仍有未完成事项，阶段总结后继续执行；若全部完成，再显式调用 finish。")
+	if query = strings.TrimSpace(query); query != "" {
+		body.WriteString("\n\n本次总结关注：\n")
+		body.WriteString(utils.ShrinkTextBlock(query, 4*1024))
+	}
+	if referenceMaterial = strings.TrimSpace(referenceMaterial); referenceMaterial != "" {
+		body.WriteString("\n\n本次总结补充证据材料：\n")
+		body.WriteString(utils.ShrinkTextBlock(referenceMaterial, 12*1024))
+	}
+	if invoker := r.GetInvoker(); invoker != nil {
+		invoker.AddToTimeline(TimelineEntryStageSummaryRequest, body.String())
+	}
+	return true
+}
+
+// MarkStageSummaryDelivered is called by the normal directly_answer action path
+// (including focus-loop overrides through DirectlyAnswerContinue).
+func (r *ReActLoop) MarkStageSummaryDelivered() {
+	if r == nil || !r.HasPendingStageSummaryRequest() {
+		return
+	}
+	r.Set(stageSummaryRequestPendingKey, false)
+	if invoker := r.GetInvoker(); invoker != nil {
+		invoker.AddToTimeline(TimelineEntryStageSummaryDelivered,
+			"阶段性总结已由主循环 directly_answer Action 输出；继续执行剩余事项，或在 TODO 全部关闭后调用 finish。")
+	}
+}

--- a/common/ai/aid/aireact/reactloops/stage_summary_test.go
+++ b/common/ai/aid/aireact/reactloops/stage_summary_test.go
@@ -1,0 +1,41 @@
+package reactloops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+func TestFinishPostIteration_ResumesForDelegatedStageSummary(t *testing.T) {
+	loop, _, _, task := newTodoGateTestLoop(t, nil)
+	loop.SetDirectlyAnswerDelegationAllowed(true)
+	loop.onPostIteration = []func(*ReActLoop, int, aicommon.AIStatefulTask, bool, any, *OnPostIterationOperator){
+		func(loop *ReActLoop, _ int, _ aicommon.AIStatefulTask, isDone bool, _ any, _ *OnPostIterationOperator) {
+			if isDone {
+				require.True(t, loop.RequestStageSummary("总结现有证据", "host reachable"))
+			}
+		},
+	}
+
+	postOp := loop.finishIterationLoopWithError(1, task, nil)
+	require.True(t, postOp.ShouldResumeLoop())
+	require.True(t, loop.HasPendingStageSummaryRequest())
+}
+
+func TestFinishPostIteration_HardErrorDoesNotDelegate(t *testing.T) {
+	loop, _, _, task := newTodoGateTestLoop(t, nil)
+	loop.SetDirectlyAnswerDelegationAllowed(true)
+	loop.onPostIteration = []func(*ReActLoop, int, aicommon.AIStatefulTask, bool, any, *OnPostIterationOperator){
+		func(loop *ReActLoop, _ int, _ aicommon.AIStatefulTask, isDone bool, _ any, _ *OnPostIterationOperator) {
+			if isDone && loop.IsDirectlyAnswerDelegationAllowed() {
+				loop.RequestStageSummary("不应委派", "")
+			}
+		},
+	}
+
+	postOp := loop.finishIterationLoopWithError(1, task, utils.Error("hard failure"))
+	require.False(t, postOp.ShouldResumeLoop())
+	require.False(t, loop.HasPendingStageSummaryRequest())
+}

--- a/common/ai/aid/aireact/reactloops/verification_gate.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate.go
@@ -190,6 +190,9 @@ func (r *ReActLoop) VerifyUserSatisfactionNow(
 	if r == nil || r.invoker == nil {
 		return nil, nil
 	}
+	if aicommon.IsAIVerificationDisabled(r.GetConfig()) {
+		return nil, nil
+	}
 	r.touchVerificationWatchdog()
 	if !r.verificationInFlight.CompareAndSwap(false, true) {
 		// 已有一次 verification 在跑, 不重入. 这条路径会被 explicit
@@ -282,6 +285,9 @@ func (r *ReActLoop) MaybeVerifyUserSatisfaction(
 	payload string,
 ) (*aicommon.VerifySatisfactionResult, bool, error) {
 	if r == nil || r.invoker == nil {
+		return nil, false, nil
+	}
+	if aicommon.IsAIVerificationDisabled(r.GetConfig()) {
 		return nil, false, nil
 	}
 	r.touchVerificationWatchdog()

--- a/common/ai/aid/aireact/reactloops/verification_gate_test.go
+++ b/common/ai/aid/aireact/reactloops/verification_gate_test.go
@@ -32,6 +32,27 @@ func (i *verificationGateTestInvoker) VerifyUserSatisfaction(ctx context.Context
 	return aicommon.NewVerifySatisfactionResult(false, "keep iterating", ""), nil
 }
 
+func TestVerificationGate_DisabledNeverCallsAI(t *testing.T) {
+	invoker := &verificationGateTestInvoker{
+		MockInvoker: mockcfg.NewMockInvoker(context.Background()),
+	}
+	invoker.GetConfig().SetConfig(aicommon.ConfigKeyDisableAIVerification, true)
+	loop := NewMinimalReActLoop(invoker.GetConfig(), invoker)
+	loop.currentIterationIndex = verificationFirstFireIterationThreshold
+	loop.SetLastPromptObservation(&PromptObservation{PromptTokens: verificationAutoTriggerHardPromptDelta})
+
+	result, triggered, err := loop.MaybeVerifyUserSatisfaction(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.False(t, triggered)
+	require.Nil(t, result)
+
+	result, err = loop.VerifyUserSatisfactionNow(context.Background(), "query", true, "tool")
+	require.NoError(t, err)
+	require.Nil(t, result)
+	require.Zero(t, invoker.verifyCalls)
+	require.Nil(t, loop.GetVerificationRuntimeSnapshot())
+}
+
 func TestShouldTriggerPeriodicCheckpointOnIteration_UsesLoopInterval(t *testing.T) {
 	invoker := &verificationGateTestInvoker{
 		MockInvoker: mockcfg.NewMockInvoker(context.Background()),

--- a/common/ai/aid/aireact/verification.go
+++ b/common/ai/aid/aireact/verification.go
@@ -18,6 +18,12 @@ import (
 
 // VerifyUserSatisfaction verifies if the materials satisfied the user's needs and provides human-readable output
 func (r *ReAct) VerifyUserSatisfaction(ctx context.Context, originalQuery string, isToolCall bool, payload string) (*aicommon.VerifySatisfactionResult, error) {
+	if r != nil && aicommon.IsAIVerificationDisabled(r.config) {
+		return &aicommon.VerifySatisfactionResult{
+			Satisfied: false,
+			Reasoning: "AI verification is disabled; completion is controlled by finish and the current TODO state",
+		}, nil
+	}
 	if utils.IsNil(ctx) {
 		ctx = r.config.GetContext()
 	}

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -551,6 +551,10 @@ func buildReActOptions(ctx context.Context, config *AIEngineConfig, outputChan c
 		options = append(options, aicommon.WithDisableToolUse(true))
 	}
 
+	if config.DisableAIVerification {
+		options = append(options, aicommon.WithDisableAIVerification(true))
+	}
+
 	if config.DisableAIForge {
 		options = append(options, aicommon.WithEnablePlanAndExec(false))
 	} else {

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -555,6 +555,10 @@ func buildReActOptions(ctx context.Context, config *AIEngineConfig, outputChan c
 		options = append(options, aicommon.WithDisableAIVerification(true))
 	}
 
+	if config.DirectlyAnswerViaMainLoop {
+		options = append(options, aicommon.WithDirectlyAnswerViaMainLoop(true))
+	}
+
 	if config.DisableAIForge {
 		options = append(options, aicommon.WithEnablePlanAndExec(false))
 	} else {

--- a/common/aiengine/config.go
+++ b/common/aiengine/config.go
@@ -38,15 +38,16 @@ type AIEngineConfig struct {
 	SessionID    string // 会话 ID，用于持久化
 
 	// 工具配置
-	DisableToolUse        bool     // 禁用工具调用
-	DisableAIVerification bool     // 禁用 AI 满意度验证，仅允许 finish + TODO 状态结束任务
-	DisableAIForge        bool     // 禁用 Forge 调用
-	DisableMCPServers     bool     // 禁用 MCPServers
-	EnableAISearchTool    bool     // 启用 AI 搜索工具
-	EnableForgeSearchTool bool     // 启用 Forge 搜索工具，默认启用
-	IncludeToolNames      []string // 包含的工具名称
-	ExcludeToolNames      []string // 排除的工具名称
-	Keywords              []string // 关键词，用于工具搜索
+	DisableToolUse            bool     // 禁用工具调用
+	DisableAIVerification     bool     // 禁用 AI 满意度验证，仅允许 finish + TODO 状态结束任务
+	DirectlyAnswerViaMainLoop bool     // 独立 DirectlyAnswer 请求回到主循环，由 directly_answer Action 执行
+	DisableAIForge            bool     // 禁用 Forge 调用
+	DisableMCPServers         bool     // 禁用 MCPServers
+	EnableAISearchTool        bool     // 启用 AI 搜索工具
+	EnableForgeSearchTool     bool     // 启用 Forge 搜索工具，默认启用
+	IncludeToolNames          []string // 包含的工具名称
+	ExcludeToolNames          []string // 排除的工具名称
+	Keywords                  []string // 关键词，用于工具搜索
 
 	// ExtraMCPServers 会话级显式挂载的 MCP server（内存态，不读 profile DB、
 	// 不进全局列表）。RestrictToSessionMCP 依赖此列表才能生效。
@@ -305,6 +306,14 @@ func WithDisableToolUse(disable bool) AIEngineConfigOption {
 func WithDisableAIVerification(disable bool) AIEngineConfigOption {
 	return func(c *AIEngineConfig) {
 		c.DisableAIVerification = disable
+	}
+}
+
+// WithDirectlyAnswerViaMainLoop routes standalone DirectlyAnswer requests into
+// the active ReAct loop as a Timeline stage-summary request.
+func WithDirectlyAnswerViaMainLoop(enable bool) AIEngineConfigOption {
+	return func(c *AIEngineConfig) {
+		c.DirectlyAnswerViaMainLoop = enable
 	}
 }
 

--- a/common/aiengine/config.go
+++ b/common/aiengine/config.go
@@ -39,6 +39,7 @@ type AIEngineConfig struct {
 
 	// 工具配置
 	DisableToolUse        bool     // 禁用工具调用
+	DisableAIVerification bool     // 禁用 AI 满意度验证，仅允许 finish + TODO 状态结束任务
 	DisableAIForge        bool     // 禁用 Forge 调用
 	DisableMCPServers     bool     // 禁用 MCPServers
 	EnableAISearchTool    bool     // 启用 AI 搜索工具
@@ -295,6 +296,15 @@ func WithLanguage(lang string) AIEngineConfigOption {
 func WithDisableToolUse(disable bool) AIEngineConfigOption {
 	return func(c *AIEngineConfig) {
 		c.DisableToolUse = disable
+	}
+}
+
+// WithDisableAIVerification disables AI-backed satisfaction verification.
+// Completion remains available only through the finish action after all TODOs
+// owned by the current task have been explicitly closed.
+func WithDisableAIVerification(disable bool) AIEngineConfigOption {
+	return func(c *AIEngineConfig) {
+		c.DisableAIVerification = disable
 	}
 }
 

--- a/common/aiengine/export.go
+++ b/common/aiengine/export.go
@@ -19,6 +19,7 @@ var Exports = map[string]interface{}{
 	"language":                  WithLanguage,
 	"disableToolUse":            WithDisableToolUse,
 	"disableAIVerification":     WithDisableAIVerification,
+	"directlyAnswerViaMainLoop": WithDirectlyAnswerViaMainLoop,
 	"disableAIForge":            WithDisableAIForge,
 	"disableMCPServers":         WithDisableMCPServers,
 	"enableAISearchTool":        WithEnableAISearchTool,

--- a/common/aiengine/export.go
+++ b/common/aiengine/export.go
@@ -18,6 +18,7 @@ var Exports = map[string]interface{}{
 	"workdir":                   WithWorkdir,
 	"language":                  WithLanguage,
 	"disableToolUse":            WithDisableToolUse,
+	"disableAIVerification":     WithDisableAIVerification,
 	"disableAIForge":            WithDisableAIForge,
 	"disableMCPServers":         WithDisableMCPServers,
 	"enableAISearchTool":        WithEnableAISearchTool,


### PR DESCRIPTION
## Summary

- add an opt-in mode that disables AI satisfaction verification and makes explicit `finish` plus deterministic TODO closure the completion gate
- add an opt-in DirectlyAnswer compatibility bridge that records a bounded stage-summary request in Timeline and resumes the ordinary main loop
- skip premature parent summaries for async blueprint/plan handoffs
- extend cachebench metadata and document both 1200-second host-health experiments

## Experiment

Executed with the repository engine via `go run common/yak/cmd/yak.go` and `aim.InvokeReAct` for `进行主机体检`.

Verification-disabled baseline:
- 376 total calls, 76 intelligent calls
- 55.74% intelligent upstream token hit
- 6 verification prompts reduced to 0

DirectlyAnswer convergence run:
- full 1200-second window, 416 total calls, 74 intelligent calls
- 55.06% intelligent upstream token hit
- host-health workload contained only one standalone Direct Answer Decision call; final async-handoff fix removes it
- final 40-prompt smoke: 0 standalone Direct Answer Decision prompts and 0 stale stage-summary requests

Conclusion: the change unifies control flow and removes redundant answer calls, but does not by itself raise cache hit to 90%. Timeline Open and dynamic archive growth remain the dominant cache bottlenecks.

## Tests

- `go test ./common/ai/aid/aicommon`
- `go test ./common/ai/aid/aireact`
- `go test ./common/ai/aid/aireact/reactloops`
- `go test ./common/aiengine`
- `go test` for loop_default, loop_http_fuzztest, loop_internet_research, loop_knowledge_enhance, loop_yaklangcode, and loopinfra
- final cachebench smoke through `go run common/yak/cmd/yak.go`
