### PR TITLE
feat(aid): bound tool results and lightweight context

### DIFF
--- a/common/ai/aid/aicache/CACHE_BOUNDARY_GUIDE.md
+++ b/common/ai/aid/aicache/CACHE_BOUNDARY_GUIDE.md
@@ -543,6 +543,8 @@ func IsTongyiExplicitCacheModel(providerType, model string) bool  // tongyi + wh
 - [ ] **timeline 必须拆 frozen + open**: 用 `TimelineDumpFrozenOpen` 接口拿到
       frozen / open 字符串, 分别送进 `<|AI_CACHE_FROZEN_semi-dynamic|>` 与
       `<|PROMPT_SECTION_timeline-open|>`, 不要再用单一 `<|PROMPT_SECTION_timeline|>`
+      。例外：LiteForge 等一次性轻量 helper 只注入有硬上限的 recent Timeline，
+      不得为了 frozen cache 重复携带完整父会话历史
 - [ ] **时间戳必须分钟粒度**: `time.Now().Format("2006-01-02 15:04")`, 严禁用
       `time.Now().String()` (会带纳秒, 必然击穿 high-static / semi-dynamic 缓存)
 - [ ] **加 splitter 单测**: 至少 1 条 `TestSplit_<TemplateName>_*`, 断言
@@ -810,5 +812,4 @@ dynamic 段尺寸并提升缓存命中:
   本次 P2.1 不动; 若 cachebench 仍发现 finish 跳变是主要 churn 源, 再考虑
   把 `finish` 也保留 + ReactiveData 段加 "[do not use finish in this turn]"
   约束转移。先观察 P2.1 单点改动收益再决定。
-
 

--- a/common/ai/aid/aicache/CACHE_HIT_BENCHMARK.md
+++ b/common/ai/aid/aicache/CACHE_HIT_BENCHMARK.md
@@ -259,7 +259,7 @@ raw/noise 主要由 6 个无 wrapper 模板贡献:
 | --- | --- | --- |
 | schema / static instruction 在 high-static 段内 | 跨 forge high-static distinct=16 | 下移到 semi-dynamic, high-static 仅留 `# Preset` + `# Output Formatter` (`liteforge.go:367+`) |
 | `PersistentMemory` 用 `time.Now().String()` (纳秒) | semi-dynamic distinct=91 | 改为 `time.Now().Format("2006-01-02 15:04")` (`memory.go:395-405`) |
-| timeline 不拆 frozen + open | frozen 段每次失效 | 调 `RenderWithFrozenBoundary` 拆 frozen + open (`liteforge.go` + `TimelineDumpFrozenOpen`) |
+| LiteForge 继承完整父 Timeline | 轻模型输入随会话线性增长 | 仅注入有 4K token 硬上限的 recent Timeline；完整 frozen/open 只属于主循环 |
 | 调用方 INSTRUCTION 走 `WithLiteForge_Prompt` 进 dynamic | 静态指令每次重发 | 用 `WithLiteForge_StaticInstruction` 提到 semi-dynamic (各 forge 调用方迁移) |
 
 ### 9.4 P1-C: dynamic 段拆分 (回收主 React loop 9.46 MB)
@@ -637,4 +637,3 @@ prompt (timeline init 不再是瓶颈, AI 调用本身才是节奏决定因素).
 | --- | --- |
 | `common/ai/aid/aicache/cachebench/run_react.yak` | 新增 `--session-id` flag + 自动隔离 + 调用链注入 `aim.sessionID` |
 | `common/ai/aid/aicache/CACHE_HIT_BENCHMARK.md` | 9.10 节 (本节) |
-

--- a/common/ai/aid/aicache/cachebench/run_react.yak
+++ b/common/ai/aid/aicache/cachebench/run_react.yak
@@ -48,6 +48,8 @@ timeoutSec = cli.Int("timeout", cli.setDefault(60*20),
     cli.setHelp("aim.InvokeReAct 与单次 LLM 调用超时, 默认 1200 秒"))
 maxIter    = cli.Int("max-iteration", cli.setDefault(15),
     cli.setHelp("React 循环最大迭代次数"))
+disablePlan = cli.Bool("disable-plan",
+    cli.setHelp("关闭 plan/AIForge 入口，直接测 ReAct 主循环与轻量 helper（默认关闭）"))
 maxPrompts = cli.Int("max-prompts", cli.setDefault(0),
     cli.setHelp("收集到 N 次 LLM prompt usage 后立即 cancel context 提前退出 (0 = 不限制)"))
 // 关键词: cachebench max-intelligent-prompts, intelligent-only sample 截断
@@ -98,8 +100,8 @@ if sessionID == "" {
     sessionID = sprintf("cachebench-%d-%d", time.Now().Unix(), os.Getpid())
 }
 
-log.info("aicache cachebench - input=%s ai-type=%s session-id=%s max-iteration=%d max-prompts=%d max-intelligent-prompts=%d max-duration=%ds stall-timeout=%ds max-throttle-events=%d abort-on-fatal-error=%v fatal-error-threshold=%d",
-    inputText, aiType, sessionID, maxIter, maxPrompts, maxIntelligentPrompts, maxDuration, stallTimeout, maxThrottleEvents, abortOnFatalError, fatalErrorThreshold)
+log.info("aicache cachebench - input=%s ai-type=%s session-id=%s disable-plan=%v max-iteration=%d max-prompts=%d max-intelligent-prompts=%d max-duration=%ds stall-timeout=%ds max-throttle-events=%d abort-on-fatal-error=%v fatal-error-threshold=%d",
+    inputText, aiType, sessionID, disablePlan, maxIter, maxPrompts, maxIntelligentPrompts, maxDuration, stallTimeout, maxThrottleEvents, abortOnFatalError, fatalErrorThreshold)
 
 // =============================================================================
 // 取消上下文 (用于 max-prompts 限流 / max-duration 时间硬截断)
@@ -496,6 +498,7 @@ err = aim.InvokeReAct(
     aim.sessionID(sessionID),
     aim.timeout(timeoutSec),
     aim.maxIteration(maxIter),
+    aim.disableAIForge(disablePlan),
     aim.language(language),
     aim.yoloMode(),
     aim.allowUserInteract(false),
@@ -566,6 +569,7 @@ benchReport["durationSec"] = durationSec
 benchReport["aiType"] = aiType
 benchReport["aiModel"] = aiModel
 benchReport["maxIteration"] = maxIter
+benchReport["disablePlan"] = disablePlan
 benchReport["maxPrompts"] = maxPrompts
 benchReport["maxPromptsTriggered"] = maxPromptsTriggered
 benchReport["maxIntelligentPrompts"] = maxIntelligentPrompts

--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -3845,6 +3845,13 @@ func (c *Config) restorePersistentSession() {
 		}
 	}
 
+	// Historical Timeline entries may still contain the complete structured
+	// ToolExecutionResult. Once the original workdir is known, externalize those
+	// envelopes exactly once and persist the canonical bounded string Data.
+	if timelineInstance.migrateLegacyToolResults(c.GetOrCreateWorkDir()) {
+		timelineInstance.Save(c.GetDB(), c.PersistentSessionId)
+	}
+
 	// Restore loaded skill names from previous session
 	if runtime.LoadedSkillNames != "" {
 		names := strings.Split(runtime.LoadedSkillNames, ",")

--- a/common/ai/aid/aicommon/general_config.go
+++ b/common/ai/aid/aicommon/general_config.go
@@ -83,3 +83,15 @@ func (g *GeneralKVConfig) GetLiteForgeStaticInstruction() string {
 	}
 	return s
 }
+
+// GetLiteForgeDisableTimeline reports whether this one-shot LiteForge call has
+// already supplied all of the context it needs. These calls must not append the
+// parent session Timeline a second time.
+func (g *GeneralKVConfig) GetLiteForgeDisableTimeline() bool {
+	result, ok := g.config.Get("liteForgeDisableTimeline")
+	if !ok {
+		return false
+	}
+	disabled, _ := result.(bool)
+	return disabled
+}

--- a/common/ai/aid/aicommon/general_config_liteforge_test.go
+++ b/common/ai/aid/aicommon/general_config_liteforge_test.go
@@ -1,0 +1,12 @@
+package aicommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneralKVConfig_LiteForgeDisableTimeline(t *testing.T) {
+	require.False(t, NewGeneralKVConfig().GetLiteForgeDisableTimeline())
+	require.True(t, NewGeneralKVConfig(WithLiteForgeDisableTimeline()).GetLiteForgeDisableTimeline())
+}

--- a/common/ai/aid/aicommon/general_config_option.go
+++ b/common/ai/aid/aicommon/general_config_option.go
@@ -39,6 +39,15 @@ func WithLiteForgeStaticInstruction(s string) GeneralKVConfigOption {
 	}
 }
 
+// WithLiteForgeDisableTimeline prevents a LiteForge helper from automatically
+// appending recent parent Timeline context. Use it when the prompt already
+// contains a deliberately bounded task-specific trace.
+func WithLiteForgeDisableTimeline() GeneralKVConfigOption {
+	return func(c *GeneralKVConfig) {
+		c.config.Set("liteForgeDisableTimeline", true)
+	}
+}
+
 // StreamableFieldCallback is a callback function that handles streaming field data during LiteForge execution.
 // key: the field key that matches one of the monitored fields
 // r: io.Reader containing the streaming data for that field

--- a/common/ai/aid/aicommon/toolcall.go
+++ b/common/ai/aid/aicommon/toolcall.go
@@ -4,21 +4,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 	"io"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 
 	"github.com/segmentio/ksuid"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
@@ -1219,14 +1216,13 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 	stdoutBuffer := &toolOutputBuffer{}
 	stderrBuffer := &toolOutputBuffer{}
 
-	// combinedOutputBuffer captures stdout and stderr writes in real-time order,
-	// preserving the actual interleaving of output rather than concatenating
-	// stdout+stderr after the fact.
-	combinedOutputBuffer := &toolOutputBuffer{}
+	artifactBundle := t.newToolCallArtifactBundle(tool, callToolId, destinationIdentifier)
 
 	// Use MultiWriter to write to both the pipe (for streaming) and the buffers (for file saving)
-	stdoutMultiWriter := io.MultiWriter(stdoutWriter, stdoutBuffer, combinedOutputBuffer)
-	stderrMultiWriter := io.MultiWriter(stderrWriter, stderrBuffer, combinedOutputBuffer)
+	stdoutUIWriter := newBoundedToolUIWriter(stdoutWriter)
+	stderrUIWriter := newBoundedToolUIWriter(stderrWriter)
+	stdoutMultiWriter := io.MultiWriter(artifactBundle.Writer(artifactStdout), stdoutUIWriter, stdoutBuffer)
+	stderrMultiWriter := io.MultiWriter(artifactBundle.Writer(artifactStderr), stderrUIWriter, stderrBuffer)
 
 	waitToolStdFlush := t.emitter.EmitToolCallStd(tool.Name, stdoutReader, stderrReader, t.task.GetIndex())
 
@@ -1272,6 +1268,9 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 		tool, invokeParams, handleUserCancel, handleError,
 		stdoutMultiWriter, stderrMultiWriter,
 		stdoutBuffer, stderrBuffer,
+		func(result *aitool.ToolResult) error {
+			return artifactBundle.finalize(t, tool, callToolId, destinationIdentifier, invokeParams, result, paramGenDuration, rawAIParamResponse)
+		},
 	)
 	t.m.Lock()
 	if !pluginInvokeStartTime.IsZero() && pluginInvokeDuration <= 0 {
@@ -1287,8 +1286,11 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 				ToolCallID:  callToolId,
 			}
 		}
-		toolResult.Error = fmt.Sprintf("error invoking tool[%v]: %v", tool.Name, err)
+		if toolResult.Error == "" {
+			toolResult.Error = fmt.Sprintf("error invoking tool[%v]: %v", tool.Name, err)
+		}
 		toolResult.Success = false
