### PR TITLE
fix(ai): reduce tool progress review frequency

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -333,7 +333,7 @@ type Config struct {
 	// By default, AI will periodically review tool execution progress
 	// Set DisableIntervalReview to true to disable this feature
 	DisableIntervalReview             bool          // Disable interval review during tool execution (default: false, meaning enabled)
-	IntervalReviewDuration            time.Duration // Duration between reviews (default 20s)
+	IntervalReviewDuration            time.Duration // Duration between reviews (default 60s)
 	ToolCallIntervalReviewExtraPrompt string        // Extra prompt injected into tool-call interval review
 	ToolComposeConcurrency            int           // Max concurrent tool calls in tool_compose DAG (default 2)
 	PlanExecTaskConcurrency           int           // Max concurrent executable tasks per PE DAG stage (default 1)
@@ -2250,14 +2250,14 @@ func WithDisableToolCallerIntervalReview(disable bool) ConfigOption {
 }
 
 // WithToolCallerIntervalReviewDuration sets the duration between interval reviews during tool execution.
-// Default is 20 seconds if not set.
+// Default is DefaultToolCallIntervalReviewDuration if not set.
 func WithToolCallerIntervalReviewDuration(duration time.Duration) ConfigOption {
 	return func(c *Config) error {
 		if c.m == nil {
 			c.m = &sync.Mutex{}
 		}
 		if duration <= 0 {
-			duration = time.Second * 20
+			duration = DefaultToolCallIntervalReviewDuration
 		}
 		c.m.Lock()
 		c.IntervalReviewDuration = duration

--- a/common/ai/aid/aicommon/config_test.go
+++ b/common/ai/aid/aicommon/config_test.go
@@ -95,6 +95,12 @@ func TestConfig_DefaultPlanExecTaskConcurrency(t *testing.T) {
 	require.Equal(t, 1, config.PlanExecTaskConcurrency)
 }
 
+func TestConfig_InvalidIntervalReviewDurationUsesSharedDefault(t *testing.T) {
+	config := NewConfig(context.Background(), WithToolCallerIntervalReviewDuration(0))
+	require.Equal(t, DefaultToolCallIntervalReviewDuration, config.IntervalReviewDuration)
+	require.Equal(t, 60*time.Second, config.IntervalReviewDuration)
+}
+
 func TestConfig_PlanExecTaskConcurrencyPropagation(t *testing.T) {
 	parent := NewConfig(context.Background(), WithPlanExecTaskConcurrency(3))
 	child := NewConfig(context.Background(), ConvertConfigToOptions(parent)...)

--- a/common/ai/aid/aicommon/emitter.go
+++ b/common/ai/aid/aicommon/emitter.go
@@ -533,6 +533,29 @@ func (r *Emitter) EmitToolCallStatus(callToolId string, status string) (*schema.
 	})
 }
 
+// ToolCallProgressReviewPayload describes one lifecycle transition of the
+// periodic AI review for a long-running tool. Output bodies are deliberately
+// excluded: the event is for observability and must not duplicate tool data.
+type ToolCallProgressReviewPayload struct {
+	CallToolID         string  `json:"call_tool_id"`
+	Tool               string  `json:"tool"`
+	Phase              string  `json:"phase"`
+	ReviewCount        int     `json:"review_count"`
+	IntervalSeconds    float64 `json:"interval_seconds"`
+	ElapsedSeconds     float64 `json:"elapsed_seconds"`
+	ReviewDurationMS   int64   `json:"review_duration_ms,omitempty"`
+	StdoutSnapshotSize int     `json:"stdout_snapshot_bytes,omitempty"`
+	StderrSnapshotSize int     `json:"stderr_snapshot_bytes,omitempty"`
+	Decision           string  `json:"decision,omitempty"`
+	Error              string  `json:"error,omitempty"`
+	NextReviewAtMS     int64   `json:"next_review_at_ms,omitempty"`
+}
+
+func (r *Emitter) EmitToolCallProgressReview(callToolID string, payload ToolCallProgressReviewPayload) (*schema.AiOutputEvent, error) {
+	payload.CallToolID = callToolID
+	return r.EmitJSON(schema.EVENT_TOOL_CALL_PROGRESS_REVIEW, callToolID, payload)
+}
+
 func (r *Emitter) EmitToolCallDone(callToolId string, endTime time.Time, startTime time.Time, purePluginDuration time.Duration) (*schema.AiOutputEvent, error) {
 	if purePluginDuration < 0 {
 		purePluginDuration = 0

--- a/common/ai/aid/aicommon/toolcall.go
+++ b/common/ai/aid/aicommon/toolcall.go
@@ -249,7 +249,7 @@ type ToolCaller struct {
 	onCallToolEnd   func(callToolId string)
 
 	intervalReviewHandler  func(ctx context.Context, tool *aitool.Tool, params aitool.InvokeParams, stdoutSnapshot, stderrSnapshot []byte, callExpectations string) (bool, error)
-	intervalReviewDuration time.Duration // interval duration for review, default is 20 seconds
+	intervalReviewDuration time.Duration // interval duration for review, default is DefaultToolCallIntervalReviewDuration
 
 	reviewWrongToolHandler  func(ctx context.Context, tool *aitool.Tool, newToolName, keyword string) (*aitool.Tool, bool, error)
 	reviewWrongParamHandler func(ctx context.Context, tool *aitool.Tool, oldParam aitool.InvokeParams, suggestion string) (aitool.InvokeParams, error)
@@ -262,6 +262,34 @@ type ToolCaller struct {
 
 const ReservedKeyCallExpectations = "__call_expectations__"
 const ReservedKeyIdentifier = "__identifier__"
+
+// DefaultToolCallIntervalReviewDuration limits how often a long-running tool
+// wakes the speed-priority model for a progress review. Keep every fallback on
+// this shared value so Config, ReAct, and ToolCaller cannot drift apart.
+const DefaultToolCallIntervalReviewDuration = 60 * time.Second
+
+type toolCallIntervalReviewMetadataContextKey struct{}
+
+// ToolCallIntervalReviewMetadata carries scheduler-owned timing into the
+// review handler without changing the long-standing handler signature.
+type ToolCallIntervalReviewMetadata struct {
+	ToolExecutionStartedAt time.Time
+	ReviewCount            int
+}
+
+func withToolCallIntervalReviewMetadata(ctx context.Context, metadata ToolCallIntervalReviewMetadata) context.Context {
+	return context.WithValue(ctx, toolCallIntervalReviewMetadataContextKey{}, metadata)
+}
+
+// ToolCallIntervalReviewMetadataFromContext returns the actual tool execution
+// start and scheduler review count for the current progress check.
+func ToolCallIntervalReviewMetadataFromContext(ctx context.Context) (ToolCallIntervalReviewMetadata, bool) {
+	if ctx == nil {
+		return ToolCallIntervalReviewMetadata{}, false
+	}
+	metadata, ok := ctx.Value(toolCallIntervalReviewMetadataContextKey{}).(ToolCallIntervalReviewMetadata)
+	return metadata, ok
+}
 
 type ToolCallerOption func(tc *ToolCaller)
 
@@ -448,7 +476,7 @@ func WithToolCaller_IntervalReviewHandler(
 }
 
 // WithToolCaller_IntervalReviewDuration sets the interval duration for the review handler.
-// Default value is 20 seconds if not set.
+// Default value is DefaultToolCallIntervalReviewDuration if not set.
 func WithToolCaller_IntervalReviewDuration(duration time.Duration) ToolCallerOption {
 	return func(tc *ToolCaller) {
 		tc.intervalReviewDuration = duration
@@ -568,10 +596,10 @@ func (t *ToolCaller) GetEmitter() *Emitter {
 }
 
 // GetIntervalReviewDuration returns the interval review duration.
-// If not set, returns the default value of 20 seconds.
+// If not set, returns DefaultToolCallIntervalReviewDuration.
 func (t *ToolCaller) GetIntervalReviewDuration() time.Duration {
 	if t.intervalReviewDuration <= 0 {
-		return time.Second * 20
+		return DefaultToolCallIntervalReviewDuration
 	}
 	return t.intervalReviewDuration
 }

--- a/common/ai/aid/aicommon/toolcall_interval_review_test.go
+++ b/common/ai/aid/aicommon/toolcall_interval_review_test.go
@@ -2,6 +2,9 @@ package aicommon
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -9,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/schema"
 )
 
 const (
@@ -22,10 +26,10 @@ const (
 
 // TestGetIntervalReviewDuration tests the GetIntervalReviewDuration method
 func TestGetIntervalReviewDuration(t *testing.T) {
-	t.Run("default duration is 20 seconds", func(t *testing.T) {
+	t.Run("default duration is 60 seconds", func(t *testing.T) {
 		tc := &ToolCaller{}
 		duration := tc.GetIntervalReviewDuration()
-		require.Equal(t, time.Second*20, duration, "default duration should be 20 seconds")
+		require.Equal(t, time.Second*60, duration, "default duration should be 60 seconds")
 	})
 
 	t.Run("zero duration returns default", func(t *testing.T) {
@@ -33,7 +37,7 @@ func TestGetIntervalReviewDuration(t *testing.T) {
 			intervalReviewDuration: 0,
 		}
 		duration := tc.GetIntervalReviewDuration()
-		require.Equal(t, time.Second*20, duration, "zero duration should return default 20 seconds")
+		require.Equal(t, time.Second*60, duration, "zero duration should return default 60 seconds")
 	})
 
 	t.Run("negative duration returns default", func(t *testing.T) {
@@ -41,7 +45,7 @@ func TestGetIntervalReviewDuration(t *testing.T) {
 			intervalReviewDuration: -time.Second,
 		}
 		duration := tc.GetIntervalReviewDuration()
-		require.Equal(t, time.Second*20, duration, "negative duration should return default 20 seconds")
+		require.Equal(t, time.Second*60, duration, "negative duration should return default 60 seconds")
 	})
 
 	t.Run("custom duration is preserved", func(t *testing.T) {
@@ -139,7 +143,9 @@ func TestIntervalReviewContext(t *testing.T) {
 
 	t.Run("exits when context is cancelled", func(t *testing.T) {
 		tc := &ToolCaller{
-			intervalReviewDuration: testMediumInterval,
+			// Deliberately much longer than the assertion timeout: cancellation
+			// must interrupt the wait rather than linger until the next review.
+			intervalReviewDuration: 5 * time.Second,
 			intervalReviewHandler: func(ctx context.Context, tool *aitool.Tool, params aitool.InvokeParams, stdout, stderr []byte, callExpectations string) (bool, error) {
 				return true, nil
 			},
@@ -202,6 +208,7 @@ func TestIntervalReviewContext(t *testing.T) {
 		var callCount int32
 		var reviewCancelCalled bool
 		var userCancelCalled bool
+		var userCancelReason any
 		var userCancelMu sync.Mutex
 
 		tc := &ToolCaller{
@@ -225,6 +232,7 @@ func TestIntervalReviewContext(t *testing.T) {
 		userCancel := func(reason any) {
 			userCancelMu.Lock()
 			userCancelCalled = true
+			userCancelReason = reason
 			userCancelMu.Unlock()
 		}
 
@@ -239,6 +247,7 @@ func TestIntervalReviewContext(t *testing.T) {
 			require.True(t, reviewCancelCalled, "reviewCancel should be called when handler returns false")
 			userCancelMu.Lock()
 			require.True(t, userCancelCalled, "userCancel should be called when handler returns false")
+			require.Equal(t, "tool execution cancelled by interval progress review", userCancelReason)
 			userCancelMu.Unlock()
 		case <-time.After(testQuickTimeout):
 			t.Fatal("intervalReviewContext should exit after handler returns false")
@@ -380,6 +389,123 @@ func TestIntervalReviewContext(t *testing.T) {
 		case <-time.After(testQuickTimeout):
 			t.Fatal("intervalReviewContext should observe updated buffer content")
 		}
+	})
+
+	t.Run("emits bounded progress review lifecycle events", func(t *testing.T) {
+		var eventsMu sync.Mutex
+		var payloads []ToolCallProgressReviewPayload
+		emitter := NewEmitter("test-progress-review", func(event *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+			if event.Type != schema.EVENT_TOOL_CALL_PROGRESS_REVIEW {
+				return event, nil
+			}
+			var payload ToolCallProgressReviewPayload
+			require.NoError(t, json.Unmarshal(event.Content, &payload))
+			eventsMu.Lock()
+			payloads = append(payloads, payload)
+			eventsMu.Unlock()
+			return event, nil
+		})
+
+		tc := &ToolCaller{
+			callToolId:             "call-progress-review",
+			emitter:                emitter,
+			intervalReviewDuration: testShortInterval,
+			intervalReviewHandler: func(ctx context.Context, tool *aitool.Tool, params aitool.InvokeParams, stdout, stderr []byte, callExpectations string) (bool, error) {
+				metadata, ok := ToolCallIntervalReviewMetadataFromContext(ctx)
+				require.True(t, ok)
+				require.False(t, metadata.ToolExecutionStartedAt.IsZero())
+				require.Equal(t, 1, metadata.ReviewCount)
+				return false, nil
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), testWaitTimeout)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			tc.intervalReviewContext(
+				ctx, cancel,
+				aitool.NewWithoutCallback("long-running-tool"), nil,
+				staticSnapshot([]byte("stdout")), staticSnapshot([]byte("stderr")), nil,
+			)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(testQuickTimeout):
+			t.Fatal("intervalReviewContext should finish after cancel decision")
+		}
+
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		require.Len(t, payloads, 3)
+		require.Equal(t, []string{
+			schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_SCHEDULED,
+			schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_STARTED,
+			schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_COMPLETED,
+		}, []string{
+			payloads[0].Phase, payloads[1].Phase, payloads[2].Phase,
+		})
+		require.Equal(t, "call-progress-review", payloads[0].CallToolID)
+		require.Equal(t, "long-running-tool", payloads[1].Tool)
+		require.Equal(t, 1, payloads[1].ReviewCount)
+		require.Equal(t, len("stdout"), payloads[1].StdoutSnapshotSize)
+		require.Equal(t, len("stderr"), payloads[1].StderrSnapshotSize)
+		require.Equal(t, "cancel", payloads[2].Decision)
+		require.Zero(t, payloads[2].NextReviewAtMS)
+	})
+
+	t.Run("emits failed review and continues to next check", func(t *testing.T) {
+		var eventsMu sync.Mutex
+		var payloads []ToolCallProgressReviewPayload
+		emitter := NewEmitter("test-progress-review-failure", func(event *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+			if event.Type == schema.EVENT_TOOL_CALL_PROGRESS_REVIEW {
+				var payload ToolCallProgressReviewPayload
+				require.NoError(t, json.Unmarshal(event.Content, &payload))
+				eventsMu.Lock()
+				payloads = append(payloads, payload)
+				eventsMu.Unlock()
+			}
+			return event, nil
+		})
+
+		var calls int32
+		tc := &ToolCaller{
+			callToolId:             "call-progress-review-failure",
+			emitter:                emitter,
+			intervalReviewDuration: testShortInterval,
+			intervalReviewHandler: func(ctx context.Context, tool *aitool.Tool, params aitool.InvokeParams, stdout, stderr []byte, callExpectations string) (bool, error) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					return true, errors.New(strings.Repeat("review failure ", 100))
+				}
+				return false, nil
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), testWaitTimeout)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			tc.intervalReviewContext(ctx, cancel, aitool.NewWithoutCallback("tool"), nil, nil, nil, nil)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(testQuickTimeout):
+			t.Fatal("intervalReviewContext should continue after failure and then cancel")
+		}
+
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		require.Len(t, payloads, 5)
+		require.Equal(t, schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_FAILED, payloads[2].Phase)
+		require.Equal(t, "continue", payloads[2].Decision)
+		require.NotEmpty(t, payloads[2].Error)
+		require.LessOrEqual(t, len(payloads[2].Error), 512)
+		require.Positive(t, payloads[2].NextReviewAtMS)
+		require.Equal(t, 2, payloads[3].ReviewCount)
+		require.Equal(t, "cancel", payloads[4].Decision)
 	})
 }
 

--- a/common/ai/aid/aicommon/toolcall_invoke.go
+++ b/common/ai/aid/aicommon/toolcall_invoke.go
@@ -98,29 +98,92 @@ func (a *ToolCaller) intervalReviewContext(
 	}
 
 	reviewDuration := a.GetIntervalReviewDuration()
+	startedAt := time.Now()
+	reviewCount := 0
+	toolName := ""
+	if tool != nil && tool.Tool != nil {
+		toolName = tool.Name
+	}
+	emitProgressReview := func(payload ToolCallProgressReviewPayload) {
+		if a.emitter == nil {
+			return
+		}
+		payload.Tool = toolName
+		payload.IntervalSeconds = reviewDuration.Seconds()
+		payload.ElapsedSeconds = time.Since(startedAt).Seconds()
+		if _, err := a.emitter.EmitToolCallProgressReview(a.callToolId, payload); err != nil {
+			log.Warnf("emit tool progress review event failed: %v", err)
+		}
+	}
+	emitProgressReview(ToolCallProgressReviewPayload{
+		Phase:          schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_SCHEDULED,
+		NextReviewAtMS: startedAt.Add(reviewDuration).UnixMilli(),
+	})
+
+	timer := time.NewTimer(reviewDuration)
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			time.Sleep(reviewDuration)
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				shouldContinue, err := a.intervalReviewHandler(ctx, tool, params, stdoutSnapshot(), stderrSnapshot(), a.callExpectations)
-				if err != nil {
-					log.Errorf("interval review handler failed: %v", err)
-					continue
-				}
-				if !shouldContinue {
-					reviewCancel()
-					if !utils.IsNil(onAICanceled) {
-						onAICanceled(fmt.Sprintf("interval review handler failed: %v", err))
-					}
+		case <-timer.C:
+			reviewCount++
+			stdout := stdoutSnapshot()
+			stderr := stderrSnapshot()
+			reviewStartedAt := time.Now()
+			emitProgressReview(ToolCallProgressReviewPayload{
+				Phase:              schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_STARTED,
+				ReviewCount:        reviewCount,
+				StdoutSnapshotSize: len(stdout),
+				StderrSnapshotSize: len(stderr),
+			})
+
+			reviewCtx := withToolCallIntervalReviewMetadata(ctx, ToolCallIntervalReviewMetadata{
+				ToolExecutionStartedAt: startedAt,
+				ReviewCount:            reviewCount,
+			})
+			shouldContinue, err := a.intervalReviewHandler(reviewCtx, tool, params, stdout, stderr, a.callExpectations)
+			reviewDurationMS := time.Since(reviewStartedAt).Milliseconds()
+			if err != nil {
+				log.Errorf("interval review handler failed: %v", err)
+				emitProgressReview(ToolCallProgressReviewPayload{
+					Phase:            schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_FAILED,
+					ReviewCount:      reviewCount,
+					ReviewDurationMS: reviewDurationMS,
+					Decision:         "continue",
+					Error:            utils.ShrinkString(err.Error(), 480),
+					NextReviewAtMS:   time.Now().Add(reviewDuration).UnixMilli(),
+				})
+				if ctx.Err() != nil {
 					return
 				}
+				timer.Reset(reviewDuration)
+				continue
 			}
+
+			decision := "continue"
+			if !shouldContinue {
+				decision = "cancel"
+			}
+			nextReviewAtMS := int64(0)
+			if shouldContinue {
+				nextReviewAtMS = time.Now().Add(reviewDuration).UnixMilli()
+			}
+			emitProgressReview(ToolCallProgressReviewPayload{
+				Phase:            schema.TOOL_CALL_PROGRESS_REVIEW_PHASE_COMPLETED,
+				ReviewCount:      reviewCount,
+				ReviewDurationMS: reviewDurationMS,
+				Decision:         decision,
+				NextReviewAtMS:   nextReviewAtMS,
+			})
+			if !shouldContinue {
+				reviewCancel()
+				if !utils.IsNil(onAICanceled) {
+					onAICanceled("tool execution cancelled by interval progress review")
+				}
+				return
+			}
+			timer.Reset(reviewDuration)
 		}
 	}
 }

--- a/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
@@ -122,12 +122,10 @@ func TestReAct_ToolCall_FileEmit(t *testing.T) {
 		}
 	}()
 
-	// 设置超时时间，确保测试在10s内完成
-	du := time.Duration(8)
-	if utils.InGithubActions() {
-		du = time.Duration(5)
-	}
-	after := time.After(du * time.Second)
+	// Artifact persistence is I/O-bound and can be slower on shared CI runners.
+	// Keep the assertion below the documented 10s budget without making CI use a
+	// stricter deadline than local runs.
+	after := time.After(8 * time.Second)
 
 	// 收集 emit 的 report markdown 文件路径
 	var reportFilePath string

--- a/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
@@ -317,12 +317,10 @@ func TestReAct_ToolCall_FileEmit_LargeResult(t *testing.T) {
 		}
 	}()
 
-	// 设置超时时间，确保测试在10s内完成
-	du := time.Duration(8)
-	if utils.InGithubActions() {
-		du = time.Duration(5)
-	}
-	after := time.After(du * time.Second)
+	// Artifact persistence is I/O-bound and can be slower on shared CI runners.
+	// Keep the assertion below the documented 10s budget without making CI use a
+	// stricter deadline than local runs.
+	after := time.After(8 * time.Second)
 
 	var reportFilePath string
 	toolCallDone := false

--- a/common/ai/aid/aireact/invoke_toolcall_interval_review.go
+++ b/common/ai/aid/aireact/invoke_toolcall_interval_review.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
@@ -71,8 +70,8 @@ func (r *ReAct) _invokeToolCall_IntervalReviewWithContext(
 	)
 	if err != nil {
 		log.Errorf("failed to generate interval review prompt: %v", err)
-		// If we can't generate the prompt, continue by default
-		return true, nil
+		// The scheduler reports the failure and continues by default.
+		return true, fmt.Errorf("generate interval review prompt: %w", err)
 	}
 
 	var shouldContinue = true
@@ -110,8 +109,7 @@ func (r *ReAct) _invokeToolCall_IntervalReviewWithContext(
 			)
 			if err != nil {
 				log.Errorf("failed to extract interval review action: %v", err)
-				// If extraction fails, continue by default
-				return nil
+				return fmt.Errorf("extract interval review action: %w", err)
 			}
 
 			decision := action.GetString("decision")
@@ -147,8 +145,8 @@ func (r *ReAct) _invokeToolCall_IntervalReviewWithContext(
 
 	if transErr != nil {
 		log.Errorf("interval review transaction failed: %v", transErr)
-		// If the transaction fails, continue by default
-		return true, nil
+		// The scheduler reports the failure and continues by default.
+		return true, fmt.Errorf("interval review transaction: %w", transErr)
 	}
 
 	return shouldContinue, nil
@@ -163,20 +161,23 @@ func (r *ReAct) CreateIntervalReviewHandler() func(ctx context.Context, tool *ai
 		return nil
 	}
 
-	// State maintained in closure
-	var startTime time.Time
-	var reviewCount int32
+	// The scheduler injects the actual tool execution start and review count via
+	// context. Keep local fallbacks for direct handler callers and old tests.
+	fallbackStartTime := time.Now()
+	var fallbackReviewCount int
 
 	return func(ctx context.Context, tool *aitool.Tool, params aitool.InvokeParams, stdoutSnapshot, stderrSnapshot []byte, callExpectations string) (bool, error) {
-		// Initialize start time on first call
-		if startTime.IsZero() {
-			startTime = time.Now()
+		startTime := fallbackStartTime
+		reviewCount := 0
+		if metadata, ok := aicommon.ToolCallIntervalReviewMetadataFromContext(ctx); ok {
+			startTime = metadata.ToolExecutionStartedAt
+			reviewCount = metadata.ReviewCount
+		} else {
+			fallbackReviewCount++
+			reviewCount = fallbackReviewCount
 		}
 
-		// Increment review count
-		count := int(atomic.AddInt32(&reviewCount, 1))
-
-		return r._invokeToolCall_IntervalReviewWithContext(ctx, tool, params, stdoutSnapshot, stderrSnapshot, startTime, count, callExpectations)
+		return r._invokeToolCall_IntervalReviewWithContext(ctx, tool, params, stdoutSnapshot, stderrSnapshot, startTime, reviewCount, callExpectations)
 	}
 }
 
@@ -187,7 +188,7 @@ func (r *ReAct) GetIntervalReviewDuration() time.Duration {
 		return 0
 	}
 	if r.config.IntervalReviewDuration <= 0 {
-		return time.Second * 20 // default 20 seconds
+		return aicommon.DefaultToolCallIntervalReviewDuration
 	}
 	return r.config.IntervalReviewDuration
 }

--- a/common/schema/ai_event.go
+++ b/common/schema/ai_event.go
@@ -139,17 +139,25 @@ const (
 	// contains score, reason, and other information to help uesr interactivation
 	EVENT_TYPE_RISK_CONTROL_PROMPT = "risk_control_prompt"
 
-	EVENT_TOOL_CALL_START       = "tool_call_start"       // tool call start event, used to emit the tool call start information
-	EVENT_TOOL_CALL_STATUS      = "tool_call_status"      // tool call status event, used to emit the tool call status information
-	EVENT_TOOL_CALL_USER_CANCEL = "tool_call_user_cancel" // tool call user cancel event, used to emit the tool call user cancel information
-	EVENT_TOOL_CALL_DONE        = "tool_call_done"        // tool call end event, used to emit the tool call end information
-	EVENT_TOOL_CALL_ERROR       = "tool_call_error"       // tool call error event, used to emit the tool call error information
-	EVENT_TOOL_CALL_SUMMARY     = "tool_call_summary"     // tool call summary event, used to emit the tool call summary information
-	EVENT_TOOL_CALL_DECISION    = "tool_call_decision"    // tool call decision event, used to emit the tool call decision information
-	EVENT_TOOL_CALL_RESULT      = "tool_call_result"      // tool call result event, used to emit the tool call result information
-	EVENT_TOOL_CALL_PARAM       = "tool_call_param"       // tool call param event, used to emit the final invoke params bound to call tool id
-	EVENT_TOOL_CALL_LOG_DIR     = "tool_call_log_dir"     // tool call log dir event, used to emit the tool call log dir information
-	EVENT_TOOL_CALL_REASON      = "tool_call_reason"      // tool call reason event, used to emit the human-readable reason of this tool call
+	EVENT_TOOL_CALL_START           = "tool_call_start"           // tool call start event, used to emit the tool call start information
+	EVENT_TOOL_CALL_STATUS          = "tool_call_status"          // tool call status event, used to emit the tool call status information
+	EVENT_TOOL_CALL_USER_CANCEL     = "tool_call_user_cancel"     // tool call user cancel event, used to emit the tool call user cancel information
+	EVENT_TOOL_CALL_DONE            = "tool_call_done"            // tool call end event, used to emit the tool call end information
+	EVENT_TOOL_CALL_ERROR           = "tool_call_error"           // tool call error event, used to emit the tool call error information
+	EVENT_TOOL_CALL_SUMMARY         = "tool_call_summary"         // tool call summary event, used to emit the tool call summary information
+	EVENT_TOOL_CALL_DECISION        = "tool_call_decision"        // tool call decision event, used to emit the tool call decision information
+	EVENT_TOOL_CALL_RESULT          = "tool_call_result"          // tool call result event, used to emit the tool call result information
+	EVENT_TOOL_CALL_PARAM           = "tool_call_param"           // tool call param event, used to emit the final invoke params bound to call tool id
+	EVENT_TOOL_CALL_LOG_DIR         = "tool_call_log_dir"         // tool call log dir event, used to emit the tool call log dir information
+	EVENT_TOOL_CALL_REASON          = "tool_call_reason"          // tool call reason event, used to emit the human-readable reason of this tool call
+	EVENT_TOOL_CALL_PROGRESS_REVIEW = "tool_call_progress_review" // periodic AI progress review lifecycle for long-running tools
+)
+
+const (
+	TOOL_CALL_PROGRESS_REVIEW_PHASE_SCHEDULED = "scheduled"
+	TOOL_CALL_PROGRESS_REVIEW_PHASE_STARTED   = "started"
+	TOOL_CALL_PROGRESS_REVIEW_PHASE_COMPLETED = "completed"
+	TOOL_CALL_PROGRESS_REVIEW_PHASE_FAILED    = "failed"
 )
 
 // ToolCallStatus is the in-progress status carried by EVENT_TOOL_CALL_STATUS (json field "status").


### PR DESCRIPTION
## Summary

- standardize long-running tool progress reviews on a shared 60-second default
- make the review timer cancellation-aware and preserve the real tool execution start time
- emit bounded scheduled/started/completed/failed progress-review lifecycle events without duplicating tool output
- report AI review failures as continue-by-default and use an explicit cancellation reason

## Tests

- `GOENV_VERSION=1.22.12 goenv exec go test ./common/ai/aid/aicommon ./common/ai/aid/aireact -count=1`
- focused interval-review and ReAct prompt/tool-call tests after final changes
- `GOENV_VERSION=1.22.12 goenv exec go test -race ./common/ai/aid/aicommon -run '^TestIntervalReviewContext$' -count=1`
- `git diff --check`