### PR TITLE
feat(aid): compact timeline and bound lightweight prompts

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -1319,25 +1319,6 @@ func (c *Config) SaveLoadedSkillNames(skillNames []string) {
 	}
 }
 
-// SaveRecentToolCache persists the recent-tool cache to the DB for the current persistent session.
-func (c *Config) SaveRecentToolCache() {
-	if c.PersistentSessionId == "" {
-		return
-	}
-	tm := c.GetAiToolManager()
-	if tm == nil {
-		return
-	}
-	db := c.GetDB()
-	if db == nil {
-		return
-	}
-	cacheJSON := tm.ExportRecentToolCache()
-	if err := yakit.UpdateAIAgentRuntimeRecentToolsCache(db, c.PersistentSessionId, cacheJSON); err != nil {
-		log.Warnf("failed to save recent tool cache for session [%s]: %v", c.PersistentSessionId, err)
-	}
-}
-
 // RecordRecentlyUsedTool keeps execution authorization in AiToolManager while
 // recording only prompt-visible mutations in Timeline Open.
 func (c *Config) RecordRecentlyUsedTool(tool *aitool.Tool) buildinaitools.RecentToolCacheMutation {
@@ -1347,38 +1328,38 @@ func (c *Config) RecordRecentlyUsedTool(tool *aitool.Tool) buildinaitools.Recent
 	}
 	mutation = c.GetAiToolManager().AddRecentlyUsedTool(tool)
 	timeline := c.GetTimeline()
+	promptMutated := false
 	if timeline != nil && mutation.Upsert != nil {
-		timeline.PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
+		promptMutated = timeline.PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
 			mutation.Upsert.Name, TimelinePromotedOperationUpsert,
-			buildinaitools.RenderRecentToolEntryForPromotion(mutation.Upsert))
+			buildinaitools.RenderRecentToolEntryForPromotion(mutation.Upsert)) || promptMutated
 	}
 	if timeline != nil {
 		for _, deleted := range mutation.Deleted {
 			if deleted == nil {
 				continue
 			}
-			timeline.PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
-				deleted.Name, TimelinePromotedOperationDelete, "")
+			promptMutated = timeline.PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
+				deleted.Name, TimelinePromotedOperationDelete, "") || promptMutated
 		}
 	}
-	c.SaveRecentToolCache()
+	if promptMutated && c.PersistentSessionId != "" && c.GetDB() != nil {
+		timeline.Save(c.GetDB(), c.PersistentSessionId)
+	}
 	return mutation
 }
 
