### PR TITLE
feat(aid): promote timeline tool cache state

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -683,9 +683,9 @@ func newConfig(ctx context.Context) *Config {
 	// NOTE: session_artifacts provider is intentionally NOT registered into
 	// ContextProviderManager. Routing the artifacts listing through Pure
 	// Dynamic / AutoContext flooded the dynamic segment with file metadata
-	// every turn. Prompt materials now render artifacts through first-class
-	// frozen/open blocks via RenderSessionArtifactsFrozenOpen.
-	// 关键词: session_artifacts 反注册, 一级 frozen/open, Pure Dynamic 反污染
+	// every turn. Artifact files remain available to the UI and download paths,
+	// but are intentionally absent from ordinary prompt construction.
+	// 关键词: session_artifacts 反注册, prompt 移除, Pure Dynamic 反污染
 
 	// Initialize emitter
 	config.Emitter = NewEmitter(id, func(e *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
@@ -1335,6 +1335,50 @@ func (c *Config) SaveRecentToolCache() {
 	cacheJSON := tm.ExportRecentToolCache()
 	if err := yakit.UpdateAIAgentRuntimeRecentToolsCache(db, c.PersistentSessionId, cacheJSON); err != nil {
 		log.Warnf("failed to save recent tool cache for session [%s]: %v", c.PersistentSessionId, err)
+	}
+}
+
+// RecordRecentlyUsedTool keeps execution authorization in AiToolManager while
+// recording only prompt-visible mutations in Timeline Open.
+func (c *Config) RecordRecentlyUsedTool(tool *aitool.Tool) buildinaitools.RecentToolCacheMutation {
+	var mutation buildinaitools.RecentToolCacheMutation
+	if c == nil || tool == nil || c.GetAiToolManager() == nil {
+		return mutation
+	}
+	mutation = c.GetAiToolManager().AddRecentlyUsedTool(tool)
+	timeline := c.GetTimeline()
+	if timeline != nil && mutation.Upsert != nil {
+		timeline.PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
+			mutation.Upsert.Name, TimelinePromotedOperationUpsert,
+			buildinaitools.RenderRecentToolEntryForPromotion(mutation.Upsert))
+	}
+	if timeline != nil {
+		for _, deleted := range mutation.Deleted {
+			if deleted == nil {
+				continue
+			}
+			timeline.PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
+				deleted.Name, TimelinePromotedOperationDelete, "")
+		}
+	}
+	c.SaveRecentToolCache()
+	return mutation
+}
+
+func (c *Config) bootstrapRecentToolsIntoTimeline() {
+	if c == nil || c.GetTimeline() == nil || c.GetAiToolManager() == nil || c.GetTimeline().HasPromotableKind(TimelinePromotedKindRecentTool) {
+		return
+	}
+	entries := c.GetAiToolManager().GetRecentToolEntries()
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		c.GetTimeline().PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
+			entry.Name, TimelinePromotedOperationUpsert, buildinaitools.RenderRecentToolEntryForPromotion(entry))
+	}
+	if len(entries) > 0 {
+		c.GetTimeline().ForcePromoteAll()
 	}
 }
 