+		enforceCanonicalToolResultLimit(toolResult)
 	}
 	if toolResult != nil {
 		toolResult.OmitParamsInTimeline = t.omitResultParamsInTimeline
@@ -1297,6 +1299,12 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 	// Close pipe writers to signal end of tool output. This triggers ThrottledCopy's
 	// final flush of any remaining buffered data. The deferred Close calls are still
 	// safe (bufpipe Close is idempotent).
+	if finishErr := stdoutUIWriter.Finish(); finishErr != nil {
+		log.Warnf("failed to flush bounded stdout tail: %v", finishErr)
+	}
+	if finishErr := stderrUIWriter.Finish(); finishErr != nil {
+		log.Warnf("failed to flush bounded stderr tail: %v", finishErr)
+	}
 	stdoutWriter.Close()
 	stderrWriter.Close()
 
@@ -1305,16 +1313,9 @@ func (t *ToolCaller) CallToolWithExistedParams(tool *aitool.Tool, presetParams b
 	// we emit the tool result event, preserving correct event ordering.
 	waitToolStdFlush()
 
-	// Save tool call report markdown (params, combined output, result merged into one file)
-	t.saveToolCallFiles(tool, callToolId, destinationIdentifier, invokeParams, combinedOutputBuffer, toolResult, paramGenDuration, rawAIParamResponse)
-
 	t.emitter.EmitInfo("start to generate and feedback tool[%v] result in task: %#v", tool.Name, t.task.GetName())
-	if toolResult.Data != nil {
-		toolExecutionResult, ok := toolResult.Data.(*aitool.ToolExecutionResult)
-		if ok {
-			t.emitter.EmitToolCallResult(callToolId, toolExecutionResult.Result)
-
-		}
+	if toolResult != nil && toolResult.Data != nil {
+		t.emitter.EmitToolCallResult(callToolId, toolResult.Data)
 	}
 
 	NotifySessionSnapshotToolCall(t.config, toolResult)
@@ -1343,210 +1344,6 @@ func isFastNoopContinueReview(ep *Endpoint, params aitool.InvokeParams, decidedA
 // markdownCodeFence is 10 backticks used as code fence in markdown to safely nest any content
 const markdownCodeFence = "``````````"
 
-func (t *ToolCaller) saveToolCallFiles(
-	tool *aitool.Tool,
-	callToolId string,
-	destinationIdentifier string,
-	params aitool.InvokeParams,
-	combinedOutputBuffer *toolOutputBuffer,
-	toolResult *aitool.ToolResult,
-	paramGenDuration time.Duration,
-	rawAIParamResponse string,
-) {
-	// Get workdir - try to get from config if it's a Config type
-	workdir := ""
-	if cfg, ok := t.config.(*Config); ok {
-		workdir = cfg.Workdir
-	}
-	if workdir == "" {
-		workdir = t.config.GetOrCreateWorkDir()
-	}
-	if workdir == "" {
-		workdir = consts.GetDefaultBaseHomeDir()
-	}
-
-	// Get task index and name for file naming
-	taskIndex := ""
-	taskName := ""
-	if t.task != nil {
-		taskIndex = t.task.GetIndex()
-		taskName = t.task.GetSemanticIdentifier()
-	}
-	if taskIndex == "" {
-		taskIndex = "0"
-	}
-
-	// Get tool call count for this task (number of previous tool calls + 1)
-	toolCallNumber := 1
-	if t.task != nil {
-		existingResults := t.task.GetAllToolCallResults()
-		toolCallNumber = len(existingResults) + 1
-	}
-
-	// Generate tool name (sanitized for filename)
-	toolName := sanitizeFilename(tool.Name)
-	if toolName == "" {
-		toolName = "unknown_tool"
-	}
-
-	// Build markdown filename: {n}_{toolName}_{identifier}.md
-	var mdFileName string
-	if destinationIdentifier != "" {
-		mdFileName = fmt.Sprintf("%d_%s_%s.md", toolCallNumber, toolName, destinationIdentifier)
-	} else {
-		mdFileName = fmt.Sprintf("%d_%s.md", toolCallNumber, toolName)
-	}
-
-	// Build full file path: task_{index}_{name}/tool_calls/{n}_{tool}_{id}.md
-	taskDirName := BuildTaskDirName(taskIndex, taskName)
-	toolCallsDir := filepath.Join(workdir, taskDirName, "tool_calls")
-	toolCallFilePath := filepath.Join(toolCallsDir, mdFileName)
-	t.emitter.EmitToolCallLogDir(callToolId, toolCallFilePath)
-
-	// Ensure tool_calls directory exists
-	if err := os.MkdirAll(toolCallsDir, 0755); err != nil {
-		log.Errorf("failed to create tool_calls directory %s: %v", toolCallsDir, err)
-		return
-	}
-
-	// Build the markdown report content
-	var md strings.Builder
-
-	// --- Header ---
-	md.WriteString(fmt.Sprintf("# Tool Call Report: %s\n\n", tool.Name))
-
-	// --- Basic Info ---
-	md.WriteString("## Basic Info\n\n")
-	md.WriteString(fmt.Sprintf("- **Tool**: %s\n", tool.Name))
-	md.WriteString(fmt.Sprintf("- **Task**: %s\n", taskIndex))
-	if destinationIdentifier != "" {
-		md.WriteString(fmt.Sprintf("- **Identifier**: %s\n", destinationIdentifier))
-	}
-	md.WriteString(fmt.Sprintf("- **Call ID**: %s\n", callToolId))
-	md.WriteString("\n")
-
-	// --- Parameters ---
-	md.WriteString("## Parameters\n\n")
-	if paramGenDuration > 0 {
-		md.WriteString(fmt.Sprintf("Parameter generation took **%.2fs**\n\n", paramGenDuration.Seconds()))
-	}
-
-	// Raw AI Response
-	md.WriteString("### Raw AI Response\n\n")
-	if rawAIParamResponse != "" {
-		md.WriteString(markdownCodeFence + "\n")
-		md.WriteString(rawAIParamResponse)
-		if !strings.HasSuffix(rawAIParamResponse, "\n") {
-			md.WriteString("\n")
-		}
-		md.WriteString(markdownCodeFence + "\n\n")
-	} else {
-		md.WriteString("(not available - preset params mode)\n\n")
-	}
-
-	// Parsed Parameters (YAML)
-	md.WriteString("### Parsed Parameters (YAML)\n\n")
-	md.WriteString(markdownCodeFence + "yaml\n")
-	md.WriteString(renderParamsAsYAML(params))
-	md.WriteString(markdownCodeFence + "\n\n")
-
-	// --- Execution Result ---
-	md.WriteString("## Execution Result\n\n")
-	resultText := extractResultHumanReadable(toolResult, t.emitter)
-	if len(resultText) > 100 {
-		md.WriteString(markdownCodeFence + "\n")
-		md.WriteString(resultText)
-		if !strings.HasSuffix(resultText, "\n") {
-			md.WriteString("\n")
-		}
-		md.WriteString(markdownCodeFence + "\n\n")
-	} else if resultText != "" {
-		md.WriteString(resultText + "\n\n")
-	} else {
-		md.WriteString("(empty)\n\n")
-	}
-
-	// --- COMBINED OUTPUT ---
-	md.WriteString("## OUTPUT\n\n")
-	combinedContent := combinedOutputBuffer.Bytes()
-	frameworkMsgPrefix := fmt.Sprintf("invoking tool[%s] ...\n", tool.Name)
-	if bytes.HasPrefix(combinedContent, []byte(frameworkMsgPrefix)) {
-		combinedContent = combinedContent[len(frameworkMsgPrefix):]
-	}
-	if len(combinedContent) > 0 {
-		// Shrink combined output if larger than 50KB, keeping 30KB total
-		// with head, tail, and a truncation notice pointing to the report file.
-		combinedStr := string(combinedContent)
-		if len(combinedStr) > 50*1024 {
-			combinedStr = shrinkCombinedOutput(combinedStr, 30*1024, toolCallFilePath)
-		}
-		md.WriteString(markdownCodeFence + "\n")
-		md.WriteString(combinedStr)
-		if !strings.HasSuffix(combinedStr, "\n") {
-			md.WriteString("\n")
-		}
-		md.WriteString(markdownCodeFence + "\n\n")
-	} else {
-		md.WriteString("(empty)\n\n")
-	}
-
-	// Write the single markdown file
-	if err := os.WriteFile(toolCallFilePath, []byte(md.String()), 0644); err != nil {
-		log.Errorf("failed to save tool call report file: %v", err)
-	} else {
-		t.emitter.EmitPinFilename(toolCallFilePath)
-		log.Infof("saved tool call report to file: %s", toolCallFilePath)
-	}
-}
-
-// shrinkCombinedOutput truncates combined output to approximately targetSize bytes,
-// keeping the head and tail portions and replacing the middle with a truncation
-// notice. The notice tells the user which portion was chunked and that the full
-// content can be found in the report file.
-//
-// targetSize is interpreted as a byte budget; the actual output may be slightly
-// larger due to rune-boundary alignment and the truncation notice.
-func shrinkCombinedOutput(content string, targetSize int, reportFilePath string) string {
-	if len(content) <= targetSize {
-		return content
-	}
-
-	runes := []rune(content)
-	// Reserve space for the truncation notice (~200 bytes)
-	noticeBudget := 200
-	contentBudget := targetSize - noticeBudget
-	if contentBudget < 200 {
-		contentBudget = 200
-	}
-
-	// Walk from the head accumulating runes until we reach ~half the content budget.
-	halfBudget := contentBudget / 2
-	headEnd := 0
-	headBytes := 0
-	for headEnd < len(runes) && headBytes+utf8.RuneLen(runes[headEnd]) <= halfBudget {
-		headBytes += utf8.RuneLen(runes[headEnd])
-		headEnd++
-	}
-
-	// Walk backwards from the tail accumulating runes until we reach ~half the content budget.
-	tailStart := len(runes)
-	tailBytes := 0
-	for tailStart > headEnd && tailBytes+utf8.RuneLen(runes[tailStart-1]) <= halfBudget {
-		tailBytes += utf8.RuneLen(runes[tailStart-1])
-		tailStart--
-	}
-
-	head := string(runes[:headEnd])
-	tail := string(runes[tailStart:])
-	chunkedBytes := len(content) - headBytes - tailBytes
-
-	notice := fmt.Sprintf(
-		"\n\n... (truncated: %d bytes in the middle were chunked, full output saved to: %s) ...\n\n",
-		chunkedBytes, reportFilePath,
-	)
-	return head + notice + tail
-}
-
 // renderParamsAsYAML renders InvokeParams as YAML for human-readable output.
 func renderParamsAsYAML(params aitool.InvokeParams) string {
 	if len(params) == 0 {
@@ -1558,60 +1355,6 @@ func renderParamsAsYAML(params aitool.InvokeParams) string {
 		return string(utils.Jsonify(params)) + "\n"
 	}
 	return string(yamlBytes)
-}
-
-// extractResultHumanReadable extracts tool result as human-readable text.
-// It handles large content saved in files and avoids raw JSON output.
-func extractResultHumanReadable(toolResult *aitool.ToolResult, emitter *Emitter) string {
-	if toolResult == nil {
-		return ""
-	}
-
-	// Try to get the original result from ToolExecutionResult
-	if toolResult.Data != nil {
-		toolExecutionResult, ok := toolResult.Data.(*aitool.ToolExecutionResult)
-		if ok && toolExecutionResult.Result != nil {
-			resultStr := utils.InterfaceToString(toolExecutionResult.Result)
-			// Check if result contains a file path (from handleLargeContent / buildSpillMarker).
-			// buildSpillMarker 格式为 "... saved to: <path>) ..."; 路径后紧跟 ")",
-			// 因此字符类必须排除 ")" 以免把括号捕获进路径导致 ReadFile 失败.
-			filePathRegex := regexp.MustCompile(`saved to: ([^()\s\n]+)`)
-			matches := filePathRegex.FindStringSubmatch(resultStr)
-			if len(matches) > 1 {
-				filePath := matches[1]
-				if fileContent, err := os.ReadFile(filePath); err == nil {
-					if emitter != nil {
-						emitter.EmitPinFilename(filePath)
-					}
-					log.Infof("found large result file from tool_invoke.go: %s, also emitting it", filePath)
-					return string(fileContent)
-				}
-				log.Warnf("failed to read large result file %s, using raw string", filePath)
-			}
-			return resultStr
-		}
-	}
-
-	// Fallback: build a readable summary from ToolResult fields
-	var buf strings.Builder
-	if toolResult.Name != "" {
-		buf.WriteString(fmt.Sprintf("Tool: %s\n", toolResult.Name))
-	}
-	if toolResult.Success {
-		buf.WriteString("Status: Success\n")
-	} else {
-		buf.WriteString("Status: Failed\n")
-	}
-	if toolResult.Error != "" {
-		buf.WriteString(fmt.Sprintf("Error: %s\n", toolResult.Error))
-	}
-	if toolResult.Data != nil {
-		dataStr := utils.InterfaceToString(toolResult.Data)
-		if dataStr != "" {
-			buf.WriteString(fmt.Sprintf("Data: %s\n", dataStr))
-		}
-	}
-	return buf.String()
 }
 
 func sanitizeFilename(name string) string {

--- a/common/ai/aid/aicommon/toolcall_artifact.go
+++ b/common/ai/aid/aicommon/toolcall_artifact.go
@@ -1,0 +1,781 @@
+package aicommon
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/ai/ytoken"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+const (
+	ToolResultTokenLimit       = 16 * 1024
+	toolResultHintReserve      = 1024
+	toolCapturePreviewBytes    = 256 * 1024
+	toolOutputSnapshotMaxBytes = 128 * 1024
+	toolUIStreamHeadBytes      = 12 * 1024
+	toolUIStreamTailBytes      = 4 * 1024
+)
+
+type boundedToolUIWriter struct {
+	mu         sync.Mutex
+	dst        io.Writer
+	headLeft   int
+	tail       []byte
+	tailLimit  int
+	suppressed int64
+}
+
+func newBoundedToolUIWriter(dst io.Writer) *boundedToolUIWriter {
+	return &boundedToolUIWriter{dst: dst, headLeft: toolUIStreamHeadBytes, tailLimit: toolUIStreamTailBytes}
+}
+
+func (w *boundedToolUIWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	originalLen := len(p)
+	if w.headLeft > 0 {
+		take := w.headLeft
+		if take > len(p) {
+			take = len(p)
+		}
+		if take > 0 {
+			if _, err := w.dst.Write(p[:take]); err != nil {
+				return 0, err
+			}
+			w.headLeft -= take
+			p = p[take:]
+		}
+	}
+	if len(p) > 0 {
+		w.suppressed += int64(len(p))
+		w.tail = append(w.tail, p...)
+		if len(w.tail) > w.tailLimit {
+			w.tail = append([]byte(nil), w.tail[len(w.tail)-w.tailLimit:]...)
+		}
+	}
+	return originalLen, nil
+}
+
+func (w *boundedToolUIWriter) Finish() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.suppressed == 0 {
+		return nil
+	}
+	omitted := w.suppressed - int64(len(w.tail))
+	marker := fmt.Sprintf("\n... [UI stream omitted %d middle bytes; complete output is in the tool artifact] ...\n", omitted)
+	if _, err := io.WriteString(w.dst, marker); err != nil {
+		return err
+	}
+	_, err := w.dst.Write(w.tail)
+	return err
+}
+
+type boundedHeadTailBuffer struct {
+	mu        sync.RWMutex
+	head      []byte
+	tail      []byte
+	total     int64
+	headLimit int
+	tailLimit int
+}
+
+func newBoundedHeadTailBuffer(limit int) *boundedHeadTailBuffer {
+	if limit < 2 {
+		limit = 2
+	}
+	return &boundedHeadTailBuffer{headLimit: limit / 2, tailLimit: limit - limit/2}
+}
+
+func (b *boundedHeadTailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := len(p)
+	b.total += int64(n)
+	if remain := b.headLimit - len(b.head); remain > 0 {
+		take := remain
+		if take > len(p) {
+			take = len(p)
+		}
+		b.head = append(b.head, p[:take]...)
+		p = p[take:]
+	}
+	if len(p) > 0 {
+		b.tail = append(b.tail, p...)
+		if len(b.tail) > b.tailLimit {
+			b.tail = append([]byte(nil), b.tail[len(b.tail)-b.tailLimit:]...)
+		}
+	}
+	return n, nil
+}
+
+func (b *boundedHeadTailBuffer) Snapshot() []byte {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.total <= int64(len(b.head)+len(b.tail)) {
+		return append(bytes.Clone(b.head), b.tail...)
+	}
+	omitted := b.total - int64(len(b.head)+len(b.tail))
+	marker := fmt.Sprintf("\n\n... [artifact preview omitted %d bytes from the middle] ...\n\n", omitted)
+	out := make([]byte, 0, len(b.head)+len(marker)+len(b.tail))
+	out = append(out, b.head...)
+	out = append(out, marker...)
+	out = append(out, b.tail...)
+	return out
+}
+
+func (b *boundedHeadTailBuffer) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return int(b.total)
+}
+
+type toolArtifactStream int
+
+const (
+	artifactStdout toolArtifactStream = iota
+	artifactStderr
+)
+
+type toolArtifactWriter struct {
+	bundle *toolCallArtifactBundle
+	stream toolArtifactStream
+}
+
+func (w toolArtifactWriter) Write(p []byte) (int, error) {
+	return w.bundle.writeStream(w.stream, p)
+}
+
+type artifactFileStats struct {
+	Path       string `json:"path"`
+	Bytes      int64  `json:"bytes"`
+	Tokens     int    `json:"tokens"`
+	Lines      int64  `json:"lines"`
+	SHA256     string `json:"sha256"`
+	Persistent bool   `json:"persistent"`
+}
+
+type toolCallArtifactManifest struct {
+	Tool       string                       `json:"tool"`
+	CallToolID string                       `json:"call_tool_id"`
+	Identifier string                       `json:"identifier,omitempty"`
+	Status     string                       `json:"status"`
+	Success    bool                         `json:"success"`
+	Error      string                       `json:"error,omitempty"`
+	Params     any                          `json:"params"`
+	CreatedAt  time.Time                    `json:"created_at"`
+	Files      map[string]artifactFileStats `json:"files"`
+}
+
+type toolCallArtifactBundle struct {
+	mu sync.Mutex
+
+	dir          string
+	reportPath   string
+	combinedPath string
+	stdoutPath   string
+	stderrPath   string
+	resultPath   string
+	manifestPath string
+
+	combined *os.File
+	stdout   *os.File
+	stderr   *os.File
+	preview  *boundedHeadTailBuffer
+	prepare  error
+	closed   bool
+}
+
+func (t *ToolCaller) newToolCallArtifactBundle(tool *aitool.Tool, callToolID, identifier string) *toolCallArtifactBundle {
+	b := &toolCallArtifactBundle{preview: newBoundedHeadTailBuffer(toolCapturePreviewBytes)}
+	workdir := ""
+	if cfg, ok := t.config.(*Config); ok {
+		workdir = cfg.Workdir
+	}
+	if workdir == "" {
+		workdir = t.config.GetOrCreateWorkDir()
+	}
+	if workdir == "" {
+		workdir = consts.GetDefaultBaseHomeDir()
+	}
+	taskIndex, taskName := "0", ""
+	if t.task != nil {
+		if t.task.GetIndex() != "" {
+			taskIndex = t.task.GetIndex()
+		}
+		taskName = t.task.GetSemanticIdentifier()
+	}
+	callNumber := 1
+	if t.task != nil {
+		callNumber = len(t.task.GetAllToolCallResults()) + 1
+	}
+	name := sanitizeFilename(tool.Name)
+	if name == "" {
+		name = "unknown_tool"
+	}
+	parts := []string{fmt.Sprintf("%d", callNumber), name}
+	if identifier != "" {
+		parts = append(parts, sanitizeFilename(identifier))
+	}
+	baseDir := filepath.Join(workdir, BuildTaskDirName(taskIndex, taskName), "tool_calls", strings.Join(parts, "_"))
+	b.dir, b.prepare = reserveToolArtifactDir(baseDir)
+	if b.prepare != nil {
+		return b
+	}
+	b.reportPath = filepath.Join(b.dir, "report.md")
+	b.combinedPath = filepath.Join(b.dir, "combined_output.txt")
+	b.stdoutPath = filepath.Join(b.dir, "stdout.txt")
+	b.stderrPath = filepath.Join(b.dir, "stderr.txt")
+	b.manifestPath = filepath.Join(b.dir, "manifest.json")
+	var err error
+	if b.combined, err = os.Create(b.combinedPath); err != nil {
+		b.prepare = err
+		return b
+	}
+	if b.stdout, err = os.Create(b.stdoutPath); err != nil {
+		b.prepare = err
+		b.closeStreams()
+		return b
+	}
+	if b.stderr, err = os.Create(b.stderrPath); err != nil {
+		b.prepare = err
+		b.closeStreams()
+		return b
+	}
+	return b
+}
+
+// reserveToolArtifactDir never reuses an existing bundle. This matters during
+// checkpoint replay: the caller prepares a bundle before it discovers the
+// stored result, and truncating the original artifact here would make the HINT
+// in the replayed Data point at destroyed files.
+func reserveToolArtifactDir(base string) (string, error) {
+	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
+		return base, err
+	}
+	for suffix := 1; suffix <= 10_000; suffix++ {
+		candidate := base
+		if suffix > 1 {
+			candidate = fmt.Sprintf("%s_%d", base, suffix)
+		}
+		if err := os.Mkdir(candidate, 0o755); err == nil {
+			return candidate, nil
+		} else if !os.IsExist(err) {
+			return candidate, err
+		}
+	}
+	return base, utils.Errorf("cannot reserve unique tool artifact directory: %s", base)
+}
+
+func (b *toolCallArtifactBundle) Writer(stream toolArtifactStream) io.Writer {
+	return toolArtifactWriter{bundle: b, stream: stream}
+}
+
+func (b *toolCallArtifactBundle) writeStream(stream toolArtifactStream, p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, _ = b.preview.Write(p)
+	if b.prepare != nil {
+		return len(p), nil
+	}
+	var target *os.File
+	if stream == artifactStderr {
+		target = b.stderr
+	} else {
+		target = b.stdout
+	}
+	if _, err := target.Write(p); err != nil {
+		b.prepare = err
+		return len(p), nil
+	}
+	if _, err := b.combined.Write(p); err != nil {
+		b.prepare = err
+	}
+	return len(p), nil
+}
+
+func (b *toolCallArtifactBundle) closeStreams() {
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for _, f := range []*os.File{b.combined, b.stdout, b.stderr} {
+		if f != nil {
+			if err := f.Close(); err != nil && b.prepare == nil {
+				b.prepare = err
+			}
+		}
+	}
+}
+
+func stableResultText(v any) (text, ext string) {
+	if v == nil {
+		return "", ".txt"
+	}
+	if s, ok := v.(string); ok {
+		return s, ".txt"
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err == nil {
+		return string(data), ".json"
+	}
+	return utils.InterfaceToString(v), ".txt"
+}
+
+func legacyExecutionParts(data any) (combined, stdout, stderr string, result any, ok bool) {
+	switch v := data.(type) {
+	case *aitool.ToolExecutionResult:
+		combined = v.CombinedOutput
+		stdout, stderr = v.Stdout, v.Stderr
+		if combined == "" {
+			if stdout != "" {
+				combined += "[STDOUT]\n" + stdout
+			}
+			if stderr != "" {
+				combined += "[STDERR]\n" + stderr
+			}
+		}
+		return combined, stdout, stderr, v.Result, true
+	case map[string]any:
+		// A plain structured tool result may also be a map containing a
+		// "result" field. Treat it as the legacy execution envelope only when
+		// at least one capture field identifies that envelope unambiguously.
+		_, hasCombined := v["combined_output"]
+		_, hasStdout := v["stdout"]
+		_, hasStderr := v["stderr"]
+		if !hasCombined && !hasStdout && !hasStderr {
+			return "", "", "", data, false
+		}
+		combined = utils.InterfaceToString(v["combined_output"])
+		stdout = utils.InterfaceToString(v["stdout"])
+		stderr = utils.InterfaceToString(v["stderr"])
+		if combined == "" {
+			if stdout != "" {
+				combined += "[STDOUT]\n" + stdout
+			}
+			if stderr != "" {
+				combined += "[STDERR]\n" + stderr
+			}
+		}
+		return combined, stdout, stderr, v["result"], true
+	default:
+		return "", "", "", data, false
+	}
+}
+
+func fileStats(path string) artifactFileStats {
+	st := artifactFileStats{Path: path}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return st
+	}
+	h := sha256.Sum256(data)
+	st.Bytes = int64(len(data))
+	st.Tokens = ytoken.CalcTokenCount(string(data))
+	st.Lines = int64(bytes.Count(data, []byte{'\n'}))
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		st.Lines++
+	}
+	st.SHA256 = hex.EncodeToString(h[:])
+	st.Persistent = true
+	return st
+}
+
+func toolArtifactHint(b *toolCallArtifactBundle, persistErr error) string {
+	if persistErr != nil || b == nil {
+		return fmt.Sprintf("HINT:\nComplete output could not be persisted (artifact_persist_failed: %v). This is a bounded preview; omitted content is unrecoverable.", persistErr)
+	}
+	return fmt.Sprintf(`HINT:
+Complete tool output is stored in artifacts:
+- combined output: %s
+- stdout: %s
+- stderr: %s
+- result: %s
+Use grep first, or read_file(file=%q, mode="lines", offset=..., lines=...).
+Do not load or cat the complete artifact unless necessary.`, b.combinedPath, b.stdoutPath, b.stderrPath, b.resultPath, b.combinedPath)
+}
+
+func shrinkBodyWithStats(body string, budget int) string {
+	if budget <= 0 {
+		return ""
+	}
+	tokens := ytoken.Encode(body)
+	if len(tokens) <= budget {
+		return body
+	}
+	marker := fmt.Sprintf("\n\n... [truncated %d tokens, %d bytes and %d lines from the middle; inspect artifacts from HINT] ...\n\n",
+		len(tokens)-budget, len(body), strings.Count(body, "\n"))
+	markerTokens := ytoken.CalcTokenCount(marker)
+	available := budget - markerTokens
+	if available <= 0 {
+		return ytoken.Decode(tokens[:budget])
+	}
+	head := available / 2
+	tail := available - head
+	return ytoken.Decode(tokens[:head]) + marker + ytoken.Decode(tokens[len(tokens)-tail:])
+}
+
+func normalizeToolResultData(toolResult *aitool.ToolResult, combined, resultText, hint string) {
+	if toolResult == nil {
+		return
+	}
+	// Data is the sole prompt representation after tool completion. Historical
+	// shrink fields must not bypass it during Timeline rendering.
+	toolResult.ShrinkResult = ""
+	toolResult.ShrinkSimilarResult = ""
+	if ytoken.CalcTokenCount(toolResult.CallExpectations) > toolResultHintReserve/2 {
+		toolResult.CallExpectations = ShrinkTextBlockByTokens(toolResult.CallExpectations, toolResultHintReserve/2)
+	}
+	if combined == "" {
+		combined = "(empty)"
+	}
+	if resultText == "" {
+		resultText = "(empty)"
+	}
+	if combined == resultText {
+		resultText = "[duplicate of COMBINED OUTPUT omitted]"
+	}
+	body := "COMBINED OUTPUT:\n" + combined + "\n\nRESULT:\n" + resultText
+	staticTokens := ytoken.CalcTokenCount("\n\n" + hint)
+	bodyBudget := ToolResultTokenLimit - toolResultHintReserve
+	if bodyBudget > ToolResultTokenLimit-staticTokens {
+		bodyBudget = ToolResultTokenLimit - staticTokens
+	}
+	if bodyBudget < 0 {
+		bodyBudget = 0
+	}
+
+	// An enormous error cannot be allowed to consume the whole Timeline item.
+	if ytoken.CalcTokenCount(toolResult.Error) > toolResultHintReserve {
+		toolResult.Error = ShrinkTextBlockByTokens(toolResult.Error, toolResultHintReserve)
+	}
+	toolResult.Data = shrinkBodyWithStats(body, bodyBudget) + "\n\n" + hint
+	if ytoken.CalcTokenCount(toolResult.Data.(string)) > ToolResultTokenLimit {
+		toolResult.Data = shrinkBodyWithStats(body, ToolResultTokenLimit-staticTokens) + "\n\n" + hint
+	}
+
+	enforceCanonicalToolResultLimit(toolResult)
+}
+
+// enforceCanonicalToolResultLimit is safe to call after finalize. The caller
+// can still attach a checkpoint/invocation error after Data was normalized; we
+// must not let that late outer error push the final Timeline item above 16K.
+func enforceCanonicalToolResultLimit(toolResult *aitool.ToolResult) {
+	if toolResult == nil {
+		return
+	}
+	if ytoken.CalcTokenCount(toolResult.Error) > toolResultHintReserve {
+		toolResult.Error = ShrinkTextBlockByTokens(toolResult.Error, toolResultHintReserve)
+	}
+	// Params remain on ToolResult for audit/checkpoint use, but an exceptionally
+	// large param block is omitted from Timeline rendering to preserve the same
+	// 16K hard ceiling as Data.
+	for attempts := 0; attempts < 8 && ytoken.CalcTokenCount(toolResult.String()) > ToolResultTokenLimit; attempts++ {
+		if !toolResult.OmitParamsInTimeline {
+			toolResult.OmitParamsInTimeline = true
+			continue
+		}
+		over := ytoken.CalcTokenCount(toolResult.String()) - ToolResultTokenLimit
+		data, ok := toolResult.Data.(string)
+		if !ok || data == "" {
+			break
+		}
+		hintIndex := strings.LastIndex(data, "\n\nHINT:\n")
+		if hintIndex < 0 {
+			break
+		}
+		body, hint := data[:hintIndex], data[hintIndex+2:]
+		bodyBudget := ytoken.CalcTokenCount(body) - over - 32
+		if bodyBudget < 0 {
+			bodyBudget = 0
+		}
+		toolResult.Data = shrinkBodyWithStats(body, bodyBudget) + "\n\n" + hint
+	}
+}
+
+func (b *toolCallArtifactBundle) finalize(
+	t *ToolCaller,
+	tool *aitool.Tool,
+	callToolID, identifier string,
+	params aitool.InvokeParams,
+	toolResult *aitool.ToolResult,
+	paramGenDuration time.Duration,
+	rawAIParamResponse string,
+) error {
+	if toolResult == nil {
+		return nil
+	}
+	if data, ok := toolResult.Data.(string); ok && strings.Contains(data, "COMBINED OUTPUT:\n") && strings.Contains(data, "\n\nRESULT:\n") && strings.Contains(data, "\n\nHINT:\n") {
+		// A current-format checkpoint already owns stable artifact paths. Do not
+		// wrap the preview again or rewrite its bytes during replay.
+		b.closeStreams()
+		for _, path := range []string{b.combinedPath, b.stdoutPath, b.stderrPath} {
+			if path != "" {
+				_ = os.Remove(path)
+			}
+		}
+		if b.dir != "" {
+			_ = os.Remove(b.dir)
+		}
+		return nil
+	}
+	b.closeStreams()
+	combined, legacyStdout, legacyStderr, rawResult, legacy := legacyExecutionParts(toolResult.Data)
+	if combined == "" {
+		combined = string(b.preview.Snapshot())
+	}
+	if !legacy && rawResult == nil {
+		rawResult = toolResult.Data
+	}
+	resultText, resultExt := stableResultText(rawResult)
+	b.resultPath = filepath.Join(b.dir, "result"+resultExt)
+
+	persistErr := b.prepare
+	if persistErr == nil {
+		if err := os.WriteFile(b.resultPath, []byte(resultText), 0o644); err != nil {
+			persistErr = err
+		}
+	}
+
+	// Legacy checkpoints contain their full combined output in Data rather than
+	// in the just-created stream files. Materialize that content exactly once.
+	if persistErr == nil && legacy {
+		if st, err := os.Stat(b.combinedPath); err == nil && st.Size() == 0 && combined != "" {
+			if err := os.WriteFile(b.combinedPath, []byte(combined), 0o644); err != nil {
+				persistErr = err
+			}
+		}
+		if st, err := os.Stat(b.stdoutPath); err == nil && st.Size() == 0 && legacyStdout != "" {
+			if err := os.WriteFile(b.stdoutPath, []byte(legacyStdout), 0o644); err != nil {
+				persistErr = err
+			}
+		}
+		if st, err := os.Stat(b.stderrPath); err == nil && st.Size() == 0 && legacyStderr != "" {
+			if err := os.WriteFile(b.stderrPath, []byte(legacyStderr), 0o644); err != nil {
+				persistErr = err
+			}
+		}
+	}
+
+	hint := toolArtifactHint(b, persistErr)
+	normalizeToolResultData(toolResult, combined, resultText, hint)
+	rawTokens := ytoken.CalcTokenCount(combined) + ytoken.CalcTokenCount(resultText)
+	if persistErr != nil && rawTokens > ToolResultTokenLimit {
+		toolResult.Success = false
+		if toolResult.Error != "" {
+			toolResult.Error += "; "
+		}
+		toolResult.Error += "artifact_persist_failed: complete oversized output is unavailable"
+		normalizeToolResultData(toolResult, combined, resultText, hint)
+		return persistErr
+	}
+	if persistErr != nil {
+		log.Warnf("tool artifact persistence failed for bounded result: %v", persistErr)
+		return nil
+	}
+
+	files := map[string]artifactFileStats{
+		"combined_output": fileStats(b.combinedPath),
+		"stdout":          fileStats(b.stdoutPath),
+		"stderr":          fileStats(b.stderrPath),
+		"result":          fileStats(b.resultPath),
+	}
+	manifest := toolCallArtifactManifest{
+		Tool:       tool.Name,
+		CallToolID: callToolID,
+		Identifier: identifier,
+		Status:     map[bool]string{true: "success", false: "failed"}[toolResult.Success],
+		Success:    toolResult.Success,
+		Error:      toolResult.Error,
+		Params:     params,
+		CreatedAt:  time.Now(),
+		Files:      files,
+	}
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err == nil {
+		err = os.WriteFile(b.manifestPath, manifestData, 0o644)
+	}
+	if err != nil {
+		return err
+	}
+
+	report := b.renderReport(tool, identifier, params, toolResult, paramGenDuration, rawAIParamResponse)
+	if err := os.WriteFile(b.reportPath, []byte(report), 0o644); err != nil {
+		return err
+	}
+	t.emitter.EmitToolCallLogDir(callToolID, b.reportPath)
+	t.emitter.EmitPinFilename(b.reportPath)
+	t.emitter.EmitPinFilename(b.dir)
+	log.Infof("saved tool call artifact bundle to: %s", b.dir)
+	return nil
+}
+
+func (b *toolCallArtifactBundle) renderReport(tool *aitool.Tool, identifier string, params aitool.InvokeParams, toolResult *aitool.ToolResult, paramGenDuration time.Duration, rawAIParamResponse string) string {
+	var md strings.Builder
+	md.WriteString(fmt.Sprintf("# Tool Call Report: %s\n\n", tool.Name))
+	md.WriteString("## Basic Info\n\n")
+	md.WriteString(fmt.Sprintf("- **Tool**: %s\n- **Call ID**: %s\n", tool.Name, toolResult.ToolCallID))
+	if identifier != "" {
+		md.WriteString(fmt.Sprintf("- **Identifier**: %s\n", identifier))
+	}
+	md.WriteString("\n## Parameters\n\n")
+	if paramGenDuration > 0 {
+		md.WriteString(fmt.Sprintf("Parameter generation took **%.2fs**\n\n", paramGenDuration.Seconds()))
+	}
+	if rawAIParamResponse != "" {
+		md.WriteString("### Raw AI Response\n\n" + markdownCodeFence + "\n" + ShrinkTextBlockByTokens(rawAIParamResponse, 2048) + "\n" + markdownCodeFence + "\n\n")
+	}
+	md.WriteString("### Parsed Parameters (YAML)\n\n" + markdownCodeFence + "yaml\n" + renderParamsAsYAML(params) + markdownCodeFence + "\n\n")
+	md.WriteString("## Execution Result Preview\n\n" + markdownCodeFence + "\n" + utils.InterfaceToString(toolResult.Data) + "\n" + markdownCodeFence + "\n\n")
+	md.WriteString("## Artifact Files\n\n")
+	md.WriteString(fmt.Sprintf("- [Combined output](%s)\n- [Stdout](%s)\n- [Stderr](%s)\n- [Result](%s)\n- [Manifest](%s)\n", b.combinedPath, b.stdoutPath, b.stderrPath, b.resultPath, b.manifestPath))
+	return md.String()
+}
+
+// migrateLegacyToolResults externalizes historical ToolExecutionResult
+// envelopes after a persistent Timeline has been restored and its workdir is
+// available. It deliberately leaves already-canonical string Data untouched.
+// The caller persists the Timeline once when this returns true.
+func (m *Timeline) migrateLegacyToolResults(workdir string) bool {
+	if m == nil || strings.TrimSpace(workdir) == "" {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	migrated := make(map[int64]*aitool.ToolResult)
+	m.idToTimelineItem.ForEach(func(id int64, item *TimelineItem) bool {
+		if item == nil {
+			return true
+		}
+		result, ok := item.value.(*aitool.ToolResult)
+		if !ok || result == nil {
+			return true
+		}
+		if !migrateLegacyTimelineToolResult(workdir, result) {
+			return true
+		}
+		migrated[id] = result
+		return true
+	})
+	if len(migrated) == 0 {
+		return false
+	}
+
+	// The serialized Timeline stores id and timestamp indexes separately, so
+	// JSON restore creates distinct TimelineItem pointers. Rebind the timestamp
+	// index to the migrated ToolResult to prevent the old envelope surviving in
+	// UI/diff paths that traverse that index.
+	m.tsToTimelineItem.ForEach(func(_ int64, item *TimelineItem) bool {
+		if item == nil {
+			return true
+		}
+		if result, ok := migrated[item.GetID()]; ok {
+			item.value = result
+		}
+		return true
+	})
+	return true
+}
+
+func migrateLegacyTimelineToolResult(workdir string, toolResult *aitool.ToolResult) bool {
+	combined, stdout, stderr, rawResult, legacy := legacyExecutionParts(toolResult.Data)
+	if !legacy {
+		return false
+	}
+
+	dir := filepath.Join(
+		workdir,
+		"task_legacy",
+		"tool_calls",
+		fmt.Sprintf("%d_%s_migrated", toolResult.ID, sanitizeFilename(toolResult.Name)),
+	)
+	b := &toolCallArtifactBundle{
+		dir:          dir,
+		reportPath:   filepath.Join(dir, "report.md"),
+		combinedPath: filepath.Join(dir, "combined_output.txt"),
+		stdoutPath:   filepath.Join(dir, "stdout.txt"),
+		stderrPath:   filepath.Join(dir, "stderr.txt"),
+		manifestPath: filepath.Join(dir, "manifest.json"),
+	}
+	resultText, resultExt := stableResultText(rawResult)
+	b.resultPath = filepath.Join(dir, "result"+resultExt)
+
+	var persistErr error
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		persistErr = err
+	}
+	for path, content := range map[string]string{
+		b.combinedPath: combined,
+		b.stdoutPath:   stdout,
+		b.stderrPath:   stderr,
+		b.resultPath:   resultText,
+	} {
+		if persistErr != nil {
+			break
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			persistErr = err
+		}
+	}
+
+	hint := toolArtifactHint(b, persistErr)
+	normalizeToolResultData(toolResult, combined, resultText, hint)
+	if persistErr != nil {
+		if ytoken.CalcTokenCount(combined)+ytoken.CalcTokenCount(resultText) > ToolResultTokenLimit {
+			toolResult.Success = false
+			if toolResult.Error != "" {
+				toolResult.Error += "; "
+			}
+			toolResult.Error += "artifact_persist_failed: historical oversized output is unavailable"
+			normalizeToolResultData(toolResult, combined, resultText, hint)
+		}
+		log.Warnf("failed to migrate legacy Timeline tool result %d: %v", toolResult.ID, persistErr)
+		return true
+	}
+
+	manifest := toolCallArtifactManifest{
+		Tool:       toolResult.Name,
+		CallToolID: toolResult.ToolCallID,
+		Identifier: "legacy-timeline-migration",
+		Status:     map[bool]string{true: "success", false: "failed"}[toolResult.Success],
+		Success:    toolResult.Success,
+		Error:      toolResult.Error,
+		Params:     toolResult.Param,
+		CreatedAt:  time.Now(),
+		Files: map[string]artifactFileStats{
+			"combined_output": fileStats(b.combinedPath),
+			"stdout":          fileStats(b.stdoutPath),
+			"stderr":          fileStats(b.stderrPath),
+			"result":          fileStats(b.resultPath),
+		},
+	}
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err == nil {
+		err = os.WriteFile(b.manifestPath, manifestData, 0o644)
+	}
+	if err == nil {
+		report := fmt.Sprintf(
+			"# Migrated Tool Call: %s\n\n## Execution Result Preview\n\n%s\n\n## Artifact Files\n\n- %s\n- %s\n- %s\n- %s\n- %s\n",
+			toolResult.Name, utils.InterfaceToString(toolResult.Data), b.combinedPath, b.stdoutPath, b.stderrPath, b.resultPath, b.manifestPath,
+		)
+		err = os.WriteFile(b.reportPath, []byte(report), 0o644)
+	}
+	if err != nil {
+		log.Warnf("legacy Timeline tool output migrated, but artifact index write failed for %d: %v", toolResult.ID, err)
+	}
+	return true
+}

--- a/common/ai/aid/aicommon/toolcall_artifact_test.go
+++ b/common/ai/aid/aicommon/toolcall_artifact_test.go
@@ -1,0 +1,412 @@
+package aicommon
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/ai/ytoken"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func oversizedToolFixture() (string, string) {
+	chunk := strings.Repeat("alpha beta gamma delta epsilon line-0123456789\n", 30000)
+	combined := "COMBINED-HEAD\n" + chunk + "COMBINED-MIDDLE-SENTINEL\n" + chunk + "COMBINED-TAIL\n"
+	result := "RESULT-HEAD\n" + chunk + "RESULT-MIDDLE-SENTINEL\n" + chunk + "RESULT-TAIL\n"
+	return combined, result
+}
+
+func TestNormalizeToolResultDataHardTokenLimit(t *testing.T) {
+	combined, result := oversizedToolFixture()
+	require.Greater(t, ytoken.CalcTokenCount(combined)+ytoken.CalcTokenCount(result), 200000)
+
+	toolResult := &aitool.ToolResult{
+		ID:      1,
+		Name:    "huge-output",
+		Param:   map[string]any{"query": "example"},
+		Success: true,
+	}
+	hint := "HINT:\nComplete tool output is stored in artifacts:\n- combined output: /tmp/artifacts/combined_output.txt\n- result: /tmp/artifacts/result.txt"
+	normalizeToolResultData(toolResult, combined, result, hint)
+
+	data, ok := toolResult.Data.(string)
+	require.True(t, ok)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(data), ToolResultTokenLimit)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
+	require.Greater(t, ytoken.CalcTokenCount(data), 14000, "preview should fill most of the 16K budget")
+	require.Contains(t, data, "COMBINED-HEAD")
+	require.Contains(t, data, "RESULT-TAIL")
+	require.Contains(t, data, hint)
+	require.NotContains(t, data, "COMBINED-MIDDLE-SENTINEL")
+	require.NotContains(t, data, "RESULT-MIDDLE-SENTINEL")
+}
+
+func TestToolResultOutputKindsOver200KTokens(t *testing.T) {
+	huge := "KIND-HEAD\n" + strings.Repeat("record-0123456789 alpha beta gamma delta\n", 25000) + "KIND-MIDDLE-SENTINEL\n" + strings.Repeat("record-9876543210 epsilon zeta eta theta\n", 25000) + "KIND-TAIL\n"
+	require.Greater(t, ytoken.CalcTokenCount(huge), 200000)
+	hint := "HINT:\nComplete tool output is stored in artifacts:\n- combined output: /tmp/tool/combined_output.txt\n- stdout: /tmp/tool/stdout.txt\n- stderr: /tmp/tool/stderr.txt\n- result: /tmp/tool/result.txt"
+
+	resultJSON, ext := stableResultText(map[string]any{"records": huge, "count": 50000})
+	require.Equal(t, ".json", ext)
+	cases := []struct {
+		name     string
+		combined string
+		result   string
+	}{
+		{name: "stdout", combined: "[STDOUT]\n" + huge},
+		{name: "stderr", combined: "[STDERR]\n" + huge},
+		{name: "stdout_stderr_interleaved", combined: "[STDOUT]\n" + huge[:len(huge)/2] + "[STDERR]\n" + huge[len(huge)/2:]},
+		{name: "result_string", result: huge},
+		{name: "result_json", result: resultJSON},
+		{name: "combined_and_result", combined: huge, result: huge + "RESULT-TAIL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			toolResult := &aitool.ToolResult{Name: tc.name, Success: true}
+			normalizeToolResultData(toolResult, tc.combined, tc.result, hint)
+			data := toolResult.Data.(string)
+			require.LessOrEqual(t, ytoken.CalcTokenCount(data), ToolResultTokenLimit)
+			require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
+			require.Contains(t, data, "HINT:")
+			require.NotContains(t, data, "KIND-MIDDLE-SENTINEL")
+		})
+	}
+}
+
+func TestNormalizeToolResultDataOmitsHugeTimelineParams(t *testing.T) {
+	toolResult := &aitool.ToolResult{
+		Name:    "huge-params",
+		Param:   map[string]any{"payload": strings.Repeat("unique-param-value-0123456789 ", 30000)},
+		Error:   strings.Repeat("large-error-0123456789 ", 5000),
+		Success: false,
+	}
+	normalizeToolResultData(toolResult, "small output", "small result", "HINT:\nartifact_persist_failed")
+	require.True(t, toolResult.OmitParamsInTimeline)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.Data.(string)), ToolResultTokenLimit)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
+}
+
+func TestLateInvocationErrorCannotPushTimelineItemOverLimit(t *testing.T) {
+	combined, result := oversizedToolFixture()
+	toolResult := &aitool.ToolResult{Name: "late-error", Success: true}
+	normalizeToolResultData(toolResult, combined, result, "HINT:\n- combined output: /tmp/late/combined_output.txt")
+	toolResult.Success = false
+	toolResult.Error = strings.Repeat("late-checkpoint-error-0123456789 ", 30000)
+
+	enforceCanonicalToolResultLimit(toolResult)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.Data.(string)), ToolResultTokenLimit)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
+	require.Contains(t, toolResult.Data.(string), "HINT:")
+}
+
+func TestToolArtifactCombinedOutputPreservesInterleaving(t *testing.T) {
+	dir := t.TempDir()
+	b := &toolCallArtifactBundle{
+		dir:          dir,
+		combinedPath: filepath.Join(dir, "combined_output.txt"),
+		stdoutPath:   filepath.Join(dir, "stdout.txt"),
+		stderrPath:   filepath.Join(dir, "stderr.txt"),
+		preview:      newBoundedHeadTailBuffer(toolCapturePreviewBytes),
+	}
+	var err error
+	b.combined, err = os.Create(b.combinedPath)
+	require.NoError(t, err)
+	b.stdout, err = os.Create(b.stdoutPath)
+	require.NoError(t, err)
+	b.stderr, err = os.Create(b.stderrPath)
+	require.NoError(t, err)
+
+	stdout := b.Writer(artifactStdout)
+	stderr := b.Writer(artifactStderr)
+	_, _ = ioWriteString(stdout, "out-1\n")
+	_, _ = ioWriteString(stderr, "err-1\n")
+	_, _ = ioWriteString(stdout, "out-2\n")
+	_, _ = ioWriteString(stderr, "err-2\n")
+	b.closeStreams()
+
+	combined, err := os.ReadFile(b.combinedPath)
+	require.NoError(t, err)
+	require.Equal(t, "out-1\nerr-1\nout-2\nerr-2\n", string(combined))
+	stdoutData, err := os.ReadFile(b.stdoutPath)
+	require.NoError(t, err)
+	require.Equal(t, "out-1\nout-2\n", string(stdoutData))
+	require.Equal(t, sha256.Sum256([]byte("out-1\nout-2\n")), sha256.Sum256(stdoutData))
+	stderrData, err := os.ReadFile(b.stderrPath)
+	require.NoError(t, err)
+	require.Equal(t, "err-1\nerr-2\n", string(stderrData))
+	require.Equal(t, sha256.Sum256([]byte("err-1\nerr-2\n")), sha256.Sum256(stderrData))
+}
+
+func ioWriteString(w interface{ Write([]byte) (int, error) }, s string) (int, error) {
+	return w.Write([]byte(s))
+}
+
+func TestBoundedToolUIWriterEmitsHeadMarkerAndTail(t *testing.T) {
+	var dst bytes.Buffer
+	w := newBoundedToolUIWriter(&dst)
+	raw := "HEAD-SENTINEL\n" + strings.Repeat("head-fill-", 2000) +
+		"OMITTED-MIDDLE-SENTINEL\n" + strings.Repeat("middle-fill-", 5000) + "\nTAIL-SENTINEL"
+	n, err := w.Write([]byte(raw))
+	require.NoError(t, err)
+	require.Equal(t, len(raw), n)
+	require.NoError(t, w.Finish())
+	out := dst.String()
+	require.Contains(t, out, "HEAD-SENTINEL")
+	require.Contains(t, out, "TAIL-SENTINEL")
+	require.Contains(t, out, "UI stream omitted")
+	require.NotContains(t, out, "OMITTED-MIDDLE-SENTINEL")
+	require.Less(t, len(out), len(raw)/2)
+}
+
+func TestStableResultTextJSON(t *testing.T) {
+	first, ext := stableResultText(map[string]any{"z": 1, "a": []any{"x", 2}})
+	second, secondExt := stableResultText(map[string]any{"a": []any{"x", 2}, "z": 1})
+	require.Equal(t, ".json", ext)
+	require.Equal(t, ext, secondExt)
+	require.Equal(t, first, second)
+}
+
+func TestLegacyCheckpointMapDecodesForArtifactMigration(t *testing.T) {
+	combined, stdout, stderr, result, ok := legacyExecutionParts(map[string]any{
+		"stdout":          "old-stdout",
+		"stderr":          "old-stderr",
+		"combined_output": "old-stdout\nold-stderr",
+		"result":          map[string]any{"status": "ok"},
+	})
+	require.True(t, ok)
+	require.Equal(t, "old-stdout\nold-stderr", combined)
+	require.Equal(t, "old-stdout", stdout)
+	require.Equal(t, "old-stderr", stderr)
+	require.Equal(t, map[string]any{"status": "ok"}, result)
+}
+
+func TestToolArtifactFinalizeReplacesDataAndPersistsRawFiles(t *testing.T) {
+	dir := t.TempDir()
+	events := make([]*schema.AiOutputEvent, 0)
+	emitter := NewEmitter("artifact-test", func(event *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+		events = append(events, event)
+		return event, nil
+	})
+	caller := &ToolCaller{emitter: emitter}
+	b := &toolCallArtifactBundle{
+		dir:          dir,
+		reportPath:   filepath.Join(dir, "report.md"),
+		combinedPath: filepath.Join(dir, "combined_output.txt"),
+		stdoutPath:   filepath.Join(dir, "stdout.txt"),
+		stderrPath:   filepath.Join(dir, "stderr.txt"),
+		manifestPath: filepath.Join(dir, "manifest.json"),
+		preview:      newBoundedHeadTailBuffer(toolCapturePreviewBytes),
+	}
+	var err error
+	b.combined, err = os.Create(b.combinedPath)
+	require.NoError(t, err)
+	b.stdout, err = os.Create(b.stdoutPath)
+	require.NoError(t, err)
+	b.stderr, err = os.Create(b.stderrPath)
+	require.NoError(t, err)
+
+	combined := "stdout-1\nstderr-1\nraw-middle-sentinel\nstdout-tail\n"
+	_, err = b.Writer(artifactStdout).Write([]byte("stdout-1\n"))
+	require.NoError(t, err)
+	_, err = b.Writer(artifactStderr).Write([]byte("stderr-1\nraw-middle-sentinel\n"))
+	require.NoError(t, err)
+	_, err = b.Writer(artifactStdout).Write([]byte("stdout-tail\n"))
+	require.NoError(t, err)
+	resultValue := map[string]any{"status": "ok", "items": []int{1, 2, 3}}
+	toolResult := &aitool.ToolResult{
+		Name:       "artifact-test-tool",
+		ToolCallID: "call-1",
+		Param:      aitool.InvokeParams{"query": "x"},
+		Success:    true,
+		Data:       &aitool.ToolExecutionResult{Result: resultValue},
+	}
+	tool, err := aitool.New("artifact-test-tool", aitool.WithSimpleCallback(func(aitool.InvokeParams, io.Writer, io.Writer) (any, error) { return nil, nil }))
+	require.NoError(t, err)
+	require.NoError(t, b.finalize(caller, tool, "call-1", "fixture", toolResult.Param.(aitool.InvokeParams), toolResult, 0, ""))
+
+	require.IsType(t, "", toolResult.Data)
+	require.Contains(t, toolResult.Data.(string), "HINT:")
+	require.Contains(t, toolResult.Data.(string), b.combinedPath)
+	raw, err := os.ReadFile(b.combinedPath)
+	require.NoError(t, err)
+	require.Equal(t, combined, string(raw))
+	require.Equal(t, sha256.Sum256([]byte(combined)), sha256.Sum256(raw))
+	require.FileExists(t, b.resultPath)
+	require.FileExists(t, b.manifestPath)
+	require.FileExists(t, b.reportPath)
+	require.NotEmpty(t, events)
+}
+
+func TestNormalizeToolResultDataDeduplicatesExactCombinedAndResult(t *testing.T) {
+	result := strings.Repeat("same-result-line\n", 100)
+	toolResult := &aitool.ToolResult{Name: "dedupe", Success: true}
+	normalizeToolResultData(toolResult, result, result, "HINT:\n/path")
+	data := toolResult.Data.(string)
+	require.Equal(t, 1, strings.Count(data, result))
+	require.Contains(t, data, "duplicate of COMBINED OUTPUT")
+}
+
+func TestToolArtifactFailureNeverFallsBackToOversizedInlineData(t *testing.T) {
+	combined, result := oversizedToolFixture()
+	b := &toolCallArtifactBundle{
+		prepare: fmt.Errorf("disk unavailable"),
+		preview: newBoundedHeadTailBuffer(toolCapturePreviewBytes),
+	}
+	_, _ = b.preview.Write([]byte(combined))
+	toolResult := &aitool.ToolResult{
+		Name:    "artifact-failure",
+		Success: true,
+		Data:    &aitool.ToolExecutionResult{Result: result},
+	}
+	tool, err := aitool.New("artifact-failure", aitool.WithSimpleCallback(func(aitool.InvokeParams, io.Writer, io.Writer) (any, error) { return nil, nil }))
+	require.NoError(t, err)
+	err = b.finalize(&ToolCaller{}, tool, "call-failure", "", nil, toolResult, 0, "")
+	require.Error(t, err)
+	require.False(t, toolResult.Success)
+	require.Contains(t, toolResult.Error, "artifact_persist_failed")
+	require.Contains(t, toolResult.Data.(string), "artifact_persist_failed")
+	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.Data.(string)), ToolResultTokenLimit)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
+	require.NotContains(t, toolResult.Data.(string), "COMBINED-MIDDLE-SENTINEL")
+}
+
+func TestSmallToolResultCanContinueWhenArtifactPersistenceFails(t *testing.T) {
+	b := &toolCallArtifactBundle{
+		prepare: fmt.Errorf("disk unavailable"),
+		preview: newBoundedHeadTailBuffer(toolCapturePreviewBytes),
+	}
+	_, _ = b.preview.Write([]byte("small combined output"))
+	toolResult := &aitool.ToolResult{
+		Name:    "small-artifact-failure",
+		Success: true,
+		Data:    &aitool.ToolExecutionResult{Result: "small result"},
+	}
+	tool, err := aitool.New("small-artifact-failure", aitool.WithSimpleCallback(func(aitool.InvokeParams, io.Writer, io.Writer) (any, error) { return nil, nil }))
+	require.NoError(t, err)
+	require.NoError(t, b.finalize(&ToolCaller{}, tool, "call-small-failure", "", nil, toolResult, 0, ""))
+	require.True(t, toolResult.Success)
+	require.Contains(t, toolResult.Data.(string), "small combined output")
+	require.Contains(t, toolResult.Data.(string), "small result")
+	require.Contains(t, toolResult.Data.(string), "artifact_persist_failed")
+}
+
+func TestCurrentCheckpointReplayKeepsCompactedDataByteStable(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tool_calls", "1_replay")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	b := &toolCallArtifactBundle{
+		dir:          dir,
+		combinedPath: filepath.Join(dir, "combined_output.txt"),
+		stdoutPath:   filepath.Join(dir, "stdout.txt"),
+		stderrPath:   filepath.Join(dir, "stderr.txt"),
+		preview:      newBoundedHeadTailBuffer(toolCapturePreviewBytes),
+	}
+	var err error
+	b.combined, err = os.Create(b.combinedPath)
+	require.NoError(t, err)
+	b.stdout, err = os.Create(b.stdoutPath)
+	require.NoError(t, err)
+	b.stderr, err = os.Create(b.stderrPath)
+	require.NoError(t, err)
+	original := "COMBINED OUTPUT:\npreview\n\nRESULT:\nresult\n\nHINT:\n- combined output: /stable/original/path"
+	toolResult := &aitool.ToolResult{Name: "replay", Success: true, Data: original}
+	tool, err := aitool.New("replay", aitool.WithSimpleCallback(func(aitool.InvokeParams, io.Writer, io.Writer) (any, error) { return nil, nil }))
+	require.NoError(t, err)
+	require.NoError(t, b.finalize(&ToolCaller{}, tool, "replay-call", "", nil, toolResult, 0, ""))
+	require.Equal(t, original, toolResult.Data)
+	_, err = os.Stat(dir)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestReserveToolArtifactDirNeverOverwritesExistingBundle(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "tool_calls", "1_replay")
+	require.NoError(t, os.MkdirAll(base, 0o755))
+	original := filepath.Join(base, "combined_output.txt")
+	require.NoError(t, os.WriteFile(original, []byte("original-artifact"), 0o644))
+
+	reserved, err := reserveToolArtifactDir(base)
+	require.NoError(t, err)
+	require.Equal(t, base+"_2", reserved)
+	content, err := os.ReadFile(original)
+	require.NoError(t, err)
+	require.Equal(t, "original-artifact", string(content))
+}
+
+func TestArtifactFileStatsCountsFinalLineWithoutNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "result.txt")
+	require.NoError(t, os.WriteFile(path, []byte("one\ntwo"), 0o644))
+	require.EqualValues(t, 2, fileStats(path).Lines)
+}
+
+func TestLegacyTimelineToolResultMigratesToArtifactAndCanonicalData(t *testing.T) {
+	workdir := t.TempDir()
+	huge := "LEGACY-HEAD\n" + strings.Repeat("legacy-record alpha beta gamma\n", 30000) + "LEGACY-MIDDLE-SENTINEL\n" + strings.Repeat("legacy-tail-record delta epsilon\n", 30000) + "LEGACY-TAIL\n"
+	timeline := NewTimeline(nil, nil)
+	timeline.PushToolResult(&aitool.ToolResult{
+		ID:      77,
+		Name:    "legacy/tool",
+		Success: true,
+		Data: &aitool.ToolExecutionResult{
+			Stdout:         huge,
+			CombinedOutput: huge,
+			Result:         map[string]any{"status": "ok", "tail": "result-tail"},
+		},
+	})
+
+	serialized, err := MarshalTimeline(timeline)
+	require.NoError(t, err)
+	restored, err := UnmarshalTimeline(serialized)
+	require.NoError(t, err)
+	require.True(t, restored.migrateLegacyToolResults(workdir))
+	require.False(t, restored.migrateLegacyToolResults(workdir), "canonical Data must not bootstrap twice")
+
+	item, ok := restored.idToTimelineItem.Get(77)
+	require.True(t, ok)
+	result := item.GetValue().(*aitool.ToolResult)
+	data, ok := result.Data.(string)
+	require.True(t, ok)
+	require.Contains(t, data, "COMBINED OUTPUT:\nLEGACY-HEAD")
+	require.Contains(t, data, "result-tail")
+	require.Contains(t, data, "HINT:\nComplete tool output is stored in artifacts:")
+	require.NotContains(t, data, "LEGACY-MIDDLE-SENTINEL")
+	require.LessOrEqual(t, ytoken.CalcTokenCount(data), ToolResultTokenLimit)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(result.String()), ToolResultTokenLimit)
+
+	bundleDir := filepath.Join(workdir, "task_legacy", "tool_calls", "77_legacy_tool_migrated")
+	rawCombined, err := os.ReadFile(filepath.Join(bundleDir, "combined_output.txt"))
+	require.NoError(t, err)
+	require.Equal(t, huge, string(rawCombined))
+	require.FileExists(t, filepath.Join(bundleDir, "stdout.txt"))
+	require.FileExists(t, filepath.Join(bundleDir, "stderr.txt"))
+	require.FileExists(t, filepath.Join(bundleDir, "result.json"))
+	require.FileExists(t, filepath.Join(bundleDir, "manifest.json"))
+	require.FileExists(t, filepath.Join(bundleDir, "report.md"))
+
+	var timestampValue *aitool.ToolResult
+	restored.tsToTimelineItem.ForEach(func(_ int64, timelineItem *TimelineItem) bool {
+		if timelineItem.GetID() == 77 {
+			timestampValue = timelineItem.GetValue().(*aitool.ToolResult)
+		}
+		return true
+	})
+	require.Same(t, result, timestampValue, "all restored Timeline indexes must share the migrated value")
+
+	remarshaled, err := MarshalTimeline(restored)
+	require.NoError(t, err)
+	require.NotContains(t, remarshaled, "LEGACY-MIDDLE-SENTINEL")
+}
+
+func BenchmarkNormalizeToolResultData200KTokens(b *testing.B) {
+	combined, result := oversizedToolFixture()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		toolResult := &aitool.ToolResult{Name: fmt.Sprintf("bench-%d", i), Success: true}
+		normalizeToolResultData(toolResult, combined, result, "HINT:\n/tmp/artifact")
+	}
+}

