### PR TITLE
fix(antlr): fix doc generation after antlr dependency migration

### DIFF
--- a/common/yak/antlr4yak/engine_compile_to_bytes.go
+++ b/common/yak/antlr4yak/engine_compile_to_bytes.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
+	"github.com/yaklang/antlr/v4"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"

--- a/docs/design/yak-stdlib-dependency-boundary-audit.md
+++ b/docs/design/yak-stdlib-dependency-boundary-audit.md
@@ -134,7 +134,7 @@ Important shortest paths:
 ```text
 runtime_go -> common/yak/yaklang/lib/builtin -> common/yak/yaklang -> common/yak/yaklib -> common/cybertunnel -> github.com/yaklang/pcap
 runtime_go -> common/yak/yaklang/lib/builtin -> common/utils -> common/yakgrpc/ypb -> google.golang.org/grpc
-runtime_go -> common/yak/ssaapi -> common/syntaxflow/sfvm -> github.com/antlr/antlr4/runtime/Go/antlr/v4
+runtime_go -> common/yak/ssaapi -> common/syntaxflow/sfvm -> github.com/yaklang/antlr/v4
 runtime_go -> common/yak/ssaapi -> common/yak/java/java2ssa -> common/sca
 runtime_go -> common/yak/ssaapi -> common/utils/yakgit -> github.com/go-git/go-git/v5
 runtime_go -> common/yak/ssaapi -> common/utils/yakgit -> github.com/go-git/go-git/v5 -> github.com/ProtonMail/go-crypto/openpgp
@@ -458,7 +458,7 @@ Evidence:
   - `runtime_go -> common/yak/ssaapi -> common/yak/java/java2ssa -> common/sca`
   - `runtime_go -> common/yak/ssaapi -> common/utils/yakgit -> github.com/go-git/go-git/v5`
   - `runtime_go -> common/yak/ssaapi -> common/yakgrpc/yakit -> common/cybertunnel -> github.com/yaklang/pcap`
-  - `runtime_go -> common/yak/ssaapi -> common/syntaxflow/sfvm -> github.com/antlr/antlr4/runtime/Go/antlr/v4`
+  - `runtime_go -> common/yak/ssaapi -> common/syntaxflow/sfvm -> github.com/yaklang/antlr/v4`
 - Shortest paths:
   - `runtime_go -> common/yak/ssaapi -> common/syntaxflow/sfvm`
   - `runtime_go -> common/yak/ssaapi -> common/yakgrpc/yakit -> common/ai/aispec`

--- a/go.work.sum
+++ b/go.work.sum
@@ -22,8 +22,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
-github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
-github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 h1:G1bPvciwNyF7IUmKXNt9Ak3m6u9DE1rF+RmtIkBpVdA=
 github.com/beevik/ntp v0.3.0 h1:xzVrPrE4ziasFXgBVBZJDP0Wg/KpMwk2KHJ4Ba8GrDw=
 github.com/beevik/ntp v0.3.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=


### PR DESCRIPTION
## Summary
- Replace leftover `github.com/antlr/antlr4/runtime/Go/antlr/v4` import in `engine_compile_to_bytes.go` with `github.com/yaklang/antlr/v4`, fixing Prepare Embed Docs CI failure after the antlr fork merge.
- Drop stale `github.com/antlr4-go/antlr/v4` entries from `go.work.sum` and update the dependency audit doc path.

## Test plan
- [x] `go build ./common/yak/antlr4yak/`
- [x] `go build -gcflags=all="-N -l" common/yak/yakdoc/generate_doc/generate_doc.go`
- [x] `go list -m all | rg antlr` only shows `github.com/yaklang/antlr/v4`
- [ ] Confirm Prepare Embed Docs / Generate Document job passes on this PR


Made with [Cursor](https://cursor.com)