@@ -3852,6 +3896,7 @@ func (c *Config) restorePersistentSession() {
 	if runtime.RecentToolsCache != "" {
 		if tm := c.GetAiToolManager(); tm != nil {
 			tm.ImportRecentToolCache(runtime.RecentToolsCache)
+			c.bootstrapRecentToolsIntoTimeline()
 			log.Infof("restored recent tool cache from persistent session [%s]", c.PersistentSessionId)
 		}
 	}

--- a/common/ai/aid/aicommon/contextprovider.go
+++ b/common/ai/aid/aicommon/contextprovider.go
@@ -461,8 +461,8 @@ const ArtifactsContextMaxTokens = 8 * 1024
 
 // ArtifactsContextProvider is a thin wrapper around RenderSessionArtifactsListing
 // that adds the legacy "# Session Artifacts" heading expected by older callers
-// and existing tests. New prompt code should call RenderSessionArtifactsFrozenOpen
-// and render artifacts as first-class frozen/open blocks.
+// and existing tests. New prompt code must not call it during ordinary prompt
+// construction; artifact files remain accessible through UI/download surfaces.
 //
 // Deprecated: this provider used to be registered into ContextProviderManager
 // (which routed it into Pure Dynamic / AutoContext). That registration has been

--- a/common/ai/aid/aicommon/invoke_runtime.go
+++ b/common/ai/aid/aicommon/invoke_runtime.go
@@ -207,13 +207,8 @@ type LoopPromptAssemblyInput struct {
 	ReactiveData   string
 	InjectedMemory string
 
-	// RecentToolsCache 是 CACHE_TOOL_CALL 块的渲染输出 (含 directly_call_tool
-	// routing hint + 最近工具的 schema/footer). 标签 nonce 稳定, 但工具集合正文
-	// 会随任务推进变化, 因此物理位置在 timeline-open 段、最后 cache boundary
-	// 之后, 避免一次工具集合变化击穿 Skills + Schema 的大前缀缓存.
-	//
-	// 关键词: LoopPromptAssemblyInput, RecentToolsCache, timeline-open 易变尾段,
-	//        cache boundary 之后
+	// Deprecated: ignored by prompt assembly. Recent tool schemas are supplied by
+	// Timeline promotion state so they have exactly one prompt source.
 	RecentToolsCache string
 
 	// FrozenUserContext 用于承载 PE-TASK 等场景下"PLAN 阶段产出 + 用户原始

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -25,9 +25,11 @@ type PromptMaterials struct {
 	//   - aireact: SkillsContext
 	//   - aid: PlanHelp / OriginalUserInput / StableInstruction 等 prompt-specific
 	//     但仍属可缓存半动态前缀的内容
-	SkillsContext string
-	// RecentToolsCache 的标签 nonce 稳定, 但正文会随着最近使用工具集合变化。
-	// 因此它属于 timeline-open 易变尾段, 不能放在 semi-2 cache boundary 之前。
+	SkillsContext        string
+	PromotedSemiDynamic1 string
+	// Deprecated: recent-tool prompt visibility is projected from Timeline
+	// promotion state. This field remains only for source compatibility and is
+	// intentionally ignored by all shared templates.
 	RecentToolsCache  string
 	PlanHelp          string
 	OriginalUserInput string
@@ -67,8 +69,7 @@ type PromptMaterials struct {
 	WorkingDir             string
 	WorkingDirGlance       string
 
-	// Deprecated: SessionArtifactsListing 保留给旧测试 / 兼容调用面。新 prompt
-	// 主路径使用 SessionArtifactsFrozen / SessionArtifactsOpen 两个一级字段。
+	// Deprecated: Session Artifacts no longer participate in prompt construction.
 	SessionArtifactsListing string
 	// Deprecated: SessionEvidence 保留给旧调用路径 fallback。新主路径使用
 	// SessionEvidenceFrozen / SessionEvidenceOpen 两个一级字段。
@@ -95,10 +96,11 @@ func (m *PromptMaterials) SemiDynamicData() map[string]any {
 		return map[string]any{}
 	}
 	return map[string]any{
-		"SkillsContext":     m.SkillsContext,
-		"PlanHelp":          m.PlanHelp,
-		"OriginalUserInput": m.OriginalUserInput,
-		"StableInstruction": m.StableInstruction,
+		"SkillsContext":        m.SkillsContext,
+		"PromotedSemiDynamic1": m.PromotedSemiDynamic1,
+		"PlanHelp":             m.PlanHelp,
+		"OriginalUserInput":    m.OriginalUserInput,
+		"StableInstruction":    m.StableInstruction,
 	}
 }
 
@@ -138,7 +140,6 @@ func (m *PromptMaterials) FrozenBlockData() map[string]any {
 		"ForgeInventory":         m.ForgeInventory,
 		"AIForgeList":            m.AIForgeList,
 		"FrozenPartitions":       NormalizeFrozenBlockPartitions(m.FrozenPartitions),
-		"SessionArtifactsFrozen": m.SessionArtifactsFrozen,
 		"SessionEvidenceFrozen":  m.SessionEvidenceFrozen,
 		"TimelineFrozen":         m.TimelineFrozen,
 		"TimelineFrozenTimeUnix": m.TimelineFrozenTimeUnix,
@@ -147,8 +148,8 @@ func (m *PromptMaterials) FrozenBlockData() map[string]any {
 
 // TimelineOpenData 供 timeline-open 模板消费, 模板字段渲染顺序 (P1-C3):
 //
-//	Timeline (Open Tail) -> SessionEvidence -> TodoSnapshot -> RecentToolsCache -> Workspace ->
-//	SessionArtifactsOpen -> UserHistory -> Current Time -> PlanContext (末尾)
+//	Timeline (Open Tail) -> SessionEvidence -> TodoSnapshot -> Workspace ->
+//	UserHistory -> Current Time -> PlanContext (末尾)
 //
 // 段内排序原则:
 //  1. Timeline (Open Tail) 在最前: 时间线最末桶是模型理解"刚发生了什么"的
@@ -190,12 +191,10 @@ func (m *PromptMaterials) TimelineOpenData() map[string]any {
 		"TimelineFrozenTimeUnix": m.TimelineFrozenTimeUnix,
 		"SessionEvidence":        sessionEvidenceOpen,
 		"TodoSnapshot":           m.TodoSnapshot,
-		"RecentToolsCache":       m.RecentToolsCache,
 		"Workspace":              m.Workspace,
 		"OSArch":                 m.OSArch,
 		"WorkingDir":             m.WorkingDir,
 		"WorkingDirGlance":       m.WorkingDirGlance,
-		"SessionArtifactsOpen":   m.SessionArtifactsOpen,
 		"UserHistory":            m.UserHistory,
 		"CurrentTime":            m.CurrentTime,
 		"PlanContext":            m.FrozenUserContext,
@@ -203,9 +202,10 @@ func (m *PromptMaterials) TimelineOpenData() map[string]any {
 }
 
 type TimelineFrozenOpenBlocks struct {
-	Frozen         string
-	Open           string
-	FrozenTimeUnix int64
+	Frozen               string
+	Open                 string
+	PromotedSemiDynamic1 string
+	FrozenTimeUnix       int64
 }
 
 func RenderTimelineFrozenOpen(timeline *Timeline) TimelineFrozenOpenBlocks {
@@ -213,23 +213,44 @@ func RenderTimelineFrozenOpen(timeline *Timeline) TimelineFrozenOpenBlocks {
 		return TimelineFrozenOpenBlocks{}
 	}
 	rb := timeline.GroupByMinutes(TimelineDumpDefaultIntervalMinutes).GetAllRenderable()
+	var sealedBeforeID int64
+	for _, block := range rb {
+		interval, ok := block.(*TimelineIntervalBlock)
+		if !ok || interval == nil || !interval.Open || len(interval.Items) == 0 {
+			continue
+		}
+		sealedBeforeID = interval.Items[0].GetID()
+		break
+	}
+	promotedSemi1, openDeltas := timeline.projectPromoted(sealedBeforeID)
+	open := rb.RenderOpenOnly(TimelineDumpDefaultAITagName)
+	if openDeltas != "" {
+		if open != "" {
+			open += "\n\n"
+		}
+		open += openDeltas
+	}
 	return TimelineFrozenOpenBlocks{
-		Frozen:         rb.RenderFrozenOnly(TimelineDumpDefaultAITagName),
-		Open:           rb.RenderOpenOnly(TimelineDumpDefaultAITagName),
-		FrozenTimeUnix: timelineFrozenTimeUnixFromRenderable(rb),
+		Frozen:               rb.RenderFrozenOnly(TimelineDumpDefaultAITagName),
+		Open:                 open,
+		PromotedSemiDynamic1: promotedSemi1,
+		FrozenTimeUnix:       timelineFrozenTimeUnixFromRenderable(rb),
 	}
 }
 
 type PromptFrozenOpenMaterials struct {
 	TimelineFrozen         string
 	TimelineOpen           string
+	PromotedSemiDynamic1   string
 	TimelineFrozenTimeUnix int64
 	FrozenPartitions       []FrozenBlockPartition
-
+	// Deprecated compatibility fields. Prompt construction no longer scans or
+	// renders Session Artifacts.
 	SessionArtifactsFrozen string
 	SessionArtifactsOpen   string
-	SessionEvidenceFrozen  string
-	SessionEvidenceOpen    string
+
+	SessionEvidenceFrozen string
+	SessionEvidenceOpen   string
 }
 
 func BuildPromptFrozenOpenMaterials(config *Config, openNonce ...string) PromptFrozenOpenMaterials {
@@ -241,15 +262,13 @@ func BuildPromptFrozenOpenMaterials(config *Config, openNonce ...string) PromptF
 		nonce = openNonce[0]
 	}
 	timelineBlocks := RenderTimelineFrozenOpen(config.GetTimeline())
-	artifactBlocks := RenderSessionArtifactsFrozenOpen(config, timelineBlocks.FrozenTimeUnix)
 	evidenceBlocks := config.GetSessionPromptState().GetSessionEvidenceFrozenOpenBlocks(timelineBlocks.FrozenTimeUnix, nonce)
 	return PromptFrozenOpenMaterials{
 		TimelineFrozen:         timelineBlocks.Frozen,
 		TimelineOpen:           timelineBlocks.Open,
+		PromotedSemiDynamic1:   timelineBlocks.PromotedSemiDynamic1,
 		TimelineFrozenTimeUnix: timelineBlocks.FrozenTimeUnix,
 		FrozenPartitions:       FrozenBlockPartitionsFromConfig(config),
-		SessionArtifactsFrozen: artifactBlocks.Frozen,
-		SessionArtifactsOpen:   artifactBlocks.Open,
 		SessionEvidenceFrozen:  evidenceBlocks.Frozen,
 		SessionEvidenceOpen:    evidenceBlocks.Open,
 	}
@@ -261,10 +280,9 @@ func ApplyPromptFrozenOpenMaterials(materials *PromptMaterials, frozenOpen Promp
 	}
 	materials.TimelineFrozen = frozenOpen.TimelineFrozen
 	materials.TimelineOpen = frozenOpen.TimelineOpen
+	materials.PromotedSemiDynamic1 = frozenOpen.PromotedSemiDynamic1
 	materials.TimelineFrozenTimeUnix = frozenOpen.TimelineFrozenTimeUnix
 	materials.FrozenPartitions = append([]FrozenBlockPartition(nil), NormalizeFrozenBlockPartitions(frozenOpen.FrozenPartitions)...)
-	materials.SessionArtifactsFrozen = frozenOpen.SessionArtifactsFrozen
-	materials.SessionArtifactsOpen = frozenOpen.SessionArtifactsOpen
 	materials.SessionEvidenceFrozen = frozenOpen.SessionEvidenceFrozen
 	materials.SessionEvidenceOpen = frozenOpen.SessionEvidenceOpen
 }

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -57,6 +57,7 @@ type PromptMaterials struct {
 
 	TimelineFrozen         string
 	TimelineOpen           string
+	PromotedTimelineOpen   string
 	TimelineFrozenTimeUnix int64
 	FrozenPartitions       []FrozenBlockPartition
 	SessionArtifactsFrozen string
@@ -188,6 +189,7 @@ func (m *PromptMaterials) TimelineOpenData() map[string]any {
 	}
 	return map[string]any{
 		"TimelineOpen":           m.TimelineOpen,
+		"PromotedTimelineOpen":   m.PromotedTimelineOpen,
 		"TimelineFrozenTimeUnix": m.TimelineFrozenTimeUnix,
 		"SessionEvidence":        sessionEvidenceOpen,
 		"TodoSnapshot":           m.TodoSnapshot,
@@ -204,6 +206,7 @@ func (m *PromptMaterials) TimelineOpenData() map[string]any {
 type TimelineFrozenOpenBlocks struct {
 	Frozen               string
 	Open                 string
+	PromotedOpen         string
 	PromotedSemiDynamic1 string
 	FrozenTimeUnix       int64
 }
@@ -223,16 +226,10 @@ func RenderTimelineFrozenOpen(timeline *Timeline) TimelineFrozenOpenBlocks {
 		break
 	}
 	promotedSemi1, openDeltas := timeline.projectPromoted(sealedBeforeID)
-	open := rb.RenderOpenOnly(TimelineDumpDefaultAITagName)
-	if openDeltas != "" {
-		if open != "" {
-			open += "\n\n"
-		}
-		open += openDeltas
-	}
 	return TimelineFrozenOpenBlocks{
 		Frozen:               rb.RenderFrozenOnly(TimelineDumpDefaultAITagName),
-		Open:                 open,
+		Open:                 rb.RenderOpenOnly(TimelineDumpDefaultAITagName),
+		PromotedOpen:         openDeltas,
 		PromotedSemiDynamic1: promotedSemi1,
 		FrozenTimeUnix:       timelineFrozenTimeUnixFromRenderable(rb),
 	}
@@ -241,6 +238,7 @@ func RenderTimelineFrozenOpen(timeline *Timeline) TimelineFrozenOpenBlocks {
 type PromptFrozenOpenMaterials struct {
 	TimelineFrozen         string
 	TimelineOpen           string
+	PromotedTimelineOpen   string
 	PromotedSemiDynamic1   string
 	TimelineFrozenTimeUnix int64
 	FrozenPartitions       []FrozenBlockPartition
@@ -266,6 +264,7 @@ func BuildPromptFrozenOpenMaterials(config *Config, openNonce ...string) PromptF
 	return PromptFrozenOpenMaterials{
 		TimelineFrozen:         timelineBlocks.Frozen,
 		TimelineOpen:           timelineBlocks.Open,
+		PromotedTimelineOpen:   timelineBlocks.PromotedOpen,
 		PromotedSemiDynamic1:   timelineBlocks.PromotedSemiDynamic1,
 		TimelineFrozenTimeUnix: timelineBlocks.FrozenTimeUnix,
 		FrozenPartitions:       FrozenBlockPartitionsFromConfig(config),
@@ -280,6 +279,7 @@ func ApplyPromptFrozenOpenMaterials(materials *PromptMaterials, frozenOpen Promp
 	}
 	materials.TimelineFrozen = frozenOpen.TimelineFrozen
 	materials.TimelineOpen = frozenOpen.TimelineOpen
+	materials.PromotedTimelineOpen = frozenOpen.PromotedTimelineOpen
 	materials.PromotedSemiDynamic1 = frozenOpen.PromotedSemiDynamic1
 	materials.TimelineFrozenTimeUnix = frozenOpen.TimelineFrozenTimeUnix
 	materials.FrozenPartitions = append([]FrozenBlockPartition(nil), NormalizeFrozenBlockPartitions(frozenOpen.FrozenPartitions)...)

--- a/common/ai/aid/aicommon/prompts/prefix/frozen_block_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/frozen_block_section.txt
@@ -32,9 +32,6 @@ You have access to {{ .ToolsCount }} built-in tools. Below are {{ .TopToolsCount
 {{ end }}
 {{ end }}
 
-{{ if .SessionArtifactsFrozen }}# Session Artifacts (Frozen)
-{{ .SessionArtifactsFrozen }}{{ end }}
-
 {{ if .SessionEvidenceFrozen }}# Session Evidence (Frozen)
 {{ .SessionEvidenceFrozen }}{{ end }}
 

--- a/common/ai/aid/aicommon/prompts/prefix/semi_dynamic_1_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/semi_dynamic_1_section.txt
@@ -1,1 +1,4 @@
 {{ if .SkillsContext }}{{ .SkillsContext }}{{ end }}
+{{ if .PromotedSemiDynamic1 }}
+
+{{ .PromotedSemiDynamic1 }}{{ end }}

--- a/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
@@ -4,6 +4,9 @@
 请把它作为"目前已经做了什么"的事实依据：判断任务进度、确认已经尝试过哪些路径、避免重复发起同一工具调用。若条目以 "midterm-memory:" 起头，则是引擎按当前主题从更早的归档时间线中召回的相关旧片段，不是本回合新发生的事件。
 
 {{ .TimelineOpen }}{{ end }}
+{{ if .PromotedTimelineOpen }}
+
+{{ .PromotedTimelineOpen }}{{ end }}
 
 {{ if .SessionEvidence }}
 

--- a/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/timeline_open_section.txt
@@ -19,11 +19,6 @@
 {{ .TodoSnapshot }}
 {{ end }}
 
-{{ if .RecentToolsCache }}
-
-{{ .RecentToolsCache }}
-{{ end }}
-
 {{ if .Workspace }}# Workspace Context
 
 工作区上下文给出 Agent 当前运行环境的"物理坐标"：操作系统 / 架构、当前工作目录的绝对路径、该目录顶层结构概览。
@@ -33,9 +28,6 @@ OS/Arch: {{ .OSArch }}
 {{ if .WorkingDir }}working dir: {{ .WorkingDir }}
 {{ end }}{{ if .WorkingDirGlance }}working dir glance: {{ .WorkingDirGlance }}
 {{ end }}{{ end }}
-
-{{ if .SessionArtifactsOpen }}# Session Artifacts (Open)
-{{ .SessionArtifactsOpen }}{{ end }}
 
 {{ if .UserHistory }}
 以下 PREV_USER_INPUT 块是当前会话内用户在此前各轮的原始输入文本，按时间先后给出，用于跨回合维持上下文连贯：理解用户的真实意图、追溯尚未完成的请求、避免反复询问用户早已明确说过的信息。

--- a/common/ai/aid/aicommon/session_artifacts_test.go
+++ b/common/ai/aid/aicommon/session_artifacts_test.go
@@ -152,11 +152,11 @@ func TestBuildPromptFrozenOpenMaterialsCoordinatesTimelineAndArtifacts(t *testin
 	require.Contains(t, materials.TimelineOpen, "verify-ok")
 	require.Len(t, materials.FrozenPartitions, 1)
 	require.Equal(t, "plan_facts", materials.FrozenPartitions[0].ID)
-	require.Contains(t, materials.SessionArtifactsFrozen, "task_1-1_scan")
-	require.Contains(t, materials.SessionArtifactsOpen, "task_1-2_verify")
+	require.Empty(t, materials.SessionArtifactsFrozen)
+	require.Empty(t, materials.SessionArtifactsOpen)
 }
 
-func TestSessionArtifactsTemplatesPlacement(t *testing.T) {
+func TestSessionArtifactsAreNotRenderedByPromptTemplates(t *testing.T) {
 	materials := &PromptMaterials{
 		SessionArtifactsFrozen: "artifacts_dir: /tmp/session\ntotal_files: 1\n\n### task_1-1_done\n- result.txt (1B, 00:00:00)\n",
 		SessionArtifactsOpen:   "artifacts_dir: /tmp/session\ntotal_files: 1\n\n### task_1-2_open\n- result.txt (1B, 00:00:00)\n",
@@ -170,15 +170,11 @@ func TestSessionArtifactsTemplatesPlacement(t *testing.T) {
 	open, err := RenderPromptTemplate("test-open-artifacts", SharedTimelineOpenTemplate, materials.TimelineOpenData())
 	require.NoError(t, err)
 
-	require.Contains(t, frozen, "# Session Artifacts (Frozen)")
-	require.Contains(t, frozen, "task_1-1_done")
-	require.Contains(t, open, "# Session Artifacts (Open)")
-	require.Contains(t, open, "task_1-2_open")
-	require.NotContains(t, open, "## Session Artifacts")
-
-	workspaceIdx := strings.Index(open, "# Workspace Context")
-	artifactsIdx := strings.Index(open, "# Session Artifacts (Open)")
-	require.Greater(t, artifactsIdx, workspaceIdx)
+	require.NotContains(t, frozen, "Session Artifacts")
+	require.NotContains(t, frozen, "task_1-1_done")
+	require.NotContains(t, open, "Session Artifacts")
+	require.NotContains(t, open, "task_1-2_open")
+	require.Contains(t, open, "# Workspace Context")
 }
 
 func TestPromptTimelineAfterCompression_KeepsQuarterAndSingleHead(t *testing.T) {

--- a/common/ai/aid/aicommon/timeline.go
+++ b/common/ai/aid/aicommon/timeline.go
@@ -39,6 +39,7 @@ type Timeline struct {
 	// compressedHistory 仅用于追溯，不参与当前并列渲染
 	compressedHistory []*TimelineCompressedHistoryNode
 	archiveRefs       *omap.OrderedMap[int64, *TimelineArchiveRef]
+	promotedState     *TimelinePromotedState
 
 	// this limit is used to limit the timeline dump content size (in tokens).
 	perDumpContentLimit   int64
@@ -182,7 +183,15 @@ func (m *Timeline) GetIdToTimelineItem() *omap.OrderedMap[int64, *TimelineItem] 
 func (m *Timeline) GetTimelineItemIDs() []int64 {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.idToTimelineItem.Keys()
+	ids := make([]int64, 0, m.idToTimelineItem.Len())
+	for _, id := range m.idToTimelineItem.Keys() {
+		item, ok := m.idToTimelineItem.Get(id)
+		if !ok || item == nil || item.deleted || isPromotableTimelineItem(item) {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 // GetMaxID 返回当前 timeline 中最大的条目 ID。
@@ -224,6 +233,15 @@ func (m *Timeline) TruncateAfter(checkpointID int64) {
 			}
 		}
 	}
+	limit := int64(0)
+	if m.promotedState != nil && m.promotedState.Watermark > 0 {
+		watermark := m.promotedState.Watermark
+		if watermark > checkpointID {
+			watermark = checkpointID
+		}
+		limit = watermark + 1
+	}
+	m.rebuildPromotedStateLocked(limit, false)
 }
 
 func (m *Timeline) ClearRuntimeConfig() {
@@ -255,6 +273,7 @@ func (m *Timeline) CopyReducibleTimelineWithMemory() *Timeline {
 		compressedHead:        cloneTimelineCompressedHead(m.compressedHead),
 		compressedHistory:     cloneTimelineCompressedHistory(m.compressedHistory),
 		archiveRefs:           m.archiveRefs.Copy(),
+		promotedState:         cloneTimelinePromotedState(m.promotedState),
 		perDumpContentLimit:   m.perDumpContentLimit,
 		totalDumpContentLimit: m.totalDumpContentLimit,
 		bucketByteSize:        m.bucketByteSize,
@@ -362,6 +381,7 @@ func NewTimeline(ai AICaller, extraMetaInfo func() string) *Timeline {
 		idToTimelineItem: omap.NewOrderedMap(map[int64]*TimelineItem{}),
 		idToTs:           omap.NewOrderedMap(map[int64]int64{}),
 		archiveRefs:      omap.NewOrderedMap(map[int64]*TimelineArchiveRef{}),
+		promotedState:    newTimelinePromotedState(),
 		compressing:      utils.NewOnce(),
 		branchTimeline:   false,
 	}
@@ -527,7 +547,7 @@ func (m *Timeline) pushTimelineItem(ts int64, id int64, item *TimelineItem) {
 	// 的高发路径之一: pushTimelineItem 在主流程已结束、outputChan 已被测试关
 	// 闭后仍可能被触发. 即便 Emitter.emit 自身已 defer recover, 这里再加一
 	// 层 recover 形成 belt-and-suspenders, 杜绝因 channel 关闭引起的进程退出.
-	if m.config != nil && m.config.GetEmitter() != nil {
+	if !isPromotableTimelineItem(item) && m.config != nil && m.config.GetEmitter() != nil {
 		emitter := m.config.GetEmitter()
 		go func() {
 			defer func() {
@@ -587,6 +607,9 @@ func (m *Timeline) calculateActualContentSizeLocked() int64 {
 	count := 0
 
 	m.idToTimelineItem.ForEach(func(id int64, item *TimelineItem) bool {
+		if isPromotableTimelineItem(item) {
+			return true
+		}
 		initOnce.Do(func() {
 			buf.WriteString("timeline:\n")
 		})
@@ -652,6 +675,7 @@ func (m *Timeline) emergencyCompressLocked(targetSize int) {
 	if m == nil {
 		return
 	}
+	m.forcePromoteAllLocked()
 
 	// Calculate current size
 	tlstr, err := marshalTimelineUnlocked(m)
@@ -669,7 +693,7 @@ func (m *Timeline) emergencyCompressLocked(targetSize int) {
 	// Get all item IDs ordered by timestamp (oldest first)
 	var itemIDs []int64
 	m.idToTimelineItem.ForEach(func(id int64, item *TimelineItem) bool {
-		if item == nil || item.deleted {
+		if item == nil || item.deleted || isPromotableTimelineItem(item) {
 			return true
 		}
 		itemIDs = append(itemIDs, id)
@@ -1279,6 +1303,10 @@ func (m *Timeline) ReassignIDs(idGenerator func() int64) int64 {
 
 	// Track old ID to new ID mapping for compressedHead remapping
 	oldToNewID := make(map[int64]int64)
+	oldPromotionWatermark := int64(0)
+	if m.promotedState != nil {
+		oldPromotionWatermark = m.promotedState.Watermark
+	}
 
 	var lastID int64
 	// Reassign IDs in order, skipping soft-deleted (inactive) items
@@ -1299,6 +1327,8 @@ func (m *Timeline) ReassignIDs(idGenerator func() int64) int64 {
 		case *UserInteraction:
 			v.ID = newID
 		case *TextTimelineItem:
+			v.ID = newID
+		case *PromotableTimelineItem:
 			v.ID = newID
 		default:
 			log.Warnf("unknown timeline item value type: %T", v)
@@ -1328,6 +1358,15 @@ func (m *Timeline) ReassignIDs(idGenerator func() int64) int64 {
 			h.CoveredEndItemID = mapped
 		}
 	}
+	if oldPromotionWatermark > 0 {
+		var newWatermark int64
+		for oldID, newID := range oldToNewID {
+			if oldID <= oldPromotionWatermark && newID > newWatermark {
+				newWatermark = newID
+			}
+		}
+		m.rebuildPromotedStateLocked(newWatermark+1, false)
+	}
 
 	log.Infof("reassigned IDs for %d timeline items, last ID: %d", len(orderedItems), lastID)
 	return lastID
@@ -1343,22 +1382,17 @@ func (m *Timeline) GetTimelineOutput() []*TimelineItemOutput {
 
 func (m *Timeline) ToTimelineItemOutputLastN(n int) []*TimelineItemOutput {
 	l := m.tsToTimelineItem.Len()
-	if l == 0 {
+	if l == 0 || n <= 0 {
 		return nil
 	}
 
-	var result []*TimelineItemOutput
-	start := l - n
-	if start < 0 {
-		start = 0
-	}
-
-	for i := start; i < l; i++ {
+	result := make([]*TimelineItemOutput, 0, n)
+	for i := l - 1; i >= 0 && len(result) < n; i-- {
 		item, ok := m.tsToTimelineItem.GetByIndex(i)
-		if !ok {
+		if !ok || item == nil || item.deleted || isPromotableTimelineItem(item) {
 			continue
 		}
-		result = append(result, item.ToTimelineItemOutput())
+		result = append([]*TimelineItemOutput{item.ToTimelineItemOutput()}, result...)
 	}
 
 	return result

--- a/common/ai/aid/aicommon/timeline_batch_compress.go
+++ b/common/ai/aid/aicommon/timeline_batch_compress.go
@@ -109,6 +109,9 @@ func (m *Timeline) compressForSizeLimit() {
 }
 
 func (m *Timeline) compressForSizeLimitLocked() {
+	// Control-plane mutations must be materialized before ordinary facts are sent
+	// to a reducer. They are excluded from activeIDs and reducer prompts below.
+	m.forcePromoteAllLocked()
 	if m.ai == nil || m.totalDumpContentLimit <= 0 {
 		return
 	}
@@ -452,7 +455,7 @@ func (m *Timeline) getActiveTimelineItemIDs() []int64 {
 	out := make([]int64, 0, len(ids))
 	for _, id := range ids {
 		item, ok := m.idToTimelineItem.Get(id)
-		if !ok || item == nil || item.deleted {
+		if !ok || item == nil || item.deleted || isPromotableTimelineItem(item) {
 			continue
 		}
 		out = append(out, id)

--- a/common/ai/aid/aicommon/timeline_fork.go
+++ b/common/ai/aid/aicommon/timeline_fork.go
@@ -128,7 +128,9 @@ func (f *TimelineFork) MergeBack() (*TimelineMergeResult, error) {
 		parent.idToTimelineItem.OrderInsert(active.id, active.item, lessInt64)
 		parent.idToTs.Set(active.id, ts)
 		parent.tsToTimelineItem.OrderInsert(ts, active.item, lessInt64)
-		result.ActiveItemsMerged++
+		if !isPromotableTimelineItem(active.item) {
+			result.ActiveItemsMerged++
+		}
 	}
 
 	if compressedHead != nil && compressedHead.head != nil {

--- a/common/ai/aid/aicommon/timeline_groups_render.go
+++ b/common/ai/aid/aicommon/timeline_groups_render.go
@@ -116,7 +116,7 @@ func (m *Timeline) groupByMinutesWithSizer(minutes int, sizer BucketSizer) *Time
 	ids := m.idToTimelineItem.Keys()
 	for _, id := range ids {
 		item, ok := m.idToTimelineItem.Get(id)
-		if !ok || item == nil || item.deleted {
+		if !ok || item == nil || item.deleted || isPromotableTimelineItem(item) {
 			continue
 		}
 		var t time.Time
@@ -208,7 +208,7 @@ func (m *Timeline) groupByMinutesAndBytesLocked(minutes int, bytesPerBucket int6
 	ids := m.idToTimelineItem.Keys()
 	for _, id := range ids {
 		item, ok := m.idToTimelineItem.Get(id)
-		if !ok || item == nil || item.deleted {
+		if !ok || item == nil || item.deleted || isPromotableTimelineItem(item) {
 			continue
 		}
 		var t time.Time

--- a/common/ai/aid/aicommon/timeline_item.go
+++ b/common/ai/aid/aicommon/timeline_item.go
@@ -63,6 +63,13 @@ func (item *TimelineItem) MarshalJSON() ([]byte, error) {
 			return nil, err
 		}
 		valueJSON = data
+	case *PromotableTimelineItem:
+		typeName = "promotable"
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		valueJSON = data
 	default:
 		typeName = "raw"
 		valueJSON = []byte(fmt.Sprintf(`"%v"`, v))
@@ -111,6 +118,12 @@ func (item *TimelineItem) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		item.value = &textItem
+	case "promotable":
+		var control PromotableTimelineItem
+		if err := json.Unmarshal(serializable.Value, &control); err != nil {
+			return err
+		}
+		item.value = &control
 	default:
 		// 对于未知类型，尝试作为字符串处理
 		item.value = &TextTimelineItem{
@@ -150,6 +163,8 @@ func (item *TimelineItem) ToTimelineItemOutput() *TimelineItemOutput {
 		typeName = "user_interaction"
 	case *TextTimelineItem:
 		typeName = "text"
+	case *PromotableTimelineItem:
+		typeName = "promotable"
 	default:
 		typeName = "raw"
 	}

--- a/common/ai/aid/aicommon/timeline_marshal.go
+++ b/common/ai/aid/aicommon/timeline_marshal.go
@@ -26,6 +26,7 @@ type timelineSerializable struct {
 	ArchiveRefs           map[string]*TimelineArchiveRef   `json:"archive_refs"`
 	PerDumpContentLimit   int64                            `json:"per_dump_content_limit"`
 	TotalDumpContentLimit int64                            `json:"total_dump_content_limit"`
+	PromotedState         *TimelinePromotedState           `json:"promoted_state,omitempty"`
 }
 
 // MarshalTimeline serializes a Timeline into a string.
@@ -88,6 +89,7 @@ func marshalTimelineUnlocked(i *Timeline) (string, error) {
 		ArchiveRefs:           archiveRefsMap,
 		PerDumpContentLimit:   i.perDumpContentLimit,
 		TotalDumpContentLimit: i.totalDumpContentLimit,
+		PromotedState:         cloneTimelinePromotedState(i.promotedState),
 	}
 
 	data, err := json.Marshal(serializable)
@@ -115,6 +117,7 @@ func UnmarshalTimeline(s string) (*Timeline, error) {
 		totalDumpContentLimit: serializable.TotalDumpContentLimit,
 		compressing:           utils.NewOnce(),
 		branchTimeline:        false,
+		promotedState:         cloneTimelinePromotedState(serializable.PromotedState),
 	}
 
 	// 恢复 idToTs

--- a/common/ai/aid/aicommon/timeline_promoted.go
+++ b/common/ai/aid/aicommon/timeline_promoted.go
@@ -1,0 +1,287 @@
+package aicommon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	TimelinePromotedTargetSemiDynamic1 = "semi-dynamic-1"
+	TimelinePromotedKindRecentTool     = "recent-tool-cache"
+	TimelinePromotedOperationUpsert    = "upsert"
+	TimelinePromotedOperationDelete    = "delete"
+)
+
+// PromotableTimelineItem is a control-plane timeline entry. It is persisted and
+// follows fork/merge/checkpoint semantics, but is deliberately excluded from the
+// user timeline, ordinary buckets, diffs and reducers.
+type PromotableTimelineItem struct {
+	ID            int64  `json:"id"`
+	Kind          string `json:"kind"`
+	TargetSection string `json:"target_section"`
+	Key           string `json:"key"`
+	Operation     string `json:"operation"`
+	Payload       string `json:"payload,omitempty"`
+	PayloadHash   string `json:"payload_hash,omitempty"`
+}
+
+func (p *PromotableTimelineItem) String() string                 { return "" }
+func (p *PromotableTimelineItem) GetID() int64                   { return p.ID }
+func (p *PromotableTimelineItem) GetShrinkResult() string        { return "" }
+func (p *PromotableTimelineItem) GetShrinkSimilarResult() string { return "" }
+func (p *PromotableTimelineItem) SetShrinkResult(string)         {}
+
+type PromotedTimelineEntry struct {
+	Kind          string `json:"kind"`
+	TargetSection string `json:"target_section"`
+	Key           string `json:"key"`
+	Payload       string `json:"payload"`
+	PayloadHash   string `json:"payload_hash"`
+	SourceItemID  int64  `json:"source_item_id"`
+}
+
+// TimelinePromotedState is the materialized, long-lived projection of sealed
+// promotable entries. The journal remains in Timeline for deterministic rollback.
+type TimelinePromotedState struct {
+	Entries   map[string]map[string]map[string]*PromotedTimelineEntry `json:"entries,omitempty"`
+	Watermark int64                                                   `json:"watermark,omitempty"`
+}
+
+func newTimelinePromotedState() *TimelinePromotedState {
+	return &TimelinePromotedState{Entries: make(map[string]map[string]map[string]*PromotedTimelineEntry)}
+}
+
+func cloneTimelinePromotedState(in *TimelinePromotedState) *TimelinePromotedState {
+	out := newTimelinePromotedState()
+	if in == nil {
+		return out
+	}
+	out.Watermark = in.Watermark
+	for target, kinds := range in.Entries {
+		out.Entries[target] = make(map[string]map[string]*PromotedTimelineEntry)
+		for kind, entries := range kinds {
+			out.Entries[target][kind] = make(map[string]*PromotedTimelineEntry)
+			for key, entry := range entries {
+				if entry == nil {
+					continue
+				}
+				cp := *entry
+				out.Entries[target][kind][key] = &cp
+			}
+		}
+	}
+	return out
+}
+
+func isPromotableTimelineItem(item *TimelineItem) bool {
+	if item == nil {
+		return false
+	}
+	_, ok := item.value.(*PromotableTimelineItem)
+	return ok
+}
+
+func promotedPayloadHash(payload string) string {
+	sum := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(sum[:])
+}
+
+// PushPromotable appends a prompt-state mutation to Timeline Open. Only Semi1
+// is accepted in the first generation so arbitrary content cannot cross cache
+// boundaries.
+func (m *Timeline) PushPromotable(id int64, kind, targetSection, key, operation, payload string) bool {
+	if m == nil || id <= 0 || targetSection != TimelinePromotedTargetSemiDynamic1 || strings.TrimSpace(kind) == "" || strings.TrimSpace(key) == "" {
+		return false
+	}
+	if operation != TimelinePromotedOperationUpsert && operation != TimelinePromotedOperationDelete {
+		return false
+	}
+	if operation == TimelinePromotedOperationDelete {
+		payload = ""
+	}
+	now := time.Now()
+	ts := now.UnixMilli()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for m.tsToTimelineItem.Have(ts) {
+		ts++
+	}
+	m.idToTs.Set(id, ts)
+	m.pushTimelineItem(ts, id, &TimelineItem{createdAt: now, value: &PromotableTimelineItem{
+		ID: id, Kind: kind, TargetSection: targetSection, Key: key,
+		Operation: operation, Payload: payload, PayloadHash: promotedPayloadHash(payload),
+	}})
+	return true
+}
+
+func (m *Timeline) rebuildPromotedStateLocked(sealedBeforeID int64, forceAll bool) {
+	state := newTimelinePromotedState()
+	if m == nil {
+		return
+	}
+	if m.idToTimelineItem == nil {
+		m.promotedState = state
+		return
+	}
+	for _, id := range m.idToTimelineItem.Keys() {
+		item, ok := m.idToTimelineItem.Get(id)
+		if !ok || item == nil || item.deleted {
+			continue
+		}
+		control, ok := item.value.(*PromotableTimelineItem)
+		if !ok || control == nil {
+			continue
+		}
+		if !forceAll && (sealedBeforeID <= 0 || id >= sealedBeforeID) {
+			continue
+		}
+		if control.TargetSection != TimelinePromotedTargetSemiDynamic1 {
+			continue
+		}
+		if id > state.Watermark {
+			state.Watermark = id
+		}
+		kinds := state.Entries[control.TargetSection]
+		if kinds == nil {
+			kinds = make(map[string]map[string]*PromotedTimelineEntry)
+			state.Entries[control.TargetSection] = kinds
+		}
+		entries := kinds[control.Kind]
+		if entries == nil {
+			entries = make(map[string]*PromotedTimelineEntry)
+			kinds[control.Kind] = entries
+		}
+		if control.Operation == TimelinePromotedOperationDelete {
+			delete(entries, control.Key)
+			continue
+		}
+		entries[control.Key] = &PromotedTimelineEntry{
+			Kind: control.Kind, TargetSection: control.TargetSection, Key: control.Key,
+			Payload: control.Payload, PayloadHash: control.PayloadHash, SourceItemID: id,
+		}
+	}
+	m.promotedState = state
+}
+
+func (m *Timeline) forcePromoteAllLocked() {
+	m.rebuildPromotedStateLocked(0, true)
+}
+
+func (m *Timeline) ForcePromoteAll() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.forcePromoteAllLocked()
+}
+
+func (m *Timeline) HasPromotableKind(kind string) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, id := range m.idToTimelineItem.Keys() {
+		item, ok := m.idToTimelineItem.Get(id)
+		if !ok || item == nil || item.deleted {
+			continue
+		}
+		if control, ok := item.value.(*PromotableTimelineItem); ok && control != nil && control.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Timeline) projectPromoted(sealedBeforeID int64) (string, string) {
+	if m == nil {
+		return "", ""
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// A previously materialized watermark never moves backwards during ordinary
+	// rendering. This also preserves force-promotion performed before compression
+	// and one-time legacy bootstrap.
+	effectiveLimit := sealedBeforeID
+	if m.promotedState != nil && m.promotedState.Watermark > 0 && m.promotedState.Watermark+1 > effectiveLimit {
+		effectiveLimit = m.promotedState.Watermark + 1
+	}
+	m.rebuildPromotedStateLocked(effectiveLimit, false)
+	semi := renderPromotedRecentTools(m.promotedState)
+	var pending []*PromotableTimelineItem
+	for _, id := range m.idToTimelineItem.Keys() {
+		item, ok := m.idToTimelineItem.Get(id)
+		if !ok || item == nil || item.deleted {
+			continue
+		}
+		control, ok := item.value.(*PromotableTimelineItem)
+		if !ok || control == nil || id <= m.promotedState.Watermark {
+			continue
+		}
+		pending = append(pending, control)
+	}
+	return semi, renderPromotableOpenDeltas(pending, semi == "")
+}
+
+func renderPromotedRecentTools(state *TimelinePromotedState) string {
+	if state == nil {
+		return ""
+	}
+	entries := state.Entries[TimelinePromotedTargetSemiDynamic1][TimelinePromotedKindRecentTool]
+	if len(entries) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var out strings.Builder
+	out.WriteString("<|CACHE_TOOL_CALL_[current-nonce]|>\n")
+	out.WriteString("# Recently Used Tools (available for directly_call_tool)\n\n")
+	for _, key := range keys {
+		if entry := entries[key]; entry != nil {
+			out.WriteString(strings.TrimSpace(entry.Payload))
+			out.WriteString("\n\n")
+		}
+	}
+	out.WriteString(recentToolRoutingInstructions)
+	out.WriteString("\n<|CACHE_TOOL_CALL_END_[current-nonce]|>")
+	return strings.TrimSpace(out.String())
+}
+
+func renderPromotableOpenDeltas(items []*PromotableTimelineItem, includeInstructions bool) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	out.WriteString("<|CACHE_TOOL_CALL_[current-nonce]|>\n")
+	out.WriteString("# Prompt State Updates (pending Timeline seal)\n\n")
+	for _, item := range items {
+		if item == nil || item.Kind != TimelinePromotedKindRecentTool {
+			continue
+		}
+		if item.Operation == TimelinePromotedOperationDelete {
+			fmt.Fprintf(&out, "- invalidated recent tool: %s\n", item.Key)
+			continue
+		}
+		out.WriteString(strings.TrimSpace(item.Payload))
+		out.WriteString("\n\n")
+	}
+	if includeInstructions {
+		out.WriteString(recentToolRoutingInstructions)
+	}
+	out.WriteString("\n<|CACHE_TOOL_CALL_END_[current-nonce]|>")
+	return strings.TrimSpace(out.String())
+}
+
+const recentToolRoutingInstructions = `## How to use directly_call_tool
+
+If the exact tool you need is already listed above, prefer directly_call_tool for faster execution.
+The schemas above are params-only shapes. Pass one directly as directly_call_tool_params; do not wrap it with @action, tool, or params.
+For multiline values, TOOL_PARAM_{param_name}_[current-nonce] AITAG blocks may be used. AITAG values override same-named JSON params.`

--- a/common/ai/aid/aicommon/timeline_promoted_test.go
+++ b/common/ai/aid/aicommon/timeline_promoted_test.go
@@ -1,0 +1,136 @@
+package aicommon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+func injectPromotable(tl *Timeline, id int64, ts time.Time, operation, key, payload string) {
+	injectTimelineItem(tl, id, ts, &PromotableTimelineItem{
+		ID:            id,
+		Kind:          TimelinePromotedKindRecentTool,
+		TargetSection: TimelinePromotedTargetSemiDynamic1,
+		Key:           key,
+		Operation:     operation,
+		Payload:       payload,
+		PayloadHash:   promotedPayloadHash(payload),
+	})
+}
+
+func TestConfigRecordRecentlyUsedToolHasSinglePromptSourceAndNoopReuse(t *testing.T) {
+	cfg := NewConfig(context.Background())
+	tool := aitool.NewWithoutCallback("alpha_tool",
+		aitool.WithDescription("alpha"),
+		aitool.WithStringParam("path"),
+	)
+	mutation := cfg.RecordRecentlyUsedTool(tool)
+	require.NotNil(t, mutation.Upsert)
+	first := BuildPromptFrozenOpenMaterials(cfg)
+	require.Contains(t, first.TimelineOpen, "## Tool: alpha_tool")
+	require.Empty(t, first.PromotedSemiDynamic1)
+	maxID := cfg.GetTimeline().GetMaxID()
+
+	mutation = cfg.RecordRecentlyUsedTool(tool)
+	require.Nil(t, mutation.Upsert)
+	require.Empty(t, mutation.Deleted)
+	require.Equal(t, maxID, cfg.GetTimeline().GetMaxID())
+	second := BuildPromptFrozenOpenMaterials(cfg)
+	require.Equal(t, first.TimelineOpen, second.TimelineOpen)
+
+	cfg.GetTimeline().ForcePromoteAll()
+	promoted := BuildPromptFrozenOpenMaterials(cfg)
+	require.NotContains(t, promoted.TimelineOpen, "## Tool: alpha_tool")
+	require.Contains(t, promoted.PromotedSemiDynamic1, "## Tool: alpha_tool")
+	require.Equal(t, 1, strings.Count(promoted.PromotedSemiDynamic1, "Direct Params Schema"))
+}
+
+func TestTimelinePromotedStateOpenSealDeleteAndRollback(t *testing.T) {
+	base := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+	tl := NewTimeline(nil, nil)
+	injectTimelineItem(tl, 1, base, &TextTimelineItem{ID: 1, Text: "ordinary-old"})
+	ordinaryBefore := tl.Dump()
+	injectPromotable(tl, 2, base.Add(time.Second), TimelinePromotedOperationUpsert, "alpha", "## Tool: alpha\nSCHEMA_ALPHA")
+
+	// Control items do not alter ordinary buckets, nonces, diffs, stats or UI.
+	require.Equal(t, ordinaryBefore, tl.Dump())
+	require.Equal(t, []int64{1}, tl.GetTimelineItemIDs())
+	require.Len(t, tl.getActiveTimelineItemIDs(), 1)
+	require.Len(t, tl.ToTimelineItemOutputLastN(10), 1)
+
+	first := RenderTimelineFrozenOpen(tl)
+	require.Empty(t, first.PromotedSemiDynamic1)
+	require.Contains(t, first.Open, "SCHEMA_ALPHA")
+	require.Equal(t, 1, strings.Count(first.Open, "How to use directly_call_tool"))
+
+	// A successor bucket seals the old narrative bucket and jointly promotes its
+	// control mutation into stable Semi1.
+	injectTimelineItem(tl, 3, base.Add(4*time.Minute), &TextTimelineItem{ID: 3, Text: "ordinary-new"})
+	sealed := RenderTimelineFrozenOpen(tl)
+	require.Contains(t, sealed.Frozen, "ordinary-old")
+	require.NotContains(t, sealed.Frozen, "SCHEMA_ALPHA")
+	require.Contains(t, sealed.Open, "ordinary-new")
+	require.NotContains(t, sealed.Open, "SCHEMA_ALPHA")
+	require.Contains(t, sealed.PromotedSemiDynamic1, "SCHEMA_ALPHA")
+	require.Equal(t, 1, strings.Count(sealed.PromotedSemiDynamic1, "How to use directly_call_tool"))
+
+	// Serialization preserves both journal and materialized watermark.
+	raw, err := MarshalTimeline(tl)
+	require.NoError(t, err)
+	restored, err := UnmarshalTimeline(raw)
+	require.NoError(t, err)
+	require.Equal(t, sealed.PromotedSemiDynamic1, RenderTimelineFrozenOpen(restored).PromotedSemiDynamic1)
+
+	// Delete is first visible as an Open tombstone, then removes the stable view
+	// on the next seal. Rolling back restores the previous materialized version.
+	injectPromotable(tl, 4, base.Add(4*time.Minute+time.Second), TimelinePromotedOperationDelete, "alpha", "")
+	pendingDelete := RenderTimelineFrozenOpen(tl)
+	require.Contains(t, pendingDelete.PromotedSemiDynamic1, "SCHEMA_ALPHA")
+	require.Contains(t, pendingDelete.Open, "invalidated recent tool: alpha")
+	require.Equal(t, 1, strings.Count(pendingDelete.PromotedSemiDynamic1+pendingDelete.Open, "How to use directly_call_tool"))
+
+	injectTimelineItem(tl, 5, base.Add(8*time.Minute), &TextTimelineItem{ID: 5, Text: "ordinary-later"})
+	deleted := RenderTimelineFrozenOpen(tl)
+	require.Empty(t, deleted.PromotedSemiDynamic1)
+	require.NotContains(t, deleted.Open, "invalidated recent tool")
+
+	tl.TruncateAfter(3)
+	rolledBack := RenderTimelineFrozenOpen(tl)
+	require.Contains(t, rolledBack.PromotedSemiDynamic1, "SCHEMA_ALPHA")
+}
+
+func TestTimelinePromotedStateStableOrdering(t *testing.T) {
+	base := time.Date(2026, 7, 18, 11, 0, 0, 0, time.UTC)
+	tl := NewTimeline(nil, nil)
+	injectTimelineItem(tl, 1, base, &TextTimelineItem{ID: 1, Text: "old"})
+	injectPromotable(tl, 2, base.Add(time.Second), TimelinePromotedOperationUpsert, "zeta", "## Tool: zeta")
+	injectPromotable(tl, 3, base.Add(2*time.Second), TimelinePromotedOperationUpsert, "alpha", "## Tool: alpha")
+	injectTimelineItem(tl, 4, base.Add(4*time.Minute), &TextTimelineItem{ID: 4, Text: "new"})
+
+	a := RenderTimelineFrozenOpen(tl).PromotedSemiDynamic1
+	b := RenderTimelineFrozenOpen(tl).PromotedSemiDynamic1
+	require.Equal(t, a, b)
+	require.Less(t, strings.Index(a, "## Tool: alpha"), strings.Index(a, "## Tool: zeta"))
+}
+
+func TestTimelineForkMergesPromotionJournalWithoutDiffNoise(t *testing.T) {
+	base := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	parent := NewTimeline(nil, nil)
+	injectTimelineItem(parent, 1, base, &TextTimelineItem{ID: 1, Text: "parent"})
+	fork, err := parent.ForkForTask("1-1", "child", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, fork)
+	injectPromotable(fork.Branch, 2, base.Add(time.Second), TimelinePromotedOperationUpsert, "branch_tool", "## Tool: branch_tool")
+
+	diff, err := fork.Diff()
+	require.NoError(t, err)
+	require.Empty(t, diff)
+	merged, err := fork.MergeBack()
+	require.NoError(t, err)
+	require.Equal(t, 0, merged.ActiveItemsMerged, "control entries must not inflate ordinary event statistics")
+	require.Contains(t, RenderTimelineFrozenOpen(parent).Open, "## Tool: branch_tool")
+}

--- a/common/ai/aid/aicommon/timeline_promoted_test.go
+++ b/common/ai/aid/aicommon/timeline_promoted_test.go
@@ -31,8 +31,14 @@ func TestConfigRecordRecentlyUsedToolHasSinglePromptSourceAndNoopReuse(t *testin
 	mutation := cfg.RecordRecentlyUsedTool(tool)
 	require.NotNil(t, mutation.Upsert)
 	first := BuildPromptFrozenOpenMaterials(cfg)
-	require.Contains(t, first.TimelineOpen, "## Tool: alpha_tool")
+	require.Empty(t, first.TimelineOpen)
+	require.Contains(t, first.PromotedTimelineOpen, "## Tool: alpha_tool")
 	require.Empty(t, first.PromotedSemiDynamic1)
+	materials := &PromptMaterials{}
+	ApplyPromptFrozenOpenMaterials(materials, first)
+	assembled, err := NewDefaultPromptPrefixBuilder().AssemblePromptPrefix(materials)
+	require.NoError(t, err)
+	require.Contains(t, assembled.TimelineOpen, "## Tool: alpha_tool")
 	maxID := cfg.GetTimeline().GetMaxID()
 
 	mutation = cfg.RecordRecentlyUsedTool(tool)
@@ -41,10 +47,11 @@ func TestConfigRecordRecentlyUsedToolHasSinglePromptSourceAndNoopReuse(t *testin
 	require.Equal(t, maxID, cfg.GetTimeline().GetMaxID())
 	second := BuildPromptFrozenOpenMaterials(cfg)
 	require.Equal(t, first.TimelineOpen, second.TimelineOpen)
+	require.Equal(t, first.PromotedTimelineOpen, second.PromotedTimelineOpen)
 
 	cfg.GetTimeline().ForcePromoteAll()
 	promoted := BuildPromptFrozenOpenMaterials(cfg)
-	require.NotContains(t, promoted.TimelineOpen, "## Tool: alpha_tool")
+	require.NotContains(t, promoted.PromotedTimelineOpen, "## Tool: alpha_tool")
 	require.Contains(t, promoted.PromotedSemiDynamic1, "## Tool: alpha_tool")
 	require.Equal(t, 1, strings.Count(promoted.PromotedSemiDynamic1, "Direct Params Schema"))
 }
@@ -64,8 +71,8 @@ func TestTimelinePromotedStateOpenSealDeleteAndRollback(t *testing.T) {
 
 	first := RenderTimelineFrozenOpen(tl)
 	require.Empty(t, first.PromotedSemiDynamic1)
-	require.Contains(t, first.Open, "SCHEMA_ALPHA")
-	require.Equal(t, 1, strings.Count(first.Open, "How to use directly_call_tool"))
+	require.Contains(t, first.PromotedOpen, "SCHEMA_ALPHA")
+	require.Equal(t, 1, strings.Count(first.PromotedOpen, "How to use directly_call_tool"))
 
 	// A successor bucket seals the old narrative bucket and jointly promotes its
 	// control mutation into stable Semi1.
@@ -75,6 +82,7 @@ func TestTimelinePromotedStateOpenSealDeleteAndRollback(t *testing.T) {
 	require.NotContains(t, sealed.Frozen, "SCHEMA_ALPHA")
 	require.Contains(t, sealed.Open, "ordinary-new")
 	require.NotContains(t, sealed.Open, "SCHEMA_ALPHA")
+	require.Empty(t, sealed.PromotedOpen)
 	require.Contains(t, sealed.PromotedSemiDynamic1, "SCHEMA_ALPHA")
 	require.Equal(t, 1, strings.Count(sealed.PromotedSemiDynamic1, "How to use directly_call_tool"))
 
@@ -90,13 +98,13 @@ func TestTimelinePromotedStateOpenSealDeleteAndRollback(t *testing.T) {
 	injectPromotable(tl, 4, base.Add(4*time.Minute+time.Second), TimelinePromotedOperationDelete, "alpha", "")
 	pendingDelete := RenderTimelineFrozenOpen(tl)
 	require.Contains(t, pendingDelete.PromotedSemiDynamic1, "SCHEMA_ALPHA")
-	require.Contains(t, pendingDelete.Open, "invalidated recent tool: alpha")
-	require.Equal(t, 1, strings.Count(pendingDelete.PromotedSemiDynamic1+pendingDelete.Open, "How to use directly_call_tool"))
+	require.Contains(t, pendingDelete.PromotedOpen, "invalidated recent tool: alpha")
+	require.Equal(t, 1, strings.Count(pendingDelete.PromotedSemiDynamic1+pendingDelete.PromotedOpen, "How to use directly_call_tool"))
 
 	injectTimelineItem(tl, 5, base.Add(8*time.Minute), &TextTimelineItem{ID: 5, Text: "ordinary-later"})
 	deleted := RenderTimelineFrozenOpen(tl)
 	require.Empty(t, deleted.PromotedSemiDynamic1)
-	require.NotContains(t, deleted.Open, "invalidated recent tool")
+	require.NotContains(t, deleted.PromotedOpen, "invalidated recent tool")
 
 	tl.TruncateAfter(3)
 	rolledBack := RenderTimelineFrozenOpen(tl)
@@ -132,5 +140,5 @@ func TestTimelineForkMergesPromotionJournalWithoutDiffNoise(t *testing.T) {
 	merged, err := fork.MergeBack()
 	require.NoError(t, err)
 	require.Equal(t, 0, merged.ActiveItemsMerged, "control entries must not inflate ordinary event statistics")
-	require.Contains(t, RenderTimelineFrozenOpen(parent).Open, "## Tool: branch_tool")
+	require.Contains(t, RenderTimelineFrozenOpen(parent).PromotedOpen, "## Tool: branch_tool")
 }

--- a/common/ai/aid/aicommon/toolcall.go
+++ b/common/ai/aid/aicommon/toolcall.go
@@ -46,7 +46,7 @@ const toolParamAITagActionKeyPrefix = "__aitag__"
 //   - 即使 LLM 不替换、直接照抄字面量输出, ActionMaker 端通过 ExtraNonces
 //     双注册也能命中 (turn nonce + [current-nonce] 同时注册 callback)
 //
-// 必须与渲染侧 (buildinaitools.GetRecentToolsSummary) 与解析侧
+// 必须与渲染侧 (Timeline promoted recent-tool-cache state) 与解析侧
 // (reactloops.syncRecentToolParamAITagFields 注册的 LoopAITagField.ExtraNonces)
 // 保持一致, 否则字面量被改变后任一侧落后都会导致解析丢失.
 //

--- a/common/ai/aid/aireact/artifacts_visibility_test.go
+++ b/common/ai/aid/aireact/artifacts_visibility_test.go
@@ -199,7 +199,8 @@ WAIT_SECOND:
 		}
 	}
 
-	// Verify the prompt from the second input contains the artifacts information
+	// Artifact files remain available through directory/UI surfaces, while the
+	// recursive listing is intentionally absent from subsequent prompts.
 	promptMu.Lock()
 	defer promptMu.Unlock()
 
@@ -209,18 +210,10 @@ WAIT_SECOND:
 
 	secondPrompt := capturedPrompts[len(capturedPrompts)-1]
 
-	assert.Contains(t, secondPrompt, "Session Artifacts",
-		"subsequent conversation prompt should still surface Session Artifacts as a first-class prompt block")
-	assert.Contains(t, secondPrompt, "task_1-1_network_scan",
-		"subsequent conversation prompt should contain task_1-1 directory name")
-	assert.Contains(t, secondPrompt, "task_1-2_vuln_analysis",
-		"subsequent conversation prompt should contain task_1-2 directory name")
-	assert.Contains(t, secondPrompt, "1_bash_nmap_scan.md",
-		"subsequent conversation prompt should contain tool call filename")
-	assert.Contains(t, secondPrompt, "task_1_1_network_scan_timeline_diff.txt",
-		"subsequent conversation prompt should contain timeline diff filename")
-	assert.Contains(t, secondPrompt, "task_1_1_network_scan_result_summary.txt",
-		"subsequent conversation prompt should contain result summary filename")
+	assert.NotContains(t, secondPrompt, "Session Artifacts")
+	assert.NotContains(t, secondPrompt, "1_bash_nmap_scan.md")
+	assert.NotContains(t, secondPrompt, "task_1_1_network_scan_timeline_diff.txt")
+	assert.NotContains(t, secondPrompt, "task_1_1_network_scan_result_summary.txt")
 
 	// 反向断言: Pure Dynamic / AutoContext 段对应的 <|AUTO_PROVIDE_CTX_*|> tag
 	// 不应再含 Session Artifacts; 通过裁切验证: 若 Session Artifacts
@@ -235,30 +228,11 @@ WAIT_SECOND:
 		}
 	}
 
-	// Workspace 与 Session Artifacts 都在 timeline-open 段, 但 Artifacts 是
-	// Workspace 后面的一级块，不再作为 Workspace 子段。
-	wsIdx := strings.Index(secondPrompt, "# Workspace Context")
-	saIdx := strings.Index(secondPrompt, "# Session Artifacts (Open)")
-	if wsIdx >= 0 && saIdx >= 0 {
-		assert.Greater(t, saIdx, wsIdx,
-			"Session Artifacts should render after Workspace Context")
-		assert.NotContains(t, secondPrompt[wsIdx:saIdx], "## Session Artifacts",
-			"Workspace Context must not contain the legacy Session Artifacts subsection")
-	}
-
-	t.Logf("artifacts section found in prompt (extracting Workspace portion):")
-	if idx := strings.Index(secondPrompt, "Session Artifacts"); idx >= 0 {
-		end := idx + 2000
-		if end > len(secondPrompt) {
-			end = len(secondPrompt)
-		}
-		t.Logf("%s", secondPrompt[idx:end])
-	}
 }
 
-// TestArtifactsVisibility_TimelineContainsArtifactsSummary verifies that after plan/forge
-// execution, the timeline contains an artifacts_summary entry with the directory structure.
-func TestArtifactsVisibility_TimelineContainsArtifactsSummary(t *testing.T) {
+// TestArtifactsVisibility_ArtifactsStayOutOfTimeline verifies that plan artifacts
+// remain on disk and pinned without leaking a recursive listing into prompt-visible Timeline.
+func TestArtifactsVisibility_ArtifactsStayOutOfTimeline(t *testing.T) {
 	in := make(chan *ypb.AIInputEvent, 10)
 	out := make(chan *ypb.AIOutputEvent, 200)
 
@@ -333,20 +307,20 @@ WAIT:
 		}
 	}
 
-	// Check timeline for artifacts_summary entry
+	// The filesystem/UI surface survives, but the prompt-visible timeline does not
+	// receive a mechanical artifact summary.
 	timeline := reactIns.config.Timeline
 	require.NotNil(t, timeline)
 
 	timelineDump := timeline.Dump()
 	t.Logf("timeline dump:\n%s", utils.ShrinkString(timelineDump, 2000))
 
-	assert.Contains(t, timelineDump, "artifacts_summary",
-		"timeline should contain artifacts_summary entry after plan completion")
-
-	// The timeline should contain the actual workdir path
+	assert.NotContains(t, timelineDump, "artifacts_summary")
 	workDir := reactIns.config.GetOrCreateWorkDir()
-	assert.Contains(t, timelineDump, workDir,
-		"timeline should contain the artifacts directory path")
+	assert.NotContains(t, timelineDump, workDir)
+	assert.True(t, reactIns.config.IsArtifactsPinned())
+	_, statErr := os.Stat(filepath.Join(workDir, "task_1-1_timeline_test", "result.txt"))
+	require.NoError(t, statErr)
 }
 
 // TestArtifactsVisibility_EmitPinDirectory verifies that EmitPinDirectory is called

--- a/common/ai/aid/aireact/invoke_toolcall_directly_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_directly_test.go
@@ -122,7 +122,7 @@ func TestReAct_DirectlyCallTool_Basic(t *testing.T) {
 	react, err := NewTestReAct(
 		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
 			if isPrimaryDecisionPrompt(r.GetPrompt()) {
-				require.Contains(t, r.GetPrompt(), "If the exact tool you need is already listed in CACHE_TOOL_CALL, prefer directly_call_tool for faster execution.")
+				require.Contains(t, r.GetPrompt(), "If the exact tool you need is already listed above, prefer directly_call_tool for faster execution.")
 			}
 			return mockedDirectlyCallTool(i, r, "sleep_test")
 		}),
@@ -135,7 +135,7 @@ func TestReAct_DirectlyCallTool_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	// pre-populate the cache so directly_call_tool is available
-	react.config.GetAiToolManager().AddRecentlyUsedTool(sleepTool)
+	react.config.RecordRecentlyUsedTool(sleepTool)
 
 	go func() {
 		in <- &ypb.AIInputEvent{
@@ -208,7 +208,7 @@ func TestReAct_DirectlyCallTool_LegacyWrappedParams(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	react.config.GetAiToolManager().AddRecentlyUsedTool(sleepTool)
+	react.config.RecordRecentlyUsedTool(sleepTool)
 
 	go func() {
 		in <- &ypb.AIInputEvent{
@@ -284,7 +284,7 @@ func TestReAct_DirectlyCallTool_AITagBlockParams(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	react.config.GetAiToolManager().AddRecentlyUsedTool(bashTool)
+	react.config.RecordRecentlyUsedTool(bashTool)
 
 	go func() {
 		in <- &ypb.AIInputEvent{

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -233,10 +233,6 @@ func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMater
 		// prompt 任何一次 iteration 都能看到当前 TODO 全貌.
 		// 关键词: TodoSnapshot 透传, timeline-open, SessionEvidence 之后
 		materials.TodoSnapshot = input.TodoSnapshot
-		// CACHE_TOOL_CALL 正文会随最近工具集合变化, 放到 timeline-open 尾段,
-		// 保护其前面的 semi-2 cache boundary 不被工具变化击穿。
-		// 关键词: RecentToolsCache 透传, timeline-open, cache boundary 之后
-		materials.RecentToolsCache = input.RecentToolsCache
 		// PE-TASK PLAN 产物 (PARENT_TASK + CURRENT_TASK + INSTRUCTION) 通过
 		// FrozenUserContext 字段透传, 渲染时位于 timeline-open 段最末尾
 		// (UserHistory 之后), 落在所有 cache 边界之外。早期版本曾尝试
@@ -324,38 +320,35 @@ func (pm *PromptManager) AssemblePromptPrefix(materials *aicommon.PromptMaterial
 
 func (pm *PromptManager) buildLoopPromptSectionData(base *reactloops.LoopPromptBaseMaterials, input *reactloops.LoopPromptAssemblyInput) map[string]any {
 	data := map[string]any{
-		"Nonce":                   "",
-		"UserQuery":               "",
-		"TaskInstruction":         "",
-		"OutputExample":           "",
-		"Schema":                  "",
-		"SkillsContext":           "",
-		"ExtraCapabilities":       "",
-		"SessionEvidence":         "",
-		"TodoSnapshot":            "",
-		"ReactiveData":            "",
-		"InjectedMemory":          "",
-		"AllowPlanAndExec":        false,
-		"AllowToolCall":           false,
-		"HasLoadCapability":       false,
-		"ShowForgeInventory":      false,
-		"CurrentTime":             "",
-		"OSArch":                  "",
-		"WorkingDir":              "",
-		"WorkingDirGlance":        "",
-		"SessionArtifactsListing": "",
-		"SessionArtifactsFrozen":  "",
-		"SessionArtifactsOpen":    "",
-		"Workspace":               false,
-		"AutoContext":             "",
-		"UserHistory":             "",
-		"ToolsCount":              0,
-		"TopToolsCount":           0,
-		"TopTools":                []*aitool.Tool{},
-		"HasMoreTools":            false,
-		"ToolInventory":           false,
-		"AIForgeList":             "",
-		"ForgeInventory":          false,
+		"Nonce":              "",
+		"UserQuery":          "",
+		"TaskInstruction":    "",
+		"OutputExample":      "",
+		"Schema":             "",
+		"SkillsContext":      "",
+		"ExtraCapabilities":  "",
+		"SessionEvidence":    "",
+		"TodoSnapshot":       "",
+		"ReactiveData":       "",
+		"InjectedMemory":     "",
+		"AllowPlanAndExec":   false,
+		"AllowToolCall":      false,
+		"HasLoadCapability":  false,
+		"ShowForgeInventory": false,
+		"CurrentTime":        "",
+		"OSArch":             "",
+		"WorkingDir":         "",
+		"WorkingDirGlance":   "",
+		"Workspace":          false,
+		"AutoContext":        "",
+		"UserHistory":        "",
+		"ToolsCount":         0,
+		"TopToolsCount":      0,
+		"TopTools":           []*aitool.Tool{},
+		"HasMoreTools":       false,
+		"ToolInventory":      false,
+		"AIForgeList":        "",
+		"ForgeInventory":     false,
 	}
 	if base != nil {
 		data["Nonce"] = base.Nonce
@@ -377,8 +370,6 @@ func (pm *PromptManager) buildLoopPromptSectionData(base *reactloops.LoopPromptB
 		data["ToolInventory"] = base.AllowToolCall && base.ToolsCount > 0
 		data["AIForgeList"] = base.AIForgeList
 		data["ForgeInventory"] = base.ShowForgeInventory && strings.TrimSpace(base.AIForgeList) != ""
-		data["SessionArtifactsFrozen"] = base.SessionArtifactsFrozen
-		data["SessionArtifactsOpen"] = base.SessionArtifactsOpen
 	}
 	if input != nil {
 		data["Nonce"] = input.Nonce
@@ -504,13 +495,6 @@ func (pm *PromptManager) buildFrozenBlockObservation(
 	}
 	children = append(children,
 		reactloops.NewPromptSectionObservation(
-			"section.frozen_block.session_artifacts_frozen",
-			"Session Artifacts (Frozen)",
-			reactloops.PromptSectionRoleFrozenBlock,
-			true,
-			renderSessionArtifactsFrozenBlock(materials),
-		),
-		reactloops.NewPromptSectionObservation(
 			"section.frozen_block.session_evidence_frozen",
 			"Session Evidence (Frozen)",
 			reactloops.PromptSectionRoleFrozenBlock,
@@ -593,6 +577,13 @@ func (pm *PromptManager) buildSemiDynamic1Observation(
 			reactloops.PromptSectionRoleSemiDynamic1,
 			true,
 			materials.SkillsContext,
+		),
+		reactloops.NewPromptSectionObservation(
+			"section.semi_dynamic_1.promoted_state",
+			"Promoted State",
+			reactloops.PromptSectionRoleSemiDynamic1,
+			true,
+			materials.PromotedSemiDynamic1,
 		),
 	}
 	section.Children = filterIncludedPromptSections(children)
@@ -682,8 +673,8 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 }
 
 // buildTimelineOpenObservation 给"PROMPT_SECTION_timeline-open 段"做观测树:
-// Timeline 末桶 (+ midterm 检索结果) + SessionEvidence + TodoSnapshot + RecentToolsCache + Workspace +
-// SessionArtifactsOpen + UserHistory + Current Time + PlanContext (末尾)。
+// Timeline 末桶 (+ midterm 检索结果) + SessionEvidence + TodoSnapshot + Workspace +
+// UserHistory + Current Time + PlanContext (末尾)。
 //
 // 段内排序原则 (P1-C3 调整):
 //  1. Timeline (Open Tail) 在最前: 时间线最末桶是模型理解"刚发生了什么"的
@@ -694,14 +685,12 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 //  3. TodoSnapshot 紧跟 SessionEvidence, 暴露全局待办状态。
 //  4. Workspace 居中: OS/Arch + working dir + glance 是相对静态的环境标识,
 //     既不属于"刚发生", 也不属于"用户视角", 居中过渡。
-//  5. Session Artifacts (Open) 在 Workspace 之后: 最近 task group 与 root files
-//     仍属易变尾段, 不污染 frozen prefix。
-//  6. User History 在 Artifacts 之后: PREV_USER_INPUT 是用户历史输入轨迹,
+//  5. User History 在 Workspace 之后: PREV_USER_INPUT 是用户历史输入轨迹,
 //     与 Current Time 一起构成"时序前缀", 紧贴当前时间。
-//  7. Current Time 紧跟 User History: 当前时间是最末稳定的时序锚点, 放在
+//  6. Current Time 紧跟 User History: 当前时间是最末稳定的时序锚点, 放在
 //     User History 之后形成"历史输入 -> 现在"的时间递进, 同时与下方
 //     PlanContext (任务规划) 形成"时间 -> 任务"的语义衔接。
-//  8. Plan Context 末尾: PE-TASK PLAN 产物本质易变 (子任务切换),
+//  7. Plan Context 末尾: PE-TASK PLAN 产物本质易变 (子任务切换),
 //     放最末让其落在所有 cache
 //     边界外, 不污染上游 system / frozen / semi 三段缓存命中率。
 //
@@ -710,7 +699,7 @@ func (pm *PromptManager) buildSemiDynamic2Observation(
 //
 // 关键词: buildTimelineOpenObservation, Timeline 末桶, SessionEvidence,
 //
-//	Workspace, SessionArtifactsOpen, UserHistory, Current Time, PlanContext 末尾,
+//	Workspace, UserHistory, Current Time, PlanContext 末尾,
 //	段内排序原则, P1-C3 顺序调整, 缓存边界外
 func (pm *PromptManager) buildTimelineOpenObservation(
 	materials *reactloops.PromptPrefixMaterials,
@@ -759,28 +748,12 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 			true,
 			materials.TodoSnapshot,
 		),
-		// RecentToolsCache 标签使用稳定 nonce, 但正文随最近使用工具集合变化。
-		// 放在最后 cache boundary 之后, 避免工具集合变化导致 semi-2 前缀冷启动。
-		reactloops.NewPromptSectionObservation(
-			"section.timeline_open.cache_tool_call",
-			"Recent Tool Routing",
-			reactloops.PromptSectionRoleTimelineOpen,
-			true,
-			materials.RecentToolsCache,
-		),
 		reactloops.NewPromptSectionObservation(
 			"section.timeline_open.workspace",
 			"Workspace",
 			reactloops.PromptSectionRoleTimelineOpen,
 			true,
 			renderWorkspaceBlock(materials),
-		),
-		reactloops.NewPromptSectionObservation(
-			"section.timeline_open.session_artifacts_open",
-			"Session Artifacts (Open)",
-			reactloops.PromptSectionRoleTimelineOpen,
-			true,
-			renderSessionArtifactsOpenBlock(materials),
 		),
 		// P1-C3: UserHistory 在 Workspace 之后, 与下方 Current Time 共同
 		// 构成"用户输入历史 -> 现在"的时序前缀.
@@ -965,10 +938,8 @@ func renderSchemaBlock(schema string) string {
 
 // renderWorkspaceBlock 渲染 timeline-open 段中 Workspace 子块.
 //
-// SessionArtifacts 已迁出 Workspace，作为 SessionArtifactsFrozen /
-// SessionArtifactsOpen 一级块渲染。Workspace 只保留 OS / working dir / glance。
-//
-// 关键词: renderWorkspaceBlock, Workspace 不再内嵌 Session Artifacts
+// Session Artifacts no longer participate in prompt construction. Workspace
+// only contains OS / working dir / glance.
 func renderWorkspaceBlock(materials *reactloops.PromptPrefixMaterials) string {
 	if materials == nil {
 		return ""
@@ -1015,20 +986,6 @@ func renderFrozenPartitionBlock(partition aicommon.FrozenBlockPartition) string 
 		partition.ID,
 		partition.Nonce,
 	)
-}
-
-func renderSessionArtifactsFrozenBlock(materials *reactloops.PromptPrefixMaterials) string {
-	if materials == nil || strings.TrimSpace(materials.SessionArtifactsFrozen) == "" {
-		return ""
-	}
-	return "# Session Artifacts (Frozen)\n" + materials.SessionArtifactsFrozen
-}
-
-func renderSessionArtifactsOpenBlock(materials *reactloops.PromptPrefixMaterials) string {
-	if materials == nil || strings.TrimSpace(materials.SessionArtifactsOpen) == "" {
-		return ""
-	}
-	return "# Session Artifacts (Open)\n" + materials.SessionArtifactsOpen
 }
 
 func renderSessionEvidenceFrozenBlock(materials *reactloops.PromptPrefixMaterials) string {

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -714,7 +714,7 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 	// "Timeline Open & Workspace" 已经表达层级.
 	// 关键词: section.timeline_open 子节点 Name 去前缀, UI 信息密度
 	//
-	// 子节点排列顺序: timeline_open -> session_evidence -> todo_list -> cache_tool_call -> workspace ->
+	// 子节点排列顺序: timeline_open -> promoted_state_updates -> session_evidence -> todo_list -> workspace ->
 	// session_artifacts_open -> user_history -> current_time -> plan_context. 该顺序与 timeline_open_section.txt
 	// 模板渲染顺序严格一致, 让"上下文成分"面板看到的层级与实际 prompt 字节
 	// 流顺序保持同步.
@@ -726,6 +726,13 @@ func (pm *PromptManager) buildTimelineOpenObservation(
 			reactloops.PromptSectionRoleTimelineOpen,
 			true,
 			renderTimelineOpenBlock(materials),
+		),
+		reactloops.NewPromptSectionObservation(
+			"section.timeline_open.promoted_state_updates",
+			"Promoted State Updates",
+			reactloops.PromptSectionRoleTimelineOpen,
+			true,
+			materials.PromotedTimelineOpen,
 		),
 		// P1-C3: SessionEvidence 紧跟 Timeline (Open Tail), 与时间线末桶
 		// 形成"会话级实证"连续块.

--- a/common/ai/aid/aireact/prompt_loop_materials_test.go
+++ b/common/ai/aid/aireact/prompt_loop_materials_test.go
@@ -233,9 +233,9 @@ func TestPromptManager_AssembleLoopPrompt_SectionOrder(t *testing.T) {
 	require.Equal(t, reactloops.PromptSectionRoleZHDynamic, sections[5].Children[0].RoleZh)
 }
 
-// TestPromptManager_RenderLoopSemiDynamic1Section_Order 验证 SEMI-1 段
-// (semi_dynamic_section_1.txt) 仅包含 SkillsContext, 不含 RecentToolsCache /
-// Schema / Persistent / OutputExample / Tool / Forge.
+// TestPromptManager_RenderLoopSemiDynamic1Section_Order 验证 SEMI-1 段包含
+// SkillsContext 与 Timeline 晋升状态，但不接受旧 RecentToolsCache 独立输入，
+// 也不包含 Schema / Persistent / OutputExample / Tool / Forge。
 //
 // 关键词: renderLoopSemiDynamic1Section, semi_dynamic_section_1 内容范围, P1.1
 func TestPromptManager_RenderLoopSemiDynamic1Section_Order(t *testing.T) {
@@ -250,24 +250,29 @@ func TestPromptManager_RenderLoopSemiDynamic1Section_Order(t *testing.T) {
 	require.NoError(t, err)
 
 	rendered, err := react.promptManager.renderLoopSemiDynamic1Section(&reactloops.PromptPrefixMaterials{
-		ToolInventory:    true,
-		ToolsCount:       2,
-		TopToolsCount:    1,
-		TopTools:         []*aitool.Tool{aitool.NewWithoutCallback("tool-a", aitool.WithDescription("tool a desc"))},
-		HasMoreTools:     true,
-		ForgeInventory:   true,
-		AIForgeList:      "* `forge-a`: forge a desc",
-		SkillsContext:    "<|SKILLS_CONTEXT_demo|>\nskill body\n<|SKILLS_CONTEXT_END_demo|>",
-		RecentToolsCache: "<|CACHE_TOOL_CALL_[current-nonce]|>\ncache body\n<|CACHE_TOOL_CALL_END_[current-nonce]|>",
-		Schema:           `{"type":"object","properties":{"@action":{"type":"string"}}}`,
-		TaskInstruction:  "follow task rules",
-		OutputExample:    "example output",
+		ToolInventory:        true,
+		ToolsCount:           2,
+		TopToolsCount:        1,
+		TopTools:             []*aitool.Tool{aitool.NewWithoutCallback("tool-a", aitool.WithDescription("tool a desc"))},
+		HasMoreTools:         true,
+		ForgeInventory:       true,
+		AIForgeList:          "* `forge-a`: forge a desc",
+		SkillsContext:        "<|SKILLS_CONTEXT_demo|>\nskill body\n<|SKILLS_CONTEXT_END_demo|>",
+		PromotedSemiDynamic1: "<|CACHE_TOOL_CALL_[current-nonce]|>\npromoted cache body\n<|CACHE_TOOL_CALL_END_[current-nonce]|>",
+		RecentToolsCache:     "legacy cache body",
+		Schema:               `{"type":"object","properties":{"@action":{"type":"string"}}}`,
+		TaskInstruction:      "follow task rules",
+		OutputExample:        "example output",
 	})
 	require.NoError(t, err)
 
 	skillsIdx := strings.Index(rendered, "<|SKILLS_CONTEXT_demo|>")
 	require.NotEqual(t, -1, skillsIdx)
-	require.NotContains(t, rendered, "<|CACHE_TOOL_CALL_[current-nonce]|>")
+	promotedIdx := strings.Index(rendered, "<|CACHE_TOOL_CALL_[current-nonce]|>")
+	require.NotEqual(t, -1, promotedIdx)
+	require.Less(t, skillsIdx, promotedIdx)
+	require.Contains(t, rendered, "promoted cache body")
+	require.NotContains(t, rendered, "legacy cache body")
 	// SEMI-1 段绝对不能含 Schema / Persistent / OutputExample / Tool / Forge.
 	require.NotContains(t, rendered, "<|SCHEMA|>")
 	require.NotContains(t, rendered, "<|PERSISTENT|>")
@@ -584,7 +589,7 @@ func TestPromptManager_AssembleLoopPrompt_HijackFiveSegment(t *testing.T) {
 	requireMessageHasNoCacheControl(t, user4, "user4 open+dynamic")
 }
 
-func TestPromptManager_AssembleLoopPrompt_HijackArtifactsFrozenOpenPlacement(t *testing.T) {
+func TestPromptManager_AssembleLoopPrompt_DoesNotRenderSessionArtifacts(t *testing.T) {
 	restore := aicache.SetMinCachableUserSegmentBytesForTest(0)
 	defer restore()
 
@@ -626,14 +631,14 @@ func TestPromptManager_AssembleLoopPrompt_HijackArtifactsFrozenOpenPlacement(t *
 
 	user1Content := chatDetailContentString(hijack.Messages[1])
 	require.Contains(t, user1Content, "<|AI_CACHE_FROZEN_semi-dynamic|>")
-	require.Contains(t, user1Content, "# Session Artifacts (Frozen)")
-	require.Contains(t, user1Content, "task_1-1_done")
+	require.NotContains(t, user1Content, "# Session Artifacts")
+	require.NotContains(t, user1Content, "task_1-1_done")
 	require.NotContains(t, user1Content, "task_1-2_open")
 
 	user4Content := chatDetailContentString(hijack.Messages[4])
 	require.Contains(t, user4Content, "<|PROMPT_SECTION_timeline-open|>")
-	require.Contains(t, user4Content, "# Session Artifacts (Open)")
-	require.Contains(t, user4Content, "task_1-2_open")
+	require.NotContains(t, user4Content, "# Session Artifacts")
+	require.NotContains(t, user4Content, "task_1-2_open")
 	require.NotContains(t, user4Content, "task_1-1_done")
 }
 
@@ -728,13 +733,7 @@ func requireMessageHasNoCacheControl(t *testing.T, detail aispec.ChatDetail, lab
 	}
 }
 
-// TestPromptManager_AssembleLoopPrompt_RecentToolsCacheAfterCacheBoundary 验证
-// CACHE_TOOL_CALL 块 (经 LoopPromptAssemblyInput.RecentToolsCache 透传) 物理位置
-// 在 timeline-open 段, 经 hijacker 切割后位于最后一个 cache boundary 之后的
-// user4, 避免最近工具集合变化击穿 semi-2 prefix cache.
-//
-// 关键词: TestPromptManager, CACHE_TOOL_CALL 物理迁移, semi-dynamic-1 段, P1.1 主路径
-func TestPromptManager_AssembleLoopPrompt_RecentToolsCacheAfterCacheBoundary(t *testing.T) {
+func TestPromptManager_AssembleLoopPrompt_IgnoresLegacyRecentToolsCacheInput(t *testing.T) {
 	react, err := NewTestReAct(
 		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
 			rsp := i.NewAIResponse()
@@ -775,43 +774,21 @@ func TestPromptManager_AssembleLoopPrompt_RecentToolsCacheAfterCacheBoundary(t *
 
 	prompt := result.Prompt
 
-	// 1. CACHE_TOOL_CALL 必须出现在 prompt 中 (经过模板渲染)
-	cacheStartIdx := strings.Index(prompt, "<|CACHE_TOOL_CALL_[current-nonce]|>")
-	cacheEndIdx := strings.Index(prompt, "<|CACHE_TOOL_CALL_END_[current-nonce]|>")
-	require.NotEqual(t, -1, cacheStartIdx, "CACHE_TOOL_CALL must appear in prompt")
-	require.NotEqual(t, -1, cacheEndIdx)
+	// The old independent source is ignored. Tool schemas now enter via
+	// promotable Timeline items and are projected into Open/Semi1 exactly once.
+	require.NotContains(t, prompt, "<|CACHE_TOOL_CALL_[current-nonce]|>")
+	require.NotContains(t, prompt, "# Fast Tool Routing")
 
-	// 2. 必须位于 timeline-open 段, 不得再污染 semi-1 / semi-2 cache prefix.
 	semi1Start := strings.Index(prompt, "<|PROMPT_SECTION_semi-dynamic-1|>")
 	semi1End := strings.Index(prompt, "<|PROMPT_SECTION_END_semi-dynamic-1|>")
 	require.NotEqual(t, -1, semi1Start)
 	require.NotEqual(t, -1, semi1End)
-	semi1Body := prompt[semi1Start:semi1End]
-	require.NotContains(t, semi1Body, "<|CACHE_TOOL_CALL_[current-nonce]|>")
-	timelineStart := strings.Index(prompt, "<|PROMPT_SECTION_timeline-open|>")
-	timelineEnd := strings.Index(prompt, "<|PROMPT_SECTION_END_timeline-open|>")
-	require.NotEqual(t, -1, timelineStart)
-	require.NotEqual(t, -1, timelineEnd)
-	require.Greater(t, cacheStartIdx, timelineStart)
-	require.Less(t, cacheEndIdx, timelineEnd)
-
-	// 3. semi-dynamic-2 段绝对不能含 CACHE_TOOL_CALL (P1.1 拆分边界)
 	semi2Start := strings.Index(prompt, "<|PROMPT_SECTION_semi-dynamic-2|>")
 	semi2End := strings.Index(prompt, "<|PROMPT_SECTION_END_semi-dynamic-2|>")
 	require.NotEqual(t, -1, semi2Start)
 	require.NotEqual(t, -1, semi2End)
-	semi2Body := prompt[semi2Start:semi2End]
-	require.NotContains(t, semi2Body, "<|CACHE_TOOL_CALL_[current-nonce]|>",
-		"CACHE_TOOL_CALL must NOT appear before the final cache boundary")
 
-	// 4. dynamic 段不含 CACHE_TOOL_CALL; 它现在属于 timeline-open 观测段.
-	dynamicStart := strings.Index(prompt, "<|PROMPT_SECTION_dynamic_turnA|>")
-	require.NotEqual(t, -1, dynamicStart)
-	dynamicTail := prompt[dynamicStart:]
-	require.NotContains(t, dynamicTail, "<|CACHE_TOOL_CALL_[current-nonce]|>",
-		"CACHE_TOOL_CALL must NOT remain in dynamic section after physical migration")
-
-	// 5. semi-1 段必须被 AI_CACHE_SEMI_semi 边界包裹 (P1.1 第一对 cache 边界)
+	// Existing cache wrappers remain structurally unchanged.
 	aiCacheSemiStart := strings.Index(prompt, "<|AI_CACHE_SEMI_semi|>")
 	aiCacheSemiEnd := strings.Index(prompt, "<|AI_CACHE_SEMI_END_semi|>")
 	require.NotEqual(t, -1, aiCacheSemiStart, "P1.1: prompt must contain AI_CACHE_SEMI_semi START")

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -459,6 +459,8 @@ func (pm *PromptManager) GenerateVerificationPrompt(originalQuery string, isTool
 	prefixMaterials.ForgeInventory = false
 	prefixMaterials.AIForgeList = ""
 	prefixMaterials.SkillsContext = ""
+	prefixMaterials.PromotedSemiDynamic1 = ""
+	prefixMaterials.PromotedTimelineOpen = ""
 	prefixMaterials.RecentToolsCache = ""
 	dynamicData := pm.buildLoopPromptSectionData(base, &reactloops.LoopPromptAssemblyInput{
 		Nonce:     nonceString,
@@ -519,6 +521,8 @@ func (pm *PromptManager) GenerateAIReviewPrompt(userQuery, toolOrTitle, params s
 	prefixMaterials.ForgeInventory = false
 	prefixMaterials.AIForgeList = ""
 	prefixMaterials.SkillsContext = ""
+	prefixMaterials.PromotedSemiDynamic1 = ""
+	prefixMaterials.PromotedTimelineOpen = ""
 	prefixMaterials.RecentToolsCache = ""
 
 	dynamicData := pm.buildLoopPromptSectionData(base, &reactloops.LoopPromptAssemblyInput{
@@ -958,6 +962,8 @@ func (pm *PromptManager) GenerateIntervalReviewPromptWithContext(
 	prefixMaterials.ForgeInventory = false
 	prefixMaterials.AIForgeList = ""
 	prefixMaterials.SkillsContext = ""
+	prefixMaterials.PromotedSemiDynamic1 = ""
+	prefixMaterials.PromotedTimelineOpen = ""
 	prefixMaterials.RecentToolsCache = ""
 
 	userQuery := ""

--- a/common/ai/aid/aireact/prompts_test.go
+++ b/common/ai/aid/aireact/prompts_test.go
@@ -1000,6 +1000,19 @@ func TestPromptManager_GenerateVerificationPrompt_UsesPromptSections(t *testing.
 	if err != nil {
 		t.Fatalf("Failed to create ReAct instance: %v", err)
 	}
+	// Specialized non-tool prompts must not inherit the promoted recent-tool
+	// cache even though it is part of the shared Timeline projection.
+	react.config.RecordRecentlyUsedTool(aitool.NewWithoutCallback(
+		"sealed_promoted_tool_must_not_leak",
+		aitool.WithDescription("sentinel sealed promoted tool"),
+		aitool.WithStringParam("value"),
+	))
+	react.config.GetTimeline().ForcePromoteAll()
+	react.config.RecordRecentlyUsedTool(aitool.NewWithoutCallback(
+		"open_promoted_tool_must_not_leak",
+		aitool.WithDescription("sentinel open promoted tool"),
+		aitool.WithStringParam("value"),
+	))
 
 	prompt, nonce, err := react.promptManager.GenerateVerificationPrompt(
 		"请验证当前子任务是否完成",
@@ -1024,6 +1037,9 @@ func TestPromptManager_GenerateVerificationPrompt_UsesPromptSections(t *testing.
 		"<|ENHANCE_DATA_"+nonce+"|>",
 	) {
 		t.Fatalf("verification prompt should be composed by prompt sections. Got:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "promoted_tool_must_not_leak") {
+		t.Fatalf("verification prompt must not include promoted recent-tool state")
 	}
 }
 

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -840,26 +840,14 @@ func WithBuiltinTools() aicommon.ConfigOption {
 	}
 }
 
-// emitArtifactsSummaryToTimeline pushes a summary of the artifacts directory into the
-// timeline after plan/forge completion, and ensures EmitPinDirectory is called for UI visibility.
-// Prompt visibility is handled by RenderSessionArtifactsFrozenOpen during prompt build.
+// emitArtifactsSummaryToTimeline keeps the legacy call site name but only pins the
+// directory for UI visibility. Mechanical directory listings must not enter Timeline
+// because Timeline is prompt-visible.
 func (r *ReAct) emitArtifactsSummaryToTimeline() {
 	artifactsDir := r.config.GetOrCreateWorkDir()
 	if artifactsDir == "" {
 		return
 	}
-
-	glance := filesys.Glance(artifactsDir)
-	if glance == "" {
-		return
-	}
-
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Artifacts directory: %s\n", artifactsDir))
-	sb.WriteString("Directory structure:\n")
-	sb.WriteString(glance)
-	r.AddToTimeline("artifacts_summary", sb.String())
-	log.Infof("emitted artifacts summary to timeline for dir: %s", artifactsDir)
 
 	// Ensure the artifacts directory is pinned for UI visibility
 	if !r.config.IsArtifactsPinned() {

--- a/common/ai/aid/aireact/re-act_persistence_test.go
+++ b/common/ai/aid/aireact/re-act_persistence_test.go
@@ -189,12 +189,12 @@ LOOP:
 }
 
 // TestReAct_PersistentSession_WorkDir tests that Session Artifacts (WorkDir) persist
-// across persistent sessions, just like Timeline does. It runs a full Plan execution
+// across persistent sessions without being injected into Timeline. It runs a full Plan execution
 // in Session 1 that produces artifacts, then creates Session 2 with the same
 // persistent session ID and verifies that:
 // 1. The WorkDir is restored (same path as Session 1)
 // 2. Plan-produced artifact files are accessible
-// 3. Timeline with artifacts_summary is restored
+// 3. Mechanical artifact summaries remain absent from Timeline
 // 4. The new runtime's DB record has the restored WorkDir
 // 5. A session without persistent ID gets no WorkDir
 func TestReAct_PersistentSession_WorkDir(t *testing.T) {
@@ -341,8 +341,8 @@ WAIT_PLAN:
 	_, err = os.Stat(filepath.Join(session1WorkDir, "task_1-2_vuln_analysis"))
 	require.NoError(t, err, "task_1-2_vuln_analysis dir should exist in session 1 WorkDir")
 
-	// Note: artifacts_summary in timeline is timing-dependent due to save throttle (3s).
-	// This is separately tested by TestArtifactsVisibility_TimelineContainsArtifactsSummary.
+	assert.NotContains(t, reactIns.DumpTimeline(), "artifacts_summary",
+		"mechanical artifact summaries must stay out of Timeline")
 
 	// Verify Session 1 WorkDir is saved in DB
 	runtime1, err := yakit.GetLatestAIAgentRuntimeByPersistentSession(consts.GetGormProjectDatabase(), pid)
@@ -406,14 +406,9 @@ WAIT_PLAN:
 	// Verify: Timeline is restored from persistent session
 	require.True(t, ins2.getTimelineTotal() > 0,
 		"session 2 should have restored timeline items from persistent session")
-	// Note: artifacts_summary content in timeline is timing-dependent (save throttle is 3s).
-	// The content assertion is covered by TestArtifactsVisibility_TimelineContainsArtifactsSummary.
 	session2Timeline := ins2.DumpTimeline()
-	if strings.Contains(session2Timeline, "artifacts_summary") {
-		log.Infof("restored timeline contains artifacts_summary (throttle flush completed)")
-	} else {
-		log.Infof("restored timeline does not contain artifacts_summary (throttle flush may not have completed, acceptable)")
-	}
+	assert.NotContains(t, session2Timeline, "artifacts_summary",
+		"restored Timeline must not contain mechanical artifact summaries")
 
 	// === Session 3: Create instance WITHOUT persistent session ===
 	in3 := make(chan *ypb.AIInputEvent, 10)

--- a/common/ai/aid/aireact/reactloops/docs/03-prompt-system.md
+++ b/common/ai/aid/aireact/reactloops/docs/03-prompt-system.md
@@ -162,12 +162,10 @@ reactloops.WithReactiveDataBuilder(func(loop *reactloops.ReActLoop, feedbacker *
 
 **特殊：CACHE_TOOL_CALL**
 
-`generateLoopPrompt` 内部还会自动追加：
-
-- `renderRecentToolRoutingHint(nonce)`：教 LLM 优先用 `directly_call_tool` 命中缓存
-- `tm.GetRecentToolsSummary(...)` 包成 `<|CACHE_TOOL_CALL_<nonce>|>`：列出最近用过的工具及参数
-
-这部分**不需要 loop 关心**，只要 `aiToolManager.HasRecentlyUsedTools()` 为真就自动生效。
+最近工具不再由 `generateLoopPrompt` 每轮独立追加。工具成功执行后会写入 Timeline
+晋升事件：尚未 Seal 时作为 Timeline Open 增量可见，Seal 后物化到 Semi Dynamic 1，
+并以稳定顺序渲染 `<|CACHE_TOOL_CALL_[current-nonce]|>`。重复使用且 Schema 未变化时
+不会改变 Prompt。
 
 ## 3.6 `OutputExample`：输出示例与反思格式
 

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
@@ -373,9 +373,10 @@ var loopAction_directlyCallTool = &reactloops.LoopAction{
 				return
 			}
 			if cachedTool, lookupErr := loop.GetConfig().GetAiToolManager().GetToolByName(name); lookupErr == nil {
-				loop.GetConfig().GetAiToolManager().AddRecentlyUsedTool(cachedTool)
 				if realCfg, ok := loop.GetConfig().(*aicommon.Config); ok {
-					realCfg.SaveRecentToolCache()
+					realCfg.RecordRecentlyUsedTool(cachedTool)
+				} else {
+					loop.GetConfig().GetAiToolManager().AddRecentlyUsedTool(cachedTool)
 				}
 			}
 		}

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_tool_require_and_call.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_tool_require_and_call.go
@@ -67,9 +67,10 @@ var loopAction_toolRequireAndCall = &reactloops.LoopAction{
 		// cache tool on successful execution (before satisfaction check)
 		if callErr == nil && result != nil {
 			if cachedTool, lookupErr := loop.GetConfig().GetAiToolManager().GetToolByName(toolPayload); lookupErr == nil {
-				loop.GetConfig().GetAiToolManager().AddRecentlyUsedTool(cachedTool)
 				if realCfg, ok := loop.GetConfig().(*aicommon.Config); ok {
-					realCfg.SaveRecentToolCache()
+					realCfg.RecordRecentlyUsedTool(cachedTool)
+				} else {
+					loop.GetConfig().GetAiToolManager().AddRecentlyUsedTool(cachedTool)
 				}
 			}
 		}

--- a/common/ai/aid/aireact/reactloops/prompt.go
+++ b/common/ai/aid/aireact/reactloops/prompt.go
@@ -22,31 +22,6 @@ func (r *ReActLoop) shouldRenderTodoSnapshot() bool {
 	return true
 }
 
-// renderRecentToolRoutingHint 渲染"快速工具路由提示", 整体使用占位符字面量
-// nonce (aicommon.RecentToolCacheStableNonce, "[current-nonce]"), 跨 turn
-// 字节稳定, 让该段进入 prefix cache. 占位符语义可让 LLM 自然把它关联到
-// 当前 turn nonce.
-//
-// 历史: 该提示曾使用 turn nonce 渲染, 与 CACHE_TOOL_CALL 一并位于 dynamic 段
-// REFLECTION 内, 每轮变化无法缓存. 现已与 CACHE_TOOL_CALL 一起迁到 semi-dynamic
-// 段并用稳定 nonce 渲染.
-//
-// 关键词: renderRecentToolRoutingHint, DIRECT_TOOL_ROUTING, stable nonce,
-//
-//	semi-dynamic 段
-func renderRecentToolRoutingHint() string {
-	return utils.MustRenderTemplate(`
-<|DIRECT_TOOL_ROUTING_{{ .Nonce }}|>
-# Fast Tool Routing
-- Before using require_tool, check CACHE_TOOL_CALL first.
-- If the exact tool you need is already listed in CACHE_TOOL_CALL, prefer directly_call_tool for faster execution.
-- Use require_tool only when the needed tool is not in the recent cache, or when you still need normal tool discovery.
-<|DIRECT_TOOL_ROUTING_END_{{ .Nonce }}|>
-	`, map[string]any{
-		"Nonce": aicommon.RecentToolCacheStableNonce,
-	})
-}
-
 //go:embed prompts/todo_list.txt
 var todoListTemplate string
 
@@ -261,30 +236,11 @@ func (r *ReActLoop) generateLoopPrompt(
 		}
 	}
 
-	// CACHE_TOOL_CALL 块的标签使用稳定 nonce, 但 Summary 正文会随最近工具集合
-	// 变化。物理位置放在 timeline-open 段、最后 cache boundary 之后, 避免正文
-	// 变化击穿前面的 Skills + Schema prefix cache.
-	//
-	// 关键词: CACHE_TOOL_CALL 物理位置, timeline-open, cache boundary 之后
-	var recentToolsCacheBlock string
+	// Execution authorization remains in AiToolManager. Prompt visibility is now
+	// projected from Timeline Open / promoted Semi1, so do not inject a second
+	// full summary on every prompt build.
 	if tm := r.config.GetAiToolManager(); tm != nil && tm.HasRecentlyUsedTools() {
 		r.syncRecentToolParamAITagFields(tm.GetRecentToolParamNames())
-		var sb strings.Builder
-		sb.WriteString(renderRecentToolRoutingHint())
-		// nonce 参数已被 GetRecentToolsSummary 内部忽略, 实际渲染使用稳定 nonce.
-		// 这里仍然传 nonce 仅为了不破坏老接口签名.
-		if summary := tm.GetRecentToolsSummary(tm.GetRecentToolCacheMaxTokens(), nonce); summary != "" {
-			cacheBlock := utils.MustRenderTemplate(`
-<|CACHE_TOOL_CALL_{{ .Nonce }}>
-{{ .Summary }}
-<|CACHE_TOOL_CALL_END_{{ .Nonce }}>
-			`, map[string]interface{}{
-				"Nonce":   aicommon.RecentToolCacheStableNonce,
-				"Summary": summary,
-			})
-			sb.WriteString(cacheBlock)
-		}
-		recentToolsCacheBlock = sb.String()
 	}
 
 	if r.invoker == nil {
@@ -306,7 +262,6 @@ func (r *ReActLoop) generateLoopPrompt(
 		TodoSnapshot:      todoSnapshot,
 		ReactiveData:      reactiveData,
 		InjectedMemory:    memory,
-		RecentToolsCache:  recentToolsCacheBlock,
 	})
 	if err != nil {
 		return "", utils.Wrap(err, "assemble loop prompt failed")

--- a/common/ai/aid/aireact/reactloops/script_edit_policy.go
+++ b/common/ai/aid/aireact/reactloops/script_edit_policy.go
@@ -156,12 +156,13 @@ func PreloadSingleRecommendedTool(loop *ReActLoop, recommendedCaps []string) boo
 	if err != nil || tool == nil {
 		return false
 	}
-	mgr.AddRecentlyUsedTool(tool)
-	if realCfg, ok := loop.GetConfig().(*aicommon.Config); ok {
-		realCfg.SaveRecentToolCache()
-	}
 	if invoker := loop.GetInvoker(); invoker != nil {
 		invoker.AddToTimeline("recent_tool_preloaded", fmt.Sprintf("精准推荐仅命中一个工具，已自动加入最近工具缓存: %s", toolName))
+	}
+	if realCfg, ok := loop.GetConfig().(*aicommon.Config); ok {
+		realCfg.RecordRecentlyUsedTool(tool)
+	} else {
+		mgr.AddRecentlyUsedTool(tool)
 	}
 	return true
 }

--- a/common/ai/aid/aitool/buildinaitools/tool_manager.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager.go
@@ -65,6 +65,14 @@ type RecentToolEntry struct {
 	Size          int    `json:"size"`
 }
 
+// RecentToolCacheMutation is the prompt-visible delta caused by an LRU update.
+// Reusing an unchanged tool may still refresh execution-side LRU order, but
+// intentionally returns no Upsert so the prompt prefix remains byte-stable.
+type RecentToolCacheMutation struct {
+	Upsert  *RecentToolEntry
+	Deleted []*RecentToolEntry
+}
+
 // AiToolManager 是工具管理器的默认实现
 type AiToolManager struct {
 	toolsGetter           func() []*aitool.Tool
@@ -532,9 +540,10 @@ func (m *AiToolManager) totalCacheSize() int {
 
 // AddRecentlyUsedTool caches a tool for later directly_call_tool usage.
 // Duplicates are moved to the tail (most recent); FIFO eviction when over budget.
-func (m *AiToolManager) AddRecentlyUsedTool(tool *aitool.Tool) {
+func (m *AiToolManager) AddRecentlyUsedTool(tool *aitool.Tool) RecentToolCacheMutation {
+	var mutation RecentToolCacheMutation
 	if tool == nil {
-		return
+		return mutation
 	}
 	m.recentToolsMu.Lock()
 	defer m.recentToolsMu.Unlock()
@@ -547,9 +556,12 @@ func (m *AiToolManager) AddRecentlyUsedTool(tool *aitool.Tool) {
 
 	// remove existing entry with same name (will be re-appended at tail)
 	filtered := make([]*RecentToolEntry, 0, len(m.recentToolsCache))
+	var previous *RecentToolEntry
 	for _, e := range m.recentToolsCache {
 		if e.Name != name {
 			filtered = append(filtered, e)
+		} else {
+			previous = e
 		}
 	}
 	m.recentToolsCache = filtered
@@ -562,11 +574,52 @@ func (m *AiToolManager) AddRecentlyUsedTool(tool *aitool.Tool) {
 		Size:          entrySize,
 	}
 	m.recentToolsCache = append(m.recentToolsCache, newEntry)
+	if previous == nil || previous.Description != newEntry.Description || previous.SchemaSnippet != newEntry.SchemaSnippet || previous.Usage != newEntry.Usage {
+		cp := *newEntry
+		mutation.Upsert = &cp
+	}
 
 	maxTokens := m.getMaxCacheTokens()
 	for m.totalCacheSize() > maxTokens && len(m.recentToolsCache) > 1 {
+		evicted := m.recentToolsCache[0]
 		m.recentToolsCache = m.recentToolsCache[1:]
+		if evicted != nil && evicted.Name != name {
+			cp := *evicted
+			mutation.Deleted = append(mutation.Deleted, &cp)
+		}
 	}
+	return mutation
+}
+
+// GetRecentToolEntries returns a defensive snapshot in execution-side LRU order.
+func (m *AiToolManager) GetRecentToolEntries() []*RecentToolEntry {
+	m.recentToolsMu.Lock()
+	defer m.recentToolsMu.Unlock()
+	out := make([]*RecentToolEntry, 0, len(m.recentToolsCache))
+	for _, entry := range m.recentToolsCache {
+		if entry == nil {
+			continue
+		}
+		cp := *entry
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// RenderRecentToolEntryForPromotion renders one stable, params-only schema.
+// Collection ordering and the shared routing instructions are owned by the
+// Timeline promoted-state projection.
+func RenderRecentToolEntryForPromotion(entry *RecentToolEntry) string {
+	if entry == nil {
+		return ""
+	}
+	return strings.TrimSpace(utils.MustRenderTemplate(recentToolEntryTemplate, map[string]interface{}{
+		"Name":                 entry.Name,
+		"Nonce":                RecentToolCacheStableNonce,
+		"Description":          entry.Description,
+		"DisplaySchemaSnippet": renderDirectlyCallParamsSchema(entry.SchemaSnippet),
+		"Usage":                entry.Usage,
+	}))
 }
 
 func (m *AiToolManager) IsRecentlyUsedTool(name string) bool {

--- a/common/ai/aid/aitool/buildinaitools/tool_manager_cache_test.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager_cache_test.go
@@ -55,6 +55,36 @@ func TestRecentToolCache_Dedup(t *testing.T) {
 	assert.Equal(t, len(names), 1, "duplicate adds should not create multiple entries")
 }
 
+func TestRecentToolCacheMutationOnlyChangesPromptStateWhenContentChanges(t *testing.T) {
+	mgr := newManagerWithCache(0)
+	original := makeTool("read_file", "Read file", aitool.WithStringParam("path"))
+	first := mgr.AddRecentlyUsedTool(original)
+	assert.Check(t, first.Upsert != nil)
+	assert.Equal(t, len(first.Deleted), 0)
+
+	repeated := mgr.AddRecentlyUsedTool(original)
+	assert.Check(t, repeated.Upsert == nil, "unchanged LRU touch must not mutate prompt state")
+	assert.Equal(t, len(repeated.Deleted), 0)
+
+	changed := makeTool("read_file", "Read file", aitool.WithStringParam("path"), aitool.WithBoolParam("raw"))
+	updated := mgr.AddRecentlyUsedTool(changed)
+	assert.Check(t, updated.Upsert != nil, "schema change must emit upsert")
+	assert.Check(t, strings.Contains(RenderRecentToolEntryForPromotion(updated.Upsert), `"raw"`))
+}
+
+func TestRecentToolCacheMutationReportsEviction(t *testing.T) {
+	probeMgr := newManagerWithCache(0)
+	probe := makeTool("probe", "same", aitool.WithStringParam("x"))
+	probeMgr.AddRecentlyUsedTool(probe)
+	mgr := newManagerWithCache(probeMgr.totalCacheSize() + 5)
+
+	mgr.AddRecentlyUsedTool(makeTool("first", "same", aitool.WithStringParam("x")))
+	mutation := mgr.AddRecentlyUsedTool(makeTool("second", "same", aitool.WithStringParam("x")))
+	assert.Check(t, mutation.Upsert != nil)
+	assert.Equal(t, len(mutation.Deleted), 1)
+	assert.Equal(t, mutation.Deleted[0].Name, "first")
+}
+
 func TestRecentToolCache_SizeLimit(t *testing.T) {
 	// measure a single entry size first
 	probe := makeTool("probe", "probe description",


### PR DESCRIPTION
## Summary

- add promotable Timeline control items and materialized Semi Dynamic 1 state with seal, compression, fork, persistence, and rollback behavior
- route recent-tool upsert/delete mutations through Timeline Open, then render stable sorted params-only schemas after promotion
- remove duplicate per-turn recent-tool injection and Session Artifacts prompt scans while retaining artifact persistence and UI pinning

## Validation

- go test -race ./common/ai/aid/aicommon -run TestTimelinePromotedState\|TestConfigRecordRecentlyUsedTool\|TestTimelineForkMergesPromotion -count=1
- go test ./common/ai/aid/aicommon -count=1
- go test ./common/ai/aid/aitool/buildinaitools -count=1
- go test ./common/ai/aid/aireact -count=1
- go test ./common/ai/aid/aireact/reactloops/... -count=1

## Notes

- go vet remains blocked by the pre-existing non-pointer json.Unmarshal call in common/ai/aid/aicommon/taskif_test.go:63.