--- a/common/ai/aid/aicommon/toolcall_invoke.go
+++ b/common/ai/aid/aicommon/toolcall_invoke.go
@@ -1,7 +1,6 @@
 package aicommon
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -29,20 +28,28 @@ const (
 )
 
 type toolOutputBuffer struct {
-	mu  sync.RWMutex
-	buf bytes.Buffer
+	mu      sync.Mutex
+	sampler *boundedHeadTailBuffer
 }
 
 func (b *toolOutputBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.Write(p)
+	if b.sampler == nil {
+		b.sampler = newBoundedHeadTailBuffer(toolOutputSnapshotMaxBytes)
+	}
+	sampler := b.sampler
+	b.mu.Unlock()
+	return sampler.Write(p)
 }
 
 func (b *toolOutputBuffer) Snapshot() []byte {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	return bytes.Clone(b.buf.Bytes())
+	b.mu.Lock()
+	sampler := b.sampler
+	b.mu.Unlock()
+	if sampler == nil {
+		return nil
+	}
+	return sampler.Snapshot()
 }
 
 func (b *toolOutputBuffer) Bytes() []byte {
@@ -50,9 +57,13 @@ func (b *toolOutputBuffer) Bytes() []byte {
 }
 
 func (b *toolOutputBuffer) Len() int {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	return b.buf.Len()
+	b.mu.Lock()
+	sampler := b.sampler
+	b.mu.Unlock()
+	if sampler == nil {
+		return 0
+	}
+	return sampler.Len()
 }
 
 func staticSnapshot(snapshot []byte) func() []byte {
@@ -143,14 +154,28 @@ func (a *ToolCaller) invoke(
 	reportError func(err any),
 	stdoutWriter, stderrWriter io.Writer,
 	stdoutSnapshotBuffer, stderrSnapshotBuffer *toolOutputBuffer,
+	finalizeResults ...func(*aitool.ToolResult) error,
 ) (*aitool.ToolResult, error) {
 	c := a.config
 	e := a.emitter
+	var finalizeResult func(*aitool.ToolResult) error
+	if len(finalizeResults) > 0 {
+		finalizeResult = finalizeResults[0]
+	}
 
 	seq := c.AcquireId()
 	if ret, ok := yakit.GetToolCallCheckpoint(c.GetDB(), c.GetRuntimeId(), seq); ok {
 		if ret.Finished {
-			return aiddb.AiCheckPointGetToolResult(ret), nil
+			res := aiddb.AiCheckPointGetToolResult(ret)
+			if finalizeResult != nil && res != nil {
+				if err := finalizeResult(res); err != nil {
+					return res, err
+				}
+				if err := c.SubmitCheckpointResponse(ret, res); err != nil {
+					return res, err
+				}
+			}
+			return res, nil
 		}
 	}
 	toolCheckpoint := c.CreateToolCallCheckpoint(seq)
@@ -195,10 +220,6 @@ func (a *ToolCaller) invoke(
 		res := newToolCallRes()
 		res.Success = true
 		res.Data = result
-		err = c.SubmitCheckpointResponse(toolCheckpoint, res)
-		if err != nil {
-			return nil, err
-		}
 		return res, nil
 	}
 
@@ -233,8 +254,6 @@ func (a *ToolCaller) invoke(
 	if noRuntimeId {
 		params.Set("runtime_id", a.runtimeId)
 	}
-
-	stdoutWriter.Write([]byte(fmt.Sprintf("invoking tool[%v] ...\n", tool.Name))) // 确保触发执行卡片，优化体验
 
 	log.Infof("start to invoke tool[%s] with params: %v", tool.Name, params)
 
@@ -302,29 +321,29 @@ func (a *ToolCaller) invoke(
 		RuntimeID:             a.callToolId,
 		BrowserSessionTracker: browserTracker,
 		FeedBacker: func(result *ypb.ExecResult) error {
-				// 处理 risk 消息
-				risk, _ := handleRiskMessage(result)
-				if risk != nil {
-					e.EmitYakitRisk(risk.ID, risk.Title, risk.RuntimeId)
-					boundRisksMu.Lock()
-					boundRisks = append(boundRisks, risk)
-					boundRisksMu.Unlock()
-				}
-				httpFlow, _ := handleHTTPFlowMessage(result)
-				if httpFlow != nil {
-					e.EmitYakitHTTPFlow(httpFlow.RuntimeId, httpFlow.HiddenIndex)
-					return nil
-				}
-				if path, ok := handleFileWriteMessage(result); ok {
-					NotifySessionSnapshotFileWrite(a.config, path)
-				}
-				// 过滤文件 Stat/Read 等高频消息，避免对前端造成压力
-				if shouldIgnoreExecResultForEmit(result) {
-					return nil
-				}
-				e.EmitYakitExecResult(result)
+			// 处理 risk 消息
+			risk, _ := handleRiskMessage(result)
+			if risk != nil {
+				e.EmitYakitRisk(risk.ID, risk.Title, risk.RuntimeId)
+				boundRisksMu.Lock()
+				boundRisks = append(boundRisks, risk)
+				boundRisksMu.Unlock()
+			}
+			httpFlow, _ := handleHTTPFlowMessage(result)
+			if httpFlow != nil {
+				e.EmitYakitHTTPFlow(httpFlow.RuntimeId, httpFlow.HiddenIndex)
 				return nil
-			},
+			}
+			if path, ok := handleFileWriteMessage(result); ok {
+				NotifySessionSnapshotFileWrite(a.config, path)
+			}
+			// 过滤文件 Stat/Read 等高频消息，避免对前端造成压力
+			if shouldIgnoreExecResultForEmit(result) {
+				return nil
+			}
+			e.EmitYakitExecResult(result)
+			return nil
+		},
 	}
 	execResult, execErr := tool.InvokeWithParams(
 		params,
@@ -335,7 +354,26 @@ func (a *ToolCaller) invoke(
 		aitool.WithResultCallback(toolCallSuccess),
 		aitool.WithCancelCallback(toolCallCancel),
 		aitool.WithRuntimeConfig(runtimeCfg),
+		aitool.WithOutputCapture(false),
 	)
+	if execResult != nil && finalizeResult != nil {
+		if finalizeErr := finalizeResult(execResult); finalizeErr != nil {
+			if execErr == nil {
+				execErr = finalizeErr
+			} else {
+				execErr = errors.Join(execErr, finalizeErr)
+			}
+		}
+	}
+	if execResult != nil {
+		if checkpointErr := c.SubmitCheckpointResponse(toolCheckpoint, execResult); checkpointErr != nil {
+			if execErr == nil {
+				execErr = checkpointErr
+			} else {
+				execErr = errors.Join(execErr, checkpointErr)
+			}
+		}
+	}
 
 	// 工具调用结束、runtime 已绑定漏洞之后, 异步提交 risk_feedback 价值反馈 (AI 自判).
 	// 这是对 cybersecurity-risk 等 "报漏洞" 工具插件的通用埋点, 与 loop 内 generate_risk

--- a/common/ai/aid/aicommon/value_feedback.go
+++ b/common/ai/aid/aicommon/value_feedback.go
@@ -43,7 +43,22 @@ const (
 	// "该漏洞是否为误报" 的反馈. 误报信号可来自 AI 自判 (source=model_judge) 或
 	// 人工确认 (source=human), 由 RiskFeedback.Source 区分.
 	ValueFeedbackTriggerRiskFeedback = "risk_feedback"
+
+	// ValueFeedbackRecentTimelineTokens bounds the trace sent to the
+	// speed-priority value evaluator. Value feedback is emitted repeatedly
+	// during a session, so using Timeline.Dump here makes every lightweight
+	// request grow with the entire session and eventually creates the periodic
+	// context spikes it is meant to observe. The persisted Timeline remains
+	// complete; only this evaluator projection is recent-only.
+	ValueFeedbackRecentTimelineTokens = 2048
 )
+
+func recentTimelineForValueFeedback(timeline *Timeline) string {
+	if timeline == nil {
+		return ""
+	}
+	return timeline.DumpRecentForPrompt(ValueFeedbackRecentTimelineTokens)
+}
 
 // ValueFeedbackAction 是一次动作的轻量表示 (避免 aicommon 反向依赖 reactloops
 // 的 ActionRecord). 由上层把 ActionRecord 转换成该结构填入.
@@ -59,20 +74,20 @@ type ValueFeedbackAction struct {
 // 的依据是 source=human, 而非 execution_policy.
 const (
 	ApprovalSourceHuman           = "human"            // 真人工裁决
-	ApprovalSourcePolicy          = "policy"            // 策略自动放行 (yolo/auto)
-	ApprovalSourceModelJudge      = "model_judge"       // AI 风控/助手判定
-	ApprovalSourceRule            = "rule"              // 规则判定
-	ApprovalSourceTimeoutFallback = "timeout_fallback"  // 超时兜底放行
+	ApprovalSourcePolicy          = "policy"           // 策略自动放行 (yolo/auto)
+	ApprovalSourceModelJudge      = "model_judge"      // AI 风控/助手判定
+	ApprovalSourceRule            = "rule"             // 规则判定
+	ApprovalSourceTimeoutFallback = "timeout_fallback" // 超时兜底放行
 )
 
 // approval.decision 枚举: 描述审批的客观结果.
 const (
-	ApprovalDecisionApprove        = "approve"           // 同意 (未改参数)
+	ApprovalDecisionApprove         = "approve"           // 同意 (未改参数)
 	ApprovalDecisionApproveWithEdit = "approve_with_edit" // 同意但修改了参数
-	ApprovalDecisionReject         = "reject"            // 拒绝
-	ApprovalDecisionCancel         = "cancel"            // 取消 (无最终参数)
-	ApprovalDecisionTimeout        = "timeout"           // 超时
-	ApprovalDecisionNotRequired    = "not_required"      // 无需审批 (策略自动放行)
+	ApprovalDecisionReject          = "reject"            // 拒绝
+	ApprovalDecisionCancel          = "cancel"            // 取消 (无最终参数)
+	ApprovalDecisionTimeout         = "timeout"           // 超时
+	ApprovalDecisionNotRequired     = "not_required"      // 无需审批 (策略自动放行)
 )
 
 // ValueFeedbackApproval 描述一次审批决策 (记录事实, 不预先下训练标签).
@@ -361,7 +376,7 @@ func (c *Config) submitReviewValueFeedback(ep *Endpoint, focusMode, reviewQuesti
 		UserQuery: c.firstUserQuery(),
 	}
 	if c.Timeline != nil {
-		record.TimelineDump = c.Timeline.Dump()
+		record.TimelineDump = recentTimelineForValueFeedback(c.Timeline)
 	}
 	SubmitValueFeedback(c, record)
 }
@@ -444,7 +459,7 @@ func (c *Config) SubmitToolRiskFeedback(focusMode string, risks []*schema.Risk) 
 		},
 	}
 	if c.Timeline != nil {
-		record.TimelineDump = c.Timeline.Dump()
+		record.TimelineDump = recentTimelineForValueFeedback(c.Timeline)
 	}
 	SubmitValueFeedback(c, record)
 }

--- a/common/ai/aid/aicommon/value_feedback_timeline_test.go
+++ b/common/ai/aid/aicommon/value_feedback_timeline_test.go
@@ -1,0 +1,20 @@
+package aicommon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecentTimelineForValueFeedbackIsBoundedAndKeepsNewestFacts(t *testing.T) {
+	timeline := NewTimeline(nil, nil)
+	timeline.PushText(1, "[note]:\nANCIENT_VALUE_FEEDBACK_FACT "+strings.Repeat("old-payload ", 12000))
+	timeline.PushText(2, "[note]:\nRECENT_VALUE_FEEDBACK_FACT")
+
+	projected := recentTimelineForValueFeedback(timeline)
+	require.LessOrEqual(t, MeasureTokens(projected), ValueFeedbackRecentTimelineTokens)
+	require.Contains(t, projected, "RECENT_VALUE_FEEDBACK_FACT")
+	require.NotContains(t, projected, "ANCIENT_VALUE_FEEDBACK_FACT")
+	require.Len(t, timeline.GetTimelineItemIDs(), 2, "projection must not delete source Timeline items")
+}

--- a/common/ai/aid/aimem/aimemory_build_memory.go
+++ b/common/ai/aid/aimem/aimemory_build_memory.go
@@ -1,13 +1,9 @@
 package aimem
 
-// TODO: migrate to AssembleLoopPrompt for prefix cache reuse
-//
-// AddRawText 仍走老的 GetBasicPromptInfo + aireact/prompts/base/base.txt 路径,
-// 是当前 aireact 中唯一一处未接入 aicommon.NewDefaultPromptPrefixBuilder 5 段
-// prefix cache 的入口。后续应改造为复用 AssembleLoopPrompt, 让 memory triage
-// 也能命中跨 turn 的 prefix cache。
-//
-// 关键词: aimem 老路径迁移, AssembleLoopPrompt, prefix cache 复用, 待治理
+// Memory triage intentionally does not embed the main ReAct base prompt. The
+// triage instruction below is self-contained; importing GetBasicPromptInfo
+// used to duplicate the complete tool inventory and session Timeline in every
+// speed-priority request.
 
 import (
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
@@ -20,21 +16,19 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 )
 
+// Memory triage extracts durable facts from a Timeline delta. It does not need
+// an entire oversized tool preview to make that decision, and its lightweight
+// request must stay bounded as the parent session grows.
+const memoryTriageInputTokenLimit = 4 * 1024
+
 // AddRawText 从原始文本生成记忆条目
 func (r *AIMemoryTriage) AddRawText(i string) ([]*aicommon.MemoryEntity, error) {
-	temp, infos, err := r.invoker.GetBasicPromptInfo(nil)
-	if err != nil {
-		return nil, utils.Errorf("GetBasicPromptInfo failed: %v", err)
-	}
-	basic, err := utils.RenderTemplate(temp, infos)
-	if err != nil {
-		return nil, utils.Errorf("RenderTemplate failed: %v", err)
-	}
-
 	nonce := utils.RandStringBytes(4)
+	i = aicommon.ShrinkTextBlockByTokens(i, memoryTriageInputTokenLimit)
 
 	var dynContext string
 	if r.contextProvider != nil {
+		var err error
 		dynContext, err = r.contextProvider()
 		if err != nil {
 			return nil, utils.Errorf("contextProvider failed: %v", err)
@@ -48,7 +42,6 @@ func (r *AIMemoryTriage) AddRawText(i string) ([]*aicommon.MemoryEntity, error) 
 	dynContext += existedTag
 
 	promptResult, err := utils.RenderTemplate(memoryTriagePrompt, map[string]any{
-		"Basic":              basic,
 		"Nonce":              nonce,
 		"Query":              i,
 		"HaveDynamicContext": dynContext != "",
@@ -80,7 +73,7 @@ func (r *AIMemoryTriage) AddRawText(i string) ([]*aicommon.MemoryEntity, error) 
 			aitool.WithNumberParam("r", aitool.WithParam_Description("相关性评分，这个信息对用户的目的有多关键？无关紧要？锦上添花？还是成败在此一举？"), aitool.WithParam_Min(0.0), aitool.WithParam_Max(1.0)),
 			aitool.WithNumberParam("c", aitool.WithParam_Description("关联度评分，这个记忆与其他记忆如何关联？这是一个一次性事实，几乎与其他事实没有什么关联程度"), aitool.WithParam_Min(0.0), aitool.WithParam_Max(1.0)),
 		),
-	})
+	}, aicommon.WithLiteForgeDisableTimeline())
 	if err != nil {
 		return nil, utils.Errorf("InvokeLiteForge failed: %v", err)
 	}

--- a/common/ai/aid/aimem/aimemory_comprehensive_test.go
+++ b/common/ai/aid/aimem/aimemory_comprehensive_test.go
@@ -306,7 +306,8 @@ func TestAIMemoryTriage_AddRawText(t *testing.T) {
 		mockInvoker.SetPromptValidator("memory-triage", func(prompt string) bool {
 			// 验证prompt包含关键信息
 			return strings.Contains(prompt, "C.O.R.E. P.A.C.T.") &&
-				strings.Contains(prompt, "Go语言并发编程")
+				strings.Contains(prompt, "Go语言并发编程") &&
+				!strings.Contains(prompt, "Mock Basic Prompt Template")
 		})
 
 		memory, err := CreateTestAIMemory(sessionID, WithInvoker(mockInvoker))

--- a/common/ai/aid/aimem/aimemory_handle_memory_test.go
+++ b/common/ai/aid/aimem/aimemory_handle_memory_test.go
@@ -5,10 +5,44 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/ai/ytoken"
 
 	"github.com/google/uuid"
 )
+
+func TestAddRawText_BoundsMemoryTriageInput(t *testing.T) {
+	sessionID := "handle-bounded-input-test-" + uuid.New().String()
+	defer cleanupEntryTestData(t, sessionID)
+
+	mockInvoker := NewAdvancedMockInvoker(context.Background())
+	mockInvoker.SetPromptValidator("memory-triage", func(prompt string) bool {
+		queryStart := strings.Index(prompt, "<|QUERY_")
+		if queryStart < 0 {
+			return false
+		}
+		queryStart = strings.Index(prompt[queryStart:], "|>\n") + queryStart + len("|>\n")
+		queryEnd := strings.Index(prompt[queryStart:], "\n<|QUERY_END_")
+		if queryStart < len("|>\n") || queryEnd < 0 {
+			return false
+		}
+		query := prompt[queryStart : queryStart+queryEnd]
+		return ytoken.CalcTokenCount(query) <= memoryTriageInputTokenLimit &&
+			strings.Contains(query, "HEAD_SENTINEL") &&
+			strings.Contains(query, "TAIL_SENTINEL") &&
+			!strings.Contains(query, "MIDDLE_SENTINEL")
+	})
+
+	memory, err := CreateTestAIMemory(sessionID, WithInvoker(mockInvoker))
+	require.NoError(t, err)
+	defer memory.Close()
+
+	input := "HEAD_SENTINEL\n" + strings.Repeat("head material ", 8000) +
+		"\nMIDDLE_SENTINEL\n" + strings.Repeat("tail material ", 8000) + "\nTAIL_SENTINEL"
+	_, err = memory.AddRawText(input)
+	require.NoError(t, err)
+}
 
 func TestHandleMemory_Basic(t *testing.T) {
 	sessionID := "handle-memory-test-" + uuid.New().String()

--- a/common/ai/aid/aimem/memory_triage.txt
+++ b/common/ai/aid/aimem/memory_triage.txt
@@ -17,8 +17,6 @@ You are an AI Memory Triage System. Your task is to analyze user input and gener
 <|AI_CACHE_SYSTEM_END_high-static|>
 
 <|PROMPT_SECTION_semi-dynamic|>
-{{ .Basic }}
-
 ## Hard Rules:
 - Do NOT create memory for one-off events, transient execution logs, tool call traces, temporary states, or pure process observations.
 - Do NOT store exact timestamps, per-visit browsing records, or single-use operational facts such as "the user visited a URL at 10:20".

--- a/common/ai/aid/aireact/invoke_liteforge.go
+++ b/common/ai/aid/aireact/invoke_liteforge.go
@@ -34,6 +34,9 @@ func (r *ReAct) invokeLiteForgeWithCallback(cb aicommon.AICallbackType, ctx cont
 	if staticInstruction := gconfig.GetLiteForgeStaticInstruction(); staticInstruction != "" {
 		fopts = append(fopts, aiforge.WithLiteForge_StaticInstruction(staticInstruction))
 	}
+	if gconfig.GetLiteForgeDisableTimeline() {
+		fopts = append(fopts, aiforge.WithLiteForge_DisableTimeline())
+	}
 	for _, i := range gconfig.GetStreamableFields() {
 		fopts = append(fopts, aiforge.WithLiteForge_StreamableFieldWithAINodeId(i.AINodeId(), i.FieldKey()))
 	}

--- a/common/ai/aid/aireact/invoke_toolcall_file_emit_multiple_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_file_emit_multiple_test.go
@@ -141,15 +141,14 @@ LOOP:
 	for {
 		select {
 		case e := <-out:
-			// 检查文件 emit 事件 - 新格式: tool_calls/{n}_{tool}_{id}.md
+			// 检查文件 emit 事件 - 新格式: tool_calls/{n}_{tool}_{id}/report.md
 			if e.Type == string(schema.EVENT_TYPE_FILESYSTEM_PIN_FILENAME) {
 				content := string(e.GetContent())
 				filePath := utils.InterfaceToString(jsonpath.FindFirst(content, "$.path"))
 				if filePath != "" && strings.HasSuffix(filePath, ".md") && strings.Contains(filePath, "tool_calls") {
-					// 从文件名中提取调用次数
-					filename := filepath.Base(filePath)
-					nameWithoutExt := strings.TrimSuffix(filename, ".md")
-					parts := strings.Split(nameWithoutExt, "_")
+					// 从 bundle 目录名中提取调用次数
+					bundleName := filepath.Base(filepath.Dir(filePath))
+					parts := strings.Split(bundleName, "_")
 					if len(parts) >= 2 {
 						callNumber := utils.InterfaceToInt(parts[0])
 						if callNumber > 0 {
@@ -207,14 +206,15 @@ LOOP:
 			continue
 		}
 
-		// 验证文件名格式: {n}_{tool}_{identifier}.md
+		// 验证 bundle 格式: {n}_{tool}_{identifier}/report.md
 		filename := filepath.Base(filePath)
-		if !strings.HasPrefix(filename, fmt.Sprintf("%d_", callNumber)) {
-			t.Errorf("Report for call %d should start with '%d_', got: %s", callNumber, callNumber, filename)
+		bundleName := filepath.Base(filepath.Dir(filePath))
+		if filename != "report.md" || !strings.HasPrefix(bundleName, fmt.Sprintf("%d_", callNumber)) {
+			t.Errorf("Bundle for call %d should start with '%d_', got: %s", callNumber, callNumber, bundleName)
 		}
-		// 验证文件名包含 identifier
-		if !strings.Contains(filename, fmt.Sprintf("call_%d_test", callNumber)) {
-			t.Errorf("Report for call %d should contain identifier 'call_%d_test', got: %s", callNumber, callNumber, filename)
+		// 验证 bundle 目录名包含 identifier
+		if !strings.Contains(bundleName, fmt.Sprintf("call_%d_test", callNumber)) {
+			t.Errorf("Bundle for call %d should contain identifier 'call_%d_test', got: %s", callNumber, callNumber, bundleName)
 		}
 
 		// 验证 report 内容包含关键部分

--- a/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
@@ -193,16 +193,14 @@ LOOP:
 	require.Contains(t, contentStr, "## Basic Info")
 	require.Contains(t, contentStr, "## Parameters")
 	require.Contains(t, contentStr, "## Execution Result")
-	// STDOUT/STDERR 已合并为单个 OUTPUT 段
-	require.Contains(t, contentStr, "## OUTPUT")
-	require.NotContains(t, contentStr, "## STDOUT")
-	require.NotContains(t, contentStr, "## STDERR")
+	require.Contains(t, contentStr, "## Execution Result Preview")
+	require.Contains(t, contentStr, "## Artifact Files")
 
 	// 验证参数内容 (YAML 格式)
 	require.Contains(t, contentStr, "message")
 	require.Contains(t, contentStr, "output_lines")
 
-	// 验证 stdout 内容(已合入 OUTPUT)
+	// 验证 stdout/stderr 内容出现在压缩预览中
 	require.Contains(t, contentStr, "stdout line")
 
 	// 验证 stderr 内容(已合入 OUTPUT)
@@ -211,18 +209,21 @@ LOOP:
 	// 验证 result 内容
 	require.Contains(t, contentStr, "success")
 
-	// 验证文件名格式: {n}_{toolName}_{identifier}.md
+	// 新格式固定使用 report.md，调用标识位于父 bundle 目录名。
 	filename := filepath.Base(reportFilePath)
-	require.True(t, strings.HasSuffix(filename, ".md"))
-	require.Contains(t, filename, "test_file_output", "filename should contain identifier")
+	require.Equal(t, "report.md", filename)
+	require.Contains(t, filepath.Base(filepath.Dir(reportFilePath)), "test_file_output", "bundle directory should contain identifier")
 
-	// 验证路径结构: task_{index}/tool_calls/{n}_{tool}_{id}.md
+	// 验证路径结构: task_{index}/tool_calls/{n}_{tool}_{id}/report.md
 	require.Contains(t, reportFilePath, "tool_calls")
+	for _, artifact := range []string{"combined_output.txt", "stdout.txt", "stderr.txt", "result.json", "manifest.json"} {
+		require.FileExists(t, filepath.Join(filepath.Dir(reportFilePath), artifact))
+	}
 	require.Contains(t, reportFilePath, "task_")
 
-	// 验证文件名第一部分是数字
-	parts := strings.Split(strings.TrimSuffix(filename, ".md"), "_")
-	require.GreaterOrEqual(t, len(parts), 2, "filename should have format '{n}_{tool}_{id}.md'")
+	// bundle 目录名第一部分是调用序号
+	parts := strings.Split(filepath.Base(filepath.Dir(reportFilePath)), "_")
+	require.GreaterOrEqual(t, len(parts), 2, "bundle directory should have format '{n}_{tool}_{id}'")
 	require.True(t, utils.MatchAllOfRegexp(parts[0], `^\d+$`), "filename first part should be numeric, got: %s", parts[0])
 
 	log.Infof("✓ Report file emitted successfully: %s", reportFilePath)
@@ -370,7 +371,7 @@ LOOP:
 		t.Fatal("Task was not completed")
 	}
 
-	// 验证 report 文件存在且包含完整的大数据
+	// report 只保留压缩预览，完整 result 只存在 bundle Artifact。
 	require.NotEmpty(t, reportFilePath, "report file should be emitted")
 	require.True(t, utils.FileExists(reportFilePath), "report file should exist")
 
@@ -378,13 +379,14 @@ LOOP:
 	require.NoError(t, err)
 
 	contentStr := string(content)
-	// 验证文件包含完整的大数据（应该包含 "AAAA..."）
-	require.Contains(t, contentStr, "AAAAAAAAAA", "report should contain large data")
+	require.Contains(t, contentStr, "AAAAAAAAAA", "report should contain a head/tail preview")
+	require.Less(t, len(content), 512*1024, "report must not duplicate the complete 5MB result")
+	resultPath := filepath.Join(filepath.Dir(reportFilePath), "result.json")
+	resultContent, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+	require.Greater(t, len(resultContent), 4*1024*1024, "result artifact should retain the complete output")
 
-	// 验证文件大小合理（应该接近 5MB，至少大于 4MB，有 markdown 开销）
-	require.Greater(t, len(content), 4*1024*1024, "report file should be large (>= 4MB), but got %d bytes", len(content))
-
-	log.Infof("✓ Large result report emitted successfully: %s (%d bytes)", reportFilePath, len(content))
+	log.Infof("✓ Large result artifact emitted successfully: %s (%d bytes)", resultPath, len(resultContent))
 
 	// 清理
 	defer func() {
@@ -542,15 +544,14 @@ LOOP:
 	require.NoError(t, err)
 	contentStr := string(reportContent)
 
-	// 验证合并后的 OUTPUT 部分标记为 (empty)
-	// STDOUT/STDERR 已合并为单个 OUTPUT 段，空输出显示为 "(empty)"
-	require.Contains(t, contentStr, "## OUTPUT")
-	require.NotContains(t, contentStr, "## STDOUT")
-	require.NotContains(t, contentStr, "## STDERR")
+	// 空 stdout/stderr 仍在统一预览中明确标记。
+	require.Contains(t, contentStr, "## Execution Result Preview")
+	require.Contains(t, contentStr, "COMBINED OUTPUT:")
+	require.Contains(t, contentStr, "(empty)")
 
 	// 验证仍然包含参数和结果
 	require.Contains(t, contentStr, "## Parameters")
-	require.Contains(t, contentStr, "## Execution Result")
+	require.Contains(t, contentStr, "## Execution Result Preview")
 	require.Contains(t, contentStr, "success")
 
 	log.Infof("✓ Empty stdout/stderr test passed: report contains (empty) sections")
@@ -702,18 +703,19 @@ LOOP:
 	require.NotEmpty(t, reportFilePath, "report file should be emitted")
 	require.True(t, utils.FileExists(reportFilePath), "report file should exist")
 
-	// Verify filename contains the identifier
+	// report 文件名固定，identifier 存在于 bundle 目录名。
 	filename := filepath.Base(reportFilePath)
-	require.Contains(t, filename, customIdentifier, "filename should contain identifier '%s', got: %s", customIdentifier, filename)
+	require.Equal(t, "report.md", filename)
+	bundleName := filepath.Base(filepath.Dir(reportFilePath))
+	require.Contains(t, bundleName, customIdentifier, "bundle directory should contain identifier '%s', got: %s", customIdentifier, bundleName)
 
 	// Verify path structure: task_{index}/tool_calls/{n}_{tool}_{identifier}.md
 	require.Contains(t, reportFilePath, "task_")
 	require.Contains(t, reportFilePath, "tool_calls")
 
-	// Verify filename format: {number}_{toolname}_{identifier}.md
-	nameWithoutExt := strings.TrimSuffix(filename, ".md")
-	parts := strings.Split(nameWithoutExt, "_")
-	require.GreaterOrEqual(t, len(parts), 3, "filename should have format '{n}_{tool}_{id}.md', got: %s", filename)
+	// Verify bundle format: {number}_{toolname}_{identifier}/report.md
+	parts := strings.Split(bundleName, "_")
+	require.GreaterOrEqual(t, len(parts), 3, "bundle should have format '{n}_{tool}_{id}', got: %s", bundleName)
 	require.True(t, utils.MatchAllOfRegexp(parts[0], `^\d+$`), "filename first part should be a number, got: %s", parts[0])
 
 	log.Infof("✓ Identifier test passed: %s", reportFilePath)
@@ -857,17 +859,17 @@ LOOP:
 	require.NotEmpty(t, reportFilePath, "report file should be emitted")
 	require.True(t, utils.FileExists(reportFilePath), "report file should exist")
 
-	// Verify filename format: {number}_{toolname}.md (without identifier)
+	// Verify bundle format: {number}_{toolname}/report.md (without identifier)
 	filename := filepath.Base(reportFilePath)
-	require.True(t, strings.HasSuffix(filename, ".md"))
+	require.Equal(t, "report.md", filename)
 
 	// Verify path structure
 	require.Contains(t, reportFilePath, "task_")
 	require.Contains(t, reportFilePath, "tool_calls")
 
-	nameWithoutExt := strings.TrimSuffix(filename, ".md")
-	parts := strings.Split(nameWithoutExt, "_")
-	require.GreaterOrEqual(t, len(parts), 2, "filename should have format '{n}_{tool}.md', got: %s", filename)
+	bundleName := filepath.Base(filepath.Dir(reportFilePath))
+	parts := strings.Split(bundleName, "_")
+	require.GreaterOrEqual(t, len(parts), 2, "bundle should have format '{n}_{tool}', got: %s", bundleName)
 	require.True(t, utils.MatchAllOfRegexp(parts[0], `^\d+$`), "filename first part should be a number, got: %s", parts[0])
 
 	log.Infof("✓ No-identifier test passed: %s", reportFilePath)
@@ -1007,7 +1009,8 @@ LOOP:
 	// Verify path structure
 	require.Contains(t, toolCallLogPath, "tool_calls")
 	require.Contains(t, toolCallLogPath, "task_")
-	require.Contains(t, filepath.Base(toolCallLogPath), "test_file_output", "filename should contain identifier")
+	require.Equal(t, "report.md", filepath.Base(toolCallLogPath))
+	require.Contains(t, filepath.Base(filepath.Dir(toolCallLogPath)), "test_file_output", "bundle directory should contain identifier")
 
 	// Verify pinned file matches the log path
 	require.NotEmpty(t, reportFilePath, "report file should be pinned")

--- a/common/ai/aid/aireact/invoke_toolcall_mcp_wait_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_mcp_wait_test.go
@@ -50,12 +50,8 @@ func TestExecuteToolCallInternal_WaitsForMCPStubBeforeInvoke(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.Success)
-	switch data := result.Data.(type) {
-	case string:
-		assert.Equal(t, "live-ok", data)
-	case *aitool.ToolExecutionResult:
-		assert.Equal(t, "live-ok", data.Result)
-	default:
-		t.Fatalf("unexpected result data type: %T", result.Data)
-	}
+	data, ok := result.Data.(string)
+	require.True(t, ok, "AI orchestration must expose the canonical bounded string Data")
+	assert.Contains(t, data, "COMBINED OUTPUT:\nlive-ok")
+	assert.Contains(t, data, "HINT:\nComplete tool output is stored in artifacts:")
 }

--- a/common/ai/aid/aireact/invoke_toolcall_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_test.go
@@ -634,9 +634,9 @@ func TestReAct_ToolUse_WithNoToolsCache(t *testing.T) {
 			rsp := i.NewAIResponse()
 			// Return satisfied only if tool execution succeeded
 			if toolExecutionSucceeded.IsSet() {
-					rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "verify-satisfaction", "user_satisfied": true, "reasoning": "tool executed successfully"}`))
+				rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "verify-satisfaction", "user_satisfied": true, "reasoning": "tool executed successfully"}`))
 			} else {
-					rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "verify-satisfaction", "user_satisfied": false, "reasoning": "tool execution failed, need to retry"}`))
+				rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "verify-satisfaction", "user_satisfied": false, "reasoning": "tool execution failed, need to retry"}`))
 			}
 			rsp.Close()
 			return rsp, nil
@@ -892,7 +892,7 @@ LOOP:
 					t.Fatalf("call tool id mismatch: should only have one callToolID, but got %s and %s", callToolID, e.CallToolID)
 				}
 				toolCallResult = true
-				result := jsonpath.FindFirst(e.GetContent(), "$..result.result")
+				result := jsonpath.FindFirst(e.GetContent(), "$.result")
 				recivedToolCallResultFlag = utils.InterfaceToString(result)
 				break LOOP
 			}
@@ -905,8 +905,8 @@ LOOP:
 		t.Fatal("tool call result not found")
 	}
 
-	if recivedToolCallResultFlag != callToolResultFlag {
-		t.Fatalf("call tool result mismatch: %s != %s", recivedToolCallResultFlag, callToolResultFlag)
+	if !strings.Contains(recivedToolCallResultFlag, callToolResultFlag) {
+		t.Fatalf("call tool result does not contain flag: %s", recivedToolCallResultFlag)
 	}
 
 	db := consts.GetGormProjectDatabase()
@@ -927,8 +927,8 @@ LOOP:
 	var hasFlag bool
 	for _, event := range event {
 		if event.Type == schema.EVENT_TOOL_CALL_RESULT {
-			result := jsonpath.FindFirst(string(event.Content), "$..result.result")
-			if utils.InterfaceToString(result) == callToolResultFlag {
+			result := jsonpath.FindFirst(string(event.Content), "$.result")
+			if strings.Contains(utils.InterfaceToString(result), callToolResultFlag) {
 				hasFlag = true
 				break
 			}

--- a/common/ai/aid/aireact/reactloops/action_from_tool.go
+++ b/common/ai/aid/aireact/reactloops/action_from_tool.go
@@ -138,8 +138,8 @@ func ConvertAIToolToLoopAction(tool *aitool.Tool) *LoopAction {
 				invokeParams[aicommon.ReservedKeyCallExpectations] = callExpectations
 			}
 
-			// Pass identifier so ToolCaller.saveToolCallFiles can use it for tool_calls/ filename,
-			// producing {N}_{toolName}_{identifier}.md matching the crawl_web naming convention.
+			// Pass identifier so ToolCaller can use it for the tool_calls/ artifact bundle directory,
+			// producing {N}_{toolName}_{identifier}/report.md for easy call identification.
 			if identifier := action.GetString("identifier"); identifier != "" {
 				invokeParams[aicommon.ReservedKeyIdentifier] = identifier
 			}

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -1029,7 +1029,7 @@ LOOP:
 
 		// Temporarily sync the invoker's currentTask with this loop's task so that
 		// any tool call made inside the action handler (via ExecuteToolRequiredAndCallWithoutRequired)
-		// writes its log files (saveToolCallFiles) into the sub-task's directory instead of
+		// writes its tool-call Artifact bundle into the sub-task's directory instead of
 		// the top-level orchestrator task's directory.
 		func() {
 			invoker := r.GetInvoker()

--- a/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
+++ b/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
@@ -133,7 +133,7 @@
 - **善用文件查看内容操作** 注意 `read_file`, `tail_file`, `head_file`, `grep` 等工具可以辅助你查看文件或文件内容内容，提供行号和上下文支持。
 - **二进制文件处理** `read_file` 使用 mimetype (magic bytes) 自动检测二进制文件格式（Excel/Word/PDF/ZIP/图片/数据库等），不会输出乱码内容，而是返回文件类型说明和推荐的处理工具。当检测到二进制文件时，优先使用推荐的**内置工具**：Excel 使用 `read_excel_info` / `query_excel_data`，Word 使用 `read_word_structure`，Office 文档使用 `parse_office_to_text`，ZIP 使用 `zip_viewer`，PCAP 使用 `analyze_pcap`。仅当内置工具无法满足需求时，再通过 `bash` 执行 Python 脚本作为替代方案。
 - **修改文件原则** 先查看文件内容，再决定修改文件，修改文件尽量使用 `modify_file` 工具，避免直接使用 `bash` 来执行 `echo '...' > file` 这类命令，因为直接覆盖文件内容可能会导致数据丢失。
-- **工具执行结果处理** 如果一个工具输出了海量的信息，一般来说会被保存在特定文件中，你需要使用 read_file 分片读取或者直接搜索你感兴趣的内容。
+- **工具执行结果处理** 工具结果中的 `Data` 是 `CombinedOutput + Result` 的有界首尾预览，不是完整结果。stdout/stderr 的真实交叉顺序以 `COMBINED OUTPUT` 及 HINT 指向的 `combined_output.txt` 为准；预览中没有出现某条记录，不代表完整结果中不存在。遇到截断标记时，必须先按 HINT 使用 `grep` 搜索 Artifact，再按需使用 `read_file(file="...", mode="lines", offset=..., lines=...)` 分片查看上下文。禁止用完整 `cat`、整文件 `read_file`、`echo` 或 `tee` 把 Artifact 重新灌入 Timeline；需要精确判断时必须发起新的文件工具调用，不能根据预览宣称“没有发现”。
 - **搜索 grep 是一个重要工具** 一次搜索可能并不对，你可以尝试使用不同的关键字或者正则多次搜索你感兴趣的东西，善于使用内置的 grep 的功能。
 - **错误处理与重试** 如果工具执行返回错误，切勿直接放弃。你必须在 `human_readable_thought` 中详细分析错误信息，尝试通过修改命令、调整参数或寻找替代方案来解决问题。确保每一次重试都有明确的改进方向，并记录你的思考过程。
 - **搜索优先：** 如果你不确定如何完成任务或是否需要特定工具，请果断使用 `tools_search` 寻找合适的工具或解决方案。搜索可以帮助你快速定位可用资源，避免浪费时间在无效尝试上。

--- a/common/ai/aid/aireact/reactloops/loop_fast_context/file_index.go
+++ b/common/ai/aid/aireact/reactloops/loop_fast_context/file_index.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/utils"
 )
 
@@ -23,17 +22,11 @@ const (
 // Allow optional log prefixes (e.g. "[info]   ") before "[file N]".
 var grepFileLinePattern = regexp.MustCompile(`\[file\s+\d+\]\s+(.+?)\s+\(\d+\s+matches\)\s*$`)
 
-// toolOutputString extracts capture stdout from a tool result Data payload.
-// InterfaceToString(*ToolExecutionResult) JSON-marshals the struct and breaks line parsers.
+// toolOutputString returns the bounded ToolResult.Data preview. Full output is
+// intentionally available only through the artifact paths embedded in it.
 func toolOutputString(data any) string {
 	if data == nil {
 		return ""
-	}
-	if exec, ok := data.(*aitool.ToolExecutionResult); ok {
-		if exec.CombinedOutput != "" {
-			return exec.CombinedOutput
-		}
-		return exec.Stdout + exec.Stderr
 	}
 	return utils.InterfaceToString(data)
 }

--- a/common/ai/aid/aireact/reactloops/loop_fast_context/search_delegate_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_fast_context/search_delegate_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops/subagent"
-	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/schema"
 )
 
@@ -77,16 +76,10 @@ func TestParseGrepFilesWithMatchesOutput(t *testing.T) {
 }
 
 func TestToolOutputString_ExtractsStdout(t *testing.T) {
-	exec := &aitool.ToolExecutionResult{
-		Stdout: "[file 1] C:\\tmp\\a.go (1 matches)\n",
-	}
-	out := toolOutputString(exec)
-	require.Equal(t, exec.Stdout, out)
+	out := toolOutputString("[file 1] C:\\tmp\\a.go (1 matches)\n")
+	require.Equal(t, "[file 1] C:\\tmp\\a.go (1 matches)\n", out)
 	paths := parseGrepFilesWithMatchesOutput(out)
 	require.Equal(t, []string{`C:\tmp\a.go`}, paths)
-
-	// JSON blob (old InterfaceToString path) must not be preferred when Data is typed.
-	require.NotContains(t, out, `"stdout"`)
 }
 
 func TestFilterAuditCandidatePaths(t *testing.T) {

--- a/common/ai/aid/aireact/reactloops/loop_intent/capability_catalog.go
+++ b/common/ai/aid/aireact/reactloops/loop_intent/capability_catalog.go
@@ -1,23 +1,18 @@
 package loop_intent
 
 import (
-	"context"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon/aiskillloader"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
-	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
-
-const catalogChunkSize = 30 * 1024
 
 // BuildCapabilityCatalog collects all available tools, forges, skills, and focus modes,
 // formats each as a single-line entry for AI consumption.
@@ -96,125 +91,60 @@ func BuildCapabilityCatalog(r aicommon.AIInvokeRuntime) string {
 	return sb.String()
 }
 
-// MatchIdentifiersFromCatalog uses aireducer-style chunking + concurrent LiteForge
-// to find matching identifiers from the capability catalog for a user query.
-// If the catalog fits in one chunk (<=catalogChunkSize), a single AI call is made.
-// Otherwise, the catalog is split and processed concurrently.
-func MatchIdentifiersFromCatalog(
-	r aicommon.AIInvokeRuntime,
-	catalog string,
-	userQuery string,
-) []string {
+// MatchExplicitIdentifiersFromCatalog recognizes capability identifiers that
+// the user wrote verbatim. Semantic matching belongs to the bounded BM25
+// query_capabilities action; sending the entire catalog through one or more
+// LiteForge calls made a short request create 20-40KB lightweight spikes.
+func MatchExplicitIdentifiersFromCatalog(catalog string, userQuery string) []string {
 	if catalog == "" || userQuery == "" {
 		return nil
 	}
-
-	chunks := splitCatalogIntoChunks(catalog, catalogChunkSize)
-	if len(chunks) == 0 {
-		return nil
-	}
-
-	ctx := r.GetConfig().GetContext()
-
-	var mu sync.Mutex
-	var allIdentifiers []string
-	var wg sync.WaitGroup
-
-	for i, chunk := range chunks {
-		wg.Add(1)
-		go func(idx int, chunkData string) {
-			defer wg.Done()
-			ids := matchChunk(ctx, r, chunkData, userQuery, idx)
-			if len(ids) > 0 {
-				mu.Lock()
-				allIdentifiers = append(allIdentifiers, ids...)
-				mu.Unlock()
-			}
-		}(i, chunk)
-	}
-
-	wg.Wait()
-
-	seen := make(map[string]bool, len(allIdentifiers))
-	var deduped []string
-	for _, id := range allIdentifiers {
-		id = strings.TrimSpace(id)
-		if id != "" && !seen[id] {
-			seen[id] = true
-			deduped = append(deduped, id)
+	query := strings.ToLower(userQuery)
+	seen := make(map[string]struct{})
+	var matched []string
+	for _, line := range strings.Split(catalog, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "[") {
+			continue
 		}
+		end := strings.IndexByte(line, ']')
+		colon := strings.IndexByte(line, ':')
+		if end <= colon+1 || colon < 1 {
+			continue
+		}
+		identifier := strings.TrimSpace(line[colon+1 : end])
+		if identifier == "" || !containsExplicitIdentifier(query, strings.ToLower(identifier)) {
+			continue
+		}
+		if _, ok := seen[identifier]; ok {
+			continue
+		}
+		seen[identifier] = struct{}{}
+		matched = append(matched, identifier)
 	}
-	return deduped
+	return matched
 }
 
-func splitCatalogIntoChunks(catalog string, maxChunkBytes int) []string {
-	if len(catalog) <= maxChunkBytes {
-		return []string{catalog}
-	}
-
-	lines := strings.Split(catalog, "\n")
-	var chunks []string
-	var current strings.Builder
-
-	for _, line := range lines {
-		if current.Len()+len(line)+1 > maxChunkBytes && current.Len() > 0 {
-			chunks = append(chunks, current.String())
-			current.Reset()
+func containsExplicitIdentifier(query, identifier string) bool {
+	for from := 0; from < len(query); {
+		idx := strings.Index(query[from:], identifier)
+		if idx < 0 {
+			return false
 		}
-		current.WriteString(line)
-		current.WriteString("\n")
+		start := from + idx
+		end := start + len(identifier)
+		leftOK := start == 0 || !isIdentifierByte(query[start-1])
+		rightOK := end == len(query) || !isIdentifierByte(query[end])
+		if leftOK && rightOK {
+			return true
+		}
+		from = start + 1
 	}
-	if current.Len() > 0 {
-		chunks = append(chunks, current.String())
-	}
-	return chunks
+	return false
 }
 
-func matchChunk(
-	ctx context.Context,
-	r aicommon.AIInvokeRuntime,
-	chunkData string,
-	userQuery string,
-	chunkIdx int,
-) []string {
-	nonce := utils.RandStringBytes(6)
-	prompt := fmt.Sprintf(`<|INSTRUCTION_%s|>
-You are a capability matcher. Given a user query and a catalog of available capabilities,
-select ALL capabilities that are relevant to the user's intent.
-
-CRITICAL RULES:
-- You MUST ONLY select identifiers that appear in the catalog below. Do NOT invent or fabricate any identifier.
-- If the user's input directly contains a capability identifier (e.g., user says "run hostscan"), that identifier MUST be included.
-- Consider both Chinese and English meanings when matching.
-- Select capabilities that could help accomplish the user's goal, even indirectly.
-- Return ONLY the identifier part (the text after the type prefix, e.g., "web_search" from "[tool:web_search]").
-<|INSTRUCTION_END_%s|>
-
-<|USER_QUERY_%s|>
-%s
-<|USER_QUERY_END_%s|>
-
-<|CAPABILITY_CATALOG_%s|>
-%s
-<|CAPABILITY_CATALOG_END_%s|>`, nonce, nonce, nonce, userQuery, nonce, nonce, chunkData, nonce)
-
-	schema := []aitool.ToolOption{
-		aitool.WithStringArrayParamEx("matched_identifiers", []aitool.PropertyOption{
-			aitool.WithParam_Description("List of matched capability identifiers from the catalog. Only include identifiers that actually exist in the catalog."),
-			aitool.WithParam_Required(true),
-		}),
-	}
-
-	forgeResult, err := r.InvokeSpeedPriorityLiteForge(ctx, "capability-catalog-match", prompt, schema)
-	if err != nil {
-		log.Warnf("capability catalog match chunk %d failed: %v", chunkIdx, err)
-		return nil
-	}
-	if forgeResult == nil {
-		return nil
-	}
-
-	return forgeResult.GetStringSlice("matched_identifiers")
+func isIdentifierByte(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= '0' && b <= '9' || b == '_' || b == '-'
 }
 
 // VerifyIdentifiers filters a list of identifier names through ResolveIdentifier,

--- a/common/ai/aid/aireact/reactloops/loop_intent/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_intent/init.go
@@ -129,14 +129,14 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		loop.Set("recommended_forges", "")
 		loop.Set("context_enrichment", "")
 
-		// Build full capability catalog for anti-hallucination matching
+		// Build the catalog locally only. Semantic matching is handled by the
+		// bounded BM25 action; here we recognize identifiers explicitly named
+		// by the user without sending the 30KB+ catalog to another model.
 		catalog := BuildCapabilityCatalog(r)
 		if catalog != "" {
-			loop.Set("capability_catalog", catalog)
 			log.Infof("intent init: built capability catalog (%d bytes)", len(catalog))
 
-			// Run AI catalog matching concurrently to pre-identify relevant identifiers
-			preMatched := MatchIdentifiersFromCatalog(r, catalog, userQuery)
+			preMatched := MatchExplicitIdentifiersFromCatalog(catalog, userQuery)
 			if len(preMatched) > 0 {
 				verified := VerifyIdentifiers(loop, preMatched)
 				if len(verified) > 0 {

--- a/common/ai/aid/aireact/reactloops/loop_intent/search_and_finalize_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_intent/search_and_finalize_test.go
@@ -227,6 +227,25 @@ func TestCapabilityDetailsJSON_EmptyAndNil(t *testing.T) {
 	}
 }
 
+func TestMatchExplicitIdentifiersFromCatalogDoesNotUseSemanticSubstring(t *testing.T) {
+	catalog := strings.Join([]string{
+		"[tool:hostscan]: Host Scan - inspect a host",
+		"[tool:syn_scan_tcp_port]: SYN Scanner - scan TCP ports",
+		"[focus_mode:smart_qa]: Smart QA - answer questions",
+	}, "\n")
+
+	matched := MatchExplicitIdentifiersFromCatalog(
+		catalog,
+		"请运行 hostscan 和 SYN_SCAN_TCP_PORT，不要仅凭 scan 这个泛词扩展其他能力",
+	)
+	if got, want := strings.Join(matched, ","), "hostscan,syn_scan_tcp_port"; got != want {
+		t.Fatalf("unexpected explicit identifier matches: got %q want %q", got, want)
+	}
+	if got := MatchExplicitIdentifiersFromCatalog(catalog, "对目标执行渗透测试和端口扫描"); len(got) != 0 {
+		t.Fatalf("semantic query must be left to bounded BM25 search, got %v", got)
+	}
+}
+
 func TestFormatRecommendedCapabilitiesDisplay_HidesEmptyArray(t *testing.T) {
 	if got := formatRecommendedCapabilitiesDisplay("[]"); got != "" {
 		t.Fatalf("expected empty output, got: %q", got)

--- a/common/ai/aid/aireact/reactloops/value_feedback_hook.go
+++ b/common/ai/aid/aireact/reactloops/value_feedback_hook.go
@@ -7,6 +7,8 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 )
 
+const valueFeedbackRecentActionLimit = 32
+
 // value_feedback_hook.go 在 reactloops 这一最底层基础设施上自动注入价值评估埋点.
 //
 // 每个通过 NewReActLoop 创建的 loop 都会在 onPostIteration 回调里组装一条
@@ -78,8 +80,8 @@ func (r *ReActLoop) submitValueFeedbackSignal(trigger string) {
 
 // submitValueFeedbackWithTrigger 组装并提交一条价值评估记录 (统一装配逻辑).
 //
-// iteration 是本条记录对应的轮次序号; 核心 trace 用完整 timeline dump (而非 diff),
-// 保证每条记录都能被后端独立复盘 "到底发生了什么".
+// iteration 是本条记录对应的轮次序号; 核心 trace 使用最近 Timeline 投影.
+// Value feedback 是高频轻模型调用，携带完整会话会使输入随会话长度线性增长。
 func (r *ReActLoop) submitValueFeedbackWithTrigger(trigger string, task aicommon.AIStatefulTask, iteration int) {
 	cfg, ok := r.config.(*aicommon.Config)
 	if !ok || cfg == nil {
@@ -97,14 +99,17 @@ func (r *ReActLoop) submitValueFeedbackWithTrigger(trigger string, task aicommon
 		SessionID:        cfg.PersistentSessionId,
 		IterationIndex:   iteration,
 	}
-	// 核心 trace: 完整 timeline dump. Timeline 缺失时退化为 diff, 保证不空手而归.
+	// 核心 trace: 只给轻模型最近窗口。原始 Timeline 本身不受影响。
 	if cfg.Timeline != nil {
-		record.TimelineDump = cfg.Timeline.Dump()
+		record.TimelineDump = cfg.Timeline.DumpRecentForPrompt(aicommon.ValueFeedbackRecentTimelineTokens)
 	} else {
-		record.TimelineDump = r.GetTimelineDiffWithoutUpdate()
+		record.TimelineDump = aicommon.ShrinkTextBlockByTokens(
+			r.GetTimelineDiffWithoutUpdate(),
+			aicommon.ValueFeedbackRecentTimelineTokens,
+		)
 	}
 
-	actions := r.GetAllExistedActionRecord()
+	actions := recentValueFeedbackActions(r.GetAllExistedActionRecord())
 	for _, a := range actions {
 		if a == nil {
 			continue
@@ -178,13 +183,13 @@ func (r *ReActLoop) SubmitRiskFeedback(riskIDs []string, riskType, severity stri
 		},
 	}
 	if cfg.Timeline != nil {
-		record.TimelineDump = cfg.Timeline.Dump()
+		record.TimelineDump = cfg.Timeline.DumpRecentForPrompt(aicommon.ValueFeedbackRecentTimelineTokens)
 	}
 	if task := r.GetCurrentTask(); !isNilTask(task) {
 		record.TaskID = task.GetId()
 		record.UserQuery = task.GetUserInput()
 	}
-	record.WhatHappenedSummary = summarizeValueFeedbackActions(r.GetAllExistedActionRecord())
+	record.WhatHappenedSummary = summarizeValueFeedbackActions(recentValueFeedbackActions(r.GetAllExistedActionRecord()))
 
 	aicommon.SubmitValueFeedback(cfg, record)
 }
@@ -206,6 +211,13 @@ func summarizeValueFeedbackActions(actions []*ActionRecord) string {
 		parts = append(parts, seg)
 	}
 	return strings.Join(parts, " -> ")
+}
+
+func recentValueFeedbackActions(actions []*ActionRecord) []*ActionRecord {
+	if len(actions) <= valueFeedbackRecentActionLimit {
+		return actions
+	}
+	return actions[len(actions)-valueFeedbackRecentActionLimit:]
 }
 
 func isNilTask(task aicommon.AIStatefulTask) bool {

--- a/common/ai/aid/aitool/tool_invoke_config.go
+++ b/common/ai/aid/aitool/tool_invoke_config.go
@@ -8,13 +8,14 @@ import (
 type ToolCallCancelCallback func(result *ToolExecutionResult, err error) (*ToolExecutionResult, error)
 
 type ToolInvokeConfig struct {
-	ctx            context.Context
-	stdout         io.Writer
-	stderr         io.Writer
-	errCallback    func(error) (*ToolResult, error)
-	resCallback    func(result *ToolExecutionResult) (*ToolResult, error)
-	cancelCallback ToolCallCancelCallback
-	runtimeConfig  *ToolRuntimeConfig
+	ctx                  context.Context
+	stdout               io.Writer
+	stderr               io.Writer
+	errCallback          func(error) (*ToolResult, error)
+	resCallback          func(result *ToolExecutionResult) (*ToolResult, error)
+	cancelCallback       ToolCallCancelCallback
+	runtimeConfig        *ToolRuntimeConfig
+	disableOutputCapture bool
 }
 
 func (i *ToolInvokeConfig) GetErrCallback() func(error) (*ToolResult, error) {
@@ -107,4 +108,18 @@ func WithRuntimeConfig(config *ToolRuntimeConfig) ToolInvokeOptions {
 	return func(toolConfig *ToolInvokeConfig) {
 		toolConfig.runtimeConfig = config
 	}
+}
+
+// WithOutputCapture controls whether ExecuteToolWithCapture keeps complete
+// stdout/stderr/combined copies in memory. AI orchestration disables this after
+// installing its artifact writers, so the transient ToolExecutionResult only
+// carries the callback result.
+func WithOutputCapture(enabled bool) ToolInvokeOptions {
+	return func(config *ToolInvokeConfig) {
+		config.disableOutputCapture = !enabled
+	}
+}
+
+func (i *ToolInvokeConfig) ShouldCaptureOutput() bool {
+	return i == nil || !i.disableOutputCapture
 }

--- a/common/ai/aid/aitool/tool_invoke_result.go
+++ b/common/ai/aid/aitool/tool_invoke_result.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/yaklang/yaklang/common/utils"
 )
@@ -107,6 +108,16 @@ func (t *ToolResult) dumpTimelineResult(writer io.Writer) {
 	} else {
 		// 处理工具执行结果
 		switch ret := t.Data.(type) {
+		case string:
+			if ret == "" {
+				buf.WriteString("no output\n")
+			} else {
+				buf.WriteString("data:\n")
+				buf.WriteString(ret)
+				if !strings.HasSuffix(ret, "\n") {
+					buf.WriteByte('\n')
+				}
+			}
 		case *ToolExecutionResult:
 			// 优先使用 CombinedOutput；兼容旧消费者回退到 stdout/stderr
 			combined := ret.CombinedOutput

--- a/common/ai/aid/aitool/tool_invoke_test.go
+++ b/common/ai/aid/aitool/tool_invoke_test.go
@@ -1,6 +1,7 @@
 package aitool
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -617,13 +618,43 @@ func TestInvokeWithParamsLargeContent(t *testing.T) {
 	require.True(t, ok, "结果类型错误，期望 *ToolExecutionResult")
 
 	// CombinedOutput 应该包含完整的 stdout 和 stderr 内容
-	// (InvokeWithParams 不再做截断，截断在 saveToolCallFiles 层完成)
+	// (InvokeWithParams 保留底层完整结果；AI 编排层会将结果外置到 Artifact，
+	// 并在进入 Timeline 前生成受 token 上限约束的字符串 Data。)
 	require.Contains(t, execResult.CombinedOutput, strings.Repeat("A", 100), "合并输出应包含 stdout 内容")
 	require.Contains(t, execResult.CombinedOutput, strings.Repeat("B", 100), "合并输出应包含 stderr 内容")
 
 	// stdout 和 stderr 仍然分别保留
 	require.Contains(t, execResult.Stdout, strings.Repeat("A", 100), "stdout 应包含 stdout 内容")
 	require.Contains(t, execResult.Stderr, strings.Repeat("B", 100), "stderr 应包含 stderr 内容")
+}
+
+func TestInvokeWithParamsCanDisableInMemoryOutputCapture(t *testing.T) {
+	tool, err := New("artifact-owned-output",
+		WithSimpleCallback(func(_ InvokeParams, stdout, stderr io.Writer) (any, error) {
+			_, _ = io.WriteString(stdout, "stdout-owned-by-artifact")
+			_, _ = io.WriteString(stderr, "stderr-owned-by-artifact")
+			return map[string]any{"status": "ok"}, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	result, err := tool.InvokeWithParams(
+		map[string]any{},
+		WithStdout(&stdout),
+		WithStderr(&stderr),
+		WithOutputCapture(false),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "stdout-owned-by-artifact", stdout.String())
+	require.Equal(t, "stderr-owned-by-artifact", stderr.String())
+
+	execution, ok := result.Data.(*ToolExecutionResult)
+	require.True(t, ok)
+	require.Empty(t, execution.Stdout)
+	require.Empty(t, execution.Stderr)
+	require.Empty(t, execution.CombinedOutput)
+	require.Equal(t, map[string]any{"status": "ok"}, execution.Result)
 }
 
 func TestApplyDefault_NestedArrayWithNilPropertyTypesDoesNotPanic(t *testing.T) {

--- a/common/ai/aid/aitool/tool_result.go
+++ b/common/ai/aid/aitool/tool_result.go
@@ -99,15 +99,24 @@ func (t *Tool) ExecuteToolWithCapture(ctx context.Context, params map[string]any
 	// 创建stdout和stderr的缓冲区
 	stdoutBuf := new(bytes.Buffer)
 	stderrBuf := new(bytes.Buffer)
-	if stdout != nil {
-		stdout = io.MultiWriter(stdout, stdoutBuf, combinedBuf)
+	if config.ShouldCaptureOutput() {
+		if stdout != nil {
+			stdout = io.MultiWriter(stdout, stdoutBuf, combinedBuf)
+		} else {
+			stdout = io.MultiWriter(stdoutBuf, combinedBuf)
+		}
+		if stderr != nil {
+			stderr = io.MultiWriter(stderr, stderrBuf, combinedBuf)
+		} else {
+			stderr = io.MultiWriter(stderrBuf, combinedBuf)
+		}
 	} else {
-		stdout = io.MultiWriter(stdoutBuf, combinedBuf)
-	}
-	if stderr != nil {
-		stderr = io.MultiWriter(stderr, stderrBuf, combinedBuf)
-	} else {
-		stderr = io.MultiWriter(stderrBuf, combinedBuf)
+		if stdout == nil {
+			stdout = io.Discard
+		}
+		if stderr == nil {
+			stderr = io.Discard
+		}
 	}
 	var res any
 	var err error

--- a/common/ai/aid/aive/value_feedback.go
+++ b/common/ai/aid/aive/value_feedback.go
@@ -227,6 +227,7 @@ func submitValueFeedbackInternal(ctx context.Context, cfg *aicommon.Config, reco
 	forge, err := aiforge.NewLiteForge(
 		valueFeedbackActionName,
 		aiforge.WithLiteForge_Prompt(prompt),
+		aiforge.WithLiteForge_DisableTimeline(),
 		aiforge.WithLiteForge_OutputSchemaRaw(valueFeedbackActionName, outputSchema),
 		aiforge.WithLiteForge_SpeedPriority(),
 		aiforge.WithExtendLiteForge_AIOption(aicommon.WithFastAICallback(cb)),

--- a/common/ai/aid/memory.go
+++ b/common/ai/aid/memory.go
@@ -204,7 +204,7 @@ func (m *PromptContextProvider) TimelineDump() string {
 }
 
 // TimelineDumpFrozenOpen 把 timeline 拆成 frozen / open 两半返回,
-// 提供给 LiteForge 等 5 段稳定性分层模板把 frozen 段塞进
+// 提供给需要完整 Timeline 的 5 段稳定性分层模板把 frozen 段塞进
 // <|AI_CACHE_FROZEN_semi-dynamic|> 块, open 段塞进
 // <|PROMPT_SECTION_timeline-open|> 块。
 //
@@ -213,7 +213,7 @@ func (m *PromptContextProvider) TimelineDump() string {
 //
 // 关键词: PromptContextProvider.TimelineDumpFrozenOpen, 5 段稳定性分层,
 //
-//	LiteForge timeline 拆分, frozen open
+//	full timeline 拆分, frozen open
 func (m *PromptContextProvider) TimelineDumpFrozenOpen() (frozen string, open string) {
 	if m == nil || m.timeline == nil {
 		return "", ""

--- a/common/aiforge/liteforge.go
+++ b/common/aiforge/liteforge.go
@@ -20,6 +20,12 @@ import (
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
 
+// liteForgeRecentTimelineTokens keeps one-shot LiteForge helpers lightweight.
+// LiteForge callers already pass the task-specific material in Prompt/Params;
+// the parent Timeline is only supporting context and must not grow with the
+// lifetime of a persistent session.
+const liteForgeRecentTimelineTokens = 4 * 1024
+
 func init() {
 	utils.Debug(func() {
 		log.Info("liteforge.go is already registered aicommon.LiteForgeExecuteCallback")
@@ -59,6 +65,7 @@ type LiteForge struct {
 	OutputSchema        string
 	OutputActionName    string
 	PreferSpeedPriority bool
+	DisableTimeline     bool
 	ExtendAIDOptions    []aicommon.ConfigOption
 
 	streamFields         *omap.OrderedMap[string, *streamableField]
@@ -121,6 +128,16 @@ func WithLiteForge_FieldStreamEmitterCallback(fieldKeys []string, callback Field
 }
 
 type LiteForgeOption func(*LiteForge) error
+
+// WithLiteForge_DisableTimeline is for callers whose dynamic prompt already
+// carries a deliberately bounded trace. It prevents LiteForge from appending
+// a second recent Timeline copy to the same lightweight request.
+func WithLiteForge_DisableTimeline() LiteForgeOption {
+	return func(l *LiteForge) error {
+		l.DisableTimeline = true
+		return nil
+	}
+}
 
 func WithLiteForge_SpeedPriority(b ...bool) LiteForgeOption {
 	return func(l *LiteForge) error {
@@ -342,7 +359,16 @@ func (l *LiteForge) ExecuteEx(ctx context.Context, params []*ypb.ExecParamItem, 
 	}
 	call := callBuffer.String()
 
-	timelineFrozen, timelineOpen := cod.ContextProvider.TimelineDumpFrozenOpen()
+	// A LiteForge created with the parent persistent-session ID restores the
+	// parent's Timeline. Feeding its complete Frozen/Open projection here made
+	// every speed-priority helper call grow with the whole session, even though
+	// the ReAct lightweight loop itself was already bounded. Keep only a recent
+	// prompt projection and deliberately leave the frozen block empty: this is a
+	// one-shot helper context, not a second copy of the main loop's history.
+	var timelineOpen string
+	if !l.DisableTimeline {
+		timelineOpen = liteForgeRecentTimeline(cod.ContextProvider.GetTimelineInstance())
+	}
 	rendered, err := renderLiteForgePrompt(liteForgePromptParams{
 		Nonce:               nonce,
 		Prompt:              string(l.Prompt),
@@ -350,7 +376,7 @@ func (l *LiteForge) ExecuteEx(ctx context.Context, params []*ypb.ExecParamItem, 
 		Params:              call,
 		Schema:              string(l.OutputSchema),
 		PersistentMemory:    cod.ContextProvider.PersistentMemory(),
-		TimelineFrozenBlock: timelineFrozen,
+		TimelineFrozenBlock: "",
 		TimelineOpen:        timelineOpen,
 	})
 	if err != nil {
@@ -436,6 +462,13 @@ func (l *LiteForge) ExecuteEx(ctx context.Context, params []*ypb.ExecParamItem, 
 	}
 	result := &ForgeResult{Action: action}
 	return result, nil
+}
+
+func liteForgeRecentTimeline(timeline *aicommon.Timeline) string {
+	if timeline == nil {
+		return ""
+	}
+	return timeline.DumpRecentForPrompt(liteForgeRecentTimelineTokens)
 }
 
 // liteForgePromptParams 是 LiteForge prompt 渲染时传入模板的字段集合。

--- a/common/aiforge/liteforge_promptsection_test.go
+++ b/common/aiforge/liteforge_promptsection_test.go
@@ -7,9 +7,33 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicache"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/ytoken"
 	"github.com/yaklang/yaklang/common/utils"
 )
+
+func TestLiteForgeRecentTimelineIsBoundedAndExcludesOldHistory(t *testing.T) {
+	timeline := aicommon.NewTimeline(nil, nil)
+	timeline.PushText(1, "OLD_SENTINEL "+strings.Repeat("old-history ", 12000))
+	timeline.PushText(2, "NEW_SENTINEL "+strings.Repeat("recent-context ", 6000))
+
+	recent := liteForgeRecentTimeline(timeline)
+	require.NotEmpty(t, recent)
+	require.LessOrEqual(t, ytoken.CalcTokenCount(recent), liteForgeRecentTimelineTokens)
+	require.Contains(t, recent, "NEW_SENTINEL")
+	require.NotContains(t, recent, "OLD_SENTINEL")
+	require.Contains(t, recent, "older timeline entries omitted")
+}
+
+func TestLiteForgeRecentTimelineHandlesNil(t *testing.T) {
+	require.Empty(t, liteForgeRecentTimeline(nil))
+}
+
+func TestLiteForgeDisableTimelineOption(t *testing.T) {
+	forge, err := NewLiteForge("bounded-trace", WithLiteForge_DisableTimeline())
+	require.NoError(t, err)
+	require.True(t, forge.DisableTimeline)
+}
 
 // TestLiteForgePrompt_SplitsIntoFourSections 验证 LiteForge 模板能被 aicache.Split 切成预期的 4 段
 // B 档语义：StaticInstruction -> high-static 段；Prompt -> dynamic 段


### PR DESCRIPTION
## What changed

- externalize complete stdout, stderr, combined output, and result into a per-call artifact bundle
- replace `ToolResult.Data` with one canonical bounded CombinedOutput + Result preview and artifact HINT
- enforce a 16K-token ceiling across Data and the rendered Timeline item, including oversized params/errors
- preserve stdout/stderr interleaving in `combined_output.txt` and bound live UI streaming to head/tail samples
- migrate legacy checkpoint/Timeline execution envelopes without retaining the original structured result in prompt state
- bound LiteForge helpers to recent Timeline context and remove duplicate full-Timeline injection from AIVE/value feedback
- remove AI catalog chunk matching from intent initialization in favor of exact local identifiers plus bounded BM25 lookup
- make memory triage self-contained, limit its input to 4K tokens, and disable automatic parent Timeline injection
- add `--disable-plan` to the cachebench ReAct runner for the production reproduction path

## Validation

- `go test ./common/ai/aid/aicommon ./common/ai/aid/aimem ./common/ai/aid/aive ./common/aiforge ./common/ai/aid/aireact/reactloops/loop_intent`
- `go test ./common/ai/aid/aitool ./common/ai/aid/aireact/...`
- 200K-token stdout/stderr/result and interleaving fixtures
- real `aim.InvokeReAct` cachebench with Plan disabled and input `渗透测试 id.redhaze.top`

## Reproduction findings

Before the bounded-helper fixes, a short run produced full catalog matcher requests and periodic helpers that duplicated the growing session Timeline. In the final run:

- `capability-catalog-match`: 0 requests
- memory triage: 19.1KB and 22.2KB total requests; Timeline section 0 bytes
- AIVE/value feedback: 9 requests; Timeline section 0 bytes; largest request 18.4KB
- main ReAct initialization remained the largest healthy lightweight request at 32.3KB
- no periodic lightweight request grew into the previous 60-100K range

Final offline report: `/tmp/yaklang-cachebench-redhaze-final-20260719/cachebench-20260719-120708.json`
