### PR TITLE
feat(aid): reduce timeline prompt noise (task header, dup params, no-op review)

### DIFF
--- a/common/ai/aid/aicommon/timeline_byte_bucket_test.go
+++ b/common/ai/aid/aicommon/timeline_byte_bucket_test.go
@@ -20,15 +20,26 @@ func TestByteBucket_EstimateMatchesRender(t *testing.T) {
 	blocks := tl.GroupByMinutesAndBytes(3, 20000).GetBlocks()
 	require.GreaterOrEqual(t, len(blocks), 1)
 	for _, b := range blocks {
-		est := intervalBlockHeaderByteLen(b.BucketStart, b.BucketEnd, b.IntervalMinutes)
-		first := true
-		for _, it := range b.Items {
-			est += timelineEntryAppendByteLen(it, b.BucketStart, first)
-			first = false
-		}
 		rendered := b.Render()
-		require.Equal(t, len(rendered), est, "estimate must match Render byte length for block")
+		require.Equal(t, len(rendered), timelineIntervalBlockRenderedByteLen(b), "estimate must match Render byte length for block")
 	}
+}
+
+func TestByteBucket_TaskContextCarriedIntoToolFirstSubBucket(t *testing.T) {
+	tl := NewTimeline(nil, nil)
+	base := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	text := &TextTimelineItem{ID: 1, Text: "[doing] [task:task-a]:\n" + strings.Repeat("A", 4000)}
+	injectTimelineItem(tl, 1, base.Add(10*time.Second), text)
+	injectTimelineItem(tl, 2, base.Add(20*time.Second), makeToolResult(2, "scan", true, strings.Repeat("B", 4000)))
+
+	blocks := tl.GroupByMinutesAndBytes(3, 5000).GetBlocks()
+	require.Len(t, blocks, 2)
+	require.Contains(t, strings.Split(blocks[0].Render(), "\n")[0], "task=task-a")
+	require.Contains(t, strings.Split(blocks[1].Render(), "\n")[0], "task=task-a",
+		"a sub-bucket beginning with a tool result must inherit the preceding task context")
+	require.Contains(t, blocks[1].Render(), "[tool/scan ok]")
+	require.NotContains(t, blocks[0].Render(), "[task:task-a]")
+	require.Contains(t, text.Text, "[task:task-a]", "render-only optimization must preserve the stored event")
 }
 
 func TestByteBucket_NoSplitWhenUnderK(t *testing.T) {

--- a/common/ai/aid/aicommon/timeline_fork_test.go
+++ b/common/ai/aid/aicommon/timeline_fork_test.go
@@ -113,6 +113,39 @@ func TestTimelineFork_ConvertConfigToOptionsSharesSeqIdProvider(t *testing.T) {
 	require.Greater(t, id2, id1)
 }
 
+func TestTimelineFork_RenderKeepsMergedTaskBoundariesWithoutRepeatingItemLabels(t *testing.T) {
+	parent := NewTimeline(nil, nil)
+	parent.PushText(1, "[doing] [task:task-root]:\nroot")
+
+	cfg := NewConfig(context.Background(), WithDisableAutoSkills(true), WithSequence(100))
+	firstFork, err := parent.ForkForTask("1-1", "first", cfg, cfg)
+	require.NoError(t, err)
+	secondFork, err := parent.ForkForTask("1-2", "second", cfg, cfg)
+	require.NoError(t, err)
+
+	firstID := cfg.AcquireId()
+	secondID := cfg.AcquireId()
+	firstFork.Branch.PushText(firstID, "[doing] [task:task-child-a]:\nchild-a")
+	secondFork.Branch.PushText(secondID, "[doing] [task:task-child-b]:\nchild-b")
+	_, err = firstFork.MergeBack()
+	require.NoError(t, err)
+	_, err = secondFork.MergeBack()
+	require.NoError(t, err)
+
+	rendered := parent.GroupByMinutesAndBytes(3, -1).GetBlocks().Render("TIMELINE")
+	require.Equal(t, 1, strings.Count(rendered, "task-root"))
+	require.Equal(t, 1, strings.Count(rendered, "task-child-a"))
+	require.Equal(t, 1, strings.Count(rendered, "task-child-b"))
+	require.NotContains(t, rendered, "[task:")
+
+	parent.mu.RLock()
+	mergedItem, ok := parent.idToTimelineItem.Get(firstID)
+	parent.mu.RUnlock()
+	require.True(t, ok)
+	require.Equal(t, "task-child-a", ParseTimelineItemHumanReadable(mergedItem).TaskID,
+		"fork merge and structured TaskID parsing must remain untouched")
+}
+
 func TestTimelineFork_InheritedCompressedHeadNotMerged(t *testing.T) {
 	parent := NewTimeline(nil, nil)
 	parent.PushText(1, "parent-A")

--- a/common/ai/aid/aicommon/timeline_groups_render.go
+++ b/common/ai/aid/aicommon/timeline_groups_render.go
@@ -26,6 +26,9 @@ type TimelineIntervalBlock struct {
 	Open            bool            // 仅整条 timeline 最末一个 interval 子桶为 true
 	SeqInBucket     int             // 同一时间日历桶内子桶序号，从 0 起
 	TotalInBucket   int             // 该日历桶内子桶总数；1 表示未拆子桶
+	// initialTaskID 只服务于渲染：字节切桶时，子桶可能从 tool/user item 开始，
+	// 需要继承前一子桶的 task context。它不改变原始 TimelineItem，也不参与持久化。
+	initialTaskID string
 }
 
 // TimelineIntervalBlocks 是按时间顺序排列的 block 切片
@@ -288,10 +291,12 @@ func packTimelineIntervalSubBlocks(bs, be time.Time, intervalMinutes int, items 
 	if len(items) == 0 {
 		return nil
 	}
-	hl := intervalBlockHeaderByteLen(bs, be, intervalMinutes)
 	var out []*TimelineIntervalBlock
 	var cur []*TimelineItem
 	var curBytes int
+	var curInitialTaskID string
+	var curRenderState timelineTaskRenderState
+	var carriedTaskID string
 
 	flush := func() {
 		if len(cur) == 0 {
@@ -303,32 +308,42 @@ func packTimelineIntervalSubBlocks(bs, be time.Time, intervalMinutes int, items 
 			IntervalMinutes: intervalMinutes,
 			Items:           append([]*TimelineItem(nil), cur...),
 			Open:            false,
+			initialTaskID:   curInitialTaskID,
 		}
 		out = append(out, blk)
 		cur = nil
 		curBytes = 0
+		curInitialTaskID = ""
+	}
+	start := func(item *TimelineItem) {
+		curInitialTaskID = carriedTaskID
+		headerTaskID := timelineBlockHeaderTaskID(curInitialTaskID, []*TimelineItem{item})
+		curRenderState = timelineTaskRenderState{activeTaskID: headerTaskID, firstEntry: true}
+		cur = []*TimelineItem{item}
+		curBytes = len(renderTimelineIntervalHeader(bs, be, intervalMinutes, headerTaskID)) +
+			len(renderTimelineEntry(item, bs, &curRenderState))
+		advanceTimelineTaskContext(&carriedTaskID, item)
 	}
 
 	for _, item := range items {
 		if item == nil || item.deleted {
 			continue
 		}
-		entFirst := timelineEntryAppendByteLen(item, bs, true)
-		entCont := timelineEntryAppendByteLen(item, bs, false)
-
 		if len(cur) == 0 {
-			cur = []*TimelineItem{item}
-			curBytes = hl + entFirst
+			start(item)
 			continue
 		}
-		if int64(curBytes+entCont) > bytesPerBucket {
+		candidateState := curRenderState
+		entry := renderTimelineEntry(item, bs, &candidateState)
+		if int64(curBytes+len(entry)) > bytesPerBucket {
 			flush()
-			cur = []*TimelineItem{item}
-			curBytes = hl + timelineEntryAppendByteLen(item, bs, true)
+			start(item)
 			continue
 		}
 		cur = append(cur, item)
-		curBytes += entCont
+		curBytes += len(entry)
+		curRenderState = candidateState
+		advanceTimelineTaskContext(&carriedTaskID, item)
 	}
 	flush()
 
@@ -354,10 +369,12 @@ func packTimelineIntervalSubBlocksWithSizer(bs, be time.Time, intervalMinutes in
 	if sizer == nil {
 		return packTimelineIntervalSubBlocks(bs, be, intervalMinutes, items, TimelineDumpDefaultBucketByteSize)
 	}
-	hl := intervalBlockHeaderByteLen(bs, be, intervalMinutes)
 	var out []*TimelineIntervalBlock
 	var cur []*TimelineItem
 	var curBytes int
+	var curInitialTaskID string
+	var curRenderState timelineTaskRenderState
+	var carriedTaskID string
 	// recentEntrySamples 用于让 sizer 看到最近若干 entry 的平均字节
 	const recentN = 8
 	var recentSizes []int
@@ -372,18 +389,30 @@ func packTimelineIntervalSubBlocksWithSizer(bs, be time.Time, intervalMinutes in
 			IntervalMinutes: intervalMinutes,
 			Items:           append([]*TimelineItem(nil), cur...),
 			Open:            false,
+			initialTaskID:   curInitialTaskID,
 		}
 		out = append(out, blk)
 		cur = nil
 		curBytes = 0
+		curInitialTaskID = ""
+	}
+	start := func(item *TimelineItem) {
+		curInitialTaskID = carriedTaskID
+		headerTaskID := timelineBlockHeaderTaskID(curInitialTaskID, []*TimelineItem{item})
+		curRenderState = timelineTaskRenderState{activeTaskID: headerTaskID, firstEntry: true}
+		cur = []*TimelineItem{item}
+		curBytes = len(renderTimelineIntervalHeader(bs, be, intervalMinutes, headerTaskID)) +
+			len(renderTimelineEntry(item, bs, &curRenderState))
+		advanceTimelineTaskContext(&carriedTaskID, item)
 	}
 
 	for _, item := range items {
 		if item == nil || item.deleted {
 			continue
 		}
-		entFirst := timelineEntryAppendByteLen(item, bs, true)
-		entCont := timelineEntryAppendByteLen(item, bs, false)
+		sampleHeaderTaskID := timelineBlockHeaderTaskID(carriedTaskID, []*TimelineItem{item})
+		sampleState := timelineTaskRenderState{activeTaskID: sampleHeaderTaskID, firstEntry: true}
+		entFirst := len(renderTimelineEntry(item, bs, &sampleState))
 
 		// 更新最近样本
 		recentSizes = append(recentSizes, entFirst)
@@ -418,18 +447,20 @@ func packTimelineIntervalSubBlocksWithSizer(bs, be time.Time, intervalMinutes in
 		}
 
 		if len(cur) == 0 {
-			cur = []*TimelineItem{item}
-			curBytes = hl + entFirst
+			start(item)
 			continue
 		}
-		if int64(curBytes+entCont) > budget {
+		candidateState := curRenderState
+		entry := renderTimelineEntry(item, bs, &candidateState)
+		if int64(curBytes+len(entry)) > budget {
 			flush()
-			cur = []*TimelineItem{item}
-			curBytes = hl + timelineEntryAppendByteLen(item, bs, true)
+			start(item)
 			continue
 		}
 		cur = append(cur, item)
-		curBytes += entCont
+		curBytes += len(entry)
+		curRenderState = candidateState
+		advanceTimelineTaskContext(&carriedTaskID, item)
 	}
 	flush()
 
@@ -441,25 +472,104 @@ func packTimelineIntervalSubBlocksWithSizer(bs, be time.Time, intervalMinutes in
 	return out
 }
 
-func intervalBlockHeaderByteLen(bucketStart, bucketEnd time.Time, intervalMinutes int) int {
-	s := fmt.Sprintf("# bucket=%s-%s interval=%dm\n",
+func renderTimelineIntervalHeader(bucketStart, bucketEnd time.Time, intervalMinutes int, taskID string) string {
+	header := fmt.Sprintf("# bucket=%s-%s interval=%dm",
 		bucketStart.Format(utils.DefaultTimeFormat3),
 		bucketEnd.Format("15:04:05"),
 		intervalMinutes,
 	)
-	return len(s)
+	if taskID != "" {
+		header += " task=" + taskID
+	}
+	return header + "\n"
 }
 
-// timelineEntryAppendByteLen 估算 Render 中单个 entry 的字节贡献（与 TimelineIntervalBlock.Render 对齐）。
-// isFirstEntry 表示当前子桶内是否为第一条 entry（无前置换行）。
-// 关键词: timelineEntryAppendByteLen, 字节估算
-func timelineEntryAppendByteLen(item *TimelineItem, bucketStart time.Time, isFirstEntry bool) int {
-	if item == nil || item.deleted {
-		return 0
+type timelineTaskRenderState struct {
+	activeTaskID string
+	firstEntry   bool
+}
+
+// timelineItemTaskContext 只从 TextTimelineItem 的原始文本读取 task context。
+// 原文保持不变，ParseTimelineItemHumanReadable / emitter / marshal 仍能取得逐条 TaskID。
+func timelineItemTaskContext(item *TimelineItem) (taskID string, explicit bool) {
+	if item == nil || item.value == nil {
+		return "", false
 	}
-	var n int
-	if !isFirstEntry {
-		n++
+	text, ok := item.value.(*TextTimelineItem)
+	if !ok {
+		return "", false
+	}
+	if matches := withTaskRegex.FindStringSubmatch(text.Text); len(matches) > 2 {
+		taskID = strings.TrimSpace(matches[2])
+		if taskID == "" || strings.ContainsAny(taskID, "\r\n") {
+			return "", false
+		}
+		return taskID, true
+	}
+	if withoutTaskRegex.MatchString(text.Text) {
+		return "", true
+	}
+	return "", false
+}
+
+func advanceTimelineTaskContext(activeTaskID *string, item *TimelineItem) {
+	if activeTaskID == nil {
+		return
+	}
+	if taskID, explicit := timelineItemTaskContext(item); explicit {
+		*activeTaskID = taskID
+	}
+}
+
+// timelineBlockHeaderTaskID 把 block 第一条有效 item 的 task 提升到 bucket header。
+// 若子桶从 tool/user 开始，则沿用字节切桶时带入的 initialTaskID。
+func timelineBlockHeaderTaskID(initialTaskID string, items []*TimelineItem) string {
+	for _, item := range items {
+		if item == nil || item.deleted {
+			continue
+		}
+		if taskID, explicit := timelineItemTaskContext(item); explicit {
+			return taskID
+		}
+		return initialTaskID
+	}
+	return initialTaskID
+}
+
+func stripTimelineTaskLabel(content, taskID string) string {
+	if content == "" || taskID == "" {
+		return content
+	}
+	matches := withTaskRegex.FindStringSubmatchIndex(content)
+	if len(matches) < 6 || matches[0] != 0 {
+		return content
+	}
+	if strings.TrimSpace(content[matches[4]:matches[5]]) != taskID {
+		return content
+	}
+	return "[" + content[matches[2]:matches[3]] + "]:" + content[matches[1]:]
+}
+
+// renderTimelineEntry 渲染一个 entry，并推进仅在当前 block 内使用的 task state。
+// 同 task 的逐条 [task:...] 标签从渲染结果中折叠；task 切换只输出一次边界。
+func renderTimelineEntry(item *TimelineItem, bucketStart time.Time, state *timelineTaskRenderState) string {
+	if item == nil || item.deleted {
+		return ""
+	}
+	if state == nil {
+		state = &timelineTaskRenderState{firstEntry: true}
+	}
+	var buf bytes.Buffer
+	taskID, explicitTask := timelineItemTaskContext(item)
+	if !state.firstEntry {
+		buf.WriteByte('\n')
+	}
+	if explicitTask && taskID != state.activeTaskID {
+		if taskID == "" {
+			buf.WriteString("# task=-\n")
+		} else {
+			buf.WriteString("# task=" + taskID + "\n")
+		}
 	}
 	var ts time.Time
 	if !item.createdAt.IsZero() {
@@ -468,11 +578,17 @@ func timelineEntryAppendByteLen(item *TimelineItem, bucketStart time.Time, isFir
 		ts = bucketStart
 	}
 	hh, mm, ss := ts.Clock()
-	header := fmt.Sprintf("%02d:%02d:%02d [%s]", hh, mm, ss, renderItemTypeVerbose(item))
-	n += len(header)
+	buf.WriteString(fmt.Sprintf("%02d:%02d:%02d [%s]", hh, mm, ss, renderItemTypeVerbose(item)))
+	state.firstEntry = false
+	if explicitTask {
+		state.activeTaskID = taskID
+	}
 	content := selectShrunkContent(item)
+	if explicitTask && taskID != "" {
+		content = stripTimelineTaskLabel(content, taskID)
+	}
 	if content == "" {
-		return n
+		return buf.String()
 	}
 	var prevBlank bool
 	for _, line := range utils.ParseStringToRawLines(content) {
@@ -482,12 +598,25 @@ func timelineEntryAppendByteLen(item *TimelineItem, bucketStart time.Time, isFir
 				continue
 			}
 			prevBlank = true
-			n++
+			buf.WriteByte('\n')
 			continue
 		}
 		prevBlank = false
-		n++
-		n += len(line)
+		buf.WriteByte('\n')
+		buf.WriteString(line)
+	}
+	return buf.String()
+}
+
+func timelineIntervalBlockRenderedByteLen(block *TimelineIntervalBlock) int {
+	if block == nil || len(block.Items) == 0 {
+		return 0
+	}
+	headerTaskID := timelineBlockHeaderTaskID(block.initialTaskID, block.Items)
+	n := len(renderTimelineIntervalHeader(block.BucketStart, block.BucketEnd, block.IntervalMinutes, headerTaskID))
+	state := timelineTaskRenderState{activeTaskID: headerTaskID, firstEntry: true}
+	for _, item := range block.Items {
+		n += len(renderTimelineEntry(item, block.BucketStart, &state))
 	}
 	return n
 }
@@ -525,53 +654,11 @@ func (b *TimelineIntervalBlock) Render() string {
 		return ""
 	}
 	var buf bytes.Buffer
-	// 首行 metadata：bucket 时间范围 + interval。同一桶永远不变，可作稳定前缀
-	buf.WriteString(fmt.Sprintf("# bucket=%s-%s interval=%dm\n",
-		b.BucketStart.Format(utils.DefaultTimeFormat3),
-		b.BucketEnd.Format("15:04:05"),
-		b.IntervalMinutes,
-	))
-
-	first := true
+	headerTaskID := timelineBlockHeaderTaskID(b.initialTaskID, b.Items)
+	buf.WriteString(renderTimelineIntervalHeader(b.BucketStart, b.BucketEnd, b.IntervalMinutes, headerTaskID))
+	state := timelineTaskRenderState{activeTaskID: headerTaskID, firstEntry: true}
 	for _, item := range b.Items {
-		if item == nil || item.deleted {
-			continue
-		}
-		var ts time.Time
-		if !item.createdAt.IsZero() {
-			ts = item.createdAt
-		} else {
-			ts = b.BucketStart
-		}
-		hh, mm, ss := ts.Clock()
-		typeVerbose := renderItemTypeVerbose(item)
-		if !first {
-			buf.WriteByte('\n')
-		}
-		// 行头：HH:MM:SS [type/verbose]
-		buf.WriteString(fmt.Sprintf("%02d:%02d:%02d [%s]", hh, mm, ss, typeVerbose))
-		first = false
-
-		content := selectShrunkContent(item)
-		if content == "" {
-			continue
-		}
-		// 折叠多个连续空行为单空行；不加任何缩进
-		var prevBlank bool
-		for _, line := range utils.ParseStringToRawLines(content) {
-			line = strings.TrimRight(line, " \t\r")
-			if strings.TrimSpace(line) == "" {
-				if prevBlank {
-					continue
-				}
-				prevBlank = true
-				buf.WriteByte('\n')
-				continue
-			}
-			prevBlank = false
-			buf.WriteByte('\n')
-			buf.WriteString(line)
-		}
+		buf.WriteString(renderTimelineEntry(item, b.BucketStart, &state))
 	}
 	return strings.TrimRight(buf.String(), "\n")
 }

--- a/common/ai/aid/aicommon/timeline_groups_render_test.go
+++ b/common/ai/aid/aicommon/timeline_groups_render_test.go
@@ -231,6 +231,61 @@ func TestGroupByMinutes_TypeVerbose(t *testing.T) {
 	require.Contains(t, rendered, "[tool/scanY fail]")
 }
 
+func TestTimelineRender_TaskHeaderDeduplicatesSameTask(t *testing.T) {
+	tl := NewTimeline(nil, nil)
+	base := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	first := &TextTimelineItem{ID: 1, Text: "[doing] [task:task-a]:\nfirst"}
+	second := &TextTimelineItem{ID: 2, Text: "[note] [task:task-a]:\nsecond"}
+	injectTimelineItem(tl, 1, base.Add(10*time.Second), first)
+	injectTimelineItem(tl, 2, base.Add(20*time.Second), second)
+
+	rendered := tl.GroupByMinutesAndBytes(3, -1).GetBlocks()[0].Render()
+	require.Contains(t, strings.Split(rendered, "\n")[0], "task=task-a")
+	require.Equal(t, 1, strings.Count(rendered, "task-a"), "same task should appear only once in the bucket header")
+	require.NotContains(t, rendered, "[task:")
+	require.Contains(t, rendered, "[doing]:\nfirst")
+	require.Contains(t, rendered, "[note]:\nsecond")
+
+	parsed := ParseTimelineItemHumanReadable(tl.GroupByMinutesAndBytes(3, -1).GetBlocks()[0].Items[0])
+	require.Equal(t, "task-a", parsed.TaskID)
+	require.Contains(t, first.Text, "[task:task-a]", "stored text must remain unchanged")
+}
+
+func TestTimelineRender_TaskSwitchAndUnscopedReset(t *testing.T) {
+	tl := NewTimeline(nil, nil)
+	base := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	injectTimelineItem(tl, 1, base.Add(10*time.Second), &TextTimelineItem{ID: 1, Text: "[doing] [task:task-a]:\na"})
+	injectTimelineItem(tl, 2, base.Add(20*time.Second), makeToolResult(2, "a-tool", true, "tool-a"))
+	injectTimelineItem(tl, 3, base.Add(30*time.Second), &TextTimelineItem{ID: 3, Text: "[doing] [task:task-b]:\nb"})
+	injectTimelineItem(tl, 4, base.Add(40*time.Second), makeToolResult(4, "b-tool", true, "tool-b"))
+	injectTimelineItem(tl, 5, base.Add(50*time.Second), &TextTimelineItem{ID: 5, Text: "[note]:\nunscoped"})
+	injectTimelineItem(tl, 6, base.Add(60*time.Second), &TextTimelineItem{ID: 6, Text: "[doing] [task:task-a]:\na-again"})
+
+	rendered := tl.GroupByMinutesAndBytes(3, -1).GetBlocks()[0].Render()
+	require.Contains(t, strings.Split(rendered, "\n")[0], "task=task-a")
+	require.Equal(t, 2, strings.Count(rendered, "task-a"), "task-a appears in header and once when switching back")
+	require.Equal(t, 1, strings.Count(rendered, "# task=task-b"))
+	require.Equal(t, 1, strings.Count(rendered, "# task=-"))
+	require.NotContains(t, rendered, "[task:")
+
+	b := strings.Index(rendered, "# task=task-b")
+	reset := strings.Index(rendered, "# task=-")
+	back := strings.LastIndex(rendered, "# task=task-a")
+	require.True(t, b > 0 && reset > b && back > reset, "task boundaries must follow event order")
+}
+
+func TestTimelineRender_LateTaskDoesNotRewriteBucketHeader(t *testing.T) {
+	tl := NewTimeline(nil, nil)
+	base := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	injectTimelineItem(tl, 1, base.Add(10*time.Second), makeToolResult(1, "setup", true, "ready"))
+	injectTimelineItem(tl, 2, base.Add(20*time.Second), &TextTimelineItem{ID: 2, Text: "[doing] [task:task-a]:\nrun"})
+
+	rendered := tl.GroupByMinutesAndBytes(3, -1).GetBlocks()[0].Render()
+	require.NotContains(t, strings.Split(rendered, "\n")[0], "task=")
+	require.Equal(t, 1, strings.Count(rendered, "# task=task-a"))
+	require.Less(t, strings.Index(rendered, "[tool/setup ok]"), strings.Index(rendered, "# task=task-a"))
+}
+
 // TestGroupByMinutes_TagWrapping 验证 aitag 兼容包裹格式
 // 关键词: GroupByMinutes aitag 包裹, TAG_END_<nonce>, 稳定 nonce
 func TestGroupByMinutes_TagWrapping(t *testing.T) {

--- a/common/ai/aid/aicommon/timeline_marshal_test.go
+++ b/common/ai/aid/aicommon/timeline_marshal_test.go
@@ -14,13 +14,14 @@ func TestTimelineMarshalUnmarshal(t *testing.T) {
 	// 添加一些数据
 	for i := 1; i <= 3; i++ {
 		originalTimeline.PushToolResult(&aitool.ToolResult{
-			ID:          int64(100 + i),
-			Name:        "test_tool",
-			Description: "test description",
-			Param:       map[string]any{"param": i},
-			Success:     true,
-			Data:        i,
-			Error:       "",
+			ID:                   int64(100 + i),
+			Name:                 "test_tool",
+			Description:          "test description",
+			Param:                map[string]any{"param": i},
+			Success:              true,
+			Data:                 i,
+			Error:                "",
+			OmitParamsInTimeline: i == 1,
 		})
 	}
 

--- a/common/ai/aid/aicommon/toolcall.go
+++ b/common/ai/aid/aicommon/toolcall.go
@@ -259,7 +259,8 @@ type ToolCaller struct {
 
 	paramAugment func(aitool.InvokeParams) aitool.InvokeParams // optional merge before tool execution
 
-	callExpectations string
+	callExpectations           string
+	omitResultParamsInTimeline bool
 }
 
 const ReservedKeyCallExpectations = "__call_expectations__"
@@ -270,6 +271,16 @@ type ToolCallerOption func(tc *ToolCaller)
 func WithToolCaller_CallExpectations(expectations string) ToolCallerOption {
 	return func(tc *ToolCaller) {
 		tc.callExpectations = expectations
+	}
+}
+
+// WithToolCaller_OmitResultParamsInTimeline is used when the final params were
+// already recorded by an earlier, dedicated timeline item. It only affects the
+// timeline rendering hint on the returned ToolResult; invocation and persisted
+// tool-call reports still retain the complete params.
+func WithToolCaller_OmitResultParamsInTimeline() ToolCallerOption {
+	return func(tc *ToolCaller) {
+		tc.omitResultParamsInTimeline = true
 	}
 }
 
@@ -685,6 +696,9 @@ func (t *ToolCaller) DirectlyCallTool(nominalTool *aitool.Tool, action *Action, 
 
 	// 4. run the post-card flow. sync.Once ensures start is not re-emitted.
 	if fallback {
+		// The direct params were rejected and the require path generated a new set,
+		// so the final result remains the only authoritative timeline copy.
+		t.omitResultParamsInTimeline = false
 		return t.CallToolWithExistedParams(tool, false, nil)
 	}
 	if finalParams == nil {
@@ -1148,14 +1162,17 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 
 		// wait for agree
 		config.DoWaitAgree(t.ctx, ep)
+		reviewDecidedAt := time.Now()
 		params := ep.GetParams()
 		t.emitter.EmitInteractiveRelease(ep.GetId(), params)
 		config.CallAfterInteractiveEventReleased(ep.GetId(), params)
-		config.CallAfterReview(
-			ep.GetSeq(),
-			reviewQuestion,
-			params,
-		)
+		if !isFastNoopContinueReview(ep, params, reviewDecidedAt) {
+			config.CallAfterReview(
+				ep.GetSeq(),
+				reviewQuestion,
+				params,
+			)
+		}
 		if params == nil {
 			// 价值评估: 用户取消工具审批 (空响应释放) 是高价值的人工否决信号, 不能漏采.
 			if cfg, ok := config.(*Config); ok {
@@ -1273,6 +1290,9 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 		toolResult.Error = fmt.Sprintf("error invoking tool[%v]: %v", tool.Name, err)
 		toolResult.Success = false
 	}
+	if toolResult != nil {
+		toolResult.OmitParamsInTimeline = t.omitResultParamsInTimeline
+	}
 
 	// Close pipe writers to signal end of tool output. This triggers ThrottledCopy's
 	// final flush of any remaining buffered data. The deferred Close calls are still
@@ -1300,6 +1320,24 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 	NotifySessionSnapshotToolCall(t.config, toolResult)
 
 	return toolResult, false, nil
+}
+
+const fastNoopContinueReviewThreshold = 500 * time.Millisecond
+
+// isFastNoopContinueReview recognizes an automatic/default pass-through: the
+// endpoint was released within 0.5s and the response contains only the default
+// "continue" suggestion. Such a response carries no user-authored information,
+// so recording it as user/review only adds noise to the timeline.
+func isFastNoopContinueReview(ep *Endpoint, params aitool.InvokeParams, decidedAt time.Time) bool {
+	if ep == nil || len(params) != 1 || !strings.EqualFold(strings.TrimSpace(params.GetString("suggestion")), "continue") {
+		return false
+	}
+	createdAtMs := ep.GetCreatedAtMs()
+	if createdAtMs <= 0 {
+		return false
+	}
+	duration := decidedAt.Sub(time.UnixMilli(createdAtMs))
+	return duration >= 0 && duration <= fastNoopContinueReviewThreshold
 }
 
 // markdownCodeFence is 10 backticks used as code fence in markdown to safely nest any content

--- a/common/ai/aid/aicommon/toolcall_review_timeline_test.go
+++ b/common/ai/aid/aicommon/toolcall_review_timeline_test.go
@@ -1,0 +1,34 @@
+package aicommon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+func TestIsFastNoopContinueReview(t *testing.T) {
+	now := time.Now()
+	ep := NewEndpointManager().CreateEndpoint()
+
+	ep.createdAtMs = now.Add(-100 * time.Millisecond).UnixMilli()
+	require.True(t, isFastNoopContinueReview(ep, aitool.InvokeParams{
+		"suggestion": "continue",
+	}, now))
+
+	require.False(t, isFastNoopContinueReview(ep, aitool.InvokeParams{
+		"suggestion":   "continue",
+		"extra_prompt": "change the command",
+	}, now), "user-authored review input must remain in the timeline")
+
+	ep.createdAtMs = now.Add(-501 * time.Millisecond).UnixMilli()
+	require.False(t, isFastNoopContinueReview(ep, aitool.InvokeParams{
+		"suggestion": "continue",
+	}, now), "slow/manual reviews must remain in the timeline")
+
+	ep.createdAtMs = now.Add(-100 * time.Millisecond).UnixMilli()
+	require.False(t, isFastNoopContinueReview(ep, aitool.InvokeParams{
+		"suggestion": "wrong_params",
+	}, now), "non-continue decisions must remain in the timeline")
+}

--- a/common/ai/aid/aicommon/verification_todo_store.go
+++ b/common/ai/aid/aicommon/verification_todo_store.go
@@ -109,10 +109,10 @@ func (s *VerificationTodoStore) Clone() *VerificationTodoStore {
 }
 
 // VerificationTodoApplyResult reports the outcome of applying one
-// next_movements op under the supplied task scope. Every movement yields a
-// result entry — successful or not — so callers can render a uniform per-op
-// summary instead of only seeing the failures. When Success is false, Reason
-// carries the human-readable failure explanation.
+// next_movements op under the supplied task scope. Applied movements and real
+// failures yield result entries so callers can render a uniform per-op summary.
+// Idempotent DOING heartbeats are intentionally omitted. When Success is false,
+// Reason carries the human-readable failure explanation.
 //
 // 关键词: VerificationTodoApplyResult, Success, per-op 结果, 方便结果输出
 type VerificationTodoApplyResult struct {
@@ -216,13 +216,14 @@ func FormatVerificationTodoApplyErrors(results []VerificationTodoApplyResult) st
 // 吞掉. 成功应用的 op 以 Success=true 的结果条目返回, 让调用方可以做统一的
 // per-op 结果输出 (见 FormatVerificationTodoApplyResults).
 //
-// 冗余更新视为失败: 当一个 op 应用前后 TODO 的状态 (status / content) 完全
+// 冗余更新通常视为失败: 当一个 op 应用前后 TODO 的状态 (status / content) 完全
 // 不变时, 视为冗余更新, 返回 Success=false 并给出 "redundant <op>: ..." 的
 // Reason, 不推进 UpdatedAt. 典型场景: 重复 add 同 id 同 content 的 PENDING
 // 任务、对已经 DONE 的 TODO 再次 done、对已经 DELETED / SKIPPED 的 TODO 再次
-// delete / skip. 这让调用方可以识别"AI 没有实际推进 TODO"的空转轮次.
+// delete / skip. 唯一例外是重复 doing/pending: 它只是无害的进行中状态心跳,
+// Apply 会静默丢弃, 不生成成功或失败噪声.
 //
-// 关键词: Apply 取消自动翻 SKIPPED, 显式关闭, AI 主动 done/delete/skip, per-op 结果, 冗余更新即失败
+// 关键词: Apply 取消自动翻 SKIPPED, 显式关闭, AI 主动 done/delete/skip, per-op 结果, redundant doing 静默
 func (s *VerificationTodoStore) Apply(scope VerificationTodoScope, satisfied bool, movements []VerifyNextMovement) []VerificationTodoApplyResult {
 	if s == nil {
 		return nil
@@ -246,6 +247,12 @@ func (s *VerificationTodoStore) Apply(scope VerificationTodoScope, satisfied boo
 			result = s.applyAdd(movement, scope, id, roundIndex)
 		case "doing", "pending":
 			result = s.applyStatusMutation(movement, scope, id, VerificationTodoStatusDoing, true, roundIndex)
+			// Reasserting DOING without changing content is an idempotent heartbeat,
+			// not a failed movement. Drop it entirely so it produces neither
+			// `FAILED DOING[...]` nor an equally-unhelpful success line.
+			if !result.Success && result.Reason == redundantTodoMutationReason(VerificationTodoStatusDoing) {
+				continue
+			}
 		case "done":
 			result = s.applyStatusMutation(movement, scope, id, VerificationTodoStatusDone, false, roundIndex)
 		case "delete":

--- a/common/ai/aid/aicommon/verification_todo_store_test.go
+++ b/common/ai/aid/aicommon/verification_todo_store_test.go
@@ -146,9 +146,9 @@ func TestVerificationTodoStore_Apply_RedundantUpdateIsFailure(t *testing.T) {
 		results := store.Apply(VerificationTodoScope{}, false, []VerifyNextMovement{
 			{Op: "doing", ID: "x"},
 		})
-		require.Len(t, results, 1)
-		require.False(t, results[0].Success)
-		require.Contains(t, results[0].Reason, "redundant doing")
+		require.Empty(t, results, "redundant doing should be silently ignored")
+		require.Empty(t, FormatVerificationTodoApplyResults(results))
+		require.Empty(t, FormatVerificationTodoApplyErrors(results))
 	})
 
 	t.Run("doing with new content is not redundant", func(t *testing.T) {

--- a/common/ai/aid/aireact/invoke_toolcall.go
+++ b/common/ai/aid/aireact/invoke_toolcall.go
@@ -300,7 +300,13 @@ func (r *ReAct) DirectlyCallTool(ctx context.Context, toolName string, action *a
 
 	// Always attach the param-gen builder so fallbackToRequire can reuse this card
 	// and switch to the AI param-generation path.
-	toolCaller, err := r.newToolCallerForCall(ctx, currentTask, toolName, true)
+	toolCaller, err := r.newToolCallerForCall(
+		ctx,
+		currentTask,
+		toolName,
+		true,
+		aicommon.WithToolCaller_OmitResultParamsInTimeline(),
+	)
 	if err != nil {
 		return nil, false, err
 	}

--- a/common/ai/aid/aireact/invoke_toolcall_directly_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_directly_test.go
@@ -173,6 +173,11 @@ LOOP:
 
 	require.True(t, taskCompleted, "task should complete")
 	require.Equal(t, int32(1), atomic.LoadInt32(&toolCallCount), "tool should be called exactly once")
+	timeline := react.config.Timeline.String()
+	require.Contains(t, timeline, "[DIRECT_CALL_PARAMS]")
+	require.Contains(t, timeline, "[seconds]: 0.1")
+	require.NotContains(t, timeline, "param:", "direct-call result must not duplicate the params")
+	require.NotContains(t, timeline, "[user/review]", "fast no-op continue must not enter the timeline")
 }
 
 func TestReAct_DirectlyCallTool_LegacyWrappedParams(t *testing.T) {

--- a/common/ai/aid/aireact/invoke_toolcall_for_mcp_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_for_mcp_test.go
@@ -384,8 +384,8 @@ LOOP:
 	if !strings.Contains(tl, `mocked thought for mcp tool calling`) {
 		t.Fatal("timeline does not contain mocked thought for mcp tool calling")
 	}
-	if !utils.MatchAllOfSubString(tl, `system-question`, "user-answer", "when review") {
-		t.Fatal("timeline does not contain system-question")
+	if strings.Contains(tl, `when review`) {
+		t.Fatal("auto-continue review must not pollute the timeline")
 	}
 	if !utils.MatchAllOfSubString(tl, `ReAct iteration 1`, `ReAct Iteration Done[1]`) {
 		t.Fatal("timeline does not contain ReAct iteration")

--- a/common/ai/aid/aireact/invoke_toolcall_from_db_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_from_db_test.go
@@ -489,8 +489,8 @@ LOOP:
 		t.Fatal("timeline does not contain mocked thought")
 	}
 
-	if !utils.MatchAllOfSubString(tl, "system-question", "user-answer", "when review") {
-		t.Fatal("timeline does not contain system-question")
+	if strings.Contains(tl, `when review`) {
+		t.Fatal("auto-continue review must not pollute the timeline")
 	}
 
 	if !utils.MatchAllOfSubString(tl, "ReAct iteration 1", "ReAct Iteration Done[1]") {

--- a/common/ai/aid/aireact/invoke_toolcall_multicall_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_multicall_test.go
@@ -181,8 +181,8 @@ LOOP:
 	if !strings.Contains(tl, `mocked thought for tool calling`) {
 		t.Fatal("timeline does not contain mocked thought")
 	}
-	if !utils.MatchAllOfSubString(tl, `system-question`, "user-answer", "when review") {
-		t.Fatal("timeline does not contain system-question")
+	if strings.Contains(tl, `when review`) {
+		t.Fatal("auto-continue review must not pollute the timeline")
 	}
 	if !utils.MatchAllOfSubString(tl, `ReAct iteration 1`, `ReAct iteration 2`, `ReAct iteration 3`, `ReAct iteration 4`, `ReAct Iteration Done[4]`) {
 		t.Fatal("timeline does not contain ReAct iteration")

--- a/common/ai/aid/aireact/invoke_toolcall_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_test.go
@@ -360,8 +360,8 @@ LOOP:
 	if !strings.Contains(tl, `mocked thought for tool calling`) {
 		t.Fatal("timeline does not contain mocked thought")
 	}
-	if !utils.MatchAllOfSubString(tl, `system-question`, "user-answer", "when review") {
-		t.Fatal("timeline does not contain system-question")
+	if strings.Contains(tl, `when review`) {
+		t.Fatal("auto-continue review must not pollute the timeline")
 	}
 	if !utils.MatchAllOfSubString(tl, `ReAct iteration 1`, `ReAct Iteration Done[1]`) {
 		t.Fatal("timeline does not contain ReAct iteration")

--- a/common/ai/aid/aireact/re-act_persistence_test.go
+++ b/common/ai/aid/aireact/re-act_persistence_test.go
@@ -142,8 +142,8 @@ LOOP:
 	if !strings.Contains(tl, `mocked thought for tool calling`) {
 		t.Fatal("timeline does not contain mocked thought")
 	}
-	if !utils.MatchAllOfSubString(tl, `system-question`, "user-answer", "when review") {
-		t.Fatal("timeline does not contain system-question")
+	if strings.Contains(tl, `when review`) {
+		t.Fatal("auto-continue review must not pollute the timeline")
 	}
 	if !utils.MatchAllOfSubString(tl, `ReAct iteration 1`, `ReAct Iteration Done[1]`) {
 		fmt.Println(tl)

--- a/common/ai/aid/aitool/tool_invoke_result.go
+++ b/common/ai/aid/aitool/tool_invoke_result.go
@@ -29,44 +29,50 @@ type ToolResult struct {
 	ShrinkResult string `json:"shrink_result,omitempty"`
 
 	CallExpectations string `json:"call_expectations,omitempty"`
+
+	// OmitParamsInTimeline indicates that the params have already been emitted as
+	// a dedicated timeline item (for example [DIRECT_CALL_PARAMS]) and should not
+	// be duplicated when this result is rendered into the timeline.
+	OmitParamsInTimeline bool `json:"omit_params_in_timeline,omitempty"`
 }
 
-func (t *ToolResult) DumpTimelineItem(buf io.Writer) {
-
+type ToolResultDumpOptions struct {
+	IncludeParams bool
 }
 
-func (t *ToolResult) GetShrinkResult() string {
-	if t.ShrinkResult != "" {
-		return t.ShrinkResult
+type ToolResultDumpOption func(*ToolResultDumpOptions)
+
+func WithToolResultDumpParams(include bool) ToolResultDumpOption {
+	return func(opts *ToolResultDumpOptions) {
+		opts.IncludeParams = include
 	}
-	return t.ShrinkSimilarResult
 }
 
-func (t *ToolResult) SetShrinkResult(i string) {
-	t.ShrinkResult = i
-}
-
-func (t *ToolResult) GetShrinkSimilarResult() string {
-	if t.ShrinkSimilarResult != "" {
-		return t.ShrinkSimilarResult
+func (t *ToolResult) DumpTimelineItem(buf io.Writer, options ...ToolResultDumpOption) {
+	opts := &ToolResultDumpOptions{IncludeParams: true}
+	for _, option := range options {
+		option(opts)
 	}
-	return t.ShrinkResult
-}
-
-func (t *ToolResult) String() string {
-	buf := bytes.NewBuffer(nil)
 	if t.ID > 0 {
-		buf.WriteString(fmt.Sprintf("id: %v; ", t.ID))
+		fmt.Fprintf(buf, "id: %v; ", t.ID)
 	}
-	buf.WriteString(fmt.Sprintf("tool_name: %#v\n", t.Name))
+	fmt.Fprintf(buf, "tool_name: %#v\n", t.Name)
 
 	if t.CallExpectations != "" {
-		buf.WriteString(fmt.Sprintf("call_expectations: %s\n", t.CallExpectations))
+		fmt.Fprintf(buf, "call_expectations: %s\n", t.CallExpectations)
 	}
 
+	if opts.IncludeParams {
+		t.dumpTimelineParams(buf)
+	}
+
+	t.dumpTimelineResult(buf)
+}
+
+func (t *ToolResult) dumpTimelineParams(buf io.Writer) {
 	paramParsed := utils.InterfaceToGeneralMap(t.Param)
 	if len(paramParsed) > 0 {
-		buf.WriteString("param:\n")
+		fmt.Fprintln(buf, "param:")
 		out, err := yaml.Marshal(paramParsed)
 		if err != nil {
 			// 旧实现给 fallback 行加 '  - ' 前缀, 配合 yaml-marshal 路径的统一
@@ -74,7 +80,7 @@ func (t *ToolResult) String() string {
 			// 是合法 yaml.
 			// 关键词: ToolResult.String fallback 去外层缩进
 			for k, v := range paramParsed {
-				buf.WriteString(fmt.Sprintf("- %v: %s\n", k, v))
+				fmt.Fprintf(buf, "- %v: %s\n", k, v)
 			}
 		} else {
 			// yaml.Marshal 自身已经产生合法相对缩进 (顶层 key 顶头, 嵌套 value
@@ -84,11 +90,15 @@ func (t *ToolResult) String() string {
 			// 进 (yaml 4 + 外套 2). 直接拼 yaml 原文, 既减 token 又仍可被
 			// yaml.Unmarshal 正确解析. yaml.Marshal 输出末尾自带 '\n'.
 			// 关键词: ToolResult.String yaml 顶层不再外套 '  ', timeline prompt 紧凑
-			buf.Write(out)
+			_, _ = buf.Write(out)
 		}
 	} else {
-		buf.WriteString(fmt.Sprintf("param: %s\n", utils.Jsonify(t.Param)))
+		fmt.Fprintf(buf, "param: %s\n", utils.Jsonify(t.Param))
 	}
+}
+
+func (t *ToolResult) dumpTimelineResult(writer io.Writer) {
+	buf := bytes.NewBuffer(nil)
 
 	if t.ShrinkResult != "" { // shrink result preface
 		buf.WriteString(fmt.Sprintf("shrink_result: %#v\n", t.ShrinkResult))
@@ -154,6 +164,30 @@ func (t *ToolResult) String() string {
 		buf.WriteString(fmt.Sprintf("err: %s\n", t.Error))
 	}
 
+	_, _ = writer.Write(buf.Bytes())
+}
+
+func (t *ToolResult) GetShrinkResult() string {
+	if t.ShrinkResult != "" {
+		return t.ShrinkResult
+	}
+	return t.ShrinkSimilarResult
+}
+
+func (t *ToolResult) SetShrinkResult(i string) {
+	t.ShrinkResult = i
+}
+
+func (t *ToolResult) GetShrinkSimilarResult() string {
+	if t.ShrinkSimilarResult != "" {
+		return t.ShrinkSimilarResult
+	}
+	return t.ShrinkResult
+}
+
+func (t *ToolResult) String() string {
+	buf := bytes.NewBuffer(nil)
+	t.DumpTimelineItem(buf, WithToolResultDumpParams(!t.OmitParamsInTimeline))
 	return buf.String()
 }
 

--- a/common/ai/aid/aitool/tool_invoke_result_test.go
+++ b/common/ai/aid/aitool/tool_invoke_result_test.go
@@ -1,12 +1,35 @@
 package aitool
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+func TestToolResult_DumpTimelineItem_ParamsOption(t *testing.T) {
+	tr := &ToolResult{
+		Name:  "direct_tool",
+		Param: map[string]any{"secret_marker": "only-once"},
+		Data:  map[string]any{"result": "ok"},
+	}
+
+	withParams := bytes.NewBuffer(nil)
+	tr.DumpTimelineItem(withParams)
+	require.Contains(t, withParams.String(), "param:")
+	require.Contains(t, withParams.String(), "secret_marker")
+
+	withoutParams := bytes.NewBuffer(nil)
+	tr.DumpTimelineItem(withoutParams, WithToolResultDumpParams(false))
+	require.NotContains(t, withoutParams.String(), "param:")
+	require.NotContains(t, withoutParams.String(), "secret_marker")
+	require.Contains(t, withoutParams.String(), "result:")
+
+	tr.OmitParamsInTimeline = true
+	require.Equal(t, withoutParams.String(), tr.String())
+}
 
 // TestToolResult_String_YAMLParamFlushLeft 验证 ToolResult.String() 的 yaml param
 // 块顶层 key 顶头 (无外层 "  " 缩进), 节省 prompt token; yaml 自身的 block scalar


### PR DESCRIPTION
## Summary

Render-side and review-flow optimizations that cut **timeline token noise** when it is rendered into the AI prompt. No stored events, no tool invocation paths, and no marshal/unmarshal semantics change.

## What changed

| Area | Before | After |
|---|---|---|
| **Task label** | Every entry repeated `[task:react-...]` inline | Hoisted to bucket header (`# task=...`); a single `# task=` boundary line emitted only on task switch. Original `TextTimelineItem.Text` is **unchanged** — `ParseTimelineItemHumanReadable` and marshal still parse per-item `TaskID`. |
| **Direct-call params** | `[DIRECT_CALL_PARAMS]` printed the params, then the result card printed them **again** | Result card skips params when they were already emitted (`WithToolCaller_OmitResultParamsInTimeline` / `ToolResult.OmitParamsInTimeline`). Persisted tool-call reports still keep full params. |
| **Tool review** | Every `{"suggestion":"continue"}` auto-pass-through became a `[user/review]` timeline item | A **fast (<0.5s) default "continue"** is treated as automatic pass-through with no user-authored info and is no longer recorded. Non-continue and slow/manual reviews are kept. |
| **Verification todo** | Reasserting DOING emitted `FAILED DOING[...]: redundant doing: todo already doing` | Treated as an idempotent heartbeat and silently dropped — no success, no failure noise. |

## Tests

- New tests added for task-header dedup, task-switch boundaries, late-task-not-rewriting-header, fast-no-op-continue review suppression, and `OmitParamsInTimeline`.
- Updated the 5 existing tests (`TestReAct_ToolUse`, `_ToolUse_MultiCalls`, `_ToolUse_FromDB_DirectCall`, `_PersistentSession_ToolUse`, `_MCPToolUse`) that previously asserted the auto-continue review pollutes the timeline — they now assert the opposite, matching the intended behavior.
- Tests that send non-`continue` suggestions (`direct_answer`, `wrong_params`, `wrong_tool`) are unchanged — their reviews are still recorded.

## Verification

Locally ran (mirroring CI with `CI=true`):
- `./common/ai/aid/aicommon/...` ✅
- `./common/ai/aid/aitool/...` ✅ (incl. `yakscripttools/test`, whose scan_port integration test self-skips under `CI=true`)
- `./common/ai/aid/aireact/...` ✅

`go build ./common/ai/aid/...` clean.

## Notes

- The `scan_port` integration test `TestScanPortTool_SynMode_UsesSynscanxForPointToPointRoute` fails locally against an unreachable scan target but is skipped under `CI=true` (and failed identically on `main`) — unrelated to this PR.
- Pre-existing `go vet` warning on untouched `taskif_test.go:63` is out of scope.