-func (c *Config) bootstrapRecentToolsIntoTimeline() {
-	if c == nil || c.GetTimeline() == nil || c.GetAiToolManager() == nil || c.GetTimeline().HasPromotableKind(TimelinePromotedKindRecentTool) {
+func (c *Config) restoreRecentToolsFromTimeline() {
+	if c == nil || c.GetTimeline() == nil || c.GetAiToolManager() == nil {
 		return
 	}
-	entries := c.GetAiToolManager().GetRecentToolEntries()
-	for _, entry := range entries {
-		if entry == nil {
+	for _, name := range c.GetTimeline().effectivePromotedKeys(TimelinePromotedTargetSemiDynamic1, TimelinePromotedKindRecentTool) {
+		tool, err := c.GetAiToolManager().GetToolByName(name)
+		if err != nil || tool == nil {
+			log.Warnf("failed to restore promoted recent tool [%s] for session [%s]: %v", name, c.PersistentSessionId, err)
 			continue
 		}
-		c.GetTimeline().PushPromotable(c.AcquireId(), TimelinePromotedKindRecentTool, TimelinePromotedTargetSemiDynamic1,
-			entry.Name, TimelinePromotedOperationUpsert, buildinaitools.RenderRecentToolEntryForPromotion(entry))
-	}
-	if len(entries) > 0 {
-		c.GetTimeline().ForcePromoteAll()
+		c.GetAiToolManager().AddRecentlyUsedTool(tool)
 	}
 }
 
@@ -3845,7 +3826,7 @@ func (c *Config) restorePersistentSession() {
 
 	// Reassign IDs to all restored timeline items to avoid ID conflicts
 	// This uses the current idGenerator to ensure sequential IDs
-	lastID := timelineInstance.ReassignIDs(c.SeqIdProvider.CurrentID)
+	lastID := timelineInstance.ReassignIDs(c.AcquireId)
 	if lastID > 0 {
 		log.Infof("reassigned timeline IDs, last assigned ID: %d", lastID)
 	}
@@ -3892,14 +3873,7 @@ func (c *Config) restorePersistentSession() {
 			c.PersistentSessionId, len([]rune(evidence)))
 	}
 
-	// Restore recent-tool cache from previous session
-	if runtime.RecentToolsCache != "" {
-		if tm := c.GetAiToolManager(); tm != nil {
-			tm.ImportRecentToolCache(runtime.RecentToolsCache)
-			c.bootstrapRecentToolsIntoTimeline()
-			log.Infof("restored recent tool cache from persistent session [%s]", c.PersistentSessionId)
-		}
-	}
+	c.restoreRecentToolsFromTimeline()
 
 	c.InitStatus.SetPersistentSessionRestored(true)
 	log.Infof("successfully restored timeline instance from persistent session [%s] with %d items",

--- a/common/ai/aid/aicommon/config_ai_wrapper.go
+++ b/common/ai/aid/aicommon/config_ai_wrapper.go
@@ -427,6 +427,7 @@ func (c *Config) wrapper(i AICallbackType, tier consts.ModelTier) AICallbackType
 					"provider_name":           provider,
 					"cache_hit_token":         cacheHitTokens,
 					"token_source":            usageMetrics.TokenSource,
+					"caller_label":            callerLabel,
 				})
 				c.EmitJSON(schema.EVENT_TYPE_AI_TOTAL_COST_MS, "system", map[string]any{
 					"ms":                      du.Milliseconds(),

--- a/common/ai/aid/aicommon/invoke_runtime.go
+++ b/common/ai/aid/aicommon/invoke_runtime.go
@@ -188,7 +188,14 @@ func NewSelectedKnowledgeBaseResult(reason string, knowledgeBases []string) *Sel
 }
 
 type LoopPromptAssemblyInput struct {
-	Nonce             string
+	Nonce string
+
+	// Lightweight selects the bounded speed-priority projection: the full
+	// frozen session history is replaced by a recent Timeline window and large
+	// auxiliary context fields are capped. The action schema remains intact so
+	// execution semantics do not change.
+	Lightweight bool
+
 	UserQuery         string
 	TaskInstruction   string
 	OutputExample     string

--- a/common/ai/aid/aicommon/invoke_runtime.go
+++ b/common/ai/aid/aicommon/invoke_runtime.go
@@ -207,10 +207,6 @@ type LoopPromptAssemblyInput struct {
 	ReactiveData   string
 	InjectedMemory string
 
-	// Deprecated: ignored by prompt assembly. Recent tool schemas are supplied by
-	// Timeline promotion state so they have exactly one prompt source.
-	RecentToolsCache string
-
 	// FrozenUserContext 用于承载 PE-TASK 等场景下"PLAN 阶段产出 + 用户原始
 	// 输入"两类只读上下文。注: 命名虽为 "Frozen", 但实际并不放入冻结段;
 	// 跨同一 plan 周期内同一子任务执行的多次 turn 字节稳定, 但子任务切换仍

--- a/common/ai/aid/aicommon/prompt_materials.go
+++ b/common/ai/aid/aicommon/prompt_materials.go
@@ -27,13 +27,9 @@ type PromptMaterials struct {
 	//     但仍属可缓存半动态前缀的内容
 	SkillsContext        string
 	PromotedSemiDynamic1 string
-	// Deprecated: recent-tool prompt visibility is projected from Timeline
-	// promotion state. This field remains only for source compatibility and is
-	// intentionally ignored by all shared templates.
-	RecentToolsCache  string
-	PlanHelp          string
-	OriginalUserInput string
-	StableInstruction string
+	PlanHelp             string
+	OriginalUserInput    string
+	StableInstruction    string
 
 	// ForcedSkills 是「用户强制加载」SKILL 满内容, 进 frozen_block 顶部 (最高优先级).
 	// 空时 frozen_block 顶部子块不渲染.
@@ -226,9 +222,10 @@ func RenderTimelineFrozenOpen(timeline *Timeline) TimelineFrozenOpenBlocks {
 		break
 	}
 	promotedSemi1, openDeltas := timeline.projectPromoted(sealedBeforeID)
+	promptBlocks := projectTimelineRenderableBlocksForPrompt(rb)
 	return TimelineFrozenOpenBlocks{
-		Frozen:               rb.RenderFrozenOnly(TimelineDumpDefaultAITagName),
-		Open:                 rb.RenderOpenOnly(TimelineDumpDefaultAITagName),
+		Frozen:               promptBlocks.RenderFrozenOnly(TimelineDumpDefaultAITagName),
+		Open:                 promptBlocks.RenderOpenOnly(TimelineDumpDefaultAITagName),
 		PromotedOpen:         openDeltas,
 		PromotedSemiDynamic1: promotedSemi1,
 		FrozenTimeUnix:       timelineFrozenTimeUnixFromRenderable(rb),

--- a/common/ai/aid/aicommon/timeline.go
+++ b/common/ai/aid/aicommon/timeline.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -841,7 +842,7 @@ func (m *Timeline) renderSummaryPrompt(result *TimelineItem) string {
 	var nonce = strings.ToLower(utils.RandStringBytes(6))
 
 	// Get timeline dump and truncate if too large
-	timelineDump := m.Dump()
+	timelineDump := m.DumpForPrompt()
 	if len(timelineDump) > MaxSummaryPromptTimelineSize {
 		log.Warnf("summary prompt: timeline dump too large (%d > %d), truncating",
 			len(timelineDump), MaxSummaryPromptTimelineSize)
@@ -914,6 +915,22 @@ func (m *Timeline) Dump() string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.dumpLocked()
+}
+
+// DumpForPrompt renders the same raw bucket topology as Dump while applying
+// prompt-only bookkeeping noise reduction to interval items.
+func (m *Timeline) DumpForPrompt() string {
+	if m == nil {
+		return ""
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	blocks := m.groupByMinutesAndBytesLocked(TimelineDumpDefaultIntervalMinutes, m.getEffectiveBucketByteSize()).GetAllRenderable()
+	return projectTimelineRenderableBlocksForPrompt(blocks).RenderWithFrozenBoundary(
+		TimelineDumpDefaultAITagName,
+		TimelineFrozenBoundaryTagName,
+		TimelineFrozenBoundaryNonce,
+	)
 }
 
 func (m *Timeline) dumpLocked() string {
@@ -1291,6 +1308,15 @@ func (m *Timeline) ReassignIDs(idGenerator func() int64) int64 {
 	m.tsToTimelineItem.ForEach(func(ts int64, item *TimelineItem) bool {
 		orderedItems = append(orderedItems, itemWithTs{ts: ts, item: item})
 		return true
+	})
+	// UnmarshalTimeline rebuilds this ordered map from JSON object keys, whose
+	// iteration order is intentionally undefined. Sort explicitly so restored
+	// IDs, promotion watermarks and pending journal order remain deterministic.
+	sort.SliceStable(orderedItems, func(i, j int) bool {
+		if orderedItems[i].ts == orderedItems[j].ts {
+			return orderedItems[i].item.GetID() < orderedItems[j].item.GetID()
+		}
+		return orderedItems[i].ts < orderedItems[j].ts
 	})
 
 	if len(orderedItems) == 0 {

--- a/common/ai/aid/aicommon/timeline.go
+++ b/common/ai/aid/aicommon/timeline.go
@@ -933,6 +933,97 @@ func (m *Timeline) DumpForPrompt() string {
 	)
 }
 
+// DumpRecentForPrompt renders the newest prompt-visible Timeline items within
+// a strict token budget. It is intended for speed-priority helper calls that
+// only need the latest execution facts and must not inherit the full frozen
+// session prefix.
+//
+// Selection happens from newest to oldest, but the returned items retain their
+// original chronological order. Prompt-only noise projection is applied before
+// accounting, and raw Timeline state is never mutated. If the newest single
+// item exceeds the whole budget, only that item's head and tail are retained so
+// the helper prompt remains bounded.
+func (m *Timeline) DumpRecentForPrompt(tokenLimit int) string {
+	if m == nil || tokenLimit <= 0 {
+		return ""
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	const (
+		header    = "<|TIMELINE_RECENT|>\n"
+		footer    = "\n<|TIMELINE_RECENT_END|>"
+		truncated = "[older timeline entries omitted]\n"
+	)
+	baseTokens := MeasureTokens(header + footer)
+	if baseTokens >= tokenLimit {
+		return ""
+	}
+
+	remaining := tokenLimit - baseTokens
+	selected := make([]string, 0)
+	omitted := false
+	for i := m.tsToTimelineItem.Len() - 1; i >= 0; i-- {
+		item, ok := m.tsToTimelineItem.GetByIndex(i)
+		if !ok || item == nil || item.deleted || isPromotableTimelineItem(item) {
+			continue
+		}
+		projected := projectTimelineItemForPrompt(item)
+		if projected == nil {
+			continue
+		}
+		content := strings.TrimSpace(projected.String())
+		if content == "" {
+			continue
+		}
+		cost := MeasureTokens(content)
+		if len(selected) > 0 {
+			cost += MeasureTokens("\n\n")
+		}
+		if cost > remaining {
+			omitted = true
+			if len(selected) == 0 {
+				markerTokens := MeasureTokens(truncated)
+				if remaining > markerTokens {
+					shrunk := strings.TrimSpace(ShrinkTextBlockByTokens(content, remaining-markerTokens))
+					if shrunk != "" {
+						selected = append(selected, shrunk)
+					}
+				}
+			}
+			break
+		}
+		remaining -= cost
+		selected = append([]string{content}, selected...)
+	}
+	if len(selected) == 0 {
+		return ""
+	}
+
+	body := strings.Join(selected, "\n\n")
+	if omitted {
+		body = truncated + body
+	}
+	result := header + body + footer
+	// Tokenizers can merge differently across concatenation boundaries. Keep a
+	// final guard so the public contract remains a hard upper bound.
+	if MeasureTokens(result) > tokenLimit {
+		bodyBudget := tokenLimit - baseTokens
+		for bodyBudget > 0 && MeasureTokens(result) > tokenLimit {
+			bodyBudget--
+			body = strings.TrimSpace(ShrinkTextBlockByTokens(body, bodyBudget))
+			if body == "" {
+				return ""
+			}
+			result = header + body + footer
+		}
+	}
+	if MeasureTokens(result) > tokenLimit {
+		return ""
+	}
+	return result
+}
+
 func (m *Timeline) dumpLocked() string {
 	return m.groupByMinutesAndBytesLocked(TimelineDumpDefaultIntervalMinutes, m.getEffectiveBucketByteSize()).
 		GetAllRenderable().

--- a/common/ai/aid/aicommon/timeline_batch_compress.go
+++ b/common/ai/aid/aicommon/timeline_batch_compress.go
@@ -396,7 +396,9 @@ func (m *Timeline) renderBatchCompressPrompt(currentHead *TimelineCompressedHead
 
 	// 1) 先构造 RECENT_KEEP 段（从最新向旧填，超限就在前面加 truncate notice）
 	// 关键词: renderBatchCompressPrompt, RECENT_KEEP 截断, 从新向旧填充
-	recentStr, recentCount, recentTruncated := buildRecentKeptString(recentKeep, MaxBatchCompressRecentSize)
+	promptRecentKeep := projectTimelineItemsForPrompt(recentKeep)
+	promptToCompress := projectTimelineItemsForPrompt(toCompress)
+	recentStr, recentCount, recentTruncated := buildRecentKeptString(promptRecentKeep, MaxBatchCompressRecentSize)
 
 	// 2) 剩余预算给 ITEMS_TO_COMPRESS（保留 1KB 给模板/指引/JSON schema）
 	const templateOverheadReserve = 1024
@@ -406,17 +408,22 @@ func (m *Timeline) renderBatchCompressPrompt(currentHead *TimelineCompressedHead
 		remainingBudget = 1024
 	}
 
-	itemsStr, actualItemCount, itemsTruncated := buildItemsToCompressString(toCompress, remainingBudget)
+	itemsStr, actualItemCount, itemsTruncated := buildItemsToCompressString(promptToCompress, remainingBudget)
 
 	if actualItemCount == 0 {
-		log.Warnf("batch compress: no items could fit within size limit, using truncated first item")
-		firstItem := toCompress[0].String()
-		if len(firstItem) > remainingBudget-100 {
-			firstItem = firstItem[:remainingBudget-100] + "... [truncated]"
+		if len(promptToCompress) == 0 {
+			itemsStr = "[system bookkeeping omitted from prompt projection]"
+			itemsTruncated = false
+		} else {
+			log.Warnf("batch compress: no items could fit within size limit, using truncated first item")
+			firstItem := promptToCompress[0].String()
+			if len(firstItem) > remainingBudget-100 {
+				firstItem = firstItem[:remainingBudget-100] + "... [truncated]"
+			}
+			itemsStr = fmt.Sprintf("[1] %s", firstItem)
+			actualItemCount = 1
+			itemsTruncated = true
 		}
-		itemsStr = fmt.Sprintf("[1] %s", firstItem)
-		actualItemCount = 1
-		itemsTruncated = true
 	}
 
 	if recentTruncated {

--- a/common/ai/aid/aicommon/timeline_promoted.go
+++ b/common/ai/aid/aicommon/timeline_promoted.go
@@ -198,6 +198,76 @@ func (m *Timeline) HasPromotableKind(kind string) bool {
 	return false
 }
 
+// effectivePromotedKeys returns the current materialized membership for one
+// promotion namespace, including mutations that are still in Timeline Open.
+// It is deliberately read-only: session restore must not seal buckets or move
+// the promotion watermark merely to rebuild execution-side authorization.
+//
+// Ordering follows the latest mutation source ID. Reuse of an unchanged tool
+// does not create a prompt mutation, so exact execution-side LRU touches are
+// intentionally not persisted across process restarts.
+func (m *Timeline) effectivePromotedKeys(targetSection, kind string) []string {
+	if m == nil || strings.TrimSpace(targetSection) == "" || strings.TrimSpace(kind) == "" {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type activePromotion struct {
+		key      string
+		sourceID int64
+	}
+	active := make(map[string]activePromotion)
+	watermark := int64(0)
+	if m.promotedState != nil {
+		watermark = m.promotedState.Watermark
+		if kinds := m.promotedState.Entries[targetSection]; kinds != nil {
+			for key, entry := range kinds[kind] {
+				if entry == nil {
+					continue
+				}
+				active[key] = activePromotion{key: key, sourceID: entry.SourceItemID}
+			}
+		}
+	}
+	ids := append([]int64(nil), m.idToTimelineItem.Keys()...)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		if id <= watermark {
+			continue
+		}
+		item, ok := m.idToTimelineItem.Get(id)
+		if !ok || item == nil || item.deleted {
+			continue
+		}
+		control, ok := item.value.(*PromotableTimelineItem)
+		if !ok || control == nil || control.TargetSection != targetSection || control.Kind != kind {
+			continue
+		}
+		if control.Operation == TimelinePromotedOperationDelete {
+			delete(active, control.Key)
+			continue
+		}
+		active[control.Key] = activePromotion{key: control.Key, sourceID: id}
+	}
+
+	ordered := make([]activePromotion, 0, len(active))
+	for _, entry := range active {
+		ordered = append(ordered, entry)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].sourceID == ordered[j].sourceID {
+			return ordered[i].key < ordered[j].key
+		}
+		return ordered[i].sourceID < ordered[j].sourceID
+	})
+	keys := make([]string, 0, len(ordered))
+	for _, entry := range ordered {
+		keys = append(keys, entry.key)
+	}
+	return keys
+}
+
 func (m *Timeline) projectPromoted(sealedBeforeID int64) (string, string) {
 	if m == nil {
 		return "", ""

--- a/common/ai/aid/aicommon/timeline_promoted_test.go
+++ b/common/ai/aid/aicommon/timeline_promoted_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools"
 )
 
 func injectPromotable(tl *Timeline, id int64, ts time.Time, operation, key, payload string) {
@@ -123,6 +124,49 @@ func TestTimelinePromotedStateStableOrdering(t *testing.T) {
 	b := RenderTimelineFrozenOpen(tl).PromotedSemiDynamic1
 	require.Equal(t, a, b)
 	require.Less(t, strings.Index(a, "## Tool: alpha"), strings.Index(a, "## Tool: zeta"))
+}
+
+func TestTimelineEffectivePromotedKeysRestoresSealedAndPendingStateWithoutMutation(t *testing.T) {
+	base := time.Date(2026, 7, 18, 11, 30, 0, 0, time.UTC)
+	tl := NewTimeline(nil, nil)
+	injectPromotable(tl, 1, base, TimelinePromotedOperationUpsert, "alpha", "## Tool: alpha")
+	injectPromotable(tl, 2, base.Add(time.Second), TimelinePromotedOperationUpsert, "beta", "## Tool: beta")
+	tl.ForcePromoteAll()
+	require.Equal(t, int64(2), tl.promotedState.Watermark)
+
+	// Pending journal changes overlay the sealed snapshot without advancing the
+	// watermark or forcing a Timeline seal.
+	injectPromotable(tl, 3, base.Add(2*time.Second), TimelinePromotedOperationDelete, "alpha", "")
+	injectPromotable(tl, 4, base.Add(3*time.Second), TimelinePromotedOperationUpsert, "gamma", "## Tool: gamma")
+	beforeWatermark := tl.promotedState.Watermark
+	beforeDump := tl.Dump()
+	require.Equal(t, []string{"beta", "gamma"}, tl.effectivePromotedKeys(TimelinePromotedTargetSemiDynamic1, TimelinePromotedKindRecentTool))
+	require.Equal(t, beforeWatermark, tl.promotedState.Watermark)
+	require.Equal(t, beforeDump, tl.Dump())
+
+	beta := aitool.NewWithoutCallback("beta", aitool.WithDescription("beta"), aitool.WithStringParam("value"))
+	gamma := aitool.NewWithoutCallback("gamma", aitool.WithDescription("gamma"), aitool.WithStringParam("value"))
+	manager := buildinaitools.NewToolManagerByToolGetter(func() []*aitool.Tool { return []*aitool.Tool{beta, gamma} }, buildinaitools.WithEnableAllTools())
+	cfg := NewConfig(context.Background(), WithToolManager(manager))
+	cfg.Timeline = tl
+	cfg.restoreRecentToolsFromTimeline()
+	require.False(t, manager.IsRecentlyUsedTool("alpha"))
+	require.True(t, manager.IsRecentlyUsedTool("beta"))
+	require.True(t, manager.IsRecentlyUsedTool("gamma"))
+	require.Equal(t, beforeWatermark, tl.promotedState.Watermark)
+	require.Equal(t, beforeDump, tl.Dump())
+
+	raw, err := MarshalTimeline(tl)
+	require.NoError(t, err)
+	restored, err := UnmarshalTimeline(raw)
+	require.NoError(t, err)
+	nextID := int64(100)
+	restored.ReassignIDs(func() int64 {
+		nextID++
+		return nextID
+	})
+	require.Len(t, restored.idToTimelineItem.Keys(), 4, "restoring must not collapse multiple timeline entries onto one ID")
+	require.Equal(t, []string{"beta", "gamma"}, restored.effectivePromotedKeys(TimelinePromotedTargetSemiDynamic1, TimelinePromotedKindRecentTool))
 }
 
 func TestTimelineForkMergesPromotionJournalWithoutDiffNoise(t *testing.T) {

--- a/common/ai/aid/aicommon/timeline_prompt_projection.go
+++ b/common/ai/aid/aicommon/timeline_prompt_projection.go
@@ -1,0 +1,124 @@
+package aicommon
+
+import (
+	"regexp"
+	"strings"
+)
+
+var iterationCompletionHeartbeatPattern = regexp.MustCompile(`(?i)^\[[^\]]+\]\s*ReAct Iteration Done\[[^\]]+\]\s+max:\S+\s+continue to next iteration\s*$`)
+
+// projectTimelineItemForPrompt removes control-plane bookkeeping that is
+// already represented by materialized prompt state. It never mutates the raw
+// Timeline item: UI, diff, persistence, fork and rollback continue to observe
+// the original event stream.
+func projectTimelineItemForPrompt(item *TimelineItem) *TimelineItem {
+	if item == nil || item.deleted || item.value == nil {
+		return nil
+	}
+	textItem, ok := item.value.(*TextTimelineItem)
+	if !ok || textItem == nil {
+		// ToolResult and UserInteraction are deliberately opaque to this pass.
+		return item
+	}
+
+	parsed := ParseTimelineItemHumanReadable(item)
+	if parsed == nil {
+		return item
+	}
+	category := normalizeTimelinePromptCategory(parsed.EntryType)
+	switch category {
+	case "NEXT_MOVEMENTS", "EVIDENCE_OPS":
+		return nil
+	case "ITERATION":
+		if iterationCompletionHeartbeatPattern.MatchString(strings.TrimSpace(parsed.Content)) {
+			return nil
+		}
+		return item
+	case "NEXT_MOVEMENTS_ERROR":
+		filtered := filterRedundantTodoErrorLines(parsed.Content)
+		if filtered == "" {
+			return nil
+		}
+		if filtered == strings.TrimSpace(parsed.Content) {
+			return item
+		}
+		return cloneTextTimelineItemForPrompt(item, textItem, replaceTimelineTextBody(textItem.Text, filtered))
+	default:
+		return item
+	}
+}
+
+func normalizeTimelinePromptCategory(category string) string {
+	return strings.ToUpper(strings.Trim(strings.TrimSpace(category), "[] \t\r\n"))
+}
+
+func filterRedundantTodoErrorLines(content string) string {
+	kept := make([]string, 0)
+	for _, line := range strings.Split(strings.TrimSpace(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if strings.Contains(lower, "redundant ") && strings.Contains(lower, "todo already ") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+func replaceTimelineTextBody(text, body string) string {
+	if idx := strings.Index(text, ":\n"); idx >= 0 {
+		return text[:idx+2] + body
+	}
+	if idx := strings.Index(text, ":"); idx >= 0 {
+		return text[:idx+1] + "\n" + body
+	}
+	return body
+}
+
+func cloneTextTimelineItemForPrompt(item *TimelineItem, textItem *TextTimelineItem, text string) *TimelineItem {
+	textCopy := *textItem
+	textCopy.Text = text
+	// A precomputed shrink belongs to the original text and must not bypass the
+	// prompt projection's filtered body.
+	textCopy.ShrinkResult = ""
+	textCopy.ShrinkSimilarResult = ""
+	return &TimelineItem{createdAt: item.createdAt, value: &textCopy}
+}
+
+func projectTimelineItemsForPrompt(items []*TimelineItem) []*TimelineItem {
+	projected := make([]*TimelineItem, 0, len(items))
+	for _, item := range items {
+		if promptItem := projectTimelineItemForPrompt(item); promptItem != nil {
+			projected = append(projected, promptItem)
+		}
+	}
+	return projected
+}
+
+// projectTimelineRenderableBlocksForPrompt preserves the raw block topology
+// and stable nonces. Empty projected interval blocks remain present so noise
+// filtering cannot move the Frozen/Open boundary.
+func projectTimelineRenderableBlocksForPrompt(blocks TimelineRenderableBlocks) TimelineRenderableBlocks {
+	projected := make(TimelineRenderableBlocks, 0, len(blocks))
+	for _, block := range blocks {
+		switch typed := block.(type) {
+		case *TimelineIntervalBlock:
+			if typed == nil {
+				continue
+			}
+			copyBlock := *typed
+			copyBlock.Items = projectTimelineItemsForPrompt(typed.Items)
+			projected = append(projected, &copyBlock)
+		default:
+			// Existing compressed heads are historical facts. Rewriting them here
+			// would alter reducer semantics and is outside projection cleanup.
+			if block != nil {
+				projected = append(projected, block)
+			}
+		}
+	}
+	return projected
+}

--- a/common/ai/aid/aicommon/timeline_prompt_projection_test.go
+++ b/common/ai/aid/aicommon/timeline_prompt_projection_test.go
@@ -99,6 +99,42 @@ func TestTimelinePromptProjectionKeepsRealAndDropsOnlyRedundantErrorLines(t *tes
 	require.Nil(t, projectTimelineItemForPrompt(onlyRedundant))
 }
 
+func TestTimelineDumpRecentForPromptKeepsNewestCompleteItemsWithinBudget(t *testing.T) {
+	base := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	tl := NewTimeline(nil, nil)
+	injectTimelineItem(tl, 1, base, &TextTimelineItem{ID: 1, Text: "[note]:\nANCIENT " + strings.Repeat("old ", 3000)})
+	injectTimelineItem(tl, 2, base.Add(time.Second), &TextTimelineItem{ID: 2, Text: "[NEXT_MOVEMENTS]:\nDROP_BOOKKEEPING"})
+	injectTimelineItem(tl, 3, base.Add(2*time.Second), &TextTimelineItem{ID: 3, Text: "[note]:\nRECENT_FACT_ONE"})
+	injectTimelineItem(tl, 4, base.Add(3*time.Second), &TextTimelineItem{ID: 4, Text: "[note]:\nRECENT_FACT_TWO"})
+
+	const budget = 128
+	prompt := tl.DumpRecentForPrompt(budget)
+	require.LessOrEqual(t, MeasureTokens(prompt), budget)
+	require.Contains(t, prompt, "<|TIMELINE_RECENT|>")
+	require.Contains(t, prompt, "RECENT_FACT_ONE")
+	require.Contains(t, prompt, "RECENT_FACT_TWO")
+	require.NotContains(t, prompt, "ANCIENT")
+	require.NotContains(t, prompt, "DROP_BOOKKEEPING")
+
+	// Prompt projection must not modify the raw Timeline.
+	raw := tl.Dump()
+	require.Contains(t, raw, "ANCIENT")
+	require.Contains(t, raw, "DROP_BOOKKEEPING")
+}
+
+func TestTimelineDumpRecentForPromptBoundsOversizedNewestItem(t *testing.T) {
+	tl := NewTimeline(nil, nil)
+	injectTimelineItem(tl, 1, time.Now(), &TextTimelineItem{
+		ID: 1, Text: "[tool_result]:\nHEAD " + strings.Repeat("payload ", 5000) + " TAIL",
+	})
+
+	const budget = 96
+	prompt := tl.DumpRecentForPrompt(budget)
+	require.LessOrEqual(t, MeasureTokens(prompt), budget)
+	require.Contains(t, prompt, "HEAD")
+	require.Contains(t, prompt, "TAIL")
+}
+
 func TestTimelineBatchReducerPromptUsesProjectionWithoutRewritingToolData(t *testing.T) {
 	tl := NewTimeline(nil, nil)
 	toCompress := []*TimelineItem{

--- a/common/ai/aid/aicommon/timeline_prompt_projection_test.go
+++ b/common/ai/aid/aicommon/timeline_prompt_projection_test.go
@@ -1,0 +1,120 @@
+package aicommon
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+func TestTimelinePromptProjectionFiltersOnlySystemBookkeeping(t *testing.T) {
+	base := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+	tl := NewTimeline(nil, nil)
+	injectTimelineItem(tl, 1, base, &TextTimelineItem{ID: 1, Text: "[iteration]:\n[default]======== ReAct iteration 1 ========\nReason/Next-Step: keep-decision"})
+	injectTimelineItem(tl, 2, base.Add(time.Second), &TextTimelineItem{ID: 2, Text: "[iteration]:\n[default]ReAct Iteration Done[1] max:100 continue to next iteration"})
+	injectTimelineItem(tl, 3, base.Add(2*time.Second), &TextTimelineItem{ID: 3, Text: "[NEXT_MOVEMENTS]:\nDONE[finished]: applied"})
+	injectTimelineItem(tl, 4, base.Add(3*time.Second), &TextTimelineItem{ID: 4, Text: "[evidence_ops]:\nUPSERT[evidence-1]: applied"})
+	injectTimelineItem(tl, 5, base.Add(4*time.Second), &TextTimelineItem{ID: 5, Text: "[[NEXT_MOVEMENTS_ERROR]]:\nFAILED DOING[done]: redundant doing: todo already doing\nFAILED DONE[foreign]: todo belongs to another task scope"})
+	directParams := &TextTimelineItem{ID: 6, Text: "[DIRECT_CALL_PARAMS]:\n{\"path\":\"KEEP_PARAMS\"}"}
+	injectTimelineItem(tl, 6, base.Add(5*time.Second), directParams)
+	toolResult := &aitool.ToolResult{ID: 7, Name: "opaque_tool", Success: true, Data: "KEEP_TOOL_RESULT"}
+	injectTimelineItem(tl, 7, base.Add(6*time.Second), toolResult)
+
+	raw := tl.Dump()
+	prompt := tl.DumpForPrompt()
+	require.Contains(t, raw, "ReAct Iteration Done")
+	require.Contains(t, raw, "DONE[finished]")
+	require.Contains(t, raw, "UPSERT[evidence-1]")
+	require.Contains(t, raw, "redundant doing")
+
+	require.Contains(t, prompt, "Reason/Next-Step: keep-decision")
+	require.Contains(t, prompt, "todo belongs to another task scope")
+	require.Contains(t, prompt, "KEEP_PARAMS")
+	require.Contains(t, prompt, "KEEP_TOOL_RESULT")
+	require.NotContains(t, prompt, "ReAct Iteration Done")
+	require.NotContains(t, prompt, "DONE[finished]")
+	require.NotContains(t, prompt, "UPSERT[evidence-1]")
+	require.NotContains(t, prompt, "redundant doing")
+
+	// Opaque values and unaffected text remain the exact same objects. The
+	// projector therefore cannot rewrite tool results or DIRECT_CALL_PARAMS.
+	toolItem, _ := tl.idToTimelineItem.Get(7)
+	require.Same(t, toolItem, projectTimelineItemForPrompt(toolItem))
+	paramsItem, _ := tl.idToTimelineItem.Get(6)
+	require.Same(t, paramsItem, projectTimelineItemForPrompt(paramsItem))
+	require.Same(t, toolResult, projectTimelineItemForPrompt(toolItem).GetValue())
+	require.Same(t, directParams, projectTimelineItemForPrompt(paramsItem).GetValue())
+}
+
+func TestTimelinePromptProjectionPreservesRawBucketTopology(t *testing.T) {
+	base := time.Date(2026, 7, 18, 11, 0, 0, 0, time.UTC)
+	tl := NewTimeline(nil, nil)
+	for i := 1; i <= 8; i++ {
+		category := "note"
+		body := strings.Repeat("payload ", i*20)
+		if i%2 == 0 {
+			category = "NEXT_MOVEMENTS"
+		}
+		injectTimelineItem(tl, int64(i), base.Add(time.Duration(i)*time.Minute), &TextTimelineItem{
+			ID: int64(i), Text: "[" + category + "]:\n" + body,
+		})
+	}
+
+	raw := tl.GroupByMinutes(TimelineDumpDefaultIntervalMinutes).GetAllRenderable()
+	projected := projectTimelineRenderableBlocksForPrompt(raw)
+	require.Len(t, projected, len(raw))
+	for i := range raw {
+		rawBlock, rawOK := raw[i].(*TimelineIntervalBlock)
+		projectedBlock, projectedOK := projected[i].(*TimelineIntervalBlock)
+		require.Equal(t, rawOK, projectedOK)
+		if !rawOK {
+			continue
+		}
+		require.Equal(t, rawBlock.BucketStart, projectedBlock.BucketStart)
+		require.Equal(t, rawBlock.BucketEnd, projectedBlock.BucketEnd)
+		require.Equal(t, rawBlock.Open, projectedBlock.Open)
+		require.Equal(t, rawBlock.SeqInBucket, projectedBlock.SeqInBucket)
+		require.Equal(t, rawBlock.TotalInBucket, projectedBlock.TotalInBucket)
+		require.Equal(t, rawBlock.StableNonce(), projectedBlock.StableNonce())
+	}
+}
+
+func TestTimelinePromptProjectionKeepsRealAndDropsOnlyRedundantErrorLines(t *testing.T) {
+	item := &TimelineItem{createdAt: time.Now(), value: &TextTimelineItem{
+		ID:   9,
+		Text: "[[NEXT_MOVEMENTS_ERROR]]:\nredundant done: todo already done\nmissing required field: id\nillegal op: explode",
+	}}
+	projected := projectTimelineItemForPrompt(item)
+	require.NotNil(t, projected)
+	require.NotSame(t, item, projected)
+	require.NotContains(t, projected.String(), "todo already done")
+	require.Contains(t, projected.String(), "missing required field: id")
+	require.Contains(t, projected.String(), "illegal op: explode")
+
+	onlyRedundant := &TimelineItem{createdAt: time.Now(), value: &TextTimelineItem{
+		ID: 10, Text: "[NEXT_MOVEMENTS_ERROR]:\nFAILED DONE[x]: redundant done: todo already done",
+	}}
+	require.Nil(t, projectTimelineItemForPrompt(onlyRedundant))
+}
+
+func TestTimelineBatchReducerPromptUsesProjectionWithoutRewritingToolData(t *testing.T) {
+	tl := NewTimeline(nil, nil)
+	toCompress := []*TimelineItem{
+		{createdAt: time.Now(), value: &TextTimelineItem{ID: 1, Text: "[NEXT_MOVEMENTS]:\nDROP_REDUCER_BREADCRUMB"}},
+		{createdAt: time.Now(), value: &aitool.ToolResult{ID: 2, Name: "opaque", Success: true, Data: "KEEP_REDUCER_TOOL_DATA"}},
+		{createdAt: time.Now(), value: &TextTimelineItem{ID: 3, Text: "[DIRECT_CALL_PARAMS]:\nKEEP_REDUCER_DIRECT_PARAMS"}},
+	}
+	recentKeep := []*TimelineItem{
+		{createdAt: time.Now(), value: &TextTimelineItem{ID: 4, Text: "[evidence_ops]:\nDROP_RECENT_EVIDENCE_BREADCRUMB"}},
+		{createdAt: time.Now(), value: &TextTimelineItem{ID: 5, Text: "[reflection]:\nKEEP_RECENT_REFLECTION"}},
+	}
+
+	prompt := tl.renderBatchCompressPrompt(nil, toCompress, recentKeep, "PROJECTION")
+	require.NotContains(t, prompt, "DROP_REDUCER_BREADCRUMB")
+	require.NotContains(t, prompt, "DROP_RECENT_EVIDENCE_BREADCRUMB")
+	require.Contains(t, prompt, "KEEP_REDUCER_TOOL_DATA")
+	require.Contains(t, prompt, "KEEP_REDUCER_DIRECT_PARAMS")
+	require.Contains(t, prompt, "KEEP_RECENT_REFLECTION")
+}

--- a/common/ai/aid/aicommon/verification_todo_store.go
+++ b/common/ai/aid/aicommon/verification_todo_store.go
@@ -3,6 +3,7 @@ package aicommon
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/yaklang/yaklang/common/ai/ytoken"
@@ -665,7 +666,10 @@ func (s *VerificationTodoStore) Render() string {
 	if s == nil || len(s.Items) == 0 {
 		return "- no tracked TODO items"
 	}
-	return truncateVerificationTodoLines(renderVerificationTodoItemLines(s.SnapshotItems()))
+	active, closed := splitVerificationTodoPromptItems(s.SnapshotItems())
+	lines := renderVerificationTodoActiveLines(active)
+	lines = append(lines, renderVerificationTodoClosedSummaryLines(closed)...)
+	return truncateVerificationTodoLines(lines)
 }
 
 // RenderWithCurrentScope renders the session TODO snapshot grouped by task
@@ -697,20 +701,39 @@ func (s *VerificationTodoStore) RenderWithCurrentScope(currentScope Verification
 		}
 	}
 
-	lines := make([]string, 0, len(s.Items)+8)
+	currentActive, currentClosed := splitVerificationTodoPromptItems(currentItems)
+	lines := make([]string, 0, len(s.Items)+12)
 	lines = append(lines, formatVerificationTodoCurrentTaskHeader(currentScope))
 	if len(currentItems) == 0 {
 		lines = append(lines, "- (no TODO items tracked for the current task yet)")
 	} else {
 		lines = append(lines, "- You MUST advance or close ONLY the TODOs in this section via adjust_todolist / verification next_movements.")
-		lines = append(lines, renderVerificationTodoItemLines(currentItems)...)
+		if len(currentActive) == 0 {
+			lines = append(lines, "- (no active TODO items for the current task)")
+		} else {
+			lines = append(lines, renderVerificationTodoActiveLines(currentActive)...)
+		}
 	}
 
 	if len(otherItems) > 0 {
 		lines = append(lines, "")
 		lines = append(lines, "### OTHER TASKS (read-only context)")
 		lines = append(lines, "- TODOs below belong to sibling or finished tasks. Do NOT mutate them; use them only as history/context.")
-		lines = append(lines, renderVerificationTodoOtherTaskSections(otherItems)...)
+		lines = append(lines, renderVerificationTodoOtherTaskActiveSections(otherItems)...)
+	}
+
+	// Closed state is useful for avoiding repeated work, but its content is not
+	// actionable. Render it only after all active TODOs so history cannot evict
+	// current work from the fixed prompt budget.
+	if len(currentClosed) > 0 {
+		lines = append(lines, "", "### CURRENT TASK CLOSED SUMMARY")
+		lines = append(lines, renderVerificationTodoClosedSummaryLines(currentClosed)...)
+	}
+	if len(otherItems) > 0 {
+		if closedLines := renderVerificationTodoOtherTaskClosedSections(otherItems); len(closedLines) > 0 {
+			lines = append(lines, "", "### OTHER TASKS CLOSED SUMMARY (read-only)")
+			lines = append(lines, closedLines...)
+		}
 	}
 
 	return truncateVerificationTodoLines(lines)
@@ -728,9 +751,9 @@ func formatVerificationTodoCurrentTaskHeader(scope VerificationTodoScope) string
 	}
 }
 
-func renderVerificationTodoOtherTaskSections(items []VerificationTodoItem) []string {
+func groupVerificationTodoItemsByTask(items []VerificationTodoItem) ([]string, map[string][]VerificationTodoItem) {
 	if len(items) == 0 {
-		return nil
+		return nil, nil
 	}
 	grouped := make(map[string][]VerificationTodoItem)
 	order := make([]string, 0)
@@ -741,12 +764,34 @@ func renderVerificationTodoOtherTaskSections(items []VerificationTodoItem) []str
 		}
 		grouped[key] = append(grouped[key], item)
 	}
+	return order, grouped
+}
 
+func renderVerificationTodoOtherTaskActiveSections(items []VerificationTodoItem) []string {
+	order, grouped := groupVerificationTodoItemsByTask(items)
 	lines := make([]string, 0, len(items)+len(order))
 	for _, key := range order {
+		active, _ := splitVerificationTodoPromptItems(grouped[key])
+		if len(active) == 0 {
+			continue
+		}
 		lines = append(lines, "")
 		lines = append(lines, "#### "+key)
-		lines = append(lines, renderVerificationTodoItemLines(grouped[key])...)
+		lines = append(lines, renderVerificationTodoActiveLines(active)...)
+	}
+	return lines
+}
+
+func renderVerificationTodoOtherTaskClosedSections(items []VerificationTodoItem) []string {
+	order, grouped := groupVerificationTodoItemsByTask(items)
+	lines := make([]string, 0, len(items)+len(order))
+	for _, key := range order {
+		_, closed := splitVerificationTodoPromptItems(grouped[key])
+		if len(closed) == 0 {
+			continue
+		}
+		lines = append(lines, "#### "+key)
+		lines = append(lines, renderVerificationTodoClosedSummaryLines(closed)...)
 	}
 	return lines
 }
@@ -765,31 +810,82 @@ func formatVerificationTodoOtherTaskGroupKey(item VerificationTodoItem) string {
 	}
 }
 
-func renderVerificationTodoItemLines(items []VerificationTodoItem) []string {
-	pending := make([]VerificationTodoItem, 0)
-	doing := make([]VerificationTodoItem, 0)
-	closed := make([]VerificationTodoItem, 0)
+func splitVerificationTodoPromptItems(items []VerificationTodoItem) (active, closed []VerificationTodoItem) {
+	active = make([]VerificationTodoItem, 0, len(items))
+	closed = make([]VerificationTodoItem, 0, len(items))
 	for _, item := range items {
 		switch item.Status {
-		case VerificationTodoStatusPending:
-			pending = append(pending, item)
-		case VerificationTodoStatusDoing:
-			doing = append(doing, item)
+		case VerificationTodoStatusPending, VerificationTodoStatusDoing:
+			active = append(active, item)
 		default:
 			closed = append(closed, item)
 		}
 	}
+	sortVerificationTodoItemsRecentFirst(active)
+	sortVerificationTodoItemsRecentFirst(closed)
+	return active, closed
+}
 
-	// 倒序输出每组, 让"最近更新"先被 LLM 看到
+func sortVerificationTodoItemsRecentFirst(items []VerificationTodoItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].UpdatedAt != items[j].UpdatedAt {
+			return items[i].UpdatedAt > items[j].UpdatedAt
+		}
+		if items[i].CreatedAt != items[j].CreatedAt {
+			return items[i].CreatedAt > items[j].CreatedAt
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func renderVerificationTodoActiveLines(items []VerificationTodoItem) []string {
 	lines := make([]string, 0, len(items))
-	for index := len(doing) - 1; index >= 0; index-- {
-		lines = append(lines, FormatVerificationTodoLine(doing[index]))
+	for _, item := range items {
+		status := "[ ]"
+		if item.Status == VerificationTodoStatusDoing {
+			status = "[DOING]"
+		}
+		content := strings.Join(strings.Fields(item.Content), " ")
+		if content == "" {
+			content = "(no content)"
+		}
+		lines = append(lines, fmt.Sprintf("- %s: [id: %s]: %s", status, item.ID, content))
 	}
-	for index := len(pending) - 1; index >= 0; index-- {
-		lines = append(lines, FormatVerificationTodoLine(pending[index]))
+	return lines
+}
+
+const verificationTodoClosedIDsPerStatus = 64
+
+func renderVerificationTodoClosedSummaryLines(items []VerificationTodoItem) []string {
+	byStatus := map[VerificationTodoStatus][]VerificationTodoItem{}
+	for _, item := range items {
+		byStatus[item.Status] = append(byStatus[item.Status], item)
 	}
-	for index := len(closed) - 1; index >= 0; index-- {
-		lines = append(lines, FormatVerificationTodoLine(closed[index]))
+	statuses := []VerificationTodoStatus{
+		VerificationTodoStatusDone,
+		VerificationTodoStatusDeleted,
+		VerificationTodoStatusSkipped,
+	}
+	lines := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		statusItems := byStatus[status]
+		if len(statusItems) == 0 {
+			continue
+		}
+		sortVerificationTodoItemsRecentFirst(statusItems)
+		visible := len(statusItems)
+		if visible > verificationTodoClosedIDsPerStatus {
+			visible = verificationTodoClosedIDsPerStatus
+		}
+		ids := make([]string, 0, visible)
+		for _, item := range statusItems[:visible] {
+			ids = append(ids, item.ID)
+		}
+		line := fmt.Sprintf("- %s (%d): %s", status, len(statusItems), strings.Join(ids, ", "))
+		if omitted := len(statusItems) - visible; omitted > 0 {
+			line += fmt.Sprintf("; +%d omitted", omitted)
+		}
+		lines = append(lines, line)
 	}
 	return lines
 }

--- a/common/ai/aid/aicommon/verification_todo_store_test.go
+++ b/common/ai/aid/aicommon/verification_todo_store_test.go
@@ -1,6 +1,7 @@
 package aicommon
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -26,9 +27,11 @@ func TestVerificationTodoStore_ApplyAndRender(t *testing.T) {
 	})
 
 	rendered := store.Render()
-	require.Contains(t, rendered, "- [x]: [id: collect_signal]: 收集页面响应信号")
-	require.Contains(t, rendered, "- [DELETED]: [id: fix_title]: 修正标题")
+	require.Contains(t, rendered, "- DONE (1): collect_signal")
+	require.Contains(t, rendered, "- DELETED (1): fix_title")
 	require.Contains(t, rendered, "- [ ]: [id: replay_payload]: 使用新 payload 复测")
+	require.NotContains(t, rendered, "收集页面响应信号")
+	require.NotContains(t, rendered, "修正标题")
 }
 
 // TestVerificationTodoStore_Apply_ReportsSuccessPerOp 验证 Apply 现在为每个
@@ -233,7 +236,8 @@ func TestVerificationTodoStore_ExplicitSkipOpMarksSkipped(t *testing.T) {
 		"explicit skip must keep the original content so the prompt can still describe what was skipped")
 
 	rendered := store.Render()
-	require.Contains(t, rendered, "- [SKIPPED]: [id: stale_idea]: 本次范围内不打算继续推进")
+	require.Contains(t, rendered, "- SKIPPED (1): stale_idea")
+	require.NotContains(t, rendered, "本次范围内不打算继续推进")
 }
 
 // TestVerificationTodoStore_ExplicitSkipOpCanUpdateContent 验证 skip op 与
@@ -486,8 +490,42 @@ func TestVerificationTodoStore_RenderWithCurrentScope_SplitsCurrentAndOther(t *t
 	require.Contains(t, rendered, "- [DOING]: [id: todo_1_2]: 子任务 1-2 的待办")
 	require.Contains(t, rendered, "### OTHER TASKS (read-only context)")
 	require.Contains(t, rendered, "#### task_index=1-1, task_id=task-1")
-	require.Contains(t, rendered, "- [x]: [id: todo_1_1]: 子任务 1-1 的待办")
+	require.Contains(t, rendered, "- DONE (1): todo_1_1")
+	require.NotContains(t, rendered, "子任务 1-1 的待办")
 	require.NotContains(t, rendered, "- [DOING]: [id: todo_1_1]")
+}
+
+func TestVerificationTodoStore_PromptKeepsActiveContentAndCompactsClosedHistory(t *testing.T) {
+	longActiveContent := strings.Repeat("active-detail-", 80)
+	store := &VerificationTodoStore{Items: []*VerificationTodoItem{
+		{ID: "active-old", Content: "older active", Status: VerificationTodoStatusPending, CreatedAt: 1, UpdatedAt: 1},
+		{ID: "done-old", Content: "CLOSED_CONTENT_MUST_NOT_RENDER", Status: VerificationTodoStatusDone, CreatedAt: 2, UpdatedAt: 2},
+		{ID: "active-new", Content: longActiveContent, Status: VerificationTodoStatusDoing, CreatedAt: 3, UpdatedAt: 3},
+	}}
+
+	rendered := store.Render()
+	require.Contains(t, rendered, longActiveContent)
+	require.Contains(t, rendered, "- DONE (1): done-old")
+	require.NotContains(t, rendered, "CLOSED_CONTENT_MUST_NOT_RENDER")
+	require.Less(t, strings.Index(rendered, "active-new"), strings.Index(rendered, "active-old"))
+	require.Less(t, strings.Index(rendered, "active-old"), strings.Index(rendered, "DONE (1)"))
+}
+
+func TestVerificationTodoStore_ClosedSummaryCapsIDsAndReportsOmitted(t *testing.T) {
+	store := NewVerificationTodoStore()
+	for i := 0; i < 70; i++ {
+		store.Items = append(store.Items, &VerificationTodoItem{
+			ID:        fmt.Sprintf("done-%02d", i),
+			Content:   "closed content should not render",
+			Status:    VerificationTodoStatusDone,
+			CreatedAt: i,
+			UpdatedAt: i,
+		})
+	}
+	rendered := store.Render()
+	require.Contains(t, rendered, "- DONE (70): done-69, done-68")
+	require.Contains(t, rendered, "+6 omitted")
+	require.NotContains(t, rendered, "closed content should not render")
 }
 
 func TestSessionPromptState_GetVerificationTodoMarkdownDelta_IsPreview(t *testing.T) {

--- a/common/ai/aid/aireact/invoke_toolcall_aimemory_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_aimemory_test.go
@@ -375,8 +375,18 @@ LOOP:
 		if err := db.Where("session_id = ?", sessionID).Find(&memoryEntities).Error; err != nil {
 			t.Fatalf("Failed to query memory entities: %v", err)
 		}
-		return len(memoryEntities) > 0
-	}, 5*time.Second, 50*time.Millisecond, "Expected to find memory entities in database, but found none")
+		foundToolRejection := false
+		foundSystemBehavior := false
+		for _, entity := range memoryEntities {
+			if utils.MatchAllOfSubString(entity.Content, "拒绝", "sleep") {
+				foundToolRejection = true
+			}
+			if utils.MatchAllOfSubString(entity.Content, "ReAct", "直接回答") {
+				foundSystemBehavior = true
+			}
+		}
+		return foundToolRejection && foundSystemBehavior
+	}, 5*time.Second, 50*time.Millisecond, "Expected both memory entities to be persisted")
 	fmt.Printf("Found %d memory entities in database\n", len(memoryEntities))
 
 	// 验证 memory entities 的内容

--- a/common/ai/aid/aireact/invoke_toolcall_interval_review.go
+++ b/common/ai/aid/aireact/invoke_toolcall_interval_review.go
@@ -65,7 +65,7 @@ func (r *ReAct) _invokeToolCall_IntervalReviewWithContext(
 	elapsed := time.Since(startTime)
 	log.Infof("toolcall interval review #%d triggered for tool [%s], elapsed: %v", reviewCount, tool.Name, elapsed)
 
-	// Generate the interval review prompt with full context
+	// Generate a bounded speed-priority prompt from the newest Timeline facts.
 	prompt, err := r.promptManager.GenerateIntervalReviewPromptWithContext(
 		tool, params, stdoutSnapshot, stderrSnapshot, startTime, reviewCount, callExpectations,
 	)

--- a/common/ai/aid/aireact/midterm_context_provider.go
+++ b/common/ai/aid/aireact/midterm_context_provider.go
@@ -26,7 +26,7 @@ type midtermTimelineSearchQuery struct {
 func buildTimelineDumpWithMidtermMemory(react *ReAct, timeline *aicommon.Timeline) string {
 	baseTimeline := ""
 	if timeline != nil {
-		baseTimeline = timeline.Dump()
+		baseTimeline = timeline.DumpForPrompt()
 	}
 	queries := react.consumePendingMidtermTimelineQueries()
 	if len(queries) == 0 {

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -157,13 +157,17 @@ func (pm *PromptManager) AssembleLoopPrompt(tools []*aitool.Tool, input *reactlo
 	if err != nil {
 		return nil, err
 	}
+	effectiveInput := input
+	if input.Lightweight {
+		base, effectiveInput = pm.projectLightweightLoopMaterials(base, input)
+	}
 
-	prefixMaterials := pm.NewPromptMaterials(base, input)
+	prefixMaterials := pm.NewPromptMaterials(base, effectiveInput)
 	prefix, err := pm.AssemblePromptPrefix(prefixMaterials)
 	if err != nil {
 		return nil, err
 	}
-	dynamicData := pm.buildLoopPromptSectionData(base, input)
+	dynamicData := pm.buildLoopPromptSectionData(base, effectiveInput)
 	dynamic, err := pm.renderLoopDynamicSection(dynamicData)
 	if err != nil {
 		return nil, err
@@ -171,7 +175,7 @@ func (pm *PromptManager) AssembleLoopPrompt(tools []*aitool.Tool, input *reactlo
 
 	sections := make([]*reactloops.PromptSectionObservation, 0, len(prefix.Sections))
 	sections = append(sections, prefix.Sections...)
-	if dynamicSection := pm.buildDynamicObservation(base, input, dynamic); dynamicSection != nil {
+	if dynamicSection := pm.buildDynamicObservation(base, effectiveInput, dynamic); dynamicSection != nil {
 		sections = append(sections, dynamicSection)
 	}
 
@@ -188,6 +192,74 @@ func (pm *PromptManager) AssembleLoopPrompt(tools []*aitool.Tool, input *reactlo
 		Prompt:   prompt,
 		Sections: sections,
 	}, nil
+}
+
+const (
+	lightweightLoopRecentTimelineTokens  = 4096
+	lightweightLoopUserQueryTokens       = 2048
+	lightweightLoopTaskInstructionTokens = 6144
+	lightweightLoopOutputExampleTokens   = 1024
+	lightweightLoopSkillsTokens          = 1024
+	lightweightLoopSkillBodyTokens       = 2048
+	lightweightLoopPlanContextTokens     = 2048
+	lightweightLoopTodoTokens            = 2048
+	lightweightLoopExtraTokens           = 1024
+	lightweightLoopReactiveTokens        = 3072
+	lightweightLoopMemoryTokens          = 1024
+)
+
+// projectLightweightLoopMaterials keeps the ReAct protocol and task-specific
+// schema intact while removing the full-session context that is uneconomical
+// for speed-priority models. The recent Timeline window is the sole historical
+// execution source; volatile auxiliary fields receive explicit budgets.
+func (pm *PromptManager) projectLightweightLoopMaterials(
+	base *reactloops.LoopPromptBaseMaterials,
+	input *reactloops.LoopPromptAssemblyInput,
+) (*reactloops.LoopPromptBaseMaterials, *reactloops.LoopPromptAssemblyInput) {
+	if base == nil || input == nil {
+		return base, input
+	}
+	lightBase := *base
+	lightBase.PromptFrozenOpenMaterials = aicommon.PromptFrozenOpenMaterials{}
+	if pm != nil && pm.react != nil && pm.react.config != nil && pm.react.config.GetTimeline() != nil {
+		lightBase.TimelineOpen = pm.react.config.GetTimeline().DumpRecentForPrompt(lightweightLoopRecentTimelineTokens)
+	}
+	lightBase.AutoContext = ""
+	lightBase.UserHistory = ""
+	lightBase.ShowForgeInventory = false
+	lightBase.AIForgeList = ""
+	lightBase.TopTools = aicommon.SelectToolsByTokenBudget(lightBase.TopTools, 2048, 0)
+	lightBase.TopToolsCount = len(lightBase.TopTools)
+	lightBase.HasMoreTools = lightBase.ToolsCount > lightBase.TopToolsCount
+	lightBase.MoreToolsCount = lightBase.ToolsCount - lightBase.TopToolsCount
+
+	lightInput := *input
+	lightInput.UserQuery = aicommon.ShrinkTextBlockByTokens(input.UserQuery, lightweightLoopUserQueryTokens)
+	lightInput.TaskInstruction = boundedLightweightPromptBlock(input.TaskInstruction, lightweightLoopTaskInstructionTokens, "task instruction")
+	lightInput.OutputExample = boundedLightweightPromptBlock(input.OutputExample, lightweightLoopOutputExampleTokens, "output example")
+	lightInput.SkillsContext = boundedLightweightPromptBlock(input.SkillsContext, lightweightLoopSkillsTokens, "skills context")
+	lightInput.ForcedSkills = boundedLightweightPromptBlock(input.ForcedSkills, lightweightLoopSkillBodyTokens, "forced skill body")
+	lightInput.AutoLoadedSkills = boundedLightweightPromptBlock(input.AutoLoadedSkills, lightweightLoopSkillBodyTokens, "auto-loaded skill body")
+	lightInput.FrozenUserContext = boundedLightweightPromptBlock(input.FrozenUserContext, lightweightLoopPlanContextTokens, "plan context")
+	lightInput.FrozenPartitions = nil
+	lightInput.SessionEvidence = ""
+	lightInput.TodoSnapshot = boundedLightweightPromptBlock(input.TodoSnapshot, lightweightLoopTodoTokens, "TODO snapshot")
+	lightInput.ExtraCapabilities = aicommon.ShrinkTextBlockByTokens(input.ExtraCapabilities, lightweightLoopExtraTokens)
+	lightInput.ReactiveData = aicommon.ShrinkTextBlockByTokens(input.ReactiveData, lightweightLoopReactiveTokens)
+	lightInput.InjectedMemory = aicommon.ShrinkTextBlockByTokens(input.InjectedMemory, lightweightLoopMemoryTokens)
+	return &lightBase, &lightInput
+}
+
+func boundedLightweightPromptBlock(content string, tokenLimit int, label string) string {
+	if strings.TrimSpace(content) == "" {
+		return ""
+	}
+	if aicommon.MeasureTokens(content) <= tokenLimit {
+		return content
+	}
+	// These inputs often already contain AITAG wrappers. Cutting through them
+	// creates malformed prompt structure, so omit an oversized block atomically.
+	return fmt.Sprintf("[%s omitted from lightweight prompt: exceeds %d-token budget]", label, tokenLimit)
 }
 
 func (pm *PromptManager) NewPromptMaterials(base *reactloops.LoopPromptBaseMaterials, input *reactloops.LoopPromptAssemblyInput) *aicommon.PromptMaterials {

--- a/common/ai/aid/aireact/prompt_loop_materials_test.go
+++ b/common/ai/aid/aireact/prompt_loop_materials_test.go
@@ -25,6 +25,42 @@ func mustLoopPromptSections(t *testing.T, raw any) []*reactloops.PromptSectionOb
 	return sections
 }
 
+func TestPromptManager_AssembleLoopPrompt_LightweightUsesBoundedRecentTimeline(t *testing.T) {
+	react, err := NewTestReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			rsp := i.NewAIResponse()
+			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action":"object"}`))
+			rsp.Close()
+			return rsp, nil
+		}),
+	)
+	require.NoError(t, err)
+	react.AddToTimeline("note", "ANCIENT_LIGHTWEIGHT_CONTEXT "+strings.Repeat("old ", 20000))
+	react.AddToTimeline("note", "RECENT_LIGHTWEIGHT_FACT")
+
+	result, err := react.promptManager.AssembleLoopPrompt(nil, &reactloops.LoopPromptAssemblyInput{
+		Nonce:             "light-1",
+		Lightweight:       true,
+		UserQuery:         strings.Repeat("query ", 5000),
+		TaskInstruction:   "keep the task protocol",
+		Schema:            `{"type":"object","properties":{"@action":{"type":"string"}}}`,
+		SkillsContext:     strings.Repeat("skill ", 5000),
+		TodoSnapshot:      strings.Repeat("todo ", 5000),
+		ReactiveData:      strings.Repeat("reactive ", 5000),
+		InjectedMemory:    strings.Repeat("memory ", 5000),
+		SessionEvidence:   strings.Repeat("evidence ", 5000),
+		FrozenUserContext: strings.Repeat("plan ", 5000),
+	})
+	require.NoError(t, err)
+	require.Contains(t, result.Prompt, "RECENT_LIGHTWEIGHT_FACT")
+	require.NotContains(t, result.Prompt, "ANCIENT_LIGHTWEIGHT_CONTEXT")
+	require.NotContains(t, result.Prompt, "evidence evidence evidence")
+	require.NotContains(t, result.Prompt, "Timeline Memory (Frozen)")
+	promptTokens := ytoken.CalcTokenCount(result.Prompt)
+	t.Logf("bounded lightweight loop prompt tokens: %d", promptTokens)
+	require.LessOrEqual(t, promptTokens, 30000)
+}
+
 // TestPromptManager_AssembleLoopPrompt_SectionOrder 验证"按稳定性分层"路径
 // 下 6 段顺序: high_static -> frozen_block -> semi_dynamic_1 (Skills)
 // -> semi_dynamic_2 (ExecutionPolicy + TaskInstruction + Schema + OutputExample) -> timeline_open ->

--- a/common/ai/aid/aireact/prompt_loop_materials_test.go
+++ b/common/ai/aid/aireact/prompt_loop_materials_test.go
@@ -182,7 +182,7 @@ func TestPromptManager_AssembleLoopPrompt_SectionOrder(t *testing.T) {
 	require.Equal(t, "Tool Inventory", sections[1].Children[0].Label)
 	require.Equal(t, reactloops.PromptSectionRoleFrozenBlock, sections[1].Children[0].Role)
 
-	// semi_dynamic_1 段子结构: skills_context (本用例 RecentToolsCache 为空被过滤).
+	// semi_dynamic_1 段子结构: skills_context。
 	// 关键词: semi_dynamic_1 children, skills_context, Name 去前缀
 	require.Len(t, sections[2].Children, 1)
 	require.Equal(t, "section.semi_dynamic_1.skills_context", sections[2].Children[0].Key)
@@ -234,7 +234,7 @@ func TestPromptManager_AssembleLoopPrompt_SectionOrder(t *testing.T) {
 }
 
 // TestPromptManager_RenderLoopSemiDynamic1Section_Order 验证 SEMI-1 段包含
-// SkillsContext 与 Timeline 晋升状态，但不接受旧 RecentToolsCache 独立输入，
+// SkillsContext 与 Timeline 晋升状态，
 // 也不包含 Schema / Persistent / OutputExample / Tool / Forge。
 //
 // 关键词: renderLoopSemiDynamic1Section, semi_dynamic_section_1 内容范围, P1.1
@@ -259,7 +259,6 @@ func TestPromptManager_RenderLoopSemiDynamic1Section_Order(t *testing.T) {
 		AIForgeList:          "* `forge-a`: forge a desc",
 		SkillsContext:        "<|SKILLS_CONTEXT_demo|>\nskill body\n<|SKILLS_CONTEXT_END_demo|>",
 		PromotedSemiDynamic1: "<|CACHE_TOOL_CALL_[current-nonce]|>\npromoted cache body\n<|CACHE_TOOL_CALL_END_[current-nonce]|>",
-		RecentToolsCache:     "legacy cache body",
 		Schema:               `{"type":"object","properties":{"@action":{"type":"string"}}}`,
 		TaskInstruction:      "follow task rules",
 		OutputExample:        "example output",
@@ -272,7 +271,6 @@ func TestPromptManager_RenderLoopSemiDynamic1Section_Order(t *testing.T) {
 	require.NotEqual(t, -1, promotedIdx)
 	require.Less(t, skillsIdx, promotedIdx)
 	require.Contains(t, rendered, "promoted cache body")
-	require.NotContains(t, rendered, "legacy cache body")
 	// SEMI-1 段绝对不能含 Schema / Persistent / OutputExample / Tool / Forge.
 	require.NotContains(t, rendered, "<|SCHEMA|>")
 	require.NotContains(t, rendered, "<|PERSISTENT|>")
@@ -298,11 +296,10 @@ func TestPromptManager_RenderLoopSemiDynamic2Section_Order(t *testing.T) {
 	require.NoError(t, err)
 
 	rendered, err := react.promptManager.renderLoopSemiDynamic2Section(&reactloops.PromptPrefixMaterials{
-		SkillsContext:    "<|SKILLS_CONTEXT_demo|>\nskill body\n<|SKILLS_CONTEXT_END_demo|>",
-		RecentToolsCache: "<|CACHE_TOOL_CALL_[current-nonce]|>\ncache body\n<|CACHE_TOOL_CALL_END_[current-nonce]|>",
-		Schema:           `{"type":"object","properties":{"@action":{"type":"string"}}}`,
-		TaskInstruction:  "follow task rules",
-		OutputExample:    "example output",
+		SkillsContext:   "<|SKILLS_CONTEXT_demo|>\nskill body\n<|SKILLS_CONTEXT_END_demo|>",
+		Schema:          `{"type":"object","properties":{"@action":{"type":"string"}}}`,
+		TaskInstruction: "follow task rules",
+		OutputExample:   "example output",
 	})
 	require.NoError(t, err)
 
@@ -733,86 +730,10 @@ func requireMessageHasNoCacheControl(t *testing.T, detail aispec.ChatDetail, lab
 	}
 }
 
-func TestPromptManager_AssembleLoopPrompt_IgnoresLegacyRecentToolsCacheInput(t *testing.T) {
-	react, err := NewTestReAct(
-		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
-			rsp := i.NewAIResponse()
-			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action":"object","next_action":{"type":"directly_answer","answer_payload":"ok"},"cumulative_summary":"ok","human_readable_thought":"ok"}`))
-			rsp.Close()
-			return rsp, nil
-		}),
-	)
-	require.NoError(t, err)
-
-	tool := aitool.NewWithoutCallback("tool-a", aitool.WithDescription("tool a desc"))
-
-	// 模拟 reactloops/prompt.go 中给 RecentToolsCache 注入的 CACHE_TOOL_CALL 块,
-	// 用占位符字面量 nonce "[current-nonce]" 渲染, 跨轮字节稳定.
-	// 关键词: CACHE_TOOL_CALL 物理迁移, [current-nonce] 占位符 nonce
-	cacheBlock := strings.Join([]string{
-		"<|DIRECT_TOOL_ROUTING_[current-nonce]|>",
-		"# Fast Tool Routing",
-		"Recent tools available via directly_call_tool.",
-		"<|DIRECT_TOOL_ROUTING_END_[current-nonce]|>",
-		"",
-		"<|CACHE_TOOL_CALL_[current-nonce]|>",
-		"<|TOOL_bash_[current-nonce]|>",
-		"## Tool: bash",
-		"<|TOOL_bash_END_[current-nonce]|>",
-		"<|CACHE_TOOL_CALL_END_[current-nonce]|>",
-	}, "\n")
-
-	result, err := react.promptManager.AssembleLoopPrompt([]*aitool.Tool{tool}, &reactloops.LoopPromptAssemblyInput{
-		Nonce:            "turnA",
-		UserQuery:        "user query",
-		TaskInstruction:  "task rules",
-		Schema:           `{"type":"object"}`,
-		SkillsContext:    "<|SKILLS_CONTEXT_demo|>\nskill\n<|SKILLS_CONTEXT_END_demo|>",
-		RecentToolsCache: cacheBlock,
-	})
-	require.NoError(t, err)
-
-	prompt := result.Prompt
-
-	// The old independent source is ignored. Tool schemas now enter via
-	// promotable Timeline items and are projected into Open/Semi1 exactly once.
-	require.NotContains(t, prompt, "<|CACHE_TOOL_CALL_[current-nonce]|>")
-	require.NotContains(t, prompt, "# Fast Tool Routing")
-
-	semi1Start := strings.Index(prompt, "<|PROMPT_SECTION_semi-dynamic-1|>")
-	semi1End := strings.Index(prompt, "<|PROMPT_SECTION_END_semi-dynamic-1|>")
-	require.NotEqual(t, -1, semi1Start)
-	require.NotEqual(t, -1, semi1End)
-	semi2Start := strings.Index(prompt, "<|PROMPT_SECTION_semi-dynamic-2|>")
-	semi2End := strings.Index(prompt, "<|PROMPT_SECTION_END_semi-dynamic-2|>")
-	require.NotEqual(t, -1, semi2Start)
-	require.NotEqual(t, -1, semi2End)
-
-	// Existing cache wrappers remain structurally unchanged.
-	aiCacheSemiStart := strings.Index(prompt, "<|AI_CACHE_SEMI_semi|>")
-	aiCacheSemiEnd := strings.Index(prompt, "<|AI_CACHE_SEMI_END_semi|>")
-	require.NotEqual(t, -1, aiCacheSemiStart, "P1.1: prompt must contain AI_CACHE_SEMI_semi START")
-	require.NotEqual(t, -1, aiCacheSemiEnd, "P1.1: prompt must contain AI_CACHE_SEMI_semi END")
-	require.Less(t, aiCacheSemiStart, semi1Start,
-		"AI_CACHE_SEMI START must wrap PROMPT_SECTION_semi-dynamic-1")
-	require.Greater(t, aiCacheSemiEnd, semi1End,
-		"AI_CACHE_SEMI END must wrap PROMPT_SECTION_semi-dynamic-1")
-
-	// 6. semi-2 段必须被 AI_CACHE_SEMI2_semi 边界包裹 (P1.1 第二对 cache 边界)
-	aiCacheSemi2Start := strings.Index(prompt, "<|AI_CACHE_SEMI2_semi|>")
-	aiCacheSemi2End := strings.Index(prompt, "<|AI_CACHE_SEMI2_END_semi|>")
-	require.NotEqual(t, -1, aiCacheSemi2Start, "P1.1: prompt must contain AI_CACHE_SEMI2_semi START")
-	require.NotEqual(t, -1, aiCacheSemi2End, "P1.1: prompt must contain AI_CACHE_SEMI2_semi END")
-	require.Less(t, aiCacheSemi2Start, semi2Start,
-		"AI_CACHE_SEMI2 START must wrap PROMPT_SECTION_semi-dynamic-2")
-	require.Greater(t, aiCacheSemi2End, semi2End,
-		"AI_CACHE_SEMI2 END must wrap PROMPT_SECTION_semi-dynamic-2")
-}
-
 // TestPromptManager_AssembleLoopPrompt_SemiSegmentByteStableAcrossTurns 验证
 // 在 turn nonce 不同的两次 AssembleLoopPrompt 调用中, semi-dynamic-1 与
-// semi-dynamic-2 段都跨 turn 字节稳定。RecentToolsCache 已位于最后 cache
-// boundary 之后, Schema / Persistent / OutputExample 也不依赖 turn nonce.
+// semi-dynamic-2 段都跨 turn 字节稳定。Schema / Persistent /
+// OutputExample 也不依赖 turn nonce.
 //
 // 这是 P1.1 三 cache 边界生效的前提: hijacker 切到 user2 (semi-1) 与 user3
 // (semi-2) 的字节流必须跨 turn 一致, 才能命中 dashscope prefix cache.
@@ -831,25 +752,13 @@ func TestPromptManager_AssembleLoopPrompt_SemiSegmentByteStableAcrossTurns(t *te
 
 	tool := aitool.NewWithoutCallback("tool-a", aitool.WithDescription("tool a desc"))
 
-	cacheBlock := strings.Join([]string{
-		"<|DIRECT_TOOL_ROUTING_[current-nonce]|>",
-		"# Fast Tool Routing",
-		"<|DIRECT_TOOL_ROUTING_END_[current-nonce]|>",
-		"<|CACHE_TOOL_CALL_[current-nonce]|>",
-		"<|TOOL_bash_[current-nonce]|>",
-		"## Tool: bash",
-		"<|TOOL_bash_END_[current-nonce]|>",
-		"<|CACHE_TOOL_CALL_END_[current-nonce]|>",
-	}, "\n")
-
 	mk := func(turnNonce string, userQuery string) string {
 		result, err := react.promptManager.AssembleLoopPrompt([]*aitool.Tool{tool}, &reactloops.LoopPromptAssemblyInput{
-			Nonce:            turnNonce,
-			UserQuery:        userQuery,
-			TaskInstruction:  "task rules",
-			Schema:           `{"type":"object"}`,
-			SkillsContext:    "<|SKILLS_CONTEXT_demo|>\nskill\n<|SKILLS_CONTEXT_END_demo|>",
-			RecentToolsCache: cacheBlock,
+			Nonce:           turnNonce,
+			UserQuery:       userQuery,
+			TaskInstruction: "task rules",
+			Schema:          `{"type":"object"}`,
+			SkillsContext:   "<|SKILLS_CONTEXT_demo|>\nskill\n<|SKILLS_CONTEXT_END_demo|>",
 		})
 		require.NoError(t, err)
 		return result.Prompt

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -920,17 +920,18 @@ func (pm *PromptManager) GenerateIntervalReviewPrompt(
 	return pm.GenerateIntervalReviewPromptWithContext(tool, params, stdoutSnapshot, stderrSnapshot, time.Time{}, 0, "")
 }
 
-// GenerateIntervalReviewPromptWithContext generates interval review prompt with shared prompt
-// prefix assembly.
+// GenerateIntervalReviewPromptWithContext generates a dedicated bounded prompt
+// for speed-priority progress review.
 //
-// aicache 命中率优化:
-//   - 复用 preparePromptPrefixMaterials + assemblePromptWithDynamicSection
+// 轻量上下文控制:
+//   - 不继承主循环的 high-static / frozen Timeline / promoted state
+//   - 只读取最近 2048 tokens 的 prompt-visible Timeline
 //   - 审核规则 / schema / valid output example 固定在 semi-dynamic-2
-//   - 当前时间、运行时长、stdout/stderr 快照、额外提示等高抖动字段保留在 dynamic
+//   - dynamic 各字段独立限额，整条 prompt 设置 9000-token 硬上限
 //
-// 关键词: GenerateIntervalReviewPromptWithContext, interval-review,
+// 关键词: GenerateIntervalReviewPromptWithContext, interval-review, recent timeline,
 //
-//	preparePromptPrefixMaterials, assemblePromptWithDynamicSection
+//	lightweight prompt budget
 func (pm *PromptManager) GenerateIntervalReviewPromptWithContext(
 	tool *aitool.Tool,
 	params aitool.InvokeParams,
@@ -940,49 +941,43 @@ func (pm *PromptManager) GenerateIntervalReviewPromptWithContext(
 	callExpectations string,
 ) (string, error) {
 	nonceString := nonce()
-	base, prefixMaterials, err := pm.preparePromptPrefixMaterials(nil, &reactloops.LoopPromptAssemblyInput{
-		Nonce:  nonceString,
-		Schema: intervalReviewSchemaJSON,
-	})
-	if err != nil {
-		return "", err
-	}
-	prefixMaterials.AllowToolCall = false
-	prefixMaterials.AllowPlanAndExec = false
-	prefixMaterials.HasLoadCapability = false
-	prefixMaterials.TaskInstruction = strings.TrimSpace(intervalReviewInstructionText)
-	prefixMaterials.OutputExample = strings.TrimSpace(intervalReviewOutputExampleText)
-	prefixMaterials.ToolInventory = false
-	prefixMaterials.ToolsCount = 0
-	prefixMaterials.TopToolsCount = 0
-	prefixMaterials.TopTools = nil
-	prefixMaterials.HasMoreTools = false
-	prefixMaterials.ForgeInventory = false
-	prefixMaterials.AIForgeList = ""
-	prefixMaterials.SkillsContext = ""
-	prefixMaterials.PromotedSemiDynamic1 = ""
-	prefixMaterials.PromotedTimelineOpen = ""
+	const (
+		intervalReviewMaxPromptTokens        = 9000
+		intervalReviewTimelineTokens         = 2048
+		intervalReviewUserQueryTokens        = 1024
+		intervalReviewTaskGoalTokens         = 256
+		intervalReviewToolDescriptionTokens  = 512
+		intervalReviewToolNameTokens         = 128
+		intervalReviewToolParamsTokens       = 1536
+		intervalReviewStdoutTokens           = 1024
+		intervalReviewStderrTokens           = 512
+		intervalReviewCallExpectationTokens  = 512
+		intervalReviewExtraInstructionTokens = 512
+	)
 
 	userQuery := ""
 	taskGoal := ""
 	if task := pm.react.GetCurrentTask(); task != nil {
-		userQuery = task.GetUserInput()
-		taskGoal = task.GetName()
+		userQuery = aicommon.ShrinkTextBlockByTokens(task.GetUserInput(), intervalReviewUserQueryTokens)
+		taskGoal = aicommon.ShrinkTextBlockByTokens(task.GetName(), intervalReviewTaskGoalTokens)
 	}
 
-	dynamicData := pm.buildLoopPromptSectionData(base, &reactloops.LoopPromptAssemblyInput{
-		Nonce:     nonceString,
-		UserQuery: userQuery,
-	})
-	dynamicData["ToolName"] = tool.Name
-	dynamicData["ToolDescription"] = tool.Description
-	dynamicData["ToolParams"] = params.Dump()
+	dynamicData := map[string]any{
+		"Nonce":     nonceString,
+		"UserQuery": userQuery,
+	}
+	dynamicData["ToolName"] = aicommon.ShrinkStringByTokens(tool.Name, intervalReviewToolNameTokens)
+	dynamicData["ToolDescription"] = aicommon.ShrinkTextBlockByTokens(tool.Description, intervalReviewToolDescriptionTokens)
+	dynamicData["ToolParams"] = aicommon.ShrinkTextBlockByTokens(params.Dump(), intervalReviewToolParamsTokens)
 	dynamicData["CurrentTime"] = time.Now().Format("2006-01-02 15:04:05")
 	dynamicData["ReviewCount"] = reviewCount
-	dynamicData["StdoutSnapshot"] = utils.ShrinkString(string(stdoutSnapshot), 3000)
-	dynamicData["StderrSnapshot"] = utils.ShrinkString(string(stderrSnapshot), 1500)
-	dynamicData["CallExpectations"] = callExpectations
-	dynamicData["ExtraPrompt"] = strings.TrimSpace(pm.react.config.GetConfigString(aicommon.ConfigKeyToolCallIntervalReviewExtraPrompt))
+	dynamicData["StdoutSnapshot"] = aicommon.ShrinkTextBlockByTokens(string(stdoutSnapshot), intervalReviewStdoutTokens)
+	dynamicData["StderrSnapshot"] = aicommon.ShrinkTextBlockByTokens(string(stderrSnapshot), intervalReviewStderrTokens)
+	dynamicData["CallExpectations"] = aicommon.ShrinkTextBlockByTokens(callExpectations, intervalReviewCallExpectationTokens)
+	dynamicData["ExtraPrompt"] = aicommon.ShrinkTextBlockByTokens(
+		strings.TrimSpace(pm.react.config.GetConfigString(aicommon.ConfigKeyToolCallIntervalReviewExtraPrompt)),
+		intervalReviewExtraInstructionTokens,
+	)
 	dynamicData["TaskGoal"] = taskGoal
 
 	if !startTime.IsZero() {
@@ -994,12 +989,42 @@ func (pm *PromptManager) GenerateIntervalReviewPromptWithContext(
 		dynamicData["StartTime"] = "unknown"
 	}
 
-	return pm.assemblePromptWithDynamicSection(
-		prefixMaterials,
-		"interval-review-dynamic",
-		intervalReviewDynamicTemplate,
-		dynamicData,
+	dynamic, err := aicommon.RenderPromptTemplate("interval-review-dynamic", intervalReviewDynamicTemplate, dynamicData)
+	if err != nil {
+		return "", err
+	}
+	semiDynamic2, err := aicommon.RenderPromptTemplate(
+		"interval-review-semi-dynamic-2",
+		aicommon.SharedTaskInstructionSchemaExampleTemplate,
+		(&aicommon.PromptMaterials{
+			TaskInstruction: strings.TrimSpace(intervalReviewInstructionText),
+			Schema:          strings.TrimSpace(intervalReviewSchemaJSON),
+			OutputExample:   strings.TrimSpace(intervalReviewOutputExampleText),
+		}).SemiDynamic2Data(),
 	)
+	if err != nil {
+		return "", err
+	}
+	recentTimeline := ""
+	if pm.react != nil && pm.react.config != nil && pm.react.config.GetTimeline() != nil {
+		recentTimeline = pm.react.config.GetTimeline().DumpRecentForPrompt(intervalReviewTimelineTokens)
+	}
+	if recentTimeline == "" {
+		recentTimeline = "<|TIMELINE_RECENT|>\n(no recent Timeline items)\n<|TIMELINE_RECENT_END|>"
+	}
+	prompt := aicommon.BuildTaggedPromptSections(
+		"You are performing a bounded progress review for one running tool call.",
+		"",
+		"",
+		semiDynamic2,
+		recentTimeline,
+		dynamic,
+		nonceString,
+	)
+	if tokens := aicommon.MeasureTokens(prompt); tokens > intervalReviewMaxPromptTokens {
+		return "", fmt.Errorf("interval review prompt exceeds %d-token hard limit: %d", intervalReviewMaxPromptTokens, tokens)
+	}
+	return prompt, nil
 }
 
 // formatDuration formats a duration into a human-readable string

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -461,7 +461,6 @@ func (pm *PromptManager) GenerateVerificationPrompt(originalQuery string, isTool
 	prefixMaterials.SkillsContext = ""
 	prefixMaterials.PromotedSemiDynamic1 = ""
 	prefixMaterials.PromotedTimelineOpen = ""
-	prefixMaterials.RecentToolsCache = ""
 	dynamicData := pm.buildLoopPromptSectionData(base, &reactloops.LoopPromptAssemblyInput{
 		Nonce:     nonceString,
 		UserQuery: originalQuery,
@@ -523,7 +522,6 @@ func (pm *PromptManager) GenerateAIReviewPrompt(userQuery, toolOrTitle, params s
 	prefixMaterials.SkillsContext = ""
 	prefixMaterials.PromotedSemiDynamic1 = ""
 	prefixMaterials.PromotedTimelineOpen = ""
-	prefixMaterials.RecentToolsCache = ""
 
 	dynamicData := pm.buildLoopPromptSectionData(base, &reactloops.LoopPromptAssemblyInput{
 		Nonce:     nonceString,
@@ -964,7 +962,6 @@ func (pm *PromptManager) GenerateIntervalReviewPromptWithContext(
 	prefixMaterials.SkillsContext = ""
 	prefixMaterials.PromotedSemiDynamic1 = ""
 	prefixMaterials.PromotedTimelineOpen = ""
-	prefixMaterials.RecentToolsCache = ""
 
 	userQuery := ""
 	taskGoal := ""

--- a/common/ai/aid/aireact/prompts_test.go
+++ b/common/ai/aid/aireact/prompts_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
@@ -1358,6 +1359,42 @@ func TestGenerateIntervalReviewPrompt_IncludesConcreteStringGuidance(t *testing.
 	) {
 		t.Fatalf("interval review prompt should contain anti-schema guidance and concrete example. Got:\n%s", prompt)
 	}
+}
+
+func TestGenerateIntervalReviewPrompt_UsesOnlyBoundedRecentTimeline(t *testing.T) {
+	react, err := NewTestReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			rsp := i.NewAIResponse()
+			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action":"interval-toolcall-review","decision":"continue"}`))
+			rsp.Close()
+			return rsp, nil
+		}),
+	)
+	require.NoError(t, err)
+	react.AddToTimeline("note", "ANCIENT_INTERVAL_CONTEXT "+strings.Repeat("old ", 12000))
+	react.AddToTimeline("note", "RECENT_INTERVAL_FACT")
+
+	tool := aitool.NewWithoutCallback(
+		"network_diagnose",
+		aitool.WithDescription(strings.Repeat("description ", 4000)),
+		aitool.WithStringParam("target"),
+	)
+	prompt, err := react.promptManager.GenerateIntervalReviewPromptWithContext(
+		tool,
+		aitool.InvokeParams{"target": strings.Repeat("127.0.0.1 ", 4000)},
+		[]byte(strings.Repeat("stdout ", 4000)),
+		[]byte(strings.Repeat("stderr ", 4000)),
+		time.Unix(0, 0),
+		1,
+		strings.Repeat("expectation ", 4000),
+	)
+	require.NoError(t, err)
+	require.Contains(t, prompt, "RECENT_INTERVAL_FACT")
+	require.NotContains(t, prompt, "ANCIENT_INTERVAL_CONTEXT")
+	require.NotContains(t, prompt, "Timeline Memory (Frozen)")
+	promptTokens := aicommon.MeasureTokens(prompt)
+	t.Logf("bounded interval-review prompt tokens: %d", promptTokens)
+	require.LessOrEqual(t, promptTokens, 9000)
 }
 
 func TestGenerateIntervalReviewPrompt_WithExtraPrompt(t *testing.T) {

--- a/common/ai/aid/aireact/prompts_test.go
+++ b/common/ai/aid/aireact/prompts_test.go
@@ -1174,8 +1174,8 @@ func TestGenerateVerificationPrompt_RendersTodoSnapshot(t *testing.T) {
 		"# TODO:",
 		"- [ ]: [id: verify_file]: 检查 A.md 是否已写入预期内容",
 		"- [ ]: [id: create_file]: 创建一个 A.md 文件",
-		"- [DELETED]: [id: obsolete_step]: 不再需要的临时步骤",
-		"- [x]: [id: rename_file]: 将临时文件改名为最终文件名",
+		"- DONE (1): rename_file",
+		"- DELETED (1): obsolete_step",
 		"next_movements 只输出增量",
 		"{\"op\": \"doing\", \"id\": \"stable_id\"}",
 		"{\"op\": \"delete\", \"id\": \"stable_id\"}",
@@ -1229,8 +1229,7 @@ func TestGenerateVerificationPrompt_RendersAbandonedTodosAfterSatisfied(t *testi
 
 	if !utils.MatchAllOfSubString(
 		prompt,
-		"- [SKIPPED]: [id: collect_signal]: 收集页面回显信号",
-		"- [SKIPPED]: [id: retry_payload]: 更换 payload 再次验证",
+		"- SKIPPED (2): collect_signal, retry_payload",
 		"必须被显式关闭",
 		"系统不再自动把剩余未关闭 TODO 标记为 `SKIPPED`",
 	) {

--- a/common/ai/aid/aireact/reactloops/perception.go
+++ b/common/ai/aid/aireact/reactloops/perception.go
@@ -52,9 +52,10 @@ const (
 	perceptionMaxContextTokens          = 500
 	perceptionKnowledgeMaxContextTokens = 15 * 1024
 
-	// perceptionMaxInputTokens is the token budget for the entire perception input.
+	// perceptionMaxInputTokens is the token budget for the entire speed-priority
+	// perception input. Keep it well below the main model context.
 	// Fields exceeding their share will be shrunk via ShrinkTextBlockByTokens.
-	perceptionMaxInputTokens = 30000
+	perceptionMaxInputTokens = 20000
 )
 
 // IntentShift 取值约定 — 描述本轮 perception 与上一轮相比意图的"方向性"变化粒度.
@@ -293,8 +294,8 @@ func (pc *perceptionController) getCurrent() *PerceptionState {
 	return pc.current
 }
 
-// buildPerceptionInput assembles input for the perception model with a generous
-// token budget (~30K tokens). Individual sections are shrunk only when the total
+// buildPerceptionInput assembles input for the perception model with a bounded
+// token budget (~20K tokens). Individual sections are shrunk only when the total
 // would exceed perceptionMaxInputTokens.
 // It returns the core input string and a map of extra template variables
 // (BaseFrame, Facts, Evidence, DynamicContext) for the prompt template.
@@ -308,7 +309,7 @@ func (r *ReActLoop) buildPerceptionInput(trigger string) (string, map[string]str
 		userInput = task.GetUserInput()
 	}
 	if userInput != "" {
-		userInput = aicommon.ShrinkTextBlockByTokens(userInput, 8000)
+		userInput = aicommon.ShrinkTextBlockByTokens(userInput, 4000)
 	}
 	buf.WriteString(fmt.Sprintf("User Goal: %s\n", userInput))
 	buf.WriteString(fmt.Sprintf("Loop: %s, iteration %d/%d\n", r.loopName, r.currentIterationIndex, r.maxIterations))
@@ -379,7 +380,11 @@ func (r *ReActLoop) buildPerceptionInput(trigger string) (string, map[string]str
 	}
 	if v, ok := baseFrame["Timeline"]; ok {
 		timeline := fmt.Sprintf("%v", v)
-		timeline = aicommon.ShrinkTextBlockByTokens(timeline, 3000)
+		if cfg, ok := r.config.(interface{ GetTimeline() *aicommon.Timeline }); ok && cfg.GetTimeline() != nil {
+			timeline = cfg.GetTimeline().DumpRecentForPrompt(2048)
+		} else {
+			timeline = aicommon.ShrinkTextBlockByTokens(timeline, 2048)
+		}
 		baseFrameBuf.WriteString(fmt.Sprintf("Timeline:\n%s\n", timeline))
 	}
 	if baseFrameStr := baseFrameBuf.String(); baseFrameStr != "" {
@@ -387,12 +392,12 @@ func (r *ReActLoop) buildPerceptionInput(trigger string) (string, map[string]str
 	}
 
 	if facts := strings.TrimSpace(r.Get("plan_facts")); facts != "" {
-		facts = aicommon.ShrinkTextBlockByTokens(facts, 4000)
+		facts = aicommon.ShrinkTextBlockByTokens(facts, 2048)
 		extra["Facts"] = facts
 	}
 
 	if evidence := strings.TrimSpace(r.Get("plan_evidence")); evidence != "" {
-		evidence = aicommon.ShrinkTextBlockByTokens(evidence, 4000)
+		evidence = aicommon.ShrinkTextBlockByTokens(evidence, 2048)
 		extra["Evidence"] = evidence
 	}
 
@@ -401,7 +406,7 @@ func (r *ReActLoop) buildPerceptionInput(trigger string) (string, map[string]str
 		if cpm := cfg.GetContextProviderManager(); cpm != nil {
 			dynCtx := cpm.Execute(cfg, r.emitter)
 			if dynCtx = strings.TrimSpace(dynCtx); dynCtx != "" {
-				dynCtx = aicommon.ShrinkTextBlockByTokens(dynCtx, 4000)
+				dynCtx = aicommon.ShrinkTextBlockByTokens(dynCtx, 2048)
 				extra["DynamicContext"] = dynCtx
 			}
 		}

--- a/common/ai/aid/aireact/reactloops/prompt.go
+++ b/common/ai/aid/aireact/reactloops/prompt.go
@@ -249,6 +249,7 @@ func (r *ReActLoop) generateLoopPrompt(
 
 	result, err := r.invoker.AssembleLoopPrompt(tools, &LoopPromptAssemblyInput{
 		Nonce:             nonce,
+		Lightweight:       r.useSpeedPriorityAI,
 		UserQuery:         userInput,
 		FrozenUserContext: frozenUserContext,
 		FrozenPartitions:  frozenPartitions,
@@ -271,12 +272,6 @@ func (r *ReActLoop) generateLoopPrompt(
 	}
 	observation := BuildPromptObservation(r.loopName, nonce, result.Prompt, getLoopPromptObservationSections(result))
 	r.SetLastPromptObservation(observation)
-	// 把 high-static / frozen-block / timeline-open 三段的"段内内容"
-	// (不含外层 boundary 标签)单独缓存, 供异步自我反思 prompt 复用. 反思
-	// prompt 把这三段拼回完全相同的 boundary 标签内, 与主循环字节对齐,
-	// 共享 LLM provider 侧的 prefix cache 命中.
-	// 关键词: 反思 prompt 缓存复用, prefix cache reuse, 字节对齐前缀
-	r.cachePrefixBodiesFromObservation(observation)
 	// 传 0 走 defaultPromptSummaryBytes; 当前默认 = 0 = 段内容完整透传.
 	// 用户实测段体量在数 KB ~ 数十 KB 量级, 本地 ipc 完全可承受;
 	// 想换成截断模式时改成显式正数即可.
@@ -298,91 +293,6 @@ func getLoopPromptObservationSections(result *LoopPromptAssemblyResult) []*Promp
 		return sections
 	}
 	return nil
-}
-
-// cachedPrefixHighStaticKey / cachedPrefixFrozenBlockKey / cachedPrefixTimelineOpenKey
-// 是把主循环 prompt 的 high-static / frozen-block / timeline-open 三段
-// "段内内容"(不含外层 boundary 标签)按 key 存到 r.vars 的稳定 key.
-// 异步反思 goroutine 从这里读取做缓存复用.
-// 关键词: 反思 prefix cache 复用 key, vars 持久化
-const (
-	cachedPrefixHighStaticKey   = "last_prompt_section_high_static"
-	cachedPrefixFrozenBlockKey  = "last_prompt_section_frozen_block"
-	cachedPrefixTimelineOpenKey = "last_prompt_section_timeline_open"
-)
-
-// cachePrefixBodiesFromObservation 从最新一次 prompt 观测树里抽出 high-static /
-// frozen-block / timeline-open 三段的"段内内容"(纯渲染文本, 不含 boundary 标签),
-// 缓存到 r.vars 供异步反思 prompt 复用. 反思路径会用 aicommon.BuildTaggedPromptSections
-// 在这三段外面套回完全相同的 boundary 标签, 与主循环字节对齐, 享受同一份 prefix cache.
-//
-// 设计要点:
-//   - observation 已经把每段(含 container)按 role 排好, 直接按 role 找顶级节点即可.
-//   - 段内内容拼接顺序与 main loop 渲染保持一致 (Children 顺序 + \n\n 分隔 + TrimSpace),
-//     确保字节级稳定; 否则即使内容相同, 字节顺序不同也会破坏 prefix cache 命中.
-//
-// 关键词: cachePrefixBodiesFromObservation, 字节稳定提取, prefix cache 复用
-func (r *ReActLoop) cachePrefixBodiesFromObservation(observation *PromptObservation) {
-	if r == nil || observation == nil {
-		return
-	}
-	for _, section := range observation.Sections {
-		if section == nil {
-			continue
-		}
-		body := concatPromptSectionContent(section)
-		switch section.Role {
-		case PromptSectionRoleHighStatic:
-			r.Set(cachedPrefixHighStaticKey, body)
-		case PromptSectionRoleFrozenBlock:
-			r.Set(cachedPrefixFrozenBlockKey, body)
-		case PromptSectionRoleTimelineOpen:
-			r.Set(cachedPrefixTimelineOpenKey, body)
-		}
-	}
-}
-
-// concatPromptSectionContent 把一个 section (可能是 container) 的 Children 内容
-// 按 \n\n 拼接后 TrimSpace. 与 prompt 模板渲染的拼接方式一致, 保证字节稳定.
-// 关键词: section 内容拼接, 字节稳定
-func concatPromptSectionContent(section *PromptSectionObservation) string {
-	if section == nil {
-		return ""
-	}
-	if len(section.Children) == 0 {
-		return strings.TrimSpace(section.Content)
-	}
-	parts := make([]string, 0, len(section.Children))
-	for _, child := range section.Children {
-		if child == nil {
-			continue
-		}
-		body := concatPromptSectionContent(child)
-		if body == "" {
-			continue
-		}
-		parts = append(parts, body)
-	}
-	return strings.TrimSpace(strings.Join(parts, "\n\n"))
-}
-
-// getCachedPrefixBodies 读取 cachePrefixBodiesFromObservation 缓存好的
-// 三段 prefix bodies. 异步反思 prompt 复用入口.
-// 关键词: 反思 prefix cache 读取, 字节对齐
-func (r *ReActLoop) getCachedPrefixBodies() (highStatic, frozenBlock, timelineOpen string) {
-	if r == nil {
-		return "", "", ""
-	}
-	if v, ok := r.GetVariable(cachedPrefixHighStaticKey).(string); ok {
-		highStatic = v
-	}
-	if v, ok := r.GetVariable(cachedPrefixFrozenBlockKey).(string); ok {
-		frozenBlock = v
-	}
-	if v, ok := r.GetVariable(cachedPrefixTimelineOpenKey).(string); ok {
-		timelineOpen = v
-	}
-	return
 }
 
 // syncRecentToolParamAITagFields 给当前 react loop 的 aiTagFields 注册

--- a/common/ai/aid/aireact/reactloops/reflection.go
+++ b/common/ai/aid/aireact/reactloops/reflection.go
@@ -291,11 +291,9 @@ func (r *ReActLoop) performAIReflection(ctx context.Context, reflection *ActionR
 	task := r.GetCurrentTask()
 	nonce := utils.RandStringBytes(4)
 
-	// 反思 prompt 构建: 复用主循环 prefix cache (high-static / frozen-block /
-	// timeline-open), dynamic 段只放反思特有内容 (action 详情 + SPIN + schema).
-	// 去掉 RelevantMemories / PreviousReflections — 它们是 cache 杀手, 且 SPIN
-	// 决策的真正依据已经在 timeline-open + action 历史里覆盖.
-	// 关键词: 反思 prompt 复用 prefix cache, 去内存噪声
+	// 反思 prompt 构建: speed-priority 路径只带受限的最近 Timeline，dynamic
+	// 段放 action 详情 + SPIN + schema，不继承主循环完整冻结前缀。
+	// 关键词: 反思 prompt recent timeline, 去全会话前缀
 	prompt, err := r.buildReflectionPrompt(reflection, nonce)
 	if err != nil {
 		log.Errorf("failed to build reflection prompt: %v", err)

--- a/common/ai/aid/aireact/reactloops/reflection_prompt.go
+++ b/common/ai/aid/aireact/reactloops/reflection_prompt.go
@@ -17,17 +17,15 @@ var selfReflectionTemplate string
 // buildReflectionPrompt 构建反思 prompt.
 //
 // 设计要点:
-//   - 反思 prompt 的"前缀"(high-static + frozen-block + timeline-open) 直接
-//     复用主循环最近一次 prompt 的对应段, 用同一套 boundary 标签 (AI_CACHE_SYSTEM /
-//     AI_CACHE_FROZEN / PROMPT_SECTION) 套回, 字节对齐, 享受 LLM provider 侧
-//     的 prefix cache 命中, 显著降低反思 AI 调用的 token 成本与首字延迟.
+//   - 反思走 speed-priority 模型，只读取受硬预算约束的最近 Timeline，不继承
+//     主循环的 high-static / frozen-block 全会话前缀。
 //   - 反思特有内容 (action 详情 + SPIN 检测信息 + 输出 schema) 单独走 dynamic
-//     段, 用反思 goroutine 自己的 nonce 包裹, 不影响 prefix cache.
+//     段, 用反思 goroutine 自己的 nonce 包裹。
 //   - 去掉了历史的 RelevantMemories / PreviousReflections / EnvironmentalImpact
 //     大段, 减少 cache 杀手 — SPIN 决策的核心依据是 timeline-open + 最近 action
 //     历史, 这两者已经在 prefix + dynamic 段里覆盖.
 //
-// 关键词: buildReflectionPrompt, prefix cache 复用, dynamic 段隔离,
+// 关键词: buildReflectionPrompt, speed-priority, recent timeline, dynamic 段隔离,
 //
 //	反思 prompt 精简
 func (r *ReActLoop) buildReflectionPrompt(
@@ -61,13 +59,14 @@ func (r *ReActLoop) buildReflectionPrompt(
 		return "", utils.Wrap(err, "render self-reflection template failed")
 	}
 
-	// 复用主循环最近一次 prompt 的 high-static / frozen-block / timeline-open
-	// 三段, 与主循环保持字节对齐. semi-dynamic 段反思场景不需要, 留空让
-	// BuildTaggedPromptSections 自然过滤.
-	highStatic, frozenBlock, timelineOpen := r.getCachedPrefixBodies()
+	const reflectionRecentTimelineTokens = 4096
+	timelineOpen := ""
+	if cfg, ok := r.GetConfig().(interface{ GetTimeline() *aicommon.Timeline }); ok && cfg.GetTimeline() != nil {
+		timelineOpen = cfg.GetTimeline().DumpRecentForPrompt(reflectionRecentTimelineTokens)
+	}
 	prompt := aicommon.BuildTaggedPromptSections(
-		highStatic,
-		frozenBlock,
+		"",
+		"",
 		"", // semi-dynamic-1 (反思不需要 SkillsContext)
 		"", // semi-dynamic-2 (反思不需要主循环的 TaskInstruction / Schema)
 		timelineOpen,

--- a/common/ai/aid/aireact/reactloops/spin_detection.go
+++ b/common/ai/aid/aireact/reactloops/spin_detection.go
@@ -209,23 +209,10 @@ func (r *ReActLoop) getTimelineContentForSpinDetection() string {
 		return ""
 	}
 
-	// 获取最近的 Timeline 条目（限制数量以避免过长）
-	// 获取最近 20 条 Timeline 条目用于分析
-	outputs := timeline.ToTimelineItemOutputLastN(20)
-	if len(outputs) == 0 {
-		return ""
-	}
-
-	var content strings.Builder
-	content.WriteString("最近的 Timeline 条目：\n\n")
-	for i, output := range outputs {
-		content.WriteString(fmt.Sprintf("%d. [%s] %s\n", i+1, output.Type, output.Content))
-		if i >= 19 { // 限制最多 20 条
-			break
-		}
-	}
-
-	return content.String()
+	// Item count cannot bound a single huge tool result. Use the shared recent
+	// projection so reflection remains cheap even when the latest observation is
+	// large, while still preferring the newest facts.
+	return timeline.DumpRecentForPrompt(2048)
 }
 
 // buildSpinDetectionPrompt 构建 SPIN 检测的 prompt

--- a/common/ai/aid/aireact/verification_todo_test.go
+++ b/common/ai/aid/aireact/verification_todo_test.go
@@ -41,9 +41,12 @@ func TestRenderVerificationTodoSnapshot_AggregatesStatuses(t *testing.T) {
 	}
 
 	snapshot := renderVerificationTodoSnapshot(history)
-	require.Contains(t, snapshot, "- [x]: [id: collect_signal]: 收集页面响应信号")
-	require.Contains(t, snapshot, "- [DELETED]: [id: fix_title]: 修正标题")
-	require.Contains(t, snapshot, "- [SKIPPED]: [id: replay_payload]: 使用新 payload 复测")
+	require.Contains(t, snapshot, "- DONE (1): collect_signal")
+	require.Contains(t, snapshot, "- DELETED (1): fix_title")
+	require.Contains(t, snapshot, "- SKIPPED (1): replay_payload")
+	require.NotContains(t, snapshot, "收集页面响应信号")
+	require.NotContains(t, snapshot, "修正标题")
+	require.NotContains(t, snapshot, "使用新 payload 复测")
 }
 
 func TestRenderVerificationTodoSnapshot_PrioritizesActiveItemsUnderLimit(t *testing.T) {

--- a/common/ai/aid/aitool/buildinaitools/tool_manager.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager.go
@@ -24,38 +24,6 @@ import (
 
 const defaultRecentToolCacheMaxTokens = 30 * 1024
 
-func isSupportedRecentToolAITagParamName(paramName string) bool {
-	if paramName == "" {
-		return false
-	}
-	for _, ch := range paramName {
-		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-func filterSupportedRecentToolAITagParamNames(paramNames []string) []string {
-	if len(paramNames) == 0 {
-		return nil
-	}
-	filtered := make([]string, 0, len(paramNames))
-	seen := make(map[string]struct{}, len(paramNames))
-	for _, paramName := range paramNames {
-		if !isSupportedRecentToolAITagParamName(paramName) {
-			continue
-		}
-		if _, ok := seen[paramName]; ok {
-			continue
-		}
-		seen[paramName] = struct{}{}
-		filtered = append(filtered, paramName)
-	}
-	return filtered
-}
-
 // RecentToolEntry records a recently used tool for directly_call_tool action.
 type RecentToolEntry struct {
 	Name          string `json:"name"`
@@ -591,21 +559,6 @@ func (m *AiToolManager) AddRecentlyUsedTool(tool *aitool.Tool) RecentToolCacheMu
 	return mutation
 }
 
-// GetRecentToolEntries returns a defensive snapshot in execution-side LRU order.
-func (m *AiToolManager) GetRecentToolEntries() []*RecentToolEntry {
-	m.recentToolsMu.Lock()
-	defer m.recentToolsMu.Unlock()
-	out := make([]*RecentToolEntry, 0, len(m.recentToolsCache))
-	for _, entry := range m.recentToolsCache {
-		if entry == nil {
-			continue
-		}
-		cp := *entry
-		out = append(out, &cp)
-	}
-	return out
-}
-
 // RenderRecentToolEntryForPromotion renders one stable, params-only schema.
 // Collection ordering and the shared routing instructions are owned by the
 // Timeline promoted-state projection.
@@ -671,40 +624,6 @@ Direct Params Schema (for directly_call_tool only):
 {{ end }}<|TOOL_{{ .Name }}_END_{{ .Nonce }}|>
 `
 
-const recentToolSummaryFooterTemplate = `## How to use directly_call_tool
-
-The schema shown above is the params-only shape for directly_call_tool.
-Pass it directly as directly_call_tool_params. Do not wrap it with @action, tool, or params.
-
-### JSON-only mode
-{"@action": "directly_call_tool", "directly_call_tool_name": "<name>", "directly_call_identifier": "<snake_case_intent>", "directly_call_expectations": "<timing and fallback>", "directly_call_tool_params": <params object matching the Params Schema>}
-
-### Hybrid mode for block parameters
-Use JSON for simple fields and AITAG blocks for multi-line or escape-heavy fields such as command, body, packet, headers, script, content, query.
-
-Example (the literal "{{ .Nonce }}" below is a placeholder; replace it with the SAME nonce that other AITAG blocks in this prompt are using, e.g. the nonce from <|USER_QUERY_xxxx|>):
-{"@action": "directly_call_tool", "directly_call_tool_name": "<name>", "directly_call_identifier": "<snake_case_intent>", "directly_call_expectations": "<timing and fallback>", "directly_call_tool_params": {"timeout": 20}}
-<|TOOL_PARAM_command_{{ .Nonce }}|>
-#!/bin/bash
-echo "hello"
-<|TOOL_PARAM_command_END_{{ .Nonce }}|>
-
-AITAG rules:
-- Start tag: <|TOOL_PARAM_{param_name}_{nonce}|>
-- End tag:   <|TOOL_PARAM_{param_name}_END_{nonce}|>
-- The token "{{ .Nonce }}" written above in this prompt is a PLACEHOLDER for "the current per-turn nonce". When you emit your AITAG blocks, prefer to substitute it with the same nonce that is used by other AITAG blocks in this prompt (look at <|USER_QUERY_xxxx|> for the exact value).
-- If unsure, you may also keep the literal "{{ .Nonce }}" verbatim; the parser accepts both forms.
-- AITAG block values override same-named JSON params.
-- If all params are block-style, directly_call_tool_params may be omitted or left as an empty object.
-{{ if .ParamNames }}
-
-AITAG-capable params seen in cached tools:
-{{- range .ParamNames }}
-- {{ . }}
-{{- end }}
-{{ end }}
-`
-
 func extractDirectlyCallParamsSchema(schemaSnippet string) aitool.InvokeParams {
 	if strings.TrimSpace(schemaSnippet) == "" {
 		return nil
@@ -743,13 +662,6 @@ func extractDirectlyCallParamNamesFromSchema(schemaSnippet string) []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-func renderRecentToolSummaryFooter(nonce string, paramNames []string) string {
-	return utils.MustRenderTemplate(recentToolSummaryFooterTemplate, map[string]any{
-		"Nonce":      nonce,
-		"ParamNames": filterSupportedRecentToolAITagParamNames(paramNames),
-	})
 }
 
 func renderDirectlyCallParamsSchema(schemaSnippet string) string {
@@ -821,102 +733,6 @@ func (m *AiToolManager) GetRecentToolParamNamesByTool(name string) []string {
 		return nil
 	}
 	return extractDirectlyCallParamNamesFromSchema(tool.ToJSONSchemaString())
-}
-
-// ExportRecentToolCache serializes the recent-tool cache entries to a JSON string
-// for persistent storage (e.g. in AIAgentRuntime.RecentToolsCache).
-func (m *AiToolManager) ExportRecentToolCache() string {
-	m.recentToolsMu.Lock()
-	defer m.recentToolsMu.Unlock()
-
-	if len(m.recentToolsCache) == 0 {
-		return ""
-	}
-	raw, err := json.Marshal(m.recentToolsCache)
-	if err != nil {
-		log.Errorf("ExportRecentToolCache marshal error: %v", err)
-		return ""
-	}
-	return string(raw)
-}
-
-// ImportRecentToolCache restores cache entries from a JSON string produced by ExportRecentToolCache.
-// Existing entries with the same name are replaced; FIFO eviction still applies.
-func (m *AiToolManager) ImportRecentToolCache(jsonStr string) {
-	if jsonStr == "" {
-		return
-	}
-	var entries []*RecentToolEntry
-	if err := json.Unmarshal([]byte(jsonStr), &entries); err != nil {
-		log.Errorf("ImportRecentToolCache unmarshal error: %v", err)
-		return
-	}
-
-	m.recentToolsMu.Lock()
-	defer m.recentToolsMu.Unlock()
-
-	existing := make(map[string]struct{})
-	for _, e := range m.recentToolsCache {
-		existing[e.Name] = struct{}{}
-	}
-	for _, entry := range entries {
-		if _, ok := existing[entry.Name]; ok {
-			continue
-		}
-		m.recentToolsCache = append(m.recentToolsCache, entry)
-		existing[entry.Name] = struct{}{}
-	}
-
-	maxTokens := m.getMaxCacheTokens()
-	for m.totalCacheSize() > maxTokens && len(m.recentToolsCache) > 1 {
-		m.recentToolsCache = m.recentToolsCache[1:]
-	}
-}
-
-// GetRecentToolsSummary builds a prompt-friendly summary of cached tools within maxTokens.
-// Each tool is wrapped in AITAG boundaries <|TOOL_{name}_{nonce}|> to prevent confusion.
-//
-// 注意: 自从 CACHE_TOOL_CALL 块迁到 semi-dynamic 段并加上 AI_CACHE_SEMI 缓存边界后,
-// 块内所有 AITAG (TOOL_xxx 包装 / TOOL_PARAM_xxx 示例) 的 nonce 一律使用字面量稳定
-// 常量 RecentToolCacheStableNonce, 让该段跨 turn 字节稳定、可命中 prefix cache.
-// 参数 nonce 保留是为了向后兼容旧调用方, 但不再参与渲染.
-//
-// 关键词: GetRecentToolsSummary, RecentToolCacheStableNonce, prefix cache
-func (m *AiToolManager) GetRecentToolsSummary(maxTokens int, nonce string) string {
-	m.recentToolsMu.Lock()
-	defer m.recentToolsMu.Unlock()
-	_ = nonce // 保留参数兼容旧调用; 真正用于渲染的是稳定 nonce.
-
-	if len(m.recentToolsCache) == 0 {
-		return ""
-	}
-
-	var sb strings.Builder
-	sb.WriteString("# Recently Used Tools (available for directly_call_tool)\n\n")
-	totalTokens := ytoken.CalcTokenCount(sb.String())
-	entryWritten := false
-	for reverseIndex := len(m.recentToolsCache) - 1; reverseIndex >= 0; reverseIndex-- {
-		entry := m.recentToolsCache[reverseIndex]
-		block := utils.MustRenderTemplate(recentToolEntryTemplate, map[string]interface{}{
-			"Name":                 entry.Name,
-			"Nonce":                RecentToolCacheStableNonce,
-			"Description":          entry.Description,
-			"DisplaySchemaSnippet": renderDirectlyCallParamsSchema(entry.SchemaSnippet),
-			"Usage":                entry.Usage,
-		})
-		// Always include the most recent entry even if it exceeds maxTokens.
-		if entryWritten && maxTokens > 0 && totalTokens+ytoken.CalcTokenCount(block) > maxTokens {
-			break
-		}
-		sb.WriteString(block)
-		totalTokens += ytoken.CalcTokenCount(block)
-		entryWritten = true
-	}
-	if !entryWritten {
-		return ""
-	}
-	sb.WriteString(renderRecentToolSummaryFooter(RecentToolCacheStableNonce, m.getRecentToolParamNamesLocked()))
-	return sb.String()
 }
 
 // BuildStubToolFromMCPCachePublic is the exported wrapper for buildStubToolFromMCPCache.

--- a/common/ai/aid/aitool/buildinaitools/tool_manager_cache_test.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager_cache_test.go
@@ -123,88 +123,12 @@ func TestRecentToolCache_SizeLimit(t *testing.T) {
 		"total cache size %d should not exceed max %d", total, mgr.getMaxCacheTokens())
 }
 
-func TestRecentToolCache_Summary(t *testing.T) {
-	mgr := newManagerWithCache(0)
-
-	t1 := makeTool("sleep_test", "Sleep for N seconds",
-		aitool.WithNumberParam("seconds"),
-		aitool.WithUsage("pass seconds as a float, e.g. 0.5 for 500ms"),
-	)
-	t2 := makeTool("read_file", "Read file content",
-		aitool.WithStringParam("path"),
-	)
-	mgr.AddRecentlyUsedTool(t1)
-	mgr.AddRecentlyUsedTool(t2)
-
-	// CACHE_TOOL_CALL 块固定使用占位符字面量 nonce, 与传入的 nonce 参数解耦,
-	// 让 prompt 段跨 turn 字节稳定可被 prefix cache 命中.
-	// 关键词: TestRecentToolCache_Summary, [current-nonce] 占位符断言
-	summary := mgr.GetRecentToolsSummary(10240, "testnonce")
-	stableNonce := RecentToolCacheStableNonce
-	assert.Check(t, summary != "", "summary should not be empty")
-	assert.Check(t, strings.Contains(summary, "sleep_test"), "summary should contain sleep_test")
-	assert.Check(t, strings.Contains(summary, "read_file"), "summary should contain read_file")
-	assert.Check(t, strings.Contains(summary, "Direct Params Schema (for directly_call_tool only):"), "summary should contain direct params schema section")
-	assert.Check(t, strings.Contains(summary, `"seconds"`), "summary should contain tool param fields")
-	assert.Check(t, !strings.Contains(summary, `"const": "call-tool"`), "summary should not include wrapped @action schema")
-	assert.Check(t, !strings.Contains(summary, `"tool": {`), "summary should not include wrapped tool schema")
-	assert.Check(t, !strings.Contains(summary, `"params": {`), "summary should not include wrapped params shell")
-
-	// 渲染应忽略传入的 testnonce, 一律使用 stableNonce
-	assert.Check(t, !strings.Contains(summary, "testnonce"), "summary must not leak passed-in nonce; should be byte-stable across turns")
-
-	// AITAG boundaries: stableNonce 占位符字面量
-	assert.Check(t, strings.Contains(summary, "<|TOOL_sleep_test_"+stableNonce+"|>"), "summary should have AITAG open boundary with stable nonce")
-	assert.Check(t, strings.Contains(summary, "<|TOOL_sleep_test_END_"+stableNonce+"|>"), "summary should have AITAG close boundary with stable nonce")
-	assert.Check(t, strings.Contains(summary, "<|TOOL_read_file_"+stableNonce+"|>"), "read_file should have AITAG open boundary with stable nonce")
-	assert.Check(t, strings.Contains(summary, "<|TOOL_read_file_END_"+stableNonce+"|>"), "read_file should have AITAG close boundary with stable nonce")
-
-	// __USAGE__ only appears for tools that have it
-	assert.Check(t, strings.Contains(summary, "__USAGE__: pass seconds as a float"), "sleep_test should show __USAGE__")
-
-	// footer with directly_call_tool instruction including new fields
-	assert.Check(t, strings.Contains(summary, "directly_call_tool"), "footer should reference directly_call_tool")
-	assert.Check(t, strings.Contains(summary, "directly_call_tool_params"), "footer should reference directly_call_tool_params")
-	assert.Check(t, strings.Contains(summary, "directly_call_identifier"), "footer should reference directly_call_identifier")
-	assert.Check(t, strings.Contains(summary, "directly_call_expectations"), "footer should reference directly_call_expectations")
-	assert.Check(t, strings.Contains(summary, "Do not wrap it with @action, tool, or params."), "footer should clarify params-only usage")
-	assert.Check(t, strings.Contains(summary, "Hybrid mode for block parameters"), "footer should describe hybrid block-param mode")
-	assert.Check(t, strings.Contains(summary, "<|TOOL_PARAM_command_"+stableNonce+"|>"), "footer should include stable-nonce AITAG example")
-	assert.Check(t, strings.Contains(summary, "AITAG block values override same-named JSON params."), "footer should explain AITAG precedence")
-	// 占位符语义: footer 应明确告知 LLM 这个 nonce 是占位符, 可替换为真实 turn nonce
-	assert.Check(t, strings.Contains(summary, "PLACEHOLDER"), "footer should document placeholder semantics for stable nonce")
-}
-
-func TestRecentToolCache_SummaryMaxTokens(t *testing.T) {
-	mgr := newManagerWithCache(0)
-
-	for i := 0; i < 20; i++ {
-		name := strings.Repeat("x", 50) + string(rune('a'+i))
-		tool := makeTool(name, strings.Repeat("description ", 20),
-			aitool.WithStringParam("param1"),
-		)
-		mgr.AddRecentlyUsedTool(tool)
-	}
-
-	// first entry is always included even if it exceeds token budget
-	summary := mgr.GetRecentToolsSummary(200, "n")
-	assert.Check(t, summary != "", "summary should not be empty when cache has entries")
-	toolCount := strings.Count(summary, "## Tool: ")
-	assert.Check(t, toolCount == 1, "expected exactly 1 tool entry, got %d", toolCount)
-
-	// with large budget, all remaining entries should be included
-	largeSummary := mgr.GetRecentToolsSummary(0, "n")
-	largeToolCount := strings.Count(largeSummary, "## Tool: ")
-	assert.Check(t, largeToolCount > 1, "with unlimited budget, should have multiple tools, got %d entries", largeToolCount)
-}
-
 func TestRecentToolCache_EmptyManager(t *testing.T) {
 	mgr := newManagerWithCache(0)
 
 	assert.Check(t, !mgr.HasRecentlyUsedTools(), "new manager should have no cached tools")
 	assert.Check(t, !mgr.IsRecentlyUsedTool("anything"), "nothing should be found in empty cache")
 	assert.Equal(t, len(mgr.GetRecentToolNames()), 0)
-	assert.Equal(t, mgr.GetRecentToolsSummary(10240, "x"), "")
 }
 
 func TestRecentToolCache_NilTool(t *testing.T) {
@@ -227,7 +151,6 @@ func TestRecentToolCache_Concurrent(t *testing.T) {
 			mgr.IsRecentlyUsedTool(name)
 			mgr.GetRecentToolNames()
 			mgr.HasRecentlyUsedTools()
-			mgr.GetRecentToolsSummary(10240, "concurrent")
 		}(i)
 	}
 	wg.Wait()
@@ -262,25 +185,6 @@ func TestRecentToolCache_ReaddMovesToTail(t *testing.T) {
 	assert.Equal(t, names[1], "alpha")
 }
 
-func TestRecentToolCache_SummaryPrefersMostRecentEntries(t *testing.T) {
-	mgr := newManagerWithCache(0)
-
-	oldTool := makeTool("older_tool", "older tool description",
-		aitool.WithStringParam("path"),
-	)
-	newTool := makeTool("newer_tool", strings.Repeat("newer tool description ", 40),
-		aitool.WithStringParam("payload"),
-		aitool.WithUsage(strings.Repeat("usage block ", 80)),
-	)
-
-	mgr.AddRecentlyUsedTool(oldTool)
-	mgr.AddRecentlyUsedTool(newTool)
-
-	summary := mgr.GetRecentToolsSummary(len("# Recently Used Tools (available for directly_call_tool)\n\n")+1, "recent")
-	assert.Check(t, strings.Contains(summary, "newer_tool"), "summary should keep the most recent tool when budget is tight")
-	assert.Check(t, !strings.Contains(summary, "older_tool"), "summary should drop older tools before newer ones")
-}
-
 func TestRecentToolCache_ActualToolSizes(t *testing.T) {
 	loadYakToolMetadata := func(name string, path string) int {
 		embedFS := yakscripttools.GetEmbedFS()
@@ -305,20 +209,4 @@ func TestRecentToolCache_ActualToolSizes(t *testing.T) {
 	assert.Check(t, combinedSize > bashSize, "combined metadata-backed cache size should exceed bash alone")
 	assert.Check(t, combinedSize > httpSize, "combined metadata-backed cache size should exceed do_http_request alone")
 	assert.Check(t, combinedSize < defaultRecentToolCacheMaxTokens, "bash + do_http_request metadata-backed cache size should fit in the token budget")
-}
-
-func TestRecentToolCache_SummaryFooterOnlyListsAITAGSupportedParams(t *testing.T) {
-	mgr := newManagerWithCache(0)
-	tool := makeTool("taggable_tool", "tool with mixed param names",
-		aitool.WithStringParam("command"),
-		aitool.WithStringParam("raw_content"),
-		aitool.WithStringParam("raw-content"),
-	)
-	mgr.AddRecentlyUsedTool(tool)
-
-	summary := mgr.GetRecentToolsSummary(0, "nonce")
-	assert.Check(t, strings.Contains(summary, "AITAG-capable params seen in cached tools:"), "footer should describe AITAG-capable params")
-	assert.Check(t, strings.Contains(summary, "- command"), "supported param should be listed")
-	assert.Check(t, strings.Contains(summary, "- raw_content"), "supported underscore param should be listed")
-	assert.Check(t, !strings.Contains(summary, "- raw-content"), "unsupported param names should be filtered from AITAG hints")
 }

--- a/common/ai/aid/test/config_ai_call_summary_test.go
+++ b/common/ai/aid/test/config_ai_call_summary_test.go
@@ -124,7 +124,7 @@ LOOP:
 					log.Errorf("failed to parse pressure event: %v", err)
 					continue
 				}
-				requiredFields := []string{"current_cost_token_size", "pressure_token_size", "model_tier"}
+				requiredFields := []string{"current_cost_token_size", "pressure_token_size", "model_tier", "caller_label"}
 				for _, field := range requiredFields {
 					if _, ok := data[field]; !ok {
 						t.Fatalf("pressure event missing '%s' field", field)

--- a/common/schema/ai_infra.go
+++ b/common/schema/ai_infra.go
@@ -46,10 +46,6 @@ type AIAgentRuntime struct {
 	// Used to restore skills across conversations within the same persistent session.
 	LoadedSkillNames string `json:"loaded_skill_names"`
 
-	// RecentToolsCache stores JSON-serialized recently-used tool entries for directly_call_tool.
-	// Persisted per persistent_session so that tools used in one conversation are available in the next.
-	RecentToolsCache string `json:"recent_tools_cache"`
-
 	// QuotedEvidence stores session-level evidence as quoted JSON (EvidenceStore).
 	// Persisted per persistent_session so that observations survive across loops and conversations.
 	QuotedEvidence string `json:"quoted_evidence"`

--- a/common/yakgrpc/yakit/ai_infra.go
+++ b/common/yakgrpc/yakit/ai_infra.go
@@ -113,10 +113,6 @@ func UpdateAIAgentRuntimeLoadedSkillNames(db *gorm.DB, persistentId string, skil
 	return db.Model(&schema.AIAgentRuntime{}).Where("persistent_session = ?", persistentId).Update("loaded_skill_names", skillNames).Error
 }
 
-func UpdateAIAgentRuntimeRecentToolsCache(db *gorm.DB, persistentId string, cacheJSON string) error {
-	return db.Model(&schema.AIAgentRuntime{}).Where("persistent_session = ?", persistentId).Update("recent_tools_cache", cacheJSON).Error
-}
-
 // UpdateAIAgentRuntimeUserInput updates the quoted_user_input field for an AIAgentRuntime by uuid.
 func UpdateAIAgentRuntimeUserInput(db *gorm.DB, uuid string, quotedInput string) error {
 	return db.Model(&schema.AIAgentRuntime{}).Where("uuid = ?", uuid).Update("quoted_user_input", quotedInput).Error


### PR DESCRIPTION
## Summary

- remove the legacy RecentToolsCache prompt/DB serialization path and restore execution authorization from Timeline promotion state
- add a prompt-only Timeline projector for system breadcrumbs while preserving raw Timeline, bucket topology, nonces, tool results, and DIRECT_CALL_PARAMS
- compact TODO prompt snapshots so active items keep full content while closed history renders only status counts and IDs
- make persistent Timeline ID reassignment deterministic so promoted sealed/pending state restores without collapsing or reordering entries
- replace full-session speed-priority prompt inheritance with a recent-Timeline projection and explicit per-field token budgets
- restore interval tool review to a dedicated bounded prompt: 2K recent Timeline and a 9K hard total limit
- bound lightweight ReAct, reflection, spin detection, and perception paths; expose caller_label in pressure telemetry

## Scope guards

- quality-priority main-loop prompt composition remains unchanged
- raw Timeline, Timeline UI, fork/diff/persistence, bucket boundaries, nonce, Seal and cache-control remain unchanged
- DIRECT_CALL_PARAMS remains unchanged
- no destructive database migration; legacy physical columns remain ignored

## Size regression

- oversized interval-review fixture: 5,142 tokens, with the newest fact retained and old Timeline excluded
- oversized lightweight-loop fixture: 15,577 tokens, with the newest fact retained and full Frozen Timeline excluded

## Tests

- go test ./common/ai/aid/aicommon
- go test ./common/ai/aid/aireact
- go test ./common/ai/aid/aireact/reactloops
- go test ./common/ai/aid/aitool/buildinaitools
- go test ./common/schema ./common/yakgrpc/yakit
- go test ./common/ai/aid/test -run TestCoordinator_AICallSummaryEvent
- promotion restore stress: 50 repeated runs
- persistent direct-call restore: 3 repeated runs