### PR TITLE
feat(yakit): spill multipart file parts to sidecar with editable skel…

### DIFF
--- a/common/schema/plugin_usage_count.go
+++ b/common/schema/plugin_usage_count.go
@@ -1,6 +1,6 @@
 package schema
 
-import "github.com/jinzhu/gorm"
+import "github.com/yaklang/gorm"
 
 // PluginUsageCount 记录插件的全局使用次数，注册在 profile 库（与 yak_scripts 同库），
 // 供 QueryYakScript 按使用次数排序（单库子查询，避免跨库 JOIN）。

--- a/common/yakgrpc/grpc_fuzzer_test.go
+++ b/common/yakgrpc/grpc_fuzzer_test.go
@@ -1527,8 +1527,11 @@ Content-Type: image/jpeg
 	if flow.TooLargeRequestBodyFile == "" {
 		t.Fatal("too large request body file path missing")
 	}
-	if !strings.Contains(string(flow.Request), "request too large") {
-		t.Fatal("GetHTTPFlowById should return header with truncate notice, got: " + utils.ByteSize(uint64(len(flow.Request))))
+	// Oversized multipart requests carrying a file part are skeletonized: the
+	// in-DB request holds an editable multipart skeleton with a per-file
+	// placeholder, not the flat "request too large" truncate notice.
+	if !strings.Contains(string(flow.Request), "multipart file spilled") {
+		t.Fatal("GetHTTPFlowById should return multipart skeleton with spilled-file placeholder, got: " + utils.ByteSize(uint64(len(flow.Request))))
 	}
 
 	bodyStream, err := client.GetHTTPFlowBodyById(context.Background(), &ypb.GetHTTPFlowBodyByIdRequest{

--- a/common/yakgrpc/grpc_httpflow.go
+++ b/common/yakgrpc/grpc_httpflow.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"fmt"
 	"github.com/yaklang/yaklang/common/go-funk"
 	"golang.org/x/exp/slices"
 	"io"
@@ -137,18 +138,52 @@ func (s *Server) GetHTTPFlowBodyById(r *ypb.GetHTTPFlowBodyByIdRequest, stream y
 		if r.IsRisk {
 			packet = risk.QuotedRequest
 		} else if flow.TooLargeRequestBodyFile != "" {
-			fh, err := os.Open(flow.TooLargeRequestBodyFile)
-			if err != nil {
-				return utils.Wrap(err, "GetHTTPFlowBodyById: open request body file error")
-			}
-			defer fh.Close()
-			reader = fh
-			u := utils.ParseStringToUrl(flow.Url)
-			base := path.Base(u.Path)
-			if base != "" && base != "." && base != "/" {
-				filename = base
+			// Multipart-spilled request: per-part files live in the sidecar
+			// directory and the body file is a 0-byte placeholder. Either
+			// stream a single part (PartIndex >= 0) or rebuild the complete
+			// multipart body on demand (PartIndex < 0).
+			if yakit.FlowIsMultipartSpill(flow) {
+				if r.PartIndex != nil {
+					partIdx := int(*r.PartIndex)
+					fh, partFilename, ferr := yakit.OpenFlowMultipartPart(flow, partIdx)
+					if ferr != nil {
+						return utils.Wrap(ferr, "GetHTTPFlowBodyById: open multipart part file error")
+					}
+					defer fh.Close()
+					reader = fh
+					if partFilename != "" {
+						filename = partFilename
+					} else {
+						filename = fmt.Sprintf("part-%d.bin", partIdx)
+					}
+				} else {
+					rr, rerr := yakit.RebuildFlowMultipartBody(flow)
+					if rerr != nil {
+						return utils.Wrap(rerr, "GetHTTPFlowBodyById: rebuild multipart body error")
+					}
+					reader = rr
+					u := utils.ParseStringToUrl(flow.Url)
+					base := path.Base(u.Path)
+					if base != "" && base != "." && base != "/" {
+						filename = base
+					} else {
+						filename = "multipart-body.bin"
+					}
+				}
 			} else {
-				filename = "request-body.bin"
+				fh, err := os.Open(flow.TooLargeRequestBodyFile)
+				if err != nil {
+					return utils.Wrap(err, "GetHTTPFlowBodyById: open request body file error")
+				}
+				defer fh.Close()
+				reader = fh
+				u := utils.ParseStringToUrl(flow.Url)
+				base := path.Base(u.Path)
+				if base != "" && base != "." && base != "/" {
+					filename = base
+				} else {
+					filename = "request-body.bin"
+				}
 			}
 		} else {
 			packet = flow.Request

--- a/common/yakgrpc/grpc_httpflow_multipart_body_test.go
+++ b/common/yakgrpc/grpc_httpflow_multipart_body_test.go
@@ -1,0 +1,167 @@
+package yakgrpc
+
+import (
+	"context"
+	"io"
+	"mime/multipart"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// buildBigMultipartRequest builds an oversized multipart/form-data request
+// carrying one text field and two file parts (so it triggers skeleton spill).
+func buildBigMultipartRequest(t *testing.T) ([]byte, []byte, []byte) {
+	t.Helper()
+	boundary := "----YakTestBoundary"
+
+	body := &strings.Builder{}
+	// text field
+	body.WriteString("--" + boundary + "\r\n")
+	body.WriteString(`Content-Disposition: form-data; name="desc"` + "\r\n\r\n")
+	body.WriteString("hello-field" + "\r\n")
+
+	// file part 0 (oversized, > 200KB threshold to trigger spill)
+	f0 := []byte(strings.Repeat("F", 250 * 1024))
+	body.WriteString("--" + boundary + "\r\n")
+	body.WriteString(`Content-Disposition: form-data; name="file0"; filename="big0.bin"` + "\r\n")
+	body.WriteString("Content-Type: application/octet-stream\r\n\r\n")
+	body.Write(f0)
+	body.WriteString("\r\n")
+
+	// file part 1 (small)
+	f1 := []byte("small-1")
+	body.WriteString("--" + boundary + "\r\n")
+	body.WriteString(`Content-Disposition: form-data; name="file1"; filename="note.txt"` + "\r\n")
+	body.WriteString("Content-Type: text/plain\r\n\r\n")
+	body.Write(f1)
+	body.WriteString("\r\n")
+
+	body.WriteString("--" + boundary + "--\r\n")
+	bodyStr := body.String()
+	header := "POST /upload/case/safe HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:8080\r\n" +
+		"Content-Type: multipart/form-data; boundary=" + boundary + "\r\n" +
+		"Content-Length: " + strconv.Itoa(len(bodyStr)) + "\r\n\r\n"
+	return []byte(header + bodyStr), f0, f1
+}
+
+func TestGRPCMUSTPASS_GetHTTPFlowBodyById_MultipartPartIndex(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	// Clean up any prior flows of this source type.
+	yakit.DeleteHTTPFlow(consts.GetGormProjectDatabase(), &ypb.DeleteHTTPFlowRequest{
+		Filter: &ypb.QueryHTTPFlowRequest{SourceType: "multipart-spill-test"},
+	})
+
+	packet, f0, f1 := buildBigMultipartRequest(t)
+	flow, err := yakit.CreateHTTPFlowFromHTTPWithBodySavedFromRaw(
+		false, packet, []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"),
+		"multipart-spill-test", "http://127.0.0.1:8080/upload/case/safe", "",
+	)
+	require.NoError(t, err)
+	flow.CalcHash()
+	require.NoError(t, consts.GetGormProjectDatabase().Save(flow).Error)
+	defer func() {
+		_ = yakit.DeleteHTTPFlow(consts.GetGormProjectDatabase(), &ypb.DeleteHTTPFlowRequest{
+			Filter: &ypb.QueryHTTPFlowRequest{SourceType: "multipart-spill-test"},
+		})
+	}()
+
+	// Detail query should expose MultipartFiles so the frontend can render a
+	// dropdown.
+	detail, err := client.GetHTTPFlowById(context.Background(), &ypb.GetHTTPFlowByIdRequest{Id: int64(flow.ID)})
+	require.NoError(t, err)
+	require.True(t, detail.GetIsTooLargeRequest(), "should be marked too large")
+	require.NotEmpty(t, detail.GetTooLargeRequestBodyFile(), "body placeholder path should be set")
+	files := detail.GetMultipartFiles()
+	require.Len(t, files, 2, "should expose two file parts")
+	// Find the big0.bin part index.
+	var big0Idx int32 = -1
+	for _, f := range files {
+		if f.GetFilename() == "big0.bin" {
+			big0Idx = f.GetPartIndex()
+		}
+	}
+	require.GreaterOrEqual(t, big0Idx, int32(0), "big0.bin part not found in manifest")
+
+	// Download that single part via PartIndex.
+	stream, err := client.GetHTTPFlowBodyById(context.Background(), &ypb.GetHTTPFlowBodyByIdRequest{
+		Id:        int64(flow.ID),
+		IsRequest: true,
+		PartIndex: &big0Idx,
+	})
+	require.NoError(t, err)
+	var (
+		gotBody   []byte
+		gotName   string
+		sawHeader bool
+	)
+	for {
+		msg, rerr := stream.Recv()
+		if rerr != nil {
+			if rerr == io.EOF {
+				break
+			}
+			t.Fatal(rerr)
+		}
+		if msg == nil {
+			break
+		}
+		if !sawHeader {
+			gotName = msg.GetFilename()
+			sawHeader = true
+		}
+		gotBody = append(gotBody, msg.GetData()...)
+		if msg.GetEOF() {
+			break
+		}
+	}
+	require.Equal(t, "big0.bin", gotName, "streamed filename should be the part's original name")
+	require.Equal(t, f0, gotBody, "streamed part content should match the uploaded file")
+
+	// Without PartIndex: full rebuilt multipart body should contain both files
+	// and the text field, parseable as multipart.
+	fullStream, err := client.GetHTTPFlowBodyById(context.Background(), &ypb.GetHTTPFlowBodyByIdRequest{
+		Id:        int64(flow.ID),
+		IsRequest: true,
+	})
+	require.NoError(t, err)
+	var fullBody []byte
+	for {
+		msg, rerr := fullStream.Recv()
+		if rerr != nil {
+			if rerr == io.EOF {
+				break
+			}
+			t.Fatal(rerr)
+		}
+		if msg == nil {
+			break
+		}
+		fullBody = append(fullBody, msg.GetData()...)
+		if msg.GetEOF() {
+			break
+		}
+	}
+	// Parse the rebuilt body and verify parts.
+	mr := multipart.NewReader(strings.NewReader(string(fullBody)), "----YakTestBoundary")
+	parts := map[string][]byte{}
+	for {
+		p, rerr := mr.NextPart()
+		if rerr != nil {
+			break
+		}
+		b, _ := io.ReadAll(p)
+		parts[p.FormName()] = b
+	}
+	require.Equal(t, "hello-field", string(parts["desc"]))
+	require.Equal(t, f0, parts["file0"])
+	require.Equal(t, f1, parts["file1"])
+}

--- a/common/yakgrpc/model/httpflow.go
+++ b/common/yakgrpc/model/httpflow.go
@@ -452,14 +452,13 @@ func FuzzParamsToGRPCFuzzableParam(r *mutate.FuzzHTTPRequestParam, isHttps bool,
 const modelMultipartSkeletonMarker = "[[yakit: multipart file spilled"
 
 // modelMultipartSidecarDirFromBodyFile mirrors yakit.multipartSidecarDirFromBodyFile.
+// For multipart spills the body file is the first spilled part file, so its
+// parent directory is the sidecar.
 func modelMultipartSidecarDirFromBodyFile(bodyFile string) string {
 	if bodyFile == "" {
 		return ""
 	}
-	dir := filepath.Dir(bodyFile)
-	base := filepath.Base(bodyFile)
-	stem := strings.TrimSuffix(base, filepath.Ext(base))
-	return filepath.Join(dir, stem+"-parts")
+	return filepath.Dir(bodyFile)
 }
 
 // manifestJSONEntry mirrors yakit.manifestJSONEntry (on-disk manifest.json).
@@ -501,6 +500,9 @@ func loadFlowMultipartFiles(f *schema.HTTPFlow) []*ypb.MultipartFileInfo {
 			Filename:    utf8safe(e.Filename),
 			ContentType: utf8safe(e.ContentType),
 			Size:        e.Size,
+			// Absolute on-disk path so the frontend can open it directly via
+			// openABSFileLocated, mirroring the existing "view body" flow.
+			FilePath: utf8safe(filepath.Join(dir, e.File)),
 		})
 	}
 	return out

--- a/common/yakgrpc/model/httpflow.go
+++ b/common/yakgrpc/model/httpflow.go
@@ -2,7 +2,10 @@ package model
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -182,6 +185,13 @@ func toHTTPFlowGRPCModel(f *schema.HTTPFlow, full bool) (*ypb.HTTPFlow, error) {
 			return utf8safe(i)
 		}),
 		Host: f.Host,
+	}
+
+	// Fill MultipartFiles for multipart-spilled requests so the frontend can
+	// render a per-file download dropdown. The manifest lives next to the
+	// 0-byte body placeholder in the sidecar directory.
+	if mpFiles := loadFlowMultipartFiles(f); len(mpFiles) > 0 {
+		flow.MultipartFiles = mpFiles
 	}
 	// 设置 title
 	var (
@@ -433,4 +443,65 @@ func FuzzParamsToGRPCFuzzableParam(r *mutate.FuzzHTTPRequestParam, isHttps bool,
 		}
 	}
 	return p
+}
+
+// multipartSkeletonMarker mirrors yakit.multipartSkeletonMarker — the prefix
+// of the in-DB skeleton placeholder for a spilled file part. Duplicated here
+// because model cannot import yakit (yakit imports model); keeping the marker
+// literal in sync is the only coupling.
+const modelMultipartSkeletonMarker = "[[yakit: multipart file spilled"
+
+// modelMultipartSidecarDirFromBodyFile mirrors yakit.multipartSidecarDirFromBodyFile.
+func modelMultipartSidecarDirFromBodyFile(bodyFile string) string {
+	if bodyFile == "" {
+		return ""
+	}
+	dir := filepath.Dir(bodyFile)
+	base := filepath.Base(bodyFile)
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	return filepath.Join(dir, stem+"-parts")
+}
+
+// manifestJSONEntry mirrors yakit.manifestJSONEntry (on-disk manifest.json).
+type manifestJSONEntry struct {
+	PartIndex   int    `json:"partIndex"`
+	FieldName   string `json:"fieldName"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	Size        int64  `json:"size"`
+	File        string `json:"file"`
+}
+
+// loadFlowMultipartFiles reads the sidecar manifest.json for a multipart-
+// spilled request and converts it to gRPC MultipartFileInfo entries for the
+// frontend dropdown. Returns nil when the flow is not a multipart spill or the
+// manifest is absent.
+func loadFlowMultipartFiles(f *schema.HTTPFlow) []*ypb.MultipartFileInfo {
+	if f == nil || !f.IsTooLargeRequest || f.TooLargeRequestBodyFile == "" {
+		return nil
+	}
+	if !bytes.Contains([]byte(f.GetRequest()), []byte(modelMultipartSkeletonMarker)) {
+		return nil
+	}
+	dir := modelMultipartSidecarDirFromBodyFile(f.TooLargeRequestBodyFile)
+	data, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		return nil
+	}
+	var entries []manifestJSONEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		log.Errorf("load multipart manifest failed: %s", err)
+		return nil
+	}
+	out := make([]*ypb.MultipartFileInfo, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, &ypb.MultipartFileInfo{
+			PartIndex:   int32(e.PartIndex),
+			FieldName:   utf8safe(e.FieldName),
+			Filename:    utf8safe(e.Filename),
+			ContentType: utf8safe(e.ContentType),
+			Size:        e.Size,
+		})
+	}
+	return out
 }

--- a/common/yakgrpc/yakgrpc.proto
+++ b/common/yakgrpc/yakgrpc.proto
@@ -7064,6 +7064,11 @@ message GetHTTPFlowBodyByIdRequest {
   string RuntimeId = 4;
 
   bool IsRisk = 5;
+
+  // multipart 请求：指定要流式返回的文件 part 索引（来自 HTTPFlow.MultipartFiles）。
+  // 未设 = 返回完整 body（multipart 时现场流式重建完整 body）。
+  // 用 optional 以区分「未设」与「part 0」。
+  optional int32 PartIndex = 6;
 }
 
 message MITMExtractAggregateFlowFilterRow {
@@ -7332,6 +7337,20 @@ message HTTPFlow {
   string TooLargeRequestBodyFile = 56;
   // 列表查询时由 SQL 计算：request 过大或 DB 中 request 过长
   bool IsRequestOversize = 57;
+
+  // 超大 multipart 请求的文件 part 列表（落盘 sidecar，manifest.json 派生）。
+  // 前端据此渲染「查看/下载 xxx 文件」下拉，而非整块 body。
+  // 非空时 GetHTTPFlowBodyById 可带 PartIndex 流式返回单个文件内容。
+  repeated MultipartFileInfo MultipartFiles = 58;
+}
+
+// MultipartFileInfo 描述一个落盘的 multipart 文件 part 元数据。
+message MultipartFileInfo {
+  int32 PartIndex = 1;    // part 在 multipart 中的解析顺序索引，对应 GetHTTPFlowBodyByIdRequest.PartIndex
+  string FieldName = 2;   // Content-Disposition: name
+  string Filename = 3;    // Content-Disposition: filename（原始文件名）
+  string ContentType = 4; // 该 part 的 Content-Type
+  int64 Size = 5;         // 该 part 内容字节数
 }
 
 message FuzzableParam {

--- a/common/yakgrpc/yakgrpc.proto
+++ b/common/yakgrpc/yakgrpc.proto
@@ -7351,6 +7351,7 @@ message MultipartFileInfo {
   string Filename = 3;    // Content-Disposition: filename（原始文件名）
   string ContentType = 4; // 该 part 的 Content-Type
   int64 Size = 5;         // 该 part 内容字节数
+  string FilePath = 6;    // 该 part 落盘文件的绝对路径，前端可直接 openABSFileLocated 打开
 }
 
 message FuzzableParam {

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -831,6 +831,12 @@ func GetHTTPFlowByHiddenIndex(db *gorm.DB, index string) (*schema.HTTPFlow, erro
 }
 
 func DeleteHTTPFlowByID(db *gorm.DB, id int64) error {
+	// Clean up multipart sidecar parts derived from the spilled body file
+	// before the row is removed, since the body file path lives only on the
+	// flow record. (Flat spill file cleanup is a separate concern.)
+	if flow, err := GetHTTPFlow(db, id); err == nil && flow != nil {
+		cleanupMultipartSidecar(flow.TooLargeRequestBodyFile)
+	}
 	if db := db.Model(&schema.HTTPFlow{}).Where(
 		"id = ?", id,
 	).Unscoped().Delete(&schema.HTTPFlow{}); db.Error != nil {

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -832,10 +833,13 @@ func GetHTTPFlowByHiddenIndex(db *gorm.DB, index string) (*schema.HTTPFlow, erro
 
 func DeleteHTTPFlowByID(db *gorm.DB, id int64) error {
 	// Clean up multipart sidecar parts derived from the spilled body file
-	// before the row is removed, since the body file path lives only on the
-	// flow record. (Flat spill file cleanup is a separate concern.)
+	// before the row is removed, since the body/header file paths live only
+	// on the flow record. (Flat spill file cleanup is a separate concern.)
 	if flow, err := GetHTTPFlow(db, id); err == nil && flow != nil {
 		cleanupMultipartSidecar(flow.TooLargeRequestBodyFile)
+		if flow.TooLargeRequestHeaderFile != "" {
+			_ = os.Remove(flow.TooLargeRequestHeaderFile)
+		}
 	}
 	if db := db.Model(&schema.HTTPFlow{}).Where(
 		"id = ?", id,

--- a/common/yakgrpc/yakit/httpflow_large_request.go
+++ b/common/yakgrpc/yakit/httpflow_large_request.go
@@ -113,6 +113,21 @@ func spillLargeHTTPFlowRequestIfNeeded(packet []byte) (largeRequestSpillResult, 
 		return res, nil
 	}
 
+	// Multipart/form-data uploads carrying file parts are skeletonized: each
+	// file part spills to its own disk file and the in-DB body keeps only an
+	// editable skeleton with placeholders. Falls back to flat spill when the
+	// body is not multipart or carries no file part.
+	if mpRes, err := spillMultipartFilesIfNeeded(packet); err != nil {
+		log.Errorf("spill multipart request failed: %s, fall back to flat spill", err)
+	} else if mpRes.IsTooLarge {
+		res.StoredPacket = mpRes.StoredPacket
+		res.IsTooLarge = true
+		res.HeaderFile = mpRes.HeaderFile
+		res.BodyFile = mpRes.BodyFile
+		res.OriginalBodyLen = mpRes.OriginalBodyLen
+		return res, nil
+	}
+
 	uid := ksuid.New().String()
 	suffix := fmt.Sprintf(`%v_%v`, time.Now().Format(utils.DatetimePretty()), uid)
 

--- a/common/yakgrpc/yakit/httpflow_multipart_request.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request.go
@@ -92,7 +92,7 @@ func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
 	header, body := lowhttp.SplitHTTPHeadersAndBodyFromPacket(packet)
 	res.OriginalBodyLen = len(body)
 	// Only engage for oversized bodies; small multiparts take the normal path.
-	if len(body) <= maxHTTPFlowRequestBodyInDBBytes {
+	if len(body) <= MaxHTTPFlowRequestBodyInDBBytes {
 		return res, nil
 	}
 

--- a/common/yakgrpc/yakit/httpflow_multipart_request.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request.go
@@ -2,6 +2,7 @@ package yakit
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/segmentio/ksuid"
 	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
 	customMultipart "github.com/yaklang/yaklang/common/utils/multipart"
@@ -42,13 +44,17 @@ var multipartSpillMarkerPattern = regexp.MustCompile(
 // multipart/form-data body carrying at least one file part, and:
 //   - StoredPacket is the in-DB skeleton (header + skeleton body with
 //     placeholders) — small and editable.
-//   - HeaderFile / BodyFile follow the same contract as the flat spill path:
-//     HeaderFile holds the request headers, BodyFile holds the *rebuilt*
-//     complete multipart body (skeleton text fields + spilled file parts
-//     streamed back from disk). This keeps GetHTTPFlowBodyById unchanged.
-//   - MultipartDir is the sidecar directory containing the per-part files.
-//     It is always filepath.Dir(BodyFile); kept here for convenience.
-//   - Manifest lists every file part, primarily for tests/diagnostics.
+//   - HeaderFile holds the request headers (same contract as flat spill).
+//   - BodyFile is a 0-byte placeholder: the real file contents live in the
+//     sidecar part files (MultipartDir). The complete multipart body is
+//     rebuilt on demand by GetHTTPFlowBodyById via io.Pipe streaming. The
+//     placeholder name anchors the sidecar directory derivation
+//     (multipartSidecarDirFromBodyFile) so cleanup/locating parts work from
+//     the persisted TooLargeRequestBodyFile path alone.
+//   - MultipartDir is the sidecar directory containing the per-part files
+//     and manifest.json.
+//   - Manifest lists every file part; also persisted to manifest.json in
+//     MultipartDir for downstream readers.
 type multipartSpillResult struct {
 	StoredPacket    []byte
 	IsTooLarge      bool
@@ -71,8 +77,9 @@ type multipartPartMeta struct {
 
 // spillMultipartFilesIfNeeded inspects an oversized request packet and, when
 // it is a multipart/form-data body carrying at least one file part, spills each
-// file part to a sidecar file, writes the rebuilt complete body to a temp body
-// file, and returns a skeleton packet safe to store in the DB.
+// file part to a sidecar file, writes manifest.json, leaves a 0-byte body
+// placeholder, and returns a skeleton packet safe to store in the DB. The
+// complete multipart body is rebuilt on demand by GetHTTPFlowBodyById.
 //
 // When the packet is not multipart or carries no file part, IsTooLarge is false
 // and the caller falls back to the flat large-request spill path.
@@ -242,10 +249,21 @@ func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
 	headerPath := headerFP.Name()
 	headerFP.Close()
 
-	// Rebuild the complete body into the body file: stream file parts back
-	// from disk alongside the skeleton's text fields. The body file name
-	// matches the base used to derive the sidecar directory so cleanup can
-	// locate the parts from the persisted body file path.
+	// Write manifest.json into the sidecar directory so downstream readers
+	// (toHTTPFlowGRPCModel, GetHTTPFlowBodyById) can enumerate file parts
+	// without re-parsing the skeleton.
+	if err := writeMultipartManifest(dir, res.Manifest); err != nil {
+		_ = os.RemoveAll(dir)
+		_ = os.Remove(headerPath)
+		return res, err
+	}
+
+	// BodyFile is a 0-byte placeholder: the real file contents live in the
+	// sidecar part files, and the complete multipart body is rebuilt on demand
+	// by GetHTTPFlowBodyById (streamed via io.Pipe). The placeholder name is
+	// the anchor from which the sidecar directory is derived
+	// (multipartSidecarDirFromBodyFile), so cleanup and locating parts work
+	// from the persisted TooLargeRequestBodyFile path alone.
 	bodyFP, err := utils.OpenTempFile(bodyFileRel)
 	if err != nil {
 		_ = os.RemoveAll(dir)
@@ -253,13 +271,6 @@ func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
 		return res, err
 	}
 	bodyPath := bodyFP.Name()
-	if err := rebuildMultipartBodyToWriter(skeletonBuf.Bytes(), dir, bodyFP); err != nil {
-		bodyFP.Close()
-		_ = os.RemoveAll(dir)
-		_ = os.Remove(headerPath)
-		_ = os.Remove(bodyPath)
-		return res, err
-	}
 	bodyFP.Close()
 
 	stored := lowhttp.ReplaceHTTPPacketBody([]byte(header), skeletonBuf.Bytes(), false)
@@ -388,6 +399,80 @@ func containsMultipartSpillMarker(packet []byte) bool {
 	return bytes.Contains(packet, []byte(multipartSkeletonMarker))
 }
 
+// FlowIsMultipartSpill reports whether a stored HTTPFlow's request was
+// skeletonized as a multipart spill: the request is marked too-large and the
+// in-DB skeleton carries the multipart placeholder.
+func FlowIsMultipartSpill(flow *schema.HTTPFlow) bool {
+	if flow == nil || !flow.IsTooLargeRequest || flow.TooLargeRequestBodyFile == "" {
+		return false
+	}
+	return containsMultipartSpillMarker([]byte(flow.GetRequest()))
+}
+
+// FlowMultipartSidecarDir returns the sidecar directory path for a flow's
+// spilled multipart parts, derived from TooLargeRequestBodyFile. Returns ""
+// when not applicable.
+func FlowMultipartSidecarDir(flow *schema.HTTPFlow) string {
+	if flow == nil {
+		return ""
+	}
+	return multipartSidecarDirFromBodyFile(flow.TooLargeRequestBodyFile)
+}
+
+// LoadFlowMultipartManifest loads the part manifest for a flow from its
+// sidecar directory. Returns nil when the flow is not a multipart spill or
+// the manifest is absent.
+func LoadFlowMultipartManifest(flow *schema.HTTPFlow) ([]multipartPartMeta, error) {
+	if !FlowIsMultipartSpill(flow) {
+		return nil, nil
+	}
+	return loadMultipartManifest(FlowMultipartSidecarDir(flow))
+}
+
+// FlowMultipartSkeletonBody returns the skeleton body (headers stripped) of a
+// multipart-spilled flow, used as the template for on-demand rebuild.
+func FlowMultipartSkeletonBody(flow *schema.HTTPFlow) []byte {
+	if !FlowIsMultipartSpill(flow) {
+		return nil
+	}
+	_, body := lowhttp.SplitHTTPPacketFast(flow.GetRequest())
+	return []byte(body)
+}
+
+// OpenFlowMultipartPart opens one spilled part file by manifest entry index.
+// partIndex must match a manifest entry's PartIndex.
+func OpenFlowMultipartPart(flow *schema.HTTPFlow, partIndex int) (*os.File, string, error) {
+	manifest, err := LoadFlowMultipartManifest(flow)
+	if err != nil {
+		return nil, "", err
+	}
+	var meta *multipartPartMeta
+	for i := range manifest {
+		if manifest[i].Index == partIndex {
+			meta = &manifest[i]
+			break
+		}
+	}
+	if meta == nil {
+		return nil, "", utils.Errorf("multipart part %d not found in manifest", partIndex)
+	}
+	f, err := openMultipartPart(FlowMultipartSidecarDir(flow), *meta)
+	if err != nil {
+		return nil, "", err
+	}
+	return f, meta.Filename, nil
+}
+
+// RebuildFlowMultipartBody returns a reader streaming the complete rebuilt
+// multipart body for a flow (skeleton text fields + spilled file parts from
+// disk), via io.Pipe so large parts never load fully into memory.
+func RebuildFlowMultipartBody(flow *schema.HTTPFlow) (io.Reader, error) {
+	if !FlowIsMultipartSpill(flow) {
+		return nil, utils.Error("flow is not a multipart spill")
+	}
+	return rebuildMultipartBodyToReader(FlowMultipartSkeletonBody(flow), FlowMultipartSidecarDir(flow)), nil
+}
+
 // sanitizeFilename strips path separators and other filesystem-unsafe chars
 // from a part filename so it can be used as a disk filename inside the
 // sidecar directory.
@@ -440,4 +525,106 @@ func cleanupMultipartSidecar(bodyFile string) {
 	if info, err := os.Stat(dir); err == nil && info.IsDir() {
 		_ = os.RemoveAll(dir)
 	}
+}
+
+// manifestFileName is the sidecar file recording the per-part metadata so
+// downstream readers can enumerate file parts without re-parsing the skeleton.
+const manifestFileName = "manifest.json"
+
+// writeMultipartManifest persists the manifest entries as JSON into sidecarDir.
+func writeMultipartManifest(sidecarDir string, manifest []multipartPartMeta) error {
+	if sidecarDir == "" {
+		return utils.Error("empty sidecar dir")
+	}
+	data, err := jsonMarshalManifest(manifest)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(sidecarDir, manifestFileName), data, 0o644)
+}
+
+// loadMultipartManifest reads manifest.json from sidecarDir. Returns nil
+// manifest and no error when the file is absent (e.g. flat spill or legacy).
+func loadMultipartManifest(sidecarDir string) ([]multipartPartMeta, error) {
+	if sidecarDir == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(filepath.Join(sidecarDir, manifestFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return jsonUnmarshalManifest(data)
+}
+
+// openMultipartPart opens the on-disk file for one spilled part.
+func openMultipartPart(sidecarDir string, meta multipartPartMeta) (*os.File, error) {
+	if sidecarDir == "" {
+		return nil, utils.Error("empty sidecar dir")
+	}
+	return os.Open(filepath.Join(sidecarDir, meta.File))
+}
+
+// manifestJSONEntry is the on-disk JSON representation of a part meta. Field
+// names are stable and lowerCamel to match the gRPC MultipartFileInfo shape.
+type manifestJSONEntry struct {
+	PartIndex    int    `json:"partIndex"`
+	FieldName    string `json:"fieldName"`
+	Filename     string `json:"filename"`
+	ContentType  string `json:"contentType"`
+	Size         int64  `json:"size"`
+	File         string `json:"file"`
+}
+
+func jsonMarshalManifest(manifest []multipartPartMeta) ([]byte, error) {
+	entries := make([]manifestJSONEntry, len(manifest))
+	for i, m := range manifest {
+		entries[i] = manifestJSONEntry{
+			PartIndex:   m.Index,
+			FieldName:   m.FieldName,
+			Filename:    m.Filename,
+			ContentType: m.ContentType,
+			Size:        m.Size,
+			File:        m.File,
+		}
+	}
+	return json.MarshalIndent(entries, "", "  ")
+}
+
+func jsonUnmarshalManifest(data []byte) ([]multipartPartMeta, error) {
+	var entries []manifestJSONEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, err
+	}
+	out := make([]multipartPartMeta, len(entries))
+	for i, e := range entries {
+		out[i] = multipartPartMeta{
+			Index:       e.PartIndex,
+			FieldName:   e.FieldName,
+			Filename:    e.Filename,
+			ContentType: e.ContentType,
+			Size:        e.Size,
+			File:        e.File,
+		}
+	}
+	return out, nil
+}
+
+// rebuildMultipartBodyToReader returns a reader that streams the complete
+// multipart body rebuilt from the skeleton (text fields verbatim) plus the
+// spilled file parts (streamed from disk). It uses an io.Pipe so large file
+// parts never need to be fully loaded into memory: a goroutine writes into the
+// pipe while the caller reads from the returned reader.
+//
+// If the rebuild fails, the goroutine closes the pipe with the error and the
+// caller's Read will surface it.
+func rebuildMultipartBodyToReader(skeletonBody []byte, sidecarDir string) io.Reader {
+	pr, pw := io.Pipe()
+	go func() {
+		err := rebuildMultipartBodyToWriter(skeletonBody, sidecarDir, pw)
+		_ = pw.CloseWithError(err)
+	}()
+	return pr
 }

--- a/common/yakgrpc/yakit/httpflow_multipart_request.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request.go
@@ -144,17 +144,13 @@ func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
 		return res, nil
 	}
 
-	// Prepare sidecar directory for per-part files. It is derived from the
-	// body file name (see multipartSidecarDirFromBodyFile) so cleanup can
-	// locate it from the persisted TooLargeRequestBodyFile path alone.
+	// Prepare sidecar directory for per-part files. Its name is derived from
+	// the spill suffix so cleanup can locate it from the persisted
+	// TooLargeRequestBodyFile path (its parent dir) without extra state.
 	uid := ksuid.New().String()
 	suffix := fmt.Sprintf("%v_%v", time.Now().Format(utils.DatetimePretty()), uid)
-	bodyFileBase := fmt.Sprintf("large-request-body-%v.txt", suffix)
-	bodyFileRel := bodyFileBase
-	// Defer the real creation until after we know the temp dir, but we need
-	// the dir up front for part files. Use the same base dir as OpenTempFile.
 	tempDir := consts.GetDefaultYakitBaseTempDir()
-	dir := filepath.Join(tempDir, strings.TrimSuffix(bodyFileBase, filepath.Ext(bodyFileBase))+"-parts")
+	dir := filepath.Join(tempDir, fmt.Sprintf("large-request-body-%v-parts", suffix))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return res, err
 	}
@@ -195,7 +191,7 @@ func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
 				contentType = "application/octet-stream"
 			}
 
-			partFileName := fmt.Sprintf("part-%d-%s", partIndex, sanitizeFilename(filename))
+			partFileName := fmt.Sprintf("part-%d-%s.txt", partIndex, sanitizeFilename(filename))
 			partPath := filepath.Join(dir, partFileName)
 			f, err := os.Create(partPath)
 			if err != nil {
@@ -258,20 +254,13 @@ func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
 		return res, err
 	}
 
-	// BodyFile is a 0-byte placeholder: the real file contents live in the
-	// sidecar part files, and the complete multipart body is rebuilt on demand
-	// by GetHTTPFlowBodyById (streamed via io.Pipe). The placeholder name is
-	// the anchor from which the sidecar directory is derived
-	// (multipartSidecarDirFromBodyFile), so cleanup and locating parts work
-	// from the persisted TooLargeRequestBodyFile path alone.
-	bodyFP, err := utils.OpenTempFile(bodyFileRel)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		_ = os.Remove(headerPath)
-		return res, err
-	}
-	bodyPath := bodyFP.Name()
-	bodyFP.Close()
+	// TooLargeRequestBodyFile points at the first spilled part file. It is a
+	// real file (not a placeholder), serves as the anchor from which the
+	// sidecar directory is derived (its parent dir), and keeps
+	// IsTooLargeRequest / non-multipart read paths consistent. The complete
+	// multipart body is rebuilt on demand by GetHTTPFlowBodyById (streamed via
+	// io.Pipe) and LoadHTTPFlowRequestPacket.
+	bodyPath := filepath.Join(dir, res.Manifest[0].File)
 
 	stored := lowhttp.ReplaceHTTPPacketBody([]byte(header), skeletonBuf.Bytes(), false)
 	res.StoredPacket = stored
@@ -340,7 +329,7 @@ func rebuildMultipartBodyToWriter(skeletonBody []byte, sidecarDir string, dst io
 		}
 		isFile := p.FileName() != ""
 		if isFile {
-			partFileName := fmt.Sprintf("part-%d-%s", partIndex, sanitizeFilename(p.FileName()))
+			partFileName := fmt.Sprintf("part-%d-%s.txt", partIndex, sanitizeFilename(p.FileName()))
 			partPath := filepath.Join(sidecarDir, partFileName)
 			f, ferr := os.Open(partPath)
 			if ferr != nil {
@@ -501,25 +490,28 @@ func copyMIMEHeader(h textproto.MIMEHeader) textproto.MIMEHeader {
 }
 
 // multipartSidecarDirFromBodyFile derives the per-part sidecar directory path
-// from the persisted TooLargeRequestBodyFile path. The sidecar directory is
-// the body file name with its extension replaced by "-parts", sitting next to
-// the body file in the same temp dir. Returns "" when bodyFile is empty.
+// from the persisted TooLargeRequestBodyFile path. For multipart spills the
+// body file is the first spilled part file, so its parent directory is the
+// sidecar. Returns "" when bodyFile is empty.
 func multipartSidecarDirFromBodyFile(bodyFile string) string {
 	if bodyFile == "" {
 		return ""
 	}
-	dir := filepath.Dir(bodyFile)
-	base := filepath.Base(bodyFile)
-	stem := strings.TrimSuffix(base, filepath.Ext(base))
-	return filepath.Join(dir, stem+"-parts")
+	return filepath.Dir(bodyFile)
 }
 
-// cleanupMultipartSidecar removes the per-part sidecar directory derived from
-// bodyFile. Safe to call when bodyFile is a flat spill file (no sidecar
-// directory exists).
+// cleanupMultipartSidecar removes the per-part sidecar directory holding the
+// spilled file parts (and manifest.json) for a multipart flow. The body file
+// for a multipart spill is the first part file, so the sidecar is its parent
+// directory. To avoid nuking the shared temp root for flat (non-multipart)
+// spills — whose body file also lives in the temp root — only a directory
+// whose base name ends with "-parts" is removed. Safe to call for any flow.
 func cleanupMultipartSidecar(bodyFile string) {
 	dir := multipartSidecarDirFromBodyFile(bodyFile)
 	if dir == "" {
+		return
+	}
+	if !strings.HasSuffix(filepath.Base(dir), "-parts") {
 		return
 	}
 	if info, err := os.Stat(dir); err == nil && info.IsDir() {

--- a/common/yakgrpc/yakit/httpflow_multipart_request.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request.go
@@ -1,0 +1,443 @@
+package yakit
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	customMultipart "github.com/yaklang/yaklang/common/utils/multipart"
+)
+
+// multipartSkeletonMarker is the prefix of the single-line placeholder that
+// replaces a spilled file part inside the in-DB skeleton body. It carries the
+// part index, original filename and size so the skeleton stays human-readable
+// and the part can be located in the sidecar directory on rebuild.
+//
+// Example:
+//
+//	[[yakit: multipart file spilled, part=0, file=Yakit-1.4.8.exe, size=167232]]
+const multipartSkeletonMarker = "[[yakit: multipart file spilled"
+
+// multipartSpillMarkerPattern matches the placeholder line produced by
+// spillMultipartFilesIfNeeded. Kept for callers that want to parse part
+// index/filename/size out of a skeleton (e.g. a future single-part download).
+var multipartSpillMarkerPattern = regexp.MustCompile(
+	`(?m)^\[\[yakit: multipart file spilled, part=(\d+), file=(.*?), size=(\d+)\]\]$`,
+)
+
+// multipartSpillResult is the multipart-aware counterpart of
+// largeRequestSpillResult. When IsTooLarge is true the request was a
+// multipart/form-data body carrying at least one file part, and:
+//   - StoredPacket is the in-DB skeleton (header + skeleton body with
+//     placeholders) — small and editable.
+//   - HeaderFile / BodyFile follow the same contract as the flat spill path:
+//     HeaderFile holds the request headers, BodyFile holds the *rebuilt*
+//     complete multipart body (skeleton text fields + spilled file parts
+//     streamed back from disk). This keeps GetHTTPFlowBodyById unchanged.
+//   - MultipartDir is the sidecar directory containing the per-part files.
+//     It is always filepath.Dir(BodyFile); kept here for convenience.
+//   - Manifest lists every file part, primarily for tests/diagnostics.
+type multipartSpillResult struct {
+	StoredPacket    []byte
+	IsTooLarge      bool
+	HeaderFile      string
+	BodyFile        string
+	MultipartDir    string
+	OriginalBodyLen int
+	Manifest        []multipartPartMeta
+}
+
+// multipartPartMeta records metadata about one spilled file part.
+type multipartPartMeta struct {
+	Index       int
+	FieldName   string
+	Filename    string
+	ContentType string
+	Size        int64
+	File        string // disk filename inside MultipartDir (part-N-<sanitized>)
+}
+
+// spillMultipartFilesIfNeeded inspects an oversized request packet and, when
+// it is a multipart/form-data body carrying at least one file part, spills each
+// file part to a sidecar file, writes the rebuilt complete body to a temp body
+// file, and returns a skeleton packet safe to store in the DB.
+//
+// When the packet is not multipart or carries no file part, IsTooLarge is false
+// and the caller falls back to the flat large-request spill path.
+func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
+	var res multipartSpillResult
+	if len(packet) == 0 {
+		return res, nil
+	}
+
+	header, body := lowhttp.SplitHTTPHeadersAndBodyFromPacket(packet)
+	res.OriginalBodyLen = len(body)
+	// Only engage for oversized bodies; small multiparts take the normal path.
+	if len(body) <= maxHTTPFlowRequestBodyInDBBytes {
+		return res, nil
+	}
+
+	ct := lowhttp.GetHTTPPacketHeader([]byte(header), "Content-Type")
+	mediaType, params, err := mime.ParseMediaType(ct)
+	if err != nil || !strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+		return res, nil
+	}
+	boundary, ok := params["boundary"]
+	if !ok || boundary == "" {
+		return res, nil
+	}
+
+	// First pass: enumerate parts using the boundary-tolerant reader and
+	// decide whether this is worth skeletonizing (>=1 file part).
+	mr := customMultipart.NewReader(bytes.NewReader(body))
+	var partInfos []struct {
+		header textproto.MIMEHeader
+		isFile bool
+	}
+	for {
+		p, err := mr.NextPart()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			// Malformed multipart: bail out to flat spill so we never lose data.
+			return res, nil
+		}
+		isFile := p.FileName() != ""
+		partInfos = append(partInfos, struct {
+			header textproto.MIMEHeader
+			isFile bool
+		}{header: copyMIMEHeader(p.Header), isFile: isFile})
+	}
+	if len(partInfos) == 0 {
+		return res, nil
+	}
+	hasFilePart := false
+	for _, pi := range partInfos {
+		if pi.isFile {
+			hasFilePart = true
+			break
+		}
+	}
+	if !hasFilePart {
+		// Oversized multipart with only text fields: keep flat path, no
+		// benefit in skeletonizing tiny editable fields.
+		return res, nil
+	}
+
+	// Prepare sidecar directory for per-part files. It is derived from the
+	// body file name (see multipartSidecarDirFromBodyFile) so cleanup can
+	// locate it from the persisted TooLargeRequestBodyFile path alone.
+	uid := ksuid.New().String()
+	suffix := fmt.Sprintf("%v_%v", time.Now().Format(utils.DatetimePretty()), uid)
+	bodyFileBase := fmt.Sprintf("large-request-body-%v.txt", suffix)
+	bodyFileRel := bodyFileBase
+	// Defer the real creation until after we know the temp dir, but we need
+	// the dir up front for part files. Use the same base dir as OpenTempFile.
+	tempDir := consts.GetDefaultYakitBaseTempDir()
+	dir := filepath.Join(tempDir, strings.TrimSuffix(bodyFileBase, filepath.Ext(bodyFileBase))+"-parts")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return res, err
+	}
+	res.MultipartDir = dir
+
+	// Second pass: spill file parts to disk and build the skeleton body.
+	// We write the multipart framing manually into skeletonBuf so the
+	// skeleton keeps the original boundary and part headers verbatim (the
+	// standard multipart.Writer would normalize them).
+	mr = customMultipart.NewReader(bytes.NewReader(body))
+	skeletonBuf := new(bytes.Buffer)
+
+	partIndex := 0
+	for {
+		p, err := mr.NextPart()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			_ = os.RemoveAll(dir)
+			return res, nil
+		}
+
+		isFile := p.FileName() != ""
+		// Opening boundary line for this part.
+		skeletonBuf.WriteString("--" + boundary + "\r\n")
+		if err := writePartHeaders(skeletonBuf, p.Header); err != nil {
+			_ = os.RemoveAll(dir)
+			return res, err
+		}
+		skeletonBuf.WriteString("\r\n")
+
+		if isFile {
+			fieldName := p.FormName()
+			filename := p.FileName()
+			contentType := p.GetHeader("Content-Type")
+			if contentType == "" {
+				contentType = "application/octet-stream"
+			}
+
+			partFileName := fmt.Sprintf("part-%d-%s", partIndex, sanitizeFilename(filename))
+			partPath := filepath.Join(dir, partFileName)
+			f, err := os.Create(partPath)
+			if err != nil {
+				_ = os.RemoveAll(dir)
+				return res, err
+			}
+			n, copyErr := io.Copy(f, p)
+			f.Close()
+			if copyErr != nil {
+				_ = os.RemoveAll(dir)
+				return res, copyErr
+			}
+
+			res.Manifest = append(res.Manifest, multipartPartMeta{
+				Index:       partIndex,
+				FieldName:   fieldName,
+				Filename:    filename,
+				ContentType: contentType,
+				Size:        n,
+				File:        partFileName,
+			})
+
+			// Skeleton placeholder line replaces the file content; the
+			// trailing CRLF terminates the part body.
+			fmt.Fprintf(skeletonBuf, "%s, part=%d, file=%s, size=%d]]\r\n",
+				multipartSkeletonMarker, partIndex, filename, n)
+		} else {
+			// Text field: preserve value verbatim in the skeleton.
+			if _, err := io.Copy(skeletonBuf, p); err != nil {
+				_ = os.RemoveAll(dir)
+				return res, err
+			}
+			skeletonBuf.WriteString("\r\n")
+		}
+		partIndex++
+	}
+	// Closing boundary.
+	skeletonBuf.WriteString("--" + boundary + "--\r\n")
+
+	// Write the header file (same contract as flat spill).
+	headerFP, err := utils.OpenTempFile(fmt.Sprintf("large-request-header-%v.txt", suffix))
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return res, err
+	}
+	if _, err := headerFP.Write([]byte(header)); err != nil {
+		headerFP.Close()
+		_ = os.RemoveAll(dir)
+		return res, err
+	}
+	headerPath := headerFP.Name()
+	headerFP.Close()
+
+	// Rebuild the complete body into the body file: stream file parts back
+	// from disk alongside the skeleton's text fields. The body file name
+	// matches the base used to derive the sidecar directory so cleanup can
+	// locate the parts from the persisted body file path.
+	bodyFP, err := utils.OpenTempFile(bodyFileRel)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		_ = os.Remove(headerPath)
+		return res, err
+	}
+	bodyPath := bodyFP.Name()
+	if err := rebuildMultipartBodyToWriter(skeletonBuf.Bytes(), dir, bodyFP); err != nil {
+		bodyFP.Close()
+		_ = os.RemoveAll(dir)
+		_ = os.Remove(headerPath)
+		_ = os.Remove(bodyPath)
+		return res, err
+	}
+	bodyFP.Close()
+
+	stored := lowhttp.ReplaceHTTPPacketBody([]byte(header), skeletonBuf.Bytes(), false)
+	res.StoredPacket = stored
+	res.IsTooLarge = true
+	res.HeaderFile = headerPath
+	res.BodyFile = bodyPath
+	return res, nil
+}
+
+// writePartHeaders writes the given part headers in a stable, verbatim style
+// (key: value\r\n) into w. It preserves the original header casing stored by
+// the custom multipart reader.
+func writePartHeaders(w io.Writer, header textproto.MIMEHeader) error {
+	// textproto.MIMEHeader canonicalizes keys, but the custom reader stores
+	// them via CanonicalMIMEHeaderKey too, so this is consistent with the
+	// reader's view. Iterate a stable order for reproducibility.
+	keys := make([]string, 0, len(header))
+	for k := range header {
+		keys = append(keys, k)
+	}
+	// Put Content-Disposition first for readability of the skeleton.
+	if cd, ok := header["Content-Disposition"]; ok && len(cd) > 0 {
+		if _, err := fmt.Fprintf(w, "Content-Disposition: %s\r\n", cd[0]); err != nil {
+			return err
+		}
+	}
+	for _, k := range keys {
+		if k == "Content-Disposition" {
+			continue
+		}
+		vals := header[k]
+		if len(vals) == 0 {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "%s: %s\r\n", k, vals[0]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// rebuildMultipartBodyToWriter parses a skeleton multipart body and writes the
+// complete body to dst, streaming each spilled file part from sidecarDir.
+// Text fields are copied verbatim from the skeleton; file parts are replaced
+// by the contents of the corresponding part-N-<filename> file on disk.
+func rebuildMultipartBodyToWriter(skeletonBody []byte, sidecarDir string, dst io.Writer) error {
+	// Detect boundary from the skeleton's first boundary line.
+	boundary, err := detectBoundary(skeletonBody)
+	if err != nil {
+		return err
+	}
+
+	mr := customMultipart.NewReader(bytes.NewReader(skeletonBody))
+	mw := multipart.NewWriter(dst)
+	if err := mw.SetBoundary(boundary); err != nil {
+		return err
+	}
+	partIndex := 0
+	for {
+		p, err := mr.NextPart()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		isFile := p.FileName() != ""
+		if isFile {
+			partFileName := fmt.Sprintf("part-%d-%s", partIndex, sanitizeFilename(p.FileName()))
+			partPath := filepath.Join(sidecarDir, partFileName)
+			f, ferr := os.Open(partPath)
+			if ferr != nil {
+				return utils.Wrapf(ferr, "open spilled part file %q failed", partPath)
+			}
+			partWriter, werr := mw.CreatePart(p.Header)
+			if werr != nil {
+				f.Close()
+				return werr
+			}
+			if _, cerr := io.Copy(partWriter, f); cerr != nil {
+				f.Close()
+				return cerr
+			}
+			f.Close()
+		} else {
+			// Text field: write the value verbatim from the skeleton into the
+			// part body returned by CreatePart.
+			partWriter, werr := mw.CreatePart(p.Header)
+			if werr != nil {
+				return werr
+			}
+			if _, cerr := io.Copy(partWriter, p); cerr != nil {
+				return cerr
+			}
+		}
+		partIndex++
+	}
+	return mw.Close()
+}
+
+// detectBoundary extracts the boundary string from a multipart skeleton body
+// by locating the first "--<boundary>" line.
+func detectBoundary(body []byte) (string, error) {
+	lines := bytes.Split(body, []byte("\n"))
+	for _, line := range lines {
+		trimmed := bytes.TrimRight(line, "\r")
+		if bytes.HasPrefix(trimmed, []byte("--")) {
+			candidate := string(trimmed[2:])
+			// A trailing "--" marks the closing delimiter, not a boundary.
+			if strings.HasSuffix(candidate, "--") {
+				candidate = candidate[:len(candidate)-2]
+			}
+			if candidate != "" {
+				return candidate, nil
+			}
+		}
+	}
+	return "", utils.Error("multipart: boundary not found in skeleton body")
+}
+
+// containsMultipartSpillMarker reports whether the stored packet carries the
+// multipart skeleton placeholder. Used to detect legacy/serialized flows that
+// were skeletonized.
+func containsMultipartSpillMarker(packet []byte) bool {
+	return bytes.Contains(packet, []byte(multipartSkeletonMarker))
+}
+
+// sanitizeFilename strips path separators and other filesystem-unsafe chars
+// from a part filename so it can be used as a disk filename inside the
+// sidecar directory.
+func sanitizeFilename(name string) string {
+	if name == "" {
+		return "unnamed"
+	}
+	base := filepath.Base(name)
+	if base == "" || base == "." || base == string(os.PathSeparator) {
+		base = "unnamed"
+	}
+	// Replace any remaining separators inside the base just in case.
+	base = strings.ReplaceAll(base, string(os.PathSeparator), "_")
+	base = strings.ReplaceAll(base, "/", "_")
+	return base
+}
+
+func copyMIMEHeader(h textproto.MIMEHeader) textproto.MIMEHeader {
+	out := make(textproto.MIMEHeader, len(h))
+	for k, vs := range h {
+		cp := make([]string, len(vs))
+		copy(cp, vs)
+		out[k] = cp
+	}
+	return out
+}
+
+// multipartSidecarDirFromBodyFile derives the per-part sidecar directory path
+// from the persisted TooLargeRequestBodyFile path. The sidecar directory is
+// the body file name with its extension replaced by "-parts", sitting next to
+// the body file in the same temp dir. Returns "" when bodyFile is empty.
+func multipartSidecarDirFromBodyFile(bodyFile string) string {
+	if bodyFile == "" {
+		return ""
+	}
+	dir := filepath.Dir(bodyFile)
+	base := filepath.Base(bodyFile)
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	return filepath.Join(dir, stem+"-parts")
+}
+
+// cleanupMultipartSidecar removes the per-part sidecar directory derived from
+// bodyFile. Safe to call when bodyFile is a flat spill file (no sidecar
+// directory exists).
+func cleanupMultipartSidecar(bodyFile string) {
+	dir := multipartSidecarDirFromBodyFile(bodyFile)
+	if dir == "" {
+		return
+	}
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		_ = os.RemoveAll(dir)
+	}
+}

--- a/common/yakgrpc/yakit/httpflow_multipart_request_test.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request_test.go
@@ -2,6 +2,7 @@ package yakit
 
 import (
 	"bytes"
+	"io"
 	"mime"
 	"mime/multipart"
 	"net/textproto"
@@ -94,13 +95,23 @@ func TestSpillMultipartFilesIfNeeded_SingleFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fileContent, got)
 
-	// Rebuilt body file parses back to the same parts.
-	bodyOnDisk, err := os.ReadFile(res.BodyFile)
-	require.NoError(t, err)
-	parts := parseMultipartParts(t, bodyOnDisk, boundaryFromBodyPacket(t, packet))
+	// Rebuilt complete body (on demand) parses back to the same parts.
+	_, skeletonBody := lowhttp.SplitHTTPPacketFast(res.StoredPacket)
+	rebuilt := readAll(t, rebuildMultipartBodyToReader(skeletonBody, res.MultipartDir))
+	parts := parseMultipartParts(t, rebuilt, boundaryFromBodyPacket(t, packet))
 	require.Len(t, parts, 2)
 	require.Equal(t, "hello", string(parts["desc"].body))
 	require.Equal(t, fileContent, parts["filename"].body)
+
+	// BodyFile is now a 0-byte placeholder (real content is in the sidecar).
+	fi, err := os.Stat(res.BodyFile)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), fi.Size(), "BodyFile should be 0-byte placeholder")
+	// manifest.json lives in the sidecar directory.
+	manifest, err := loadMultipartManifest(res.MultipartDir)
+	require.NoError(t, err)
+	require.Len(t, manifest, 1)
+	require.Equal(t, "Yakit-1.4.8.exe", manifest[0].Filename)
 }
 
 func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
@@ -152,11 +163,11 @@ func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
 	// No raw file bytes leak into the skeleton.
 	require.NotContains(t, skel, string(f1[:64]))
 
-	// Rebuilt body file parses back to all parts with correct contents.
+	// Rebuilt complete body (on demand) parses back to all parts with correct contents.
 	boundary := boundaryFromBodyPacket(t, packet)
-	bodyOnDisk, err := os.ReadFile(res.BodyFile)
-	require.NoError(t, err)
-	parts := parseMultipartParts(t, bodyOnDisk, boundary)
+	_, skeletonBody := lowhttp.SplitHTTPPacketFast(res.StoredPacket)
+	rebuilt := readAll(t, rebuildMultipartBodyToReader(skeletonBody, res.MultipartDir))
+	parts := parseMultipartParts(t, rebuilt, boundary)
 	require.Len(t, parts, 5)
 	require.Equal(t, "abc", string(parts["token"].body))
 	require.Equal(t, "safe", string(parts["case"].body))
@@ -224,11 +235,11 @@ func TestSpillLargeHTTPFlowRequestIfNeeded_MultipartRoute(t *testing.T) {
 	require.Contains(t, string(res.StoredPacket), multipartSkeletonMarker)
 	require.NotContains(t, string(res.StoredPacket), "request too large(")
 
-	// Rebuilt body file parses back to the original parts.
+	// Rebuilt complete body (on demand) parses back to the original parts.
 	boundary := boundaryFromBodyPacket(t, packet)
-	bodyOnDisk, err := os.ReadFile(res.BodyFile)
-	require.NoError(t, err)
-	parts := parseMultipartParts(t, bodyOnDisk, boundary)
+	_, skeletonBody := lowhttp.SplitHTTPPacketFast(res.StoredPacket)
+	rebuilt := readAll(t, rebuildMultipartBodyToReader(skeletonBody, multipartSidecarDirFromBodyFile(res.BodyFile)))
+	parts := parseMultipartParts(t, rebuilt, boundary)
 	require.Equal(t, "v", string(parts["n"].body))
 	require.Equal(t, fileContent, parts["up"].body)
 }
@@ -287,6 +298,14 @@ func readAllPart(t *testing.T, p *multipart.Part) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	_, err := buf.ReadFrom(p)
 	return buf.Bytes(), err
+}
+
+// readAll reads all bytes from r, failing the test on read error.
+func readAll(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return b
 }
 
 func boundaryFromBodyPacket(t *testing.T, packet []byte) string {

--- a/common/yakgrpc/yakit/httpflow_multipart_request_test.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request_test.go
@@ -58,7 +58,7 @@ func buildMultipartRequest(t *testing.T, textFields map[string]string, fileParts
 }
 
 func TestSpillMultipartFilesIfNeeded_SingleFile(t *testing.T) {
-	fileContent := bytes.Repeat([]byte("X"), maxHTTPFlowRequestBodyInDBBytes+1024)
+	fileContent := bytes.Repeat([]byte("X"), MaxHTTPFlowRequestBodyInDBBytes+1024)
 	packet, _ := buildMultipartRequest(t, map[string]string{"desc": "hello"}, map[string]struct {
 		Filename    string
 		ContentType string
@@ -120,8 +120,8 @@ func TestSpillMultipartFilesIfNeeded_SingleFile(t *testing.T) {
 }
 
 func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
-	f1 := bytes.Repeat([]byte("A"), maxHTTPFlowRequestBodyInDBBytes/2)
-	f2 := bytes.Repeat([]byte("B"), maxHTTPFlowRequestBodyInDBBytes/2)
+	f1 := bytes.Repeat([]byte("A"), MaxHTTPFlowRequestBodyInDBBytes/2)
+	f2 := bytes.Repeat([]byte("B"), MaxHTTPFlowRequestBodyInDBBytes/2)
 	f3 := bytes.Repeat([]byte("C"), 1024)
 	packet, _ := buildMultipartRequest(t,
 		map[string]string{"token": "abc", "case": "safe"},
@@ -184,7 +184,7 @@ func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
 func TestSpillMultipartFilesIfNeeded_TextOnlyNotSpilled(t *testing.T) {
 	// Oversized multipart but no file parts: must NOT skeletonize; fall back
 	// to flat spill is handled by the caller, so here IsTooLarge is false.
-	big := bytes.Repeat([]byte("z"), maxHTTPFlowRequestBodyInDBBytes+512)
+	big := bytes.Repeat([]byte("z"), MaxHTTPFlowRequestBodyInDBBytes+512)
 	packet, _ := buildMultipartRequest(t, map[string]string{"blob": string(big)}, nil)
 
 	res, err := spillMultipartFilesIfNeeded(packet)
@@ -207,7 +207,7 @@ func TestSpillMultipartFilesIfNeeded_SmallMultipartNotSpilled(t *testing.T) {
 }
 
 func TestSpillMultipartFilesIfNeeded_NonMultipartNotSpilled(t *testing.T) {
-	body := bytes.Repeat([]byte("Q"), maxHTTPFlowRequestBodyInDBBytes+64)
+	body := bytes.Repeat([]byte("Q"), MaxHTTPFlowRequestBodyInDBBytes+64)
 	packet := []byte("POST /up HTTP/1.1\r\nHost: a\r\nContent-Type: application/json\r\nContent-Length: " +
 		strconv.Itoa(len(body)) + "\r\n\r\n" + string(body))
 	res, err := spillMultipartFilesIfNeeded(packet)
@@ -216,7 +216,7 @@ func TestSpillMultipartFilesIfNeeded_NonMultipartNotSpilled(t *testing.T) {
 }
 
 func TestSpillLargeHTTPFlowRequestIfNeeded_MultipartRoute(t *testing.T) {
-	fileContent := bytes.Repeat([]byte("M"), maxHTTPFlowRequestBodyInDBBytes+2048)
+	fileContent := bytes.Repeat([]byte("M"), MaxHTTPFlowRequestBodyInDBBytes+2048)
 	packet, _ := buildMultipartRequest(t, map[string]string{"n": "v"}, map[string]struct {
 		Filename    string
 		ContentType string

--- a/common/yakgrpc/yakit/httpflow_multipart_request_test.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request_test.go
@@ -103,15 +103,20 @@ func TestSpillMultipartFilesIfNeeded_SingleFile(t *testing.T) {
 	require.Equal(t, "hello", string(parts["desc"].body))
 	require.Equal(t, fileContent, parts["filename"].body)
 
-	// BodyFile is now a 0-byte placeholder (real content is in the sidecar).
+	// BodyFile points at the first spilled part file (a real file, not a
+	// placeholder). Its parent dir is the sidecar directory.
+	require.NotEmpty(t, res.BodyFile)
+	require.Equal(t, res.MultipartDir, filepath.Dir(res.BodyFile))
 	fi, err := os.Stat(res.BodyFile)
 	require.NoError(t, err)
-	require.Equal(t, int64(0), fi.Size(), "BodyFile should be 0-byte placeholder")
+	require.Greater(t, fi.Size(), int64(0), "BodyFile should be the real first part file")
 	// manifest.json lives in the sidecar directory.
 	manifest, err := loadMultipartManifest(res.MultipartDir)
 	require.NoError(t, err)
 	require.Len(t, manifest, 1)
 	require.Equal(t, "Yakit-1.4.8.exe", manifest[0].Filename)
+	// Part files use the .txt suffix to match the flat spill naming style.
+	require.True(t, strings.HasSuffix(manifest[0].File, ".txt"), "part file should end with .txt, got %s", manifest[0].File)
 }
 
 func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
@@ -245,13 +250,13 @@ func TestSpillLargeHTTPFlowRequestIfNeeded_MultipartRoute(t *testing.T) {
 }
 
 func TestCleanupMultipartSidecar_DerivesFromBodyFile(t *testing.T) {
-	// Create a fake sidecar dir derived from a body file path and confirm
-	// cleanup removes it.
-	dir := t.TempDir()
-	bodyFile := filepath.Join(dir, "large-request-body-test.txt")
-	partsDir := filepath.Join(dir, "large-request-body-test-parts")
+	// For a multipart spill the body file is the first part file inside the
+	// sidecar dir; cleanup removes that dir (and all parts inside).
+	partsDir := t.TempDir()
+	partsDir = filepath.Join(filepath.Dir(partsDir), "large-request-body-test-parts")
 	require.NoError(t, os.MkdirAll(partsDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(partsDir, "part-0-x.bin"), []byte("x"), 0o644))
+	bodyFile := filepath.Join(partsDir, "part-0-yak.bin.txt")
+	require.NoError(t, os.WriteFile(bodyFile, []byte("x"), 0o644))
 	require.DirExists(t, partsDir)
 
 	cleanupMultipartSidecar(bodyFile)
@@ -259,12 +264,15 @@ func TestCleanupMultipartSidecar_DerivesFromBodyFile(t *testing.T) {
 }
 
 func TestCleanupMultipartSidecar_FlatBodyFileNoop(t *testing.T) {
+	// A flat (non-multipart) spill body file lives in the shared temp root;
+	// its parent dir name does not end with "-parts", so cleanup must NOT
+	// touch the directory (it would otherwise nuke the shared temp root).
 	dir := t.TempDir()
 	bodyFile := filepath.Join(dir, "large-request-body-flat.txt")
 	require.NoError(t, os.WriteFile(bodyFile, []byte("flat"), 0o644))
-	// No sidecar dir exists; cleanup must not remove the body file or error.
 	cleanupMultipartSidecar(bodyFile)
 	require.FileExists(t, bodyFile)
+	require.DirExists(t, dir)
 }
 
 // --- helpers ---

--- a/common/yakgrpc/yakit/httpflow_multipart_request_test.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request_test.go
@@ -1,0 +1,300 @@
+package yakit
+
+import (
+	"bytes"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+)
+
+// buildMultipartRequest builds a POST multipart/form-data request packet
+// carrying the given text fields and file parts. fileParts maps field name to
+// (filename, content). Returns the full packet bytes and the boundary used.
+func buildMultipartRequest(t *testing.T, textFields map[string]string, fileParts map[string]struct {
+	Filename    string
+	ContentType string
+	Content     []byte
+}) (packet []byte, boundary string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	for name, val := range textFields {
+		if err := mw.WriteField(name, val); err != nil {
+			t.Fatalf("write field %q: %v", name, err)
+		}
+	}
+	for name, fp := range fileParts {
+		hdr := make(textproto.MIMEHeader)
+		hdr.Set("Content-Disposition", `form-data; name="`+name+`"; filename="`+fp.Filename+`"`)
+		if fp.ContentType != "" {
+			hdr.Set("Content-Type", fp.ContentType)
+		}
+		pw, err := mw.CreatePart(hdr)
+		if err != nil {
+			t.Fatalf("create file part %q: %v", name, err)
+		}
+		if _, err := pw.Write(fp.Content); err != nil {
+			t.Fatalf("write file part %q: %v", name, err)
+		}
+	}
+	boundary = mw.Boundary()
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	header := "POST /upload/case/safe HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:8080\r\n" +
+		"Content-Type: " + mw.FormDataContentType() + "\r\n" +
+		"Content-Length: " + strconv.Itoa(body.Len()) + "\r\n\r\n"
+	return []byte(header + body.String()), boundary
+}
+
+func TestSpillMultipartFilesIfNeeded_SingleFile(t *testing.T) {
+	fileContent := bytes.Repeat([]byte("X"), maxHTTPFlowRequestBodyInDBBytes+1024)
+	packet, _ := buildMultipartRequest(t, map[string]string{"desc": "hello"}, map[string]struct {
+		Filename    string
+		ContentType string
+		Content     []byte
+	}{
+		"filename": {Filename: "Yakit-1.4.8.exe", ContentType: "application/x-msdownload", Content: fileContent},
+	})
+
+	res, err := spillMultipartFilesIfNeeded(packet)
+	require.NoError(t, err)
+	require.True(t, res.IsTooLarge, "oversized multipart with file part should spill")
+	require.NotEmpty(t, res.HeaderFile)
+	require.NotEmpty(t, res.BodyFile)
+	require.NotEmpty(t, res.MultipartDir)
+	require.Len(t, res.Manifest, 1)
+	defer func() {
+		_ = os.RemoveAll(res.MultipartDir)
+		_ = os.Remove(res.HeaderFile)
+		_ = os.Remove(res.BodyFile)
+	}()
+
+	// Skeleton stored packet contains the placeholder, not the file bytes.
+	require.Contains(t, string(res.StoredPacket), multipartSkeletonMarker)
+	require.NotContains(t, string(res.StoredPacket), string(fileContent[:100]))
+
+	// Skeleton keeps the editable field and filename.
+	require.Contains(t, string(res.StoredPacket), `name="desc"`)
+	require.Contains(t, string(res.StoredPacket), `filename="Yakit-1.4.8.exe"`)
+	require.Contains(t, string(res.StoredPacket), "hello")
+
+	// Part file on disk holds the original content.
+	partPath := filepath.Join(res.MultipartDir, res.Manifest[0].File)
+	got, err := os.ReadFile(partPath)
+	require.NoError(t, err)
+	require.Equal(t, fileContent, got)
+
+	// Rebuilt body file parses back to the same parts.
+	bodyOnDisk, err := os.ReadFile(res.BodyFile)
+	require.NoError(t, err)
+	parts := parseMultipartParts(t, bodyOnDisk, boundaryFromBodyPacket(t, packet))
+	require.Len(t, parts, 2)
+	require.Equal(t, "hello", string(parts["desc"].body))
+	require.Equal(t, fileContent, parts["filename"].body)
+}
+
+func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
+	f1 := bytes.Repeat([]byte("A"), maxHTTPFlowRequestBodyInDBBytes/2)
+	f2 := bytes.Repeat([]byte("B"), maxHTTPFlowRequestBodyInDBBytes/2)
+	f3 := bytes.Repeat([]byte("C"), 1024)
+	packet, _ := buildMultipartRequest(t,
+		map[string]string{"token": "abc", "case": "safe"},
+		map[string]struct {
+			Filename    string
+			ContentType string
+			Content     []byte
+		}{
+			"file1": {Filename: "report.pdf", ContentType: "application/pdf", Content: f1},
+			"file2": {Filename: "data.bin", ContentType: "application/octet-stream", Content: f2},
+			"file3": {Filename: "logo.png", ContentType: "image/png", Content: f3},
+		})
+
+	res, err := spillMultipartFilesIfNeeded(packet)
+	require.NoError(t, err)
+	require.True(t, res.IsTooLarge)
+	require.Len(t, res.Manifest, 3)
+	defer func() {
+		_ = os.RemoveAll(res.MultipartDir)
+		_ = os.Remove(res.HeaderFile)
+		_ = os.Remove(res.BodyFile)
+	}()
+
+	// Each file part has its own disk file, named by its parse-order index.
+	seenIndexes := map[int]bool{}
+	for _, m := range res.Manifest {
+		require.True(t, strings.HasPrefix(m.File, "part-"+strconv.Itoa(m.Index)+"-"),
+			"part file should be named part-<index>-*, got %s", m.File)
+		require.False(t, seenIndexes[m.Index], "duplicate part index %d", m.Index)
+		seenIndexes[m.Index] = true
+		p := filepath.Join(res.MultipartDir, m.File)
+		got, err := os.ReadFile(p)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+	}
+
+	// Skeleton keeps all three filenames and the text fields editable.
+	skel := string(res.StoredPacket)
+	require.Contains(t, skel, `filename="report.pdf"`)
+	require.Contains(t, skel, `filename="data.bin"`)
+	require.Contains(t, skel, `filename="logo.png"`)
+	require.Contains(t, skel, "abc")
+	require.Contains(t, skel, "safe")
+	// No raw file bytes leak into the skeleton.
+	require.NotContains(t, skel, string(f1[:64]))
+
+	// Rebuilt body file parses back to all parts with correct contents.
+	boundary := boundaryFromBodyPacket(t, packet)
+	bodyOnDisk, err := os.ReadFile(res.BodyFile)
+	require.NoError(t, err)
+	parts := parseMultipartParts(t, bodyOnDisk, boundary)
+	require.Len(t, parts, 5)
+	require.Equal(t, "abc", string(parts["token"].body))
+	require.Equal(t, "safe", string(parts["case"].body))
+	require.Equal(t, f1, parts["file1"].body)
+	require.Equal(t, f2, parts["file2"].body)
+	require.Equal(t, f3, parts["file3"].body)
+}
+
+func TestSpillMultipartFilesIfNeeded_TextOnlyNotSpilled(t *testing.T) {
+	// Oversized multipart but no file parts: must NOT skeletonize; fall back
+	// to flat spill is handled by the caller, so here IsTooLarge is false.
+	big := bytes.Repeat([]byte("z"), maxHTTPFlowRequestBodyInDBBytes+512)
+	packet, _ := buildMultipartRequest(t, map[string]string{"blob": string(big)}, nil)
+
+	res, err := spillMultipartFilesIfNeeded(packet)
+	require.NoError(t, err)
+	require.False(t, res.IsTooLarge, "text-only multipart should not skeletonize")
+	require.Empty(t, res.MultipartDir)
+}
+
+func TestSpillMultipartFilesIfNeeded_SmallMultipartNotSpilled(t *testing.T) {
+	packet, _ := buildMultipartRequest(t, map[string]string{"a": "1"}, map[string]struct {
+		Filename    string
+		ContentType string
+		Content     []byte
+	}{
+		"f": {Filename: "tiny.txt", Content: []byte("hi")},
+	})
+	res, err := spillMultipartFilesIfNeeded(packet)
+	require.NoError(t, err)
+	require.False(t, res.IsTooLarge, "small multipart should not spill")
+}
+
+func TestSpillMultipartFilesIfNeeded_NonMultipartNotSpilled(t *testing.T) {
+	body := bytes.Repeat([]byte("Q"), maxHTTPFlowRequestBodyInDBBytes+64)
+	packet := []byte("POST /up HTTP/1.1\r\nHost: a\r\nContent-Type: application/json\r\nContent-Length: " +
+		strconv.Itoa(len(body)) + "\r\n\r\n" + string(body))
+	res, err := spillMultipartFilesIfNeeded(packet)
+	require.NoError(t, err)
+	require.False(t, res.IsTooLarge, "non-multipart should not skeletonize")
+}
+
+func TestSpillLargeHTTPFlowRequestIfNeeded_MultipartRoute(t *testing.T) {
+	fileContent := bytes.Repeat([]byte("M"), maxHTTPFlowRequestBodyInDBBytes+2048)
+	packet, _ := buildMultipartRequest(t, map[string]string{"n": "v"}, map[string]struct {
+		Filename    string
+		ContentType string
+		Content     []byte
+	}{
+		"up": {Filename: "big.bin", Content: fileContent},
+	})
+
+	res, err := spillLargeHTTPFlowRequestIfNeeded(packet)
+	require.NoError(t, err)
+	require.True(t, res.IsTooLarge)
+	require.NotEmpty(t, res.BodyFile)
+	require.NotEmpty(t, res.HeaderFile)
+	defer func() {
+		_ = os.RemoveAll(multipartSidecarDirFromBodyFile(res.BodyFile))
+		_ = os.Remove(res.BodyFile)
+		_ = os.Remove(res.HeaderFile)
+	}()
+
+	// The stored packet is the skeleton (placeholder present), not flat notice.
+	require.Contains(t, string(res.StoredPacket), multipartSkeletonMarker)
+	require.NotContains(t, string(res.StoredPacket), "request too large(")
+
+	// Rebuilt body file parses back to the original parts.
+	boundary := boundaryFromBodyPacket(t, packet)
+	bodyOnDisk, err := os.ReadFile(res.BodyFile)
+	require.NoError(t, err)
+	parts := parseMultipartParts(t, bodyOnDisk, boundary)
+	require.Equal(t, "v", string(parts["n"].body))
+	require.Equal(t, fileContent, parts["up"].body)
+}
+
+func TestCleanupMultipartSidecar_DerivesFromBodyFile(t *testing.T) {
+	// Create a fake sidecar dir derived from a body file path and confirm
+	// cleanup removes it.
+	dir := t.TempDir()
+	bodyFile := filepath.Join(dir, "large-request-body-test.txt")
+	partsDir := filepath.Join(dir, "large-request-body-test-parts")
+	require.NoError(t, os.MkdirAll(partsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(partsDir, "part-0-x.bin"), []byte("x"), 0o644))
+	require.DirExists(t, partsDir)
+
+	cleanupMultipartSidecar(bodyFile)
+	require.NoDirExists(t, partsDir)
+}
+
+func TestCleanupMultipartSidecar_FlatBodyFileNoop(t *testing.T) {
+	dir := t.TempDir()
+	bodyFile := filepath.Join(dir, "large-request-body-flat.txt")
+	require.NoError(t, os.WriteFile(bodyFile, []byte("flat"), 0o644))
+	// No sidecar dir exists; cleanup must not remove the body file or error.
+	cleanupMultipartSidecar(bodyFile)
+	require.FileExists(t, bodyFile)
+}
+
+// --- helpers ---
+
+type parsedPart struct {
+	header textproto.MIMEHeader
+	body   []byte
+}
+
+func parseMultipartParts(t *testing.T, body []byte, boundary string) map[string]parsedPart {
+	t.Helper()
+	mr := multipart.NewReader(bytes.NewReader(body), boundary)
+	out := make(map[string]parsedPart)
+	for {
+		p, err := mr.NextPart()
+		if err != nil {
+			break
+		}
+		b, readErr := readAllPart(t, p)
+		out[p.FormName()] = parsedPart{header: p.Header, body: b}
+		if readErr != nil {
+			t.Fatalf("read part %q: %v", p.FormName(), readErr)
+		}
+	}
+	return out
+}
+
+func readAllPart(t *testing.T, p *multipart.Part) ([]byte, error) {
+	t.Helper()
+	defer p.Close()
+	buf := &bytes.Buffer{}
+	_, err := buf.ReadFrom(p)
+	return buf.Bytes(), err
+}
+
+func boundaryFromBodyPacket(t *testing.T, packet []byte) string {
+	t.Helper()
+	ct := lowhttp.GetHTTPPacketHeader(packet, "Content-Type")
+	require.NotEmpty(t, ct, "missing Content-Type")
+	_, params, err := mime.ParseMediaType(ct)
+	require.NoError(t, err)
+	require.NotEmpty(t, params["boundary"], "missing boundary in Content-Type")
+	return params["boundary"]
+}

--- a/common/yakgrpc/yakit/httpflow_packet_part.go
+++ b/common/yakgrpc/yakit/httpflow_packet_part.go
@@ -15,6 +15,13 @@ func LoadHTTPFlowRequestPacket(flow *schema.HTTPFlow) ([]byte, error) {
 	if flow == nil {
 		return nil, utils.Error("flow is nil")
 	}
+	// Multipart-spilled request: in-DB skeleton carries placeholders; rebuild
+	// the complete body on demand from the sidecar part files. This loads the
+	// full body into memory and is only used by caller-driven paths (HAR
+	// export, encode-to-file), never by list queries.
+	if FlowIsMultipartSpill(flow) {
+		return loadMultipartSpillRequestPacket(flow)
+	}
 	if flow.Request != "" {
 		reqRaw, err := strconv.Unquote(flow.Request)
 		if err != nil {
@@ -28,6 +35,24 @@ func LoadHTTPFlowRequestPacket(flow *schema.HTTPFlow) ([]byte, error) {
 		return readHTTPFlowSpillPacket(flow.TooLargeRequestHeaderFile, flow.TooLargeRequestBodyFile)
 	}
 	return nil, nil
+}
+
+// loadMultipartSpillRequestPacket reconstructs the full request packet for a
+// multipart-spilled flow: header file + rebuilt complete multipart body.
+func loadMultipartSpillRequestPacket(flow *schema.HTTPFlow) ([]byte, error) {
+	header, err := os.ReadFile(flow.TooLargeRequestHeaderFile)
+	if err != nil {
+		return nil, utils.Wrap(err, "read multipart spill header file failed")
+	}
+	rr, err := RebuildFlowMultipartBody(flow)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(rr)
+	if err != nil {
+		return nil, utils.Wrap(err, "rebuild multipart body failed")
+	}
+	return append(header, body...), nil
 }
 
 func LoadHTTPFlowResponsePacket(flow *schema.HTTPFlow) ([]byte, error) {
@@ -111,6 +136,22 @@ func ExtractHTTPPacketPart(packet []byte, flow *schema.HTTPFlow, isRequest bool,
 		return []byte(header), nil
 	case "body":
 		if flow != nil {
+			// Multipart-spilled request: body file is a 0-byte placeholder;
+			// rebuild the complete multipart body from the sidecar parts.
+			if isRequest && FlowIsMultipartSpill(flow) {
+				rr, rerr := RebuildFlowMultipartBody(flow)
+				if rerr != nil {
+					return nil, rerr
+				}
+				body, berr := io.ReadAll(rr)
+				if berr != nil {
+					return nil, berr
+				}
+				if len(body) == 0 {
+					return nil, utils.Error("empty rebuilt multipart body")
+				}
+				return body, nil
+			}
 			bodyFile := flow.TooLargeRequestBodyFile
 			if !isRequest {
 				bodyFile = flow.TooLargeResponseBodyFile

--- a/common/yakgrpc/yakit/plugin_usage_count.go
+++ b/common/yakgrpc/yakit/plugin_usage_count.go
@@ -3,7 +3,7 @@ package yakit
 import (
 	"time"
 
-	"github.com/jinzhu/gorm"
+	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"

--- a/common/yakgrpc/ypb/yakgrpc.pb.go
+++ b/common/yakgrpc/ypb/yakgrpc.pb.go
@@ -53113,6 +53113,7 @@ type MultipartFileInfo struct {
 	Filename      string                 `protobuf:"bytes,3,opt,name=Filename,proto3" json:"Filename,omitempty"`       // Content-Disposition: filename（原始文件名）
 	ContentType   string                 `protobuf:"bytes,4,opt,name=ContentType,proto3" json:"ContentType,omitempty"` // 该 part 的 Content-Type
 	Size          int64                  `protobuf:"varint,5,opt,name=Size,proto3" json:"Size,omitempty"`              // 该 part 内容字节数
+	FilePath      string                 `protobuf:"bytes,6,opt,name=FilePath,proto3" json:"FilePath,omitempty"`       // 该 part 落盘文件的绝对路径，前端可直接 openABSFileLocated 打开
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -53180,6 +53181,13 @@ func (x *MultipartFileInfo) GetSize() int64 {
 		return x.Size
 	}
 	return 0
+}
+
+func (x *MultipartFileInfo) GetFilePath() string {
+	if x != nil {
+		return x.FilePath
+	}
+	return ""
 }
 
 type FuzzableParam struct {
@@ -77499,13 +77507,14 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x19TooLargeRequestHeaderFile\x187 \x01(\tR\x19TooLargeRequestHeaderFile\x128\n" +
 	"\x17TooLargeRequestBodyFile\x188 \x01(\tR\x17TooLargeRequestBodyFile\x12,\n" +
 	"\x11IsRequestOversize\x189 \x01(\bR\x11IsRequestOversize\x12>\n" +
-	"\x0eMultipartFiles\x18: \x03(\v2\x16.ypb.MultipartFileInfoR\x0eMultipartFiles\"\xa1\x01\n" +
+	"\x0eMultipartFiles\x18: \x03(\v2\x16.ypb.MultipartFileInfoR\x0eMultipartFiles\"\xbd\x01\n" +
 	"\x11MultipartFileInfo\x12\x1c\n" +
 	"\tPartIndex\x18\x01 \x01(\x05R\tPartIndex\x12\x1c\n" +
 	"\tFieldName\x18\x02 \x01(\tR\tFieldName\x12\x1a\n" +
 	"\bFilename\x18\x03 \x01(\tR\bFilename\x12 \n" +
 	"\vContentType\x18\x04 \x01(\tR\vContentType\x12\x12\n" +
-	"\x04Size\x18\x05 \x01(\x03R\x04Size\"\xa9\x01\n" +
+	"\x04Size\x18\x05 \x01(\x03R\x04Size\x12\x1a\n" +
+	"\bFilePath\x18\x06 \x01(\tR\bFilePath\"\xa9\x01\n" +
 	"\rFuzzableParam\x12\x1a\n" +
 	"\bPosition\x18\x01 \x01(\tR\bPosition\x12\x1c\n" +
 	"\tParamName\x18\x02 \x01(\tR\tParamName\x12 \n" +

--- a/common/yakgrpc/ypb/yakgrpc.pb.go
+++ b/common/yakgrpc/ypb/yakgrpc.pb.go
@@ -51057,12 +51057,16 @@ func (x *GetHTTPFlowByIdsRequest) GetIds() []int64 {
 }
 
 type GetHTTPFlowBodyByIdRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            int64                  `protobuf:"varint,1,opt,name=Id,proto3" json:"Id,omitempty"`
-	IsRequest     bool                   `protobuf:"varint,2,opt,name=IsRequest,proto3" json:"IsRequest,omitempty"`
-	BufSize       int64                  `protobuf:"varint,3,opt,name=BufSize,proto3" json:"BufSize,omitempty"`
-	RuntimeId     string                 `protobuf:"bytes,4,opt,name=RuntimeId,proto3" json:"RuntimeId,omitempty"`
-	IsRisk        bool                   `protobuf:"varint,5,opt,name=IsRisk,proto3" json:"IsRisk,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Id        int64                  `protobuf:"varint,1,opt,name=Id,proto3" json:"Id,omitempty"`
+	IsRequest bool                   `protobuf:"varint,2,opt,name=IsRequest,proto3" json:"IsRequest,omitempty"`
+	BufSize   int64                  `protobuf:"varint,3,opt,name=BufSize,proto3" json:"BufSize,omitempty"`
+	RuntimeId string                 `protobuf:"bytes,4,opt,name=RuntimeId,proto3" json:"RuntimeId,omitempty"`
+	IsRisk    bool                   `protobuf:"varint,5,opt,name=IsRisk,proto3" json:"IsRisk,omitempty"`
+	// multipart 请求：指定要流式返回的文件 part 索引（来自 HTTPFlow.MultipartFiles）。
+	// 未设 = 返回完整 body（multipart 时现场流式重建完整 body）。
+	// 用 optional 以区分「未设」与「part 0」。
+	PartIndex     *int32 `protobuf:"varint,6,opt,name=PartIndex,proto3,oneof" json:"PartIndex,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -51130,6 +51134,13 @@ func (x *GetHTTPFlowBodyByIdRequest) GetIsRisk() bool {
 		return x.IsRisk
 	}
 	return false
+}
+
+func (x *GetHTTPFlowBodyByIdRequest) GetPartIndex() int32 {
+	if x != nil && x.PartIndex != nil {
+		return *x.PartIndex
+	}
+	return 0
 }
 
 type MITMExtractAggregateFlowFilterRow struct {
@@ -52664,8 +52675,12 @@ type HTTPFlow struct {
 	TooLargeRequestBodyFile   string `protobuf:"bytes,56,opt,name=TooLargeRequestBodyFile,proto3" json:"TooLargeRequestBodyFile,omitempty"`
 	// 列表查询时由 SQL 计算：request 过大或 DB 中 request 过长
 	IsRequestOversize bool `protobuf:"varint,57,opt,name=IsRequestOversize,proto3" json:"IsRequestOversize,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// 超大 multipart 请求的文件 part 列表（落盘 sidecar，manifest.json 派生）。
+	// 前端据此渲染「查看/下载 xxx 文件」下拉，而非整块 body。
+	// 非空时 GetHTTPFlowBodyById 可带 PartIndex 流式返回单个文件内容。
+	MultipartFiles []*MultipartFileInfo `protobuf:"bytes,58,rep,name=MultipartFiles,proto3" json:"MultipartFiles,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *HTTPFlow) Reset() {
@@ -53083,6 +53098,90 @@ func (x *HTTPFlow) GetIsRequestOversize() bool {
 	return false
 }
 
+func (x *HTTPFlow) GetMultipartFiles() []*MultipartFileInfo {
+	if x != nil {
+		return x.MultipartFiles
+	}
+	return nil
+}
+
+// MultipartFileInfo 描述一个落盘的 multipart 文件 part 元数据。
+type MultipartFileInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PartIndex     int32                  `protobuf:"varint,1,opt,name=PartIndex,proto3" json:"PartIndex,omitempty"`    // part 在 multipart 中的解析顺序索引，对应 GetHTTPFlowBodyByIdRequest.PartIndex
+	FieldName     string                 `protobuf:"bytes,2,opt,name=FieldName,proto3" json:"FieldName,omitempty"`     // Content-Disposition: name
+	Filename      string                 `protobuf:"bytes,3,opt,name=Filename,proto3" json:"Filename,omitempty"`       // Content-Disposition: filename（原始文件名）
+	ContentType   string                 `protobuf:"bytes,4,opt,name=ContentType,proto3" json:"ContentType,omitempty"` // 该 part 的 Content-Type
+	Size          int64                  `protobuf:"varint,5,opt,name=Size,proto3" json:"Size,omitempty"`              // 该 part 内容字节数
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MultipartFileInfo) Reset() {
+	*x = MultipartFileInfo{}
+	mi := &file_yakgrpc_proto_msgTypes[726]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MultipartFileInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultipartFileInfo) ProtoMessage() {}
+
+func (x *MultipartFileInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_yakgrpc_proto_msgTypes[726]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultipartFileInfo.ProtoReflect.Descriptor instead.
+func (*MultipartFileInfo) Descriptor() ([]byte, []int) {
+	return file_yakgrpc_proto_rawDescGZIP(), []int{726}
+}
+
+func (x *MultipartFileInfo) GetPartIndex() int32 {
+	if x != nil {
+		return x.PartIndex
+	}
+	return 0
+}
+
+func (x *MultipartFileInfo) GetFieldName() string {
+	if x != nil {
+		return x.FieldName
+	}
+	return ""
+}
+
+func (x *MultipartFileInfo) GetFilename() string {
+	if x != nil {
+		return x.Filename
+	}
+	return ""
+}
+
+func (x *MultipartFileInfo) GetContentType() string {
+	if x != nil {
+		return x.ContentType
+	}
+	return ""
+}
+
+func (x *MultipartFileInfo) GetSize() int64 {
+	if x != nil {
+		return x.Size
+	}
+	return 0
+}
+
 type FuzzableParam struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Position      string                 `protobuf:"bytes,1,opt,name=Position,proto3" json:"Position,omitempty"`
@@ -53096,7 +53195,7 @@ type FuzzableParam struct {
 
 func (x *FuzzableParam) Reset() {
 	*x = FuzzableParam{}
-	mi := &file_yakgrpc_proto_msgTypes[726]
+	mi := &file_yakgrpc_proto_msgTypes[727]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53108,7 +53207,7 @@ func (x *FuzzableParam) String() string {
 func (*FuzzableParam) ProtoMessage() {}
 
 func (x *FuzzableParam) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[726]
+	mi := &file_yakgrpc_proto_msgTypes[727]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53121,7 +53220,7 @@ func (x *FuzzableParam) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FuzzableParam.ProtoReflect.Descriptor instead.
 func (*FuzzableParam) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{726}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{727}
 }
 
 func (x *FuzzableParam) GetPosition() string {
@@ -53170,7 +53269,7 @@ type GetHTTPFlowBodyByIdResponse struct {
 
 func (x *GetHTTPFlowBodyByIdResponse) Reset() {
 	*x = GetHTTPFlowBodyByIdResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[727]
+	mi := &file_yakgrpc_proto_msgTypes[728]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53182,7 +53281,7 @@ func (x *GetHTTPFlowBodyByIdResponse) String() string {
 func (*GetHTTPFlowBodyByIdResponse) ProtoMessage() {}
 
 func (x *GetHTTPFlowBodyByIdResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[727]
+	mi := &file_yakgrpc_proto_msgTypes[728]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53195,7 +53294,7 @@ func (x *GetHTTPFlowBodyByIdResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHTTPFlowBodyByIdResponse.ProtoReflect.Descriptor instead.
 func (*GetHTTPFlowBodyByIdResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{727}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{728}
 }
 
 func (x *GetHTTPFlowBodyByIdResponse) GetData() []byte {
@@ -53230,7 +53329,7 @@ type QueryHTTPFlowResponse struct {
 
 func (x *QueryHTTPFlowResponse) Reset() {
 	*x = QueryHTTPFlowResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[728]
+	mi := &file_yakgrpc_proto_msgTypes[729]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53242,7 +53341,7 @@ func (x *QueryHTTPFlowResponse) String() string {
 func (*QueryHTTPFlowResponse) ProtoMessage() {}
 
 func (x *QueryHTTPFlowResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[728]
+	mi := &file_yakgrpc_proto_msgTypes[729]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53255,7 +53354,7 @@ func (x *QueryHTTPFlowResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryHTTPFlowResponse.ProtoReflect.Descriptor instead.
 func (*QueryHTTPFlowResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{728}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{729}
 }
 
 func (x *QueryHTTPFlowResponse) GetPagination() *Paging {
@@ -53289,7 +53388,7 @@ type HTTPFlowsFieldGroupRequest struct {
 
 func (x *HTTPFlowsFieldGroupRequest) Reset() {
 	*x = HTTPFlowsFieldGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[729]
+	mi := &file_yakgrpc_proto_msgTypes[730]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53301,7 +53400,7 @@ func (x *HTTPFlowsFieldGroupRequest) String() string {
 func (*HTTPFlowsFieldGroupRequest) ProtoMessage() {}
 
 func (x *HTTPFlowsFieldGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[729]
+	mi := &file_yakgrpc_proto_msgTypes[730]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53314,7 +53413,7 @@ func (x *HTTPFlowsFieldGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPFlowsFieldGroupRequest.ProtoReflect.Descriptor instead.
 func (*HTTPFlowsFieldGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{729}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{730}
 }
 
 func (x *HTTPFlowsFieldGroupRequest) GetRefreshRequest() bool {
@@ -53342,7 +53441,7 @@ type HTTPFlowsFieldGroupResponse struct {
 
 func (x *HTTPFlowsFieldGroupResponse) Reset() {
 	*x = HTTPFlowsFieldGroupResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[730]
+	mi := &file_yakgrpc_proto_msgTypes[731]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53354,7 +53453,7 @@ func (x *HTTPFlowsFieldGroupResponse) String() string {
 func (*HTTPFlowsFieldGroupResponse) ProtoMessage() {}
 
 func (x *HTTPFlowsFieldGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[730]
+	mi := &file_yakgrpc_proto_msgTypes[731]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53367,7 +53466,7 @@ func (x *HTTPFlowsFieldGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPFlowsFieldGroupResponse.ProtoReflect.Descriptor instead.
 func (*HTTPFlowsFieldGroupResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{730}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{731}
 }
 
 func (x *HTTPFlowsFieldGroupResponse) GetTags() []*TagsCode {
@@ -53406,7 +53505,7 @@ type HTTPFlowsShareRequest struct {
 
 func (x *HTTPFlowsShareRequest) Reset() {
 	*x = HTTPFlowsShareRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[731]
+	mi := &file_yakgrpc_proto_msgTypes[732]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53418,7 +53517,7 @@ func (x *HTTPFlowsShareRequest) String() string {
 func (*HTTPFlowsShareRequest) ProtoMessage() {}
 
 func (x *HTTPFlowsShareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[731]
+	mi := &file_yakgrpc_proto_msgTypes[732]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53431,7 +53530,7 @@ func (x *HTTPFlowsShareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPFlowsShareRequest.ProtoReflect.Descriptor instead.
 func (*HTTPFlowsShareRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{731}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{732}
 }
 
 func (x *HTTPFlowsShareRequest) GetIds() []int64 {
@@ -53493,7 +53592,7 @@ type HTTPFlowsShareResponse struct {
 
 func (x *HTTPFlowsShareResponse) Reset() {
 	*x = HTTPFlowsShareResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[732]
+	mi := &file_yakgrpc_proto_msgTypes[733]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53505,7 +53604,7 @@ func (x *HTTPFlowsShareResponse) String() string {
 func (*HTTPFlowsShareResponse) ProtoMessage() {}
 
 func (x *HTTPFlowsShareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[732]
+	mi := &file_yakgrpc_proto_msgTypes[733]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53518,7 +53617,7 @@ func (x *HTTPFlowsShareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPFlowsShareResponse.ProtoReflect.Descriptor instead.
 func (*HTTPFlowsShareResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{732}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{733}
 }
 
 func (x *HTTPFlowsShareResponse) GetShareId() string {
@@ -53544,7 +53643,7 @@ type HTTPFlowsExtractRequest struct {
 
 func (x *HTTPFlowsExtractRequest) Reset() {
 	*x = HTTPFlowsExtractRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[733]
+	mi := &file_yakgrpc_proto_msgTypes[734]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53556,7 +53655,7 @@ func (x *HTTPFlowsExtractRequest) String() string {
 func (*HTTPFlowsExtractRequest) ProtoMessage() {}
 
 func (x *HTTPFlowsExtractRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[733]
+	mi := &file_yakgrpc_proto_msgTypes[734]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53569,7 +53668,7 @@ func (x *HTTPFlowsExtractRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPFlowsExtractRequest.ProtoReflect.Descriptor instead.
 func (*HTTPFlowsExtractRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{733}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{734}
 }
 
 func (x *HTTPFlowsExtractRequest) GetShareExtractContent() string {
@@ -53590,7 +53689,7 @@ type TagsCode struct {
 
 func (x *TagsCode) Reset() {
 	*x = TagsCode{}
-	mi := &file_yakgrpc_proto_msgTypes[734]
+	mi := &file_yakgrpc_proto_msgTypes[735]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53602,7 +53701,7 @@ func (x *TagsCode) String() string {
 func (*TagsCode) ProtoMessage() {}
 
 func (x *TagsCode) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[734]
+	mi := &file_yakgrpc_proto_msgTypes[735]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53615,7 +53714,7 @@ func (x *TagsCode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TagsCode.ProtoReflect.Descriptor instead.
 func (*TagsCode) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{734}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{735}
 }
 
 func (x *TagsCode) GetValue() string {
@@ -53650,7 +53749,7 @@ type WebsocketFlows struct {
 
 func (x *WebsocketFlows) Reset() {
 	*x = WebsocketFlows{}
-	mi := &file_yakgrpc_proto_msgTypes[735]
+	mi := &file_yakgrpc_proto_msgTypes[736]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53662,7 +53761,7 @@ func (x *WebsocketFlows) String() string {
 func (*WebsocketFlows) ProtoMessage() {}
 
 func (x *WebsocketFlows) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[735]
+	mi := &file_yakgrpc_proto_msgTypes[736]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53675,7 +53774,7 @@ func (x *WebsocketFlows) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebsocketFlows.ProtoReflect.Descriptor instead.
 func (*WebsocketFlows) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{735}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{736}
 }
 
 func (x *WebsocketFlows) GetPagination() *Paging {
@@ -53720,7 +53819,7 @@ type WebsocketFlow struct {
 
 func (x *WebsocketFlow) Reset() {
 	*x = WebsocketFlow{}
-	mi := &file_yakgrpc_proto_msgTypes[736]
+	mi := &file_yakgrpc_proto_msgTypes[737]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53732,7 +53831,7 @@ func (x *WebsocketFlow) String() string {
 func (*WebsocketFlow) ProtoMessage() {}
 
 func (x *WebsocketFlow) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[736]
+	mi := &file_yakgrpc_proto_msgTypes[737]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53745,7 +53844,7 @@ func (x *WebsocketFlow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebsocketFlow.ProtoReflect.Descriptor instead.
 func (*WebsocketFlow) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{736}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{737}
 }
 
 func (x *WebsocketFlow) GetID() int64 {
@@ -53856,7 +53955,7 @@ type SetMITMFilterRequest struct {
 
 func (x *SetMITMFilterRequest) Reset() {
 	*x = SetMITMFilterRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[737]
+	mi := &file_yakgrpc_proto_msgTypes[738]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53868,7 +53967,7 @@ func (x *SetMITMFilterRequest) String() string {
 func (*SetMITMFilterRequest) ProtoMessage() {}
 
 func (x *SetMITMFilterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[737]
+	mi := &file_yakgrpc_proto_msgTypes[738]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53881,7 +53980,7 @@ func (x *SetMITMFilterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetMITMFilterRequest.ProtoReflect.Descriptor instead.
 func (*SetMITMFilterRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{737}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{738}
 }
 
 func (x *SetMITMFilterRequest) GetIncludeHostname() []string {
@@ -53955,7 +54054,7 @@ type SetMITMFilterResponse struct {
 
 func (x *SetMITMFilterResponse) Reset() {
 	*x = SetMITMFilterResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[738]
+	mi := &file_yakgrpc_proto_msgTypes[739]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53967,7 +54066,7 @@ func (x *SetMITMFilterResponse) String() string {
 func (*SetMITMFilterResponse) ProtoMessage() {}
 
 func (x *SetMITMFilterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[738]
+	mi := &file_yakgrpc_proto_msgTypes[739]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -53980,7 +54079,7 @@ func (x *SetMITMFilterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetMITMFilterResponse.ProtoReflect.Descriptor instead.
 func (*SetMITMFilterResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{738}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{739}
 }
 
 // 中间人劫持的问题
@@ -54081,7 +54180,7 @@ type MITMRequest struct {
 
 func (x *MITMRequest) Reset() {
 	*x = MITMRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[739]
+	mi := &file_yakgrpc_proto_msgTypes[740]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54093,7 +54192,7 @@ func (x *MITMRequest) String() string {
 func (*MITMRequest) ProtoMessage() {}
 
 func (x *MITMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[739]
+	mi := &file_yakgrpc_proto_msgTypes[740]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -54106,7 +54205,7 @@ func (x *MITMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MITMRequest.ProtoReflect.Descriptor instead.
 func (*MITMRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{739}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{740}
 }
 
 func (x *MITMRequest) GetRequest() []byte {
@@ -54547,7 +54646,7 @@ type FilterDataItem struct {
 
 func (x *FilterDataItem) Reset() {
 	*x = FilterDataItem{}
-	mi := &file_yakgrpc_proto_msgTypes[740]
+	mi := &file_yakgrpc_proto_msgTypes[741]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54559,7 +54658,7 @@ func (x *FilterDataItem) String() string {
 func (*FilterDataItem) ProtoMessage() {}
 
 func (x *FilterDataItem) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[740]
+	mi := &file_yakgrpc_proto_msgTypes[741]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -54572,7 +54671,7 @@ func (x *FilterDataItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterDataItem.ProtoReflect.Descriptor instead.
 func (*FilterDataItem) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{740}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{741}
 }
 
 func (x *FilterDataItem) GetMatcherType() string {
@@ -54614,7 +54713,7 @@ type MITMFilterData struct {
 
 func (x *MITMFilterData) Reset() {
 	*x = MITMFilterData{}
-	mi := &file_yakgrpc_proto_msgTypes[741]
+	mi := &file_yakgrpc_proto_msgTypes[742]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54626,7 +54725,7 @@ func (x *MITMFilterData) String() string {
 func (*MITMFilterData) ProtoMessage() {}
 
 func (x *MITMFilterData) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[741]
+	mi := &file_yakgrpc_proto_msgTypes[742]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -54639,7 +54738,7 @@ func (x *MITMFilterData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MITMFilterData.ProtoReflect.Descriptor instead.
 func (*MITMFilterData) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{741}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{742}
 }
 
 func (x *MITMFilterData) GetIncludeHostnames() []*FilterDataItem {
@@ -54720,7 +54819,7 @@ type Certificate struct {
 
 func (x *Certificate) Reset() {
 	*x = Certificate{}
-	mi := &file_yakgrpc_proto_msgTypes[742]
+	mi := &file_yakgrpc_proto_msgTypes[743]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54732,7 +54831,7 @@ func (x *Certificate) String() string {
 func (*Certificate) ProtoMessage() {}
 
 func (x *Certificate) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[742]
+	mi := &file_yakgrpc_proto_msgTypes[743]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -54745,7 +54844,7 @@ func (x *Certificate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Certificate.ProtoReflect.Descriptor instead.
 func (*Certificate) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{742}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{743}
 }
 
 func (x *Certificate) GetCrtPem() []byte {
@@ -54807,7 +54906,7 @@ type RegexOutputStage struct {
 
 func (x *RegexOutputStage) Reset() {
 	*x = RegexOutputStage{}
-	mi := &file_yakgrpc_proto_msgTypes[743]
+	mi := &file_yakgrpc_proto_msgTypes[744]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54819,7 +54918,7 @@ func (x *RegexOutputStage) String() string {
 func (*RegexOutputStage) ProtoMessage() {}
 
 func (x *RegexOutputStage) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[743]
+	mi := &file_yakgrpc_proto_msgTypes[744]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -54832,7 +54931,7 @@ func (x *RegexOutputStage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegexOutputStage.ProtoReflect.Descriptor instead.
 func (*RegexOutputStage) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{743}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{744}
 }
 
 func (x *RegexOutputStage) GetRegexp() string {
@@ -54909,7 +55008,7 @@ type MITMContentReplacer struct {
 
 func (x *MITMContentReplacer) Reset() {
 	*x = MITMContentReplacer{}
-	mi := &file_yakgrpc_proto_msgTypes[744]
+	mi := &file_yakgrpc_proto_msgTypes[745]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54921,7 +55020,7 @@ func (x *MITMContentReplacer) String() string {
 func (*MITMContentReplacer) ProtoMessage() {}
 
 func (x *MITMContentReplacer) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[744]
+	mi := &file_yakgrpc_proto_msgTypes[745]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -54934,7 +55033,7 @@ func (x *MITMContentReplacer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MITMContentReplacer.ProtoReflect.Descriptor instead.
 func (*MITMContentReplacer) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{744}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{745}
 }
 
 func (x *MITMContentReplacer) GetRule() string {
@@ -55109,7 +55208,7 @@ type RemoveHookParams struct {
 
 func (x *RemoveHookParams) Reset() {
 	*x = RemoveHookParams{}
-	mi := &file_yakgrpc_proto_msgTypes[745]
+	mi := &file_yakgrpc_proto_msgTypes[746]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55121,7 +55220,7 @@ func (x *RemoveHookParams) String() string {
 func (*RemoveHookParams) ProtoMessage() {}
 
 func (x *RemoveHookParams) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[745]
+	mi := &file_yakgrpc_proto_msgTypes[746]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55134,7 +55233,7 @@ func (x *RemoveHookParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveHookParams.ProtoReflect.Descriptor instead.
 func (*RemoveHookParams) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{745}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{746}
 }
 
 func (x *RemoveHookParams) GetClearAll() bool {
@@ -55211,7 +55310,7 @@ type MITMResponse struct {
 
 func (x *MITMResponse) Reset() {
 	*x = MITMResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[746]
+	mi := &file_yakgrpc_proto_msgTypes[747]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55223,7 +55322,7 @@ func (x *MITMResponse) String() string {
 func (*MITMResponse) ProtoMessage() {}
 
 func (x *MITMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[746]
+	mi := &file_yakgrpc_proto_msgTypes[747]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55236,7 +55335,7 @@ func (x *MITMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MITMResponse.ProtoReflect.Descriptor instead.
 func (*MITMResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{746}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{747}
 }
 
 func (x *MITMResponse) GetRequest() []byte {
@@ -55493,7 +55592,7 @@ type TraceInfo struct {
 
 func (x *TraceInfo) Reset() {
 	*x = TraceInfo{}
-	mi := &file_yakgrpc_proto_msgTypes[747]
+	mi := &file_yakgrpc_proto_msgTypes[748]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55505,7 +55604,7 @@ func (x *TraceInfo) String() string {
 func (*TraceInfo) ProtoMessage() {}
 
 func (x *TraceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[747]
+	mi := &file_yakgrpc_proto_msgTypes[748]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55518,7 +55617,7 @@ func (x *TraceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceInfo.ProtoReflect.Descriptor instead.
 func (*TraceInfo) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{747}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{748}
 }
 
 func (x *TraceInfo) GetAvailableDNSServers() []string {
@@ -55587,7 +55686,7 @@ type YakScriptHooks struct {
 
 func (x *YakScriptHooks) Reset() {
 	*x = YakScriptHooks{}
-	mi := &file_yakgrpc_proto_msgTypes[748]
+	mi := &file_yakgrpc_proto_msgTypes[749]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55599,7 +55698,7 @@ func (x *YakScriptHooks) String() string {
 func (*YakScriptHooks) ProtoMessage() {}
 
 func (x *YakScriptHooks) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[748]
+	mi := &file_yakgrpc_proto_msgTypes[749]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55612,7 +55711,7 @@ func (x *YakScriptHooks) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use YakScriptHooks.ProtoReflect.Descriptor instead.
 func (*YakScriptHooks) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{748}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{749}
 }
 
 func (x *YakScriptHooks) GetHookName() string {
@@ -55640,7 +55739,7 @@ type YakScriptHookItem struct {
 
 func (x *YakScriptHookItem) Reset() {
 	*x = YakScriptHookItem{}
-	mi := &file_yakgrpc_proto_msgTypes[749]
+	mi := &file_yakgrpc_proto_msgTypes[750]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55652,7 +55751,7 @@ func (x *YakScriptHookItem) String() string {
 func (*YakScriptHookItem) ProtoMessage() {}
 
 func (x *YakScriptHookItem) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[749]
+	mi := &file_yakgrpc_proto_msgTypes[750]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55665,7 +55764,7 @@ func (x *YakScriptHookItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use YakScriptHookItem.ProtoReflect.Descriptor instead.
 func (*YakScriptHookItem) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{749}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{750}
 }
 
 func (x *YakScriptHookItem) GetYakScriptId() int64 {
@@ -55699,7 +55798,7 @@ type EchoRequest struct {
 
 func (x *EchoRequest) Reset() {
 	*x = EchoRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[750]
+	mi := &file_yakgrpc_proto_msgTypes[751]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55711,7 +55810,7 @@ func (x *EchoRequest) String() string {
 func (*EchoRequest) ProtoMessage() {}
 
 func (x *EchoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[750]
+	mi := &file_yakgrpc_proto_msgTypes[751]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55724,7 +55823,7 @@ func (x *EchoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EchoRequest.ProtoReflect.Descriptor instead.
 func (*EchoRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{750}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{751}
 }
 
 func (x *EchoRequest) GetText() string {
@@ -55743,7 +55842,7 @@ type EchoResposne struct {
 
 func (x *EchoResposne) Reset() {
 	*x = EchoResposne{}
-	mi := &file_yakgrpc_proto_msgTypes[751]
+	mi := &file_yakgrpc_proto_msgTypes[752]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55755,7 +55854,7 @@ func (x *EchoResposne) String() string {
 func (*EchoResposne) ProtoMessage() {}
 
 func (x *EchoResposne) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[751]
+	mi := &file_yakgrpc_proto_msgTypes[752]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55768,7 +55867,7 @@ func (x *EchoResposne) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EchoResposne.ProtoReflect.Descriptor instead.
 func (*EchoResposne) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{751}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{752}
 }
 
 func (x *EchoResposne) GetResult() string {
@@ -55788,7 +55887,7 @@ type HandshakeRequest struct {
 
 func (x *HandshakeRequest) Reset() {
 	*x = HandshakeRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[752]
+	mi := &file_yakgrpc_proto_msgTypes[753]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55800,7 +55899,7 @@ func (x *HandshakeRequest) String() string {
 func (*HandshakeRequest) ProtoMessage() {}
 
 func (x *HandshakeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[752]
+	mi := &file_yakgrpc_proto_msgTypes[753]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55813,7 +55912,7 @@ func (x *HandshakeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HandshakeRequest.ProtoReflect.Descriptor instead.
 func (*HandshakeRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{752}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{753}
 }
 
 func (x *HandshakeRequest) GetName() string {
@@ -55832,7 +55931,7 @@ type HandshakeResponse struct {
 
 func (x *HandshakeResponse) Reset() {
 	*x = HandshakeResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[753]
+	mi := &file_yakgrpc_proto_msgTypes[754]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55844,7 +55943,7 @@ func (x *HandshakeResponse) String() string {
 func (*HandshakeResponse) ProtoMessage() {}
 
 func (x *HandshakeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[753]
+	mi := &file_yakgrpc_proto_msgTypes[754]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55857,7 +55956,7 @@ func (x *HandshakeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HandshakeResponse.ProtoReflect.Descriptor instead.
 func (*HandshakeResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{753}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{754}
 }
 
 func (x *HandshakeResponse) GetSuccess() bool {
@@ -55882,7 +55981,7 @@ type Input struct {
 
 func (x *Input) Reset() {
 	*x = Input{}
-	mi := &file_yakgrpc_proto_msgTypes[754]
+	mi := &file_yakgrpc_proto_msgTypes[755]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55894,7 +55993,7 @@ func (x *Input) String() string {
 func (*Input) ProtoMessage() {}
 
 func (x *Input) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[754]
+	mi := &file_yakgrpc_proto_msgTypes[755]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55907,7 +56006,7 @@ func (x *Input) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Input.ProtoReflect.Descriptor instead.
 func (*Input) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{754}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{755}
 }
 
 func (x *Input) GetRaw() []byte {
@@ -55969,7 +56068,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_yakgrpc_proto_msgTypes[755]
+	mi := &file_yakgrpc_proto_msgTypes[756]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55981,7 +56080,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[755]
+	mi := &file_yakgrpc_proto_msgTypes[756]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -55994,7 +56093,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{755}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{756}
 }
 
 func (x *Output) GetRaw() []byte {
@@ -56050,7 +56149,7 @@ type ExecParamItem struct {
 
 func (x *ExecParamItem) Reset() {
 	*x = ExecParamItem{}
-	mi := &file_yakgrpc_proto_msgTypes[756]
+	mi := &file_yakgrpc_proto_msgTypes[757]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56062,7 +56161,7 @@ func (x *ExecParamItem) String() string {
 func (*ExecParamItem) ProtoMessage() {}
 
 func (x *ExecParamItem) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[756]
+	mi := &file_yakgrpc_proto_msgTypes[757]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56075,7 +56174,7 @@ func (x *ExecParamItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecParamItem.ProtoReflect.Descriptor instead.
 func (*ExecParamItem) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{756}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{757}
 }
 
 func (x *ExecParamItem) GetKey() string {
@@ -56110,7 +56209,7 @@ type ExecRequest struct {
 
 func (x *ExecRequest) Reset() {
 	*x = ExecRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[757]
+	mi := &file_yakgrpc_proto_msgTypes[758]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56122,7 +56221,7 @@ func (x *ExecRequest) String() string {
 func (*ExecRequest) ProtoMessage() {}
 
 func (x *ExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[757]
+	mi := &file_yakgrpc_proto_msgTypes[758]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56135,7 +56234,7 @@ func (x *ExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecRequest.ProtoReflect.Descriptor instead.
 func (*ExecRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{757}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{758}
 }
 
 func (x *ExecRequest) GetParams() []*ExecParamItem {
@@ -56212,7 +56311,7 @@ type ExecResult struct {
 
 func (x *ExecResult) Reset() {
 	*x = ExecResult{}
-	mi := &file_yakgrpc_proto_msgTypes[758]
+	mi := &file_yakgrpc_proto_msgTypes[759]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56224,7 +56323,7 @@ func (x *ExecResult) String() string {
 func (*ExecResult) ProtoMessage() {}
 
 func (x *ExecResult) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[758]
+	mi := &file_yakgrpc_proto_msgTypes[759]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56237,7 +56336,7 @@ func (x *ExecResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResult.ProtoReflect.Descriptor instead.
 func (*ExecResult) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{758}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{759}
 }
 
 func (x *ExecResult) GetHash() string {
@@ -56312,7 +56411,7 @@ type GetLicenseResponse struct {
 
 func (x *GetLicenseResponse) Reset() {
 	*x = GetLicenseResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[759]
+	mi := &file_yakgrpc_proto_msgTypes[760]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56324,7 +56423,7 @@ func (x *GetLicenseResponse) String() string {
 func (*GetLicenseResponse) ProtoMessage() {}
 
 func (x *GetLicenseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[759]
+	mi := &file_yakgrpc_proto_msgTypes[760]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56337,7 +56436,7 @@ func (x *GetLicenseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLicenseResponse.ProtoReflect.Descriptor instead.
 func (*GetLicenseResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{759}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{760}
 }
 
 func (x *GetLicenseResponse) GetLicense() string {
@@ -56357,7 +56456,7 @@ type CheckLicenseRequest struct {
 
 func (x *CheckLicenseRequest) Reset() {
 	*x = CheckLicenseRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[760]
+	mi := &file_yakgrpc_proto_msgTypes[761]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56369,7 +56468,7 @@ func (x *CheckLicenseRequest) String() string {
 func (*CheckLicenseRequest) ProtoMessage() {}
 
 func (x *CheckLicenseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[760]
+	mi := &file_yakgrpc_proto_msgTypes[761]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56382,7 +56481,7 @@ func (x *CheckLicenseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckLicenseRequest.ProtoReflect.Descriptor instead.
 func (*CheckLicenseRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{760}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{761}
 }
 
 func (x *CheckLicenseRequest) GetLicenseActivation() string {
@@ -56408,7 +56507,7 @@ type DefaultDnsServerResponse struct {
 
 func (x *DefaultDnsServerResponse) Reset() {
 	*x = DefaultDnsServerResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[761]
+	mi := &file_yakgrpc_proto_msgTypes[762]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56420,7 +56519,7 @@ func (x *DefaultDnsServerResponse) String() string {
 func (*DefaultDnsServerResponse) ProtoMessage() {}
 
 func (x *DefaultDnsServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[761]
+	mi := &file_yakgrpc_proto_msgTypes[762]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56433,7 +56532,7 @@ func (x *DefaultDnsServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DefaultDnsServerResponse.ProtoReflect.Descriptor instead.
 func (*DefaultDnsServerResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{761}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{762}
 }
 
 func (x *DefaultDnsServerResponse) GetDefaultDnsServer() []string {
@@ -56453,7 +56552,7 @@ type HTTPFlowBareRequest struct {
 
 func (x *HTTPFlowBareRequest) Reset() {
 	*x = HTTPFlowBareRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[762]
+	mi := &file_yakgrpc_proto_msgTypes[763]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56465,7 +56564,7 @@ func (x *HTTPFlowBareRequest) String() string {
 func (*HTTPFlowBareRequest) ProtoMessage() {}
 
 func (x *HTTPFlowBareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[762]
+	mi := &file_yakgrpc_proto_msgTypes[763]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56478,7 +56577,7 @@ func (x *HTTPFlowBareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPFlowBareRequest.ProtoReflect.Descriptor instead.
 func (*HTTPFlowBareRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{762}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{763}
 }
 
 func (x *HTTPFlowBareRequest) GetId() int64 {
@@ -56505,7 +56604,7 @@ type HTTPFlowBareResponse struct {
 
 func (x *HTTPFlowBareResponse) Reset() {
 	*x = HTTPFlowBareResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[763]
+	mi := &file_yakgrpc_proto_msgTypes[764]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56517,7 +56616,7 @@ func (x *HTTPFlowBareResponse) String() string {
 func (*HTTPFlowBareResponse) ProtoMessage() {}
 
 func (x *HTTPFlowBareResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[763]
+	mi := &file_yakgrpc_proto_msgTypes[764]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56530,7 +56629,7 @@ func (x *HTTPFlowBareResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPFlowBareResponse.ProtoReflect.Descriptor instead.
 func (*HTTPFlowBareResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{763}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{764}
 }
 
 func (x *HTTPFlowBareResponse) GetId() int64 {
@@ -56556,7 +56655,7 @@ type ImportHTTPFuzzerTaskFromYamlRequest struct {
 
 func (x *ImportHTTPFuzzerTaskFromYamlRequest) Reset() {
 	*x = ImportHTTPFuzzerTaskFromYamlRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[764]
+	mi := &file_yakgrpc_proto_msgTypes[765]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56568,7 +56667,7 @@ func (x *ImportHTTPFuzzerTaskFromYamlRequest) String() string {
 func (*ImportHTTPFuzzerTaskFromYamlRequest) ProtoMessage() {}
 
 func (x *ImportHTTPFuzzerTaskFromYamlRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[764]
+	mi := &file_yakgrpc_proto_msgTypes[765]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56581,7 +56680,7 @@ func (x *ImportHTTPFuzzerTaskFromYamlRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ImportHTTPFuzzerTaskFromYamlRequest.ProtoReflect.Descriptor instead.
 func (*ImportHTTPFuzzerTaskFromYamlRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{764}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{765}
 }
 
 func (x *ImportHTTPFuzzerTaskFromYamlRequest) GetYamlContent() string {
@@ -56601,7 +56700,7 @@ type ImportHTTPFuzzerTaskFromYamlResponse struct {
 
 func (x *ImportHTTPFuzzerTaskFromYamlResponse) Reset() {
 	*x = ImportHTTPFuzzerTaskFromYamlResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[765]
+	mi := &file_yakgrpc_proto_msgTypes[766]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56613,7 +56712,7 @@ func (x *ImportHTTPFuzzerTaskFromYamlResponse) String() string {
 func (*ImportHTTPFuzzerTaskFromYamlResponse) ProtoMessage() {}
 
 func (x *ImportHTTPFuzzerTaskFromYamlResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[765]
+	mi := &file_yakgrpc_proto_msgTypes[766]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56626,7 +56725,7 @@ func (x *ImportHTTPFuzzerTaskFromYamlResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use ImportHTTPFuzzerTaskFromYamlResponse.ProtoReflect.Descriptor instead.
 func (*ImportHTTPFuzzerTaskFromYamlResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{765}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{766}
 }
 
 func (x *ImportHTTPFuzzerTaskFromYamlResponse) GetStatus() *GeneralResponse {
@@ -56653,7 +56752,7 @@ type ExportHTTPFuzzerTaskToYamlRequest struct {
 
 func (x *ExportHTTPFuzzerTaskToYamlRequest) Reset() {
 	*x = ExportHTTPFuzzerTaskToYamlRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[766]
+	mi := &file_yakgrpc_proto_msgTypes[767]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56665,7 +56764,7 @@ func (x *ExportHTTPFuzzerTaskToYamlRequest) String() string {
 func (*ExportHTTPFuzzerTaskToYamlRequest) ProtoMessage() {}
 
 func (x *ExportHTTPFuzzerTaskToYamlRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[766]
+	mi := &file_yakgrpc_proto_msgTypes[767]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56678,7 +56777,7 @@ func (x *ExportHTTPFuzzerTaskToYamlRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ExportHTTPFuzzerTaskToYamlRequest.ProtoReflect.Descriptor instead.
 func (*ExportHTTPFuzzerTaskToYamlRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{766}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{767}
 }
 
 func (x *ExportHTTPFuzzerTaskToYamlRequest) GetRequests() *FuzzerRequests {
@@ -56705,7 +56804,7 @@ type ExportHTTPFuzzerTaskToYamlResponse struct {
 
 func (x *ExportHTTPFuzzerTaskToYamlResponse) Reset() {
 	*x = ExportHTTPFuzzerTaskToYamlResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[767]
+	mi := &file_yakgrpc_proto_msgTypes[768]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56717,7 +56816,7 @@ func (x *ExportHTTPFuzzerTaskToYamlResponse) String() string {
 func (*ExportHTTPFuzzerTaskToYamlResponse) ProtoMessage() {}
 
 func (x *ExportHTTPFuzzerTaskToYamlResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[767]
+	mi := &file_yakgrpc_proto_msgTypes[768]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56730,7 +56829,7 @@ func (x *ExportHTTPFuzzerTaskToYamlResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use ExportHTTPFuzzerTaskToYamlResponse.ProtoReflect.Descriptor instead.
 func (*ExportHTTPFuzzerTaskToYamlResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{767}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{768}
 }
 
 func (x *ExportHTTPFuzzerTaskToYamlResponse) GetStatus() *GeneralResponse {
@@ -56756,7 +56855,7 @@ type RenderHTTPFuzzerPacketRequest struct {
 
 func (x *RenderHTTPFuzzerPacketRequest) Reset() {
 	*x = RenderHTTPFuzzerPacketRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[768]
+	mi := &file_yakgrpc_proto_msgTypes[769]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56768,7 +56867,7 @@ func (x *RenderHTTPFuzzerPacketRequest) String() string {
 func (*RenderHTTPFuzzerPacketRequest) ProtoMessage() {}
 
 func (x *RenderHTTPFuzzerPacketRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[768]
+	mi := &file_yakgrpc_proto_msgTypes[769]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56781,7 +56880,7 @@ func (x *RenderHTTPFuzzerPacketRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenderHTTPFuzzerPacketRequest.ProtoReflect.Descriptor instead.
 func (*RenderHTTPFuzzerPacketRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{768}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{769}
 }
 
 func (x *RenderHTTPFuzzerPacketRequest) GetPacket() []byte {
@@ -56800,7 +56899,7 @@ type RenderHTTPFuzzerPacketResponse struct {
 
 func (x *RenderHTTPFuzzerPacketResponse) Reset() {
 	*x = RenderHTTPFuzzerPacketResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[769]
+	mi := &file_yakgrpc_proto_msgTypes[770]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56812,7 +56911,7 @@ func (x *RenderHTTPFuzzerPacketResponse) String() string {
 func (*RenderHTTPFuzzerPacketResponse) ProtoMessage() {}
 
 func (x *RenderHTTPFuzzerPacketResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[769]
+	mi := &file_yakgrpc_proto_msgTypes[770]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56825,7 +56924,7 @@ func (x *RenderHTTPFuzzerPacketResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenderHTTPFuzzerPacketResponse.ProtoReflect.Descriptor instead.
 func (*RenderHTTPFuzzerPacketResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{769}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{770}
 }
 
 func (x *RenderHTTPFuzzerPacketResponse) GetPacket() []byte {
@@ -56846,7 +56945,7 @@ type SmokingEvaluatePluginBatchRequest struct {
 
 func (x *SmokingEvaluatePluginBatchRequest) Reset() {
 	*x = SmokingEvaluatePluginBatchRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[770]
+	mi := &file_yakgrpc_proto_msgTypes[771]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56858,7 +56957,7 @@ func (x *SmokingEvaluatePluginBatchRequest) String() string {
 func (*SmokingEvaluatePluginBatchRequest) ProtoMessage() {}
 
 func (x *SmokingEvaluatePluginBatchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[770]
+	mi := &file_yakgrpc_proto_msgTypes[771]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56871,7 +56970,7 @@ func (x *SmokingEvaluatePluginBatchRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SmokingEvaluatePluginBatchRequest.ProtoReflect.Descriptor instead.
 func (*SmokingEvaluatePluginBatchRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{770}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{771}
 }
 
 func (x *SmokingEvaluatePluginBatchRequest) GetScriptNames() []string {
@@ -56899,7 +56998,7 @@ type SmokingEvaluatePluginBatchResponse struct {
 
 func (x *SmokingEvaluatePluginBatchResponse) Reset() {
 	*x = SmokingEvaluatePluginBatchResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[771]
+	mi := &file_yakgrpc_proto_msgTypes[772]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56911,7 +57010,7 @@ func (x *SmokingEvaluatePluginBatchResponse) String() string {
 func (*SmokingEvaluatePluginBatchResponse) ProtoMessage() {}
 
 func (x *SmokingEvaluatePluginBatchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[771]
+	mi := &file_yakgrpc_proto_msgTypes[772]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56924,7 +57023,7 @@ func (x *SmokingEvaluatePluginBatchResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SmokingEvaluatePluginBatchResponse.ProtoReflect.Descriptor instead.
 func (*SmokingEvaluatePluginBatchResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{771}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{772}
 }
 
 func (x *SmokingEvaluatePluginBatchResponse) GetProgress() float64 {
@@ -56961,7 +57060,7 @@ type GenerateURLRequest struct {
 
 func (x *GenerateURLRequest) Reset() {
 	*x = GenerateURLRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[772]
+	mi := &file_yakgrpc_proto_msgTypes[773]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56973,7 +57072,7 @@ func (x *GenerateURLRequest) String() string {
 func (*GenerateURLRequest) ProtoMessage() {}
 
 func (x *GenerateURLRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[772]
+	mi := &file_yakgrpc_proto_msgTypes[773]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56986,7 +57085,7 @@ func (x *GenerateURLRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateURLRequest.ProtoReflect.Descriptor instead.
 func (*GenerateURLRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{772}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{773}
 }
 
 func (x *GenerateURLRequest) GetScheme() string {
@@ -57033,7 +57132,7 @@ type GenerateURLResponse struct {
 
 func (x *GenerateURLResponse) Reset() {
 	*x = GenerateURLResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[773]
+	mi := &file_yakgrpc_proto_msgTypes[774]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57045,7 +57144,7 @@ func (x *GenerateURLResponse) String() string {
 func (*GenerateURLResponse) ProtoMessage() {}
 
 func (x *GenerateURLResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[773]
+	mi := &file_yakgrpc_proto_msgTypes[774]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57058,7 +57157,7 @@ func (x *GenerateURLResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateURLResponse.ProtoReflect.Descriptor instead.
 func (*GenerateURLResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{773}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{774}
 }
 
 func (x *GenerateURLResponse) GetURL() string {
@@ -57078,7 +57177,7 @@ type YakVersionAtLeastRequest struct {
 
 func (x *YakVersionAtLeastRequest) Reset() {
 	*x = YakVersionAtLeastRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[774]
+	mi := &file_yakgrpc_proto_msgTypes[775]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57090,7 +57189,7 @@ func (x *YakVersionAtLeastRequest) String() string {
 func (*YakVersionAtLeastRequest) ProtoMessage() {}
 
 func (x *YakVersionAtLeastRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[774]
+	mi := &file_yakgrpc_proto_msgTypes[775]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57103,7 +57202,7 @@ func (x *YakVersionAtLeastRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use YakVersionAtLeastRequest.ProtoReflect.Descriptor instead.
 func (*YakVersionAtLeastRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{774}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{775}
 }
 
 func (x *YakVersionAtLeastRequest) GetAtLeastVersion() string {
@@ -57130,7 +57229,7 @@ type ParseTrafficRequest struct {
 
 func (x *ParseTrafficRequest) Reset() {
 	*x = ParseTrafficRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[775]
+	mi := &file_yakgrpc_proto_msgTypes[776]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57142,7 +57241,7 @@ func (x *ParseTrafficRequest) String() string {
 func (*ParseTrafficRequest) ProtoMessage() {}
 
 func (x *ParseTrafficRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[775]
+	mi := &file_yakgrpc_proto_msgTypes[776]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57155,7 +57254,7 @@ func (x *ParseTrafficRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParseTrafficRequest.ProtoReflect.Descriptor instead.
 func (*ParseTrafficRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{775}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{776}
 }
 
 func (x *ParseTrafficRequest) GetId() int64 {
@@ -57183,7 +57282,7 @@ type ParseTrafficResponse struct {
 
 func (x *ParseTrafficResponse) Reset() {
 	*x = ParseTrafficResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[776]
+	mi := &file_yakgrpc_proto_msgTypes[777]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57195,7 +57294,7 @@ func (x *ParseTrafficResponse) String() string {
 func (*ParseTrafficResponse) ProtoMessage() {}
 
 func (x *ParseTrafficResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[776]
+	mi := &file_yakgrpc_proto_msgTypes[777]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57208,7 +57307,7 @@ func (x *ParseTrafficResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParseTrafficResponse.ProtoReflect.Descriptor instead.
 func (*ParseTrafficResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{776}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{777}
 }
 
 func (x *ParseTrafficResponse) GetOK() bool {
@@ -57241,7 +57340,7 @@ type TraceRouteRequest struct {
 
 func (x *TraceRouteRequest) Reset() {
 	*x = TraceRouteRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[777]
+	mi := &file_yakgrpc_proto_msgTypes[778]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57253,7 +57352,7 @@ func (x *TraceRouteRequest) String() string {
 func (*TraceRouteRequest) ProtoMessage() {}
 
 func (x *TraceRouteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[777]
+	mi := &file_yakgrpc_proto_msgTypes[778]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57266,7 +57365,7 @@ func (x *TraceRouteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceRouteRequest.ProtoReflect.Descriptor instead.
 func (*TraceRouteRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{777}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{778}
 }
 
 func (x *TraceRouteRequest) GetHost() string {
@@ -57288,7 +57387,7 @@ type TraceRouteResponse struct {
 
 func (x *TraceRouteResponse) Reset() {
 	*x = TraceRouteResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[778]
+	mi := &file_yakgrpc_proto_msgTypes[779]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57300,7 +57399,7 @@ func (x *TraceRouteResponse) String() string {
 func (*TraceRouteResponse) ProtoMessage() {}
 
 func (x *TraceRouteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[778]
+	mi := &file_yakgrpc_proto_msgTypes[779]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57313,7 +57412,7 @@ func (x *TraceRouteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceRouteResponse.ProtoReflect.Descriptor instead.
 func (*TraceRouteResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{778}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{779}
 }
 
 func (x *TraceRouteResponse) GetIp() string {
@@ -57355,7 +57454,7 @@ type EvaluateExpressionRequest struct {
 
 func (x *EvaluateExpressionRequest) Reset() {
 	*x = EvaluateExpressionRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[779]
+	mi := &file_yakgrpc_proto_msgTypes[780]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57367,7 +57466,7 @@ func (x *EvaluateExpressionRequest) String() string {
 func (*EvaluateExpressionRequest) ProtoMessage() {}
 
 func (x *EvaluateExpressionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[779]
+	mi := &file_yakgrpc_proto_msgTypes[780]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57380,7 +57479,7 @@ func (x *EvaluateExpressionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateExpressionRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateExpressionRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{779}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{780}
 }
 
 func (x *EvaluateExpressionRequest) GetExpression() string {
@@ -57414,7 +57513,7 @@ type EvaluateExpressionResponse struct {
 
 func (x *EvaluateExpressionResponse) Reset() {
 	*x = EvaluateExpressionResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[780]
+	mi := &file_yakgrpc_proto_msgTypes[781]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57426,7 +57525,7 @@ func (x *EvaluateExpressionResponse) String() string {
 func (*EvaluateExpressionResponse) ProtoMessage() {}
 
 func (x *EvaluateExpressionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[780]
+	mi := &file_yakgrpc_proto_msgTypes[781]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57439,7 +57538,7 @@ func (x *EvaluateExpressionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateExpressionResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateExpressionResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{780}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{781}
 }
 
 func (x *EvaluateExpressionResponse) GetResult() string {
@@ -57467,7 +57566,7 @@ type EvaluateMultiExpressionRequest struct {
 
 func (x *EvaluateMultiExpressionRequest) Reset() {
 	*x = EvaluateMultiExpressionRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[781]
+	mi := &file_yakgrpc_proto_msgTypes[782]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57479,7 +57578,7 @@ func (x *EvaluateMultiExpressionRequest) String() string {
 func (*EvaluateMultiExpressionRequest) ProtoMessage() {}
 
 func (x *EvaluateMultiExpressionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[781]
+	mi := &file_yakgrpc_proto_msgTypes[782]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57492,7 +57591,7 @@ func (x *EvaluateMultiExpressionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateMultiExpressionRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateMultiExpressionRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{781}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{782}
 }
 
 func (x *EvaluateMultiExpressionRequest) GetExpressions() []string {
@@ -57525,7 +57624,7 @@ type EvaluateMultiExpressionResponse struct {
 
 func (x *EvaluateMultiExpressionResponse) Reset() {
 	*x = EvaluateMultiExpressionResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[782]
+	mi := &file_yakgrpc_proto_msgTypes[783]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57537,7 +57636,7 @@ func (x *EvaluateMultiExpressionResponse) String() string {
 func (*EvaluateMultiExpressionResponse) ProtoMessage() {}
 
 func (x *EvaluateMultiExpressionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[782]
+	mi := &file_yakgrpc_proto_msgTypes[783]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57550,7 +57649,7 @@ func (x *EvaluateMultiExpressionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EvaluateMultiExpressionResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateMultiExpressionResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{782}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{783}
 }
 
 func (x *EvaluateMultiExpressionResponse) GetResults() []*EvaluateExpressionResponse {
@@ -57575,7 +57674,7 @@ type ThirdPartyAppConfigItemTemplate struct {
 
 func (x *ThirdPartyAppConfigItemTemplate) Reset() {
 	*x = ThirdPartyAppConfigItemTemplate{}
-	mi := &file_yakgrpc_proto_msgTypes[783]
+	mi := &file_yakgrpc_proto_msgTypes[784]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57587,7 +57686,7 @@ func (x *ThirdPartyAppConfigItemTemplate) String() string {
 func (*ThirdPartyAppConfigItemTemplate) ProtoMessage() {}
 
 func (x *ThirdPartyAppConfigItemTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[783]
+	mi := &file_yakgrpc_proto_msgTypes[784]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57600,7 +57699,7 @@ func (x *ThirdPartyAppConfigItemTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThirdPartyAppConfigItemTemplate.ProtoReflect.Descriptor instead.
 func (*ThirdPartyAppConfigItemTemplate) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{783}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{784}
 }
 
 func (x *ThirdPartyAppConfigItemTemplate) GetRequired() bool {
@@ -57664,7 +57763,7 @@ type GetThirdPartyAppConfigTemplate struct {
 
 func (x *GetThirdPartyAppConfigTemplate) Reset() {
 	*x = GetThirdPartyAppConfigTemplate{}
-	mi := &file_yakgrpc_proto_msgTypes[784]
+	mi := &file_yakgrpc_proto_msgTypes[785]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57676,7 +57775,7 @@ func (x *GetThirdPartyAppConfigTemplate) String() string {
 func (*GetThirdPartyAppConfigTemplate) ProtoMessage() {}
 
 func (x *GetThirdPartyAppConfigTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[784]
+	mi := &file_yakgrpc_proto_msgTypes[785]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57689,7 +57788,7 @@ func (x *GetThirdPartyAppConfigTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetThirdPartyAppConfigTemplate.ProtoReflect.Descriptor instead.
 func (*GetThirdPartyAppConfigTemplate) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{784}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{785}
 }
 
 func (x *GetThirdPartyAppConfigTemplate) GetName() string {
@@ -57729,7 +57828,7 @@ type GetThirdPartyAppConfigTemplateResponse struct {
 
 func (x *GetThirdPartyAppConfigTemplateResponse) Reset() {
 	*x = GetThirdPartyAppConfigTemplateResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[785]
+	mi := &file_yakgrpc_proto_msgTypes[786]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57741,7 +57840,7 @@ func (x *GetThirdPartyAppConfigTemplateResponse) String() string {
 func (*GetThirdPartyAppConfigTemplateResponse) ProtoMessage() {}
 
 func (x *GetThirdPartyAppConfigTemplateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[785]
+	mi := &file_yakgrpc_proto_msgTypes[786]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57754,7 +57853,7 @@ func (x *GetThirdPartyAppConfigTemplateResponse) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use GetThirdPartyAppConfigTemplateResponse.ProtoReflect.Descriptor instead.
 func (*GetThirdPartyAppConfigTemplateResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{785}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{786}
 }
 
 func (x *GetThirdPartyAppConfigTemplateResponse) GetTemplates() []*GetThirdPartyAppConfigTemplate {
@@ -57773,7 +57872,7 @@ type GetApiKeyByOnlineRequest struct {
 
 func (x *GetApiKeyByOnlineRequest) Reset() {
 	*x = GetApiKeyByOnlineRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[786]
+	mi := &file_yakgrpc_proto_msgTypes[787]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57785,7 +57884,7 @@ func (x *GetApiKeyByOnlineRequest) String() string {
 func (*GetApiKeyByOnlineRequest) ProtoMessage() {}
 
 func (x *GetApiKeyByOnlineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[786]
+	mi := &file_yakgrpc_proto_msgTypes[787]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57798,7 +57897,7 @@ func (x *GetApiKeyByOnlineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetApiKeyByOnlineRequest.ProtoReflect.Descriptor instead.
 func (*GetApiKeyByOnlineRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{786}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{787}
 }
 
 func (x *GetApiKeyByOnlineRequest) GetToken() string {
@@ -57817,7 +57916,7 @@ type GetApiKeyByOnlineResponse struct {
 
 func (x *GetApiKeyByOnlineResponse) Reset() {
 	*x = GetApiKeyByOnlineResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[787]
+	mi := &file_yakgrpc_proto_msgTypes[788]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57829,7 +57928,7 @@ func (x *GetApiKeyByOnlineResponse) String() string {
 func (*GetApiKeyByOnlineResponse) ProtoMessage() {}
 
 func (x *GetApiKeyByOnlineResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[787]
+	mi := &file_yakgrpc_proto_msgTypes[788]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57842,7 +57941,7 @@ func (x *GetApiKeyByOnlineResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetApiKeyByOnlineResponse.ProtoReflect.Descriptor instead.
 func (*GetApiKeyByOnlineResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{787}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{788}
 }
 
 func (x *GetApiKeyByOnlineResponse) GetApiKey() string {
@@ -57860,7 +57959,7 @@ type GetFingerprintRequest struct {
 
 func (x *GetFingerprintRequest) Reset() {
 	*x = GetFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[788]
+	mi := &file_yakgrpc_proto_msgTypes[789]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57872,7 +57971,7 @@ func (x *GetFingerprintRequest) String() string {
 func (*GetFingerprintRequest) ProtoMessage() {}
 
 func (x *GetFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[788]
+	mi := &file_yakgrpc_proto_msgTypes[789]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57885,7 +57984,7 @@ func (x *GetFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*GetFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{788}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{789}
 }
 
 type GetFingerprintResponse struct {
@@ -57896,7 +57995,7 @@ type GetFingerprintResponse struct {
 
 func (x *GetFingerprintResponse) Reset() {
 	*x = GetFingerprintResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[789]
+	mi := &file_yakgrpc_proto_msgTypes[790]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57908,7 +58007,7 @@ func (x *GetFingerprintResponse) String() string {
 func (*GetFingerprintResponse) ProtoMessage() {}
 
 func (x *GetFingerprintResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[789]
+	mi := &file_yakgrpc_proto_msgTypes[790]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57921,7 +58020,7 @@ func (x *GetFingerprintResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFingerprintResponse.ProtoReflect.Descriptor instead.
 func (*GetFingerprintResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{789}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{790}
 }
 
 type AddFingerprintRequest struct {
@@ -57934,7 +58033,7 @@ type AddFingerprintRequest struct {
 
 func (x *AddFingerprintRequest) Reset() {
 	*x = AddFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[790]
+	mi := &file_yakgrpc_proto_msgTypes[791]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57946,7 +58045,7 @@ func (x *AddFingerprintRequest) String() string {
 func (*AddFingerprintRequest) ProtoMessage() {}
 
 func (x *AddFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[790]
+	mi := &file_yakgrpc_proto_msgTypes[791]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57959,7 +58058,7 @@ func (x *AddFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*AddFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{790}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{791}
 }
 
 func (x *AddFingerprintRequest) GetName() string {
@@ -57984,7 +58083,7 @@ type AddFingerprintResponse struct {
 
 func (x *AddFingerprintResponse) Reset() {
 	*x = AddFingerprintResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[791]
+	mi := &file_yakgrpc_proto_msgTypes[792]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -57996,7 +58095,7 @@ func (x *AddFingerprintResponse) String() string {
 func (*AddFingerprintResponse) ProtoMessage() {}
 
 func (x *AddFingerprintResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[791]
+	mi := &file_yakgrpc_proto_msgTypes[792]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58009,7 +58108,7 @@ func (x *AddFingerprintResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFingerprintResponse.ProtoReflect.Descriptor instead.
 func (*AddFingerprintResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{791}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{792}
 }
 
 type ModifyFingerprintRequest struct {
@@ -58020,7 +58119,7 @@ type ModifyFingerprintRequest struct {
 
 func (x *ModifyFingerprintRequest) Reset() {
 	*x = ModifyFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[792]
+	mi := &file_yakgrpc_proto_msgTypes[793]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58032,7 +58131,7 @@ func (x *ModifyFingerprintRequest) String() string {
 func (*ModifyFingerprintRequest) ProtoMessage() {}
 
 func (x *ModifyFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[792]
+	mi := &file_yakgrpc_proto_msgTypes[793]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58045,7 +58144,7 @@ func (x *ModifyFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModifyFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*ModifyFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{792}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{793}
 }
 
 type ModifyFingerprintResponse struct {
@@ -58056,7 +58155,7 @@ type ModifyFingerprintResponse struct {
 
 func (x *ModifyFingerprintResponse) Reset() {
 	*x = ModifyFingerprintResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[793]
+	mi := &file_yakgrpc_proto_msgTypes[794]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58068,7 +58167,7 @@ func (x *ModifyFingerprintResponse) String() string {
 func (*ModifyFingerprintResponse) ProtoMessage() {}
 
 func (x *ModifyFingerprintResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[793]
+	mi := &file_yakgrpc_proto_msgTypes[794]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58081,7 +58180,7 @@ func (x *ModifyFingerprintResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModifyFingerprintResponse.ProtoReflect.Descriptor instead.
 func (*ModifyFingerprintResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{793}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{794}
 }
 
 type ReadFileRequest struct {
@@ -58095,7 +58194,7 @@ type ReadFileRequest struct {
 
 func (x *ReadFileRequest) Reset() {
 	*x = ReadFileRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[794]
+	mi := &file_yakgrpc_proto_msgTypes[795]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58107,7 +58206,7 @@ func (x *ReadFileRequest) String() string {
 func (*ReadFileRequest) ProtoMessage() {}
 
 func (x *ReadFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[794]
+	mi := &file_yakgrpc_proto_msgTypes[795]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58120,7 +58219,7 @@ func (x *ReadFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadFileRequest.ProtoReflect.Descriptor instead.
 func (*ReadFileRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{794}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{795}
 }
 
 func (x *ReadFileRequest) GetFilePath() string {
@@ -58154,7 +58253,7 @@ type ReadFileResponse struct {
 
 func (x *ReadFileResponse) Reset() {
 	*x = ReadFileResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[795]
+	mi := &file_yakgrpc_proto_msgTypes[796]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58166,7 +58265,7 @@ func (x *ReadFileResponse) String() string {
 func (*ReadFileResponse) ProtoMessage() {}
 
 func (x *ReadFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[795]
+	mi := &file_yakgrpc_proto_msgTypes[796]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58179,7 +58278,7 @@ func (x *ReadFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadFileResponse.ProtoReflect.Descriptor instead.
 func (*ReadFileResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{795}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{796}
 }
 
 func (x *ReadFileResponse) GetData() []byte {
@@ -58206,7 +58305,7 @@ type GetReverseShellProgramListRequest struct {
 
 func (x *GetReverseShellProgramListRequest) Reset() {
 	*x = GetReverseShellProgramListRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[796]
+	mi := &file_yakgrpc_proto_msgTypes[797]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58218,7 +58317,7 @@ func (x *GetReverseShellProgramListRequest) String() string {
 func (*GetReverseShellProgramListRequest) ProtoMessage() {}
 
 func (x *GetReverseShellProgramListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[796]
+	mi := &file_yakgrpc_proto_msgTypes[797]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58231,7 +58330,7 @@ func (x *GetReverseShellProgramListRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetReverseShellProgramListRequest.ProtoReflect.Descriptor instead.
 func (*GetReverseShellProgramListRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{796}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{797}
 }
 
 func (x *GetReverseShellProgramListRequest) GetSystem() string {
@@ -58258,7 +58357,7 @@ type GetReverseShellProgramListResponse struct {
 
 func (x *GetReverseShellProgramListResponse) Reset() {
 	*x = GetReverseShellProgramListResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[797]
+	mi := &file_yakgrpc_proto_msgTypes[798]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58270,7 +58369,7 @@ func (x *GetReverseShellProgramListResponse) String() string {
 func (*GetReverseShellProgramListResponse) ProtoMessage() {}
 
 func (x *GetReverseShellProgramListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[797]
+	mi := &file_yakgrpc_proto_msgTypes[798]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58283,7 +58382,7 @@ func (x *GetReverseShellProgramListResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetReverseShellProgramListResponse.ProtoReflect.Descriptor instead.
 func (*GetReverseShellProgramListResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{797}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{798}
 }
 
 func (x *GetReverseShellProgramListResponse) GetProgramList() []string {
@@ -58315,7 +58414,7 @@ type GenerateReverseShellCommandRequest struct {
 
 func (x *GenerateReverseShellCommandRequest) Reset() {
 	*x = GenerateReverseShellCommandRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[798]
+	mi := &file_yakgrpc_proto_msgTypes[799]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58327,7 +58426,7 @@ func (x *GenerateReverseShellCommandRequest) String() string {
 func (*GenerateReverseShellCommandRequest) ProtoMessage() {}
 
 func (x *GenerateReverseShellCommandRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[798]
+	mi := &file_yakgrpc_proto_msgTypes[799]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58340,7 +58439,7 @@ func (x *GenerateReverseShellCommandRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GenerateReverseShellCommandRequest.ProtoReflect.Descriptor instead.
 func (*GenerateReverseShellCommandRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{798}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{799}
 }
 
 func (x *GenerateReverseShellCommandRequest) GetSystem() string {
@@ -58402,7 +58501,7 @@ type GenerateReverseShellCommandResponse struct {
 
 func (x *GenerateReverseShellCommandResponse) Reset() {
 	*x = GenerateReverseShellCommandResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[799]
+	mi := &file_yakgrpc_proto_msgTypes[800]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58414,7 +58513,7 @@ func (x *GenerateReverseShellCommandResponse) String() string {
 func (*GenerateReverseShellCommandResponse) ProtoMessage() {}
 
 func (x *GenerateReverseShellCommandResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[799]
+	mi := &file_yakgrpc_proto_msgTypes[800]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58427,7 +58526,7 @@ func (x *GenerateReverseShellCommandResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use GenerateReverseShellCommandResponse.ProtoReflect.Descriptor instead.
 func (*GenerateReverseShellCommandResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{799}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{800}
 }
 
 func (x *GenerateReverseShellCommandResponse) GetStatus() *GeneralResponse {
@@ -58457,7 +58556,7 @@ type DbOperateMessage struct {
 
 func (x *DbOperateMessage) Reset() {
 	*x = DbOperateMessage{}
-	mi := &file_yakgrpc_proto_msgTypes[800]
+	mi := &file_yakgrpc_proto_msgTypes[801]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58469,7 +58568,7 @@ func (x *DbOperateMessage) String() string {
 func (*DbOperateMessage) ProtoMessage() {}
 
 func (x *DbOperateMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[800]
+	mi := &file_yakgrpc_proto_msgTypes[801]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58482,7 +58581,7 @@ func (x *DbOperateMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DbOperateMessage.ProtoReflect.Descriptor instead.
 func (*DbOperateMessage) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{800}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{801}
 }
 
 func (x *DbOperateMessage) GetTableName() string {
@@ -58535,7 +58634,7 @@ type CPE struct {
 
 func (x *CPE) Reset() {
 	*x = CPE{}
-	mi := &file_yakgrpc_proto_msgTypes[801]
+	mi := &file_yakgrpc_proto_msgTypes[802]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58547,7 +58646,7 @@ func (x *CPE) String() string {
 func (*CPE) ProtoMessage() {}
 
 func (x *CPE) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[801]
+	mi := &file_yakgrpc_proto_msgTypes[802]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58560,7 +58659,7 @@ func (x *CPE) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CPE.ProtoReflect.Descriptor instead.
 func (*CPE) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{801}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{802}
 }
 
 func (x *CPE) GetPart() string {
@@ -58627,7 +58726,7 @@ type FingerprintRule struct {
 
 func (x *FingerprintRule) Reset() {
 	*x = FingerprintRule{}
-	mi := &file_yakgrpc_proto_msgTypes[802]
+	mi := &file_yakgrpc_proto_msgTypes[803]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58639,7 +58738,7 @@ func (x *FingerprintRule) String() string {
 func (*FingerprintRule) ProtoMessage() {}
 
 func (x *FingerprintRule) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[802]
+	mi := &file_yakgrpc_proto_msgTypes[803]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58652,7 +58751,7 @@ func (x *FingerprintRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FingerprintRule.ProtoReflect.Descriptor instead.
 func (*FingerprintRule) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{802}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{803}
 }
 
 func (x *FingerprintRule) GetId() int64 {
@@ -58718,7 +58817,7 @@ type FingerprintFilter struct {
 
 func (x *FingerprintFilter) Reset() {
 	*x = FingerprintFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[803]
+	mi := &file_yakgrpc_proto_msgTypes[804]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58730,7 +58829,7 @@ func (x *FingerprintFilter) String() string {
 func (*FingerprintFilter) ProtoMessage() {}
 
 func (x *FingerprintFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[803]
+	mi := &file_yakgrpc_proto_msgTypes[804]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58743,7 +58842,7 @@ func (x *FingerprintFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FingerprintFilter.ProtoReflect.Descriptor instead.
 func (*FingerprintFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{803}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{804}
 }
 
 func (x *FingerprintFilter) GetVendor() []string {
@@ -58798,7 +58897,7 @@ type QueryFingerprintRequest struct {
 
 func (x *QueryFingerprintRequest) Reset() {
 	*x = QueryFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[804]
+	mi := &file_yakgrpc_proto_msgTypes[805]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58810,7 +58909,7 @@ func (x *QueryFingerprintRequest) String() string {
 func (*QueryFingerprintRequest) ProtoMessage() {}
 
 func (x *QueryFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[804]
+	mi := &file_yakgrpc_proto_msgTypes[805]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58823,7 +58922,7 @@ func (x *QueryFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*QueryFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{804}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{805}
 }
 
 func (x *QueryFingerprintRequest) GetFilter() *FingerprintFilter {
@@ -58851,7 +58950,7 @@ type QueryFingerprintResponse struct {
 
 func (x *QueryFingerprintResponse) Reset() {
 	*x = QueryFingerprintResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[805]
+	mi := &file_yakgrpc_proto_msgTypes[806]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58863,7 +58962,7 @@ func (x *QueryFingerprintResponse) String() string {
 func (*QueryFingerprintResponse) ProtoMessage() {}
 
 func (x *QueryFingerprintResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[805]
+	mi := &file_yakgrpc_proto_msgTypes[806]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58876,7 +58975,7 @@ func (x *QueryFingerprintResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryFingerprintResponse.ProtoReflect.Descriptor instead.
 func (*QueryFingerprintResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{805}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{806}
 }
 
 func (x *QueryFingerprintResponse) GetPagination() *Paging {
@@ -58909,7 +59008,7 @@ type DeleteFingerprintRequest struct {
 
 func (x *DeleteFingerprintRequest) Reset() {
 	*x = DeleteFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[806]
+	mi := &file_yakgrpc_proto_msgTypes[807]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58921,7 +59020,7 @@ func (x *DeleteFingerprintRequest) String() string {
 func (*DeleteFingerprintRequest) ProtoMessage() {}
 
 func (x *DeleteFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[806]
+	mi := &file_yakgrpc_proto_msgTypes[807]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58934,7 +59033,7 @@ func (x *DeleteFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*DeleteFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{806}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{807}
 }
 
 func (x *DeleteFingerprintRequest) GetFilter() *FingerprintFilter {
@@ -58953,7 +59052,7 @@ type CreateFingerprintRequest struct {
 
 func (x *CreateFingerprintRequest) Reset() {
 	*x = CreateFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[807]
+	mi := &file_yakgrpc_proto_msgTypes[808]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58965,7 +59064,7 @@ func (x *CreateFingerprintRequest) String() string {
 func (*CreateFingerprintRequest) ProtoMessage() {}
 
 func (x *CreateFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[807]
+	mi := &file_yakgrpc_proto_msgTypes[808]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58978,7 +59077,7 @@ func (x *CreateFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*CreateFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{807}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{808}
 }
 
 func (x *CreateFingerprintRequest) GetRule() *FingerprintRule {
@@ -58999,7 +59098,7 @@ type UpdateFingerprintRequest struct {
 
 func (x *UpdateFingerprintRequest) Reset() {
 	*x = UpdateFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[808]
+	mi := &file_yakgrpc_proto_msgTypes[809]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59011,7 +59110,7 @@ func (x *UpdateFingerprintRequest) String() string {
 func (*UpdateFingerprintRequest) ProtoMessage() {}
 
 func (x *UpdateFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[808]
+	mi := &file_yakgrpc_proto_msgTypes[809]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59024,7 +59123,7 @@ func (x *UpdateFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{808}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{809}
 }
 
 func (x *UpdateFingerprintRequest) GetId() int64 {
@@ -59058,7 +59157,7 @@ type FingerprintGroup struct {
 
 func (x *FingerprintGroup) Reset() {
 	*x = FingerprintGroup{}
-	mi := &file_yakgrpc_proto_msgTypes[809]
+	mi := &file_yakgrpc_proto_msgTypes[810]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59070,7 +59169,7 @@ func (x *FingerprintGroup) String() string {
 func (*FingerprintGroup) ProtoMessage() {}
 
 func (x *FingerprintGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[809]
+	mi := &file_yakgrpc_proto_msgTypes[810]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59083,7 +59182,7 @@ func (x *FingerprintGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FingerprintGroup.ProtoReflect.Descriptor instead.
 func (*FingerprintGroup) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{809}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{810}
 }
 
 func (x *FingerprintGroup) GetGroupName() string {
@@ -59109,7 +59208,7 @@ type FingerprintGroups struct {
 
 func (x *FingerprintGroups) Reset() {
 	*x = FingerprintGroups{}
-	mi := &file_yakgrpc_proto_msgTypes[810]
+	mi := &file_yakgrpc_proto_msgTypes[811]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59121,7 +59220,7 @@ func (x *FingerprintGroups) String() string {
 func (*FingerprintGroups) ProtoMessage() {}
 
 func (x *FingerprintGroups) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[810]
+	mi := &file_yakgrpc_proto_msgTypes[811]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59134,7 +59233,7 @@ func (x *FingerprintGroups) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FingerprintGroups.ProtoReflect.Descriptor instead.
 func (*FingerprintGroups) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{810}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{811}
 }
 
 func (x *FingerprintGroups) GetData() []*FingerprintGroup {
@@ -59154,7 +59253,7 @@ type RenameFingerprintGroupRequest struct {
 
 func (x *RenameFingerprintGroupRequest) Reset() {
 	*x = RenameFingerprintGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[811]
+	mi := &file_yakgrpc_proto_msgTypes[812]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59166,7 +59265,7 @@ func (x *RenameFingerprintGroupRequest) String() string {
 func (*RenameFingerprintGroupRequest) ProtoMessage() {}
 
 func (x *RenameFingerprintGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[811]
+	mi := &file_yakgrpc_proto_msgTypes[812]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59179,7 +59278,7 @@ func (x *RenameFingerprintGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameFingerprintGroupRequest.ProtoReflect.Descriptor instead.
 func (*RenameFingerprintGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{811}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{812}
 }
 
 func (x *RenameFingerprintGroupRequest) GetGroupName() string {
@@ -59205,7 +59304,7 @@ type DeleteFingerprintGroupRequest struct {
 
 func (x *DeleteFingerprintGroupRequest) Reset() {
 	*x = DeleteFingerprintGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[812]
+	mi := &file_yakgrpc_proto_msgTypes[813]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59217,7 +59316,7 @@ func (x *DeleteFingerprintGroupRequest) String() string {
 func (*DeleteFingerprintGroupRequest) ProtoMessage() {}
 
 func (x *DeleteFingerprintGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[812]
+	mi := &file_yakgrpc_proto_msgTypes[813]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59230,7 +59329,7 @@ func (x *DeleteFingerprintGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteFingerprintGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeleteFingerprintGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{812}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{813}
 }
 
 func (x *DeleteFingerprintGroupRequest) GetGroupNames() []string {
@@ -59251,7 +59350,7 @@ type BatchUpdateFingerprintToGroupRequest struct {
 
 func (x *BatchUpdateFingerprintToGroupRequest) Reset() {
 	*x = BatchUpdateFingerprintToGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[813]
+	mi := &file_yakgrpc_proto_msgTypes[814]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59263,7 +59362,7 @@ func (x *BatchUpdateFingerprintToGroupRequest) String() string {
 func (*BatchUpdateFingerprintToGroupRequest) ProtoMessage() {}
 
 func (x *BatchUpdateFingerprintToGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[813]
+	mi := &file_yakgrpc_proto_msgTypes[814]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59276,7 +59375,7 @@ func (x *BatchUpdateFingerprintToGroupRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use BatchUpdateFingerprintToGroupRequest.ProtoReflect.Descriptor instead.
 func (*BatchUpdateFingerprintToGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{813}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{814}
 }
 
 func (x *BatchUpdateFingerprintToGroupRequest) GetAppendGroupName() []string {
@@ -59310,7 +59409,7 @@ type GetFingerprintGroupSetRequest struct {
 
 func (x *GetFingerprintGroupSetRequest) Reset() {
 	*x = GetFingerprintGroupSetRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[814]
+	mi := &file_yakgrpc_proto_msgTypes[815]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59322,7 +59421,7 @@ func (x *GetFingerprintGroupSetRequest) String() string {
 func (*GetFingerprintGroupSetRequest) ProtoMessage() {}
 
 func (x *GetFingerprintGroupSetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[814]
+	mi := &file_yakgrpc_proto_msgTypes[815]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59335,7 +59434,7 @@ func (x *GetFingerprintGroupSetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFingerprintGroupSetRequest.ProtoReflect.Descriptor instead.
 func (*GetFingerprintGroupSetRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{814}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{815}
 }
 
 func (x *GetFingerprintGroupSetRequest) GetFilter() *FingerprintFilter {
@@ -59363,7 +59462,7 @@ type ExportFingerprintRequest struct {
 
 func (x *ExportFingerprintRequest) Reset() {
 	*x = ExportFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[815]
+	mi := &file_yakgrpc_proto_msgTypes[816]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59375,7 +59474,7 @@ func (x *ExportFingerprintRequest) String() string {
 func (*ExportFingerprintRequest) ProtoMessage() {}
 
 func (x *ExportFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[815]
+	mi := &file_yakgrpc_proto_msgTypes[816]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59388,7 +59487,7 @@ func (x *ExportFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*ExportFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{815}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{816}
 }
 
 func (x *ExportFingerprintRequest) GetFilter() *FingerprintFilter {
@@ -59422,7 +59521,7 @@ type ImportFingerprintRequest struct {
 
 func (x *ImportFingerprintRequest) Reset() {
 	*x = ImportFingerprintRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[816]
+	mi := &file_yakgrpc_proto_msgTypes[817]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59434,7 +59533,7 @@ func (x *ImportFingerprintRequest) String() string {
 func (*ImportFingerprintRequest) ProtoMessage() {}
 
 func (x *ImportFingerprintRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[816]
+	mi := &file_yakgrpc_proto_msgTypes[817]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59447,7 +59546,7 @@ func (x *ImportFingerprintRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportFingerprintRequest.ProtoReflect.Descriptor instead.
 func (*ImportFingerprintRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{816}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{817}
 }
 
 func (x *ImportFingerprintRequest) GetInputPath() string {
@@ -59474,7 +59573,7 @@ type DataTransferProgress struct {
 
 func (x *DataTransferProgress) Reset() {
 	*x = DataTransferProgress{}
-	mi := &file_yakgrpc_proto_msgTypes[817]
+	mi := &file_yakgrpc_proto_msgTypes[818]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59486,7 +59585,7 @@ func (x *DataTransferProgress) String() string {
 func (*DataTransferProgress) ProtoMessage() {}
 
 func (x *DataTransferProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[817]
+	mi := &file_yakgrpc_proto_msgTypes[818]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59499,7 +59598,7 @@ func (x *DataTransferProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataTransferProgress.ProtoReflect.Descriptor instead.
 func (*DataTransferProgress) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{817}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{818}
 }
 
 func (x *DataTransferProgress) GetProgress() float64 {
@@ -59526,7 +59625,7 @@ type QuerySyntaxFlowRuleRequest struct {
 
 func (x *QuerySyntaxFlowRuleRequest) Reset() {
 	*x = QuerySyntaxFlowRuleRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[818]
+	mi := &file_yakgrpc_proto_msgTypes[819]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59538,7 +59637,7 @@ func (x *QuerySyntaxFlowRuleRequest) String() string {
 func (*QuerySyntaxFlowRuleRequest) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[818]
+	mi := &file_yakgrpc_proto_msgTypes[819]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59551,7 +59650,7 @@ func (x *QuerySyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowRuleRequest.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowRuleRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{818}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{819}
 }
 
 func (x *QuerySyntaxFlowRuleRequest) GetPagination() *Paging {
@@ -59596,7 +59695,7 @@ type SyntaxFlowRule struct {
 
 func (x *SyntaxFlowRule) Reset() {
 	*x = SyntaxFlowRule{}
-	mi := &file_yakgrpc_proto_msgTypes[819]
+	mi := &file_yakgrpc_proto_msgTypes[820]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59608,7 +59707,7 @@ func (x *SyntaxFlowRule) String() string {
 func (*SyntaxFlowRule) ProtoMessage() {}
 
 func (x *SyntaxFlowRule) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[819]
+	mi := &file_yakgrpc_proto_msgTypes[820]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59621,7 +59720,7 @@ func (x *SyntaxFlowRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowRule.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowRule) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{819}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{820}
 }
 
 func (x *SyntaxFlowRule) GetId() int64 {
@@ -59776,7 +59875,7 @@ type AlertMessage struct {
 
 func (x *AlertMessage) Reset() {
 	*x = AlertMessage{}
-	mi := &file_yakgrpc_proto_msgTypes[820]
+	mi := &file_yakgrpc_proto_msgTypes[821]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59788,7 +59887,7 @@ func (x *AlertMessage) String() string {
 func (*AlertMessage) ProtoMessage() {}
 
 func (x *AlertMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[820]
+	mi := &file_yakgrpc_proto_msgTypes[821]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59801,7 +59900,7 @@ func (x *AlertMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AlertMessage.ProtoReflect.Descriptor instead.
 func (*AlertMessage) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{820}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{821}
 }
 
 func (x *AlertMessage) GetTitle() string {
@@ -59896,7 +59995,7 @@ type SyntaxFlowRuleInput struct {
 
 func (x *SyntaxFlowRuleInput) Reset() {
 	*x = SyntaxFlowRuleInput{}
-	mi := &file_yakgrpc_proto_msgTypes[821]
+	mi := &file_yakgrpc_proto_msgTypes[822]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59908,7 +60007,7 @@ func (x *SyntaxFlowRuleInput) String() string {
 func (*SyntaxFlowRuleInput) ProtoMessage() {}
 
 func (x *SyntaxFlowRuleInput) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[821]
+	mi := &file_yakgrpc_proto_msgTypes[822]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59921,7 +60020,7 @@ func (x *SyntaxFlowRuleInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowRuleInput.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowRuleInput) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{821}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{822}
 }
 
 func (x *SyntaxFlowRuleInput) GetRuleName() string {
@@ -59999,7 +60098,7 @@ type SyntaxFlowRuleFilter struct {
 
 func (x *SyntaxFlowRuleFilter) Reset() {
 	*x = SyntaxFlowRuleFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[822]
+	mi := &file_yakgrpc_proto_msgTypes[823]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60011,7 +60110,7 @@ func (x *SyntaxFlowRuleFilter) String() string {
 func (*SyntaxFlowRuleFilter) ProtoMessage() {}
 
 func (x *SyntaxFlowRuleFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[822]
+	mi := &file_yakgrpc_proto_msgTypes[823]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60024,7 +60123,7 @@ func (x *SyntaxFlowRuleFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowRuleFilter.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowRuleFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{822}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{823}
 }
 
 func (x *SyntaxFlowRuleFilter) GetRuleNames() []string {
@@ -60170,7 +60269,7 @@ type SSAProgram struct {
 
 func (x *SSAProgram) Reset() {
 	*x = SSAProgram{}
-	mi := &file_yakgrpc_proto_msgTypes[823]
+	mi := &file_yakgrpc_proto_msgTypes[824]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60182,7 +60281,7 @@ func (x *SSAProgram) String() string {
 func (*SSAProgram) ProtoMessage() {}
 
 func (x *SSAProgram) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[823]
+	mi := &file_yakgrpc_proto_msgTypes[824]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60195,7 +60294,7 @@ func (x *SSAProgram) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProgram.ProtoReflect.Descriptor instead.
 func (*SSAProgram) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{823}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{824}
 }
 
 func (x *SSAProgram) GetCreateAt() int64 {
@@ -60343,7 +60442,7 @@ type SSARiskDiffItem struct {
 
 func (x *SSARiskDiffItem) Reset() {
 	*x = SSARiskDiffItem{}
-	mi := &file_yakgrpc_proto_msgTypes[824]
+	mi := &file_yakgrpc_proto_msgTypes[825]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60355,7 +60454,7 @@ func (x *SSARiskDiffItem) String() string {
 func (*SSARiskDiffItem) ProtoMessage() {}
 
 func (x *SSARiskDiffItem) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[824]
+	mi := &file_yakgrpc_proto_msgTypes[825]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60368,7 +60467,7 @@ func (x *SSARiskDiffItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARiskDiffItem.ProtoReflect.Descriptor instead.
 func (*SSARiskDiffItem) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{824}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{825}
 }
 
 func (x *SSARiskDiffItem) GetProgramName() string {
@@ -60410,7 +60509,7 @@ type SSARiskDiffRequest struct {
 
 func (x *SSARiskDiffRequest) Reset() {
 	*x = SSARiskDiffRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[825]
+	mi := &file_yakgrpc_proto_msgTypes[826]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60422,7 +60521,7 @@ func (x *SSARiskDiffRequest) String() string {
 func (*SSARiskDiffRequest) ProtoMessage() {}
 
 func (x *SSARiskDiffRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[825]
+	mi := &file_yakgrpc_proto_msgTypes[826]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60435,7 +60534,7 @@ func (x *SSARiskDiffRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARiskDiffRequest.ProtoReflect.Descriptor instead.
 func (*SSARiskDiffRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{825}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{826}
 }
 
 func (x *SSARiskDiffRequest) GetBaseLine() *SSARiskDiffItem {
@@ -60471,7 +60570,7 @@ type SSARiskDiffResponse struct {
 
 func (x *SSARiskDiffResponse) Reset() {
 	*x = SSARiskDiffResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[826]
+	mi := &file_yakgrpc_proto_msgTypes[827]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60483,7 +60582,7 @@ func (x *SSARiskDiffResponse) String() string {
 func (*SSARiskDiffResponse) ProtoMessage() {}
 
 func (x *SSARiskDiffResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[826]
+	mi := &file_yakgrpc_proto_msgTypes[827]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60496,7 +60595,7 @@ func (x *SSARiskDiffResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARiskDiffResponse.ProtoReflect.Descriptor instead.
 func (*SSARiskDiffResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{826}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{827}
 }
 
 func (x *SSARiskDiffResponse) GetBaseRisk() *SSARisk {
@@ -60537,7 +60636,7 @@ type SSAProgramInput struct {
 
 func (x *SSAProgramInput) Reset() {
 	*x = SSAProgramInput{}
-	mi := &file_yakgrpc_proto_msgTypes[827]
+	mi := &file_yakgrpc_proto_msgTypes[828]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60549,7 +60648,7 @@ func (x *SSAProgramInput) String() string {
 func (*SSAProgramInput) ProtoMessage() {}
 
 func (x *SSAProgramInput) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[827]
+	mi := &file_yakgrpc_proto_msgTypes[828]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60562,7 +60661,7 @@ func (x *SSAProgramInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProgramInput.ProtoReflect.Descriptor instead.
 func (*SSAProgramInput) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{827}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{828}
 }
 
 func (x *SSAProgramInput) GetName() string {
@@ -60599,7 +60698,7 @@ type SSAProgramFilter struct {
 
 func (x *SSAProgramFilter) Reset() {
 	*x = SSAProgramFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[828]
+	mi := &file_yakgrpc_proto_msgTypes[829]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60611,7 +60710,7 @@ func (x *SSAProgramFilter) String() string {
 func (*SSAProgramFilter) ProtoMessage() {}
 
 func (x *SSAProgramFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[828]
+	mi := &file_yakgrpc_proto_msgTypes[829]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60624,7 +60723,7 @@ func (x *SSAProgramFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProgramFilter.ProtoReflect.Descriptor instead.
 func (*SSAProgramFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{828}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{829}
 }
 
 func (x *SSAProgramFilter) GetProgramNames() []string {
@@ -60701,7 +60800,7 @@ type QuerySSAProgramRequest struct {
 
 func (x *QuerySSAProgramRequest) Reset() {
 	*x = QuerySSAProgramRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[829]
+	mi := &file_yakgrpc_proto_msgTypes[830]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60713,7 +60812,7 @@ func (x *QuerySSAProgramRequest) String() string {
 func (*QuerySSAProgramRequest) ProtoMessage() {}
 
 func (x *QuerySSAProgramRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[829]
+	mi := &file_yakgrpc_proto_msgTypes[830]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60726,7 +60825,7 @@ func (x *QuerySSAProgramRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSAProgramRequest.ProtoReflect.Descriptor instead.
 func (*QuerySSAProgramRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{829}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{830}
 }
 
 func (x *QuerySSAProgramRequest) GetPaging() *Paging {
@@ -60759,7 +60858,7 @@ type UpdateSSAProgramRequest struct {
 
 func (x *UpdateSSAProgramRequest) Reset() {
 	*x = UpdateSSAProgramRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[830]
+	mi := &file_yakgrpc_proto_msgTypes[831]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60771,7 +60870,7 @@ func (x *UpdateSSAProgramRequest) String() string {
 func (*UpdateSSAProgramRequest) ProtoMessage() {}
 
 func (x *UpdateSSAProgramRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[830]
+	mi := &file_yakgrpc_proto_msgTypes[831]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60784,7 +60883,7 @@ func (x *UpdateSSAProgramRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSSAProgramRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSSAProgramRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{830}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{831}
 }
 
 func (x *UpdateSSAProgramRequest) GetProgramInput() *SSAProgramInput {
@@ -60804,7 +60903,7 @@ type DeleteSSAProgramRequest struct {
 
 func (x *DeleteSSAProgramRequest) Reset() {
 	*x = DeleteSSAProgramRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[831]
+	mi := &file_yakgrpc_proto_msgTypes[832]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60816,7 +60915,7 @@ func (x *DeleteSSAProgramRequest) String() string {
 func (*DeleteSSAProgramRequest) ProtoMessage() {}
 
 func (x *DeleteSSAProgramRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[831]
+	mi := &file_yakgrpc_proto_msgTypes[832]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60829,7 +60928,7 @@ func (x *DeleteSSAProgramRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSSAProgramRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSSAProgramRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{831}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{832}
 }
 
 func (x *DeleteSSAProgramRequest) GetDeleteAll() bool {
@@ -60859,7 +60958,7 @@ type QuerySSAProgramResponse struct {
 
 func (x *QuerySSAProgramResponse) Reset() {
 	*x = QuerySSAProgramResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[832]
+	mi := &file_yakgrpc_proto_msgTypes[833]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60871,7 +60970,7 @@ func (x *QuerySSAProgramResponse) String() string {
 func (*QuerySSAProgramResponse) ProtoMessage() {}
 
 func (x *QuerySSAProgramResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[832]
+	mi := &file_yakgrpc_proto_msgTypes[833]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60884,7 +60983,7 @@ func (x *QuerySSAProgramResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSAProgramResponse.ProtoReflect.Descriptor instead.
 func (*QuerySSAProgramResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{832}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{833}
 }
 
 func (x *QuerySSAProgramResponse) GetPaging() *Paging {
@@ -60931,7 +61030,7 @@ type CreateSyntaxFlowRuleRequest struct {
 
 func (x *CreateSyntaxFlowRuleRequest) Reset() {
 	*x = CreateSyntaxFlowRuleRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[833]
+	mi := &file_yakgrpc_proto_msgTypes[834]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60943,7 +61042,7 @@ func (x *CreateSyntaxFlowRuleRequest) String() string {
 func (*CreateSyntaxFlowRuleRequest) ProtoMessage() {}
 
 func (x *CreateSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[833]
+	mi := &file_yakgrpc_proto_msgTypes[834]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60956,7 +61055,7 @@ func (x *CreateSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSyntaxFlowRuleRequest.ProtoReflect.Descriptor instead.
 func (*CreateSyntaxFlowRuleRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{833}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{834}
 }
 
 func (x *CreateSyntaxFlowRuleRequest) GetSyntaxFlowInput() *SyntaxFlowRuleInput {
@@ -60976,7 +61075,7 @@ type CreateSyntaxFlowRuleResponse struct {
 
 func (x *CreateSyntaxFlowRuleResponse) Reset() {
 	*x = CreateSyntaxFlowRuleResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[834]
+	mi := &file_yakgrpc_proto_msgTypes[835]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60988,7 +61087,7 @@ func (x *CreateSyntaxFlowRuleResponse) String() string {
 func (*CreateSyntaxFlowRuleResponse) ProtoMessage() {}
 
 func (x *CreateSyntaxFlowRuleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[834]
+	mi := &file_yakgrpc_proto_msgTypes[835]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61001,7 +61100,7 @@ func (x *CreateSyntaxFlowRuleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSyntaxFlowRuleResponse.ProtoReflect.Descriptor instead.
 func (*CreateSyntaxFlowRuleResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{834}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{835}
 }
 
 func (x *CreateSyntaxFlowRuleResponse) GetMessage() *DbOperateMessage {
@@ -61027,7 +61126,7 @@ type UpdateSyntaxFlowRuleRequest struct {
 
 func (x *UpdateSyntaxFlowRuleRequest) Reset() {
 	*x = UpdateSyntaxFlowRuleRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[835]
+	mi := &file_yakgrpc_proto_msgTypes[836]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61039,7 +61138,7 @@ func (x *UpdateSyntaxFlowRuleRequest) String() string {
 func (*UpdateSyntaxFlowRuleRequest) ProtoMessage() {}
 
 func (x *UpdateSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[835]
+	mi := &file_yakgrpc_proto_msgTypes[836]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61052,7 +61151,7 @@ func (x *UpdateSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSyntaxFlowRuleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSyntaxFlowRuleRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{835}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{836}
 }
 
 func (x *UpdateSyntaxFlowRuleRequest) GetSyntaxFlowInput() *SyntaxFlowRuleInput {
@@ -61072,7 +61171,7 @@ type UpdateSyntaxFlowRuleResponse struct {
 
 func (x *UpdateSyntaxFlowRuleResponse) Reset() {
 	*x = UpdateSyntaxFlowRuleResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[836]
+	mi := &file_yakgrpc_proto_msgTypes[837]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61084,7 +61183,7 @@ func (x *UpdateSyntaxFlowRuleResponse) String() string {
 func (*UpdateSyntaxFlowRuleResponse) ProtoMessage() {}
 
 func (x *UpdateSyntaxFlowRuleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[836]
+	mi := &file_yakgrpc_proto_msgTypes[837]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61097,7 +61196,7 @@ func (x *UpdateSyntaxFlowRuleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSyntaxFlowRuleResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSyntaxFlowRuleResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{836}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{837}
 }
 
 func (x *UpdateSyntaxFlowRuleResponse) GetMessage() *DbOperateMessage {
@@ -61126,7 +61225,7 @@ type QuerySyntaxFlowRuleResponse struct {
 
 func (x *QuerySyntaxFlowRuleResponse) Reset() {
 	*x = QuerySyntaxFlowRuleResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[837]
+	mi := &file_yakgrpc_proto_msgTypes[838]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61138,7 +61237,7 @@ func (x *QuerySyntaxFlowRuleResponse) String() string {
 func (*QuerySyntaxFlowRuleResponse) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowRuleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[837]
+	mi := &file_yakgrpc_proto_msgTypes[838]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61151,7 +61250,7 @@ func (x *QuerySyntaxFlowRuleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowRuleResponse.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowRuleResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{837}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{838}
 }
 
 func (x *QuerySyntaxFlowRuleResponse) GetPagination() *Paging {
@@ -61191,7 +61290,7 @@ type DeleteSyntaxFlowRuleRequest struct {
 
 func (x *DeleteSyntaxFlowRuleRequest) Reset() {
 	*x = DeleteSyntaxFlowRuleRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[838]
+	mi := &file_yakgrpc_proto_msgTypes[839]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61203,7 +61302,7 @@ func (x *DeleteSyntaxFlowRuleRequest) String() string {
 func (*DeleteSyntaxFlowRuleRequest) ProtoMessage() {}
 
 func (x *DeleteSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[838]
+	mi := &file_yakgrpc_proto_msgTypes[839]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61216,7 +61315,7 @@ func (x *DeleteSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSyntaxFlowRuleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSyntaxFlowRuleRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{838}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{839}
 }
 
 func (x *DeleteSyntaxFlowRuleRequest) GetFilter() *SyntaxFlowRuleFilter {
@@ -61234,7 +61333,7 @@ type CheckSyntaxFlowRuleUpdateRequest struct {
 
 func (x *CheckSyntaxFlowRuleUpdateRequest) Reset() {
 	*x = CheckSyntaxFlowRuleUpdateRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[839]
+	mi := &file_yakgrpc_proto_msgTypes[840]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61246,7 +61345,7 @@ func (x *CheckSyntaxFlowRuleUpdateRequest) String() string {
 func (*CheckSyntaxFlowRuleUpdateRequest) ProtoMessage() {}
 
 func (x *CheckSyntaxFlowRuleUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[839]
+	mi := &file_yakgrpc_proto_msgTypes[840]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61259,7 +61358,7 @@ func (x *CheckSyntaxFlowRuleUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckSyntaxFlowRuleUpdateRequest.ProtoReflect.Descriptor instead.
 func (*CheckSyntaxFlowRuleUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{839}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{840}
 }
 
 type CheckSyntaxFlowRuleUpdateResponse struct {
@@ -61272,7 +61371,7 @@ type CheckSyntaxFlowRuleUpdateResponse struct {
 
 func (x *CheckSyntaxFlowRuleUpdateResponse) Reset() {
 	*x = CheckSyntaxFlowRuleUpdateResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[840]
+	mi := &file_yakgrpc_proto_msgTypes[841]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61284,7 +61383,7 @@ func (x *CheckSyntaxFlowRuleUpdateResponse) String() string {
 func (*CheckSyntaxFlowRuleUpdateResponse) ProtoMessage() {}
 
 func (x *CheckSyntaxFlowRuleUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[840]
+	mi := &file_yakgrpc_proto_msgTypes[841]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61297,7 +61396,7 @@ func (x *CheckSyntaxFlowRuleUpdateResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use CheckSyntaxFlowRuleUpdateResponse.ProtoReflect.Descriptor instead.
 func (*CheckSyntaxFlowRuleUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{840}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{841}
 }
 
 func (x *CheckSyntaxFlowRuleUpdateResponse) GetNeedUpdate() bool {
@@ -61322,7 +61421,7 @@ type ApplySyntaxFlowRuleUpdateRequest struct {
 
 func (x *ApplySyntaxFlowRuleUpdateRequest) Reset() {
 	*x = ApplySyntaxFlowRuleUpdateRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[841]
+	mi := &file_yakgrpc_proto_msgTypes[842]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61334,7 +61433,7 @@ func (x *ApplySyntaxFlowRuleUpdateRequest) String() string {
 func (*ApplySyntaxFlowRuleUpdateRequest) ProtoMessage() {}
 
 func (x *ApplySyntaxFlowRuleUpdateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[841]
+	mi := &file_yakgrpc_proto_msgTypes[842]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61347,7 +61446,7 @@ func (x *ApplySyntaxFlowRuleUpdateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplySyntaxFlowRuleUpdateRequest.ProtoReflect.Descriptor instead.
 func (*ApplySyntaxFlowRuleUpdateRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{841}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{842}
 }
 
 type ApplySyntaxFlowRuleUpdateResponse struct {
@@ -61360,7 +61459,7 @@ type ApplySyntaxFlowRuleUpdateResponse struct {
 
 func (x *ApplySyntaxFlowRuleUpdateResponse) Reset() {
 	*x = ApplySyntaxFlowRuleUpdateResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[842]
+	mi := &file_yakgrpc_proto_msgTypes[843]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61372,7 +61471,7 @@ func (x *ApplySyntaxFlowRuleUpdateResponse) String() string {
 func (*ApplySyntaxFlowRuleUpdateResponse) ProtoMessage() {}
 
 func (x *ApplySyntaxFlowRuleUpdateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[842]
+	mi := &file_yakgrpc_proto_msgTypes[843]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61385,7 +61484,7 @@ func (x *ApplySyntaxFlowRuleUpdateResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ApplySyntaxFlowRuleUpdateResponse.ProtoReflect.Descriptor instead.
 func (*ApplySyntaxFlowRuleUpdateResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{842}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{843}
 }
 
 func (x *ApplySyntaxFlowRuleUpdateResponse) GetPercent() float64 {
@@ -61414,7 +61513,7 @@ type SyntaxFlowRuleGroupFilter struct {
 
 func (x *SyntaxFlowRuleGroupFilter) Reset() {
 	*x = SyntaxFlowRuleGroupFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[843]
+	mi := &file_yakgrpc_proto_msgTypes[844]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61426,7 +61525,7 @@ func (x *SyntaxFlowRuleGroupFilter) String() string {
 func (*SyntaxFlowRuleGroupFilter) ProtoMessage() {}
 
 func (x *SyntaxFlowRuleGroupFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[843]
+	mi := &file_yakgrpc_proto_msgTypes[844]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61439,7 +61538,7 @@ func (x *SyntaxFlowRuleGroupFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowRuleGroupFilter.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowRuleGroupFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{843}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{844}
 }
 
 func (x *SyntaxFlowRuleGroupFilter) GetGroupNames() []string {
@@ -61474,7 +61573,7 @@ type SyntaxFlowGroup struct {
 
 func (x *SyntaxFlowGroup) Reset() {
 	*x = SyntaxFlowGroup{}
-	mi := &file_yakgrpc_proto_msgTypes[844]
+	mi := &file_yakgrpc_proto_msgTypes[845]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61486,7 +61585,7 @@ func (x *SyntaxFlowGroup) String() string {
 func (*SyntaxFlowGroup) ProtoMessage() {}
 
 func (x *SyntaxFlowGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[844]
+	mi := &file_yakgrpc_proto_msgTypes[845]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61499,7 +61598,7 @@ func (x *SyntaxFlowGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowGroup.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowGroup) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{844}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{845}
 }
 
 func (x *SyntaxFlowGroup) GetGroupName() string {
@@ -61533,7 +61632,7 @@ type QuerySyntaxFlowRuleGroupRequest struct {
 
 func (x *QuerySyntaxFlowRuleGroupRequest) Reset() {
 	*x = QuerySyntaxFlowRuleGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[845]
+	mi := &file_yakgrpc_proto_msgTypes[846]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61545,7 +61644,7 @@ func (x *QuerySyntaxFlowRuleGroupRequest) String() string {
 func (*QuerySyntaxFlowRuleGroupRequest) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowRuleGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[845]
+	mi := &file_yakgrpc_proto_msgTypes[846]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61558,7 +61657,7 @@ func (x *QuerySyntaxFlowRuleGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowRuleGroupRequest.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowRuleGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{845}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{846}
 }
 
 func (x *QuerySyntaxFlowRuleGroupRequest) GetFilter() *SyntaxFlowRuleGroupFilter {
@@ -61585,7 +61684,7 @@ type QuerySyntaxFlowRuleGroupResponse struct {
 
 func (x *QuerySyntaxFlowRuleGroupResponse) Reset() {
 	*x = QuerySyntaxFlowRuleGroupResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[846]
+	mi := &file_yakgrpc_proto_msgTypes[847]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61597,7 +61696,7 @@ func (x *QuerySyntaxFlowRuleGroupResponse) String() string {
 func (*QuerySyntaxFlowRuleGroupResponse) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowRuleGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[846]
+	mi := &file_yakgrpc_proto_msgTypes[847]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61610,7 +61709,7 @@ func (x *QuerySyntaxFlowRuleGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowRuleGroupResponse.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowRuleGroupResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{846}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{847}
 }
 
 func (x *QuerySyntaxFlowRuleGroupResponse) GetGroup() []*SyntaxFlowGroup {
@@ -61636,7 +61735,7 @@ type CreateSyntaxFlowGroupRequest struct {
 
 func (x *CreateSyntaxFlowGroupRequest) Reset() {
 	*x = CreateSyntaxFlowGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[847]
+	mi := &file_yakgrpc_proto_msgTypes[848]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61648,7 +61747,7 @@ func (x *CreateSyntaxFlowGroupRequest) String() string {
 func (*CreateSyntaxFlowGroupRequest) ProtoMessage() {}
 
 func (x *CreateSyntaxFlowGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[847]
+	mi := &file_yakgrpc_proto_msgTypes[848]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61661,7 +61760,7 @@ func (x *CreateSyntaxFlowGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSyntaxFlowGroupRequest.ProtoReflect.Descriptor instead.
 func (*CreateSyntaxFlowGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{847}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{848}
 }
 
 func (x *CreateSyntaxFlowGroupRequest) GetGroupName() string {
@@ -61681,7 +61780,7 @@ type UpdateSyntaxFlowRuleGroupRequest struct {
 
 func (x *UpdateSyntaxFlowRuleGroupRequest) Reset() {
 	*x = UpdateSyntaxFlowRuleGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[848]
+	mi := &file_yakgrpc_proto_msgTypes[849]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61693,7 +61792,7 @@ func (x *UpdateSyntaxFlowRuleGroupRequest) String() string {
 func (*UpdateSyntaxFlowRuleGroupRequest) ProtoMessage() {}
 
 func (x *UpdateSyntaxFlowRuleGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[848]
+	mi := &file_yakgrpc_proto_msgTypes[849]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61706,7 +61805,7 @@ func (x *UpdateSyntaxFlowRuleGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSyntaxFlowRuleGroupRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSyntaxFlowRuleGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{848}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{849}
 }
 
 func (x *UpdateSyntaxFlowRuleGroupRequest) GetOldGroupName() string {
@@ -61735,7 +61834,7 @@ type UpdateSyntaxFlowRuleAndGroupRequest struct {
 
 func (x *UpdateSyntaxFlowRuleAndGroupRequest) Reset() {
 	*x = UpdateSyntaxFlowRuleAndGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[849]
+	mi := &file_yakgrpc_proto_msgTypes[850]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61747,7 +61846,7 @@ func (x *UpdateSyntaxFlowRuleAndGroupRequest) String() string {
 func (*UpdateSyntaxFlowRuleAndGroupRequest) ProtoMessage() {}
 
 func (x *UpdateSyntaxFlowRuleAndGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[849]
+	mi := &file_yakgrpc_proto_msgTypes[850]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61760,7 +61859,7 @@ func (x *UpdateSyntaxFlowRuleAndGroupRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UpdateSyntaxFlowRuleAndGroupRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSyntaxFlowRuleAndGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{849}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{850}
 }
 
 func (x *UpdateSyntaxFlowRuleAndGroupRequest) GetFilter() *SyntaxFlowRuleFilter {
@@ -61800,7 +61899,7 @@ type QuerySyntaxFlowSameGroupRequest struct {
 
 func (x *QuerySyntaxFlowSameGroupRequest) Reset() {
 	*x = QuerySyntaxFlowSameGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[850]
+	mi := &file_yakgrpc_proto_msgTypes[851]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61812,7 +61911,7 @@ func (x *QuerySyntaxFlowSameGroupRequest) String() string {
 func (*QuerySyntaxFlowSameGroupRequest) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowSameGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[850]
+	mi := &file_yakgrpc_proto_msgTypes[851]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61825,7 +61924,7 @@ func (x *QuerySyntaxFlowSameGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowSameGroupRequest.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowSameGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{850}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{851}
 }
 
 func (x *QuerySyntaxFlowSameGroupRequest) GetFilter() *SyntaxFlowRuleFilter {
@@ -61844,7 +61943,7 @@ type QuerySyntaxFlowSameGroupResponse struct {
 
 func (x *QuerySyntaxFlowSameGroupResponse) Reset() {
 	*x = QuerySyntaxFlowSameGroupResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[851]
+	mi := &file_yakgrpc_proto_msgTypes[852]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61856,7 +61955,7 @@ func (x *QuerySyntaxFlowSameGroupResponse) String() string {
 func (*QuerySyntaxFlowSameGroupResponse) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowSameGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[851]
+	mi := &file_yakgrpc_proto_msgTypes[852]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61869,7 +61968,7 @@ func (x *QuerySyntaxFlowSameGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowSameGroupResponse.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowSameGroupResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{851}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{852}
 }
 
 func (x *QuerySyntaxFlowSameGroupResponse) GetGroup() []*SyntaxFlowGroup {
@@ -61888,7 +61987,7 @@ type DeleteSyntaxFlowRuleGroupRequest struct {
 
 func (x *DeleteSyntaxFlowRuleGroupRequest) Reset() {
 	*x = DeleteSyntaxFlowRuleGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[852]
+	mi := &file_yakgrpc_proto_msgTypes[853]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61900,7 +61999,7 @@ func (x *DeleteSyntaxFlowRuleGroupRequest) String() string {
 func (*DeleteSyntaxFlowRuleGroupRequest) ProtoMessage() {}
 
 func (x *DeleteSyntaxFlowRuleGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[852]
+	mi := &file_yakgrpc_proto_msgTypes[853]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61913,7 +62012,7 @@ func (x *DeleteSyntaxFlowRuleGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSyntaxFlowRuleGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSyntaxFlowRuleGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{852}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{853}
 }
 
 func (x *DeleteSyntaxFlowRuleGroupRequest) GetFilter() *SyntaxFlowRuleGroupFilter {
@@ -61934,7 +62033,7 @@ type SyntaxFlowRuleToOnlineRequest struct {
 
 func (x *SyntaxFlowRuleToOnlineRequest) Reset() {
 	*x = SyntaxFlowRuleToOnlineRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[853]
+	mi := &file_yakgrpc_proto_msgTypes[854]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61946,7 +62045,7 @@ func (x *SyntaxFlowRuleToOnlineRequest) String() string {
 func (*SyntaxFlowRuleToOnlineRequest) ProtoMessage() {}
 
 func (x *SyntaxFlowRuleToOnlineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[853]
+	mi := &file_yakgrpc_proto_msgTypes[854]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61959,7 +62058,7 @@ func (x *SyntaxFlowRuleToOnlineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowRuleToOnlineRequest.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowRuleToOnlineRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{853}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{854}
 }
 
 func (x *SyntaxFlowRuleToOnlineRequest) GetPagination() *Paging {
@@ -61995,7 +62094,7 @@ type SyntaxFlowRuleOnlineProgress struct {
 
 func (x *SyntaxFlowRuleOnlineProgress) Reset() {
 	*x = SyntaxFlowRuleOnlineProgress{}
-	mi := &file_yakgrpc_proto_msgTypes[854]
+	mi := &file_yakgrpc_proto_msgTypes[855]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62007,7 +62106,7 @@ func (x *SyntaxFlowRuleOnlineProgress) String() string {
 func (*SyntaxFlowRuleOnlineProgress) ProtoMessage() {}
 
 func (x *SyntaxFlowRuleOnlineProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[854]
+	mi := &file_yakgrpc_proto_msgTypes[855]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62020,7 +62119,7 @@ func (x *SyntaxFlowRuleOnlineProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowRuleOnlineProgress.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowRuleOnlineProgress) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{854}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{855}
 }
 
 func (x *SyntaxFlowRuleOnlineProgress) GetProgress() float64 {
@@ -62054,7 +62153,7 @@ type DownloadSyntaxFlowRuleRequest struct {
 
 func (x *DownloadSyntaxFlowRuleRequest) Reset() {
 	*x = DownloadSyntaxFlowRuleRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[855]
+	mi := &file_yakgrpc_proto_msgTypes[856]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62066,7 +62165,7 @@ func (x *DownloadSyntaxFlowRuleRequest) String() string {
 func (*DownloadSyntaxFlowRuleRequest) ProtoMessage() {}
 
 func (x *DownloadSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[855]
+	mi := &file_yakgrpc_proto_msgTypes[856]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62079,7 +62178,7 @@ func (x *DownloadSyntaxFlowRuleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadSyntaxFlowRuleRequest.ProtoReflect.Descriptor instead.
 func (*DownloadSyntaxFlowRuleRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{855}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{856}
 }
 
 func (x *DownloadSyntaxFlowRuleRequest) GetToken() string {
@@ -62121,7 +62220,7 @@ type SyntaxFlowScanRequest struct {
 
 func (x *SyntaxFlowScanRequest) Reset() {
 	*x = SyntaxFlowScanRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[856]
+	mi := &file_yakgrpc_proto_msgTypes[857]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62133,7 +62232,7 @@ func (x *SyntaxFlowScanRequest) String() string {
 func (*SyntaxFlowScanRequest) ProtoMessage() {}
 
 func (x *SyntaxFlowScanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[856]
+	mi := &file_yakgrpc_proto_msgTypes[857]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62146,7 +62245,7 @@ func (x *SyntaxFlowScanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowScanRequest.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowScanRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{856}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{857}
 }
 
 func (x *SyntaxFlowScanRequest) GetControlMode() string {
@@ -62230,7 +62329,7 @@ type QuerySyntaxFlowScanTaskRequest struct {
 
 func (x *QuerySyntaxFlowScanTaskRequest) Reset() {
 	*x = QuerySyntaxFlowScanTaskRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[857]
+	mi := &file_yakgrpc_proto_msgTypes[858]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62242,7 +62341,7 @@ func (x *QuerySyntaxFlowScanTaskRequest) String() string {
 func (*QuerySyntaxFlowScanTaskRequest) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowScanTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[857]
+	mi := &file_yakgrpc_proto_msgTypes[858]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62255,7 +62354,7 @@ func (x *QuerySyntaxFlowScanTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowScanTaskRequest.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowScanTaskRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{857}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{858}
 }
 
 func (x *QuerySyntaxFlowScanTaskRequest) GetPagination() *Paging {
@@ -62296,7 +62395,7 @@ type SyntaxFlowScanTaskFilter struct {
 
 func (x *SyntaxFlowScanTaskFilter) Reset() {
 	*x = SyntaxFlowScanTaskFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[858]
+	mi := &file_yakgrpc_proto_msgTypes[859]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62308,7 +62407,7 @@ func (x *SyntaxFlowScanTaskFilter) String() string {
 func (*SyntaxFlowScanTaskFilter) ProtoMessage() {}
 
 func (x *SyntaxFlowScanTaskFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[858]
+	mi := &file_yakgrpc_proto_msgTypes[859]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62321,7 +62420,7 @@ func (x *SyntaxFlowScanTaskFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowScanTaskFilter.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowScanTaskFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{858}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{859}
 }
 
 func (x *SyntaxFlowScanTaskFilter) GetPrograms() []string {
@@ -62398,7 +62497,7 @@ type QuerySyntaxFlowScanTaskResponse struct {
 
 func (x *QuerySyntaxFlowScanTaskResponse) Reset() {
 	*x = QuerySyntaxFlowScanTaskResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[859]
+	mi := &file_yakgrpc_proto_msgTypes[860]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62410,7 +62509,7 @@ func (x *QuerySyntaxFlowScanTaskResponse) String() string {
 func (*QuerySyntaxFlowScanTaskResponse) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowScanTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[859]
+	mi := &file_yakgrpc_proto_msgTypes[860]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62423,7 +62522,7 @@ func (x *QuerySyntaxFlowScanTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowScanTaskResponse.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowScanTaskResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{859}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{860}
 }
 
 func (x *QuerySyntaxFlowScanTaskResponse) GetPagination() *Paging {
@@ -62485,7 +62584,7 @@ type SyntaxFlowScanTask struct {
 
 func (x *SyntaxFlowScanTask) Reset() {
 	*x = SyntaxFlowScanTask{}
-	mi := &file_yakgrpc_proto_msgTypes[860]
+	mi := &file_yakgrpc_proto_msgTypes[861]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62497,7 +62596,7 @@ func (x *SyntaxFlowScanTask) String() string {
 func (*SyntaxFlowScanTask) ProtoMessage() {}
 
 func (x *SyntaxFlowScanTask) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[860]
+	mi := &file_yakgrpc_proto_msgTypes[861]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62510,7 +62609,7 @@ func (x *SyntaxFlowScanTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowScanTask.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowScanTask) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{860}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{861}
 }
 
 func (x *SyntaxFlowScanTask) GetId() uint64 {
@@ -62705,7 +62804,7 @@ type DeleteSyntaxFlowScanTaskRequest struct {
 
 func (x *DeleteSyntaxFlowScanTaskRequest) Reset() {
 	*x = DeleteSyntaxFlowScanTaskRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[861]
+	mi := &file_yakgrpc_proto_msgTypes[862]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62717,7 +62816,7 @@ func (x *DeleteSyntaxFlowScanTaskRequest) String() string {
 func (*DeleteSyntaxFlowScanTaskRequest) ProtoMessage() {}
 
 func (x *DeleteSyntaxFlowScanTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[861]
+	mi := &file_yakgrpc_proto_msgTypes[862]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62730,7 +62829,7 @@ func (x *DeleteSyntaxFlowScanTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSyntaxFlowScanTaskRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSyntaxFlowScanTaskRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{861}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{862}
 }
 
 func (x *DeleteSyntaxFlowScanTaskRequest) GetDeleteAll() bool {
@@ -62764,7 +62863,7 @@ type SyntaxFlowScanResponse struct {
 
 func (x *SyntaxFlowScanResponse) Reset() {
 	*x = SyntaxFlowScanResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[862]
+	mi := &file_yakgrpc_proto_msgTypes[863]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62776,7 +62875,7 @@ func (x *SyntaxFlowScanResponse) String() string {
 func (*SyntaxFlowScanResponse) ProtoMessage() {}
 
 func (x *SyntaxFlowScanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[862]
+	mi := &file_yakgrpc_proto_msgTypes[863]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62789,7 +62888,7 @@ func (x *SyntaxFlowScanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowScanResponse.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowScanResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{862}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{863}
 }
 
 func (x *SyntaxFlowScanResponse) GetTaskID() string {
@@ -62856,7 +62955,7 @@ type SyntaxFlowScanActiveTask struct {
 
 func (x *SyntaxFlowScanActiveTask) Reset() {
 	*x = SyntaxFlowScanActiveTask{}
-	mi := &file_yakgrpc_proto_msgTypes[863]
+	mi := &file_yakgrpc_proto_msgTypes[864]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62868,7 +62967,7 @@ func (x *SyntaxFlowScanActiveTask) String() string {
 func (*SyntaxFlowScanActiveTask) ProtoMessage() {}
 
 func (x *SyntaxFlowScanActiveTask) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[863]
+	mi := &file_yakgrpc_proto_msgTypes[864]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62881,7 +62980,7 @@ func (x *SyntaxFlowScanActiveTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowScanActiveTask.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowScanActiveTask) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{863}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{864}
 }
 
 func (x *SyntaxFlowScanActiveTask) GetRuleName() string {
@@ -62937,7 +63036,7 @@ type SyntaxFlowResultFilter struct {
 
 func (x *SyntaxFlowResultFilter) Reset() {
 	*x = SyntaxFlowResultFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[864]
+	mi := &file_yakgrpc_proto_msgTypes[865]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62949,7 +63048,7 @@ func (x *SyntaxFlowResultFilter) String() string {
 func (*SyntaxFlowResultFilter) ProtoMessage() {}
 
 func (x *SyntaxFlowResultFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[864]
+	mi := &file_yakgrpc_proto_msgTypes[865]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62962,7 +63061,7 @@ func (x *SyntaxFlowResultFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowResultFilter.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowResultFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{864}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{865}
 }
 
 func (x *SyntaxFlowResultFilter) GetTaskIDs() []string {
@@ -63045,7 +63144,7 @@ type QuerySyntaxFlowResultRequest struct {
 
 func (x *QuerySyntaxFlowResultRequest) Reset() {
 	*x = QuerySyntaxFlowResultRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[865]
+	mi := &file_yakgrpc_proto_msgTypes[866]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63057,7 +63156,7 @@ func (x *QuerySyntaxFlowResultRequest) String() string {
 func (*QuerySyntaxFlowResultRequest) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowResultRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[865]
+	mi := &file_yakgrpc_proto_msgTypes[866]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63070,7 +63169,7 @@ func (x *QuerySyntaxFlowResultRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowResultRequest.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowResultRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{865}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{866}
 }
 
 func (x *QuerySyntaxFlowResultRequest) GetPagination() *Paging {
@@ -63099,7 +63198,7 @@ type QuerySyntaxFlowResultResponse struct {
 
 func (x *QuerySyntaxFlowResultResponse) Reset() {
 	*x = QuerySyntaxFlowResultResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[866]
+	mi := &file_yakgrpc_proto_msgTypes[867]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63111,7 +63210,7 @@ func (x *QuerySyntaxFlowResultResponse) String() string {
 func (*QuerySyntaxFlowResultResponse) ProtoMessage() {}
 
 func (x *QuerySyntaxFlowResultResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[866]
+	mi := &file_yakgrpc_proto_msgTypes[867]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63124,7 +63223,7 @@ func (x *QuerySyntaxFlowResultResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySyntaxFlowResultResponse.ProtoReflect.Descriptor instead.
 func (*QuerySyntaxFlowResultResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{866}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{867}
 }
 
 func (x *QuerySyntaxFlowResultResponse) GetPagination() *Paging {
@@ -63181,7 +63280,7 @@ type SyntaxFlowResult struct {
 
 func (x *SyntaxFlowResult) Reset() {
 	*x = SyntaxFlowResult{}
-	mi := &file_yakgrpc_proto_msgTypes[867]
+	mi := &file_yakgrpc_proto_msgTypes[868]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63193,7 +63292,7 @@ func (x *SyntaxFlowResult) String() string {
 func (*SyntaxFlowResult) ProtoMessage() {}
 
 func (x *SyntaxFlowResult) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[867]
+	mi := &file_yakgrpc_proto_msgTypes[868]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63206,7 +63305,7 @@ func (x *SyntaxFlowResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxFlowResult.ProtoReflect.Descriptor instead.
 func (*SyntaxFlowResult) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{867}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{868}
 }
 
 func (x *SyntaxFlowResult) GetResultID() uint64 {
@@ -63318,7 +63417,7 @@ type DeleteSyntaxFlowResultRequest struct {
 
 func (x *DeleteSyntaxFlowResultRequest) Reset() {
 	*x = DeleteSyntaxFlowResultRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[868]
+	mi := &file_yakgrpc_proto_msgTypes[869]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63330,7 +63429,7 @@ func (x *DeleteSyntaxFlowResultRequest) String() string {
 func (*DeleteSyntaxFlowResultRequest) ProtoMessage() {}
 
 func (x *DeleteSyntaxFlowResultRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[868]
+	mi := &file_yakgrpc_proto_msgTypes[869]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63343,7 +63442,7 @@ func (x *DeleteSyntaxFlowResultRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSyntaxFlowResultRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSyntaxFlowResultRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{868}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{869}
 }
 
 func (x *DeleteSyntaxFlowResultRequest) GetDeleteContainRisk() bool {
@@ -63376,7 +63475,7 @@ type DeleteSyntaxFlowResultResponse struct {
 
 func (x *DeleteSyntaxFlowResultResponse) Reset() {
 	*x = DeleteSyntaxFlowResultResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[869]
+	mi := &file_yakgrpc_proto_msgTypes[870]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63388,7 +63487,7 @@ func (x *DeleteSyntaxFlowResultResponse) String() string {
 func (*DeleteSyntaxFlowResultResponse) ProtoMessage() {}
 
 func (x *DeleteSyntaxFlowResultResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[869]
+	mi := &file_yakgrpc_proto_msgTypes[870]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63401,7 +63500,7 @@ func (x *DeleteSyntaxFlowResultResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSyntaxFlowResultResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSyntaxFlowResultResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{869}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{870}
 }
 
 func (x *DeleteSyntaxFlowResultResponse) GetMessage() *DbOperateMessage {
@@ -63420,7 +63519,7 @@ type QueryPluginEnvRequest struct {
 
 func (x *QueryPluginEnvRequest) Reset() {
 	*x = QueryPluginEnvRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[870]
+	mi := &file_yakgrpc_proto_msgTypes[871]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63432,7 +63531,7 @@ func (x *QueryPluginEnvRequest) String() string {
 func (*QueryPluginEnvRequest) ProtoMessage() {}
 
 func (x *QueryPluginEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[870]
+	mi := &file_yakgrpc_proto_msgTypes[871]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63445,7 +63544,7 @@ func (x *QueryPluginEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryPluginEnvRequest.ProtoReflect.Descriptor instead.
 func (*QueryPluginEnvRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{870}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{871}
 }
 
 func (x *QueryPluginEnvRequest) GetKey() []string {
@@ -63464,7 +63563,7 @@ type PluginEnvData struct {
 
 func (x *PluginEnvData) Reset() {
 	*x = PluginEnvData{}
-	mi := &file_yakgrpc_proto_msgTypes[871]
+	mi := &file_yakgrpc_proto_msgTypes[872]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63476,7 +63575,7 @@ func (x *PluginEnvData) String() string {
 func (*PluginEnvData) ProtoMessage() {}
 
 func (x *PluginEnvData) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[871]
+	mi := &file_yakgrpc_proto_msgTypes[872]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63489,7 +63588,7 @@ func (x *PluginEnvData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginEnvData.ProtoReflect.Descriptor instead.
 func (*PluginEnvData) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{871}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{872}
 }
 
 func (x *PluginEnvData) GetEnv() []*KVPair {
@@ -63509,7 +63608,7 @@ type DeletePluginEnvRequest struct {
 
 func (x *DeletePluginEnvRequest) Reset() {
 	*x = DeletePluginEnvRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[872]
+	mi := &file_yakgrpc_proto_msgTypes[873]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63521,7 +63620,7 @@ func (x *DeletePluginEnvRequest) String() string {
 func (*DeletePluginEnvRequest) ProtoMessage() {}
 
 func (x *DeletePluginEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[872]
+	mi := &file_yakgrpc_proto_msgTypes[873]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63534,7 +63633,7 @@ func (x *DeletePluginEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePluginEnvRequest.ProtoReflect.Descriptor instead.
 func (*DeletePluginEnvRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{872}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{873}
 }
 
 func (x *DeletePluginEnvRequest) GetKey() string {
@@ -63560,7 +63659,7 @@ type GetAllFuzztagInfoRequest struct {
 
 func (x *GetAllFuzztagInfoRequest) Reset() {
 	*x = GetAllFuzztagInfoRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[873]
+	mi := &file_yakgrpc_proto_msgTypes[874]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63572,7 +63671,7 @@ func (x *GetAllFuzztagInfoRequest) String() string {
 func (*GetAllFuzztagInfoRequest) ProtoMessage() {}
 
 func (x *GetAllFuzztagInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[873]
+	mi := &file_yakgrpc_proto_msgTypes[874]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63585,7 +63684,7 @@ func (x *GetAllFuzztagInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAllFuzztagInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetAllFuzztagInfoRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{873}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{874}
 }
 
 func (x *GetAllFuzztagInfoRequest) GetKey() string {
@@ -63604,7 +63703,7 @@ type GetAllFuzztagInfoResponse struct {
 
 func (x *GetAllFuzztagInfoResponse) Reset() {
 	*x = GetAllFuzztagInfoResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[874]
+	mi := &file_yakgrpc_proto_msgTypes[875]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63616,7 +63715,7 @@ func (x *GetAllFuzztagInfoResponse) String() string {
 func (*GetAllFuzztagInfoResponse) ProtoMessage() {}
 
 func (x *GetAllFuzztagInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[874]
+	mi := &file_yakgrpc_proto_msgTypes[875]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63629,7 +63728,7 @@ func (x *GetAllFuzztagInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAllFuzztagInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetAllFuzztagInfoResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{874}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{875}
 }
 
 func (x *GetAllFuzztagInfoResponse) GetData() []*FuzztagInfo {
@@ -63653,7 +63752,7 @@ type FuzztagArgumentType struct {
 
 func (x *FuzztagArgumentType) Reset() {
 	*x = FuzztagArgumentType{}
-	mi := &file_yakgrpc_proto_msgTypes[875]
+	mi := &file_yakgrpc_proto_msgTypes[876]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63665,7 +63764,7 @@ func (x *FuzztagArgumentType) String() string {
 func (*FuzztagArgumentType) ProtoMessage() {}
 
 func (x *FuzztagArgumentType) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[875]
+	mi := &file_yakgrpc_proto_msgTypes[876]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63678,7 +63777,7 @@ func (x *FuzztagArgumentType) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FuzztagArgumentType.ProtoReflect.Descriptor instead.
 func (*FuzztagArgumentType) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{875}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{876}
 }
 
 func (x *FuzztagArgumentType) GetName() string {
@@ -63736,7 +63835,7 @@ type FuzztagInfo struct {
 
 func (x *FuzztagInfo) Reset() {
 	*x = FuzztagInfo{}
-	mi := &file_yakgrpc_proto_msgTypes[876]
+	mi := &file_yakgrpc_proto_msgTypes[877]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63748,7 +63847,7 @@ func (x *FuzztagInfo) String() string {
 func (*FuzztagInfo) ProtoMessage() {}
 
 func (x *FuzztagInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[876]
+	mi := &file_yakgrpc_proto_msgTypes[877]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63761,7 +63860,7 @@ func (x *FuzztagInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FuzztagInfo.ProtoReflect.Descriptor instead.
 func (*FuzztagInfo) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{876}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{877}
 }
 
 func (x *FuzztagInfo) GetName() string {
@@ -63810,7 +63909,7 @@ type GenerateFuzztagRequest struct {
 
 func (x *GenerateFuzztagRequest) Reset() {
 	*x = GenerateFuzztagRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[877]
+	mi := &file_yakgrpc_proto_msgTypes[878]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63822,7 +63921,7 @@ func (x *GenerateFuzztagRequest) String() string {
 func (*GenerateFuzztagRequest) ProtoMessage() {}
 
 func (x *GenerateFuzztagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[877]
+	mi := &file_yakgrpc_proto_msgTypes[878]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63835,7 +63934,7 @@ func (x *GenerateFuzztagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateFuzztagRequest.ProtoReflect.Descriptor instead.
 func (*GenerateFuzztagRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{877}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{878}
 }
 
 func (x *GenerateFuzztagRequest) GetName() string {
@@ -63869,7 +63968,7 @@ type GenerateFuzztagResponse struct {
 
 func (x *GenerateFuzztagResponse) Reset() {
 	*x = GenerateFuzztagResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[878]
+	mi := &file_yakgrpc_proto_msgTypes[879]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63881,7 +63980,7 @@ func (x *GenerateFuzztagResponse) String() string {
 func (*GenerateFuzztagResponse) ProtoMessage() {}
 
 func (x *GenerateFuzztagResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[878]
+	mi := &file_yakgrpc_proto_msgTypes[879]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63894,7 +63993,7 @@ func (x *GenerateFuzztagResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateFuzztagResponse.ProtoReflect.Descriptor instead.
 func (*GenerateFuzztagResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{878}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{879}
 }
 
 func (x *GenerateFuzztagResponse) GetStatus() *GeneralResponse {
@@ -63922,7 +64021,7 @@ type FuzzTagSuggestionRequest struct {
 
 func (x *FuzzTagSuggestionRequest) Reset() {
 	*x = FuzzTagSuggestionRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[879]
+	mi := &file_yakgrpc_proto_msgTypes[880]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63934,7 +64033,7 @@ func (x *FuzzTagSuggestionRequest) String() string {
 func (*FuzzTagSuggestionRequest) ProtoMessage() {}
 
 func (x *FuzzTagSuggestionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[879]
+	mi := &file_yakgrpc_proto_msgTypes[880]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63947,7 +64046,7 @@ func (x *FuzzTagSuggestionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FuzzTagSuggestionRequest.ProtoReflect.Descriptor instead.
 func (*FuzzTagSuggestionRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{879}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{880}
 }
 
 func (x *FuzzTagSuggestionRequest) GetHotPatchCode() string {
@@ -64011,7 +64110,7 @@ type SSARisk struct {
 
 func (x *SSARisk) Reset() {
 	*x = SSARisk{}
-	mi := &file_yakgrpc_proto_msgTypes[880]
+	mi := &file_yakgrpc_proto_msgTypes[881]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64023,7 +64122,7 @@ func (x *SSARisk) String() string {
 func (*SSARisk) ProtoMessage() {}
 
 func (x *SSARisk) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[880]
+	mi := &file_yakgrpc_proto_msgTypes[881]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64036,7 +64135,7 @@ func (x *SSARisk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARisk.ProtoReflect.Descriptor instead.
 func (*SSARisk) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{880}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{881}
 }
 
 func (x *SSARisk) GetId() int64 {
@@ -64284,7 +64383,7 @@ type SSARisksFilter struct {
 
 func (x *SSARisksFilter) Reset() {
 	*x = SSARisksFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[881]
+	mi := &file_yakgrpc_proto_msgTypes[882]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64296,7 +64395,7 @@ func (x *SSARisksFilter) String() string {
 func (*SSARisksFilter) ProtoMessage() {}
 
 func (x *SSARisksFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[881]
+	mi := &file_yakgrpc_proto_msgTypes[882]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64309,7 +64408,7 @@ func (x *SSARisksFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARisksFilter.ProtoReflect.Descriptor instead.
 func (*SSARisksFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{881}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{882}
 }
 
 func (x *SSARisksFilter) GetID() []int64 {
@@ -64455,7 +64554,7 @@ type QuerySSARisksRequest struct {
 
 func (x *QuerySSARisksRequest) Reset() {
 	*x = QuerySSARisksRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[882]
+	mi := &file_yakgrpc_proto_msgTypes[883]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64467,7 +64566,7 @@ func (x *QuerySSARisksRequest) String() string {
 func (*QuerySSARisksRequest) ProtoMessage() {}
 
 func (x *QuerySSARisksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[882]
+	mi := &file_yakgrpc_proto_msgTypes[883]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64480,7 +64579,7 @@ func (x *QuerySSARisksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSARisksRequest.ProtoReflect.Descriptor instead.
 func (*QuerySSARisksRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{882}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{883}
 }
 
 func (x *QuerySSARisksRequest) GetPagination() *Paging {
@@ -64508,7 +64607,7 @@ type QuerySSARisksResponse struct {
 
 func (x *QuerySSARisksResponse) Reset() {
 	*x = QuerySSARisksResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[883]
+	mi := &file_yakgrpc_proto_msgTypes[884]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64520,7 +64619,7 @@ func (x *QuerySSARisksResponse) String() string {
 func (*QuerySSARisksResponse) ProtoMessage() {}
 
 func (x *QuerySSARisksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[883]
+	mi := &file_yakgrpc_proto_msgTypes[884]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64533,7 +64632,7 @@ func (x *QuerySSARisksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSARisksResponse.ProtoReflect.Descriptor instead.
 func (*QuerySSARisksResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{883}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{884}
 }
 
 func (x *QuerySSARisksResponse) GetPagination() *Paging {
@@ -64566,7 +64665,7 @@ type QueryNewSSARisksRequest struct {
 
 func (x *QueryNewSSARisksRequest) Reset() {
 	*x = QueryNewSSARisksRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[884]
+	mi := &file_yakgrpc_proto_msgTypes[885]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64578,7 +64677,7 @@ func (x *QueryNewSSARisksRequest) String() string {
 func (*QueryNewSSARisksRequest) ProtoMessage() {}
 
 func (x *QueryNewSSARisksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[884]
+	mi := &file_yakgrpc_proto_msgTypes[885]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64591,7 +64690,7 @@ func (x *QueryNewSSARisksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryNewSSARisksRequest.ProtoReflect.Descriptor instead.
 func (*QueryNewSSARisksRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{884}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{885}
 }
 
 func (x *QueryNewSSARisksRequest) GetAfterID() int64 {
@@ -64613,7 +64712,7 @@ type QueryNewSSARisksResponse struct {
 
 func (x *QueryNewSSARisksResponse) Reset() {
 	*x = QueryNewSSARisksResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[885]
+	mi := &file_yakgrpc_proto_msgTypes[886]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64625,7 +64724,7 @@ func (x *QueryNewSSARisksResponse) String() string {
 func (*QueryNewSSARisksResponse) ProtoMessage() {}
 
 func (x *QueryNewSSARisksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[885]
+	mi := &file_yakgrpc_proto_msgTypes[886]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64638,7 +64737,7 @@ func (x *QueryNewSSARisksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryNewSSARisksResponse.ProtoReflect.Descriptor instead.
 func (*QueryNewSSARisksResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{885}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{886}
 }
 
 func (x *QueryNewSSARisksResponse) GetData() []*SSARisk {
@@ -64678,7 +64777,7 @@ type DeleteSSARisksRequest struct {
 
 func (x *DeleteSSARisksRequest) Reset() {
 	*x = DeleteSSARisksRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[886]
+	mi := &file_yakgrpc_proto_msgTypes[887]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64690,7 +64789,7 @@ func (x *DeleteSSARisksRequest) String() string {
 func (*DeleteSSARisksRequest) ProtoMessage() {}
 
 func (x *DeleteSSARisksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[886]
+	mi := &file_yakgrpc_proto_msgTypes[887]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64703,7 +64802,7 @@ func (x *DeleteSSARisksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSSARisksRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSSARisksRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{886}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{887}
 }
 
 func (x *DeleteSSARisksRequest) GetFilter() *SSARisksFilter {
@@ -64723,7 +64822,7 @@ type UpdateSSARiskTagsRequest struct {
 
 func (x *UpdateSSARiskTagsRequest) Reset() {
 	*x = UpdateSSARiskTagsRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[887]
+	mi := &file_yakgrpc_proto_msgTypes[888]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64735,7 +64834,7 @@ func (x *UpdateSSARiskTagsRequest) String() string {
 func (*UpdateSSARiskTagsRequest) ProtoMessage() {}
 
 func (x *UpdateSSARiskTagsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[887]
+	mi := &file_yakgrpc_proto_msgTypes[888]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64748,7 +64847,7 @@ func (x *UpdateSSARiskTagsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSSARiskTagsRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSSARiskTagsRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{887}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{888}
 }
 
 func (x *UpdateSSARiskTagsRequest) GetID() int64 {
@@ -64774,7 +64873,7 @@ type GetSSARiskFieldGroupRequest struct {
 
 func (x *GetSSARiskFieldGroupRequest) Reset() {
 	*x = GetSSARiskFieldGroupRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[888]
+	mi := &file_yakgrpc_proto_msgTypes[889]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64786,7 +64885,7 @@ func (x *GetSSARiskFieldGroupRequest) String() string {
 func (*GetSSARiskFieldGroupRequest) ProtoMessage() {}
 
 func (x *GetSSARiskFieldGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[888]
+	mi := &file_yakgrpc_proto_msgTypes[889]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64799,7 +64898,7 @@ func (x *GetSSARiskFieldGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSSARiskFieldGroupRequest.ProtoReflect.Descriptor instead.
 func (*GetSSARiskFieldGroupRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{888}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{889}
 }
 
 func (x *GetSSARiskFieldGroupRequest) GetFilter() *SSARisksFilter {
@@ -64820,7 +64919,7 @@ type SSARiskFieldGroupResponse struct {
 
 func (x *SSARiskFieldGroupResponse) Reset() {
 	*x = SSARiskFieldGroupResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[889]
+	mi := &file_yakgrpc_proto_msgTypes[890]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64832,7 +64931,7 @@ func (x *SSARiskFieldGroupResponse) String() string {
 func (*SSARiskFieldGroupResponse) ProtoMessage() {}
 
 func (x *SSARiskFieldGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[889]
+	mi := &file_yakgrpc_proto_msgTypes[890]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64845,7 +64944,7 @@ func (x *SSARiskFieldGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARiskFieldGroupResponse.ProtoReflect.Descriptor instead.
 func (*SSARiskFieldGroupResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{889}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{890}
 }
 
 func (x *SSARiskFieldGroupResponse) GetFileField() []*FieldGroup {
@@ -64878,7 +64977,7 @@ type NewSSARiskReadRequest struct {
 
 func (x *NewSSARiskReadRequest) Reset() {
 	*x = NewSSARiskReadRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[890]
+	mi := &file_yakgrpc_proto_msgTypes[891]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64890,7 +64989,7 @@ func (x *NewSSARiskReadRequest) String() string {
 func (*NewSSARiskReadRequest) ProtoMessage() {}
 
 func (x *NewSSARiskReadRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[890]
+	mi := &file_yakgrpc_proto_msgTypes[891]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64903,7 +65002,7 @@ func (x *NewSSARiskReadRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewSSARiskReadRequest.ProtoReflect.Descriptor instead.
 func (*NewSSARiskReadRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{890}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{891}
 }
 
 func (x *NewSSARiskReadRequest) GetFilter() *SSARisksFilter {
@@ -64921,7 +65020,7 @@ type NewSSARiskReadResponse struct {
 
 func (x *NewSSARiskReadResponse) Reset() {
 	*x = NewSSARiskReadResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[891]
+	mi := &file_yakgrpc_proto_msgTypes[892]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64933,7 +65032,7 @@ func (x *NewSSARiskReadResponse) String() string {
 func (*NewSSARiskReadResponse) ProtoMessage() {}
 
 func (x *NewSSARiskReadResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[891]
+	mi := &file_yakgrpc_proto_msgTypes[892]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64946,7 +65045,7 @@ func (x *NewSSARiskReadResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewSSARiskReadResponse.ProtoReflect.Descriptor instead.
 func (*NewSSARiskReadResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{891}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{892}
 }
 
 type ExportSSARiskRequest struct {
@@ -64961,7 +65060,7 @@ type ExportSSARiskRequest struct {
 
 func (x *ExportSSARiskRequest) Reset() {
 	*x = ExportSSARiskRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[892]
+	mi := &file_yakgrpc_proto_msgTypes[893]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64973,7 +65072,7 @@ func (x *ExportSSARiskRequest) String() string {
 func (*ExportSSARiskRequest) ProtoMessage() {}
 
 func (x *ExportSSARiskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[892]
+	mi := &file_yakgrpc_proto_msgTypes[893]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64986,7 +65085,7 @@ func (x *ExportSSARiskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportSSARiskRequest.ProtoReflect.Descriptor instead.
 func (*ExportSSARiskRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{892}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{893}
 }
 
 func (x *ExportSSARiskRequest) GetFilter() *SSARisksFilter {
@@ -65027,7 +65126,7 @@ type ExportSSARiskResponse struct {
 
 func (x *ExportSSARiskResponse) Reset() {
 	*x = ExportSSARiskResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[893]
+	mi := &file_yakgrpc_proto_msgTypes[894]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65039,7 +65138,7 @@ func (x *ExportSSARiskResponse) String() string {
 func (*ExportSSARiskResponse) ProtoMessage() {}
 
 func (x *ExportSSARiskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[893]
+	mi := &file_yakgrpc_proto_msgTypes[894]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65052,7 +65151,7 @@ func (x *ExportSSARiskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportSSARiskResponse.ProtoReflect.Descriptor instead.
 func (*ExportSSARiskResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{893}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{894}
 }
 
 func (x *ExportSSARiskResponse) GetProcess() float64 {
@@ -65078,7 +65177,7 @@ type ImportSSARiskRequest struct {
 
 func (x *ImportSSARiskRequest) Reset() {
 	*x = ImportSSARiskRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[894]
+	mi := &file_yakgrpc_proto_msgTypes[895]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65090,7 +65189,7 @@ func (x *ImportSSARiskRequest) String() string {
 func (*ImportSSARiskRequest) ProtoMessage() {}
 
 func (x *ImportSSARiskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[894]
+	mi := &file_yakgrpc_proto_msgTypes[895]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65103,7 +65202,7 @@ func (x *ImportSSARiskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportSSARiskRequest.ProtoReflect.Descriptor instead.
 func (*ImportSSARiskRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{894}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{895}
 }
 
 func (x *ImportSSARiskRequest) GetInputPath() string {
@@ -65123,7 +65222,7 @@ type ImportSSARiskResponse struct {
 
 func (x *ImportSSARiskResponse) Reset() {
 	*x = ImportSSARiskResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[895]
+	mi := &file_yakgrpc_proto_msgTypes[896]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65135,7 +65234,7 @@ func (x *ImportSSARiskResponse) String() string {
 func (*ImportSSARiskResponse) ProtoMessage() {}
 
 func (x *ImportSSARiskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[895]
+	mi := &file_yakgrpc_proto_msgTypes[896]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65148,7 +65247,7 @@ func (x *ImportSSARiskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportSSARiskResponse.ProtoReflect.Descriptor instead.
 func (*ImportSSARiskResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{895}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{896}
 }
 
 func (x *ImportSSARiskResponse) GetProcess() float64 {
@@ -65175,7 +65274,7 @@ type SSARiskFeedbackToOnlineRequest struct {
 
 func (x *SSARiskFeedbackToOnlineRequest) Reset() {
 	*x = SSARiskFeedbackToOnlineRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[896]
+	mi := &file_yakgrpc_proto_msgTypes[897]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65187,7 +65286,7 @@ func (x *SSARiskFeedbackToOnlineRequest) String() string {
 func (*SSARiskFeedbackToOnlineRequest) ProtoMessage() {}
 
 func (x *SSARiskFeedbackToOnlineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[896]
+	mi := &file_yakgrpc_proto_msgTypes[897]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65200,7 +65299,7 @@ func (x *SSARiskFeedbackToOnlineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARiskFeedbackToOnlineRequest.ProtoReflect.Descriptor instead.
 func (*SSARiskFeedbackToOnlineRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{896}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{897}
 }
 
 func (x *SSARiskFeedbackToOnlineRequest) GetToken() string {
@@ -65232,7 +65331,7 @@ type SSARiskDisposalData struct {
 
 func (x *SSARiskDisposalData) Reset() {
 	*x = SSARiskDisposalData{}
-	mi := &file_yakgrpc_proto_msgTypes[897]
+	mi := &file_yakgrpc_proto_msgTypes[898]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65244,7 +65343,7 @@ func (x *SSARiskDisposalData) String() string {
 func (*SSARiskDisposalData) ProtoMessage() {}
 
 func (x *SSARiskDisposalData) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[897]
+	mi := &file_yakgrpc_proto_msgTypes[898]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65257,7 +65356,7 @@ func (x *SSARiskDisposalData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARiskDisposalData.ProtoReflect.Descriptor instead.
 func (*SSARiskDisposalData) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{897}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{898}
 }
 
 func (x *SSARiskDisposalData) GetId() int64 {
@@ -65322,7 +65421,7 @@ type SSARiskDisposalsFilter struct {
 
 func (x *SSARiskDisposalsFilter) Reset() {
 	*x = SSARiskDisposalsFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[898]
+	mi := &file_yakgrpc_proto_msgTypes[899]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65334,7 +65433,7 @@ func (x *SSARiskDisposalsFilter) String() string {
 func (*SSARiskDisposalsFilter) ProtoMessage() {}
 
 func (x *SSARiskDisposalsFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[898]
+	mi := &file_yakgrpc_proto_msgTypes[899]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65347,7 +65446,7 @@ func (x *SSARiskDisposalsFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSARiskDisposalsFilter.ProtoReflect.Descriptor instead.
 func (*SSARiskDisposalsFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{898}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{899}
 }
 
 func (x *SSARiskDisposalsFilter) GetID() []int64 {
@@ -65389,7 +65488,7 @@ type CreateSSARiskDisposalsRequest struct {
 
 func (x *CreateSSARiskDisposalsRequest) Reset() {
 	*x = CreateSSARiskDisposalsRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[899]
+	mi := &file_yakgrpc_proto_msgTypes[900]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65401,7 +65500,7 @@ func (x *CreateSSARiskDisposalsRequest) String() string {
 func (*CreateSSARiskDisposalsRequest) ProtoMessage() {}
 
 func (x *CreateSSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[899]
+	mi := &file_yakgrpc_proto_msgTypes[900]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65414,7 +65513,7 @@ func (x *CreateSSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSSARiskDisposalsRequest.ProtoReflect.Descriptor instead.
 func (*CreateSSARiskDisposalsRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{899}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{900}
 }
 
 func (x *CreateSSARiskDisposalsRequest) GetRiskIds() []int64 {
@@ -65447,7 +65546,7 @@ type CreateSSARiskDisposalsResponse struct {
 
 func (x *CreateSSARiskDisposalsResponse) Reset() {
 	*x = CreateSSARiskDisposalsResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[900]
+	mi := &file_yakgrpc_proto_msgTypes[901]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65459,7 +65558,7 @@ func (x *CreateSSARiskDisposalsResponse) String() string {
 func (*CreateSSARiskDisposalsResponse) ProtoMessage() {}
 
 func (x *CreateSSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[900]
+	mi := &file_yakgrpc_proto_msgTypes[901]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65472,7 +65571,7 @@ func (x *CreateSSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSSARiskDisposalsResponse.ProtoReflect.Descriptor instead.
 func (*CreateSSARiskDisposalsResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{900}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{901}
 }
 
 func (x *CreateSSARiskDisposalsResponse) GetData() []*SSARiskDisposalData {
@@ -65492,7 +65591,7 @@ type QuerySSARiskDisposalsRequest struct {
 
 func (x *QuerySSARiskDisposalsRequest) Reset() {
 	*x = QuerySSARiskDisposalsRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[901]
+	mi := &file_yakgrpc_proto_msgTypes[902]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65504,7 +65603,7 @@ func (x *QuerySSARiskDisposalsRequest) String() string {
 func (*QuerySSARiskDisposalsRequest) ProtoMessage() {}
 
 func (x *QuerySSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[901]
+	mi := &file_yakgrpc_proto_msgTypes[902]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65517,7 +65616,7 @@ func (x *QuerySSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSARiskDisposalsRequest.ProtoReflect.Descriptor instead.
 func (*QuerySSARiskDisposalsRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{901}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{902}
 }
 
 func (x *QuerySSARiskDisposalsRequest) GetPagination() *Paging {
@@ -65545,7 +65644,7 @@ type QuerySSARiskDisposalsResponse struct {
 
 func (x *QuerySSARiskDisposalsResponse) Reset() {
 	*x = QuerySSARiskDisposalsResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[902]
+	mi := &file_yakgrpc_proto_msgTypes[903]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65557,7 +65656,7 @@ func (x *QuerySSARiskDisposalsResponse) String() string {
 func (*QuerySSARiskDisposalsResponse) ProtoMessage() {}
 
 func (x *QuerySSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[902]
+	mi := &file_yakgrpc_proto_msgTypes[903]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65570,7 +65669,7 @@ func (x *QuerySSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSARiskDisposalsResponse.ProtoReflect.Descriptor instead.
 func (*QuerySSARiskDisposalsResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{902}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{903}
 }
 
 func (x *QuerySSARiskDisposalsResponse) GetPagination() *Paging {
@@ -65606,7 +65705,7 @@ type UpdateSSARiskDisposalsRequest struct {
 
 func (x *UpdateSSARiskDisposalsRequest) Reset() {
 	*x = UpdateSSARiskDisposalsRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[903]
+	mi := &file_yakgrpc_proto_msgTypes[904]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65618,7 +65717,7 @@ func (x *UpdateSSARiskDisposalsRequest) String() string {
 func (*UpdateSSARiskDisposalsRequest) ProtoMessage() {}
 
 func (x *UpdateSSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[903]
+	mi := &file_yakgrpc_proto_msgTypes[904]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65631,7 +65730,7 @@ func (x *UpdateSSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSSARiskDisposalsRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSSARiskDisposalsRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{903}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{904}
 }
 
 func (x *UpdateSSARiskDisposalsRequest) GetFilter() *SSARiskDisposalsFilter {
@@ -65671,7 +65770,7 @@ type UpdateSSARiskDisposalsResponse struct {
 
 func (x *UpdateSSARiskDisposalsResponse) Reset() {
 	*x = UpdateSSARiskDisposalsResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[904]
+	mi := &file_yakgrpc_proto_msgTypes[905]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65683,7 +65782,7 @@ func (x *UpdateSSARiskDisposalsResponse) String() string {
 func (*UpdateSSARiskDisposalsResponse) ProtoMessage() {}
 
 func (x *UpdateSSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[904]
+	mi := &file_yakgrpc_proto_msgTypes[905]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65696,7 +65795,7 @@ func (x *UpdateSSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSSARiskDisposalsResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSSARiskDisposalsResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{904}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{905}
 }
 
 func (x *UpdateSSARiskDisposalsResponse) GetData() []*SSARiskDisposalData {
@@ -65715,7 +65814,7 @@ type DeleteSSARiskDisposalsRequest struct {
 
 func (x *DeleteSSARiskDisposalsRequest) Reset() {
 	*x = DeleteSSARiskDisposalsRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[905]
+	mi := &file_yakgrpc_proto_msgTypes[906]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65727,7 +65826,7 @@ func (x *DeleteSSARiskDisposalsRequest) String() string {
 func (*DeleteSSARiskDisposalsRequest) ProtoMessage() {}
 
 func (x *DeleteSSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[905]
+	mi := &file_yakgrpc_proto_msgTypes[906]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65740,7 +65839,7 @@ func (x *DeleteSSARiskDisposalsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSSARiskDisposalsRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSSARiskDisposalsRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{905}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{906}
 }
 
 func (x *DeleteSSARiskDisposalsRequest) GetFilter() *SSARiskDisposalsFilter {
@@ -65759,7 +65858,7 @@ type DeleteSSARiskDisposalsResponse struct {
 
 func (x *DeleteSSARiskDisposalsResponse) Reset() {
 	*x = DeleteSSARiskDisposalsResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[906]
+	mi := &file_yakgrpc_proto_msgTypes[907]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65771,7 +65870,7 @@ func (x *DeleteSSARiskDisposalsResponse) String() string {
 func (*DeleteSSARiskDisposalsResponse) ProtoMessage() {}
 
 func (x *DeleteSSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[906]
+	mi := &file_yakgrpc_proto_msgTypes[907]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65784,7 +65883,7 @@ func (x *DeleteSSARiskDisposalsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSSARiskDisposalsResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSSARiskDisposalsResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{906}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{907}
 }
 
 func (x *DeleteSSARiskDisposalsResponse) GetMessage() *DbOperateMessage {
@@ -65804,7 +65903,7 @@ type GetSSARiskDisposalRequest struct {
 
 func (x *GetSSARiskDisposalRequest) Reset() {
 	*x = GetSSARiskDisposalRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[907]
+	mi := &file_yakgrpc_proto_msgTypes[908]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65816,7 +65915,7 @@ func (x *GetSSARiskDisposalRequest) String() string {
 func (*GetSSARiskDisposalRequest) ProtoMessage() {}
 
 func (x *GetSSARiskDisposalRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[907]
+	mi := &file_yakgrpc_proto_msgTypes[908]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65829,7 +65928,7 @@ func (x *GetSSARiskDisposalRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSSARiskDisposalRequest.ProtoReflect.Descriptor instead.
 func (*GetSSARiskDisposalRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{907}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{908}
 }
 
 func (x *GetSSARiskDisposalRequest) GetRiskId() int64 {
@@ -65855,7 +65954,7 @@ type GetSSARiskDisposalResponse struct {
 
 func (x *GetSSARiskDisposalResponse) Reset() {
 	*x = GetSSARiskDisposalResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[908]
+	mi := &file_yakgrpc_proto_msgTypes[909]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65867,7 +65966,7 @@ func (x *GetSSARiskDisposalResponse) String() string {
 func (*GetSSARiskDisposalResponse) ProtoMessage() {}
 
 func (x *GetSSARiskDisposalResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[908]
+	mi := &file_yakgrpc_proto_msgTypes[909]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65880,7 +65979,7 @@ func (x *GetSSARiskDisposalResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSSARiskDisposalResponse.ProtoReflect.Descriptor instead.
 func (*GetSSARiskDisposalResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{908}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{909}
 }
 
 func (x *GetSSARiskDisposalResponse) GetData() []*SSARiskDisposalData {
@@ -65901,7 +66000,7 @@ type ExportSyntaxFlowsRequest struct {
 
 func (x *ExportSyntaxFlowsRequest) Reset() {
 	*x = ExportSyntaxFlowsRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[909]
+	mi := &file_yakgrpc_proto_msgTypes[910]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65913,7 +66012,7 @@ func (x *ExportSyntaxFlowsRequest) String() string {
 func (*ExportSyntaxFlowsRequest) ProtoMessage() {}
 
 func (x *ExportSyntaxFlowsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[909]
+	mi := &file_yakgrpc_proto_msgTypes[910]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65926,7 +66025,7 @@ func (x *ExportSyntaxFlowsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportSyntaxFlowsRequest.ProtoReflect.Descriptor instead.
 func (*ExportSyntaxFlowsRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{909}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{910}
 }
 
 func (x *ExportSyntaxFlowsRequest) GetFilter() *SyntaxFlowRuleFilter {
@@ -65960,7 +66059,7 @@ type ImportSyntaxFlowsRequest struct {
 
 func (x *ImportSyntaxFlowsRequest) Reset() {
 	*x = ImportSyntaxFlowsRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[910]
+	mi := &file_yakgrpc_proto_msgTypes[911]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65972,7 +66071,7 @@ func (x *ImportSyntaxFlowsRequest) String() string {
 func (*ImportSyntaxFlowsRequest) ProtoMessage() {}
 
 func (x *ImportSyntaxFlowsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[910]
+	mi := &file_yakgrpc_proto_msgTypes[911]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65985,7 +66084,7 @@ func (x *ImportSyntaxFlowsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportSyntaxFlowsRequest.ProtoReflect.Descriptor instead.
 func (*ImportSyntaxFlowsRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{910}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{911}
 }
 
 func (x *ImportSyntaxFlowsRequest) GetInputPath() string {
@@ -66014,7 +66113,7 @@ type SyntaxflowsProgress struct {
 
 func (x *SyntaxflowsProgress) Reset() {
 	*x = SyntaxflowsProgress{}
-	mi := &file_yakgrpc_proto_msgTypes[911]
+	mi := &file_yakgrpc_proto_msgTypes[912]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66026,7 +66125,7 @@ func (x *SyntaxflowsProgress) String() string {
 func (*SyntaxflowsProgress) ProtoMessage() {}
 
 func (x *SyntaxflowsProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[911]
+	mi := &file_yakgrpc_proto_msgTypes[912]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66039,7 +66138,7 @@ func (x *SyntaxflowsProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyntaxflowsProgress.ProtoReflect.Descriptor instead.
 func (*SyntaxflowsProgress) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{911}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{912}
 }
 
 func (x *SyntaxflowsProgress) GetProgress() float64 {
@@ -66069,7 +66168,7 @@ type HotPatchTemplate struct {
 
 func (x *HotPatchTemplate) Reset() {
 	*x = HotPatchTemplate{}
-	mi := &file_yakgrpc_proto_msgTypes[912]
+	mi := &file_yakgrpc_proto_msgTypes[913]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66081,7 +66180,7 @@ func (x *HotPatchTemplate) String() string {
 func (*HotPatchTemplate) ProtoMessage() {}
 
 func (x *HotPatchTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[912]
+	mi := &file_yakgrpc_proto_msgTypes[913]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66094,7 +66193,7 @@ func (x *HotPatchTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotPatchTemplate.ProtoReflect.Descriptor instead.
 func (*HotPatchTemplate) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{912}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{913}
 }
 
 func (x *HotPatchTemplate) GetName() string {
@@ -66138,7 +66237,7 @@ type HotPatchTemplateRequest struct {
 
 func (x *HotPatchTemplateRequest) Reset() {
 	*x = HotPatchTemplateRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[913]
+	mi := &file_yakgrpc_proto_msgTypes[914]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66150,7 +66249,7 @@ func (x *HotPatchTemplateRequest) String() string {
 func (*HotPatchTemplateRequest) ProtoMessage() {}
 
 func (x *HotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[913]
+	mi := &file_yakgrpc_proto_msgTypes[914]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66163,7 +66262,7 @@ func (x *HotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HotPatchTemplateRequest.ProtoReflect.Descriptor instead.
 func (*HotPatchTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{913}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{914}
 }
 
 func (x *HotPatchTemplateRequest) GetId() []int64 {
@@ -66211,7 +66310,7 @@ type UpdateHotPatchTemplateRequest struct {
 
 func (x *UpdateHotPatchTemplateRequest) Reset() {
 	*x = UpdateHotPatchTemplateRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[914]
+	mi := &file_yakgrpc_proto_msgTypes[915]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66223,7 +66322,7 @@ func (x *UpdateHotPatchTemplateRequest) String() string {
 func (*UpdateHotPatchTemplateRequest) ProtoMessage() {}
 
 func (x *UpdateHotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[914]
+	mi := &file_yakgrpc_proto_msgTypes[915]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66236,7 +66335,7 @@ func (x *UpdateHotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateHotPatchTemplateRequest.ProtoReflect.Descriptor instead.
 func (*UpdateHotPatchTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{914}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{915}
 }
 
 func (x *UpdateHotPatchTemplateRequest) GetCondition() *HotPatchTemplateRequest {
@@ -66263,7 +66362,7 @@ type DeleteHotPatchTemplateRequest struct {
 
 func (x *DeleteHotPatchTemplateRequest) Reset() {
 	*x = DeleteHotPatchTemplateRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[915]
+	mi := &file_yakgrpc_proto_msgTypes[916]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66275,7 +66374,7 @@ func (x *DeleteHotPatchTemplateRequest) String() string {
 func (*DeleteHotPatchTemplateRequest) ProtoMessage() {}
 
 func (x *DeleteHotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[915]
+	mi := &file_yakgrpc_proto_msgTypes[916]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66288,7 +66387,7 @@ func (x *DeleteHotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteHotPatchTemplateRequest.ProtoReflect.Descriptor instead.
 func (*DeleteHotPatchTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{915}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{916}
 }
 
 func (x *DeleteHotPatchTemplateRequest) GetCondition() *HotPatchTemplateRequest {
@@ -66314,7 +66413,7 @@ type CreateHotPatchTemplateResponse struct {
 
 func (x *CreateHotPatchTemplateResponse) Reset() {
 	*x = CreateHotPatchTemplateResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[916]
+	mi := &file_yakgrpc_proto_msgTypes[917]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66326,7 +66425,7 @@ func (x *CreateHotPatchTemplateResponse) String() string {
 func (*CreateHotPatchTemplateResponse) ProtoMessage() {}
 
 func (x *CreateHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[916]
+	mi := &file_yakgrpc_proto_msgTypes[917]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66339,7 +66438,7 @@ func (x *CreateHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateHotPatchTemplateResponse.ProtoReflect.Descriptor instead.
 func (*CreateHotPatchTemplateResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{916}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{917}
 }
 
 func (x *CreateHotPatchTemplateResponse) GetMessage() *DbOperateMessage {
@@ -66358,7 +66457,7 @@ type DeleteHotPatchTemplateResponse struct {
 
 func (x *DeleteHotPatchTemplateResponse) Reset() {
 	*x = DeleteHotPatchTemplateResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[917]
+	mi := &file_yakgrpc_proto_msgTypes[918]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66370,7 +66469,7 @@ func (x *DeleteHotPatchTemplateResponse) String() string {
 func (*DeleteHotPatchTemplateResponse) ProtoMessage() {}
 
 func (x *DeleteHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[917]
+	mi := &file_yakgrpc_proto_msgTypes[918]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66383,7 +66482,7 @@ func (x *DeleteHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteHotPatchTemplateResponse.ProtoReflect.Descriptor instead.
 func (*DeleteHotPatchTemplateResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{917}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{918}
 }
 
 func (x *DeleteHotPatchTemplateResponse) GetMessage() *DbOperateMessage {
@@ -66402,7 +66501,7 @@ type UpdateHotPatchTemplateResponse struct {
 
 func (x *UpdateHotPatchTemplateResponse) Reset() {
 	*x = UpdateHotPatchTemplateResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[918]
+	mi := &file_yakgrpc_proto_msgTypes[919]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66414,7 +66513,7 @@ func (x *UpdateHotPatchTemplateResponse) String() string {
 func (*UpdateHotPatchTemplateResponse) ProtoMessage() {}
 
 func (x *UpdateHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[918]
+	mi := &file_yakgrpc_proto_msgTypes[919]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66427,7 +66526,7 @@ func (x *UpdateHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateHotPatchTemplateResponse.ProtoReflect.Descriptor instead.
 func (*UpdateHotPatchTemplateResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{918}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{919}
 }
 
 func (x *UpdateHotPatchTemplateResponse) GetMessage() *DbOperateMessage {
@@ -66447,7 +66546,7 @@ type QueryHotPatchTemplateResponse struct {
 
 func (x *QueryHotPatchTemplateResponse) Reset() {
 	*x = QueryHotPatchTemplateResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[919]
+	mi := &file_yakgrpc_proto_msgTypes[920]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66459,7 +66558,7 @@ func (x *QueryHotPatchTemplateResponse) String() string {
 func (*QueryHotPatchTemplateResponse) ProtoMessage() {}
 
 func (x *QueryHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[919]
+	mi := &file_yakgrpc_proto_msgTypes[920]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66472,7 +66571,7 @@ func (x *QueryHotPatchTemplateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryHotPatchTemplateResponse.ProtoReflect.Descriptor instead.
 func (*QueryHotPatchTemplateResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{919}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{920}
 }
 
 func (x *QueryHotPatchTemplateResponse) GetMessage() *DbOperateMessage {
@@ -66498,7 +66597,7 @@ type QueryHotPatchTemplateListRequest struct {
 
 func (x *QueryHotPatchTemplateListRequest) Reset() {
 	*x = QueryHotPatchTemplateListRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[920]
+	mi := &file_yakgrpc_proto_msgTypes[921]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66510,7 +66609,7 @@ func (x *QueryHotPatchTemplateListRequest) String() string {
 func (*QueryHotPatchTemplateListRequest) ProtoMessage() {}
 
 func (x *QueryHotPatchTemplateListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[920]
+	mi := &file_yakgrpc_proto_msgTypes[921]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66523,7 +66622,7 @@ func (x *QueryHotPatchTemplateListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryHotPatchTemplateListRequest.ProtoReflect.Descriptor instead.
 func (*QueryHotPatchTemplateListRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{920}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{921}
 }
 
 func (x *QueryHotPatchTemplateListRequest) GetType() string {
@@ -66544,7 +66643,7 @@ type QueryHotPatchTemplateListResponse struct {
 
 func (x *QueryHotPatchTemplateListResponse) Reset() {
 	*x = QueryHotPatchTemplateListResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[921]
+	mi := &file_yakgrpc_proto_msgTypes[922]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66556,7 +66655,7 @@ func (x *QueryHotPatchTemplateListResponse) String() string {
 func (*QueryHotPatchTemplateListResponse) ProtoMessage() {}
 
 func (x *QueryHotPatchTemplateListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[921]
+	mi := &file_yakgrpc_proto_msgTypes[922]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66569,7 +66668,7 @@ func (x *QueryHotPatchTemplateListResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use QueryHotPatchTemplateListResponse.ProtoReflect.Descriptor instead.
 func (*QueryHotPatchTemplateListResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{921}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{922}
 }
 
 func (x *QueryHotPatchTemplateListResponse) GetPagination() *Paging {
@@ -66602,7 +66701,7 @@ type GetHotPatchTemplateTagsResponse struct {
 
 func (x *GetHotPatchTemplateTagsResponse) Reset() {
 	*x = GetHotPatchTemplateTagsResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[922]
+	mi := &file_yakgrpc_proto_msgTypes[923]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66614,7 +66713,7 @@ func (x *GetHotPatchTemplateTagsResponse) String() string {
 func (*GetHotPatchTemplateTagsResponse) ProtoMessage() {}
 
 func (x *GetHotPatchTemplateTagsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[922]
+	mi := &file_yakgrpc_proto_msgTypes[923]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66627,7 +66726,7 @@ func (x *GetHotPatchTemplateTagsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHotPatchTemplateTagsResponse.ProtoReflect.Descriptor instead.
 func (*GetHotPatchTemplateTagsResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{922}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{923}
 }
 
 func (x *GetHotPatchTemplateTagsResponse) GetTags() []*Tags {
@@ -66652,7 +66751,7 @@ type GlobalHotPatchTemplateRef struct {
 
 func (x *GlobalHotPatchTemplateRef) Reset() {
 	*x = GlobalHotPatchTemplateRef{}
-	mi := &file_yakgrpc_proto_msgTypes[923]
+	mi := &file_yakgrpc_proto_msgTypes[924]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66664,7 +66763,7 @@ func (x *GlobalHotPatchTemplateRef) String() string {
 func (*GlobalHotPatchTemplateRef) ProtoMessage() {}
 
 func (x *GlobalHotPatchTemplateRef) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[923]
+	mi := &file_yakgrpc_proto_msgTypes[924]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66677,7 +66776,7 @@ func (x *GlobalHotPatchTemplateRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlobalHotPatchTemplateRef.ProtoReflect.Descriptor instead.
 func (*GlobalHotPatchTemplateRef) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{923}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{924}
 }
 
 func (x *GlobalHotPatchTemplateRef) GetName() string {
@@ -66712,7 +66811,7 @@ type GlobalHotPatchConfig struct {
 
 func (x *GlobalHotPatchConfig) Reset() {
 	*x = GlobalHotPatchConfig{}
-	mi := &file_yakgrpc_proto_msgTypes[924]
+	mi := &file_yakgrpc_proto_msgTypes[925]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66724,7 +66823,7 @@ func (x *GlobalHotPatchConfig) String() string {
 func (*GlobalHotPatchConfig) ProtoMessage() {}
 
 func (x *GlobalHotPatchConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[924]
+	mi := &file_yakgrpc_proto_msgTypes[925]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66737,7 +66836,7 @@ func (x *GlobalHotPatchConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlobalHotPatchConfig.ProtoReflect.Descriptor instead.
 func (*GlobalHotPatchConfig) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{924}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{925}
 }
 
 func (x *GlobalHotPatchConfig) GetEnabled() bool {
@@ -66771,7 +66870,7 @@ type SetGlobalHotPatchConfigRequest struct {
 
 func (x *SetGlobalHotPatchConfigRequest) Reset() {
 	*x = SetGlobalHotPatchConfigRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[925]
+	mi := &file_yakgrpc_proto_msgTypes[926]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66783,7 +66882,7 @@ func (x *SetGlobalHotPatchConfigRequest) String() string {
 func (*SetGlobalHotPatchConfigRequest) ProtoMessage() {}
 
 func (x *SetGlobalHotPatchConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[925]
+	mi := &file_yakgrpc_proto_msgTypes[926]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66796,7 +66895,7 @@ func (x *SetGlobalHotPatchConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetGlobalHotPatchConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetGlobalHotPatchConfigRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{925}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{926}
 }
 
 func (x *SetGlobalHotPatchConfigRequest) GetConfig() *GlobalHotPatchConfig {
@@ -66824,7 +66923,7 @@ type GroupTableColumnRequest struct {
 
 func (x *GroupTableColumnRequest) Reset() {
 	*x = GroupTableColumnRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[926]
+	mi := &file_yakgrpc_proto_msgTypes[927]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66836,7 +66935,7 @@ func (x *GroupTableColumnRequest) String() string {
 func (*GroupTableColumnRequest) ProtoMessage() {}
 
 func (x *GroupTableColumnRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[926]
+	mi := &file_yakgrpc_proto_msgTypes[927]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66849,7 +66948,7 @@ func (x *GroupTableColumnRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupTableColumnRequest.ProtoReflect.Descriptor instead.
 func (*GroupTableColumnRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{926}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{927}
 }
 
 func (x *GroupTableColumnRequest) GetDatabaseName() string {
@@ -66882,7 +66981,7 @@ type GroupTableColumnResponse struct {
 
 func (x *GroupTableColumnResponse) Reset() {
 	*x = GroupTableColumnResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[927]
+	mi := &file_yakgrpc_proto_msgTypes[928]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66894,7 +66993,7 @@ func (x *GroupTableColumnResponse) String() string {
 func (*GroupTableColumnResponse) ProtoMessage() {}
 
 func (x *GroupTableColumnResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[927]
+	mi := &file_yakgrpc_proto_msgTypes[928]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66907,7 +67006,7 @@ func (x *GroupTableColumnResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupTableColumnResponse.ProtoReflect.Descriptor instead.
 func (*GroupTableColumnResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{927}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{928}
 }
 
 func (x *GroupTableColumnResponse) GetData() []string {
@@ -66928,7 +67027,7 @@ type UploadHotPatchTemplateToOnlineRequest struct {
 
 func (x *UploadHotPatchTemplateToOnlineRequest) Reset() {
 	*x = UploadHotPatchTemplateToOnlineRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[928]
+	mi := &file_yakgrpc_proto_msgTypes[929]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66940,7 +67039,7 @@ func (x *UploadHotPatchTemplateToOnlineRequest) String() string {
 func (*UploadHotPatchTemplateToOnlineRequest) ProtoMessage() {}
 
 func (x *UploadHotPatchTemplateToOnlineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[928]
+	mi := &file_yakgrpc_proto_msgTypes[929]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66953,7 +67052,7 @@ func (x *UploadHotPatchTemplateToOnlineRequest) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use UploadHotPatchTemplateToOnlineRequest.ProtoReflect.Descriptor instead.
 func (*UploadHotPatchTemplateToOnlineRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{928}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{929}
 }
 
 func (x *UploadHotPatchTemplateToOnlineRequest) GetToken() string {
@@ -66988,7 +67087,7 @@ type DownloadHotPatchTemplateRequest struct {
 
 func (x *DownloadHotPatchTemplateRequest) Reset() {
 	*x = DownloadHotPatchTemplateRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[929]
+	mi := &file_yakgrpc_proto_msgTypes[930]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67000,7 +67099,7 @@ func (x *DownloadHotPatchTemplateRequest) String() string {
 func (*DownloadHotPatchTemplateRequest) ProtoMessage() {}
 
 func (x *DownloadHotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[929]
+	mi := &file_yakgrpc_proto_msgTypes[930]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67013,7 +67112,7 @@ func (x *DownloadHotPatchTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadHotPatchTemplateRequest.ProtoReflect.Descriptor instead.
 func (*DownloadHotPatchTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{929}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{930}
 }
 
 func (x *DownloadHotPatchTemplateRequest) GetName() string {
@@ -67049,7 +67148,7 @@ type ExportHTTPFlowStreamRequest struct {
 
 func (x *ExportHTTPFlowStreamRequest) Reset() {
 	*x = ExportHTTPFlowStreamRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[930]
+	mi := &file_yakgrpc_proto_msgTypes[931]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67061,7 +67160,7 @@ func (x *ExportHTTPFlowStreamRequest) String() string {
 func (*ExportHTTPFlowStreamRequest) ProtoMessage() {}
 
 func (x *ExportHTTPFlowStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[930]
+	mi := &file_yakgrpc_proto_msgTypes[931]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67074,7 +67173,7 @@ func (x *ExportHTTPFlowStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportHTTPFlowStreamRequest.ProtoReflect.Descriptor instead.
 func (*ExportHTTPFlowStreamRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{930}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{931}
 }
 
 func (x *ExportHTTPFlowStreamRequest) GetFilter() *QueryHTTPFlowRequest {
@@ -67115,7 +67214,7 @@ type ExportHTTPFlowStreamResponse struct {
 
 func (x *ExportHTTPFlowStreamResponse) Reset() {
 	*x = ExportHTTPFlowStreamResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[931]
+	mi := &file_yakgrpc_proto_msgTypes[932]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67127,7 +67226,7 @@ func (x *ExportHTTPFlowStreamResponse) String() string {
 func (*ExportHTTPFlowStreamResponse) ProtoMessage() {}
 
 func (x *ExportHTTPFlowStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[931]
+	mi := &file_yakgrpc_proto_msgTypes[932]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67140,7 +67239,7 @@ func (x *ExportHTTPFlowStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportHTTPFlowStreamResponse.ProtoReflect.Descriptor instead.
 func (*ExportHTTPFlowStreamResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{931}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{932}
 }
 
 func (x *ExportHTTPFlowStreamResponse) GetPercent() float64 {
@@ -67166,7 +67265,7 @@ type ImportHTTPFlowStreamRequest struct {
 
 func (x *ImportHTTPFlowStreamRequest) Reset() {
 	*x = ImportHTTPFlowStreamRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[932]
+	mi := &file_yakgrpc_proto_msgTypes[933]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67178,7 +67277,7 @@ func (x *ImportHTTPFlowStreamRequest) String() string {
 func (*ImportHTTPFlowStreamRequest) ProtoMessage() {}
 
 func (x *ImportHTTPFlowStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[932]
+	mi := &file_yakgrpc_proto_msgTypes[933]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67191,7 +67290,7 @@ func (x *ImportHTTPFlowStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportHTTPFlowStreamRequest.ProtoReflect.Descriptor instead.
 func (*ImportHTTPFlowStreamRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{932}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{933}
 }
 
 func (x *ImportHTTPFlowStreamRequest) GetInputPath() string {
@@ -67211,7 +67310,7 @@ type ImportHTTPFlowStreamResponse struct {
 
 func (x *ImportHTTPFlowStreamResponse) Reset() {
 	*x = ImportHTTPFlowStreamResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[933]
+	mi := &file_yakgrpc_proto_msgTypes[934]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67223,7 +67322,7 @@ func (x *ImportHTTPFlowStreamResponse) String() string {
 func (*ImportHTTPFlowStreamResponse) ProtoMessage() {}
 
 func (x *ImportHTTPFlowStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[933]
+	mi := &file_yakgrpc_proto_msgTypes[934]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67236,7 +67335,7 @@ func (x *ImportHTTPFlowStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportHTTPFlowStreamResponse.ProtoReflect.Descriptor instead.
 func (*ImportHTTPFlowStreamResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{933}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{934}
 }
 
 func (x *ImportHTTPFlowStreamResponse) GetPercent() float64 {
@@ -67266,7 +67365,7 @@ type Note struct {
 
 func (x *Note) Reset() {
 	*x = Note{}
-	mi := &file_yakgrpc_proto_msgTypes[934]
+	mi := &file_yakgrpc_proto_msgTypes[935]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67278,7 +67377,7 @@ func (x *Note) String() string {
 func (*Note) ProtoMessage() {}
 
 func (x *Note) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[934]
+	mi := &file_yakgrpc_proto_msgTypes[935]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67291,7 +67390,7 @@ func (x *Note) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Note.ProtoReflect.Descriptor instead.
 func (*Note) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{934}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{935}
 }
 
 func (x *Note) GetId() uint64 {
@@ -67341,7 +67440,7 @@ type NoteContent struct {
 
 func (x *NoteContent) Reset() {
 	*x = NoteContent{}
-	mi := &file_yakgrpc_proto_msgTypes[935]
+	mi := &file_yakgrpc_proto_msgTypes[936]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67353,7 +67452,7 @@ func (x *NoteContent) String() string {
 func (*NoteContent) ProtoMessage() {}
 
 func (x *NoteContent) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[935]
+	mi := &file_yakgrpc_proto_msgTypes[936]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67366,7 +67465,7 @@ func (x *NoteContent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NoteContent.ProtoReflect.Descriptor instead.
 func (*NoteContent) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{935}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{936}
 }
 
 func (x *NoteContent) GetNote() *Note {
@@ -67408,7 +67507,7 @@ type NoteFilter struct {
 
 func (x *NoteFilter) Reset() {
 	*x = NoteFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[936]
+	mi := &file_yakgrpc_proto_msgTypes[937]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67420,7 +67519,7 @@ func (x *NoteFilter) String() string {
 func (*NoteFilter) ProtoMessage() {}
 
 func (x *NoteFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[936]
+	mi := &file_yakgrpc_proto_msgTypes[937]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67433,7 +67532,7 @@ func (x *NoteFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NoteFilter.ProtoReflect.Descriptor instead.
 func (*NoteFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{936}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{937}
 }
 
 func (x *NoteFilter) GetId() []uint64 {
@@ -67467,7 +67566,7 @@ type CreateNoteRequest struct {
 
 func (x *CreateNoteRequest) Reset() {
 	*x = CreateNoteRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[937]
+	mi := &file_yakgrpc_proto_msgTypes[938]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67479,7 +67578,7 @@ func (x *CreateNoteRequest) String() string {
 func (*CreateNoteRequest) ProtoMessage() {}
 
 func (x *CreateNoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[937]
+	mi := &file_yakgrpc_proto_msgTypes[938]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67492,7 +67591,7 @@ func (x *CreateNoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateNoteRequest.ProtoReflect.Descriptor instead.
 func (*CreateNoteRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{937}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{938}
 }
 
 func (x *CreateNoteRequest) GetTitle() string {
@@ -67519,7 +67618,7 @@ type CreateNoteResponse struct {
 
 func (x *CreateNoteResponse) Reset() {
 	*x = CreateNoteResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[938]
+	mi := &file_yakgrpc_proto_msgTypes[939]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67531,7 +67630,7 @@ func (x *CreateNoteResponse) String() string {
 func (*CreateNoteResponse) ProtoMessage() {}
 
 func (x *CreateNoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[938]
+	mi := &file_yakgrpc_proto_msgTypes[939]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67544,7 +67643,7 @@ func (x *CreateNoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateNoteResponse.ProtoReflect.Descriptor instead.
 func (*CreateNoteResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{938}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{939}
 }
 
 func (x *CreateNoteResponse) GetMessage() *DbOperateMessage {
@@ -67574,7 +67673,7 @@ type UpdateNoteRequest struct {
 
 func (x *UpdateNoteRequest) Reset() {
 	*x = UpdateNoteRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[939]
+	mi := &file_yakgrpc_proto_msgTypes[940]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67586,7 +67685,7 @@ func (x *UpdateNoteRequest) String() string {
 func (*UpdateNoteRequest) ProtoMessage() {}
 
 func (x *UpdateNoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[939]
+	mi := &file_yakgrpc_proto_msgTypes[940]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67599,7 +67698,7 @@ func (x *UpdateNoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateNoteRequest.ProtoReflect.Descriptor instead.
 func (*UpdateNoteRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{939}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{940}
 }
 
 func (x *UpdateNoteRequest) GetFilter() *NoteFilter {
@@ -67646,7 +67745,7 @@ type DeleteNoteRequest struct {
 
 func (x *DeleteNoteRequest) Reset() {
 	*x = DeleteNoteRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[940]
+	mi := &file_yakgrpc_proto_msgTypes[941]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67658,7 +67757,7 @@ func (x *DeleteNoteRequest) String() string {
 func (*DeleteNoteRequest) ProtoMessage() {}
 
 func (x *DeleteNoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[940]
+	mi := &file_yakgrpc_proto_msgTypes[941]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67671,7 +67770,7 @@ func (x *DeleteNoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteNoteRequest.ProtoReflect.Descriptor instead.
 func (*DeleteNoteRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{940}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{941}
 }
 
 func (x *DeleteNoteRequest) GetFilter() *NoteFilter {
@@ -67691,7 +67790,7 @@ type QueryNoteRequest struct {
 
 func (x *QueryNoteRequest) Reset() {
 	*x = QueryNoteRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[941]
+	mi := &file_yakgrpc_proto_msgTypes[942]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67703,7 +67802,7 @@ func (x *QueryNoteRequest) String() string {
 func (*QueryNoteRequest) ProtoMessage() {}
 
 func (x *QueryNoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[941]
+	mi := &file_yakgrpc_proto_msgTypes[942]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67716,7 +67815,7 @@ func (x *QueryNoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryNoteRequest.ProtoReflect.Descriptor instead.
 func (*QueryNoteRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{941}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{942}
 }
 
 func (x *QueryNoteRequest) GetFilter() *NoteFilter {
@@ -67744,7 +67843,7 @@ type QueryNoteResponse struct {
 
 func (x *QueryNoteResponse) Reset() {
 	*x = QueryNoteResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[942]
+	mi := &file_yakgrpc_proto_msgTypes[943]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67756,7 +67855,7 @@ func (x *QueryNoteResponse) String() string {
 func (*QueryNoteResponse) ProtoMessage() {}
 
 func (x *QueryNoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[942]
+	mi := &file_yakgrpc_proto_msgTypes[943]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67769,7 +67868,7 @@ func (x *QueryNoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryNoteResponse.ProtoReflect.Descriptor instead.
 func (*QueryNoteResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{942}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{943}
 }
 
 func (x *QueryNoteResponse) GetPagination() *Paging {
@@ -67803,7 +67902,7 @@ type SearchNoteContentRequest struct {
 
 func (x *SearchNoteContentRequest) Reset() {
 	*x = SearchNoteContentRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[943]
+	mi := &file_yakgrpc_proto_msgTypes[944]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67815,7 +67914,7 @@ func (x *SearchNoteContentRequest) String() string {
 func (*SearchNoteContentRequest) ProtoMessage() {}
 
 func (x *SearchNoteContentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[943]
+	mi := &file_yakgrpc_proto_msgTypes[944]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67828,7 +67927,7 @@ func (x *SearchNoteContentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchNoteContentRequest.ProtoReflect.Descriptor instead.
 func (*SearchNoteContentRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{943}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{944}
 }
 
 func (x *SearchNoteContentRequest) GetKeyword() string {
@@ -67856,7 +67955,7 @@ type SearchNoteContentResponse struct {
 
 func (x *SearchNoteContentResponse) Reset() {
 	*x = SearchNoteContentResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[944]
+	mi := &file_yakgrpc_proto_msgTypes[945]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67868,7 +67967,7 @@ func (x *SearchNoteContentResponse) String() string {
 func (*SearchNoteContentResponse) ProtoMessage() {}
 
 func (x *SearchNoteContentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[944]
+	mi := &file_yakgrpc_proto_msgTypes[945]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67881,7 +67980,7 @@ func (x *SearchNoteContentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchNoteContentResponse.ProtoReflect.Descriptor instead.
 func (*SearchNoteContentResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{944}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{945}
 }
 
 func (x *SearchNoteContentResponse) GetPagination() *Paging {
@@ -67914,7 +68013,7 @@ type ImportNoteRequest struct {
 
 func (x *ImportNoteRequest) Reset() {
 	*x = ImportNoteRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[945]
+	mi := &file_yakgrpc_proto_msgTypes[946]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67926,7 +68025,7 @@ func (x *ImportNoteRequest) String() string {
 func (*ImportNoteRequest) ProtoMessage() {}
 
 func (x *ImportNoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[945]
+	mi := &file_yakgrpc_proto_msgTypes[946]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67939,7 +68038,7 @@ func (x *ImportNoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportNoteRequest.ProtoReflect.Descriptor instead.
 func (*ImportNoteRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{945}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{946}
 }
 
 func (x *ImportNoteRequest) GetTargetPath() string {
@@ -67960,7 +68059,7 @@ type ImportNoteResponse struct {
 
 func (x *ImportNoteResponse) Reset() {
 	*x = ImportNoteResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[946]
+	mi := &file_yakgrpc_proto_msgTypes[947]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -67972,7 +68071,7 @@ func (x *ImportNoteResponse) String() string {
 func (*ImportNoteResponse) ProtoMessage() {}
 
 func (x *ImportNoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[946]
+	mi := &file_yakgrpc_proto_msgTypes[947]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67985,7 +68084,7 @@ func (x *ImportNoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportNoteResponse.ProtoReflect.Descriptor instead.
 func (*ImportNoteResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{946}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{947}
 }
 
 func (x *ImportNoteResponse) GetPercent() float64 {
@@ -68019,7 +68118,7 @@ type ExportNoteRequest struct {
 
 func (x *ExportNoteRequest) Reset() {
 	*x = ExportNoteRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[947]
+	mi := &file_yakgrpc_proto_msgTypes[948]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68031,7 +68130,7 @@ func (x *ExportNoteRequest) String() string {
 func (*ExportNoteRequest) ProtoMessage() {}
 
 func (x *ExportNoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[947]
+	mi := &file_yakgrpc_proto_msgTypes[948]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68044,7 +68143,7 @@ func (x *ExportNoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportNoteRequest.ProtoReflect.Descriptor instead.
 func (*ExportNoteRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{947}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{948}
 }
 
 func (x *ExportNoteRequest) GetFilter() *NoteFilter {
@@ -68071,7 +68170,7 @@ type ExportNoteResponse struct {
 
 func (x *ExportNoteResponse) Reset() {
 	*x = ExportNoteResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[948]
+	mi := &file_yakgrpc_proto_msgTypes[949]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68083,7 +68182,7 @@ func (x *ExportNoteResponse) String() string {
 func (*ExportNoteResponse) ProtoMessage() {}
 
 func (x *ExportNoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[948]
+	mi := &file_yakgrpc_proto_msgTypes[949]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68096,7 +68195,7 @@ func (x *ExportNoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportNoteResponse.ProtoReflect.Descriptor instead.
 func (*ExportNoteResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{948}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{949}
 }
 
 func (x *ExportNoteResponse) GetPercent() float64 {
@@ -68122,7 +68221,7 @@ type ListAiModelRequest struct {
 
 func (x *ListAiModelRequest) Reset() {
 	*x = ListAiModelRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[949]
+	mi := &file_yakgrpc_proto_msgTypes[950]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68134,7 +68233,7 @@ func (x *ListAiModelRequest) String() string {
 func (*ListAiModelRequest) ProtoMessage() {}
 
 func (x *ListAiModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[949]
+	mi := &file_yakgrpc_proto_msgTypes[950]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68147,7 +68246,7 @@ func (x *ListAiModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAiModelRequest.ProtoReflect.Descriptor instead.
 func (*ListAiModelRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{949}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{950}
 }
 
 func (x *ListAiModelRequest) GetConfig() string {
@@ -68166,7 +68265,7 @@ type ListAiModelResponse struct {
 
 func (x *ListAiModelResponse) Reset() {
 	*x = ListAiModelResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[950]
+	mi := &file_yakgrpc_proto_msgTypes[951]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68178,7 +68277,7 @@ func (x *ListAiModelResponse) String() string {
 func (*ListAiModelResponse) ProtoMessage() {}
 
 func (x *ListAiModelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[950]
+	mi := &file_yakgrpc_proto_msgTypes[951]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68191,7 +68290,7 @@ func (x *ListAiModelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAiModelResponse.ProtoReflect.Descriptor instead.
 func (*ListAiModelResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{950}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{951}
 }
 
 func (x *ListAiModelResponse) GetModelName() []string {
@@ -68211,7 +68310,7 @@ type AIConfigHealthCheckRequest struct {
 
 func (x *AIConfigHealthCheckRequest) Reset() {
 	*x = AIConfigHealthCheckRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[951]
+	mi := &file_yakgrpc_proto_msgTypes[952]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68223,7 +68322,7 @@ func (x *AIConfigHealthCheckRequest) String() string {
 func (*AIConfigHealthCheckRequest) ProtoMessage() {}
 
 func (x *AIConfigHealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[951]
+	mi := &file_yakgrpc_proto_msgTypes[952]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68236,7 +68335,7 @@ func (x *AIConfigHealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AIConfigHealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*AIConfigHealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{951}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{952}
 }
 
 func (x *AIConfigHealthCheckRequest) GetConfig() *ThirdPartyApplicationConfig {
@@ -68270,7 +68369,7 @@ type AIConfigHealthCheckResponse struct {
 
 func (x *AIConfigHealthCheckResponse) Reset() {
 	*x = AIConfigHealthCheckResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[952]
+	mi := &file_yakgrpc_proto_msgTypes[953]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68282,7 +68381,7 @@ func (x *AIConfigHealthCheckResponse) String() string {
 func (*AIConfigHealthCheckResponse) ProtoMessage() {}
 
 func (x *AIConfigHealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[952]
+	mi := &file_yakgrpc_proto_msgTypes[953]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68295,7 +68394,7 @@ func (x *AIConfigHealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AIConfigHealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*AIConfigHealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{952}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{953}
 }
 
 func (x *AIConfigHealthCheckResponse) GetFirstByteCostMs() int64 {
@@ -68371,7 +68470,7 @@ type AIProvider struct {
 
 func (x *AIProvider) Reset() {
 	*x = AIProvider{}
-	mi := &file_yakgrpc_proto_msgTypes[953]
+	mi := &file_yakgrpc_proto_msgTypes[954]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68383,7 +68482,7 @@ func (x *AIProvider) String() string {
 func (*AIProvider) ProtoMessage() {}
 
 func (x *AIProvider) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[953]
+	mi := &file_yakgrpc_proto_msgTypes[954]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68396,7 +68495,7 @@ func (x *AIProvider) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AIProvider.ProtoReflect.Descriptor instead.
 func (*AIProvider) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{953}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{954}
 }
 
 func (x *AIProvider) GetId() int64 {
@@ -68423,7 +68522,7 @@ type AIProviderFilter struct {
 
 func (x *AIProviderFilter) Reset() {
 	*x = AIProviderFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[954]
+	mi := &file_yakgrpc_proto_msgTypes[955]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68435,7 +68534,7 @@ func (x *AIProviderFilter) String() string {
 func (*AIProviderFilter) ProtoMessage() {}
 
 func (x *AIProviderFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[954]
+	mi := &file_yakgrpc_proto_msgTypes[955]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68448,7 +68547,7 @@ func (x *AIProviderFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AIProviderFilter.ProtoReflect.Descriptor instead.
 func (*AIProviderFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{954}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{955}
 }
 
 func (x *AIProviderFilter) GetIds() []int64 {
@@ -68475,7 +68574,7 @@ type QueryAIProvidersRequest struct {
 
 func (x *QueryAIProvidersRequest) Reset() {
 	*x = QueryAIProvidersRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[955]
+	mi := &file_yakgrpc_proto_msgTypes[956]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68487,7 +68586,7 @@ func (x *QueryAIProvidersRequest) String() string {
 func (*QueryAIProvidersRequest) ProtoMessage() {}
 
 func (x *QueryAIProvidersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[955]
+	mi := &file_yakgrpc_proto_msgTypes[956]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68500,7 +68599,7 @@ func (x *QueryAIProvidersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryAIProvidersRequest.ProtoReflect.Descriptor instead.
 func (*QueryAIProvidersRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{955}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{956}
 }
 
 func (x *QueryAIProvidersRequest) GetFilter() *AIProviderFilter {
@@ -68528,7 +68627,7 @@ type QueryAIProvidersResponse struct {
 
 func (x *QueryAIProvidersResponse) Reset() {
 	*x = QueryAIProvidersResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[956]
+	mi := &file_yakgrpc_proto_msgTypes[957]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68540,7 +68639,7 @@ func (x *QueryAIProvidersResponse) String() string {
 func (*QueryAIProvidersResponse) ProtoMessage() {}
 
 func (x *QueryAIProvidersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[956]
+	mi := &file_yakgrpc_proto_msgTypes[957]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68553,7 +68652,7 @@ func (x *QueryAIProvidersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryAIProvidersResponse.ProtoReflect.Descriptor instead.
 func (*QueryAIProvidersResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{956}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{957}
 }
 
 func (x *QueryAIProvidersResponse) GetPagination() *Paging {
@@ -68586,7 +68685,7 @@ type ListAIProvidersResponse struct {
 
 func (x *ListAIProvidersResponse) Reset() {
 	*x = ListAIProvidersResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[957]
+	mi := &file_yakgrpc_proto_msgTypes[958]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68598,7 +68697,7 @@ func (x *ListAIProvidersResponse) String() string {
 func (*ListAIProvidersResponse) ProtoMessage() {}
 
 func (x *ListAIProvidersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[957]
+	mi := &file_yakgrpc_proto_msgTypes[958]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68611,7 +68710,7 @@ func (x *ListAIProvidersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAIProvidersResponse.ProtoReflect.Descriptor instead.
 func (*ListAIProvidersResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{957}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{958}
 }
 
 func (x *ListAIProvidersResponse) GetProviders() []*AIProvider {
@@ -68630,7 +68729,7 @@ type UpsertAIProviderRequest struct {
 
 func (x *UpsertAIProviderRequest) Reset() {
 	*x = UpsertAIProviderRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[958]
+	mi := &file_yakgrpc_proto_msgTypes[959]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68642,7 +68741,7 @@ func (x *UpsertAIProviderRequest) String() string {
 func (*UpsertAIProviderRequest) ProtoMessage() {}
 
 func (x *UpsertAIProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[958]
+	mi := &file_yakgrpc_proto_msgTypes[959]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68655,7 +68754,7 @@ func (x *UpsertAIProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertAIProviderRequest.ProtoReflect.Descriptor instead.
 func (*UpsertAIProviderRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{958}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{959}
 }
 
 func (x *UpsertAIProviderRequest) GetProvider() *AIProvider {
@@ -68674,7 +68773,7 @@ type UpsertAIProviderResponse struct {
 
 func (x *UpsertAIProviderResponse) Reset() {
 	*x = UpsertAIProviderResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[959]
+	mi := &file_yakgrpc_proto_msgTypes[960]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68686,7 +68785,7 @@ func (x *UpsertAIProviderResponse) String() string {
 func (*UpsertAIProviderResponse) ProtoMessage() {}
 
 func (x *UpsertAIProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[959]
+	mi := &file_yakgrpc_proto_msgTypes[960]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68699,7 +68798,7 @@ func (x *UpsertAIProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertAIProviderResponse.ProtoReflect.Descriptor instead.
 func (*UpsertAIProviderResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{959}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{960}
 }
 
 func (x *UpsertAIProviderResponse) GetProvider() *AIProvider {
@@ -68718,7 +68817,7 @@ type DeleteAIProviderRequest struct {
 
 func (x *DeleteAIProviderRequest) Reset() {
 	*x = DeleteAIProviderRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[960]
+	mi := &file_yakgrpc_proto_msgTypes[961]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68730,7 +68829,7 @@ func (x *DeleteAIProviderRequest) String() string {
 func (*DeleteAIProviderRequest) ProtoMessage() {}
 
 func (x *DeleteAIProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[960]
+	mi := &file_yakgrpc_proto_msgTypes[961]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68743,7 +68842,7 @@ func (x *DeleteAIProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAIProviderRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAIProviderRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{960}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{961}
 }
 
 func (x *DeleteAIProviderRequest) GetId() int64 {
@@ -68766,7 +68865,7 @@ type AIModelConfig struct {
 
 func (x *AIModelConfig) Reset() {
 	*x = AIModelConfig{}
-	mi := &file_yakgrpc_proto_msgTypes[961]
+	mi := &file_yakgrpc_proto_msgTypes[962]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68778,7 +68877,7 @@ func (x *AIModelConfig) String() string {
 func (*AIModelConfig) ProtoMessage() {}
 
 func (x *AIModelConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[961]
+	mi := &file_yakgrpc_proto_msgTypes[962]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68791,7 +68890,7 @@ func (x *AIModelConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AIModelConfig.ProtoReflect.Descriptor instead.
 func (*AIModelConfig) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{961}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{962}
 }
 
 func (x *AIModelConfig) GetProviderId() int64 {
@@ -68847,7 +68946,7 @@ type AIGlobalConfig struct {
 
 func (x *AIGlobalConfig) Reset() {
 	*x = AIGlobalConfig{}
-	mi := &file_yakgrpc_proto_msgTypes[962]
+	mi := &file_yakgrpc_proto_msgTypes[963]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68859,7 +68958,7 @@ func (x *AIGlobalConfig) String() string {
 func (*AIGlobalConfig) ProtoMessage() {}
 
 func (x *AIGlobalConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[962]
+	mi := &file_yakgrpc_proto_msgTypes[963]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68872,7 +68971,7 @@ func (x *AIGlobalConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AIGlobalConfig.ProtoReflect.Descriptor instead.
 func (*AIGlobalConfig) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{962}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{963}
 }
 
 func (x *AIGlobalConfig) GetEnabled() bool {
@@ -68956,7 +69055,7 @@ type IsLlamaServerReadyResponse struct {
 
 func (x *IsLlamaServerReadyResponse) Reset() {
 	*x = IsLlamaServerReadyResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[963]
+	mi := &file_yakgrpc_proto_msgTypes[964]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -68968,7 +69067,7 @@ func (x *IsLlamaServerReadyResponse) String() string {
 func (*IsLlamaServerReadyResponse) ProtoMessage() {}
 
 func (x *IsLlamaServerReadyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[963]
+	mi := &file_yakgrpc_proto_msgTypes[964]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68981,7 +69080,7 @@ func (x *IsLlamaServerReadyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IsLlamaServerReadyResponse.ProtoReflect.Descriptor instead.
 func (*IsLlamaServerReadyResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{963}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{964}
 }
 
 func (x *IsLlamaServerReadyResponse) GetOk() bool {
@@ -69007,7 +69106,7 @@ type IsLocalModelReadyRequest struct {
 
 func (x *IsLocalModelReadyRequest) Reset() {
 	*x = IsLocalModelReadyRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[964]
+	mi := &file_yakgrpc_proto_msgTypes[965]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69019,7 +69118,7 @@ func (x *IsLocalModelReadyRequest) String() string {
 func (*IsLocalModelReadyRequest) ProtoMessage() {}
 
 func (x *IsLocalModelReadyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[964]
+	mi := &file_yakgrpc_proto_msgTypes[965]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69032,7 +69131,7 @@ func (x *IsLocalModelReadyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IsLocalModelReadyRequest.ProtoReflect.Descriptor instead.
 func (*IsLocalModelReadyRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{964}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{965}
 }
 
 func (x *IsLocalModelReadyRequest) GetModelName() string {
@@ -69052,7 +69151,7 @@ type IsLocalModelReadyResponse struct {
 
 func (x *IsLocalModelReadyResponse) Reset() {
 	*x = IsLocalModelReadyResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[965]
+	mi := &file_yakgrpc_proto_msgTypes[966]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69064,7 +69163,7 @@ func (x *IsLocalModelReadyResponse) String() string {
 func (*IsLocalModelReadyResponse) ProtoMessage() {}
 
 func (x *IsLocalModelReadyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[965]
+	mi := &file_yakgrpc_proto_msgTypes[966]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69077,7 +69176,7 @@ func (x *IsLocalModelReadyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IsLocalModelReadyResponse.ProtoReflect.Descriptor instead.
 func (*IsLocalModelReadyResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{965}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{966}
 }
 
 func (x *IsLocalModelReadyResponse) GetOk() bool {
@@ -69103,7 +69202,7 @@ type InstallLlamaServerRequest struct {
 
 func (x *InstallLlamaServerRequest) Reset() {
 	*x = InstallLlamaServerRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[966]
+	mi := &file_yakgrpc_proto_msgTypes[967]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69115,7 +69214,7 @@ func (x *InstallLlamaServerRequest) String() string {
 func (*InstallLlamaServerRequest) ProtoMessage() {}
 
 func (x *InstallLlamaServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[966]
+	mi := &file_yakgrpc_proto_msgTypes[967]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69128,7 +69227,7 @@ func (x *InstallLlamaServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallLlamaServerRequest.ProtoReflect.Descriptor instead.
 func (*InstallLlamaServerRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{966}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{967}
 }
 
 func (x *InstallLlamaServerRequest) GetProxy() string {
@@ -69156,7 +69255,7 @@ type StartLocalModelRequest struct {
 
 func (x *StartLocalModelRequest) Reset() {
 	*x = StartLocalModelRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[967]
+	mi := &file_yakgrpc_proto_msgTypes[968]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69168,7 +69267,7 @@ func (x *StartLocalModelRequest) String() string {
 func (*StartLocalModelRequest) ProtoMessage() {}
 
 func (x *StartLocalModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[967]
+	mi := &file_yakgrpc_proto_msgTypes[968]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69181,7 +69280,7 @@ func (x *StartLocalModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartLocalModelRequest.ProtoReflect.Descriptor instead.
 func (*StartLocalModelRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{967}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{968}
 }
 
 func (x *StartLocalModelRequest) GetModelName() string {
@@ -69264,7 +69363,7 @@ type DownloadLocalModelRequest struct {
 
 func (x *DownloadLocalModelRequest) Reset() {
 	*x = DownloadLocalModelRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[968]
+	mi := &file_yakgrpc_proto_msgTypes[969]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69276,7 +69375,7 @@ func (x *DownloadLocalModelRequest) String() string {
 func (*DownloadLocalModelRequest) ProtoMessage() {}
 
 func (x *DownloadLocalModelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[968]
+	mi := &file_yakgrpc_proto_msgTypes[969]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69289,7 +69388,7 @@ func (x *DownloadLocalModelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadLocalModelRequest.ProtoReflect.Descriptor instead.
 func (*DownloadLocalModelRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{968}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{969}
 }
 
 func (x *DownloadLocalModelRequest) GetModelName() string {
@@ -69324,7 +69423,7 @@ type LocalModelConfig struct {
 
 func (x *LocalModelConfig) Reset() {
 	*x = LocalModelConfig{}
-	mi := &file_yakgrpc_proto_msgTypes[969]
+	mi := &file_yakgrpc_proto_msgTypes[970]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69336,7 +69435,7 @@ func (x *LocalModelConfig) String() string {
 func (*LocalModelConfig) ProtoMessage() {}
 
 func (x *LocalModelConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[969]
+	mi := &file_yakgrpc_proto_msgTypes[970]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69349,7 +69448,7 @@ func (x *LocalModelConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocalModelConfig.ProtoReflect.Descriptor instead.
 func (*LocalModelConfig) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{969}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{970}
 }
 
 func (x *LocalModelConfig) GetName() string {
@@ -69431,7 +69530,7 @@ type GetSupportedLocalModelsResponse struct {
 
 func (x *GetSupportedLocalModelsResponse) Reset() {
 	*x = GetSupportedLocalModelsResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[970]
+	mi := &file_yakgrpc_proto_msgTypes[971]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69443,7 +69542,7 @@ func (x *GetSupportedLocalModelsResponse) String() string {
 func (*GetSupportedLocalModelsResponse) ProtoMessage() {}
 
 func (x *GetSupportedLocalModelsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[970]
+	mi := &file_yakgrpc_proto_msgTypes[971]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69456,7 +69555,7 @@ func (x *GetSupportedLocalModelsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSupportedLocalModelsResponse.ProtoReflect.Descriptor instead.
 func (*GetSupportedLocalModelsResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{970}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{971}
 }
 
 func (x *GetSupportedLocalModelsResponse) GetModels() []*LocalModelConfig {
@@ -69476,7 +69575,7 @@ type WatchProcessStartParams struct {
 
 func (x *WatchProcessStartParams) Reset() {
 	*x = WatchProcessStartParams{}
-	mi := &file_yakgrpc_proto_msgTypes[971]
+	mi := &file_yakgrpc_proto_msgTypes[972]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69488,7 +69587,7 @@ func (x *WatchProcessStartParams) String() string {
 func (*WatchProcessStartParams) ProtoMessage() {}
 
 func (x *WatchProcessStartParams) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[971]
+	mi := &file_yakgrpc_proto_msgTypes[972]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69501,7 +69600,7 @@ func (x *WatchProcessStartParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchProcessStartParams.ProtoReflect.Descriptor instead.
 func (*WatchProcessStartParams) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{971}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{972}
 }
 
 func (x *WatchProcessStartParams) GetCheckIntervalSeconds() int64 {
@@ -69528,7 +69627,7 @@ type WatchProcessRequest struct {
 
 func (x *WatchProcessRequest) Reset() {
 	*x = WatchProcessRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[972]
+	mi := &file_yakgrpc_proto_msgTypes[973]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69540,7 +69639,7 @@ func (x *WatchProcessRequest) String() string {
 func (*WatchProcessRequest) ProtoMessage() {}
 
 func (x *WatchProcessRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[972]
+	mi := &file_yakgrpc_proto_msgTypes[973]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69553,7 +69652,7 @@ func (x *WatchProcessRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchProcessRequest.ProtoReflect.Descriptor instead.
 func (*WatchProcessRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{972}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{973}
 }
 
 func (x *WatchProcessRequest) GetStartParams() *WatchProcessStartParams {
@@ -69582,7 +69681,7 @@ type ProcessInfo struct {
 
 func (x *ProcessInfo) Reset() {
 	*x = ProcessInfo{}
-	mi := &file_yakgrpc_proto_msgTypes[973]
+	mi := &file_yakgrpc_proto_msgTypes[974]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69594,7 +69693,7 @@ func (x *ProcessInfo) String() string {
 func (*ProcessInfo) ProtoMessage() {}
 
 func (x *ProcessInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[973]
+	mi := &file_yakgrpc_proto_msgTypes[974]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69607,7 +69706,7 @@ func (x *ProcessInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessInfo.ProtoReflect.Descriptor instead.
 func (*ProcessInfo) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{973}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{974}
 }
 
 func (x *ProcessInfo) GetPid() int32 {
@@ -69650,7 +69749,7 @@ type ConnectionInfo struct {
 
 func (x *ConnectionInfo) Reset() {
 	*x = ConnectionInfo{}
-	mi := &file_yakgrpc_proto_msgTypes[974]
+	mi := &file_yakgrpc_proto_msgTypes[975]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69662,7 +69761,7 @@ func (x *ConnectionInfo) String() string {
 func (*ConnectionInfo) ProtoMessage() {}
 
 func (x *ConnectionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[974]
+	mi := &file_yakgrpc_proto_msgTypes[975]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69675,7 +69774,7 @@ func (x *ConnectionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectionInfo.ProtoReflect.Descriptor instead.
 func (*ConnectionInfo) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{974}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{975}
 }
 
 func (x *ConnectionInfo) GetLocalAddress() string {
@@ -69717,7 +69816,7 @@ type WatchProcessResponse struct {
 
 func (x *WatchProcessResponse) Reset() {
 	*x = WatchProcessResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[975]
+	mi := &file_yakgrpc_proto_msgTypes[976]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69729,7 +69828,7 @@ func (x *WatchProcessResponse) String() string {
 func (*WatchProcessResponse) ProtoMessage() {}
 
 func (x *WatchProcessResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[975]
+	mi := &file_yakgrpc_proto_msgTypes[976]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69742,7 +69841,7 @@ func (x *WatchProcessResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchProcessResponse.ProtoReflect.Descriptor instead.
 func (*WatchProcessResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{975}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{976}
 }
 
 func (x *WatchProcessResponse) GetAction() string {
@@ -69863,7 +69962,7 @@ type MITMV2Request struct {
 
 func (x *MITMV2Request) Reset() {
 	*x = MITMV2Request{}
-	mi := &file_yakgrpc_proto_msgTypes[976]
+	mi := &file_yakgrpc_proto_msgTypes[977]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -69875,7 +69974,7 @@ func (x *MITMV2Request) String() string {
 func (*MITMV2Request) ProtoMessage() {}
 
 func (x *MITMV2Request) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[976]
+	mi := &file_yakgrpc_proto_msgTypes[977]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69888,7 +69987,7 @@ func (x *MITMV2Request) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MITMV2Request.ProtoReflect.Descriptor instead.
 func (*MITMV2Request) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{976}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{977}
 }
 
 func (x *MITMV2Request) GetHost() string {
@@ -70324,7 +70423,7 @@ type MITMV2Response struct {
 
 func (x *MITMV2Response) Reset() {
 	*x = MITMV2Response{}
-	mi := &file_yakgrpc_proto_msgTypes[977]
+	mi := &file_yakgrpc_proto_msgTypes[978]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -70336,7 +70435,7 @@ func (x *MITMV2Response) String() string {
 func (*MITMV2Response) ProtoMessage() {}
 
 func (x *MITMV2Response) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[977]
+	mi := &file_yakgrpc_proto_msgTypes[978]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -70349,7 +70448,7 @@ func (x *MITMV2Response) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MITMV2Response.ProtoReflect.Descriptor instead.
 func (*MITMV2Response) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{977}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{978}
 }
 
 func (x *MITMV2Response) GetJustFilter() bool {
@@ -70471,7 +70570,7 @@ type SingleManualHijackControlMessage struct {
 
 func (x *SingleManualHijackControlMessage) Reset() {
 	*x = SingleManualHijackControlMessage{}
-	mi := &file_yakgrpc_proto_msgTypes[978]
+	mi := &file_yakgrpc_proto_msgTypes[979]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -70483,7 +70582,7 @@ func (x *SingleManualHijackControlMessage) String() string {
 func (*SingleManualHijackControlMessage) ProtoMessage() {}
 
 func (x *SingleManualHijackControlMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[978]
+	mi := &file_yakgrpc_proto_msgTypes[979]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -70496,7 +70595,7 @@ func (x *SingleManualHijackControlMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SingleManualHijackControlMessage.ProtoReflect.Descriptor instead.
 func (*SingleManualHijackControlMessage) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{978}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{979}
 }
 
 func (x *SingleManualHijackControlMessage) GetTaskID() string {
@@ -70599,7 +70698,7 @@ type SingleManualHijackInfoMessage struct {
 
 func (x *SingleManualHijackInfoMessage) Reset() {
 	*x = SingleManualHijackInfoMessage{}
-	mi := &file_yakgrpc_proto_msgTypes[979]
+	mi := &file_yakgrpc_proto_msgTypes[980]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -70611,7 +70710,7 @@ func (x *SingleManualHijackInfoMessage) String() string {
 func (*SingleManualHijackInfoMessage) ProtoMessage() {}
 
 func (x *SingleManualHijackInfoMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[979]
+	mi := &file_yakgrpc_proto_msgTypes[980]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -70624,7 +70723,7 @@ func (x *SingleManualHijackInfoMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SingleManualHijackInfoMessage.ProtoReflect.Descriptor instead.
 func (*SingleManualHijackInfoMessage) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{979}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{980}
 }
 
 func (x *SingleManualHijackInfoMessage) GetTaskID() string {
@@ -70734,7 +70833,7 @@ type QueryMITMReplacerRulesRequest struct {
 
 func (x *QueryMITMReplacerRulesRequest) Reset() {
 	*x = QueryMITMReplacerRulesRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[980]
+	mi := &file_yakgrpc_proto_msgTypes[981]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -70746,7 +70845,7 @@ func (x *QueryMITMReplacerRulesRequest) String() string {
 func (*QueryMITMReplacerRulesRequest) ProtoMessage() {}
 
 func (x *QueryMITMReplacerRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[980]
+	mi := &file_yakgrpc_proto_msgTypes[981]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -70759,7 +70858,7 @@ func (x *QueryMITMReplacerRulesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryMITMReplacerRulesRequest.ProtoReflect.Descriptor instead.
 func (*QueryMITMReplacerRulesRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{980}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{981}
 }
 
 func (x *QueryMITMReplacerRulesRequest) GetKeyWord() string {
@@ -70778,7 +70877,7 @@ type QueryMITMReplacerRulesResponse struct {
 
 func (x *QueryMITMReplacerRulesResponse) Reset() {
 	*x = QueryMITMReplacerRulesResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[981]
+	mi := &file_yakgrpc_proto_msgTypes[982]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -70790,7 +70889,7 @@ func (x *QueryMITMReplacerRulesResponse) String() string {
 func (*QueryMITMReplacerRulesResponse) ProtoMessage() {}
 
 func (x *QueryMITMReplacerRulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[981]
+	mi := &file_yakgrpc_proto_msgTypes[982]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -70803,7 +70902,7 @@ func (x *QueryMITMReplacerRulesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryMITMReplacerRulesResponse.ProtoReflect.Descriptor instead.
 func (*QueryMITMReplacerRulesResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{981}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{982}
 }
 
 func (x *QueryMITMReplacerRulesResponse) GetRules() *MITMContentReplacers {
@@ -70832,7 +70931,7 @@ type PluginExecutionTrace struct {
 
 func (x *PluginExecutionTrace) Reset() {
 	*x = PluginExecutionTrace{}
-	mi := &file_yakgrpc_proto_msgTypes[982]
+	mi := &file_yakgrpc_proto_msgTypes[983]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -70844,7 +70943,7 @@ func (x *PluginExecutionTrace) String() string {
 func (*PluginExecutionTrace) ProtoMessage() {}
 
 func (x *PluginExecutionTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[982]
+	mi := &file_yakgrpc_proto_msgTypes[983]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -70857,7 +70956,7 @@ func (x *PluginExecutionTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginExecutionTrace.ProtoReflect.Descriptor instead.
 func (*PluginExecutionTrace) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{982}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{983}
 }
 
 func (x *PluginExecutionTrace) GetTraceID() string {
@@ -70944,7 +71043,7 @@ type PluginTraceRequest struct {
 
 func (x *PluginTraceRequest) Reset() {
 	*x = PluginTraceRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[983]
+	mi := &file_yakgrpc_proto_msgTypes[984]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -70956,7 +71055,7 @@ func (x *PluginTraceRequest) String() string {
 func (*PluginTraceRequest) ProtoMessage() {}
 
 func (x *PluginTraceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[983]
+	mi := &file_yakgrpc_proto_msgTypes[984]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -70969,7 +71068,7 @@ func (x *PluginTraceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginTraceRequest.ProtoReflect.Descriptor instead.
 func (*PluginTraceRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{983}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{984}
 }
 
 func (x *PluginTraceRequest) GetControlMode() string {
@@ -71010,7 +71109,7 @@ type PluginTraceResponse struct {
 
 func (x *PluginTraceResponse) Reset() {
 	*x = PluginTraceResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[984]
+	mi := &file_yakgrpc_proto_msgTypes[985]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71022,7 +71121,7 @@ func (x *PluginTraceResponse) String() string {
 func (*PluginTraceResponse) ProtoMessage() {}
 
 func (x *PluginTraceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[984]
+	mi := &file_yakgrpc_proto_msgTypes[985]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71035,7 +71134,7 @@ func (x *PluginTraceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginTraceResponse.ProtoReflect.Descriptor instead.
 func (*PluginTraceResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{984}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{985}
 }
 
 func (x *PluginTraceResponse) GetResponseType() string {
@@ -71086,7 +71185,7 @@ type PluginTraceStats struct {
 
 func (x *PluginTraceStats) Reset() {
 	*x = PluginTraceStats{}
-	mi := &file_yakgrpc_proto_msgTypes[985]
+	mi := &file_yakgrpc_proto_msgTypes[986]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71098,7 +71197,7 @@ func (x *PluginTraceStats) String() string {
 func (*PluginTraceStats) ProtoMessage() {}
 
 func (x *PluginTraceStats) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[985]
+	mi := &file_yakgrpc_proto_msgTypes[986]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71111,7 +71210,7 @@ func (x *PluginTraceStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginTraceStats.ProtoReflect.Descriptor instead.
 func (*PluginTraceStats) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{985}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{986}
 }
 
 func (x *PluginTraceStats) GetTotalTraces() int64 {
@@ -71161,7 +71260,7 @@ type GenerateSSAReportRequest struct {
 
 func (x *GenerateSSAReportRequest) Reset() {
 	*x = GenerateSSAReportRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[986]
+	mi := &file_yakgrpc_proto_msgTypes[987]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71173,7 +71272,7 @@ func (x *GenerateSSAReportRequest) String() string {
 func (*GenerateSSAReportRequest) ProtoMessage() {}
 
 func (x *GenerateSSAReportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[986]
+	mi := &file_yakgrpc_proto_msgTypes[987]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71186,7 +71285,7 @@ func (x *GenerateSSAReportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateSSAReportRequest.ProtoReflect.Descriptor instead.
 func (*GenerateSSAReportRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{986}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{987}
 }
 
 func (x *GenerateSSAReportRequest) GetTaskID() string {
@@ -71221,7 +71320,7 @@ type GenerateSSAReportResponse struct {
 
 func (x *GenerateSSAReportResponse) Reset() {
 	*x = GenerateSSAReportResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[987]
+	mi := &file_yakgrpc_proto_msgTypes[988]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71233,7 +71332,7 @@ func (x *GenerateSSAReportResponse) String() string {
 func (*GenerateSSAReportResponse) ProtoMessage() {}
 
 func (x *GenerateSSAReportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[987]
+	mi := &file_yakgrpc_proto_msgTypes[988]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71246,7 +71345,7 @@ func (x *GenerateSSAReportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateSSAReportResponse.ProtoReflect.Descriptor instead.
 func (*GenerateSSAReportResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{987}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{988}
 }
 
 func (x *GenerateSSAReportResponse) GetSuccess() bool {
@@ -71302,7 +71401,7 @@ type SSAProject struct {
 
 func (x *SSAProject) Reset() {
 	*x = SSAProject{}
-	mi := &file_yakgrpc_proto_msgTypes[988]
+	mi := &file_yakgrpc_proto_msgTypes[989]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71314,7 +71413,7 @@ func (x *SSAProject) String() string {
 func (*SSAProject) ProtoMessage() {}
 
 func (x *SSAProject) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[988]
+	mi := &file_yakgrpc_proto_msgTypes[989]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71327,7 +71426,7 @@ func (x *SSAProject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProject.ProtoReflect.Descriptor instead.
 func (*SSAProject) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{988}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{989}
 }
 
 func (x *SSAProject) GetID() int64 {
@@ -71449,7 +71548,7 @@ type SSAProjectCompileConfig struct {
 
 func (x *SSAProjectCompileConfig) Reset() {
 	*x = SSAProjectCompileConfig{}
-	mi := &file_yakgrpc_proto_msgTypes[989]
+	mi := &file_yakgrpc_proto_msgTypes[990]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71461,7 +71560,7 @@ func (x *SSAProjectCompileConfig) String() string {
 func (*SSAProjectCompileConfig) ProtoMessage() {}
 
 func (x *SSAProjectCompileConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[989]
+	mi := &file_yakgrpc_proto_msgTypes[990]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71474,7 +71573,7 @@ func (x *SSAProjectCompileConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProjectCompileConfig.ProtoReflect.Descriptor instead.
 func (*SSAProjectCompileConfig) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{989}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{990}
 }
 
 func (x *SSAProjectCompileConfig) GetStrictMode() bool {
@@ -71530,7 +71629,7 @@ type SSAProjectScanConfig struct {
 
 func (x *SSAProjectScanConfig) Reset() {
 	*x = SSAProjectScanConfig{}
-	mi := &file_yakgrpc_proto_msgTypes[990]
+	mi := &file_yakgrpc_proto_msgTypes[991]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71542,7 +71641,7 @@ func (x *SSAProjectScanConfig) String() string {
 func (*SSAProjectScanConfig) ProtoMessage() {}
 
 func (x *SSAProjectScanConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[990]
+	mi := &file_yakgrpc_proto_msgTypes[991]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71555,7 +71654,7 @@ func (x *SSAProjectScanConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProjectScanConfig.ProtoReflect.Descriptor instead.
 func (*SSAProjectScanConfig) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{990}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{991}
 }
 
 func (x *SSAProjectScanConfig) GetConcurrency() uint32 {
@@ -71588,7 +71687,7 @@ type SSAProjectScanRuleConfig struct {
 
 func (x *SSAProjectScanRuleConfig) Reset() {
 	*x = SSAProjectScanRuleConfig{}
-	mi := &file_yakgrpc_proto_msgTypes[991]
+	mi := &file_yakgrpc_proto_msgTypes[992]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71600,7 +71699,7 @@ func (x *SSAProjectScanRuleConfig) String() string {
 func (*SSAProjectScanRuleConfig) ProtoMessage() {}
 
 func (x *SSAProjectScanRuleConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[991]
+	mi := &file_yakgrpc_proto_msgTypes[992]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71613,7 +71712,7 @@ func (x *SSAProjectScanRuleConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProjectScanRuleConfig.ProtoReflect.Descriptor instead.
 func (*SSAProjectScanRuleConfig) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{991}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{992}
 }
 
 func (x *SSAProjectScanRuleConfig) GetRuleFilter() *SyntaxFlowRuleFilter {
@@ -71635,7 +71734,7 @@ type SSAProjectFilter struct {
 
 func (x *SSAProjectFilter) Reset() {
 	*x = SSAProjectFilter{}
-	mi := &file_yakgrpc_proto_msgTypes[992]
+	mi := &file_yakgrpc_proto_msgTypes[993]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71647,7 +71746,7 @@ func (x *SSAProjectFilter) String() string {
 func (*SSAProjectFilter) ProtoMessage() {}
 
 func (x *SSAProjectFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[992]
+	mi := &file_yakgrpc_proto_msgTypes[993]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71660,7 +71759,7 @@ func (x *SSAProjectFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAProjectFilter.ProtoReflect.Descriptor instead.
 func (*SSAProjectFilter) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{992}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{993}
 }
 
 func (x *SSAProjectFilter) GetIDs() []int64 {
@@ -71701,7 +71800,7 @@ type CreateSSAProjectRequest struct {
 
 func (x *CreateSSAProjectRequest) Reset() {
 	*x = CreateSSAProjectRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[993]
+	mi := &file_yakgrpc_proto_msgTypes[994]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71713,7 +71812,7 @@ func (x *CreateSSAProjectRequest) String() string {
 func (*CreateSSAProjectRequest) ProtoMessage() {}
 
 func (x *CreateSSAProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[993]
+	mi := &file_yakgrpc_proto_msgTypes[994]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71726,7 +71825,7 @@ func (x *CreateSSAProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSSAProjectRequest.ProtoReflect.Descriptor instead.
 func (*CreateSSAProjectRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{993}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{994}
 }
 
 func (x *CreateSSAProjectRequest) GetProject() *SSAProject {
@@ -71753,7 +71852,7 @@ type CreateSSAProjectResponse struct {
 
 func (x *CreateSSAProjectResponse) Reset() {
 	*x = CreateSSAProjectResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[994]
+	mi := &file_yakgrpc_proto_msgTypes[995]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71765,7 +71864,7 @@ func (x *CreateSSAProjectResponse) String() string {
 func (*CreateSSAProjectResponse) ProtoMessage() {}
 
 func (x *CreateSSAProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[994]
+	mi := &file_yakgrpc_proto_msgTypes[995]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71778,7 +71877,7 @@ func (x *CreateSSAProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSSAProjectResponse.ProtoReflect.Descriptor instead.
 func (*CreateSSAProjectResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{994}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{995}
 }
 
 func (x *CreateSSAProjectResponse) GetProject() *SSAProject {
@@ -71804,7 +71903,7 @@ type UpdateSSAProjectRequest struct {
 
 func (x *UpdateSSAProjectRequest) Reset() {
 	*x = UpdateSSAProjectRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[995]
+	mi := &file_yakgrpc_proto_msgTypes[996]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71816,7 +71915,7 @@ func (x *UpdateSSAProjectRequest) String() string {
 func (*UpdateSSAProjectRequest) ProtoMessage() {}
 
 func (x *UpdateSSAProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[995]
+	mi := &file_yakgrpc_proto_msgTypes[996]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71829,7 +71928,7 @@ func (x *UpdateSSAProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSSAProjectRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSSAProjectRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{995}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{996}
 }
 
 func (x *UpdateSSAProjectRequest) GetProject() *SSAProject {
@@ -71849,7 +71948,7 @@ type UpdateSSAProjectResponse struct {
 
 func (x *UpdateSSAProjectResponse) Reset() {
 	*x = UpdateSSAProjectResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[996]
+	mi := &file_yakgrpc_proto_msgTypes[997]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71861,7 +71960,7 @@ func (x *UpdateSSAProjectResponse) String() string {
 func (*UpdateSSAProjectResponse) ProtoMessage() {}
 
 func (x *UpdateSSAProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[996]
+	mi := &file_yakgrpc_proto_msgTypes[997]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71874,7 +71973,7 @@ func (x *UpdateSSAProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSSAProjectResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSSAProjectResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{996}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{997}
 }
 
 func (x *UpdateSSAProjectResponse) GetProject() *SSAProject {
@@ -71906,7 +72005,7 @@ type DeleteSSAProjectRequest struct {
 
 func (x *DeleteSSAProjectRequest) Reset() {
 	*x = DeleteSSAProjectRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[997]
+	mi := &file_yakgrpc_proto_msgTypes[998]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71918,7 +72017,7 @@ func (x *DeleteSSAProjectRequest) String() string {
 func (*DeleteSSAProjectRequest) ProtoMessage() {}
 
 func (x *DeleteSSAProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[997]
+	mi := &file_yakgrpc_proto_msgTypes[998]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71931,7 +72030,7 @@ func (x *DeleteSSAProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSSAProjectRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSSAProjectRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{997}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{998}
 }
 
 func (x *DeleteSSAProjectRequest) GetFilter() *SSAProjectFilter {
@@ -71964,7 +72063,7 @@ type DeleteSSAProjectResponse struct {
 
 func (x *DeleteSSAProjectResponse) Reset() {
 	*x = DeleteSSAProjectResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[998]
+	mi := &file_yakgrpc_proto_msgTypes[999]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -71976,7 +72075,7 @@ func (x *DeleteSSAProjectResponse) String() string {
 func (*DeleteSSAProjectResponse) ProtoMessage() {}
 
 func (x *DeleteSSAProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[998]
+	mi := &file_yakgrpc_proto_msgTypes[999]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71989,7 +72088,7 @@ func (x *DeleteSSAProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSSAProjectResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSSAProjectResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{998}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{999}
 }
 
 func (x *DeleteSSAProjectResponse) GetMessage() *DbOperateMessage {
@@ -72009,7 +72108,7 @@ type QuerySSAProjectRequest struct {
 
 func (x *QuerySSAProjectRequest) Reset() {
 	*x = QuerySSAProjectRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[999]
+	mi := &file_yakgrpc_proto_msgTypes[1000]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72021,7 +72120,7 @@ func (x *QuerySSAProjectRequest) String() string {
 func (*QuerySSAProjectRequest) ProtoMessage() {}
 
 func (x *QuerySSAProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[999]
+	mi := &file_yakgrpc_proto_msgTypes[1000]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72034,7 +72133,7 @@ func (x *QuerySSAProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSAProjectRequest.ProtoReflect.Descriptor instead.
 func (*QuerySSAProjectRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{999}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1000}
 }
 
 func (x *QuerySSAProjectRequest) GetFilter() *SSAProjectFilter {
@@ -72062,7 +72161,7 @@ type QuerySSAProjectResponse struct {
 
 func (x *QuerySSAProjectResponse) Reset() {
 	*x = QuerySSAProjectResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[1000]
+	mi := &file_yakgrpc_proto_msgTypes[1001]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72074,7 +72173,7 @@ func (x *QuerySSAProjectResponse) String() string {
 func (*QuerySSAProjectResponse) ProtoMessage() {}
 
 func (x *QuerySSAProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1000]
+	mi := &file_yakgrpc_proto_msgTypes[1001]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72087,7 +72186,7 @@ func (x *QuerySSAProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuerySSAProjectResponse.ProtoReflect.Descriptor instead.
 func (*QuerySSAProjectResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1000}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1001}
 }
 
 func (x *QuerySSAProjectResponse) GetProjects() []*SSAProject {
@@ -72119,7 +72218,7 @@ type MigrateSSAProjectRequest struct {
 
 func (x *MigrateSSAProjectRequest) Reset() {
 	*x = MigrateSSAProjectRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[1001]
+	mi := &file_yakgrpc_proto_msgTypes[1002]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72131,7 +72230,7 @@ func (x *MigrateSSAProjectRequest) String() string {
 func (*MigrateSSAProjectRequest) ProtoMessage() {}
 
 func (x *MigrateSSAProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1001]
+	mi := &file_yakgrpc_proto_msgTypes[1002]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72144,7 +72243,7 @@ func (x *MigrateSSAProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MigrateSSAProjectRequest.ProtoReflect.Descriptor instead.
 func (*MigrateSSAProjectRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1001}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1002}
 }
 
 type MigrateSSAProjectResponse struct {
@@ -72157,7 +72256,7 @@ type MigrateSSAProjectResponse struct {
 
 func (x *MigrateSSAProjectResponse) Reset() {
 	*x = MigrateSSAProjectResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[1002]
+	mi := &file_yakgrpc_proto_msgTypes[1003]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72169,7 +72268,7 @@ func (x *MigrateSSAProjectResponse) String() string {
 func (*MigrateSSAProjectResponse) ProtoMessage() {}
 
 func (x *MigrateSSAProjectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1002]
+	mi := &file_yakgrpc_proto_msgTypes[1003]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72182,7 +72281,7 @@ func (x *MigrateSSAProjectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MigrateSSAProjectResponse.ProtoReflect.Descriptor instead.
 func (*MigrateSSAProjectResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1002}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1003}
 }
 
 func (x *MigrateSSAProjectResponse) GetPercent() float64 {
@@ -72218,7 +72317,7 @@ type GetSSAWorkbenchDashboardRequest struct {
 
 func (x *GetSSAWorkbenchDashboardRequest) Reset() {
 	*x = GetSSAWorkbenchDashboardRequest{}
-	mi := &file_yakgrpc_proto_msgTypes[1003]
+	mi := &file_yakgrpc_proto_msgTypes[1004]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72230,7 +72329,7 @@ func (x *GetSSAWorkbenchDashboardRequest) String() string {
 func (*GetSSAWorkbenchDashboardRequest) ProtoMessage() {}
 
 func (x *GetSSAWorkbenchDashboardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1003]
+	mi := &file_yakgrpc_proto_msgTypes[1004]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72243,7 +72342,7 @@ func (x *GetSSAWorkbenchDashboardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSSAWorkbenchDashboardRequest.ProtoReflect.Descriptor instead.
 func (*GetSSAWorkbenchDashboardRequest) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1003}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1004}
 }
 
 func (x *GetSSAWorkbenchDashboardRequest) GetRiskFilter() *SSARisksFilter {
@@ -72292,7 +72391,7 @@ type SSAWorkbenchSummary struct {
 
 func (x *SSAWorkbenchSummary) Reset() {
 	*x = SSAWorkbenchSummary{}
-	mi := &file_yakgrpc_proto_msgTypes[1004]
+	mi := &file_yakgrpc_proto_msgTypes[1005]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72304,7 +72403,7 @@ func (x *SSAWorkbenchSummary) String() string {
 func (*SSAWorkbenchSummary) ProtoMessage() {}
 
 func (x *SSAWorkbenchSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1004]
+	mi := &file_yakgrpc_proto_msgTypes[1005]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72317,7 +72416,7 @@ func (x *SSAWorkbenchSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAWorkbenchSummary.ProtoReflect.Descriptor instead.
 func (*SSAWorkbenchSummary) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1004}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1005}
 }
 
 func (x *SSAWorkbenchSummary) GetProjectCount() int64 {
@@ -72353,7 +72452,7 @@ type SSAWorkbenchRiskLevelItem struct {
 
 func (x *SSAWorkbenchRiskLevelItem) Reset() {
 	*x = SSAWorkbenchRiskLevelItem{}
-	mi := &file_yakgrpc_proto_msgTypes[1005]
+	mi := &file_yakgrpc_proto_msgTypes[1006]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72365,7 +72464,7 @@ func (x *SSAWorkbenchRiskLevelItem) String() string {
 func (*SSAWorkbenchRiskLevelItem) ProtoMessage() {}
 
 func (x *SSAWorkbenchRiskLevelItem) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1005]
+	mi := &file_yakgrpc_proto_msgTypes[1006]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72378,7 +72477,7 @@ func (x *SSAWorkbenchRiskLevelItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAWorkbenchRiskLevelItem.ProtoReflect.Descriptor instead.
 func (*SSAWorkbenchRiskLevelItem) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1005}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1006}
 }
 
 func (x *SSAWorkbenchRiskLevelItem) GetSeverity() string {
@@ -72421,7 +72520,7 @@ type SSAWorkbenchRiskTypeItem struct {
 
 func (x *SSAWorkbenchRiskTypeItem) Reset() {
 	*x = SSAWorkbenchRiskTypeItem{}
-	mi := &file_yakgrpc_proto_msgTypes[1006]
+	mi := &file_yakgrpc_proto_msgTypes[1007]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72433,7 +72532,7 @@ func (x *SSAWorkbenchRiskTypeItem) String() string {
 func (*SSAWorkbenchRiskTypeItem) ProtoMessage() {}
 
 func (x *SSAWorkbenchRiskTypeItem) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1006]
+	mi := &file_yakgrpc_proto_msgTypes[1007]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72446,7 +72545,7 @@ func (x *SSAWorkbenchRiskTypeItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAWorkbenchRiskTypeItem.ProtoReflect.Descriptor instead.
 func (*SSAWorkbenchRiskTypeItem) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1006}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1007}
 }
 
 func (x *SSAWorkbenchRiskTypeItem) GetRiskType() string {
@@ -72488,7 +72587,7 @@ type SSAWorkbenchRuleHitItem struct {
 
 func (x *SSAWorkbenchRuleHitItem) Reset() {
 	*x = SSAWorkbenchRuleHitItem{}
-	mi := &file_yakgrpc_proto_msgTypes[1007]
+	mi := &file_yakgrpc_proto_msgTypes[1008]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72500,7 +72599,7 @@ func (x *SSAWorkbenchRuleHitItem) String() string {
 func (*SSAWorkbenchRuleHitItem) ProtoMessage() {}
 
 func (x *SSAWorkbenchRuleHitItem) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1007]
+	mi := &file_yakgrpc_proto_msgTypes[1008]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72513,7 +72612,7 @@ func (x *SSAWorkbenchRuleHitItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAWorkbenchRuleHitItem.ProtoReflect.Descriptor instead.
 func (*SSAWorkbenchRuleHitItem) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1007}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1008}
 }
 
 func (x *SSAWorkbenchRuleHitItem) GetRuleName() string {
@@ -72553,7 +72652,7 @@ type SSAWorkbenchRecentProject struct {
 
 func (x *SSAWorkbenchRecentProject) Reset() {
 	*x = SSAWorkbenchRecentProject{}
-	mi := &file_yakgrpc_proto_msgTypes[1008]
+	mi := &file_yakgrpc_proto_msgTypes[1009]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72565,7 +72664,7 @@ func (x *SSAWorkbenchRecentProject) String() string {
 func (*SSAWorkbenchRecentProject) ProtoMessage() {}
 
 func (x *SSAWorkbenchRecentProject) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1008]
+	mi := &file_yakgrpc_proto_msgTypes[1009]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72578,7 +72677,7 @@ func (x *SSAWorkbenchRecentProject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSAWorkbenchRecentProject.ProtoReflect.Descriptor instead.
 func (*SSAWorkbenchRecentProject) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1008}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1009}
 }
 
 func (x *SSAWorkbenchRecentProject) GetID() int64 {
@@ -72651,7 +72750,7 @@ type GetSSAWorkbenchDashboardResponse struct {
 
 func (x *GetSSAWorkbenchDashboardResponse) Reset() {
 	*x = GetSSAWorkbenchDashboardResponse{}
-	mi := &file_yakgrpc_proto_msgTypes[1009]
+	mi := &file_yakgrpc_proto_msgTypes[1010]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -72663,7 +72762,7 @@ func (x *GetSSAWorkbenchDashboardResponse) String() string {
 func (*GetSSAWorkbenchDashboardResponse) ProtoMessage() {}
 
 func (x *GetSSAWorkbenchDashboardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_yakgrpc_proto_msgTypes[1009]
+	mi := &file_yakgrpc_proto_msgTypes[1010]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72676,7 +72775,7 @@ func (x *GetSSAWorkbenchDashboardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSSAWorkbenchDashboardResponse.ProtoReflect.Descriptor instead.
 func (*GetSSAWorkbenchDashboardResponse) Descriptor() ([]byte, []int) {
-	return file_yakgrpc_proto_rawDescGZIP(), []int{1009}
+	return file_yakgrpc_proto_rawDescGZIP(), []int{1010}
 }
 
 func (x *GetSSAWorkbenchDashboardResponse) GetSummary() *SSAWorkbenchSummary {
@@ -77176,13 +77275,16 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x16GetHTTPFlowByIdRequest\x12\x0e\n" +
 	"\x02Id\x18\x01 \x01(\x03R\x02Id\"+\n" +
 	"\x17GetHTTPFlowByIdsRequest\x12\x10\n" +
-	"\x03Ids\x18\x02 \x03(\x03R\x03Ids\"\x9a\x01\n" +
+	"\x03Ids\x18\x02 \x03(\x03R\x03Ids\"\xcb\x01\n" +
 	"\x1aGetHTTPFlowBodyByIdRequest\x12\x0e\n" +
 	"\x02Id\x18\x01 \x01(\x03R\x02Id\x12\x1c\n" +
 	"\tIsRequest\x18\x02 \x01(\bR\tIsRequest\x12\x18\n" +
 	"\aBufSize\x18\x03 \x01(\x03R\aBufSize\x12\x1c\n" +
 	"\tRuntimeId\x18\x04 \x01(\tR\tRuntimeId\x12\x16\n" +
-	"\x06IsRisk\x18\x05 \x01(\bR\x06IsRisk\"g\n" +
+	"\x06IsRisk\x18\x05 \x01(\bR\x06IsRisk\x12!\n" +
+	"\tPartIndex\x18\x06 \x01(\x05H\x00R\tPartIndex\x88\x01\x01B\f\n" +
+	"\n" +
+	"_PartIndex\"g\n" +
 	"!MITMExtractAggregateFlowFilterRow\x12 \n" +
 	"\vRuleVerbose\x18\x01 \x01(\tR\vRuleVerbose\x12 \n" +
 	"\vDisplayData\x18\x02 \x01(\tR\vDisplayData\"\x89\x0e\n" +
@@ -77325,7 +77427,7 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x06Header\x18\x01 \x01(\tR\x06Header\x12\x14\n" +
 	"\x05Value\x18\x02 \x01(\tR\x05Value\".\n" +
 	"\tHTTPFlows\x12!\n" +
-	"\x04Data\x18\x01 \x03(\v2\r.ypb.HTTPFlowR\x04Data\"\xe6\x10\n" +
+	"\x04Data\x18\x01 \x03(\v2\r.ypb.HTTPFlowR\x04Data\"\xa6\x11\n" +
 	"\bHTTPFlow\x12\x18\n" +
 	"\aIsHTTPS\x18\x02 \x01(\bR\aIsHTTPS\x12\x10\n" +
 	"\x03Url\x18\x03 \x01(\tR\x03Url\x125\n" +
@@ -77396,7 +77498,14 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x11IsTooLargeRequest\x186 \x01(\bR\x11IsTooLargeRequest\x12<\n" +
 	"\x19TooLargeRequestHeaderFile\x187 \x01(\tR\x19TooLargeRequestHeaderFile\x128\n" +
 	"\x17TooLargeRequestBodyFile\x188 \x01(\tR\x17TooLargeRequestBodyFile\x12,\n" +
-	"\x11IsRequestOversize\x189 \x01(\bR\x11IsRequestOversize\"\xa9\x01\n" +
+	"\x11IsRequestOversize\x189 \x01(\bR\x11IsRequestOversize\x12>\n" +
+	"\x0eMultipartFiles\x18: \x03(\v2\x16.ypb.MultipartFileInfoR\x0eMultipartFiles\"\xa1\x01\n" +
+	"\x11MultipartFileInfo\x12\x1c\n" +
+	"\tPartIndex\x18\x01 \x01(\x05R\tPartIndex\x12\x1c\n" +
+	"\tFieldName\x18\x02 \x01(\tR\tFieldName\x12\x1a\n" +
+	"\bFilename\x18\x03 \x01(\tR\bFilename\x12 \n" +
+	"\vContentType\x18\x04 \x01(\tR\vContentType\x12\x12\n" +
+	"\x04Size\x18\x05 \x01(\x03R\x04Size\"\xa9\x01\n" +
 	"\rFuzzableParam\x12\x1a\n" +
 	"\bPosition\x18\x01 \x01(\tR\bPosition\x12\x1c\n" +
 	"\tParamName\x18\x02 \x01(\tR\tParamName\x12 \n" +
@@ -79982,7 +80091,7 @@ func file_yakgrpc_proto_rawDescGZIP() []byte {
 }
 
 var file_yakgrpc_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_yakgrpc_proto_msgTypes = make([]protoimpl.MessageInfo, 1020)
+var file_yakgrpc_proto_msgTypes = make([]protoimpl.MessageInfo, 1021)
 var file_yakgrpc_proto_goTypes = []any{
 	(ShellType)(0),   // 0: ypb.ShellType
 	(ShellScript)(0), // 1: ypb.ShellScript
@@ -80714,312 +80823,313 @@ var file_yakgrpc_proto_goTypes = []any{
 	(*HTTPHeader)(nil),                                        // 727: ypb.HTTPHeader
 	(*HTTPFlows)(nil),                                         // 728: ypb.HTTPFlows
 	(*HTTPFlow)(nil),                                          // 729: ypb.HTTPFlow
-	(*FuzzableParam)(nil),                                     // 730: ypb.FuzzableParam
-	(*GetHTTPFlowBodyByIdResponse)(nil),                       // 731: ypb.GetHTTPFlowBodyByIdResponse
-	(*QueryHTTPFlowResponse)(nil),                             // 732: ypb.QueryHTTPFlowResponse
-	(*HTTPFlowsFieldGroupRequest)(nil),                        // 733: ypb.HTTPFlowsFieldGroupRequest
-	(*HTTPFlowsFieldGroupResponse)(nil),                       // 734: ypb.HTTPFlowsFieldGroupResponse
-	(*HTTPFlowsShareRequest)(nil),                             // 735: ypb.HTTPFlowsShareRequest
-	(*HTTPFlowsShareResponse)(nil),                            // 736: ypb.HTTPFlowsShareResponse
-	(*HTTPFlowsExtractRequest)(nil),                           // 737: ypb.HTTPFlowsExtractRequest
-	(*TagsCode)(nil),                                          // 738: ypb.TagsCode
-	(*WebsocketFlows)(nil),                                    // 739: ypb.WebsocketFlows
-	(*WebsocketFlow)(nil),                                     // 740: ypb.WebsocketFlow
-	(*SetMITMFilterRequest)(nil),                              // 741: ypb.SetMITMFilterRequest
-	(*SetMITMFilterResponse)(nil),                             // 742: ypb.SetMITMFilterResponse
-	(*MITMRequest)(nil),                                       // 743: ypb.MITMRequest
-	(*FilterDataItem)(nil),                                    // 744: ypb.FilterDataItem
-	(*MITMFilterData)(nil),                                    // 745: ypb.MITMFilterData
-	(*Certificate)(nil),                                       // 746: ypb.Certificate
-	(*RegexOutputStage)(nil),                                  // 747: ypb.RegexOutputStage
-	(*MITMContentReplacer)(nil),                               // 748: ypb.MITMContentReplacer
-	(*RemoveHookParams)(nil),                                  // 749: ypb.RemoveHookParams
-	(*MITMResponse)(nil),                                      // 750: ypb.MITMResponse
-	(*TraceInfo)(nil),                                         // 751: ypb.TraceInfo
-	(*YakScriptHooks)(nil),                                    // 752: ypb.YakScriptHooks
-	(*YakScriptHookItem)(nil),                                 // 753: ypb.YakScriptHookItem
-	(*EchoRequest)(nil),                                       // 754: ypb.EchoRequest
-	(*EchoResposne)(nil),                                      // 755: ypb.EchoResposne
-	(*HandshakeRequest)(nil),                                  // 756: ypb.HandshakeRequest
-	(*HandshakeResponse)(nil),                                 // 757: ypb.HandshakeResponse
-	(*Input)(nil),                                             // 758: ypb.Input
-	(*Output)(nil),                                            // 759: ypb.Output
-	(*ExecParamItem)(nil),                                     // 760: ypb.ExecParamItem
-	(*ExecRequest)(nil),                                       // 761: ypb.ExecRequest
-	(*ExecResult)(nil),                                        // 762: ypb.ExecResult
-	(*GetLicenseResponse)(nil),                                // 763: ypb.GetLicenseResponse
-	(*CheckLicenseRequest)(nil),                               // 764: ypb.CheckLicenseRequest
-	(*DefaultDnsServerResponse)(nil),                          // 765: ypb.DefaultDnsServerResponse
-	(*HTTPFlowBareRequest)(nil),                               // 766: ypb.HTTPFlowBareRequest
-	(*HTTPFlowBareResponse)(nil),                              // 767: ypb.HTTPFlowBareResponse
-	(*ImportHTTPFuzzerTaskFromYamlRequest)(nil),               // 768: ypb.ImportHTTPFuzzerTaskFromYamlRequest
-	(*ImportHTTPFuzzerTaskFromYamlResponse)(nil),              // 769: ypb.ImportHTTPFuzzerTaskFromYamlResponse
-	(*ExportHTTPFuzzerTaskToYamlRequest)(nil),                 // 770: ypb.ExportHTTPFuzzerTaskToYamlRequest
-	(*ExportHTTPFuzzerTaskToYamlResponse)(nil),                // 771: ypb.ExportHTTPFuzzerTaskToYamlResponse
-	(*RenderHTTPFuzzerPacketRequest)(nil),                     // 772: ypb.RenderHTTPFuzzerPacketRequest
-	(*RenderHTTPFuzzerPacketResponse)(nil),                    // 773: ypb.RenderHTTPFuzzerPacketResponse
-	(*SmokingEvaluatePluginBatchRequest)(nil),                 // 774: ypb.SmokingEvaluatePluginBatchRequest
-	(*SmokingEvaluatePluginBatchResponse)(nil),                // 775: ypb.SmokingEvaluatePluginBatchResponse
-	(*GenerateURLRequest)(nil),                                // 776: ypb.GenerateURLRequest
-	(*GenerateURLResponse)(nil),                               // 777: ypb.GenerateURLResponse
-	(*YakVersionAtLeastRequest)(nil),                          // 778: ypb.YakVersionAtLeastRequest
-	(*ParseTrafficRequest)(nil),                               // 779: ypb.ParseTrafficRequest
-	(*ParseTrafficResponse)(nil),                              // 780: ypb.ParseTrafficResponse
-	(*TraceRouteRequest)(nil),                                 // 781: ypb.TraceRouteRequest
-	(*TraceRouteResponse)(nil),                                // 782: ypb.TraceRouteResponse
-	(*EvaluateExpressionRequest)(nil),                         // 783: ypb.EvaluateExpressionRequest
-	(*EvaluateExpressionResponse)(nil),                        // 784: ypb.EvaluateExpressionResponse
-	(*EvaluateMultiExpressionRequest)(nil),                    // 785: ypb.EvaluateMultiExpressionRequest
-	(*EvaluateMultiExpressionResponse)(nil),                   // 786: ypb.EvaluateMultiExpressionResponse
-	(*ThirdPartyAppConfigItemTemplate)(nil),                   // 787: ypb.ThirdPartyAppConfigItemTemplate
-	(*GetThirdPartyAppConfigTemplate)(nil),                    // 788: ypb.GetThirdPartyAppConfigTemplate
-	(*GetThirdPartyAppConfigTemplateResponse)(nil),            // 789: ypb.GetThirdPartyAppConfigTemplateResponse
-	(*GetApiKeyByOnlineRequest)(nil),                          // 790: ypb.GetApiKeyByOnlineRequest
-	(*GetApiKeyByOnlineResponse)(nil),                         // 791: ypb.GetApiKeyByOnlineResponse
-	(*GetFingerprintRequest)(nil),                             // 792: ypb.GetFingerprintRequest
-	(*GetFingerprintResponse)(nil),                            // 793: ypb.GetFingerprintResponse
-	(*AddFingerprintRequest)(nil),                             // 794: ypb.AddFingerprintRequest
-	(*AddFingerprintResponse)(nil),                            // 795: ypb.AddFingerprintResponse
-	(*ModifyFingerprintRequest)(nil),                          // 796: ypb.ModifyFingerprintRequest
-	(*ModifyFingerprintResponse)(nil),                         // 797: ypb.ModifyFingerprintResponse
-	(*ReadFileRequest)(nil),                                   // 798: ypb.ReadFileRequest
-	(*ReadFileResponse)(nil),                                  // 799: ypb.ReadFileResponse
-	(*GetReverseShellProgramListRequest)(nil),                 // 800: ypb.GetReverseShellProgramListRequest
-	(*GetReverseShellProgramListResponse)(nil),                // 801: ypb.GetReverseShellProgramListResponse
-	(*GenerateReverseShellCommandRequest)(nil),                // 802: ypb.GenerateReverseShellCommandRequest
-	(*GenerateReverseShellCommandResponse)(nil),               // 803: ypb.GenerateReverseShellCommandResponse
-	(*DbOperateMessage)(nil),                                  // 804: ypb.DbOperateMessage
-	(*CPE)(nil),                                               // 805: ypb.CPE
-	(*FingerprintRule)(nil),                                   // 806: ypb.FingerprintRule
-	(*FingerprintFilter)(nil),                                 // 807: ypb.FingerprintFilter
-	(*QueryFingerprintRequest)(nil),                           // 808: ypb.QueryFingerprintRequest
-	(*QueryFingerprintResponse)(nil),                          // 809: ypb.QueryFingerprintResponse
-	(*DeleteFingerprintRequest)(nil),                          // 810: ypb.DeleteFingerprintRequest
-	(*CreateFingerprintRequest)(nil),                          // 811: ypb.CreateFingerprintRequest
-	(*UpdateFingerprintRequest)(nil),                          // 812: ypb.UpdateFingerprintRequest
-	(*FingerprintGroup)(nil),                                  // 813: ypb.FingerprintGroup
-	(*FingerprintGroups)(nil),                                 // 814: ypb.FingerprintGroups
-	(*RenameFingerprintGroupRequest)(nil),                     // 815: ypb.RenameFingerprintGroupRequest
-	(*DeleteFingerprintGroupRequest)(nil),                     // 816: ypb.DeleteFingerprintGroupRequest
-	(*BatchUpdateFingerprintToGroupRequest)(nil),              // 817: ypb.BatchUpdateFingerprintToGroupRequest
-	(*GetFingerprintGroupSetRequest)(nil),                     // 818: ypb.GetFingerprintGroupSetRequest
-	(*ExportFingerprintRequest)(nil),                          // 819: ypb.ExportFingerprintRequest
-	(*ImportFingerprintRequest)(nil),                          // 820: ypb.ImportFingerprintRequest
-	(*DataTransferProgress)(nil),                              // 821: ypb.DataTransferProgress
-	(*QuerySyntaxFlowRuleRequest)(nil),                        // 822: ypb.QuerySyntaxFlowRuleRequest
-	(*SyntaxFlowRule)(nil),                                    // 823: ypb.SyntaxFlowRule
-	(*AlertMessage)(nil),                                      // 824: ypb.AlertMessage
-	(*SyntaxFlowRuleInput)(nil),                               // 825: ypb.SyntaxFlowRuleInput
-	(*SyntaxFlowRuleFilter)(nil),                              // 826: ypb.SyntaxFlowRuleFilter
-	(*SSAProgram)(nil),                                        // 827: ypb.SSAProgram
-	(*SSARiskDiffItem)(nil),                                   // 828: ypb.SSARiskDiffItem
-	(*SSARiskDiffRequest)(nil),                                // 829: ypb.SSARiskDiffRequest
-	(*SSARiskDiffResponse)(nil),                               // 830: ypb.SSARiskDiffResponse
-	(*SSAProgramInput)(nil),                                   // 831: ypb.SSAProgramInput
-	(*SSAProgramFilter)(nil),                                  // 832: ypb.SSAProgramFilter
-	(*QuerySSAProgramRequest)(nil),                            // 833: ypb.QuerySSAProgramRequest
-	(*UpdateSSAProgramRequest)(nil),                           // 834: ypb.UpdateSSAProgramRequest
-	(*DeleteSSAProgramRequest)(nil),                           // 835: ypb.DeleteSSAProgramRequest
-	(*QuerySSAProgramResponse)(nil),                           // 836: ypb.QuerySSAProgramResponse
-	(*CreateSyntaxFlowRuleRequest)(nil),                       // 837: ypb.CreateSyntaxFlowRuleRequest
-	(*CreateSyntaxFlowRuleResponse)(nil),                      // 838: ypb.CreateSyntaxFlowRuleResponse
-	(*UpdateSyntaxFlowRuleRequest)(nil),                       // 839: ypb.UpdateSyntaxFlowRuleRequest
-	(*UpdateSyntaxFlowRuleResponse)(nil),                      // 840: ypb.UpdateSyntaxFlowRuleResponse
-	(*QuerySyntaxFlowRuleResponse)(nil),                       // 841: ypb.QuerySyntaxFlowRuleResponse
-	(*DeleteSyntaxFlowRuleRequest)(nil),                       // 842: ypb.DeleteSyntaxFlowRuleRequest
-	(*CheckSyntaxFlowRuleUpdateRequest)(nil),                  // 843: ypb.CheckSyntaxFlowRuleUpdateRequest
-	(*CheckSyntaxFlowRuleUpdateResponse)(nil),                 // 844: ypb.CheckSyntaxFlowRuleUpdateResponse
-	(*ApplySyntaxFlowRuleUpdateRequest)(nil),                  // 845: ypb.ApplySyntaxFlowRuleUpdateRequest
-	(*ApplySyntaxFlowRuleUpdateResponse)(nil),                 // 846: ypb.ApplySyntaxFlowRuleUpdateResponse
-	(*SyntaxFlowRuleGroupFilter)(nil),                         // 847: ypb.SyntaxFlowRuleGroupFilter
-	(*SyntaxFlowGroup)(nil),                                   // 848: ypb.SyntaxFlowGroup
-	(*QuerySyntaxFlowRuleGroupRequest)(nil),                   // 849: ypb.QuerySyntaxFlowRuleGroupRequest
-	(*QuerySyntaxFlowRuleGroupResponse)(nil),                  // 850: ypb.QuerySyntaxFlowRuleGroupResponse
-	(*CreateSyntaxFlowGroupRequest)(nil),                      // 851: ypb.CreateSyntaxFlowGroupRequest
-	(*UpdateSyntaxFlowRuleGroupRequest)(nil),                  // 852: ypb.UpdateSyntaxFlowRuleGroupRequest
-	(*UpdateSyntaxFlowRuleAndGroupRequest)(nil),               // 853: ypb.UpdateSyntaxFlowRuleAndGroupRequest
-	(*QuerySyntaxFlowSameGroupRequest)(nil),                   // 854: ypb.QuerySyntaxFlowSameGroupRequest
-	(*QuerySyntaxFlowSameGroupResponse)(nil),                  // 855: ypb.QuerySyntaxFlowSameGroupResponse
-	(*DeleteSyntaxFlowRuleGroupRequest)(nil),                  // 856: ypb.DeleteSyntaxFlowRuleGroupRequest
-	(*SyntaxFlowRuleToOnlineRequest)(nil),                     // 857: ypb.SyntaxFlowRuleToOnlineRequest
-	(*SyntaxFlowRuleOnlineProgress)(nil),                      // 858: ypb.SyntaxFlowRuleOnlineProgress
-	(*DownloadSyntaxFlowRuleRequest)(nil),                     // 859: ypb.DownloadSyntaxFlowRuleRequest
-	(*SyntaxFlowScanRequest)(nil),                             // 860: ypb.SyntaxFlowScanRequest
-	(*QuerySyntaxFlowScanTaskRequest)(nil),                    // 861: ypb.QuerySyntaxFlowScanTaskRequest
-	(*SyntaxFlowScanTaskFilter)(nil),                          // 862: ypb.SyntaxFlowScanTaskFilter
-	(*QuerySyntaxFlowScanTaskResponse)(nil),                   // 863: ypb.QuerySyntaxFlowScanTaskResponse
-	(*SyntaxFlowScanTask)(nil),                                // 864: ypb.SyntaxFlowScanTask
-	(*DeleteSyntaxFlowScanTaskRequest)(nil),                   // 865: ypb.DeleteSyntaxFlowScanTaskRequest
-	(*SyntaxFlowScanResponse)(nil),                            // 866: ypb.SyntaxFlowScanResponse
-	(*SyntaxFlowScanActiveTask)(nil),                          // 867: ypb.SyntaxFlowScanActiveTask
-	(*SyntaxFlowResultFilter)(nil),                            // 868: ypb.SyntaxFlowResultFilter
-	(*QuerySyntaxFlowResultRequest)(nil),                      // 869: ypb.QuerySyntaxFlowResultRequest
-	(*QuerySyntaxFlowResultResponse)(nil),                     // 870: ypb.QuerySyntaxFlowResultResponse
-	(*SyntaxFlowResult)(nil),                                  // 871: ypb.SyntaxFlowResult
-	(*DeleteSyntaxFlowResultRequest)(nil),                     // 872: ypb.DeleteSyntaxFlowResultRequest
-	(*DeleteSyntaxFlowResultResponse)(nil),                    // 873: ypb.DeleteSyntaxFlowResultResponse
-	(*QueryPluginEnvRequest)(nil),                             // 874: ypb.QueryPluginEnvRequest
-	(*PluginEnvData)(nil),                                     // 875: ypb.PluginEnvData
-	(*DeletePluginEnvRequest)(nil),                            // 876: ypb.DeletePluginEnvRequest
-	(*GetAllFuzztagInfoRequest)(nil),                          // 877: ypb.GetAllFuzztagInfoRequest
-	(*GetAllFuzztagInfoResponse)(nil),                         // 878: ypb.GetAllFuzztagInfoResponse
-	(*FuzztagArgumentType)(nil),                               // 879: ypb.FuzztagArgumentType
-	(*FuzztagInfo)(nil),                                       // 880: ypb.FuzztagInfo
-	(*GenerateFuzztagRequest)(nil),                            // 881: ypb.GenerateFuzztagRequest
-	(*GenerateFuzztagResponse)(nil),                           // 882: ypb.GenerateFuzztagResponse
-	(*FuzzTagSuggestionRequest)(nil),                          // 883: ypb.FuzzTagSuggestionRequest
-	(*SSARisk)(nil),                                           // 884: ypb.SSARisk
-	(*SSARisksFilter)(nil),                                    // 885: ypb.SSARisksFilter
-	(*QuerySSARisksRequest)(nil),                              // 886: ypb.QuerySSARisksRequest
-	(*QuerySSARisksResponse)(nil),                             // 887: ypb.QuerySSARisksResponse
-	(*QueryNewSSARisksRequest)(nil),                           // 888: ypb.QueryNewSSARisksRequest
-	(*QueryNewSSARisksResponse)(nil),                          // 889: ypb.QueryNewSSARisksResponse
-	(*DeleteSSARisksRequest)(nil),                             // 890: ypb.DeleteSSARisksRequest
-	(*UpdateSSARiskTagsRequest)(nil),                          // 891: ypb.UpdateSSARiskTagsRequest
-	(*GetSSARiskFieldGroupRequest)(nil),                       // 892: ypb.GetSSARiskFieldGroupRequest
-	(*SSARiskFieldGroupResponse)(nil),                         // 893: ypb.SSARiskFieldGroupResponse
-	(*NewSSARiskReadRequest)(nil),                             // 894: ypb.NewSSARiskReadRequest
-	(*NewSSARiskReadResponse)(nil),                            // 895: ypb.NewSSARiskReadResponse
-	(*ExportSSARiskRequest)(nil),                              // 896: ypb.ExportSSARiskRequest
-	(*ExportSSARiskResponse)(nil),                             // 897: ypb.ExportSSARiskResponse
-	(*ImportSSARiskRequest)(nil),                              // 898: ypb.ImportSSARiskRequest
-	(*ImportSSARiskResponse)(nil),                             // 899: ypb.ImportSSARiskResponse
-	(*SSARiskFeedbackToOnlineRequest)(nil),                    // 900: ypb.SSARiskFeedbackToOnlineRequest
-	(*SSARiskDisposalData)(nil),                               // 901: ypb.SSARiskDisposalData
-	(*SSARiskDisposalsFilter)(nil),                            // 902: ypb.SSARiskDisposalsFilter
-	(*CreateSSARiskDisposalsRequest)(nil),                     // 903: ypb.CreateSSARiskDisposalsRequest
-	(*CreateSSARiskDisposalsResponse)(nil),                    // 904: ypb.CreateSSARiskDisposalsResponse
-	(*QuerySSARiskDisposalsRequest)(nil),                      // 905: ypb.QuerySSARiskDisposalsRequest
-	(*QuerySSARiskDisposalsResponse)(nil),                     // 906: ypb.QuerySSARiskDisposalsResponse
-	(*UpdateSSARiskDisposalsRequest)(nil),                     // 907: ypb.UpdateSSARiskDisposalsRequest
-	(*UpdateSSARiskDisposalsResponse)(nil),                    // 908: ypb.UpdateSSARiskDisposalsResponse
-	(*DeleteSSARiskDisposalsRequest)(nil),                     // 909: ypb.DeleteSSARiskDisposalsRequest
-	(*DeleteSSARiskDisposalsResponse)(nil),                    // 910: ypb.DeleteSSARiskDisposalsResponse
-	(*GetSSARiskDisposalRequest)(nil),                         // 911: ypb.GetSSARiskDisposalRequest
-	(*GetSSARiskDisposalResponse)(nil),                        // 912: ypb.GetSSARiskDisposalResponse
-	(*ExportSyntaxFlowsRequest)(nil),                          // 913: ypb.ExportSyntaxFlowsRequest
-	(*ImportSyntaxFlowsRequest)(nil),                          // 914: ypb.ImportSyntaxFlowsRequest
-	(*SyntaxflowsProgress)(nil),                               // 915: ypb.SyntaxflowsProgress
-	(*HotPatchTemplate)(nil),                                  // 916: ypb.HotPatchTemplate
-	(*HotPatchTemplateRequest)(nil),                           // 917: ypb.HotPatchTemplateRequest
-	(*UpdateHotPatchTemplateRequest)(nil),                     // 918: ypb.UpdateHotPatchTemplateRequest
-	(*DeleteHotPatchTemplateRequest)(nil),                     // 919: ypb.DeleteHotPatchTemplateRequest
-	(*CreateHotPatchTemplateResponse)(nil),                    // 920: ypb.CreateHotPatchTemplateResponse
-	(*DeleteHotPatchTemplateResponse)(nil),                    // 921: ypb.DeleteHotPatchTemplateResponse
-	(*UpdateHotPatchTemplateResponse)(nil),                    // 922: ypb.UpdateHotPatchTemplateResponse
-	(*QueryHotPatchTemplateResponse)(nil),                     // 923: ypb.QueryHotPatchTemplateResponse
-	(*QueryHotPatchTemplateListRequest)(nil),                  // 924: ypb.QueryHotPatchTemplateListRequest
-	(*QueryHotPatchTemplateListResponse)(nil),                 // 925: ypb.QueryHotPatchTemplateListResponse
-	(*GetHotPatchTemplateTagsResponse)(nil),                   // 926: ypb.GetHotPatchTemplateTagsResponse
-	(*GlobalHotPatchTemplateRef)(nil),                         // 927: ypb.GlobalHotPatchTemplateRef
-	(*GlobalHotPatchConfig)(nil),                              // 928: ypb.GlobalHotPatchConfig
-	(*SetGlobalHotPatchConfigRequest)(nil),                    // 929: ypb.SetGlobalHotPatchConfigRequest
-	(*GroupTableColumnRequest)(nil),                           // 930: ypb.GroupTableColumnRequest
-	(*GroupTableColumnResponse)(nil),                          // 931: ypb.GroupTableColumnResponse
-	(*UploadHotPatchTemplateToOnlineRequest)(nil),             // 932: ypb.UploadHotPatchTemplateToOnlineRequest
-	(*DownloadHotPatchTemplateRequest)(nil),                   // 933: ypb.DownloadHotPatchTemplateRequest
-	(*ExportHTTPFlowStreamRequest)(nil),                       // 934: ypb.ExportHTTPFlowStreamRequest
-	(*ExportHTTPFlowStreamResponse)(nil),                      // 935: ypb.ExportHTTPFlowStreamResponse
-	(*ImportHTTPFlowStreamRequest)(nil),                       // 936: ypb.ImportHTTPFlowStreamRequest
-	(*ImportHTTPFlowStreamResponse)(nil),                      // 937: ypb.ImportHTTPFlowStreamResponse
-	(*Note)(nil),                                              // 938: ypb.Note
-	(*NoteContent)(nil),                                       // 939: ypb.NoteContent
-	(*NoteFilter)(nil),                                        // 940: ypb.NoteFilter
-	(*CreateNoteRequest)(nil),                                 // 941: ypb.CreateNoteRequest
-	(*CreateNoteResponse)(nil),                                // 942: ypb.CreateNoteResponse
-	(*UpdateNoteRequest)(nil),                                 // 943: ypb.UpdateNoteRequest
-	(*DeleteNoteRequest)(nil),                                 // 944: ypb.DeleteNoteRequest
-	(*QueryNoteRequest)(nil),                                  // 945: ypb.QueryNoteRequest
-	(*QueryNoteResponse)(nil),                                 // 946: ypb.QueryNoteResponse
-	(*SearchNoteContentRequest)(nil),                          // 947: ypb.SearchNoteContentRequest
-	(*SearchNoteContentResponse)(nil),                         // 948: ypb.SearchNoteContentResponse
-	(*ImportNoteRequest)(nil),                                 // 949: ypb.ImportNoteRequest
-	(*ImportNoteResponse)(nil),                                // 950: ypb.ImportNoteResponse
-	(*ExportNoteRequest)(nil),                                 // 951: ypb.ExportNoteRequest
-	(*ExportNoteResponse)(nil),                                // 952: ypb.ExportNoteResponse
-	(*ListAiModelRequest)(nil),                                // 953: ypb.ListAiModelRequest
-	(*ListAiModelResponse)(nil),                               // 954: ypb.ListAiModelResponse
-	(*AIConfigHealthCheckRequest)(nil),                        // 955: ypb.AIConfigHealthCheckRequest
-	(*AIConfigHealthCheckResponse)(nil),                       // 956: ypb.AIConfigHealthCheckResponse
-	(*AIProvider)(nil),                                        // 957: ypb.AIProvider
-	(*AIProviderFilter)(nil),                                  // 958: ypb.AIProviderFilter
-	(*QueryAIProvidersRequest)(nil),                           // 959: ypb.QueryAIProvidersRequest
-	(*QueryAIProvidersResponse)(nil),                          // 960: ypb.QueryAIProvidersResponse
-	(*ListAIProvidersResponse)(nil),                           // 961: ypb.ListAIProvidersResponse
-	(*UpsertAIProviderRequest)(nil),                           // 962: ypb.UpsertAIProviderRequest
-	(*UpsertAIProviderResponse)(nil),                          // 963: ypb.UpsertAIProviderResponse
-	(*DeleteAIProviderRequest)(nil),                           // 964: ypb.DeleteAIProviderRequest
-	(*AIModelConfig)(nil),                                     // 965: ypb.AIModelConfig
-	(*AIGlobalConfig)(nil),                                    // 966: ypb.AIGlobalConfig
-	(*IsLlamaServerReadyResponse)(nil),                        // 967: ypb.IsLlamaServerReadyResponse
-	(*IsLocalModelReadyRequest)(nil),                          // 968: ypb.IsLocalModelReadyRequest
-	(*IsLocalModelReadyResponse)(nil),                         // 969: ypb.IsLocalModelReadyResponse
-	(*InstallLlamaServerRequest)(nil),                         // 970: ypb.InstallLlamaServerRequest
-	(*StartLocalModelRequest)(nil),                            // 971: ypb.StartLocalModelRequest
-	(*DownloadLocalModelRequest)(nil),                         // 972: ypb.DownloadLocalModelRequest
-	(*LocalModelConfig)(nil),                                  // 973: ypb.LocalModelConfig
-	(*GetSupportedLocalModelsResponse)(nil),                   // 974: ypb.GetSupportedLocalModelsResponse
-	(*WatchProcessStartParams)(nil),                           // 975: ypb.WatchProcessStartParams
-	(*WatchProcessRequest)(nil),                               // 976: ypb.WatchProcessRequest
-	(*ProcessInfo)(nil),                                       // 977: ypb.ProcessInfo
-	(*ConnectionInfo)(nil),                                    // 978: ypb.ConnectionInfo
-	(*WatchProcessResponse)(nil),                              // 979: ypb.WatchProcessResponse
-	(*MITMV2Request)(nil),                                     // 980: ypb.MITMV2Request
-	(*MITMV2Response)(nil),                                    // 981: ypb.MITMV2Response
-	(*SingleManualHijackControlMessage)(nil),                  // 982: ypb.SingleManualHijackControlMessage
-	(*SingleManualHijackInfoMessage)(nil),                     // 983: ypb.SingleManualHijackInfoMessage
-	(*QueryMITMReplacerRulesRequest)(nil),                     // 984: ypb.QueryMITMReplacerRulesRequest
-	(*QueryMITMReplacerRulesResponse)(nil),                    // 985: ypb.QueryMITMReplacerRulesResponse
-	(*PluginExecutionTrace)(nil),                              // 986: ypb.PluginExecutionTrace
-	(*PluginTraceRequest)(nil),                                // 987: ypb.PluginTraceRequest
-	(*PluginTraceResponse)(nil),                               // 988: ypb.PluginTraceResponse
-	(*PluginTraceStats)(nil),                                  // 989: ypb.PluginTraceStats
-	(*GenerateSSAReportRequest)(nil),                          // 990: ypb.GenerateSSAReportRequest
-	(*GenerateSSAReportResponse)(nil),                         // 991: ypb.GenerateSSAReportResponse
-	(*SSAProject)(nil),                                        // 992: ypb.SSAProject
-	(*SSAProjectCompileConfig)(nil),                           // 993: ypb.SSAProjectCompileConfig
-	(*SSAProjectScanConfig)(nil),                              // 994: ypb.SSAProjectScanConfig
-	(*SSAProjectScanRuleConfig)(nil),                          // 995: ypb.SSAProjectScanRuleConfig
-	(*SSAProjectFilter)(nil),                                  // 996: ypb.SSAProjectFilter
-	(*CreateSSAProjectRequest)(nil),                           // 997: ypb.CreateSSAProjectRequest
-	(*CreateSSAProjectResponse)(nil),                          // 998: ypb.CreateSSAProjectResponse
-	(*UpdateSSAProjectRequest)(nil),                           // 999: ypb.UpdateSSAProjectRequest
-	(*UpdateSSAProjectResponse)(nil),                          // 1000: ypb.UpdateSSAProjectResponse
-	(*DeleteSSAProjectRequest)(nil),                           // 1001: ypb.DeleteSSAProjectRequest
-	(*DeleteSSAProjectResponse)(nil),                          // 1002: ypb.DeleteSSAProjectResponse
-	(*QuerySSAProjectRequest)(nil),                            // 1003: ypb.QuerySSAProjectRequest
-	(*QuerySSAProjectResponse)(nil),                           // 1004: ypb.QuerySSAProjectResponse
-	(*MigrateSSAProjectRequest)(nil),                          // 1005: ypb.MigrateSSAProjectRequest
-	(*MigrateSSAProjectResponse)(nil),                         // 1006: ypb.MigrateSSAProjectResponse
-	(*GetSSAWorkbenchDashboardRequest)(nil),                   // 1007: ypb.GetSSAWorkbenchDashboardRequest
-	(*SSAWorkbenchSummary)(nil),                               // 1008: ypb.SSAWorkbenchSummary
-	(*SSAWorkbenchRiskLevelItem)(nil),                         // 1009: ypb.SSAWorkbenchRiskLevelItem
-	(*SSAWorkbenchRiskTypeItem)(nil),                          // 1010: ypb.SSAWorkbenchRiskTypeItem
-	(*SSAWorkbenchRuleHitItem)(nil),                           // 1011: ypb.SSAWorkbenchRuleHitItem
-	(*SSAWorkbenchRecentProject)(nil),                         // 1012: ypb.SSAWorkbenchRecentProject
-	(*GetSSAWorkbenchDashboardResponse)(nil),                  // 1013: ypb.GetSSAWorkbenchDashboardResponse
-	nil,                                                       // 1014: ypb.StartIMOnboardingRequest.OptionsEntry
-	nil,                                                       // 1015: ypb.ExtractDataToFileRequest.DataEntry
-	nil,                                                       // 1016: ypb.YsoClassGeneraterOptionsWithVerbose.BindOptionsEntry
-	nil,                                                       // 1017: ypb.WebShell.HeadersEntry
-	nil,                                                       // 1018: ypb.WebShell.PostsEntry
-	nil,                                                       // 1019: ypb.UpdateWebShellRequest.HeadersEntry
-	nil,                                                       // 1020: ypb.UpdateWebShellRequest.PostsEntry
-	nil,                                                       // 1021: ypb.SyntaxFlowRule.AlertMsgEntry
-	nil,                                                       // 1022: ypb.AlertMessage.ExtraEntry
-	nil,                                                       // 1023: ypb.SyntaxFlowRuleInput.AlertMsgEntry
+	(*MultipartFileInfo)(nil),                                 // 730: ypb.MultipartFileInfo
+	(*FuzzableParam)(nil),                                     // 731: ypb.FuzzableParam
+	(*GetHTTPFlowBodyByIdResponse)(nil),                       // 732: ypb.GetHTTPFlowBodyByIdResponse
+	(*QueryHTTPFlowResponse)(nil),                             // 733: ypb.QueryHTTPFlowResponse
+	(*HTTPFlowsFieldGroupRequest)(nil),                        // 734: ypb.HTTPFlowsFieldGroupRequest
+	(*HTTPFlowsFieldGroupResponse)(nil),                       // 735: ypb.HTTPFlowsFieldGroupResponse
+	(*HTTPFlowsShareRequest)(nil),                             // 736: ypb.HTTPFlowsShareRequest
+	(*HTTPFlowsShareResponse)(nil),                            // 737: ypb.HTTPFlowsShareResponse
+	(*HTTPFlowsExtractRequest)(nil),                           // 738: ypb.HTTPFlowsExtractRequest
+	(*TagsCode)(nil),                                          // 739: ypb.TagsCode
+	(*WebsocketFlows)(nil),                                    // 740: ypb.WebsocketFlows
+	(*WebsocketFlow)(nil),                                     // 741: ypb.WebsocketFlow
+	(*SetMITMFilterRequest)(nil),                              // 742: ypb.SetMITMFilterRequest
+	(*SetMITMFilterResponse)(nil),                             // 743: ypb.SetMITMFilterResponse
+	(*MITMRequest)(nil),                                       // 744: ypb.MITMRequest
+	(*FilterDataItem)(nil),                                    // 745: ypb.FilterDataItem
+	(*MITMFilterData)(nil),                                    // 746: ypb.MITMFilterData
+	(*Certificate)(nil),                                       // 747: ypb.Certificate
+	(*RegexOutputStage)(nil),                                  // 748: ypb.RegexOutputStage
+	(*MITMContentReplacer)(nil),                               // 749: ypb.MITMContentReplacer
+	(*RemoveHookParams)(nil),                                  // 750: ypb.RemoveHookParams
+	(*MITMResponse)(nil),                                      // 751: ypb.MITMResponse
+	(*TraceInfo)(nil),                                         // 752: ypb.TraceInfo
+	(*YakScriptHooks)(nil),                                    // 753: ypb.YakScriptHooks
+	(*YakScriptHookItem)(nil),                                 // 754: ypb.YakScriptHookItem
+	(*EchoRequest)(nil),                                       // 755: ypb.EchoRequest
+	(*EchoResposne)(nil),                                      // 756: ypb.EchoResposne
+	(*HandshakeRequest)(nil),                                  // 757: ypb.HandshakeRequest
+	(*HandshakeResponse)(nil),                                 // 758: ypb.HandshakeResponse
+	(*Input)(nil),                                             // 759: ypb.Input
+	(*Output)(nil),                                            // 760: ypb.Output
+	(*ExecParamItem)(nil),                                     // 761: ypb.ExecParamItem
+	(*ExecRequest)(nil),                                       // 762: ypb.ExecRequest
+	(*ExecResult)(nil),                                        // 763: ypb.ExecResult
+	(*GetLicenseResponse)(nil),                                // 764: ypb.GetLicenseResponse
+	(*CheckLicenseRequest)(nil),                               // 765: ypb.CheckLicenseRequest
+	(*DefaultDnsServerResponse)(nil),                          // 766: ypb.DefaultDnsServerResponse
+	(*HTTPFlowBareRequest)(nil),                               // 767: ypb.HTTPFlowBareRequest
+	(*HTTPFlowBareResponse)(nil),                              // 768: ypb.HTTPFlowBareResponse
+	(*ImportHTTPFuzzerTaskFromYamlRequest)(nil),               // 769: ypb.ImportHTTPFuzzerTaskFromYamlRequest
+	(*ImportHTTPFuzzerTaskFromYamlResponse)(nil),              // 770: ypb.ImportHTTPFuzzerTaskFromYamlResponse
+	(*ExportHTTPFuzzerTaskToYamlRequest)(nil),                 // 771: ypb.ExportHTTPFuzzerTaskToYamlRequest
+	(*ExportHTTPFuzzerTaskToYamlResponse)(nil),                // 772: ypb.ExportHTTPFuzzerTaskToYamlResponse
+	(*RenderHTTPFuzzerPacketRequest)(nil),                     // 773: ypb.RenderHTTPFuzzerPacketRequest
+	(*RenderHTTPFuzzerPacketResponse)(nil),                    // 774: ypb.RenderHTTPFuzzerPacketResponse
+	(*SmokingEvaluatePluginBatchRequest)(nil),                 // 775: ypb.SmokingEvaluatePluginBatchRequest
+	(*SmokingEvaluatePluginBatchResponse)(nil),                // 776: ypb.SmokingEvaluatePluginBatchResponse
+	(*GenerateURLRequest)(nil),                                // 777: ypb.GenerateURLRequest
+	(*GenerateURLResponse)(nil),                               // 778: ypb.GenerateURLResponse
+	(*YakVersionAtLeastRequest)(nil),                          // 779: ypb.YakVersionAtLeastRequest
+	(*ParseTrafficRequest)(nil),                               // 780: ypb.ParseTrafficRequest
+	(*ParseTrafficResponse)(nil),                              // 781: ypb.ParseTrafficResponse
+	(*TraceRouteRequest)(nil),                                 // 782: ypb.TraceRouteRequest
+	(*TraceRouteResponse)(nil),                                // 783: ypb.TraceRouteResponse
+	(*EvaluateExpressionRequest)(nil),                         // 784: ypb.EvaluateExpressionRequest
+	(*EvaluateExpressionResponse)(nil),                        // 785: ypb.EvaluateExpressionResponse
+	(*EvaluateMultiExpressionRequest)(nil),                    // 786: ypb.EvaluateMultiExpressionRequest
+	(*EvaluateMultiExpressionResponse)(nil),                   // 787: ypb.EvaluateMultiExpressionResponse
+	(*ThirdPartyAppConfigItemTemplate)(nil),                   // 788: ypb.ThirdPartyAppConfigItemTemplate
+	(*GetThirdPartyAppConfigTemplate)(nil),                    // 789: ypb.GetThirdPartyAppConfigTemplate
+	(*GetThirdPartyAppConfigTemplateResponse)(nil),            // 790: ypb.GetThirdPartyAppConfigTemplateResponse
+	(*GetApiKeyByOnlineRequest)(nil),                          // 791: ypb.GetApiKeyByOnlineRequest
+	(*GetApiKeyByOnlineResponse)(nil),                         // 792: ypb.GetApiKeyByOnlineResponse
+	(*GetFingerprintRequest)(nil),                             // 793: ypb.GetFingerprintRequest
+	(*GetFingerprintResponse)(nil),                            // 794: ypb.GetFingerprintResponse
+	(*AddFingerprintRequest)(nil),                             // 795: ypb.AddFingerprintRequest
+	(*AddFingerprintResponse)(nil),                            // 796: ypb.AddFingerprintResponse
+	(*ModifyFingerprintRequest)(nil),                          // 797: ypb.ModifyFingerprintRequest
+	(*ModifyFingerprintResponse)(nil),                         // 798: ypb.ModifyFingerprintResponse
+	(*ReadFileRequest)(nil),                                   // 799: ypb.ReadFileRequest
+	(*ReadFileResponse)(nil),                                  // 800: ypb.ReadFileResponse
+	(*GetReverseShellProgramListRequest)(nil),                 // 801: ypb.GetReverseShellProgramListRequest
+	(*GetReverseShellProgramListResponse)(nil),                // 802: ypb.GetReverseShellProgramListResponse
+	(*GenerateReverseShellCommandRequest)(nil),                // 803: ypb.GenerateReverseShellCommandRequest
+	(*GenerateReverseShellCommandResponse)(nil),               // 804: ypb.GenerateReverseShellCommandResponse
+	(*DbOperateMessage)(nil),                                  // 805: ypb.DbOperateMessage
+	(*CPE)(nil),                                               // 806: ypb.CPE
+	(*FingerprintRule)(nil),                                   // 807: ypb.FingerprintRule
+	(*FingerprintFilter)(nil),                                 // 808: ypb.FingerprintFilter
+	(*QueryFingerprintRequest)(nil),                           // 809: ypb.QueryFingerprintRequest
+	(*QueryFingerprintResponse)(nil),                          // 810: ypb.QueryFingerprintResponse
+	(*DeleteFingerprintRequest)(nil),                          // 811: ypb.DeleteFingerprintRequest
+	(*CreateFingerprintRequest)(nil),                          // 812: ypb.CreateFingerprintRequest
+	(*UpdateFingerprintRequest)(nil),                          // 813: ypb.UpdateFingerprintRequest
+	(*FingerprintGroup)(nil),                                  // 814: ypb.FingerprintGroup
+	(*FingerprintGroups)(nil),                                 // 815: ypb.FingerprintGroups
+	(*RenameFingerprintGroupRequest)(nil),                     // 816: ypb.RenameFingerprintGroupRequest
+	(*DeleteFingerprintGroupRequest)(nil),                     // 817: ypb.DeleteFingerprintGroupRequest
+	(*BatchUpdateFingerprintToGroupRequest)(nil),              // 818: ypb.BatchUpdateFingerprintToGroupRequest
+	(*GetFingerprintGroupSetRequest)(nil),                     // 819: ypb.GetFingerprintGroupSetRequest
+	(*ExportFingerprintRequest)(nil),                          // 820: ypb.ExportFingerprintRequest
+	(*ImportFingerprintRequest)(nil),                          // 821: ypb.ImportFingerprintRequest
+	(*DataTransferProgress)(nil),                              // 822: ypb.DataTransferProgress
+	(*QuerySyntaxFlowRuleRequest)(nil),                        // 823: ypb.QuerySyntaxFlowRuleRequest
+	(*SyntaxFlowRule)(nil),                                    // 824: ypb.SyntaxFlowRule
+	(*AlertMessage)(nil),                                      // 825: ypb.AlertMessage
+	(*SyntaxFlowRuleInput)(nil),                               // 826: ypb.SyntaxFlowRuleInput
+	(*SyntaxFlowRuleFilter)(nil),                              // 827: ypb.SyntaxFlowRuleFilter
+	(*SSAProgram)(nil),                                        // 828: ypb.SSAProgram
+	(*SSARiskDiffItem)(nil),                                   // 829: ypb.SSARiskDiffItem
+	(*SSARiskDiffRequest)(nil),                                // 830: ypb.SSARiskDiffRequest
+	(*SSARiskDiffResponse)(nil),                               // 831: ypb.SSARiskDiffResponse
+	(*SSAProgramInput)(nil),                                   // 832: ypb.SSAProgramInput
+	(*SSAProgramFilter)(nil),                                  // 833: ypb.SSAProgramFilter
+	(*QuerySSAProgramRequest)(nil),                            // 834: ypb.QuerySSAProgramRequest
+	(*UpdateSSAProgramRequest)(nil),                           // 835: ypb.UpdateSSAProgramRequest
+	(*DeleteSSAProgramRequest)(nil),                           // 836: ypb.DeleteSSAProgramRequest
+	(*QuerySSAProgramResponse)(nil),                           // 837: ypb.QuerySSAProgramResponse
+	(*CreateSyntaxFlowRuleRequest)(nil),                       // 838: ypb.CreateSyntaxFlowRuleRequest
+	(*CreateSyntaxFlowRuleResponse)(nil),                      // 839: ypb.CreateSyntaxFlowRuleResponse
+	(*UpdateSyntaxFlowRuleRequest)(nil),                       // 840: ypb.UpdateSyntaxFlowRuleRequest
+	(*UpdateSyntaxFlowRuleResponse)(nil),                      // 841: ypb.UpdateSyntaxFlowRuleResponse
+	(*QuerySyntaxFlowRuleResponse)(nil),                       // 842: ypb.QuerySyntaxFlowRuleResponse
+	(*DeleteSyntaxFlowRuleRequest)(nil),                       // 843: ypb.DeleteSyntaxFlowRuleRequest
+	(*CheckSyntaxFlowRuleUpdateRequest)(nil),                  // 844: ypb.CheckSyntaxFlowRuleUpdateRequest
+	(*CheckSyntaxFlowRuleUpdateResponse)(nil),                 // 845: ypb.CheckSyntaxFlowRuleUpdateResponse
+	(*ApplySyntaxFlowRuleUpdateRequest)(nil),                  // 846: ypb.ApplySyntaxFlowRuleUpdateRequest
+	(*ApplySyntaxFlowRuleUpdateResponse)(nil),                 // 847: ypb.ApplySyntaxFlowRuleUpdateResponse
+	(*SyntaxFlowRuleGroupFilter)(nil),                         // 848: ypb.SyntaxFlowRuleGroupFilter
+	(*SyntaxFlowGroup)(nil),                                   // 849: ypb.SyntaxFlowGroup
+	(*QuerySyntaxFlowRuleGroupRequest)(nil),                   // 850: ypb.QuerySyntaxFlowRuleGroupRequest
+	(*QuerySyntaxFlowRuleGroupResponse)(nil),                  // 851: ypb.QuerySyntaxFlowRuleGroupResponse
+	(*CreateSyntaxFlowGroupRequest)(nil),                      // 852: ypb.CreateSyntaxFlowGroupRequest
+	(*UpdateSyntaxFlowRuleGroupRequest)(nil),                  // 853: ypb.UpdateSyntaxFlowRuleGroupRequest
+	(*UpdateSyntaxFlowRuleAndGroupRequest)(nil),               // 854: ypb.UpdateSyntaxFlowRuleAndGroupRequest
+	(*QuerySyntaxFlowSameGroupRequest)(nil),                   // 855: ypb.QuerySyntaxFlowSameGroupRequest
+	(*QuerySyntaxFlowSameGroupResponse)(nil),                  // 856: ypb.QuerySyntaxFlowSameGroupResponse
+	(*DeleteSyntaxFlowRuleGroupRequest)(nil),                  // 857: ypb.DeleteSyntaxFlowRuleGroupRequest
+	(*SyntaxFlowRuleToOnlineRequest)(nil),                     // 858: ypb.SyntaxFlowRuleToOnlineRequest
+	(*SyntaxFlowRuleOnlineProgress)(nil),                      // 859: ypb.SyntaxFlowRuleOnlineProgress
+	(*DownloadSyntaxFlowRuleRequest)(nil),                     // 860: ypb.DownloadSyntaxFlowRuleRequest
+	(*SyntaxFlowScanRequest)(nil),                             // 861: ypb.SyntaxFlowScanRequest
+	(*QuerySyntaxFlowScanTaskRequest)(nil),                    // 862: ypb.QuerySyntaxFlowScanTaskRequest
+	(*SyntaxFlowScanTaskFilter)(nil),                          // 863: ypb.SyntaxFlowScanTaskFilter
+	(*QuerySyntaxFlowScanTaskResponse)(nil),                   // 864: ypb.QuerySyntaxFlowScanTaskResponse
+	(*SyntaxFlowScanTask)(nil),                                // 865: ypb.SyntaxFlowScanTask
+	(*DeleteSyntaxFlowScanTaskRequest)(nil),                   // 866: ypb.DeleteSyntaxFlowScanTaskRequest
+	(*SyntaxFlowScanResponse)(nil),                            // 867: ypb.SyntaxFlowScanResponse
+	(*SyntaxFlowScanActiveTask)(nil),                          // 868: ypb.SyntaxFlowScanActiveTask
+	(*SyntaxFlowResultFilter)(nil),                            // 869: ypb.SyntaxFlowResultFilter
+	(*QuerySyntaxFlowResultRequest)(nil),                      // 870: ypb.QuerySyntaxFlowResultRequest
+	(*QuerySyntaxFlowResultResponse)(nil),                     // 871: ypb.QuerySyntaxFlowResultResponse
+	(*SyntaxFlowResult)(nil),                                  // 872: ypb.SyntaxFlowResult
+	(*DeleteSyntaxFlowResultRequest)(nil),                     // 873: ypb.DeleteSyntaxFlowResultRequest
+	(*DeleteSyntaxFlowResultResponse)(nil),                    // 874: ypb.DeleteSyntaxFlowResultResponse
+	(*QueryPluginEnvRequest)(nil),                             // 875: ypb.QueryPluginEnvRequest
+	(*PluginEnvData)(nil),                                     // 876: ypb.PluginEnvData
+	(*DeletePluginEnvRequest)(nil),                            // 877: ypb.DeletePluginEnvRequest
+	(*GetAllFuzztagInfoRequest)(nil),                          // 878: ypb.GetAllFuzztagInfoRequest
+	(*GetAllFuzztagInfoResponse)(nil),                         // 879: ypb.GetAllFuzztagInfoResponse
+	(*FuzztagArgumentType)(nil),                               // 880: ypb.FuzztagArgumentType
+	(*FuzztagInfo)(nil),                                       // 881: ypb.FuzztagInfo
+	(*GenerateFuzztagRequest)(nil),                            // 882: ypb.GenerateFuzztagRequest
+	(*GenerateFuzztagResponse)(nil),                           // 883: ypb.GenerateFuzztagResponse
+	(*FuzzTagSuggestionRequest)(nil),                          // 884: ypb.FuzzTagSuggestionRequest
+	(*SSARisk)(nil),                                           // 885: ypb.SSARisk
+	(*SSARisksFilter)(nil),                                    // 886: ypb.SSARisksFilter
+	(*QuerySSARisksRequest)(nil),                              // 887: ypb.QuerySSARisksRequest
+	(*QuerySSARisksResponse)(nil),                             // 888: ypb.QuerySSARisksResponse
+	(*QueryNewSSARisksRequest)(nil),                           // 889: ypb.QueryNewSSARisksRequest
+	(*QueryNewSSARisksResponse)(nil),                          // 890: ypb.QueryNewSSARisksResponse
+	(*DeleteSSARisksRequest)(nil),                             // 891: ypb.DeleteSSARisksRequest
+	(*UpdateSSARiskTagsRequest)(nil),                          // 892: ypb.UpdateSSARiskTagsRequest
+	(*GetSSARiskFieldGroupRequest)(nil),                       // 893: ypb.GetSSARiskFieldGroupRequest
+	(*SSARiskFieldGroupResponse)(nil),                         // 894: ypb.SSARiskFieldGroupResponse
+	(*NewSSARiskReadRequest)(nil),                             // 895: ypb.NewSSARiskReadRequest
+	(*NewSSARiskReadResponse)(nil),                            // 896: ypb.NewSSARiskReadResponse
+	(*ExportSSARiskRequest)(nil),                              // 897: ypb.ExportSSARiskRequest
+	(*ExportSSARiskResponse)(nil),                             // 898: ypb.ExportSSARiskResponse
+	(*ImportSSARiskRequest)(nil),                              // 899: ypb.ImportSSARiskRequest
+	(*ImportSSARiskResponse)(nil),                             // 900: ypb.ImportSSARiskResponse
+	(*SSARiskFeedbackToOnlineRequest)(nil),                    // 901: ypb.SSARiskFeedbackToOnlineRequest
+	(*SSARiskDisposalData)(nil),                               // 902: ypb.SSARiskDisposalData
+	(*SSARiskDisposalsFilter)(nil),                            // 903: ypb.SSARiskDisposalsFilter
+	(*CreateSSARiskDisposalsRequest)(nil),                     // 904: ypb.CreateSSARiskDisposalsRequest
+	(*CreateSSARiskDisposalsResponse)(nil),                    // 905: ypb.CreateSSARiskDisposalsResponse
+	(*QuerySSARiskDisposalsRequest)(nil),                      // 906: ypb.QuerySSARiskDisposalsRequest
+	(*QuerySSARiskDisposalsResponse)(nil),                     // 907: ypb.QuerySSARiskDisposalsResponse
+	(*UpdateSSARiskDisposalsRequest)(nil),                     // 908: ypb.UpdateSSARiskDisposalsRequest
+	(*UpdateSSARiskDisposalsResponse)(nil),                    // 909: ypb.UpdateSSARiskDisposalsResponse
+	(*DeleteSSARiskDisposalsRequest)(nil),                     // 910: ypb.DeleteSSARiskDisposalsRequest
+	(*DeleteSSARiskDisposalsResponse)(nil),                    // 911: ypb.DeleteSSARiskDisposalsResponse
+	(*GetSSARiskDisposalRequest)(nil),                         // 912: ypb.GetSSARiskDisposalRequest
+	(*GetSSARiskDisposalResponse)(nil),                        // 913: ypb.GetSSARiskDisposalResponse
+	(*ExportSyntaxFlowsRequest)(nil),                          // 914: ypb.ExportSyntaxFlowsRequest
+	(*ImportSyntaxFlowsRequest)(nil),                          // 915: ypb.ImportSyntaxFlowsRequest
+	(*SyntaxflowsProgress)(nil),                               // 916: ypb.SyntaxflowsProgress
+	(*HotPatchTemplate)(nil),                                  // 917: ypb.HotPatchTemplate
+	(*HotPatchTemplateRequest)(nil),                           // 918: ypb.HotPatchTemplateRequest
+	(*UpdateHotPatchTemplateRequest)(nil),                     // 919: ypb.UpdateHotPatchTemplateRequest
+	(*DeleteHotPatchTemplateRequest)(nil),                     // 920: ypb.DeleteHotPatchTemplateRequest
+	(*CreateHotPatchTemplateResponse)(nil),                    // 921: ypb.CreateHotPatchTemplateResponse
+	(*DeleteHotPatchTemplateResponse)(nil),                    // 922: ypb.DeleteHotPatchTemplateResponse
+	(*UpdateHotPatchTemplateResponse)(nil),                    // 923: ypb.UpdateHotPatchTemplateResponse
+	(*QueryHotPatchTemplateResponse)(nil),                     // 924: ypb.QueryHotPatchTemplateResponse
+	(*QueryHotPatchTemplateListRequest)(nil),                  // 925: ypb.QueryHotPatchTemplateListRequest
+	(*QueryHotPatchTemplateListResponse)(nil),                 // 926: ypb.QueryHotPatchTemplateListResponse
+	(*GetHotPatchTemplateTagsResponse)(nil),                   // 927: ypb.GetHotPatchTemplateTagsResponse
+	(*GlobalHotPatchTemplateRef)(nil),                         // 928: ypb.GlobalHotPatchTemplateRef
+	(*GlobalHotPatchConfig)(nil),                              // 929: ypb.GlobalHotPatchConfig
+	(*SetGlobalHotPatchConfigRequest)(nil),                    // 930: ypb.SetGlobalHotPatchConfigRequest
+	(*GroupTableColumnRequest)(nil),                           // 931: ypb.GroupTableColumnRequest
+	(*GroupTableColumnResponse)(nil),                          // 932: ypb.GroupTableColumnResponse
+	(*UploadHotPatchTemplateToOnlineRequest)(nil),             // 933: ypb.UploadHotPatchTemplateToOnlineRequest
+	(*DownloadHotPatchTemplateRequest)(nil),                   // 934: ypb.DownloadHotPatchTemplateRequest
+	(*ExportHTTPFlowStreamRequest)(nil),                       // 935: ypb.ExportHTTPFlowStreamRequest
+	(*ExportHTTPFlowStreamResponse)(nil),                      // 936: ypb.ExportHTTPFlowStreamResponse
+	(*ImportHTTPFlowStreamRequest)(nil),                       // 937: ypb.ImportHTTPFlowStreamRequest
+	(*ImportHTTPFlowStreamResponse)(nil),                      // 938: ypb.ImportHTTPFlowStreamResponse
+	(*Note)(nil),                                              // 939: ypb.Note
+	(*NoteContent)(nil),                                       // 940: ypb.NoteContent
+	(*NoteFilter)(nil),                                        // 941: ypb.NoteFilter
+	(*CreateNoteRequest)(nil),                                 // 942: ypb.CreateNoteRequest
+	(*CreateNoteResponse)(nil),                                // 943: ypb.CreateNoteResponse
+	(*UpdateNoteRequest)(nil),                                 // 944: ypb.UpdateNoteRequest
+	(*DeleteNoteRequest)(nil),                                 // 945: ypb.DeleteNoteRequest
+	(*QueryNoteRequest)(nil),                                  // 946: ypb.QueryNoteRequest
+	(*QueryNoteResponse)(nil),                                 // 947: ypb.QueryNoteResponse
+	(*SearchNoteContentRequest)(nil),                          // 948: ypb.SearchNoteContentRequest
+	(*SearchNoteContentResponse)(nil),                         // 949: ypb.SearchNoteContentResponse
+	(*ImportNoteRequest)(nil),                                 // 950: ypb.ImportNoteRequest
+	(*ImportNoteResponse)(nil),                                // 951: ypb.ImportNoteResponse
+	(*ExportNoteRequest)(nil),                                 // 952: ypb.ExportNoteRequest
+	(*ExportNoteResponse)(nil),                                // 953: ypb.ExportNoteResponse
+	(*ListAiModelRequest)(nil),                                // 954: ypb.ListAiModelRequest
+	(*ListAiModelResponse)(nil),                               // 955: ypb.ListAiModelResponse
+	(*AIConfigHealthCheckRequest)(nil),                        // 956: ypb.AIConfigHealthCheckRequest
+	(*AIConfigHealthCheckResponse)(nil),                       // 957: ypb.AIConfigHealthCheckResponse
+	(*AIProvider)(nil),                                        // 958: ypb.AIProvider
+	(*AIProviderFilter)(nil),                                  // 959: ypb.AIProviderFilter
+	(*QueryAIProvidersRequest)(nil),                           // 960: ypb.QueryAIProvidersRequest
+	(*QueryAIProvidersResponse)(nil),                          // 961: ypb.QueryAIProvidersResponse
+	(*ListAIProvidersResponse)(nil),                           // 962: ypb.ListAIProvidersResponse
+	(*UpsertAIProviderRequest)(nil),                           // 963: ypb.UpsertAIProviderRequest
+	(*UpsertAIProviderResponse)(nil),                          // 964: ypb.UpsertAIProviderResponse
+	(*DeleteAIProviderRequest)(nil),                           // 965: ypb.DeleteAIProviderRequest
+	(*AIModelConfig)(nil),                                     // 966: ypb.AIModelConfig
+	(*AIGlobalConfig)(nil),                                    // 967: ypb.AIGlobalConfig
+	(*IsLlamaServerReadyResponse)(nil),                        // 968: ypb.IsLlamaServerReadyResponse
+	(*IsLocalModelReadyRequest)(nil),                          // 969: ypb.IsLocalModelReadyRequest
+	(*IsLocalModelReadyResponse)(nil),                         // 970: ypb.IsLocalModelReadyResponse
+	(*InstallLlamaServerRequest)(nil),                         // 971: ypb.InstallLlamaServerRequest
+	(*StartLocalModelRequest)(nil),                            // 972: ypb.StartLocalModelRequest
+	(*DownloadLocalModelRequest)(nil),                         // 973: ypb.DownloadLocalModelRequest
+	(*LocalModelConfig)(nil),                                  // 974: ypb.LocalModelConfig
+	(*GetSupportedLocalModelsResponse)(nil),                   // 975: ypb.GetSupportedLocalModelsResponse
+	(*WatchProcessStartParams)(nil),                           // 976: ypb.WatchProcessStartParams
+	(*WatchProcessRequest)(nil),                               // 977: ypb.WatchProcessRequest
+	(*ProcessInfo)(nil),                                       // 978: ypb.ProcessInfo
+	(*ConnectionInfo)(nil),                                    // 979: ypb.ConnectionInfo
+	(*WatchProcessResponse)(nil),                              // 980: ypb.WatchProcessResponse
+	(*MITMV2Request)(nil),                                     // 981: ypb.MITMV2Request
+	(*MITMV2Response)(nil),                                    // 982: ypb.MITMV2Response
+	(*SingleManualHijackControlMessage)(nil),                  // 983: ypb.SingleManualHijackControlMessage
+	(*SingleManualHijackInfoMessage)(nil),                     // 984: ypb.SingleManualHijackInfoMessage
+	(*QueryMITMReplacerRulesRequest)(nil),                     // 985: ypb.QueryMITMReplacerRulesRequest
+	(*QueryMITMReplacerRulesResponse)(nil),                    // 986: ypb.QueryMITMReplacerRulesResponse
+	(*PluginExecutionTrace)(nil),                              // 987: ypb.PluginExecutionTrace
+	(*PluginTraceRequest)(nil),                                // 988: ypb.PluginTraceRequest
+	(*PluginTraceResponse)(nil),                               // 989: ypb.PluginTraceResponse
+	(*PluginTraceStats)(nil),                                  // 990: ypb.PluginTraceStats
+	(*GenerateSSAReportRequest)(nil),                          // 991: ypb.GenerateSSAReportRequest
+	(*GenerateSSAReportResponse)(nil),                         // 992: ypb.GenerateSSAReportResponse
+	(*SSAProject)(nil),                                        // 993: ypb.SSAProject
+	(*SSAProjectCompileConfig)(nil),                           // 994: ypb.SSAProjectCompileConfig
+	(*SSAProjectScanConfig)(nil),                              // 995: ypb.SSAProjectScanConfig
+	(*SSAProjectScanRuleConfig)(nil),                          // 996: ypb.SSAProjectScanRuleConfig
+	(*SSAProjectFilter)(nil),                                  // 997: ypb.SSAProjectFilter
+	(*CreateSSAProjectRequest)(nil),                           // 998: ypb.CreateSSAProjectRequest
+	(*CreateSSAProjectResponse)(nil),                          // 999: ypb.CreateSSAProjectResponse
+	(*UpdateSSAProjectRequest)(nil),                           // 1000: ypb.UpdateSSAProjectRequest
+	(*UpdateSSAProjectResponse)(nil),                          // 1001: ypb.UpdateSSAProjectResponse
+	(*DeleteSSAProjectRequest)(nil),                           // 1002: ypb.DeleteSSAProjectRequest
+	(*DeleteSSAProjectResponse)(nil),                          // 1003: ypb.DeleteSSAProjectResponse
+	(*QuerySSAProjectRequest)(nil),                            // 1004: ypb.QuerySSAProjectRequest
+	(*QuerySSAProjectResponse)(nil),                           // 1005: ypb.QuerySSAProjectResponse
+	(*MigrateSSAProjectRequest)(nil),                          // 1006: ypb.MigrateSSAProjectRequest
+	(*MigrateSSAProjectResponse)(nil),                         // 1007: ypb.MigrateSSAProjectResponse
+	(*GetSSAWorkbenchDashboardRequest)(nil),                   // 1008: ypb.GetSSAWorkbenchDashboardRequest
+	(*SSAWorkbenchSummary)(nil),                               // 1009: ypb.SSAWorkbenchSummary
+	(*SSAWorkbenchRiskLevelItem)(nil),                         // 1010: ypb.SSAWorkbenchRiskLevelItem
+	(*SSAWorkbenchRiskTypeItem)(nil),                          // 1011: ypb.SSAWorkbenchRiskTypeItem
+	(*SSAWorkbenchRuleHitItem)(nil),                           // 1012: ypb.SSAWorkbenchRuleHitItem
+	(*SSAWorkbenchRecentProject)(nil),                         // 1013: ypb.SSAWorkbenchRecentProject
+	(*GetSSAWorkbenchDashboardResponse)(nil),                  // 1014: ypb.GetSSAWorkbenchDashboardResponse
+	nil,                                                       // 1015: ypb.StartIMOnboardingRequest.OptionsEntry
+	nil,                                                       // 1016: ypb.ExtractDataToFileRequest.DataEntry
+	nil,                                                       // 1017: ypb.YsoClassGeneraterOptionsWithVerbose.BindOptionsEntry
+	nil,                                                       // 1018: ypb.WebShell.HeadersEntry
+	nil,                                                       // 1019: ypb.WebShell.PostsEntry
+	nil,                                                       // 1020: ypb.UpdateWebShellRequest.HeadersEntry
+	nil,                                                       // 1021: ypb.UpdateWebShellRequest.PostsEntry
+	nil,                                                       // 1022: ypb.SyntaxFlowRule.AlertMsgEntry
+	nil,                                                       // 1023: ypb.AlertMessage.ExtraEntry
+	nil,                                                       // 1024: ypb.SyntaxFlowRuleInput.AlertMsgEntry
 }
 var file_yakgrpc_proto_depIdxs = []int32{
-	760,  // 0: ypb.ExecBatchYakScriptRequest.ExtraParams:type_name -> ypb.ExecParamItem
+	761,  // 0: ypb.ExecBatchYakScriptRequest.ExtraParams:type_name -> ypb.ExecParamItem
 	626,  // 1: ypb.ExecBatchYakScriptRequest.PluginFilter:type_name -> ypb.QueryYakScriptRequest
 	630,  // 2: ypb.ExecBatchYakScriptResult.PoC:type_name -> ypb.YakScript
-	762,  // 3: ypb.ExecBatchYakScriptResult.Result:type_name -> ypb.ExecResult
-	760,  // 4: ypb.ExecBatchYakScriptResult.ExtraParam:type_name -> ypb.ExecParamItem
+	763,  // 3: ypb.ExecBatchYakScriptResult.Result:type_name -> ypb.ExecResult
+	761,  // 4: ypb.ExecBatchYakScriptResult.ExtraParam:type_name -> ypb.ExecParamItem
 	14,   // 5: ypb.SaveIMBotRequest.Bot:type_name -> ypb.IMBotConfig
 	14,   // 6: ypb.SaveIMBotResponse.Bot:type_name -> ypb.IMBotConfig
 	14,   // 7: ypb.ListIMBotResponse.Bots:type_name -> ypb.IMBotConfig
 	14,   // 8: ypb.TestIMBotRequest.Bot:type_name -> ypb.IMBotConfig
-	1014, // 9: ypb.StartIMOnboardingRequest.Options:type_name -> ypb.StartIMOnboardingRequest.OptionsEntry
+	1015, // 9: ypb.StartIMOnboardingRequest.Options:type_name -> ypb.StartIMOnboardingRequest.OptionsEntry
 	14,   // 10: ypb.IMOnboardingEvent.Bot:type_name -> ypb.IMBotConfig
 	25,   // 11: ypb.StartIMControlRequest.PlatformConfigs:type_name -> ypb.IMControlRuntimeConfig
 	32,   // 12: ypb.IMControlStateEvent.State:type_name -> ypb.IMControlState
@@ -81093,7 +81203,7 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	148,  // 80: ypb.AIInputEvent.AttachedResourceInfo:type_name -> ypb.AttachedResourceInfo
 	152,  // 81: ypb.AITriageInputEvent.Params:type_name -> ypb.AIStartParams
 	150,  // 82: ypb.AIStartParams.McpServers:type_name -> ypb.McpConfig
-	760,  // 83: ypb.AIStartParams.ForgeParams:type_name -> ypb.ExecParamItem
+	761,  // 83: ypb.AIStartParams.ForgeParams:type_name -> ypb.ExecParamItem
 	151,  // 84: ypb.AIStartParams.EnabledCapabilities:type_name -> ypb.AIEnabledCapability
 	153,  // 85: ypb.AIStartParams.Strategy:type_name -> ypb.AIExecutionStrategy
 	155,  // 86: ypb.AIEventQueryRequest.Filter:type_name -> ypb.AIEventFilter
@@ -81137,13 +81247,13 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	706,  // 124: ypb.QueryAIMemoryEntityResponse.Pagination:type_name -> ypb.Paging
 	189,  // 125: ypb.QueryAIMemoryEntityResponse.Data:type_name -> ypb.AIMemoryEntity
 	190,  // 126: ypb.DeleteAIMemoryEntityRequest.Filter:type_name -> ypb.AIMemoryEntityFilter
-	738,  // 127: ypb.CountAIMemoryEntityTagsResponse.TagsCount:type_name -> ypb.TagsCode
+	739,  // 127: ypb.CountAIMemoryEntityTagsResponse.TagsCount:type_name -> ypb.TagsCode
 	207,  // 128: ypb.DeleteHybridScanTaskRequest.Filter:type_name -> ypb.HybridScanTaskFilter
 	706,  // 129: ypb.QueryHybridScanTaskResponse.Pagination:type_name -> ypb.Paging
 	204,  // 130: ypb.QueryHybridScanTaskResponse.Data:type_name -> ypb.HybridScanTask
 	706,  // 131: ypb.QueryHybridScanTaskRequest.Pagination:type_name -> ypb.Paging
 	207,  // 132: ypb.QueryHybridScanTaskRequest.Filter:type_name -> ypb.HybridScanTaskFilter
-	762,  // 133: ypb.HybridScanResponse.ExecResult:type_name -> ypb.ExecResult
+	763,  // 133: ypb.HybridScanResponse.ExecResult:type_name -> ypb.ExecResult
 	209,  // 134: ypb.HybridScanResponse.UpdateActiveTask:type_name -> ypb.HybridScanUpdateActiveTaskTable
 	212,  // 135: ypb.HybridScanResponse.HybridScanConfig:type_name -> ypb.HybridScanRequest
 	266,  // 136: ypb.HybridScanInputTarget.HTTPRequestTemplate:type_name -> ypb.HTTPRequestBuilderParams
@@ -81171,7 +81281,7 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	230,  // 158: ypb.YakURLResource.Url:type_name -> ypb.YakURL
 	698,  // 159: ypb.YakURLResource.Extra:type_name -> ypb.KVPair
 	231,  // 160: ypb.RequestYakURLResponse.Resources:type_name -> ypb.YakURLResource
-	746,  // 161: ypb.GlobalNetworkConfig.ClientCertificates:type_name -> ypb.Certificate
+	747,  // 161: ypb.GlobalNetworkConfig.ClientCertificates:type_name -> ypb.Certificate
 	249,  // 162: ypb.GlobalNetworkConfig.AppConfigs:type_name -> ypb.ThirdPartyApplicationConfig
 	248,  // 163: ypb.GlobalNetworkConfig.AuthInfos:type_name -> ypb.AuthInfo
 	241,  // 164: ypb.GlobalNetworkConfig.TieredAIModelConfig:type_name -> ypb.TieredAIModelConfigDescriptor
@@ -81223,9 +81333,9 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	706,  // 210: ypb.GetProjectsRequest.Pagination:type_name -> ypb.Paging
 	320,  // 211: ypb.GetProjectsResponse.Projects:type_name -> ypb.ProjectDescription
 	706,  // 212: ypb.GetProjectsResponse.Pagination:type_name -> ypb.Paging
-	762,  // 213: ypb.YaklangShellResponse.RawResult:type_name -> ypb.ExecResult
+	763,  // 213: ypb.YaklangShellResponse.RawResult:type_name -> ypb.ExecResult
 	330,  // 214: ypb.YaklangShellResponse.Scope:type_name -> ypb.YaklangShellKVPair
-	760,  // 215: ypb.EncodeHTTPPacketContentRequest.Params:type_name -> ypb.ExecParamItem
+	761,  // 215: ypb.EncodeHTTPPacketContentRequest.Params:type_name -> ypb.ExecParamItem
 	343,  // 216: ypb.SaveFuzzerLabelRequest.Data:type_name -> ypb.FuzzerLabel
 	343,  // 217: ypb.QueryFuzzerLabelResponse.Data:type_name -> ypb.FuzzerLabel
 	348,  // 218: ypb.SaveFuzzerConfigRequest.Data:type_name -> ypb.FuzzerConfig
@@ -81270,10 +81380,10 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	630,  // 257: ypb.QueryYakScriptByNamesResponse.Data:type_name -> ypb.YakScript
 	630,  // 258: ypb.QueryYakScriptByIsCoreResponse.Data:type_name -> ypb.YakScript
 	440,  // 259: ypb.YakScriptRiskTypeListResponse.Data:type_name -> ypb.RiskTypeLists
-	1015, // 260: ypb.ExtractDataToFileRequest.Data:type_name -> ypb.ExtractDataToFileRequest.DataEntry
-	748,  // 261: ypb.MITMContentReplacers.Rules:type_name -> ypb.MITMContentReplacer
+	1016, // 260: ypb.ExtractDataToFileRequest.Data:type_name -> ypb.ExtractDataToFileRequest.DataEntry
+	749,  // 261: ypb.MITMContentReplacers.Rules:type_name -> ypb.MITMContentReplacer
 	626,  // 262: ypb.ExecYakitPluginsByYakScriptFilterRequest.Filter:type_name -> ypb.QueryYakScriptRequest
-	760,  // 263: ypb.ExecYakitPluginsByYakScriptFilterRequest.ExtraParams:type_name -> ypb.ExecParamItem
+	761,  // 263: ypb.ExecYakitPluginsByYakScriptFilterRequest.ExtraParams:type_name -> ypb.ExecParamItem
 	3,    // 264: ypb.GenerateYakCodeByPacketRequest.CodeTemplate:type_name -> ypb.GenerateYakCodeByPacketRequest.Template
 	454,  // 265: ypb.DeleteReportRequest.Filter:type_name -> ypb.QueryReportsRequest
 	455,  // 266: ypb.QueryReportsResponse.Data:type_name -> ypb.Report
@@ -81284,7 +81394,7 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	466,  // 271: ypb.RiskTableStats.RiskLevelStats:type_name -> ypb.Fields
 	465,  // 272: ypb.Fields.Values:type_name -> ypb.FieldName
 	467,  // 273: ypb.YsoOptionsWithVerbose.Options:type_name -> ypb.YsoOption
-	1016, // 274: ypb.YsoClassGeneraterOptionsWithVerbose.BindOptions:type_name -> ypb.YsoClassGeneraterOptionsWithVerbose.BindOptionsEntry
+	1017, // 274: ypb.YsoClassGeneraterOptionsWithVerbose.BindOptions:type_name -> ypb.YsoClassGeneraterOptionsWithVerbose.BindOptionsEntry
 	470,  // 275: ypb.YsoClassOptionsResponseWithVerbose.Options:type_name -> ypb.YsoClassGeneraterOptionsWithVerbose
 	472,  // 276: ypb.YsoClassOptionsResponse.Options:type_name -> ypb.YsoClassGeneraterOptions
 	470,  // 277: ypb.YsoOptionsRequerstWithVerbose.Options:type_name -> ypb.YsoClassGeneraterOptionsWithVerbose
@@ -81296,8 +81406,8 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	487,  // 283: ypb.HistoryHTTPFuzzerTasksResponse.Data:type_name -> ypb.HistoryHTTPFuzzerTaskDetail
 	706,  // 284: ypb.HistoryHTTPFuzzerTasksResponse.Pagination:type_name -> ypb.Paging
 	706,  // 285: ypb.QueryHistoryHTTPFuzzerTaskExParams.Pagination:type_name -> ypb.Paging
-	1017, // 286: ypb.WebShell.Headers:type_name -> ypb.WebShell.HeadersEntry
-	1018, // 287: ypb.WebShell.Posts:type_name -> ypb.WebShell.PostsEntry
+	1018, // 286: ypb.WebShell.Headers:type_name -> ypb.WebShell.HeadersEntry
+	1019, // 287: ypb.WebShell.Posts:type_name -> ypb.WebShell.PostsEntry
 	496,  // 288: ypb.WebShell.ShellOptions:type_name -> ypb.ShellOptions
 	2,    // 289: ypb.ShellGenerate.EncMode:type_name -> ypb.EncMode
 	1,    // 290: ypb.ShellGenerate.Script:type_name -> ypb.ShellScript
@@ -81305,8 +81415,8 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	706,  // 292: ypb.QueryWebShellsResponse.Pagination:type_name -> ypb.Paging
 	494,  // 293: ypb.QueryWebShellsResponse.Data:type_name -> ypb.WebShell
 	496,  // 294: ypb.UpdateWebShellRequest.ShellOptions:type_name -> ypb.ShellOptions
-	1019, // 295: ypb.UpdateWebShellRequest.Headers:type_name -> ypb.UpdateWebShellRequest.HeadersEntry
-	1020, // 296: ypb.UpdateWebShellRequest.Posts:type_name -> ypb.UpdateWebShellRequest.PostsEntry
+	1020, // 295: ypb.UpdateWebShellRequest.Headers:type_name -> ypb.UpdateWebShellRequest.HeadersEntry
+	1021, // 296: ypb.UpdateWebShellRequest.Posts:type_name -> ypb.UpdateWebShellRequest.PostsEntry
 	507,  // 297: ypb.QueryDNSLogByTokenResponse.Events:type_name -> ypb.DNSLogEvent
 	511,  // 298: ypb.AvailableLocalAddrResponse.Interfaces:type_name -> ypb.NetInterface
 	530,  // 299: ypb.ConfigGlobalReverseParams.ConnectParams:type_name -> ypb.GetTunnelServerExternalIPParams
@@ -81341,7 +81451,7 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	551,  // 328: ypb.PortsGroup.GroupLists:type_name -> ypb.GroupList
 	706,  // 329: ypb.QueryYakScriptExecResultRequest.Pagination:type_name -> ypb.Paging
 	706,  // 330: ypb.QueryYakScriptExecResultResponse.Pagination:type_name -> ypb.Paging
-	762,  // 331: ypb.QueryYakScriptExecResultResponse.Data:type_name -> ypb.ExecResult
+	763,  // 331: ypb.QueryYakScriptExecResultResponse.Data:type_name -> ypb.ExecResult
 	727,  // 332: ypb.StartBasicCrawlerRequest.Headers:type_name -> ypb.HTTPHeader
 	562,  // 333: ypb.StartBasicCrawlerRequest.Cookies:type_name -> ypb.HTTPCookie
 	626,  // 334: ypb.ExportYakScriptStreamRequest.Filter:type_name -> ypb.QueryYakScriptRequest
@@ -81389,8 +81499,8 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	653,  // 376: ypb.GetYakScriptTagsAndTypeResponse.Tag:type_name -> ypb.TagsAndType
 	653,  // 377: ypb.GetYakScriptTagsAndTypeResponse.Group:type_name -> ypb.TagsAndType
 	654,  // 378: ypb.QuerySnippetsRequest.Filter:type_name -> ypb.SnippetsFilter
-	760,  // 379: ypb.CodecRequest.Params:type_name -> ypb.ExecParamItem
-	760,  // 380: ypb.CodecWork.Params:type_name -> ypb.ExecParamItem
+	761,  // 379: ypb.CodecRequest.Params:type_name -> ypb.ExecParamItem
+	761,  // 380: ypb.CodecWork.Params:type_name -> ypb.ExecParamItem
 	660,  // 381: ypb.CodecRequestFlow.WorkFlow:type_name -> ypb.CodecWork
 	660,  // 382: ypb.CustomizeCodecFlow.WorkFlow:type_name -> ypb.CodecWork
 	660,  // 383: ypb.UpdateCodecFlowRequest.WorkFlow:type_name -> ypb.CodecWork
@@ -81436,12 +81546,12 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	711,  // 423: ypb.QueryHTTPFlowRequest.MitmExtractAggregateFilterRows:type_name -> ypb.MITMExtractAggregateFlowFilterRow
 	713,  // 424: ypb.HTTPFlowsToOnlineBatchRequest.ToOnlineWhere:type_name -> ypb.HTTPFlowsToOnlineRequest
 	712,  // 425: ypb.HTTPFlowsToOnlineBatchRequest.UploadHTTPFlowsWhere:type_name -> ypb.QueryHTTPFlowRequest
-	748,  // 426: ypb.AnalyzeHTTPFlowRequest.Replacers:type_name -> ypb.MITMContentReplacer
+	749,  // 426: ypb.AnalyzeHTTPFlowRequest.Replacers:type_name -> ypb.MITMContentReplacer
 	718,  // 427: ypb.AnalyzeHTTPFlowRequest.Config:type_name -> ypb.AnalyzeHTTPFlowConfig
 	717,  // 428: ypb.AnalyzeHTTPFlowRequest.Source:type_name -> ypb.AnalyzedDataSource
 	681,  // 429: ypb.AnalyzeHTTPFlowRequest.Matchers:type_name -> ypb.HTTPResponseMatcher
 	712,  // 430: ypb.AnalyzedDataSource.HTTPFlowFilter:type_name -> ypb.QueryHTTPFlowRequest
-	762,  // 431: ypb.AnalyzeHTTPFlowResponse.ExecResult:type_name -> ypb.ExecResult
+	763,  // 431: ypb.AnalyzeHTTPFlowResponse.ExecResult:type_name -> ypb.ExecResult
 	721,  // 432: ypb.AnalyzeHTTPFlowResponse.RuleData:type_name -> ypb.HTTPFlowRuleData
 	712,  // 433: ypb.ExportHTTPFlowsRequest.ExportWhere:type_name -> ypb.QueryHTTPFlowRequest
 	712,  // 434: ypb.DeleteHTTPFlowRequest.Filter:type_name -> ypb.QueryHTTPFlowRequest
@@ -81449,1511 +81559,1512 @@ var file_yakgrpc_proto_depIdxs = []int32{
 	729,  // 436: ypb.HTTPFlows.Data:type_name -> ypb.HTTPFlow
 	727,  // 437: ypb.HTTPFlow.RequestHeader:type_name -> ypb.HTTPHeader
 	727,  // 438: ypb.HTTPFlow.ResponseHeader:type_name -> ypb.HTTPHeader
-	730,  // 439: ypb.HTTPFlow.GetParams:type_name -> ypb.FuzzableParam
-	730,  // 440: ypb.HTTPFlow.PostParams:type_name -> ypb.FuzzableParam
-	730,  // 441: ypb.HTTPFlow.CookieParams:type_name -> ypb.FuzzableParam
-	706,  // 442: ypb.QueryHTTPFlowResponse.Pagination:type_name -> ypb.Paging
-	729,  // 443: ypb.QueryHTTPFlowResponse.Data:type_name -> ypb.HTTPFlow
-	738,  // 444: ypb.HTTPFlowsFieldGroupResponse.Tags:type_name -> ypb.TagsCode
-	738,  // 445: ypb.HTTPFlowsFieldGroupResponse.StatusCode:type_name -> ypb.TagsCode
-	738,  // 446: ypb.HTTPFlowsFieldGroupResponse.Suffixes:type_name -> ypb.TagsCode
-	706,  // 447: ypb.WebsocketFlows.Pagination:type_name -> ypb.Paging
-	740,  // 448: ypb.WebsocketFlows.Data:type_name -> ypb.WebsocketFlow
-	745,  // 449: ypb.SetMITMFilterRequest.FilterData:type_name -> ypb.MITMFilterData
-	745,  // 450: ypb.MITMRequest.FilterData:type_name -> ypb.MITMFilterData
-	760,  // 451: ypb.MITMRequest.yakScriptParams:type_name -> ypb.ExecParamItem
-	749,  // 452: ypb.MITMRequest.removeHookParams:type_name -> ypb.RemoveHookParams
-	748,  // 453: ypb.MITMRequest.replacers:type_name -> ypb.MITMContentReplacer
-	746,  // 454: ypb.MITMRequest.certificates:type_name -> ypb.Certificate
-	698,  // 455: ypb.MITMRequest.hosts:type_name -> ypb.KVPair
-	745,  // 456: ypb.MITMRequest.HijackFilterData:type_name -> ypb.MITMFilterData
-	744,  // 457: ypb.MITMFilterData.IncludeHostnames:type_name -> ypb.FilterDataItem
-	744,  // 458: ypb.MITMFilterData.ExcludeHostnames:type_name -> ypb.FilterDataItem
-	744,  // 459: ypb.MITMFilterData.IncludeSuffix:type_name -> ypb.FilterDataItem
-	744,  // 460: ypb.MITMFilterData.ExcludeSuffix:type_name -> ypb.FilterDataItem
-	744,  // 461: ypb.MITMFilterData.IncludeUri:type_name -> ypb.FilterDataItem
-	744,  // 462: ypb.MITMFilterData.ExcludeUri:type_name -> ypb.FilterDataItem
-	744,  // 463: ypb.MITMFilterData.ExcludeMethods:type_name -> ypb.FilterDataItem
-	744,  // 464: ypb.MITMFilterData.ExcludeMIME:type_name -> ypb.FilterDataItem
-	727,  // 465: ypb.MITMContentReplacer.ExtraHeaders:type_name -> ypb.HTTPHeader
-	561,  // 466: ypb.MITMContentReplacer.ExtraCookies:type_name -> ypb.HTTPCookieSetting
-	747,  // 467: ypb.MITMContentReplacer.SecondaryStages:type_name -> ypb.RegexOutputStage
-	745,  // 468: ypb.MITMResponse.FilterData:type_name -> ypb.MITMFilterData
-	748,  // 469: ypb.MITMResponse.replacers:type_name -> ypb.MITMContentReplacer
-	729,  // 470: ypb.MITMResponse.historyHTTPFlow:type_name -> ypb.HTTPFlow
-	762,  // 471: ypb.MITMResponse.message:type_name -> ypb.ExecResult
-	752,  // 472: ypb.MITMResponse.hooks:type_name -> ypb.YakScriptHooks
-	751,  // 473: ypb.MITMResponse.traceInfo:type_name -> ypb.TraceInfo
-	753,  // 474: ypb.YakScriptHooks.Hooks:type_name -> ypb.YakScriptHookItem
-	760,  // 475: ypb.ExecRequest.Params:type_name -> ypb.ExecParamItem
-	6,    // 476: ypb.ImportHTTPFuzzerTaskFromYamlResponse.Status:type_name -> ypb.GeneralResponse
-	692,  // 477: ypb.ImportHTTPFuzzerTaskFromYamlResponse.Requests:type_name -> ypb.FuzzerRequests
-	692,  // 478: ypb.ExportHTTPFuzzerTaskToYamlRequest.Requests:type_name -> ypb.FuzzerRequests
-	6,    // 479: ypb.ExportHTTPFuzzerTaskToYamlResponse.Status:type_name -> ypb.GeneralResponse
-	698,  // 480: ypb.EvaluateExpressionRequest.Variables:type_name -> ypb.KVPair
-	698,  // 481: ypb.EvaluateMultiExpressionRequest.Variables:type_name -> ypb.KVPair
-	784,  // 482: ypb.EvaluateMultiExpressionResponse.Results:type_name -> ypb.EvaluateExpressionResponse
-	787,  // 483: ypb.GetThirdPartyAppConfigTemplate.Items:type_name -> ypb.ThirdPartyAppConfigItemTemplate
-	788,  // 484: ypb.GetThirdPartyAppConfigTemplateResponse.Templates:type_name -> ypb.GetThirdPartyAppConfigTemplate
-	6,    // 485: ypb.GenerateReverseShellCommandResponse.Status:type_name -> ypb.GeneralResponse
-	805,  // 486: ypb.FingerprintRule.CPE:type_name -> ypb.CPE
-	807,  // 487: ypb.QueryFingerprintRequest.Filter:type_name -> ypb.FingerprintFilter
-	706,  // 488: ypb.QueryFingerprintRequest.Pagination:type_name -> ypb.Paging
-	706,  // 489: ypb.QueryFingerprintResponse.Pagination:type_name -> ypb.Paging
-	806,  // 490: ypb.QueryFingerprintResponse.Data:type_name -> ypb.FingerprintRule
-	807,  // 491: ypb.DeleteFingerprintRequest.Filter:type_name -> ypb.FingerprintFilter
-	806,  // 492: ypb.CreateFingerprintRequest.Rule:type_name -> ypb.FingerprintRule
-	806,  // 493: ypb.UpdateFingerprintRequest.Rule:type_name -> ypb.FingerprintRule
-	813,  // 494: ypb.FingerprintGroups.Data:type_name -> ypb.FingerprintGroup
-	807,  // 495: ypb.BatchUpdateFingerprintToGroupRequest.Filter:type_name -> ypb.FingerprintFilter
-	807,  // 496: ypb.GetFingerprintGroupSetRequest.Filter:type_name -> ypb.FingerprintFilter
-	807,  // 497: ypb.ExportFingerprintRequest.Filter:type_name -> ypb.FingerprintFilter
-	706,  // 498: ypb.QuerySyntaxFlowRuleRequest.Pagination:type_name -> ypb.Paging
-	826,  // 499: ypb.QuerySyntaxFlowRuleRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	1021, // 500: ypb.SyntaxFlowRule.AlertMsg:type_name -> ypb.SyntaxFlowRule.AlertMsgEntry
-	1022, // 501: ypb.AlertMessage.Extra:type_name -> ypb.AlertMessage.ExtraEntry
-	1023, // 502: ypb.SyntaxFlowRuleInput.AlertMsg:type_name -> ypb.SyntaxFlowRuleInput.AlertMsgEntry
-	828,  // 503: ypb.SSARiskDiffRequest.BaseLine:type_name -> ypb.SSARiskDiffItem
-	828,  // 504: ypb.SSARiskDiffRequest.Compare:type_name -> ypb.SSARiskDiffItem
-	884,  // 505: ypb.SSARiskDiffResponse.BaseRisk:type_name -> ypb.SSARisk
-	884,  // 506: ypb.SSARiskDiffResponse.CompareRisk:type_name -> ypb.SSARisk
-	706,  // 507: ypb.QuerySSAProgramRequest.Paging:type_name -> ypb.Paging
-	706,  // 508: ypb.QuerySSAProgramRequest.Pagination:type_name -> ypb.Paging
-	832,  // 509: ypb.QuerySSAProgramRequest.Filter:type_name -> ypb.SSAProgramFilter
-	831,  // 510: ypb.UpdateSSAProgramRequest.ProgramInput:type_name -> ypb.SSAProgramInput
-	832,  // 511: ypb.DeleteSSAProgramRequest.Filter:type_name -> ypb.SSAProgramFilter
-	706,  // 512: ypb.QuerySSAProgramResponse.Paging:type_name -> ypb.Paging
-	706,  // 513: ypb.QuerySSAProgramResponse.Pagination:type_name -> ypb.Paging
-	827,  // 514: ypb.QuerySSAProgramResponse.Programs:type_name -> ypb.SSAProgram
-	827,  // 515: ypb.QuerySSAProgramResponse.Data:type_name -> ypb.SSAProgram
-	825,  // 516: ypb.CreateSyntaxFlowRuleRequest.SyntaxFlowInput:type_name -> ypb.SyntaxFlowRuleInput
-	804,  // 517: ypb.CreateSyntaxFlowRuleResponse.Message:type_name -> ypb.DbOperateMessage
-	823,  // 518: ypb.CreateSyntaxFlowRuleResponse.Rule:type_name -> ypb.SyntaxFlowRule
-	825,  // 519: ypb.UpdateSyntaxFlowRuleRequest.SyntaxFlowInput:type_name -> ypb.SyntaxFlowRuleInput
-	804,  // 520: ypb.UpdateSyntaxFlowRuleResponse.Message:type_name -> ypb.DbOperateMessage
-	823,  // 521: ypb.UpdateSyntaxFlowRuleResponse.Rule:type_name -> ypb.SyntaxFlowRule
-	706,  // 522: ypb.QuerySyntaxFlowRuleResponse.Pagination:type_name -> ypb.Paging
-	804,  // 523: ypb.QuerySyntaxFlowRuleResponse.DbMessage:type_name -> ypb.DbOperateMessage
-	823,  // 524: ypb.QuerySyntaxFlowRuleResponse.Rule:type_name -> ypb.SyntaxFlowRule
-	826,  // 525: ypb.DeleteSyntaxFlowRuleRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	847,  // 526: ypb.QuerySyntaxFlowRuleGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleGroupFilter
-	706,  // 527: ypb.QuerySyntaxFlowRuleGroupRequest.Pagination:type_name -> ypb.Paging
-	848,  // 528: ypb.QuerySyntaxFlowRuleGroupResponse.Group:type_name -> ypb.SyntaxFlowGroup
-	706,  // 529: ypb.QuerySyntaxFlowRuleGroupResponse.Pagination:type_name -> ypb.Paging
-	826,  // 530: ypb.UpdateSyntaxFlowRuleAndGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	826,  // 531: ypb.QuerySyntaxFlowSameGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	848,  // 532: ypb.QuerySyntaxFlowSameGroupResponse.Group:type_name -> ypb.SyntaxFlowGroup
-	847,  // 533: ypb.DeleteSyntaxFlowRuleGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleGroupFilter
-	706,  // 534: ypb.SyntaxFlowRuleToOnlineRequest.Pagination:type_name -> ypb.Paging
-	826,  // 535: ypb.SyntaxFlowRuleToOnlineRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	826,  // 536: ypb.DownloadSyntaxFlowRuleRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	826,  // 537: ypb.SyntaxFlowScanRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	825,  // 538: ypb.SyntaxFlowScanRequest.RuleInput:type_name -> ypb.SyntaxFlowRuleInput
-	706,  // 539: ypb.QuerySyntaxFlowScanTaskRequest.Pagination:type_name -> ypb.Paging
-	862,  // 540: ypb.QuerySyntaxFlowScanTaskRequest.Filter:type_name -> ypb.SyntaxFlowScanTaskFilter
-	706,  // 541: ypb.QuerySyntaxFlowScanTaskResponse.Pagination:type_name -> ypb.Paging
-	864,  // 542: ypb.QuerySyntaxFlowScanTaskResponse.Data:type_name -> ypb.SyntaxFlowScanTask
-	860,  // 543: ypb.SyntaxFlowScanTask.Config:type_name -> ypb.SyntaxFlowScanRequest
-	862,  // 544: ypb.DeleteSyntaxFlowScanTaskRequest.Filter:type_name -> ypb.SyntaxFlowScanTaskFilter
-	762,  // 545: ypb.SyntaxFlowScanResponse.ExecResult:type_name -> ypb.ExecResult
-	871,  // 546: ypb.SyntaxFlowScanResponse.Result:type_name -> ypb.SyntaxFlowResult
-	516,  // 547: ypb.SyntaxFlowScanResponse.risks:type_name -> ypb.Risk
-	884,  // 548: ypb.SyntaxFlowScanResponse.SSARisks:type_name -> ypb.SSARisk
-	867,  // 549: ypb.SyntaxFlowScanResponse.ActiveTask:type_name -> ypb.SyntaxFlowScanActiveTask
-	706,  // 550: ypb.QuerySyntaxFlowResultRequest.Pagination:type_name -> ypb.Paging
-	868,  // 551: ypb.QuerySyntaxFlowResultRequest.Filter:type_name -> ypb.SyntaxFlowResultFilter
-	706,  // 552: ypb.QuerySyntaxFlowResultResponse.Pagination:type_name -> ypb.Paging
-	804,  // 553: ypb.QuerySyntaxFlowResultResponse.DbMessage:type_name -> ypb.DbOperateMessage
-	871,  // 554: ypb.QuerySyntaxFlowResultResponse.Results:type_name -> ypb.SyntaxFlowResult
-	868,  // 555: ypb.DeleteSyntaxFlowResultRequest.Filter:type_name -> ypb.SyntaxFlowResultFilter
-	804,  // 556: ypb.DeleteSyntaxFlowResultResponse.Message:type_name -> ypb.DbOperateMessage
-	698,  // 557: ypb.PluginEnvData.Env:type_name -> ypb.KVPair
-	880,  // 558: ypb.GetAllFuzztagInfoResponse.Data:type_name -> ypb.FuzztagInfo
-	879,  // 559: ypb.FuzztagInfo.ArgumentTypes:type_name -> ypb.FuzztagArgumentType
-	362,  // 560: ypb.GenerateFuzztagRequest.Range:type_name -> ypb.Range
-	6,    // 561: ypb.GenerateFuzztagResponse.Status:type_name -> ypb.GeneralResponse
-	829,  // 562: ypb.SSARisksFilter.SSARiskDiffRequest:type_name -> ypb.SSARiskDiffRequest
-	706,  // 563: ypb.QuerySSARisksRequest.Pagination:type_name -> ypb.Paging
-	885,  // 564: ypb.QuerySSARisksRequest.Filter:type_name -> ypb.SSARisksFilter
-	706,  // 565: ypb.QuerySSARisksResponse.Pagination:type_name -> ypb.Paging
-	884,  // 566: ypb.QuerySSARisksResponse.Data:type_name -> ypb.SSARisk
-	884,  // 567: ypb.QueryNewSSARisksResponse.Data:type_name -> ypb.SSARisk
-	885,  // 568: ypb.DeleteSSARisksRequest.Filter:type_name -> ypb.SSARisksFilter
-	885,  // 569: ypb.GetSSARiskFieldGroupRequest.Filter:type_name -> ypb.SSARisksFilter
-	523,  // 570: ypb.SSARiskFieldGroupResponse.FileField:type_name -> ypb.FieldGroup
-	465,  // 571: ypb.SSARiskFieldGroupResponse.SeverityField:type_name -> ypb.FieldName
-	465,  // 572: ypb.SSARiskFieldGroupResponse.RiskTypeField:type_name -> ypb.FieldName
-	885,  // 573: ypb.NewSSARiskReadRequest.Filter:type_name -> ypb.SSARisksFilter
-	885,  // 574: ypb.ExportSSARiskRequest.Filter:type_name -> ypb.SSARisksFilter
-	885,  // 575: ypb.SSARiskFeedbackToOnlineRequest.Filter:type_name -> ypb.SSARisksFilter
-	901,  // 576: ypb.CreateSSARiskDisposalsResponse.Data:type_name -> ypb.SSARiskDisposalData
-	706,  // 577: ypb.QuerySSARiskDisposalsRequest.Pagination:type_name -> ypb.Paging
-	902,  // 578: ypb.QuerySSARiskDisposalsRequest.Filter:type_name -> ypb.SSARiskDisposalsFilter
-	706,  // 579: ypb.QuerySSARiskDisposalsResponse.Pagination:type_name -> ypb.Paging
-	901,  // 580: ypb.QuerySSARiskDisposalsResponse.Data:type_name -> ypb.SSARiskDisposalData
-	902,  // 581: ypb.UpdateSSARiskDisposalsRequest.Filter:type_name -> ypb.SSARiskDisposalsFilter
-	901,  // 582: ypb.UpdateSSARiskDisposalsResponse.Data:type_name -> ypb.SSARiskDisposalData
-	902,  // 583: ypb.DeleteSSARiskDisposalsRequest.Filter:type_name -> ypb.SSARiskDisposalsFilter
-	804,  // 584: ypb.DeleteSSARiskDisposalsResponse.Message:type_name -> ypb.DbOperateMessage
-	901,  // 585: ypb.GetSSARiskDisposalResponse.Data:type_name -> ypb.SSARiskDisposalData
-	826,  // 586: ypb.ExportSyntaxFlowsRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
-	917,  // 587: ypb.UpdateHotPatchTemplateRequest.Condition:type_name -> ypb.HotPatchTemplateRequest
-	916,  // 588: ypb.UpdateHotPatchTemplateRequest.Data:type_name -> ypb.HotPatchTemplate
-	917,  // 589: ypb.DeleteHotPatchTemplateRequest.Condition:type_name -> ypb.HotPatchTemplateRequest
-	804,  // 590: ypb.CreateHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
-	804,  // 591: ypb.DeleteHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
-	804,  // 592: ypb.UpdateHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
-	804,  // 593: ypb.QueryHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
-	916,  // 594: ypb.QueryHotPatchTemplateResponse.Data:type_name -> ypb.HotPatchTemplate
-	706,  // 595: ypb.QueryHotPatchTemplateListResponse.Pagination:type_name -> ypb.Paging
-	429,  // 596: ypb.GetHotPatchTemplateTagsResponse.Tags:type_name -> ypb.Tags
-	927,  // 597: ypb.GlobalHotPatchConfig.Items:type_name -> ypb.GlobalHotPatchTemplateRef
-	928,  // 598: ypb.SetGlobalHotPatchConfigRequest.Config:type_name -> ypb.GlobalHotPatchConfig
-	712,  // 599: ypb.ExportHTTPFlowStreamRequest.Filter:type_name -> ypb.QueryHTTPFlowRequest
-	938,  // 600: ypb.NoteContent.Note:type_name -> ypb.Note
-	804,  // 601: ypb.CreateNoteResponse.Message:type_name -> ypb.DbOperateMessage
-	940,  // 602: ypb.UpdateNoteRequest.Filter:type_name -> ypb.NoteFilter
-	940,  // 603: ypb.DeleteNoteRequest.Filter:type_name -> ypb.NoteFilter
-	940,  // 604: ypb.QueryNoteRequest.Filter:type_name -> ypb.NoteFilter
-	706,  // 605: ypb.QueryNoteRequest.Pagination:type_name -> ypb.Paging
-	706,  // 606: ypb.QueryNoteResponse.Pagination:type_name -> ypb.Paging
-	938,  // 607: ypb.QueryNoteResponse.Data:type_name -> ypb.Note
-	706,  // 608: ypb.SearchNoteContentRequest.Pagination:type_name -> ypb.Paging
-	706,  // 609: ypb.SearchNoteContentResponse.Pagination:type_name -> ypb.Paging
-	939,  // 610: ypb.SearchNoteContentResponse.Data:type_name -> ypb.NoteContent
-	940,  // 611: ypb.ExportNoteRequest.Filter:type_name -> ypb.NoteFilter
-	249,  // 612: ypb.AIConfigHealthCheckRequest.Config:type_name -> ypb.ThirdPartyApplicationConfig
-	249,  // 613: ypb.AIConfigHealthCheckResponse.RecommendConfig:type_name -> ypb.ThirdPartyApplicationConfig
-	249,  // 614: ypb.AIProvider.Config:type_name -> ypb.ThirdPartyApplicationConfig
-	958,  // 615: ypb.QueryAIProvidersRequest.Filter:type_name -> ypb.AIProviderFilter
-	706,  // 616: ypb.QueryAIProvidersRequest.Pagination:type_name -> ypb.Paging
-	706,  // 617: ypb.QueryAIProvidersResponse.Pagination:type_name -> ypb.Paging
-	957,  // 618: ypb.QueryAIProvidersResponse.Providers:type_name -> ypb.AIProvider
-	957,  // 619: ypb.ListAIProvidersResponse.Providers:type_name -> ypb.AIProvider
-	957,  // 620: ypb.UpsertAIProviderRequest.Provider:type_name -> ypb.AIProvider
-	957,  // 621: ypb.UpsertAIProviderResponse.Provider:type_name -> ypb.AIProvider
-	249,  // 622: ypb.AIModelConfig.Provider:type_name -> ypb.ThirdPartyApplicationConfig
-	698,  // 623: ypb.AIModelConfig.ExtraParams:type_name -> ypb.KVPair
-	965,  // 624: ypb.AIGlobalConfig.IntelligentModels:type_name -> ypb.AIModelConfig
-	965,  // 625: ypb.AIGlobalConfig.LightweightModels:type_name -> ypb.AIModelConfig
-	965,  // 626: ypb.AIGlobalConfig.VisionModels:type_name -> ypb.AIModelConfig
-	82,   // 627: ypb.LocalModelConfig.Status:type_name -> ypb.LocalModelStatus
-	973,  // 628: ypb.GetSupportedLocalModelsResponse.Models:type_name -> ypb.LocalModelConfig
-	975,  // 629: ypb.WatchProcessRequest.StartParams:type_name -> ypb.WatchProcessStartParams
-	977,  // 630: ypb.WatchProcessResponse.Process:type_name -> ypb.ProcessInfo
-	978,  // 631: ypb.WatchProcessResponse.Connections:type_name -> ypb.ConnectionInfo
-	746,  // 632: ypb.MITMV2Request.Certificates:type_name -> ypb.Certificate
-	698,  // 633: ypb.MITMV2Request.hosts:type_name -> ypb.KVPair
-	698,  // 634: ypb.MITMV2Request.HostsMapping:type_name -> ypb.KVPair
-	745,  // 635: ypb.MITMV2Request.FilterData:type_name -> ypb.MITMFilterData
-	745,  // 636: ypb.MITMV2Request.HijackFilterData:type_name -> ypb.MITMFilterData
-	748,  // 637: ypb.MITMV2Request.Replacers:type_name -> ypb.MITMContentReplacer
-	760,  // 638: ypb.MITMV2Request.YakScriptParams:type_name -> ypb.ExecParamItem
-	749,  // 639: ypb.MITMV2Request.RemoveHookParams:type_name -> ypb.RemoveHookParams
-	982,  // 640: ypb.MITMV2Request.ManualHijackMessage:type_name -> ypb.SingleManualHijackControlMessage
-	698,  // 641: ypb.MITMV2Request.SNIMapping:type_name -> ypb.KVPair
-	745,  // 642: ypb.MITMV2Response.FilterData:type_name -> ypb.MITMFilterData
-	748,  // 643: ypb.MITMV2Response.Replacers:type_name -> ypb.MITMContentReplacer
-	762,  // 644: ypb.MITMV2Response.Message:type_name -> ypb.ExecResult
-	752,  // 645: ypb.MITMV2Response.Hooks:type_name -> ypb.YakScriptHooks
-	983,  // 646: ypb.MITMV2Response.ManualHijackList:type_name -> ypb.SingleManualHijackInfoMessage
-	751,  // 647: ypb.SingleManualHijackInfoMessage.TraceInfo:type_name -> ypb.TraceInfo
-	443,  // 648: ypb.QueryMITMReplacerRulesResponse.Rules:type_name -> ypb.MITMContentReplacers
-	986,  // 649: ypb.PluginTraceResponse.Traces:type_name -> ypb.PluginExecutionTrace
-	989,  // 650: ypb.PluginTraceResponse.Stats:type_name -> ypb.PluginTraceStats
-	885,  // 651: ypb.GenerateSSAReportRequest.Filter:type_name -> ypb.SSARisksFilter
-	993,  // 652: ypb.SSAProject.CompileConfig:type_name -> ypb.SSAProjectCompileConfig
-	994,  // 653: ypb.SSAProject.ScanConfig:type_name -> ypb.SSAProjectScanConfig
-	995,  // 654: ypb.SSAProject.RuleConfig:type_name -> ypb.SSAProjectScanRuleConfig
-	826,  // 655: ypb.SSAProjectScanRuleConfig.RuleFilter:type_name -> ypb.SyntaxFlowRuleFilter
-	992,  // 656: ypb.CreateSSAProjectRequest.Project:type_name -> ypb.SSAProject
-	992,  // 657: ypb.CreateSSAProjectResponse.Project:type_name -> ypb.SSAProject
-	804,  // 658: ypb.CreateSSAProjectResponse.Message:type_name -> ypb.DbOperateMessage
-	992,  // 659: ypb.UpdateSSAProjectRequest.Project:type_name -> ypb.SSAProject
-	992,  // 660: ypb.UpdateSSAProjectResponse.Project:type_name -> ypb.SSAProject
-	804,  // 661: ypb.UpdateSSAProjectResponse.Message:type_name -> ypb.DbOperateMessage
-	996,  // 662: ypb.DeleteSSAProjectRequest.Filter:type_name -> ypb.SSAProjectFilter
-	804,  // 663: ypb.DeleteSSAProjectResponse.Message:type_name -> ypb.DbOperateMessage
-	996,  // 664: ypb.QuerySSAProjectRequest.Filter:type_name -> ypb.SSAProjectFilter
-	706,  // 665: ypb.QuerySSAProjectRequest.Pagination:type_name -> ypb.Paging
-	992,  // 666: ypb.QuerySSAProjectResponse.Projects:type_name -> ypb.SSAProject
-	706,  // 667: ypb.QuerySSAProjectResponse.Pagination:type_name -> ypb.Paging
-	885,  // 668: ypb.GetSSAWorkbenchDashboardRequest.RiskFilter:type_name -> ypb.SSARisksFilter
-	826,  // 669: ypb.GetSSAWorkbenchDashboardRequest.RuleFilter:type_name -> ypb.SyntaxFlowRuleFilter
-	1008, // 670: ypb.GetSSAWorkbenchDashboardResponse.Summary:type_name -> ypb.SSAWorkbenchSummary
-	1009, // 671: ypb.GetSSAWorkbenchDashboardResponse.RiskOverview:type_name -> ypb.SSAWorkbenchRiskLevelItem
-	1010, // 672: ypb.GetSSAWorkbenchDashboardResponse.RiskDistribution:type_name -> ypb.SSAWorkbenchRiskTypeItem
-	1011, // 673: ypb.GetSSAWorkbenchDashboardResponse.TopRuleHits:type_name -> ypb.SSAWorkbenchRuleHitItem
-	1012, // 674: ypb.GetSSAWorkbenchDashboardResponse.RecentProjects:type_name -> ypb.SSAWorkbenchRecentProject
-	442,  // 675: ypb.ExtractDataToFileRequest.DataEntry.value:type_name -> ypb.ExtractableData
-	471,  // 676: ypb.YsoClassGeneraterOptionsWithVerbose.BindOptionsEntry.value:type_name -> ypb.YsoClassOptionsResponseWithVerbose
-	824,  // 677: ypb.SyntaxFlowRule.AlertMsgEntry.value:type_name -> ypb.AlertMessage
-	824,  // 678: ypb.SyntaxFlowRuleInput.AlertMsgEntry.value:type_name -> ypb.AlertMessage
-	4,    // 679: ypb.Yak.Version:input_type -> ypb.Empty
-	778,  // 680: ypb.Yak.YakVersionAtLeast:input_type -> ypb.YakVersionAtLeastRequest
-	754,  // 681: ypb.Yak.Echo:input_type -> ypb.EchoRequest
-	756,  // 682: ypb.Yak.Handshake:input_type -> ypb.HandshakeRequest
-	4,    // 683: ypb.Yak.VerifySystemCertificate:input_type -> ypb.Empty
-	4,    // 684: ypb.Yak.InstallMITMCertificate:input_type -> ypb.Empty
-	743,  // 685: ypb.Yak.MITM:input_type -> ypb.MITMRequest
-	741,  // 686: ypb.Yak.SetMITMFilter:input_type -> ypb.SetMITMFilterRequest
-	4,    // 687: ypb.Yak.GetMITMFilter:input_type -> ypb.Empty
-	4,    // 688: ypb.Yak.ResetMITMFilter:input_type -> ypb.Empty
-	4,    // 689: ypb.Yak.DownloadMITMCert:input_type -> ypb.Empty
-	4,    // 690: ypb.Yak.DownloadMITMGMCert:input_type -> ypb.Empty
-	976,  // 691: ypb.Yak.WatchProcessConnection:input_type -> ypb.WatchProcessRequest
-	980,  // 692: ypb.Yak.MITMV2:input_type -> ypb.MITMV2Request
-	758,  // 693: ypb.Yak.OpenPort:input_type -> ypb.Input
-	761,  // 694: ypb.Yak.Exec:input_type -> ypb.ExecRequest
-	670,  // 695: ypb.Yak.QueryExecHistory:input_type -> ypb.ExecHistoryRequest
-	4,    // 696: ypb.Yak.RemoveExecHistory:input_type -> ypb.Empty
-	673,  // 697: ypb.Yak.SavePluginExecutionHistory:input_type -> ypb.SavePluginExecutionHistoryRequest
-	4,    // 698: ypb.Yak.GetPluginExecutionUsageRanking:input_type -> ypb.Empty
-	4,    // 699: ypb.Yak.LoadNucleiTemplates:input_type -> ypb.Empty
-	4,    // 700: ypb.Yak.AutoUpdateYakModule:input_type -> ypb.Empty
-	761,  // 701: ypb.Yak.ExecYakScript:input_type -> ypb.ExecRequest
-	8,    // 702: ypb.Yak.ExecBatchYakScript:input_type -> ypb.ExecBatchYakScriptRequest
-	4,    // 703: ypb.Yak.GetExecBatchYakScriptUnfinishedTask:input_type -> ypb.Empty
-	408,  // 704: ypb.Yak.GetExecBatchYakScriptUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
-	408,  // 705: ypb.Yak.PopExecBatchYakScriptUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
-	409,  // 706: ypb.Yak.RecoverExecBatchYakScriptUnfinishedTask:input_type -> ypb.RecoverExecBatchYakScriptUnfinishedTaskRequest
-	626,  // 707: ypb.Yak.QueryYakScript:input_type -> ypb.QueryYakScriptRequest
-	626,  // 708: ypb.Yak.QueryYakScriptByYakScriptName:input_type -> ypb.QueryYakScriptRequest
-	630,  // 709: ypb.Yak.SaveYakScript:input_type -> ypb.YakScript
-	7,    // 710: ypb.Yak.DeleteYakScript:input_type -> ypb.DeleteYakScriptRequest
-	10,   // 711: ypb.Yak.GetYakScriptById:input_type -> ypb.GetYakScriptByIdRequest
-	11,   // 712: ypb.Yak.GetYakScriptByName:input_type -> ypb.GetYakScriptByNameRequest
-	12,   // 713: ypb.Yak.GetYakScriptByOnlineID:input_type -> ypb.GetYakScriptByOnlineIDRequest
-	7,    // 714: ypb.Yak.IgnoreYakScript:input_type -> ypb.DeleteYakScriptRequest
-	7,    // 715: ypb.Yak.UnIgnoreYakScript:input_type -> ypb.DeleteYakScriptRequest
-	563,  // 716: ypb.Yak.ExportYakScript:input_type -> ypb.ExportYakScriptRequest
-	564,  // 717: ypb.Yak.ExportYakScriptStream:input_type -> ypb.ExportYakScriptStreamRequest
-	565,  // 718: ypb.Yak.ImportYakScriptStream:input_type -> ypb.ImportYakScriptStreamRequest
-	492,  // 719: ypb.Yak.ExecutePacketYakScript:input_type -> ypb.ExecutePacketYakScriptParams
-	493,  // 720: ypb.Yak.ExecuteBatchPacketYakScript:input_type -> ypb.ExecuteBatchPacketYakScriptParams
-	4,    // 721: ypb.Yak.GetYakScriptTags:input_type -> ypb.Empty
-	430,  // 722: ypb.Yak.QueryYakScriptLocalAndUser:input_type -> ypb.QueryYakScriptLocalAndUserRequest
-	432,  // 723: ypb.Yak.QueryYakScriptByOnlineGroup:input_type -> ypb.QueryYakScriptByOnlineGroupRequest
-	4,    // 724: ypb.Yak.QueryYakScriptLocalAll:input_type -> ypb.Empty
-	433,  // 725: ypb.Yak.QueryYakScriptByNames:input_type -> ypb.QueryYakScriptByNamesRequest
-	434,  // 726: ypb.Yak.QueryYakScriptByIsCore:input_type -> ypb.QueryYakScriptByIsCoreRequest
-	437,  // 727: ypb.Yak.QueryYakScriptRiskDetailByCWE:input_type -> ypb.QueryYakScriptRiskDetailByCWERequest
-	4,    // 728: ypb.Yak.YakScriptRiskTypeList:input_type -> ypb.Empty
-	632,  // 729: ypb.Yak.SaveNewYakScript:input_type -> ypb.SaveNewYakScriptRequest
-	633,  // 730: ypb.Yak.SaveYakScriptToOnline:input_type -> ypb.SaveYakScriptToOnlineRequest
-	636,  // 731: ypb.Yak.ExportLocalYakScript:input_type -> ypb.ExportLocalYakScriptRequest
-	636,  // 732: ypb.Yak.ExportLocalYakScriptStream:input_type -> ypb.ExportLocalYakScriptRequest
-	639,  // 733: ypb.Yak.ImportYakScript:input_type -> ypb.ImportYakScriptRequest
-	641,  // 734: ypb.Yak.SetYakScriptSkipUpdate:input_type -> ypb.SetYakScriptSkipUpdateRequest
-	626,  // 735: ypb.Yak.QueryYakScriptSkipUpdate:input_type -> ypb.QueryYakScriptRequest
-	643,  // 736: ypb.Yak.QueryYakScriptGroup:input_type -> ypb.QueryYakScriptGroupRequest
-	646,  // 737: ypb.Yak.SaveYakScriptGroup:input_type -> ypb.SaveYakScriptGroupRequest
-	647,  // 738: ypb.Yak.RenameYakScriptGroup:input_type -> ypb.RenameYakScriptGroupRequest
-	648,  // 739: ypb.Yak.DeleteYakScriptGroup:input_type -> ypb.DeleteYakScriptGroupRequest
-	626,  // 740: ypb.Yak.GetYakScriptGroup:input_type -> ypb.QueryYakScriptRequest
-	650,  // 741: ypb.Yak.ResetYakScriptGroup:input_type -> ypb.ResetYakScriptGroupRequest
-	651,  // 742: ypb.Yak.SetGroup:input_type -> ypb.SetGroupRequest
-	707,  // 743: ypb.Yak.GetHTTPFlowByHash:input_type -> ypb.GetHTTPFlowByHashRequest
-	708,  // 744: ypb.Yak.GetHTTPFlowById:input_type -> ypb.GetHTTPFlowByIdRequest
-	710,  // 745: ypb.Yak.GetHTTPFlowBodyById:input_type -> ypb.GetHTTPFlowBodyByIdRequest
-	709,  // 746: ypb.Yak.GetHTTPFlowByIds:input_type -> ypb.GetHTTPFlowByIdsRequest
-	712,  // 747: ypb.Yak.QueryHTTPFlows:input_type -> ypb.QueryHTTPFlowRequest
-	724,  // 748: ypb.Yak.DeleteHTTPFlows:input_type -> ypb.DeleteHTTPFlowRequest
-	456,  // 749: ypb.Yak.SetTagForHTTPFlow:input_type -> ypb.SetTagForHTTPFlowRequest
-	725,  // 750: ypb.Yak.QueryHTTPFlowsIds:input_type -> ypb.QueryHTTPFlowsIdsRequest
-	733,  // 751: ypb.Yak.HTTPFlowsFieldGroup:input_type -> ypb.HTTPFlowsFieldGroupRequest
-	735,  // 752: ypb.Yak.HTTPFlowsShare:input_type -> ypb.HTTPFlowsShareRequest
-	737,  // 753: ypb.Yak.HTTPFlowsExtract:input_type -> ypb.HTTPFlowsExtractRequest
-	766,  // 754: ypb.Yak.GetHTTPFlowBare:input_type -> ypb.HTTPFlowBareRequest
-	722,  // 755: ypb.Yak.ExportHTTPFlows:input_type -> ypb.ExportHTTPFlowsRequest
-	713,  // 756: ypb.Yak.HTTPFlowsToOnline:input_type -> ypb.HTTPFlowsToOnlineRequest
-	712,  // 757: ypb.Yak.QueryHTTPFlowsProcessNames:input_type -> ypb.QueryHTTPFlowRequest
-	714,  // 758: ypb.Yak.HTTPFlowsToOnlineBatch:input_type -> ypb.HTTPFlowsToOnlineBatchRequest
-	716,  // 759: ypb.Yak.AnalyzeHTTPFlow:input_type -> ypb.AnalyzeHTTPFlowRequest
-	696,  // 760: ypb.Yak.ExtractUrl:input_type -> ypb.FuzzerRequest
-	486,  // 761: ypb.Yak.GetHistoryHTTPFuzzerTask:input_type -> ypb.GetHistoryHTTPFuzzerTaskRequest
-	4,    // 762: ypb.Yak.QueryHistoryHTTPFuzzerTask:input_type -> ypb.Empty
-	491,  // 763: ypb.Yak.QueryHistoryHTTPFuzzerTaskEx:input_type -> ypb.QueryHistoryHTTPFuzzerTaskExParams
-	462,  // 764: ypb.Yak.DeleteHistoryHTTPFuzzerTask:input_type -> ypb.DeleteHistoryHTTPFuzzerTaskRequest
-	696,  // 765: ypb.Yak.HTTPFuzzer:input_type -> ypb.FuzzerRequest
-	692,  // 766: ypb.Yak.HTTPFuzzerSequence:input_type -> ypb.FuzzerRequests
-	694,  // 767: ypb.Yak.HTTPFuzzerGroup:input_type -> ypb.GroupHTTPFuzzerRequest
-	689,  // 768: ypb.Yak.PreloadHTTPFuzzerParams:input_type -> ypb.PreloadHTTPFuzzerParamsRequest
-	682,  // 769: ypb.Yak.RenderVariables:input_type -> ypb.RenderVariablesRequest
-	684,  // 770: ypb.Yak.MatchHTTPResponse:input_type -> ypb.MatchHTTPResponseParams
-	688,  // 771: ypb.Yak.ExtractHTTPResponse:input_type -> ypb.ExtractHTTPResponseParams
-	700,  // 772: ypb.Yak.RedirectRequest:input_type -> ypb.RedirectRequestParams
-	539,  // 773: ypb.Yak.HTTPRequestMutate:input_type -> ypb.HTTPRequestMutateParams
-	540,  // 774: ypb.Yak.HTTPResponseMutate:input_type -> ypb.HTTPResponseMutateParams
-	421,  // 775: ypb.Yak.FixUploadPacket:input_type -> ypb.FixUploadPacketRequest
-	421,  // 776: ypb.Yak.IsMultipartFormDataRequest:input_type -> ypb.FixUploadPacketRequest
-	351,  // 777: ypb.Yak.GenerateExtractRule:input_type -> ypb.GenerateExtractRuleRequest
-	350,  // 778: ypb.Yak.ExtractData:input_type -> ypb.ExtractDataRequest
-	768,  // 779: ypb.Yak.ImportHTTPFuzzerTaskFromYaml:input_type -> ypb.ImportHTTPFuzzerTaskFromYamlRequest
-	770,  // 780: ypb.Yak.ExportHTTPFuzzerTaskToYaml:input_type -> ypb.ExportHTTPFuzzerTaskToYamlRequest
-	772,  // 781: ypb.Yak.RenderHTTPFuzzerPacket:input_type -> ypb.RenderHTTPFuzzerPacketRequest
-	341,  // 782: ypb.Yak.SaveFuzzerLabel:input_type -> ypb.SaveFuzzerLabelRequest
-	4,    // 783: ypb.Yak.QueryFuzzerLabel:input_type -> ypb.Empty
-	344,  // 784: ypb.Yak.DeleteFuzzerLabel:input_type -> ypb.DeleteFuzzerLabelRequest
-	345,  // 785: ypb.Yak.SaveFuzzerConfig:input_type -> ypb.SaveFuzzerConfigRequest
-	346,  // 786: ypb.Yak.QueryFuzzerConfig:input_type -> ypb.QueryFuzzerConfigRequest
-	349,  // 787: ypb.Yak.DeleteFuzzerConfig:input_type -> ypb.DeleteFuzzerConfigRequest
-	354,  // 788: ypb.Yak.QueryHTTPFuzzerResponseByTaskId:input_type -> ypb.QueryHTTPFuzzerResponseByTaskIdRequest
-	358,  // 789: ypb.Yak.CreateWebsocketFuzzer:input_type -> ypb.ClientWebsocketRequest
-	356,  // 790: ypb.Yak.QueryWebsocketFlowByHTTPFlowWebsocketHash:input_type -> ypb.QueryWebsocketFlowByHTTPFlowWebsocketHashRequest
-	357,  // 791: ypb.Yak.DeleteWebsocketFlowByHTTPFlowWebsocketHash:input_type -> ypb.DeleteWebsocketFlowByHTTPFlowWebsocketHashRequest
-	4,    // 792: ypb.Yak.DeleteWebsocketFlowAll:input_type -> ypb.Empty
-	703,  // 793: ypb.Yak.ConvertFuzzerResponseToHTTPFlow:input_type -> ypb.FuzzerResponse
-	676,  // 794: ypb.Yak.StringFuzzer:input_type -> ypb.StringFuzzerRequest
-	678,  // 795: ypb.Yak.HTTPRequestAnalyzer:input_type -> ypb.HTTPRequestAnalysisMaterial
-	655,  // 796: ypb.Yak.CreateSnippet:input_type -> ypb.SnippetsRequest
-	656,  // 797: ypb.Yak.UpdateSnippet:input_type -> ypb.EditSnippetsRequest
-	657,  // 798: ypb.Yak.DeleteSnippets:input_type -> ypb.QuerySnippetsRequest
-	657,  // 799: ypb.Yak.QuerySnippets:input_type -> ypb.QuerySnippetsRequest
-	659,  // 800: ypb.Yak.Codec:input_type -> ypb.CodecRequest
-	661,  // 801: ypb.Yak.NewCodec:input_type -> ypb.CodecRequestFlow
-	4,    // 802: ypb.Yak.GetAllCodecMethods:input_type -> ypb.Empty
-	662,  // 803: ypb.Yak.SaveCodecFlow:input_type -> ypb.CustomizeCodecFlow
-	663,  // 804: ypb.Yak.UpdateCodecFlow:input_type -> ypb.UpdateCodecFlowRequest
-	664,  // 805: ypb.Yak.DeleteCodecFlow:input_type -> ypb.DeleteCodecFlowRequest
-	4,    // 806: ypb.Yak.GetAllCodecFlow:input_type -> ypb.Empty
-	233,  // 807: ypb.Yak.PacketPrettifyHelper:input_type -> ypb.PacketPrettifyHelperRequest
-	620,  // 808: ypb.Yak.QueryPayload:input_type -> ypb.QueryPayloadRequest
-	618,  // 809: ypb.Yak.QueryPayloadFromFile:input_type -> ypb.QueryPayloadFromFileRequest
-	608,  // 810: ypb.Yak.DeletePayloadByFolder:input_type -> ypb.NameRequest
-	616,  // 811: ypb.Yak.DeletePayloadByGroup:input_type -> ypb.DeletePayloadByGroupRequest
-	617,  // 812: ypb.Yak.DeletePayload:input_type -> ypb.DeletePayloadRequest
-	612,  // 813: ypb.Yak.SavePayload:input_type -> ypb.SavePayloadRequest
-	612,  // 814: ypb.Yak.SavePayloadStream:input_type -> ypb.SavePayloadRequest
-	612,  // 815: ypb.Yak.SavePayloadToFileStream:input_type -> ypb.SavePayloadRequest
-	612,  // 816: ypb.Yak.SaveLargePayloadToFileStream:input_type -> ypb.SavePayloadRequest
-	607,  // 817: ypb.Yak.RenamePayloadFolder:input_type -> ypb.RenameRequest
-	607,  // 818: ypb.Yak.RenamePayloadGroup:input_type -> ypb.RenameRequest
-	613,  // 819: ypb.Yak.UpdatePayload:input_type -> ypb.UpdatePayloadRequest
-	614,  // 820: ypb.Yak.UpdatePayloadToFile:input_type -> ypb.UpdatePayloadToFileRequest
-	615,  // 821: ypb.Yak.BackUpOrCopyPayloads:input_type -> ypb.BackUpOrCopyPayloadsRequest
-	4,    // 822: ypb.Yak.GetAllPayloadGroup:input_type -> ypb.Empty
-	611,  // 823: ypb.Yak.UpdateAllPayloadGroup:input_type -> ypb.UpdateAllPayloadGroupRequest
-	623,  // 824: ypb.Yak.GetAllPayload:input_type -> ypb.GetAllPayloadRequest
-	623,  // 825: ypb.Yak.GetAllPayloadFromFile:input_type -> ypb.GetAllPayloadRequest
-	623,  // 826: ypb.Yak.ExportAllPayload:input_type -> ypb.GetAllPayloadRequest
-	623,  // 827: ypb.Yak.ExportAllPayloadFromFile:input_type -> ypb.GetAllPayloadRequest
-	608,  // 828: ypb.Yak.CreatePayloadFolder:input_type -> ypb.NameRequest
-	608,  // 829: ypb.Yak.RemoveDuplicatePayloads:input_type -> ypb.NameRequest
-	608,  // 830: ypb.Yak.CoverPayloadGroupToDatabase:input_type -> ypb.NameRequest
-	608,  // 831: ypb.Yak.ConvertPayloadGroupToDatabase:input_type -> ypb.NameRequest
-	4,    // 832: ypb.Yak.MigratePayloads:input_type -> ypb.Empty
-	380,  // 833: ypb.Yak.ExportPayloadBatch:input_type -> ypb.ExportPayloadBatchRequest
-	381,  // 834: ypb.Yak.UploadPayloadToOnline:input_type -> ypb.UploadPayloadToOnlineRequest
-	382,  // 835: ypb.Yak.DownloadPayload:input_type -> ypb.DownloadPayloadRequest
-	385,  // 836: ypb.Yak.ExportPayloadDBAndFile:input_type -> ypb.ExportPayloadDBAndFileRequest
-	4,    // 837: ypb.Yak.GetYakitCompletionRaw:input_type -> ypb.Empty
-	603,  // 838: ypb.Yak.GetYakVMBuildInMethodCompletion:input_type -> ypb.GetYakVMBuildInMethodCompletionRequest
-	374,  // 839: ypb.Yak.StaticAnalyzeError:input_type -> ypb.StaticAnalyzeErrorRequest
-	375,  // 840: ypb.Yak.YaklangCompileAndFormat:input_type -> ypb.YaklangCompileAndFormatRequest
-	364,  // 841: ypb.Yak.YaklangLanguageSuggestion:input_type -> ypb.YaklangLanguageSuggestionRequest
-	364,  // 842: ypb.Yak.YaklangLanguageFind:input_type -> ypb.YaklangLanguageSuggestionRequest
-	883,  // 843: ypb.Yak.FuzzTagSuggestion:input_type -> ypb.FuzzTagSuggestionRequest
-	363,  // 844: ypb.Yak.YaklangInspectInformation:input_type -> ypb.YaklangInspectInformationRequest
-	373,  // 845: ypb.Yak.YaklangGetCliCodeFromDatabase:input_type -> ypb.YaklangGetCliCodeFromDatabaseRequest
-	758,  // 846: ypb.Yak.YaklangTerminal:input_type -> ypb.Input
-	597,  // 847: ypb.Yak.PortScan:input_type -> ypb.PortScanRequest
-	4,    // 848: ypb.Yak.ViewPortScanCode:input_type -> ypb.Empty
-	595,  // 849: ypb.Yak.SimpleDetect:input_type -> ypb.RecordPortScanRequest
-	595,  // 850: ypb.Yak.SaveCancelSimpleDetect:input_type -> ypb.RecordPortScanRequest
-	596,  // 851: ypb.Yak.SimpleDetectCreatReport:input_type -> ypb.CreatReportRequest
-	415,  // 852: ypb.Yak.QuerySimpleDetectUnfinishedTask:input_type -> ypb.QueryUnfinishedTaskRequest
-	419,  // 853: ypb.Yak.GetSimpleDetectRecordRequestById:input_type -> ypb.GetUnfinishedTaskDetailByIdRequest
-	416,  // 854: ypb.Yak.DeleteSimpleDetectUnfinishedTask:input_type -> ypb.DeleteUnfinishedTaskRequest
-	420,  // 855: ypb.Yak.RecoverSimpleDetectTask:input_type -> ypb.RecoverUnfinishedTaskRequest
-	4,    // 856: ypb.Yak.GetSimpleDetectUnfinishedTask:input_type -> ypb.Empty
-	408,  // 857: ypb.Yak.GetSimpleDetectUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
-	408,  // 858: ypb.Yak.PopSimpleDetectUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
-	409,  // 859: ypb.Yak.RecoverSimpleDetectUnfinishedTask:input_type -> ypb.RecoverExecBatchYakScriptUnfinishedTaskRequest
-	599,  // 860: ypb.Yak.QueryPorts:input_type -> ypb.QueryPortsRequest
-	598,  // 861: ypb.Yak.DeletePorts:input_type -> ypb.DeletePortsRequest
-	542,  // 862: ypb.Yak.QueryHosts:input_type -> ypb.QueryHostsRequest
-	543,  // 863: ypb.Yak.DeleteHosts:input_type -> ypb.DeleteHostsRequest
-	545,  // 864: ypb.Yak.QueryDomains:input_type -> ypb.QueryDomainsRequest
-	546,  // 865: ypb.Yak.DeleteDomains:input_type -> ypb.DeleteDomainsRequest
-	4,    // 866: ypb.Yak.QueryPortsGroup:input_type -> ypb.Empty
-	591,  // 867: ypb.Yak.UpdateFromYakitResource:input_type -> ypb.UpdateFromYakitResourceRequest
-	592,  // 868: ypb.Yak.UpdateFromGithub:input_type -> ypb.UpdateFromGithubRequest
-	579,  // 869: ypb.Yak.AddToMenu:input_type -> ypb.AddToMenuRequest
-	578,  // 870: ypb.Yak.RemoveFromMenu:input_type -> ypb.RemoveFromMenuRequest
-	577,  // 871: ypb.Yak.YakScriptIsInMenu:input_type -> ypb.YakScriptIsInMenuRequest
-	4,    // 872: ypb.Yak.GetAllMenuItem:input_type -> ypb.Empty
-	4,    // 873: ypb.Yak.DeleteAllMenuItem:input_type -> ypb.Empty
-	582,  // 874: ypb.Yak.ImportMenuItem:input_type -> ypb.ImportMenuItemRequest
-	4,    // 875: ypb.Yak.ExportMenuItem:input_type -> ypb.Empty
-	575,  // 876: ypb.Yak.GetMenuItemById:input_type -> ypb.GetMenuItemByIdRequest
-	571,  // 877: ypb.Yak.QueryGroupsByYakScriptId:input_type -> ypb.QueryGroupsByYakScriptIdRequest
-	580,  // 878: ypb.Yak.AddMenus:input_type -> ypb.AddMenuRequest
-	581,  // 879: ypb.Yak.QueryAllMenuItem:input_type -> ypb.QueryAllMenuItemRequest
-	581,  // 880: ypb.Yak.DeleteAllMenu:input_type -> ypb.QueryAllMenuItemRequest
-	584,  // 881: ypb.Yak.AddToNavigation:input_type -> ypb.AddToNavigationRequest
-	587,  // 882: ypb.Yak.GetAllNavigationItem:input_type -> ypb.GetAllNavigationRequest
-	587,  // 883: ypb.Yak.DeleteAllNavigation:input_type -> ypb.GetAllNavigationRequest
-	589,  // 884: ypb.Yak.AddOneNavigation:input_type -> ypb.AddOneNavigationRequest
-	590,  // 885: ypb.Yak.QueryNavigationGroups:input_type -> ypb.QueryNavigationGroupsRequest
-	569,  // 886: ypb.Yak.SaveMarkdownDocument:input_type -> ypb.SaveMarkdownDocumentRequest
-	568,  // 887: ypb.Yak.GetMarkdownDocument:input_type -> ypb.GetMarkdownDocumentRequest
-	568,  // 888: ypb.Yak.DeleteMarkdownDocument:input_type -> ypb.GetMarkdownDocumentRequest
-	560,  // 889: ypb.Yak.StartBasicCrawler:input_type -> ypb.StartBasicCrawlerRequest
-	4,    // 890: ypb.Yak.ViewBasicCrawlerCode:input_type -> ypb.Empty
-	559,  // 891: ypb.Yak.GenerateWebsiteTree:input_type -> ypb.GenerateWebsiteTreeRequest
-	556,  // 892: ypb.Yak.QueryYakScriptExecResult:input_type -> ypb.QueryYakScriptExecResultRequest
-	4,    // 893: ypb.Yak.QueryYakScriptNameInExecResult:input_type -> ypb.Empty
-	554,  // 894: ypb.Yak.DeleteYakScriptExecResult:input_type -> ypb.DeleteYakScriptExecResultRequest
-	4,    // 895: ypb.Yak.DeleteYakScriptExec:input_type -> ypb.Empty
-	538,  // 896: ypb.Yak.StartBrute:input_type -> ypb.StartBruteParams
-	4,    // 897: ypb.Yak.GetAvailableBruteTypes:input_type -> ypb.Empty
-	530,  // 898: ypb.Yak.GetTunnelServerExternalIP:input_type -> ypb.GetTunnelServerExternalIPParams
-	528,  // 899: ypb.Yak.VerifyTunnelServerDomain:input_type -> ypb.VerifyTunnelServerDomainParams
-	532,  // 900: ypb.Yak.StartFacades:input_type -> ypb.StartFacadesParams
-	535,  // 901: ypb.Yak.StartFacadesWithYsoObject:input_type -> ypb.StartFacadesWithYsoParams
-	533,  // 902: ypb.Yak.ApplyClassToFacades:input_type -> ypb.ApplyClassToFacadesParamsWithVerbose
-	480,  // 903: ypb.Yak.BytesToBase64:input_type -> ypb.BytesToBase64Request
-	512,  // 904: ypb.Yak.ConfigGlobalReverse:input_type -> ypb.ConfigGlobalReverseParams
-	4,    // 905: ypb.Yak.AvailableLocalAddr:input_type -> ypb.Empty
-	4,    // 906: ypb.Yak.GetGlobalReverseServer:input_type -> ypb.Empty
-	517,  // 907: ypb.Yak.QueryRisks:input_type -> ypb.QueryRisksRequest
-	514,  // 908: ypb.Yak.QueryRisk:input_type -> ypb.QueryRiskRequest
-	513,  // 909: ypb.Yak.DeleteRisk:input_type -> ypb.DeleteRiskRequest
-	4,    // 910: ypb.Yak.QueryAvailableRiskType:input_type -> ypb.Empty
-	4,    // 911: ypb.Yak.QueryAvailableRiskLevel:input_type -> ypb.Empty
-	4,    // 912: ypb.Yak.QueryRiskTableStats:input_type -> ypb.Empty
-	4,    // 913: ypb.Yak.ResetRiskTableStats:input_type -> ypb.Empty
-	4,    // 914: ypb.Yak.QueryAvailableTarget:input_type -> ypb.Empty
-	519,  // 915: ypb.Yak.QueryNewRisk:input_type -> ypb.QueryNewRiskRequest
-	525,  // 916: ypb.Yak.NewRiskRead:input_type -> ypb.NewRiskReadRequest
-	526,  // 917: ypb.Yak.UploadRiskToOnline:input_type -> ypb.UploadRiskToOnlineRequest
-	527,  // 918: ypb.Yak.SetTagForRisk:input_type -> ypb.SetTagForRiskRequest
-	4,    // 919: ypb.Yak.QueryRiskTags:input_type -> ypb.Empty
-	4,    // 920: ypb.Yak.RiskFieldGroup:input_type -> ypb.Empty
-	526,  // 921: ypb.Yak.RiskFeedbackToOnline:input_type -> ypb.UploadRiskToOnlineRequest
-	454,  // 922: ypb.Yak.QueryReports:input_type -> ypb.QueryReportsRequest
-	451,  // 923: ypb.Yak.QueryReport:input_type -> ypb.QueryReportRequest
-	452,  // 924: ypb.Yak.DeleteReport:input_type -> ypb.DeleteReportRequest
-	4,    // 925: ypb.Yak.QueryAvailableReportFrom:input_type -> ypb.Empty
-	553,  // 926: ypb.Yak.DownloadReport:input_type -> ypb.DownloadReportRequest
-	4,    // 927: ypb.Yak.GetAllYsoGadgetOptions:input_type -> ypb.Empty
-	474,  // 928: ypb.Yak.GetAllYsoClassOptions:input_type -> ypb.YsoOptionsRequerstWithVerbose
-	474,  // 929: ypb.Yak.GetAllYsoClassGeneraterOptions:input_type -> ypb.YsoOptionsRequerstWithVerbose
-	474,  // 930: ypb.Yak.GenerateYsoCode:input_type -> ypb.YsoOptionsRequerstWithVerbose
-	474,  // 931: ypb.Yak.GenerateYsoBytes:input_type -> ypb.YsoOptionsRequerstWithVerbose
-	476,  // 932: ypb.Yak.YsoDump:input_type -> ypb.YsoBytesObject
-	494,  // 933: ypb.Yak.CreateWebShell:input_type -> ypb.WebShell
-	502,  // 934: ypb.Yak.DeleteWebShell:input_type -> ypb.DeleteWebShellRequest
-	494,  // 935: ypb.Yak.UpdateWebShell:input_type -> ypb.WebShell
-	499,  // 936: ypb.Yak.QueryWebShells:input_type -> ypb.QueryWebShellsRequest
-	497,  // 937: ypb.Yak.Ping:input_type -> ypb.WebShellRequest
-	497,  // 938: ypb.Yak.GetBasicInfo:input_type -> ypb.WebShellRequest
-	495,  // 939: ypb.Yak.GenerateWebShell:input_type -> ypb.ShellGenerate
-	503,  // 940: ypb.Yak.SetYakBridgeLogServer:input_type -> ypb.YakDNSLogBridgeAddr
-	4,    // 941: ypb.Yak.GetCurrentYakBridgeLogServer:input_type -> ypb.Empty
-	503,  // 942: ypb.Yak.RequireDNSLogDomain:input_type -> ypb.YakDNSLogBridgeAddr
-	504,  // 943: ypb.Yak.RequireDNSLogDomainByScript:input_type -> ypb.RequireDNSLogDomainByScriptRequest
-	505,  // 944: ypb.Yak.QueryDNSLogByToken:input_type -> ypb.QueryDNSLogByTokenRequest
-	504,  // 945: ypb.Yak.QueryDNSLogTokenByScript:input_type -> ypb.RequireDNSLogDomainByScriptRequest
-	4,    // 946: ypb.Yak.RequireICMPRandomLength:input_type -> ypb.Empty
-	482,  // 947: ypb.Yak.QueryICMPTrigger:input_type -> ypb.QueryICMPTriggerRequest
-	4,    // 948: ypb.Yak.RequireRandomPortToken:input_type -> ypb.Empty
-	460,  // 949: ypb.Yak.QueryRandomPortTrigger:input_type -> ypb.QueryRandomPortTriggerRequest
-	4,    // 950: ypb.Yak.QuerySupportedDnsLogPlatforms:input_type -> ypb.Empty
-	4,    // 951: ypb.Yak.GetAvailableYakScriptTags:input_type -> ypb.Empty
-	4,    // 952: ypb.Yak.ForceUpdateAvailableYakScriptTags:input_type -> ypb.Empty
-	446,  // 953: ypb.Yak.ExecYakitPluginsByYakScriptFilter:input_type -> ypb.ExecYakitPluginsByYakScriptFilterRequest
-	447,  // 954: ypb.Yak.GenerateYakCodeByPacket:input_type -> ypb.GenerateYakCodeByPacketRequest
-	448,  // 955: ypb.Yak.GenerateCSRFPocByPacket:input_type -> ypb.GenerateCSRFPocByPacketRequest
-	4,    // 956: ypb.Yak.ExportMITMReplacerRules:input_type -> ypb.Empty
-	444,  // 957: ypb.Yak.ImportMITMReplacerRules:input_type -> ypb.ImportMITMReplacerRulesRequest
-	4,    // 958: ypb.Yak.GetCurrentRules:input_type -> ypb.Empty
-	443,  // 959: ypb.Yak.SetCurrentRules:input_type -> ypb.MITMContentReplacers
-	984,  // 960: ypb.Yak.QueryMITMReplacerRules:input_type -> ypb.QueryMITMReplacerRulesRequest
-	4,    // 961: ypb.Yak.DeduplicateMITMReplacerRules:input_type -> ypb.Empty
-	776,  // 962: ypb.Yak.GenerateURL:input_type -> ypb.GenerateURLRequest
-	441,  // 963: ypb.Yak.ExtractDataToFile:input_type -> ypb.ExtractDataToFileRequest
-	424,  // 964: ypb.Yak.AutoDecode:input_type -> ypb.AutoDecodeRequest
-	4,    // 965: ypb.Yak.GetSystemProxy:input_type -> ypb.Empty
-	406,  // 966: ypb.Yak.SetSystemProxy:input_type -> ypb.SetSystemProxyRequest
-	402,  // 967: ypb.Yak.GetKey:input_type -> ypb.GetKeyRequest
-	401,  // 968: ypb.Yak.SetKey:input_type -> ypb.SetKeyRequest
-	402,  // 969: ypb.Yak.DelKey:input_type -> ypb.GetKeyRequest
-	4,    // 970: ypb.Yak.GetAllProcessEnvKey:input_type -> ypb.Empty
-	401,  // 971: ypb.Yak.SetProcessEnvKey:input_type -> ypb.SetKeyRequest
-	402,  // 972: ypb.Yak.GetProjectKey:input_type -> ypb.GetKeyRequest
-	401,  // 973: ypb.Yak.SetProjectKey:input_type -> ypb.SetKeyRequest
-	4,    // 974: ypb.Yak.GetOnlineProfile:input_type -> ypb.Empty
-	400,  // 975: ypb.Yak.SetOnlineProfile:input_type -> ypb.OnlineProfile
-	389,  // 976: ypb.Yak.DownloadOnlinePluginById:input_type -> ypb.DownloadOnlinePluginByIdRequest
-	390,  // 977: ypb.Yak.DownloadOnlinePluginByIds:input_type -> ypb.DownloadOnlinePluginByIdsRequest
-	388,  // 978: ypb.Yak.DownloadOnlinePluginAll:input_type -> ypb.DownloadOnlinePluginByTokenRequest
-	384,  // 979: ypb.Yak.DeletePluginByUserID:input_type -> ypb.DeletePluginByUserIDRequest
-	4,    // 980: ypb.Yak.DeleteAllLocalPlugins:input_type -> ypb.Empty
-	4,    // 981: ypb.Yak.GetYakScriptTagsAndType:input_type -> ypb.Empty
-	386,  // 982: ypb.Yak.DeleteLocalPluginsByWhere:input_type -> ypb.DeleteLocalPluginsByWhereRequest
-	393,  // 983: ypb.Yak.DownloadOnlinePluginByScriptNames:input_type -> ypb.DownloadOnlinePluginByScriptNamesRequest
-	391,  // 984: ypb.Yak.DownloadOnlinePlugins:input_type -> ypb.DownloadOnlinePluginsRequest
-	391,  // 985: ypb.Yak.DownloadOnlinePluginBatch:input_type -> ypb.DownloadOnlinePluginsRequest
-	393,  // 986: ypb.Yak.DownloadOnlinePluginByPluginName:input_type -> ypb.DownloadOnlinePluginByScriptNamesRequest
-	396,  // 987: ypb.Yak.DownloadOnlinePluginByUUID:input_type -> ypb.DownloadOnlinePluginByUUIDRequest
-	397,  // 988: ypb.Yak.QueryOnlinePlugins:input_type -> ypb.QueryOnlinePluginsRequest
-	361,  // 989: ypb.Yak.ExecPacketScan:input_type -> ypb.ExecPacketScanRequest
-	4,    // 990: ypb.Yak.GetEngineDefaultProxy:input_type -> ypb.Empty
-	360,  // 991: ypb.Yak.SetEngineDefaultProxy:input_type -> ypb.DefaultProxyResult
-	4,    // 992: ypb.Yak.GetMachineID:input_type -> ypb.Empty
-	4,    // 993: ypb.Yak.GetLicense:input_type -> ypb.Empty
-	764,  // 994: ypb.Yak.CheckLicense:input_type -> ypb.CheckLicenseRequest
-	336,  // 995: ypb.Yak.GetRequestBodyByHTTPFlowID:input_type -> ypb.DownloadBodyByHTTPFlowIDRequest
-	336,  // 996: ypb.Yak.GetResponseBodyByHTTPFlowID:input_type -> ypb.DownloadBodyByHTTPFlowIDRequest
-	335,  // 997: ypb.Yak.GetHTTPPacketBody:input_type -> ypb.GetHTTPPacketBodyRequest
-	337,  // 998: ypb.Yak.EncodeHTTPPacketContent:input_type -> ypb.EncodeHTTPPacketContentRequest
-	333,  // 999: ypb.Yak.RegisterFacadesHTTP:input_type -> ypb.RegisterFacadesHTTPRequest
-	332,  // 1000: ypb.Yak.ResetAndInvalidUserData:input_type -> ypb.ResetAndInvalidUserDataRequest
-	329,  // 1001: ypb.Yak.CreateYaklangShell:input_type -> ypb.YaklangShellRequest
-	328,  // 1002: ypb.Yak.AttachCombinedOutput:input_type -> ypb.AttachCombinedOutputRequest
-	4,    // 1003: ypb.Yak.IsPrivilegedForNetRaw:input_type -> ypb.Empty
-	4,    // 1004: ypb.Yak.PromotePermissionForUserPcap:input_type -> ypb.Empty
-	322,  // 1005: ypb.Yak.SetCurrentProject:input_type -> ypb.SetCurrentProjectRequest
-	4,    // 1006: ypb.Yak.GetCurrentProject:input_type -> ypb.Empty
-	323,  // 1007: ypb.Yak.GetCurrentProjectEx:input_type -> ypb.GetCurrentProjectExRequest
-	319,  // 1008: ypb.Yak.GetProjects:input_type -> ypb.GetProjectsRequest
-	317,  // 1009: ypb.Yak.NewProject:input_type -> ypb.NewProjectRequest
-	317,  // 1010: ypb.Yak.UpdateProject:input_type -> ypb.NewProjectRequest
-	316,  // 1011: ypb.Yak.IsProjectNameValid:input_type -> ypb.IsProjectNameValidRequest
-	315,  // 1012: ypb.Yak.RemoveProject:input_type -> ypb.RemoveProjectRequest
-	324,  // 1013: ypb.Yak.DeleteProject:input_type -> ypb.DeleteProjectRequest
-	4,    // 1014: ypb.Yak.GetDefaultProject:input_type -> ypb.Empty
-	325,  // 1015: ypb.Yak.GetDefaultProjectEx:input_type -> ypb.GetDefaultProjectExRequest
-	326,  // 1016: ypb.Yak.QueryProjectDetail:input_type -> ypb.QueryProjectDetailRequest
-	4,    // 1017: ypb.Yak.GetTemporaryProject:input_type -> ypb.Empty
-	327,  // 1018: ypb.Yak.GetTemporaryProjectEx:input_type -> ypb.GetTemporaryProjectExRequest
-	311,  // 1019: ypb.Yak.ExportProject:input_type -> ypb.ExportProjectRequest
-	313,  // 1020: ypb.Yak.ImportProject:input_type -> ypb.ImportProjectRequest
-	4,    // 1021: ypb.Yak.MigrateLegacyDatabase:input_type -> ypb.Empty
-	301,  // 1022: ypb.Yak.QueryMITMRuleExtractedData:input_type -> ypb.QueryMITMRuleExtractedDataRequest
-	308,  // 1023: ypb.Yak.QueryMITMExtractedAggregate:input_type -> ypb.QueryMITMExtractedAggregateRequest
-	303,  // 1024: ypb.Yak.ExportMITMRuleExtractedData:input_type -> ypb.ExportMITMRuleExtractedDataRequest
-	305,  // 1025: ypb.Yak.DeleteMITMRuleExtractedData:input_type -> ypb.DeleteMITMRuleExtractedDataRequest
-	306,  // 1026: ypb.Yak.DeduplicateMITMRuleExtractedData:input_type -> ypb.DeduplicateMITMRuleExtractedDataRequest
-	285,  // 1027: ypb.Yak.ImportChaosMakerRules:input_type -> ypb.ImportChaosMakerRulesRequest
-	293,  // 1028: ypb.Yak.QueryChaosMakerRule:input_type -> ypb.QueryChaosMakerRuleRequest
-	292,  // 1029: ypb.Yak.DeleteChaosMakerRuleByID:input_type -> ypb.DeleteChaosMakerRuleByIDRequest
-	289,  // 1030: ypb.Yak.ExecuteChaosMakerRule:input_type -> ypb.ExecuteChaosMakerRuleRequest
-	287,  // 1031: ypb.Yak.IsRemoteAddrAvailable:input_type -> ypb.IsRemoteAddrAvailableRequest
-	287,  // 1032: ypb.Yak.ConnectVulinboxAgent:input_type -> ypb.IsRemoteAddrAvailableRequest
-	253,  // 1033: ypb.Yak.GetRegisteredVulinboxAgent:input_type -> ypb.GetRegisteredAgentRequest
-	252,  // 1034: ypb.Yak.DisconnectVulinboxAgent:input_type -> ypb.DisconnectVulinboxAgentRequest
-	298,  // 1035: ypb.Yak.IsCVEDatabaseReady:input_type -> ypb.IsCVEDatabaseReadyRequest
-	296,  // 1036: ypb.Yak.UpdateCVEDatabase:input_type -> ypb.UpdateCVEDatabaseRequest
-	295,  // 1037: ypb.Yak.ExportsProfileDatabase:input_type -> ypb.ExportsProfileDatabaseRequest
-	294,  // 1038: ypb.Yak.ImportsProfileDatabase:input_type -> ypb.ImportsProfileDatabaseRequest
-	278,  // 1039: ypb.Yak.QueryCVE:input_type -> ypb.QueryCVERequest
-	277,  // 1040: ypb.Yak.GetCVE:input_type -> ypb.GetCVERequest
-	283,  // 1041: ypb.Yak.SaveTextToTemporalFile:input_type -> ypb.SaveTextToTemporalFileRequest
-	275,  // 1042: ypb.Yak.IsScrecorderReady:input_type -> ypb.IsScrecorderReadyRequest
-	274,  // 1043: ypb.Yak.InstallScrecorder:input_type -> ypb.InstallScrecorderRequest
-	273,  // 1044: ypb.Yak.StartScrecorder:input_type -> ypb.StartScrecorderRequest
-	268,  // 1045: ypb.Yak.QueryScreenRecorders:input_type -> ypb.QueryScreenRecorderRequest
-	268,  // 1046: ypb.Yak.DeleteScreenRecorders:input_type -> ypb.QueryScreenRecorderRequest
-	269,  // 1047: ypb.Yak.UploadScreenRecorders:input_type -> ypb.UploadScreenRecorderRequest
-	270,  // 1048: ypb.Yak.GetOneScreenRecorders:input_type -> ypb.GetOneScreenRecorderRequest
-	271,  // 1049: ypb.Yak.UpdateScreenRecorders:input_type -> ypb.UpdateScreenRecorderRequest
-	258,  // 1050: ypb.Yak.IsVulinboxReady:input_type -> ypb.IsVulinboxReadyRequest
-	260,  // 1051: ypb.Yak.InstallVulinbox:input_type -> ypb.InstallVulinboxRequest
-	261,  // 1052: ypb.Yak.StartVulinbox:input_type -> ypb.StartVulinboxRequest
-	262,  // 1053: ypb.Yak.GenQualityInspectionReport:input_type -> ypb.GenQualityInspectionReportRequest
-	266,  // 1054: ypb.Yak.HTTPRequestBuilder:input_type -> ypb.HTTPRequestBuilderParams
-	263,  // 1055: ypb.Yak.DebugPlugin:input_type -> ypb.DebugPluginRequest
-	255,  // 1056: ypb.Yak.SmokingEvaluatePlugin:input_type -> ypb.SmokingEvaluatePluginRequest
-	774,  // 1057: ypb.Yak.SmokingEvaluatePluginBatch:input_type -> ypb.SmokingEvaluatePluginBatchRequest
-	4,    // 1058: ypb.Yak.GetSystemDefaultDnsServers:input_type -> ypb.Empty
-	250,  // 1059: ypb.Yak.DiagnoseNetwork:input_type -> ypb.DiagnoseNetworkRequest
-	235,  // 1060: ypb.Yak.DiagnoseNetworkDNS:input_type -> ypb.DiagnoseNetworkDNSRequest
-	781,  // 1061: ypb.Yak.TraceRoute:input_type -> ypb.TraceRouteRequest
-	237,  // 1062: ypb.Yak.GetGlobalNetworkConfig:input_type -> ypb.GetGlobalNetworkConfigRequest
-	240,  // 1063: ypb.Yak.SetGlobalNetworkConfig:input_type -> ypb.GlobalNetworkConfig
-	236,  // 1064: ypb.Yak.ResetGlobalNetworkConfig:input_type -> ypb.ResetGlobalNetworkConfigRequest
-	4,    // 1065: ypb.Yak.GetGlobalProxyRulesConfig:input_type -> ypb.Empty
-	247,  // 1066: ypb.Yak.SetGlobalProxyRulesConfig:input_type -> ypb.SetGlobalProxyRulesConfigRequest
-	243,  // 1067: ypb.Yak.CheckProxyAlive:input_type -> ypb.CheckProxyAliveRequest
-	238,  // 1068: ypb.Yak.ValidP12PassWord:input_type -> ypb.ValidP12PassWordRequest
-	229,  // 1069: ypb.Yak.RequestYakURL:input_type -> ypb.RequestYakURLParams
-	798,  // 1070: ypb.Yak.ReadFile:input_type -> ypb.ReadFileRequest
-	215,  // 1071: ypb.Yak.GetPcapMetadata:input_type -> ypb.PcapMetadataRequest
-	226,  // 1072: ypb.Yak.PcapX:input_type -> ypb.PcapXRequest
-	225,  // 1073: ypb.Yak.QueryTrafficSession:input_type -> ypb.QueryTrafficSessionRequest
-	217,  // 1074: ypb.Yak.QueryTrafficPacket:input_type -> ypb.QueryTrafficPacketRequest
-	218,  // 1075: ypb.Yak.QueryTrafficTCPReassembled:input_type -> ypb.QueryTrafficTCPReassembledRequest
-	779,  // 1076: ypb.Yak.ParseTraffic:input_type -> ypb.ParseTrafficRequest
-	213,  // 1077: ypb.Yak.DuplexConnection:input_type -> ypb.DuplexConnectionRequest
-	212,  // 1078: ypb.Yak.HybridScan:input_type -> ypb.HybridScanRequest
-	206,  // 1079: ypb.Yak.QueryHybridScanTask:input_type -> ypb.QueryHybridScanTaskRequest
-	203,  // 1080: ypb.Yak.DeleteHybridScanTask:input_type -> ypb.DeleteHybridScanTaskRequest
-	200,  // 1081: ypb.Yak.GetSpaceEngineStatus:input_type -> ypb.GetSpaceEngineStatusRequest
-	199,  // 1082: ypb.Yak.GetSpaceEngineAccountStatus:input_type -> ypb.GetSpaceEngineAccountStatusRequest
-	249,  // 1083: ypb.Yak.GetSpaceEngineAccountStatusV2:input_type -> ypb.ThirdPartyApplicationConfig
-	202,  // 1084: ypb.Yak.FetchPortAssetFromSpaceEngine:input_type -> ypb.FetchPortAssetFromSpaceEngineRequest
-	783,  // 1085: ypb.Yak.EvaluateExpression:input_type -> ypb.EvaluateExpressionRequest
-	785,  // 1086: ypb.Yak.EvaluateMultiExpression:input_type -> ypb.EvaluateMultiExpressionRequest
-	4,    // 1087: ypb.Yak.GetThirdPartyAppConfigTemplate:input_type -> ypb.Empty
-	4,    // 1088: ypb.Yak.CheckHahValidAiConfig:input_type -> ypb.Empty
-	953,  // 1089: ypb.Yak.ListAiModel:input_type -> ypb.ListAiModelRequest
-	955,  // 1090: ypb.Yak.AIConfigHealthCheck:input_type -> ypb.AIConfigHealthCheckRequest
-	4,    // 1091: ypb.Yak.GetAIGlobalConfig:input_type -> ypb.Empty
-	966,  // 1092: ypb.Yak.SetAIGlobalConfig:input_type -> ypb.AIGlobalConfig
-	4,    // 1093: ypb.Yak.ListAIProviders:input_type -> ypb.Empty
-	959,  // 1094: ypb.Yak.QueryAIProvider:input_type -> ypb.QueryAIProvidersRequest
-	962,  // 1095: ypb.Yak.UpsertAIProvider:input_type -> ypb.UpsertAIProviderRequest
-	964,  // 1096: ypb.Yak.DeleteAIProvider:input_type -> ypb.DeleteAIProviderRequest
-	4,    // 1097: ypb.Yak.GetAIThirdPartyAppConfigTemplate:input_type -> ypb.Empty
-	790,  // 1098: ypb.Yak.GetApiKeyByOnline:input_type -> ypb.GetApiKeyByOnlineRequest
-	792,  // 1099: ypb.Yak.GetFingerprint:input_type -> ypb.GetFingerprintRequest
-	794,  // 1100: ypb.Yak.AddFingerprint:input_type -> ypb.AddFingerprintRequest
-	796,  // 1101: ypb.Yak.ModifyFingerprint:input_type -> ypb.ModifyFingerprintRequest
-	808,  // 1102: ypb.Yak.QueryFingerprint:input_type -> ypb.QueryFingerprintRequest
-	810,  // 1103: ypb.Yak.DeleteFingerprint:input_type -> ypb.DeleteFingerprintRequest
-	812,  // 1104: ypb.Yak.UpdateFingerprint:input_type -> ypb.UpdateFingerprintRequest
-	811,  // 1105: ypb.Yak.CreateFingerprint:input_type -> ypb.CreateFingerprintRequest
-	4,    // 1106: ypb.Yak.RecoverBuiltinFingerprint:input_type -> ypb.Empty
-	813,  // 1107: ypb.Yak.CreateFingerprintGroup:input_type -> ypb.FingerprintGroup
-	4,    // 1108: ypb.Yak.GetAllFingerprintGroup:input_type -> ypb.Empty
-	815,  // 1109: ypb.Yak.RenameFingerprintGroup:input_type -> ypb.RenameFingerprintGroupRequest
-	816,  // 1110: ypb.Yak.DeleteFingerprintGroup:input_type -> ypb.DeleteFingerprintGroupRequest
-	817,  // 1111: ypb.Yak.BatchUpdateFingerprintToGroup:input_type -> ypb.BatchUpdateFingerprintToGroupRequest
-	818,  // 1112: ypb.Yak.GetFingerprintGroupSetByFilter:input_type -> ypb.GetFingerprintGroupSetRequest
-	819,  // 1113: ypb.Yak.ExportFingerprint:input_type -> ypb.ExportFingerprintRequest
-	820,  // 1114: ypb.Yak.ImportFingerprint:input_type -> ypb.ImportFingerprintRequest
-	800,  // 1115: ypb.Yak.GetReverseShellProgramList:input_type -> ypb.GetReverseShellProgramListRequest
-	802,  // 1116: ypb.Yak.GenerateReverseShellCommand:input_type -> ypb.GenerateReverseShellCommandRequest
-	822,  // 1117: ypb.Yak.QuerySyntaxFlowRule:input_type -> ypb.QuerySyntaxFlowRuleRequest
-	837,  // 1118: ypb.Yak.CreateSyntaxFlowRule:input_type -> ypb.CreateSyntaxFlowRuleRequest
-	837,  // 1119: ypb.Yak.CreateSyntaxFlowRuleEx:input_type -> ypb.CreateSyntaxFlowRuleRequest
-	839,  // 1120: ypb.Yak.UpdateSyntaxFlowRule:input_type -> ypb.UpdateSyntaxFlowRuleRequest
-	839,  // 1121: ypb.Yak.UpdateSyntaxFlowRuleEx:input_type -> ypb.UpdateSyntaxFlowRuleRequest
-	842,  // 1122: ypb.Yak.DeleteSyntaxFlowRule:input_type -> ypb.DeleteSyntaxFlowRuleRequest
-	843,  // 1123: ypb.Yak.CheckSyntaxFlowRuleUpdate:input_type -> ypb.CheckSyntaxFlowRuleUpdateRequest
-	845,  // 1124: ypb.Yak.ApplySyntaxFlowRuleUpdate:input_type -> ypb.ApplySyntaxFlowRuleUpdateRequest
-	849,  // 1125: ypb.Yak.QuerySyntaxFlowRuleGroup:input_type -> ypb.QuerySyntaxFlowRuleGroupRequest
-	856,  // 1126: ypb.Yak.DeleteSyntaxFlowRuleGroup:input_type -> ypb.DeleteSyntaxFlowRuleGroupRequest
-	851,  // 1127: ypb.Yak.CreateSyntaxFlowRuleGroup:input_type -> ypb.CreateSyntaxFlowGroupRequest
-	852,  // 1128: ypb.Yak.UpdateSyntaxFlowRuleGroup:input_type -> ypb.UpdateSyntaxFlowRuleGroupRequest
-	853,  // 1129: ypb.Yak.UpdateSyntaxFlowRuleAndGroup:input_type -> ypb.UpdateSyntaxFlowRuleAndGroupRequest
-	854,  // 1130: ypb.Yak.QuerySyntaxFlowSameGroup:input_type -> ypb.QuerySyntaxFlowSameGroupRequest
-	857,  // 1131: ypb.Yak.SyntaxFlowRuleToOnline:input_type -> ypb.SyntaxFlowRuleToOnlineRequest
-	859,  // 1132: ypb.Yak.DownloadSyntaxFlowRule:input_type -> ypb.DownloadSyntaxFlowRuleRequest
-	860,  // 1133: ypb.Yak.SyntaxFlowScan:input_type -> ypb.SyntaxFlowScanRequest
-	861,  // 1134: ypb.Yak.QuerySyntaxFlowScanTask:input_type -> ypb.QuerySyntaxFlowScanTaskRequest
-	865,  // 1135: ypb.Yak.DeleteSyntaxFlowScanTask:input_type -> ypb.DeleteSyntaxFlowScanTaskRequest
-	869,  // 1136: ypb.Yak.QuerySyntaxFlowResult:input_type -> ypb.QuerySyntaxFlowResultRequest
-	872,  // 1137: ypb.Yak.DeleteSyntaxFlowResult:input_type -> ypb.DeleteSyntaxFlowResultRequest
-	833,  // 1138: ypb.Yak.QuerySSAPrograms:input_type -> ypb.QuerySSAProgramRequest
-	834,  // 1139: ypb.Yak.UpdateSSAProgram:input_type -> ypb.UpdateSSAProgramRequest
-	835,  // 1140: ypb.Yak.DeleteSSAPrograms:input_type -> ypb.DeleteSSAProgramRequest
-	886,  // 1141: ypb.Yak.QuerySSARisks:input_type -> ypb.QuerySSARisksRequest
-	888,  // 1142: ypb.Yak.QueryNewSSARisks:input_type -> ypb.QueryNewSSARisksRequest
-	890,  // 1143: ypb.Yak.DeleteSSARisks:input_type -> ypb.DeleteSSARisksRequest
-	891,  // 1144: ypb.Yak.UpdateSSARiskTags:input_type -> ypb.UpdateSSARiskTagsRequest
-	4,    // 1145: ypb.Yak.GetSSARiskFieldGroup:input_type -> ypb.Empty
-	892,  // 1146: ypb.Yak.GetSSARiskFieldGroupEx:input_type -> ypb.GetSSARiskFieldGroupRequest
-	894,  // 1147: ypb.Yak.NewSSARiskRead:input_type -> ypb.NewSSARiskReadRequest
-	896,  // 1148: ypb.Yak.ExportSSARisk:input_type -> ypb.ExportSSARiskRequest
-	898,  // 1149: ypb.Yak.ImportSSARisk:input_type -> ypb.ImportSSARiskRequest
-	829,  // 1150: ypb.Yak.SSARiskDiff:input_type -> ypb.SSARiskDiffRequest
-	903,  // 1151: ypb.Yak.CreateSSARiskDisposals:input_type -> ypb.CreateSSARiskDisposalsRequest
-	905,  // 1152: ypb.Yak.QuerySSARiskDisposals:input_type -> ypb.QuerySSARiskDisposalsRequest
-	907,  // 1153: ypb.Yak.UpdateSSARiskDisposals:input_type -> ypb.UpdateSSARiskDisposalsRequest
-	909,  // 1154: ypb.Yak.DeleteSSARiskDisposals:input_type -> ypb.DeleteSSARiskDisposalsRequest
-	911,  // 1155: ypb.Yak.GetSSARiskDisposal:input_type -> ypb.GetSSARiskDisposalRequest
-	900,  // 1156: ypb.Yak.SSARiskFeedbackToOnline:input_type -> ypb.SSARiskFeedbackToOnlineRequest
-	990,  // 1157: ypb.Yak.GenerateSSAReport:input_type -> ypb.GenerateSSAReportRequest
-	997,  // 1158: ypb.Yak.CreateSSAProject:input_type -> ypb.CreateSSAProjectRequest
-	999,  // 1159: ypb.Yak.UpdateSSAProject:input_type -> ypb.UpdateSSAProjectRequest
-	1001, // 1160: ypb.Yak.DeleteSSAProject:input_type -> ypb.DeleteSSAProjectRequest
-	1003, // 1161: ypb.Yak.QuerySSAProject:input_type -> ypb.QuerySSAProjectRequest
-	1005, // 1162: ypb.Yak.MigrateSSAProject:input_type -> ypb.MigrateSSAProjectRequest
-	1007, // 1163: ypb.Yak.GetSSAWorkbenchDashboard:input_type -> ypb.GetSSAWorkbenchDashboardRequest
-	4,    // 1164: ypb.Yak.GetAllPluginEnv:input_type -> ypb.Empty
-	874,  // 1165: ypb.Yak.QueryPluginEnv:input_type -> ypb.QueryPluginEnvRequest
-	875,  // 1166: ypb.Yak.CreatePluginEnv:input_type -> ypb.PluginEnvData
-	875,  // 1167: ypb.Yak.SetPluginEnv:input_type -> ypb.PluginEnvData
-	876,  // 1168: ypb.Yak.DeletePluginEnv:input_type -> ypb.DeletePluginEnvRequest
-	877,  // 1169: ypb.Yak.GetAllFuzztagInfo:input_type -> ypb.GetAllFuzztagInfoRequest
-	881,  // 1170: ypb.Yak.GenerateFuzztag:input_type -> ypb.GenerateFuzztagRequest
-	913,  // 1171: ypb.Yak.ExportSyntaxFlows:input_type -> ypb.ExportSyntaxFlowsRequest
-	914,  // 1172: ypb.Yak.ImportSyntaxFlows:input_type -> ypb.ImportSyntaxFlowsRequest
-	916,  // 1173: ypb.Yak.CreateHotPatchTemplate:input_type -> ypb.HotPatchTemplate
-	919,  // 1174: ypb.Yak.DeleteHotPatchTemplate:input_type -> ypb.DeleteHotPatchTemplateRequest
-	918,  // 1175: ypb.Yak.UpdateHotPatchTemplate:input_type -> ypb.UpdateHotPatchTemplateRequest
-	917,  // 1176: ypb.Yak.QueryHotPatchTemplate:input_type -> ypb.HotPatchTemplateRequest
-	924,  // 1177: ypb.Yak.QueryHotPatchTemplateList:input_type -> ypb.QueryHotPatchTemplateListRequest
-	4,    // 1178: ypb.Yak.GetHotPatchTemplateTags:input_type -> ypb.Empty
-	4,    // 1179: ypb.Yak.GetGlobalHotPatchConfig:input_type -> ypb.Empty
-	929,  // 1180: ypb.Yak.SetGlobalHotPatchConfig:input_type -> ypb.SetGlobalHotPatchConfigRequest
-	4,    // 1181: ypb.Yak.ResetGlobalHotPatchConfig:input_type -> ypb.Empty
-	930,  // 1182: ypb.Yak.GroupTableColumn:input_type -> ypb.GroupTableColumnRequest
-	932,  // 1183: ypb.Yak.UploadHotPatchTemplateToOnline:input_type -> ypb.UploadHotPatchTemplateToOnlineRequest
-	933,  // 1184: ypb.Yak.DownloadHotPatchTemplate:input_type -> ypb.DownloadHotPatchTemplateRequest
-	741,  // 1185: ypb.Yak.SetMITMHijackFilter:input_type -> ypb.SetMITMFilterRequest
-	4,    // 1186: ypb.Yak.GetMITMHijackFilter:input_type -> ypb.Empty
-	4,    // 1187: ypb.Yak.ResetMITMHijackFilter:input_type -> ypb.Empty
-	934,  // 1188: ypb.Yak.ExportHTTPFlowStream:input_type -> ypb.ExportHTTPFlowStreamRequest
-	936,  // 1189: ypb.Yak.ImportHTTPFlowStream:input_type -> ypb.ImportHTTPFlowStreamRequest
-	941,  // 1190: ypb.Yak.CreateNote:input_type -> ypb.CreateNoteRequest
-	943,  // 1191: ypb.Yak.UpdateNote:input_type -> ypb.UpdateNoteRequest
-	944,  // 1192: ypb.Yak.DeleteNote:input_type -> ypb.DeleteNoteRequest
-	945,  // 1193: ypb.Yak.QueryNote:input_type -> ypb.QueryNoteRequest
-	947,  // 1194: ypb.Yak.SearchNoteContent:input_type -> ypb.SearchNoteContentRequest
-	949,  // 1195: ypb.Yak.ImportNote:input_type -> ypb.ImportNoteRequest
-	951,  // 1196: ypb.Yak.ExportNote:input_type -> ypb.ExportNoteRequest
-	147,  // 1197: ypb.Yak.StartAIReAct:input_type -> ypb.AIInputEvent
-	147,  // 1198: ypb.Yak.StartAITask:input_type -> ypb.AIInputEvent
-	159,  // 1199: ypb.Yak.QueryAITask:input_type -> ypb.AITaskQueryRequest
-	161,  // 1200: ypb.Yak.DeleteAITask:input_type -> ypb.AITaskDeleteRequest
-	156,  // 1201: ypb.Yak.QueryAIEvent:input_type -> ypb.AIEventQueryRequest
-	158,  // 1202: ypb.Yak.DeleteAIEvent:input_type -> ypb.AIEventDeleteRequest
-	167,  // 1203: ypb.Yak.QueryAISession:input_type -> ypb.QueryAISessionRequest
-	169,  // 1204: ypb.Yak.UpdateAISessionTitle:input_type -> ypb.UpdateAISessionTitleRequest
-	170,  // 1205: ypb.Yak.UpdateAISessionIMMeta:input_type -> ypb.UpdateAISessionIMMetaRequest
-	173,  // 1206: ypb.Yak.DeleteAISession:input_type -> ypb.DeleteAISessionRequest
-	162,  // 1207: ypb.Yak.GetRandomAIMaterials:input_type -> ypb.GetRandomAIMaterialsRequest
-	184,  // 1208: ypb.Yak.ExportAILogs:input_type -> ypb.ExportAILogsRequest
-	188,  // 1209: ypb.Yak.CreateAIMemoryEntity:input_type -> ypb.CreateAIMemoryEntityRequest
-	189,  // 1210: ypb.Yak.UpdateAIMemoryEntity:input_type -> ypb.AIMemoryEntity
-	194,  // 1211: ypb.Yak.DeleteAIMemoryEntity:input_type -> ypb.DeleteAIMemoryEntityRequest
-	193,  // 1212: ypb.Yak.GetAIMemoryEntity:input_type -> ypb.GetAIMemoryEntityRequest
-	191,  // 1213: ypb.Yak.QueryAIMemoryEntity:input_type -> ypb.QueryAIMemoryEntityRequest
-	195,  // 1214: ypb.Yak.CountAIMemoryEntityTags:input_type -> ypb.CountAIMemoryEntityTagsRequest
-	149,  // 1215: ypb.Yak.StartAITriage:input_type -> ypb.AITriageInputEvent
-	175,  // 1216: ypb.Yak.CreateAIForge:input_type -> ypb.AIForge
-	175,  // 1217: ypb.Yak.UpdateAIForge:input_type -> ypb.AIForge
-	174,  // 1218: ypb.Yak.DeleteAIForge:input_type -> ypb.AIForgeFilter
-	176,  // 1219: ypb.Yak.QueryAIForge:input_type -> ypb.QueryAIForgeRequest
-	180,  // 1220: ypb.Yak.GetAIForge:input_type -> ypb.GetAIForgeRequest
-	178,  // 1221: ypb.Yak.ExportAIForge:input_type -> ypb.ExportAIForgeRequest
-	179,  // 1222: ypb.Yak.ImportAIForge:input_type -> ypb.ImportAIForgeRequest
-	182,  // 1223: ypb.Yak.QueryAIFocus:input_type -> ypb.QueryAIFocusRequest
-	197,  // 1224: ypb.Yak.StartMcpServer:input_type -> ypb.StartMcpServerRequest
-	4,    // 1225: ypb.Yak.GetToolSetList:input_type -> ypb.Empty
-	142,  // 1226: ypb.Yak.GetAIToolList:input_type -> ypb.GetAIToolListRequest
-	136,  // 1227: ypb.Yak.DeleteAITool:input_type -> ypb.DeleteAIToolRequest
-	133,  // 1228: ypb.Yak.SaveAITool:input_type -> ypb.SaveAIToolRequest
-	133,  // 1229: ypb.Yak.SaveAIToolV2:input_type -> ypb.SaveAIToolRequest
-	135,  // 1230: ypb.Yak.UpdateAITool:input_type -> ypb.UpdateAIToolRequest
-	137,  // 1231: ypb.Yak.ToggleAIToolFavorite:input_type -> ypb.ToggleAIToolFavoriteRequest
-	131,  // 1232: ypb.Yak.AIToolGenerateMetadata:input_type -> ypb.AIToolGenerateMetadataRequest
-	143,  // 1233: ypb.Yak.ExportAITool:input_type -> ypb.ExportAIToolRequest
-	144,  // 1234: ypb.Yak.ImportAITool:input_type -> ypb.ImportAIToolRequest
-	4,    // 1235: ypb.Yak.IsLlamaServerReady:input_type -> ypb.Empty
-	968,  // 1236: ypb.Yak.IsLocalModelReady:input_type -> ypb.IsLocalModelReadyRequest
-	970,  // 1237: ypb.Yak.InstallLlamaServer:input_type -> ypb.InstallLlamaServerRequest
-	971,  // 1238: ypb.Yak.StartLocalModel:input_type -> ypb.StartLocalModelRequest
-	81,   // 1239: ypb.Yak.StopLocalModel:input_type -> ypb.StopLocalModelRequest
-	972,  // 1240: ypb.Yak.DownloadLocalModel:input_type -> ypb.DownloadLocalModelRequest
-	4,    // 1241: ypb.Yak.GetSupportedLocalModels:input_type -> ypb.Empty
-	79,   // 1242: ypb.Yak.AddLocalModel:input_type -> ypb.AddLocalModelRequest
-	80,   // 1243: ypb.Yak.DeleteLocalModel:input_type -> ypb.DeleteLocalModelRequest
-	78,   // 1244: ypb.Yak.UpdateLocalModel:input_type -> ypb.UpdateLocalModelRequest
-	4,    // 1245: ypb.Yak.GetAllStartedLocalModels:input_type -> ypb.Empty
-	77,   // 1246: ypb.Yak.ClearAllModels:input_type -> ypb.ClearAllModelsRequest
-	125,  // 1247: ypb.Yak.IsSearchVectorDatabaseReady:input_type -> ypb.IsSearchVectorDatabaseReadyRequest
-	127,  // 1248: ypb.Yak.InitSearchVectorDatabase:input_type -> ypb.InitSearchVectorDatabaseRequest
-	4,    // 1249: ypb.Yak.GetAllVectorStoreCollections:input_type -> ypb.Empty
-	122,  // 1250: ypb.Yak.GetAllVectorStoreCollectionsWithFilter:input_type -> ypb.GetAllVectorStoreCollectionsWithFilterRequest
-	112,  // 1251: ypb.Yak.DeleteSearchVectorDatabase:input_type -> ypb.DeleteSearchVectorDatabaseRequest
-	121,  // 1252: ypb.Yak.UpdateVectorStoreCollection:input_type -> ypb.UpdateVectorStoreCollectionRequest
-	115,  // 1253: ypb.Yak.ListVectorStoreEntries:input_type -> ypb.ListVectorStoreEntriesRequest
-	116,  // 1254: ypb.Yak.CreateVectorStoreEntry:input_type -> ypb.CreateVectorStoreEntryRequest
-	119,  // 1255: ypb.Yak.GetDocumentByVectorStoreEntryID:input_type -> ypb.GetDocumentByVectorStoreEntryIDRequest
-	4,    // 1256: ypb.Yak.ListThirdPartyBinary:input_type -> ypb.Empty
-	85,   // 1257: ypb.Yak.InstallThirdPartyBinary:input_type -> ypb.InstallThirdPartyBinaryRequest
-	86,   // 1258: ypb.Yak.UninstallThirdPartyBinary:input_type -> ypb.UninstallThirdPartyBinaryRequest
-	87,   // 1259: ypb.Yak.IsThirdPartyBinaryReady:input_type -> ypb.IsThirdPartyBinaryReadyRequest
-	89,   // 1260: ypb.Yak.StartThirdPartyBinary:input_type -> ypb.StartThirdPartyBinaryRequest
-	987,  // 1261: ypb.Yak.PluginTrace:input_type -> ypb.PluginTraceRequest
-	4,    // 1262: ypb.Yak.GetKnowledgeBaseNameList:input_type -> ypb.Empty
-	97,   // 1263: ypb.Yak.GetKnowledgeBase:input_type -> ypb.GetKnowledgeBaseRequest
-	4,    // 1264: ypb.Yak.GetKnowledgeBaseTypeList:input_type -> ypb.Empty
-	111,  // 1265: ypb.Yak.DeleteKnowledgeBase:input_type -> ypb.DeleteKnowledgeBaseRequest
-	100,  // 1266: ypb.Yak.CreateKnowledgeBase:input_type -> ypb.CreateKnowledgeBaseRequest
-	38,   // 1267: ypb.Yak.CreateKnowledgeBaseV2:input_type -> ypb.CreateKnowledgeBaseV2Request
-	101,  // 1268: ypb.Yak.UpdateKnowledgeBase:input_type -> ypb.UpdateKnowledgeBaseRequest
-	102,  // 1269: ypb.Yak.DeleteKnowledgeBaseEntry:input_type -> ypb.DeleteKnowledgeBaseEntryRequest
-	108,  // 1270: ypb.Yak.CreateKnowledgeBaseEntry:input_type -> ypb.CreateKnowledgeBaseEntryRequest
-	109,  // 1271: ypb.Yak.UpdateKnowledgeBaseEntry:input_type -> ypb.UpdateKnowledgeBaseEntryRequest
-	104,  // 1272: ypb.Yak.SearchKnowledgeBaseEntry:input_type -> ypb.SearchKnowledgeBaseEntryRequest
-	105,  // 1273: ypb.Yak.QueryKnowledgeBaseByAI:input_type -> ypb.QueryKnowledgeBaseByAIRequest
-	93,   // 1274: ypb.Yak.BuildVectorIndexForKnowledgeBase:input_type -> ypb.BuildVectorIndexForKnowledgeBaseRequest
-	92,   // 1275: ypb.Yak.BuildVectorIndexForKnowledgeBaseEntry:input_type -> ypb.BuildVectorIndexForKnowledgeBaseEntryRequest
-	90,   // 1276: ypb.Yak.GenerateQuestionIndexForKnowledgeBase:input_type -> ypb.GenerateQuestionIndexForKnowledgeBaseRequest
-	4,    // 1277: ypb.Yak.ListEntityRepository:input_type -> ypb.Empty
-	63,   // 1278: ypb.Yak.QueryEntity:input_type -> ypb.QueryEntityRequest
-	61,   // 1279: ypb.Yak.CreateEntity:input_type -> ypb.Entity
-	61,   // 1280: ypb.Yak.UpdateEntity:input_type -> ypb.Entity
-	65,   // 1281: ypb.Yak.DeleteEntity:input_type -> ypb.DeleteEntityRequest
-	68,   // 1282: ypb.Yak.QueryRelationship:input_type -> ypb.QueryRelationshipRequest
-	66,   // 1283: ypb.Yak.CreateRelationship:input_type -> ypb.Relationship
-	66,   // 1284: ypb.Yak.UpdateRelationship:input_type -> ypb.Relationship
-	70,   // 1285: ypb.Yak.DeleteRelationship:input_type -> ypb.DeleteRelationshipRequest
-	71,   // 1286: ypb.Yak.QuerySubERM:input_type -> ypb.QuerySubERMRequest
-	73,   // 1287: ypb.Yak.GenerateERMDot:input_type -> ypb.GenerateERMDotRequest
-	40,   // 1288: ypb.Yak.ExportKnowledgeBase:input_type -> ypb.ExportKnowledgeBaseRequest
-	41,   // 1289: ypb.Yak.ImportKnowledgeBase:input_type -> ypb.ImportKnowledgeBaseRequest
-	45,   // 1290: ypb.Yak.AddMCPServer:input_type -> ypb.AddMCPServerRequest
-	46,   // 1291: ypb.Yak.DeleteMCPServer:input_type -> ypb.DeleteMCPServerRequest
-	47,   // 1292: ypb.Yak.UpdateMCPServer:input_type -> ypb.UpdateMCPServerRequest
-	49,   // 1293: ypb.Yak.GetAllMCPServers:input_type -> ypb.GetAllMCPServersRequest
-	48,   // 1294: ypb.Yak.UpdateMCPServerToolConfig:input_type -> ypb.UpdateMCPServerToolConfigRequest
-	55,   // 1295: ypb.Yak.GetMCPToolList:input_type -> ypb.GetMCPToolListRequest
-	58,   // 1296: ypb.Yak.GetMCPToolDetail:input_type -> ypb.GetMCPToolDetailRequest
-	57,   // 1297: ypb.Yak.SetMCPToolEnabled:input_type -> ypb.SetMCPToolEnabledRequest
-	43,   // 1298: ypb.Yak.RAGCollectionSearch:input_type -> ypb.RAGCollectionSearchRequest
-	37,   // 1299: ypb.Yak.DownloadRAGs:input_type -> ypb.DownloadRAGsRequest
-	15,   // 1300: ypb.Yak.SaveIMBot:input_type -> ypb.SaveIMBotRequest
-	17,   // 1301: ypb.Yak.ListIMBots:input_type -> ypb.ListIMBotRequest
-	19,   // 1302: ypb.Yak.DeleteIMBot:input_type -> ypb.DeleteIMBotRequest
-	21,   // 1303: ypb.Yak.TestIMBot:input_type -> ypb.TestIMBotRequest
-	23,   // 1304: ypb.Yak.StartIMOnboarding:input_type -> ypb.StartIMOnboardingRequest
-	26,   // 1305: ypb.Yak.StartIMControl:input_type -> ypb.StartIMControlRequest
-	28,   // 1306: ypb.Yak.StopIMControl:input_type -> ypb.StopIMControlRequest
-	30,   // 1307: ypb.Yak.SubscribeIMControlState:input_type -> ypb.SubscribeIMControlStateRequest
-	35,   // 1308: ypb.Yak.UpdateIMControlConfig:input_type -> ypb.UpdateIMControlConfigRequest
-	5,    // 1309: ypb.Yak.Version:output_type -> ypb.VersionResponse
-	6,    // 1310: ypb.Yak.YakVersionAtLeast:output_type -> ypb.GeneralResponse
-	755,  // 1311: ypb.Yak.Echo:output_type -> ypb.EchoResposne
-	757,  // 1312: ypb.Yak.Handshake:output_type -> ypb.HandshakeResponse
-	13,   // 1313: ypb.Yak.VerifySystemCertificate:output_type -> ypb.VerifySystemCertificateResponse
-	6,    // 1314: ypb.Yak.InstallMITMCertificate:output_type -> ypb.GeneralResponse
-	750,  // 1315: ypb.Yak.MITM:output_type -> ypb.MITMResponse
-	742,  // 1316: ypb.Yak.SetMITMFilter:output_type -> ypb.SetMITMFilterResponse
-	741,  // 1317: ypb.Yak.GetMITMFilter:output_type -> ypb.SetMITMFilterRequest
-	741,  // 1318: ypb.Yak.ResetMITMFilter:output_type -> ypb.SetMITMFilterRequest
-	464,  // 1319: ypb.Yak.DownloadMITMCert:output_type -> ypb.MITMCert
-	464,  // 1320: ypb.Yak.DownloadMITMGMCert:output_type -> ypb.MITMCert
-	979,  // 1321: ypb.Yak.WatchProcessConnection:output_type -> ypb.WatchProcessResponse
-	981,  // 1322: ypb.Yak.MITMV2:output_type -> ypb.MITMV2Response
-	759,  // 1323: ypb.Yak.OpenPort:output_type -> ypb.Output
-	762,  // 1324: ypb.Yak.Exec:output_type -> ypb.ExecResult
-	671,  // 1325: ypb.Yak.QueryExecHistory:output_type -> ypb.ExecHistoryRecordResponse
-	4,    // 1326: ypb.Yak.RemoveExecHistory:output_type -> ypb.Empty
-	4,    // 1327: ypb.Yak.SavePluginExecutionHistory:output_type -> ypb.Empty
-	674,  // 1328: ypb.Yak.GetPluginExecutionUsageRanking:output_type -> ypb.PluginExecutionUsageRankingResponse
-	4,    // 1329: ypb.Yak.LoadNucleiTemplates:output_type -> ypb.Empty
-	762,  // 1330: ypb.Yak.AutoUpdateYakModule:output_type -> ypb.ExecResult
-	762,  // 1331: ypb.Yak.ExecYakScript:output_type -> ypb.ExecResult
-	9,    // 1332: ypb.Yak.ExecBatchYakScript:output_type -> ypb.ExecBatchYakScriptResult
-	412,  // 1333: ypb.Yak.GetExecBatchYakScriptUnfinishedTask:output_type -> ypb.GetExecBatchYakScriptUnfinishedTaskResponse
-	8,    // 1334: ypb.Yak.GetExecBatchYakScriptUnfinishedTaskByUid:output_type -> ypb.ExecBatchYakScriptRequest
-	8,    // 1335: ypb.Yak.PopExecBatchYakScriptUnfinishedTaskByUid:output_type -> ypb.ExecBatchYakScriptRequest
-	9,    // 1336: ypb.Yak.RecoverExecBatchYakScriptUnfinishedTask:output_type -> ypb.ExecBatchYakScriptResult
-	628,  // 1337: ypb.Yak.QueryYakScript:output_type -> ypb.QueryYakScriptResponse
-	630,  // 1338: ypb.Yak.QueryYakScriptByYakScriptName:output_type -> ypb.YakScript
-	630,  // 1339: ypb.Yak.SaveYakScript:output_type -> ypb.YakScript
-	4,    // 1340: ypb.Yak.DeleteYakScript:output_type -> ypb.Empty
-	630,  // 1341: ypb.Yak.GetYakScriptById:output_type -> ypb.YakScript
-	630,  // 1342: ypb.Yak.GetYakScriptByName:output_type -> ypb.YakScript
-	630,  // 1343: ypb.Yak.GetYakScriptByOnlineID:output_type -> ypb.YakScript
-	4,    // 1344: ypb.Yak.IgnoreYakScript:output_type -> ypb.Empty
-	4,    // 1345: ypb.Yak.UnIgnoreYakScript:output_type -> ypb.Empty
-	566,  // 1346: ypb.Yak.ExportYakScript:output_type -> ypb.ExportYakScriptResponse
-	762,  // 1347: ypb.Yak.ExportYakScriptStream:output_type -> ypb.ExecResult
-	762,  // 1348: ypb.Yak.ImportYakScriptStream:output_type -> ypb.ExecResult
-	762,  // 1349: ypb.Yak.ExecutePacketYakScript:output_type -> ypb.ExecResult
-	9,    // 1350: ypb.Yak.ExecuteBatchPacketYakScript:output_type -> ypb.ExecBatchYakScriptResult
-	428,  // 1351: ypb.Yak.GetYakScriptTags:output_type -> ypb.GetYakScriptTagsResponse
-	431,  // 1352: ypb.Yak.QueryYakScriptLocalAndUser:output_type -> ypb.QueryYakScriptLocalAndUserResponse
-	431,  // 1353: ypb.Yak.QueryYakScriptByOnlineGroup:output_type -> ypb.QueryYakScriptLocalAndUserResponse
-	431,  // 1354: ypb.Yak.QueryYakScriptLocalAll:output_type -> ypb.QueryYakScriptLocalAndUserResponse
-	435,  // 1355: ypb.Yak.QueryYakScriptByNames:output_type -> ypb.QueryYakScriptByNamesResponse
-	436,  // 1356: ypb.Yak.QueryYakScriptByIsCore:output_type -> ypb.QueryYakScriptByIsCoreResponse
-	438,  // 1357: ypb.Yak.QueryYakScriptRiskDetailByCWE:output_type -> ypb.QueryYakScriptRiskDetailByCWEResponse
-	439,  // 1358: ypb.Yak.YakScriptRiskTypeList:output_type -> ypb.YakScriptRiskTypeListResponse
-	630,  // 1359: ypb.Yak.SaveNewYakScript:output_type -> ypb.YakScript
-	634,  // 1360: ypb.Yak.SaveYakScriptToOnline:output_type -> ypb.SaveYakScriptToOnlineResponse
-	637,  // 1361: ypb.Yak.ExportLocalYakScript:output_type -> ypb.ExportLocalYakScriptResponse
-	638,  // 1362: ypb.Yak.ExportLocalYakScriptStream:output_type -> ypb.ExportYakScriptLocalResponse
-	640,  // 1363: ypb.Yak.ImportYakScript:output_type -> ypb.ImportYakScriptResult
-	4,    // 1364: ypb.Yak.SetYakScriptSkipUpdate:output_type -> ypb.Empty
-	642,  // 1365: ypb.Yak.QueryYakScriptSkipUpdate:output_type -> ypb.QueryYakScriptSkipUpdateResponse
-	644,  // 1366: ypb.Yak.QueryYakScriptGroup:output_type -> ypb.QueryYakScriptGroupResponse
-	4,    // 1367: ypb.Yak.SaveYakScriptGroup:output_type -> ypb.Empty
-	4,    // 1368: ypb.Yak.RenameYakScriptGroup:output_type -> ypb.Empty
-	4,    // 1369: ypb.Yak.DeleteYakScriptGroup:output_type -> ypb.Empty
-	649,  // 1370: ypb.Yak.GetYakScriptGroup:output_type -> ypb.GetYakScriptGroupResponse
-	4,    // 1371: ypb.Yak.ResetYakScriptGroup:output_type -> ypb.Empty
-	4,    // 1372: ypb.Yak.SetGroup:output_type -> ypb.Empty
-	729,  // 1373: ypb.Yak.GetHTTPFlowByHash:output_type -> ypb.HTTPFlow
-	729,  // 1374: ypb.Yak.GetHTTPFlowById:output_type -> ypb.HTTPFlow
-	731,  // 1375: ypb.Yak.GetHTTPFlowBodyById:output_type -> ypb.GetHTTPFlowBodyByIdResponse
-	728,  // 1376: ypb.Yak.GetHTTPFlowByIds:output_type -> ypb.HTTPFlows
-	732,  // 1377: ypb.Yak.QueryHTTPFlows:output_type -> ypb.QueryHTTPFlowResponse
-	4,    // 1378: ypb.Yak.DeleteHTTPFlows:output_type -> ypb.Empty
-	4,    // 1379: ypb.Yak.SetTagForHTTPFlow:output_type -> ypb.Empty
-	726,  // 1380: ypb.Yak.QueryHTTPFlowsIds:output_type -> ypb.QueryHTTPFlowsIdsResponse
-	734,  // 1381: ypb.Yak.HTTPFlowsFieldGroup:output_type -> ypb.HTTPFlowsFieldGroupResponse
-	736,  // 1382: ypb.Yak.HTTPFlowsShare:output_type -> ypb.HTTPFlowsShareResponse
-	4,    // 1383: ypb.Yak.HTTPFlowsExtract:output_type -> ypb.Empty
-	767,  // 1384: ypb.Yak.GetHTTPFlowBare:output_type -> ypb.HTTPFlowBareResponse
-	732,  // 1385: ypb.Yak.ExportHTTPFlows:output_type -> ypb.QueryHTTPFlowResponse
-	4,    // 1386: ypb.Yak.HTTPFlowsToOnline:output_type -> ypb.Empty
-	723,  // 1387: ypb.Yak.QueryHTTPFlowsProcessNames:output_type -> ypb.QueryHTTPFlowsProcessNamesResponse
-	715,  // 1388: ypb.Yak.HTTPFlowsToOnlineBatch:output_type -> ypb.HTTPFlowsToOnlineBatchResponse
-	719,  // 1389: ypb.Yak.AnalyzeHTTPFlow:output_type -> ypb.AnalyzeHTTPFlowResponse
-	701,  // 1390: ypb.Yak.ExtractUrl:output_type -> ypb.ExtractedUrl
-	487,  // 1391: ypb.Yak.GetHistoryHTTPFuzzerTask:output_type -> ypb.HistoryHTTPFuzzerTaskDetail
-	489,  // 1392: ypb.Yak.QueryHistoryHTTPFuzzerTask:output_type -> ypb.HistoryHTTPFuzzerTasks
-	490,  // 1393: ypb.Yak.QueryHistoryHTTPFuzzerTaskEx:output_type -> ypb.HistoryHTTPFuzzerTasksResponse
-	4,    // 1394: ypb.Yak.DeleteHistoryHTTPFuzzerTask:output_type -> ypb.Empty
-	703,  // 1395: ypb.Yak.HTTPFuzzer:output_type -> ypb.FuzzerResponse
-	702,  // 1396: ypb.Yak.HTTPFuzzerSequence:output_type -> ypb.FuzzerSequenceResponse
-	695,  // 1397: ypb.Yak.HTTPFuzzerGroup:output_type -> ypb.GroupHTTPFuzzerResponse
-	690,  // 1398: ypb.Yak.PreloadHTTPFuzzerParams:output_type -> ypb.PreloadHTTPFuzzerParamsResponse
-	683,  // 1399: ypb.Yak.RenderVariables:output_type -> ypb.RenderVariablesResponse
-	685,  // 1400: ypb.Yak.MatchHTTPResponse:output_type -> ypb.MatchHTTPResponseResult
-	687,  // 1401: ypb.Yak.ExtractHTTPResponse:output_type -> ypb.ExtractHTTPResponseResult
-	703,  // 1402: ypb.Yak.RedirectRequest:output_type -> ypb.FuzzerResponse
-	541,  // 1403: ypb.Yak.HTTPRequestMutate:output_type -> ypb.MutateResult
-	541,  // 1404: ypb.Yak.HTTPResponseMutate:output_type -> ypb.MutateResult
-	422,  // 1405: ypb.Yak.FixUploadPacket:output_type -> ypb.FixUploadPacketResponse
-	423,  // 1406: ypb.Yak.IsMultipartFormDataRequest:output_type -> ypb.IsMultipartFormDataRequestResult
-	352,  // 1407: ypb.Yak.GenerateExtractRule:output_type -> ypb.GenerateExtractRuleResponse
-	340,  // 1408: ypb.Yak.ExtractData:output_type -> ypb.ExtractDataResponse
-	769,  // 1409: ypb.Yak.ImportHTTPFuzzerTaskFromYaml:output_type -> ypb.ImportHTTPFuzzerTaskFromYamlResponse
-	771,  // 1410: ypb.Yak.ExportHTTPFuzzerTaskToYaml:output_type -> ypb.ExportHTTPFuzzerTaskToYamlResponse
-	773,  // 1411: ypb.Yak.RenderHTTPFuzzerPacket:output_type -> ypb.RenderHTTPFuzzerPacketResponse
-	4,    // 1412: ypb.Yak.SaveFuzzerLabel:output_type -> ypb.Empty
-	342,  // 1413: ypb.Yak.QueryFuzzerLabel:output_type -> ypb.QueryFuzzerLabelResponse
-	4,    // 1414: ypb.Yak.DeleteFuzzerLabel:output_type -> ypb.Empty
-	804,  // 1415: ypb.Yak.SaveFuzzerConfig:output_type -> ypb.DbOperateMessage
-	347,  // 1416: ypb.Yak.QueryFuzzerConfig:output_type -> ypb.QueryFuzzerConfigResponse
-	804,  // 1417: ypb.Yak.DeleteFuzzerConfig:output_type -> ypb.DbOperateMessage
-	355,  // 1418: ypb.Yak.QueryHTTPFuzzerResponseByTaskId:output_type -> ypb.QueryHTTPFuzzerResponseByTaskIdResponse
-	359,  // 1419: ypb.Yak.CreateWebsocketFuzzer:output_type -> ypb.ClientWebsocketResponse
-	739,  // 1420: ypb.Yak.QueryWebsocketFlowByHTTPFlowWebsocketHash:output_type -> ypb.WebsocketFlows
-	4,    // 1421: ypb.Yak.DeleteWebsocketFlowByHTTPFlowWebsocketHash:output_type -> ypb.Empty
-	4,    // 1422: ypb.Yak.DeleteWebsocketFlowAll:output_type -> ypb.Empty
-	729,  // 1423: ypb.Yak.ConvertFuzzerResponseToHTTPFlow:output_type -> ypb.HTTPFlow
-	677,  // 1424: ypb.Yak.StringFuzzer:output_type -> ypb.StringFuzzerResponse
-	680,  // 1425: ypb.Yak.HTTPRequestAnalyzer:output_type -> ypb.HTTPRequestAnalysis
-	4,    // 1426: ypb.Yak.CreateSnippet:output_type -> ypb.Empty
-	4,    // 1427: ypb.Yak.UpdateSnippet:output_type -> ypb.Empty
-	4,    // 1428: ypb.Yak.DeleteSnippets:output_type -> ypb.Empty
-	658,  // 1429: ypb.Yak.QuerySnippets:output_type -> ypb.SnippetsResponse
-	666,  // 1430: ypb.Yak.Codec:output_type -> ypb.CodecResponse
-	666,  // 1431: ypb.Yak.NewCodec:output_type -> ypb.CodecResponse
-	667,  // 1432: ypb.Yak.GetAllCodecMethods:output_type -> ypb.CodecMethods
-	4,    // 1433: ypb.Yak.SaveCodecFlow:output_type -> ypb.Empty
-	4,    // 1434: ypb.Yak.UpdateCodecFlow:output_type -> ypb.Empty
-	4,    // 1435: ypb.Yak.DeleteCodecFlow:output_type -> ypb.Empty
-	665,  // 1436: ypb.Yak.GetAllCodecFlow:output_type -> ypb.GetCodecFlowResponse
-	234,  // 1437: ypb.Yak.PacketPrettifyHelper:output_type -> ypb.PacketPrettifyHelperResponse
-	621,  // 1438: ypb.Yak.QueryPayload:output_type -> ypb.QueryPayloadResponse
-	619,  // 1439: ypb.Yak.QueryPayloadFromFile:output_type -> ypb.QueryPayloadFromFileResponse
-	4,    // 1440: ypb.Yak.DeletePayloadByFolder:output_type -> ypb.Empty
-	4,    // 1441: ypb.Yak.DeletePayloadByGroup:output_type -> ypb.Empty
-	4,    // 1442: ypb.Yak.DeletePayload:output_type -> ypb.Empty
-	4,    // 1443: ypb.Yak.SavePayload:output_type -> ypb.Empty
-	379,  // 1444: ypb.Yak.SavePayloadStream:output_type -> ypb.SavePayloadProgress
-	379,  // 1445: ypb.Yak.SavePayloadToFileStream:output_type -> ypb.SavePayloadProgress
-	379,  // 1446: ypb.Yak.SaveLargePayloadToFileStream:output_type -> ypb.SavePayloadProgress
-	4,    // 1447: ypb.Yak.RenamePayloadFolder:output_type -> ypb.Empty
-	4,    // 1448: ypb.Yak.RenamePayloadGroup:output_type -> ypb.Empty
-	4,    // 1449: ypb.Yak.UpdatePayload:output_type -> ypb.Empty
-	4,    // 1450: ypb.Yak.UpdatePayloadToFile:output_type -> ypb.Empty
-	4,    // 1451: ypb.Yak.BackUpOrCopyPayloads:output_type -> ypb.Empty
-	610,  // 1452: ypb.Yak.GetAllPayloadGroup:output_type -> ypb.GetAllPayloadGroupResponse
-	4,    // 1453: ypb.Yak.UpdateAllPayloadGroup:output_type -> ypb.Empty
-	624,  // 1454: ypb.Yak.GetAllPayload:output_type -> ypb.GetAllPayloadResponse
-	625,  // 1455: ypb.Yak.GetAllPayloadFromFile:output_type -> ypb.GetAllPayloadFromFileResponse
-	624,  // 1456: ypb.Yak.ExportAllPayload:output_type -> ypb.GetAllPayloadResponse
-	624,  // 1457: ypb.Yak.ExportAllPayloadFromFile:output_type -> ypb.GetAllPayloadResponse
-	4,    // 1458: ypb.Yak.CreatePayloadFolder:output_type -> ypb.Empty
-	379,  // 1459: ypb.Yak.RemoveDuplicatePayloads:output_type -> ypb.SavePayloadProgress
-	379,  // 1460: ypb.Yak.CoverPayloadGroupToDatabase:output_type -> ypb.SavePayloadProgress
-	379,  // 1461: ypb.Yak.ConvertPayloadGroupToDatabase:output_type -> ypb.SavePayloadProgress
-	379,  // 1462: ypb.Yak.MigratePayloads:output_type -> ypb.SavePayloadProgress
-	624,  // 1463: ypb.Yak.ExportPayloadBatch:output_type -> ypb.GetAllPayloadResponse
-	383,  // 1464: ypb.Yak.UploadPayloadToOnline:output_type -> ypb.DownloadProgress
-	383,  // 1465: ypb.Yak.DownloadPayload:output_type -> ypb.DownloadProgress
-	624,  // 1466: ypb.Yak.ExportPayloadDBAndFile:output_type -> ypb.GetAllPayloadResponse
-	602,  // 1467: ypb.Yak.GetYakitCompletionRaw:output_type -> ypb.YakitCompletionRawResponse
-	606,  // 1468: ypb.Yak.GetYakVMBuildInMethodCompletion:output_type -> ypb.GetYakVMBuildInMethodCompletionResponse
-	378,  // 1469: ypb.Yak.StaticAnalyzeError:output_type -> ypb.StaticAnalyzeErrorResponse
-	376,  // 1470: ypb.Yak.YaklangCompileAndFormat:output_type -> ypb.YaklangCompileAndFormatResponse
-	367,  // 1471: ypb.Yak.YaklangLanguageSuggestion:output_type -> ypb.YaklangLanguageSuggestionResponse
-	368,  // 1472: ypb.Yak.YaklangLanguageFind:output_type -> ypb.YaklangLanguageFindResponse
-	367,  // 1473: ypb.Yak.FuzzTagSuggestion:output_type -> ypb.YaklangLanguageSuggestionResponse
-	369,  // 1474: ypb.Yak.YaklangInspectInformation:output_type -> ypb.YaklangInspectInformationResponse
-	372,  // 1475: ypb.Yak.YaklangGetCliCodeFromDatabase:output_type -> ypb.YaklangGetCliCodeFromDatabaseResponse
-	759,  // 1476: ypb.Yak.YaklangTerminal:output_type -> ypb.Output
-	762,  // 1477: ypb.Yak.PortScan:output_type -> ypb.ExecResult
-	593,  // 1478: ypb.Yak.ViewPortScanCode:output_type -> ypb.SimpleScript
-	762,  // 1479: ypb.Yak.SimpleDetect:output_type -> ypb.ExecResult
-	4,    // 1480: ypb.Yak.SaveCancelSimpleDetect:output_type -> ypb.Empty
-	762,  // 1481: ypb.Yak.SimpleDetectCreatReport:output_type -> ypb.ExecResult
-	418,  // 1482: ypb.Yak.QuerySimpleDetectUnfinishedTask:output_type -> ypb.QueryUnfinishedTaskResponse
-	595,  // 1483: ypb.Yak.GetSimpleDetectRecordRequestById:output_type -> ypb.RecordPortScanRequest
-	4,    // 1484: ypb.Yak.DeleteSimpleDetectUnfinishedTask:output_type -> ypb.Empty
-	762,  // 1485: ypb.Yak.RecoverSimpleDetectTask:output_type -> ypb.ExecResult
-	413,  // 1486: ypb.Yak.GetSimpleDetectUnfinishedTask:output_type -> ypb.GetSimpleDetectUnfinishedTaskResponse
-	595,  // 1487: ypb.Yak.GetSimpleDetectUnfinishedTaskByUid:output_type -> ypb.RecordPortScanRequest
-	595,  // 1488: ypb.Yak.PopSimpleDetectUnfinishedTaskByUid:output_type -> ypb.RecordPortScanRequest
-	762,  // 1489: ypb.Yak.RecoverSimpleDetectUnfinishedTask:output_type -> ypb.ExecResult
-	600,  // 1490: ypb.Yak.QueryPorts:output_type -> ypb.QueryPortsResponse
-	4,    // 1491: ypb.Yak.DeletePorts:output_type -> ypb.Empty
-	544,  // 1492: ypb.Yak.QueryHosts:output_type -> ypb.QueryHostsResponse
-	4,    // 1493: ypb.Yak.DeleteHosts:output_type -> ypb.Empty
-	547,  // 1494: ypb.Yak.QueryDomains:output_type -> ypb.QueryDomainsResponse
-	4,    // 1495: ypb.Yak.DeleteDomains:output_type -> ypb.Empty
-	549,  // 1496: ypb.Yak.QueryPortsGroup:output_type -> ypb.QueryPortsGroupResponse
-	4,    // 1497: ypb.Yak.UpdateFromYakitResource:output_type -> ypb.Empty
-	4,    // 1498: ypb.Yak.UpdateFromGithub:output_type -> ypb.Empty
-	4,    // 1499: ypb.Yak.AddToMenu:output_type -> ypb.Empty
-	4,    // 1500: ypb.Yak.RemoveFromMenu:output_type -> ypb.Empty
-	4,    // 1501: ypb.Yak.YakScriptIsInMenu:output_type -> ypb.Empty
-	576,  // 1502: ypb.Yak.GetAllMenuItem:output_type -> ypb.MenuByGroup
-	4,    // 1503: ypb.Yak.DeleteAllMenuItem:output_type -> ypb.Empty
-	4,    // 1504: ypb.Yak.ImportMenuItem:output_type -> ypb.Empty
-	583,  // 1505: ypb.Yak.ExportMenuItem:output_type -> ypb.ExportMenuItemResult
-	572,  // 1506: ypb.Yak.GetMenuItemById:output_type -> ypb.MenuItem
-	570,  // 1507: ypb.Yak.QueryGroupsByYakScriptId:output_type -> ypb.GroupNames
-	4,    // 1508: ypb.Yak.AddMenus:output_type -> ypb.Empty
-	576,  // 1509: ypb.Yak.QueryAllMenuItem:output_type -> ypb.MenuByGroup
-	4,    // 1510: ypb.Yak.DeleteAllMenu:output_type -> ypb.Empty
-	4,    // 1511: ypb.Yak.AddToNavigation:output_type -> ypb.Empty
-	588,  // 1512: ypb.Yak.GetAllNavigationItem:output_type -> ypb.GetAllNavigationItemResponse
-	4,    // 1513: ypb.Yak.DeleteAllNavigation:output_type -> ypb.Empty
-	4,    // 1514: ypb.Yak.AddOneNavigation:output_type -> ypb.Empty
-	570,  // 1515: ypb.Yak.QueryNavigationGroups:output_type -> ypb.GroupNames
-	4,    // 1516: ypb.Yak.SaveMarkdownDocument:output_type -> ypb.Empty
-	567,  // 1517: ypb.Yak.GetMarkdownDocument:output_type -> ypb.GetMarkdownDocumentResponse
-	4,    // 1518: ypb.Yak.DeleteMarkdownDocument:output_type -> ypb.Empty
-	762,  // 1519: ypb.Yak.StartBasicCrawler:output_type -> ypb.ExecResult
-	593,  // 1520: ypb.Yak.ViewBasicCrawlerCode:output_type -> ypb.SimpleScript
-	558,  // 1521: ypb.Yak.GenerateWebsiteTree:output_type -> ypb.GenerateWebsiteTreeResponse
-	557,  // 1522: ypb.Yak.QueryYakScriptExecResult:output_type -> ypb.QueryYakScriptExecResultResponse
-	555,  // 1523: ypb.Yak.QueryYakScriptNameInExecResult:output_type -> ypb.YakScriptNames
-	4,    // 1524: ypb.Yak.DeleteYakScriptExecResult:output_type -> ypb.Empty
-	4,    // 1525: ypb.Yak.DeleteYakScriptExec:output_type -> ypb.Empty
-	762,  // 1526: ypb.Yak.StartBrute:output_type -> ypb.ExecResult
-	537,  // 1527: ypb.Yak.GetAvailableBruteTypes:output_type -> ypb.GetAvailableBruteTypesResponse
-	531,  // 1528: ypb.Yak.GetTunnelServerExternalIP:output_type -> ypb.GetTunnelServerExternalIPResponse
-	529,  // 1529: ypb.Yak.VerifyTunnelServerDomain:output_type -> ypb.VerifyTunnelServerDomainResponse
-	762,  // 1530: ypb.Yak.StartFacades:output_type -> ypb.ExecResult
-	762,  // 1531: ypb.Yak.StartFacadesWithYsoObject:output_type -> ypb.ExecResult
-	4,    // 1532: ypb.Yak.ApplyClassToFacades:output_type -> ypb.Empty
-	481,  // 1533: ypb.Yak.BytesToBase64:output_type -> ypb.BytesToBase64Response
-	4,    // 1534: ypb.Yak.ConfigGlobalReverse:output_type -> ypb.Empty
-	510,  // 1535: ypb.Yak.AvailableLocalAddr:output_type -> ypb.AvailableLocalAddrResponse
-	509,  // 1536: ypb.Yak.GetGlobalReverseServer:output_type -> ypb.GetGlobalReverseServerResponse
-	518,  // 1537: ypb.Yak.QueryRisks:output_type -> ypb.QueryRisksResponse
-	516,  // 1538: ypb.Yak.QueryRisk:output_type -> ypb.Risk
-	4,    // 1539: ypb.Yak.DeleteRisk:output_type -> ypb.Empty
-	466,  // 1540: ypb.Yak.QueryAvailableRiskType:output_type -> ypb.Fields
-	466,  // 1541: ypb.Yak.QueryAvailableRiskLevel:output_type -> ypb.Fields
-	463,  // 1542: ypb.Yak.QueryRiskTableStats:output_type -> ypb.RiskTableStats
-	4,    // 1543: ypb.Yak.ResetRiskTableStats:output_type -> ypb.Empty
-	466,  // 1544: ypb.Yak.QueryAvailableTarget:output_type -> ypb.Fields
-	520,  // 1545: ypb.Yak.QueryNewRisk:output_type -> ypb.QueryNewRiskResponse
-	4,    // 1546: ypb.Yak.NewRiskRead:output_type -> ypb.Empty
-	4,    // 1547: ypb.Yak.UploadRiskToOnline:output_type -> ypb.Empty
-	4,    // 1548: ypb.Yak.SetTagForRisk:output_type -> ypb.Empty
-	521,  // 1549: ypb.Yak.QueryRiskTags:output_type -> ypb.QueryRiskTagsResponse
-	522,  // 1550: ypb.Yak.RiskFieldGroup:output_type -> ypb.RiskFieldGroupResponse
-	4,    // 1551: ypb.Yak.RiskFeedbackToOnline:output_type -> ypb.Empty
-	453,  // 1552: ypb.Yak.QueryReports:output_type -> ypb.QueryReportsResponse
-	455,  // 1553: ypb.Yak.QueryReport:output_type -> ypb.Report
-	4,    // 1554: ypb.Yak.DeleteReport:output_type -> ypb.Empty
-	466,  // 1555: ypb.Yak.QueryAvailableReportFrom:output_type -> ypb.Fields
-	4,    // 1556: ypb.Yak.DownloadReport:output_type -> ypb.Empty
-	468,  // 1557: ypb.Yak.GetAllYsoGadgetOptions:output_type -> ypb.YsoOptionsWithVerbose
-	468,  // 1558: ypb.Yak.GetAllYsoClassOptions:output_type -> ypb.YsoOptionsWithVerbose
-	471,  // 1559: ypb.Yak.GetAllYsoClassGeneraterOptions:output_type -> ypb.YsoClassOptionsResponseWithVerbose
-	478,  // 1560: ypb.Yak.GenerateYsoCode:output_type -> ypb.YsoCodeResponse
-	479,  // 1561: ypb.Yak.GenerateYsoBytes:output_type -> ypb.YsoBytesResponse
-	477,  // 1562: ypb.Yak.YsoDump:output_type -> ypb.YsoDumpResponse
-	494,  // 1563: ypb.Yak.CreateWebShell:output_type -> ypb.WebShell
-	4,    // 1564: ypb.Yak.DeleteWebShell:output_type -> ypb.Empty
-	494,  // 1565: ypb.Yak.UpdateWebShell:output_type -> ypb.WebShell
-	500,  // 1566: ypb.Yak.QueryWebShells:output_type -> ypb.QueryWebShellsResponse
-	498,  // 1567: ypb.Yak.Ping:output_type -> ypb.WebShellResponse
-	498,  // 1568: ypb.Yak.GetBasicInfo:output_type -> ypb.WebShellResponse
-	498,  // 1569: ypb.Yak.GenerateWebShell:output_type -> ypb.WebShellResponse
-	4,    // 1570: ypb.Yak.SetYakBridgeLogServer:output_type -> ypb.Empty
-	503,  // 1571: ypb.Yak.GetCurrentYakBridgeLogServer:output_type -> ypb.YakDNSLogBridgeAddr
-	508,  // 1572: ypb.Yak.RequireDNSLogDomain:output_type -> ypb.DNSLogRootDomain
-	508,  // 1573: ypb.Yak.RequireDNSLogDomainByScript:output_type -> ypb.DNSLogRootDomain
-	506,  // 1574: ypb.Yak.QueryDNSLogByToken:output_type -> ypb.QueryDNSLogByTokenResponse
-	506,  // 1575: ypb.Yak.QueryDNSLogTokenByScript:output_type -> ypb.QueryDNSLogByTokenResponse
-	458,  // 1576: ypb.Yak.RequireICMPRandomLength:output_type -> ypb.RequireICMPRandomLengthResponse
-	483,  // 1577: ypb.Yak.QueryICMPTrigger:output_type -> ypb.QueryICMPTriggerResponse
-	461,  // 1578: ypb.Yak.RequireRandomPortToken:output_type -> ypb.RandomPortInfo
-	459,  // 1579: ypb.Yak.QueryRandomPortTrigger:output_type -> ypb.RandomPortTriggerNotification
-	484,  // 1580: ypb.Yak.QuerySupportedDnsLogPlatforms:output_type -> ypb.QuerySupportedDnsLogPlatformsResponse
-	466,  // 1581: ypb.Yak.GetAvailableYakScriptTags:output_type -> ypb.Fields
-	4,    // 1582: ypb.Yak.ForceUpdateAvailableYakScriptTags:output_type -> ypb.Empty
-	762,  // 1583: ypb.Yak.ExecYakitPluginsByYakScriptFilter:output_type -> ypb.ExecResult
-	450,  // 1584: ypb.Yak.GenerateYakCodeByPacket:output_type -> ypb.GenerateYakCodeByPacketResponse
-	449,  // 1585: ypb.Yak.GenerateCSRFPocByPacket:output_type -> ypb.GenerateCSRFPocByPacketResponse
-	445,  // 1586: ypb.Yak.ExportMITMReplacerRules:output_type -> ypb.ExportMITMReplacerRulesResponse
-	4,    // 1587: ypb.Yak.ImportMITMReplacerRules:output_type -> ypb.Empty
-	443,  // 1588: ypb.Yak.GetCurrentRules:output_type -> ypb.MITMContentReplacers
-	4,    // 1589: ypb.Yak.SetCurrentRules:output_type -> ypb.Empty
-	985,  // 1590: ypb.Yak.QueryMITMReplacerRules:output_type -> ypb.QueryMITMReplacerRulesResponse
-	804,  // 1591: ypb.Yak.DeduplicateMITMReplacerRules:output_type -> ypb.DbOperateMessage
-	777,  // 1592: ypb.Yak.GenerateURL:output_type -> ypb.GenerateURLResponse
-	427,  // 1593: ypb.Yak.ExtractDataToFile:output_type -> ypb.ExtractDataToFileResult
-	426,  // 1594: ypb.Yak.AutoDecode:output_type -> ypb.AutoDecodeResponse
-	407,  // 1595: ypb.Yak.GetSystemProxy:output_type -> ypb.GetSystemProxyResult
-	4,    // 1596: ypb.Yak.SetSystemProxy:output_type -> ypb.Empty
-	403,  // 1597: ypb.Yak.GetKey:output_type -> ypb.GetKeyResult
-	4,    // 1598: ypb.Yak.SetKey:output_type -> ypb.Empty
-	4,    // 1599: ypb.Yak.DelKey:output_type -> ypb.Empty
-	405,  // 1600: ypb.Yak.GetAllProcessEnvKey:output_type -> ypb.GetProcessEnvKeyResult
-	4,    // 1601: ypb.Yak.SetProcessEnvKey:output_type -> ypb.Empty
-	403,  // 1602: ypb.Yak.GetProjectKey:output_type -> ypb.GetKeyResult
-	4,    // 1603: ypb.Yak.SetProjectKey:output_type -> ypb.Empty
-	400,  // 1604: ypb.Yak.GetOnlineProfile:output_type -> ypb.OnlineProfile
-	4,    // 1605: ypb.Yak.SetOnlineProfile:output_type -> ypb.Empty
-	4,    // 1606: ypb.Yak.DownloadOnlinePluginById:output_type -> ypb.Empty
-	4,    // 1607: ypb.Yak.DownloadOnlinePluginByIds:output_type -> ypb.Empty
-	387,  // 1608: ypb.Yak.DownloadOnlinePluginAll:output_type -> ypb.DownloadOnlinePluginProgress
-	4,    // 1609: ypb.Yak.DeletePluginByUserID:output_type -> ypb.Empty
-	4,    // 1610: ypb.Yak.DeleteAllLocalPlugins:output_type -> ypb.Empty
-	652,  // 1611: ypb.Yak.GetYakScriptTagsAndType:output_type -> ypb.GetYakScriptTagsAndTypeResponse
-	4,    // 1612: ypb.Yak.DeleteLocalPluginsByWhere:output_type -> ypb.Empty
-	394,  // 1613: ypb.Yak.DownloadOnlinePluginByScriptNames:output_type -> ypb.DownloadOnlinePluginByScriptNamesResponse
-	387,  // 1614: ypb.Yak.DownloadOnlinePlugins:output_type -> ypb.DownloadOnlinePluginProgress
-	4,    // 1615: ypb.Yak.DownloadOnlinePluginBatch:output_type -> ypb.Empty
-	394,  // 1616: ypb.Yak.DownloadOnlinePluginByPluginName:output_type -> ypb.DownloadOnlinePluginByScriptNamesResponse
-	630,  // 1617: ypb.Yak.DownloadOnlinePluginByUUID:output_type -> ypb.YakScript
-	398,  // 1618: ypb.Yak.QueryOnlinePlugins:output_type -> ypb.QueryOnlinePluginsResponse
-	762,  // 1619: ypb.Yak.ExecPacketScan:output_type -> ypb.ExecResult
-	360,  // 1620: ypb.Yak.GetEngineDefaultProxy:output_type -> ypb.DefaultProxyResult
-	4,    // 1621: ypb.Yak.SetEngineDefaultProxy:output_type -> ypb.Empty
-	353,  // 1622: ypb.Yak.GetMachineID:output_type -> ypb.GetMachineIDResponse
-	763,  // 1623: ypb.Yak.GetLicense:output_type -> ypb.GetLicenseResponse
-	4,    // 1624: ypb.Yak.CheckLicense:output_type -> ypb.Empty
-	339,  // 1625: ypb.Yak.GetRequestBodyByHTTPFlowID:output_type -> ypb.Bytes
-	339,  // 1626: ypb.Yak.GetResponseBodyByHTTPFlowID:output_type -> ypb.Bytes
-	339,  // 1627: ypb.Yak.GetHTTPPacketBody:output_type -> ypb.Bytes
-	338,  // 1628: ypb.Yak.EncodeHTTPPacketContent:output_type -> ypb.EncodeHTTPPacketContentResponse
-	334,  // 1629: ypb.Yak.RegisterFacadesHTTP:output_type -> ypb.RegisterFacadesHTTPResponse
-	4,    // 1630: ypb.Yak.ResetAndInvalidUserData:output_type -> ypb.Empty
-	331,  // 1631: ypb.Yak.CreateYaklangShell:output_type -> ypb.YaklangShellResponse
-	762,  // 1632: ypb.Yak.AttachCombinedOutput:output_type -> ypb.ExecResult
-	314,  // 1633: ypb.Yak.IsPrivilegedForNetRaw:output_type -> ypb.IsPrivilegedForNetRawResponse
-	4,    // 1634: ypb.Yak.PromotePermissionForUserPcap:output_type -> ypb.Empty
-	4,    // 1635: ypb.Yak.SetCurrentProject:output_type -> ypb.Empty
-	320,  // 1636: ypb.Yak.GetCurrentProject:output_type -> ypb.ProjectDescription
-	320,  // 1637: ypb.Yak.GetCurrentProjectEx:output_type -> ypb.ProjectDescription
-	321,  // 1638: ypb.Yak.GetProjects:output_type -> ypb.GetProjectsResponse
-	318,  // 1639: ypb.Yak.NewProject:output_type -> ypb.NewProjectResponse
-	318,  // 1640: ypb.Yak.UpdateProject:output_type -> ypb.NewProjectResponse
-	4,    // 1641: ypb.Yak.IsProjectNameValid:output_type -> ypb.Empty
-	4,    // 1642: ypb.Yak.RemoveProject:output_type -> ypb.Empty
-	4,    // 1643: ypb.Yak.DeleteProject:output_type -> ypb.Empty
-	320,  // 1644: ypb.Yak.GetDefaultProject:output_type -> ypb.ProjectDescription
-	320,  // 1645: ypb.Yak.GetDefaultProjectEx:output_type -> ypb.ProjectDescription
-	320,  // 1646: ypb.Yak.QueryProjectDetail:output_type -> ypb.ProjectDescription
-	320,  // 1647: ypb.Yak.GetTemporaryProject:output_type -> ypb.ProjectDescription
-	320,  // 1648: ypb.Yak.GetTemporaryProjectEx:output_type -> ypb.ProjectDescription
-	312,  // 1649: ypb.Yak.ExportProject:output_type -> ypb.ProjectIOProgress
-	312,  // 1650: ypb.Yak.ImportProject:output_type -> ypb.ProjectIOProgress
-	4,    // 1651: ypb.Yak.MigrateLegacyDatabase:output_type -> ypb.Empty
-	300,  // 1652: ypb.Yak.QueryMITMRuleExtractedData:output_type -> ypb.QueryMITMRuleExtractedDataResponse
-	310,  // 1653: ypb.Yak.QueryMITMExtractedAggregate:output_type -> ypb.QueryMITMExtractedAggregateResponse
-	304,  // 1654: ypb.Yak.ExportMITMRuleExtractedData:output_type -> ypb.ExportMITMRuleExtractedDataResponse
-	4,    // 1655: ypb.Yak.DeleteMITMRuleExtractedData:output_type -> ypb.Empty
-	307,  // 1656: ypb.Yak.DeduplicateMITMRuleExtractedData:output_type -> ypb.DeduplicateMITMRuleExtractedDataResponse
-	4,    // 1657: ypb.Yak.ImportChaosMakerRules:output_type -> ypb.Empty
-	291,  // 1658: ypb.Yak.QueryChaosMakerRule:output_type -> ypb.QueryChaosMakerRuleResponse
-	4,    // 1659: ypb.Yak.DeleteChaosMakerRuleByID:output_type -> ypb.Empty
-	762,  // 1660: ypb.Yak.ExecuteChaosMakerRule:output_type -> ypb.ExecResult
-	288,  // 1661: ypb.Yak.IsRemoteAddrAvailable:output_type -> ypb.IsRemoteAddrAvailableResponse
-	288,  // 1662: ypb.Yak.ConnectVulinboxAgent:output_type -> ypb.IsRemoteAddrAvailableResponse
-	254,  // 1663: ypb.Yak.GetRegisteredVulinboxAgent:output_type -> ypb.GetRegisteredAgentResponse
-	4,    // 1664: ypb.Yak.DisconnectVulinboxAgent:output_type -> ypb.Empty
-	297,  // 1665: ypb.Yak.IsCVEDatabaseReady:output_type -> ypb.IsCVEDatabaseReadyResponse
-	762,  // 1666: ypb.Yak.UpdateCVEDatabase:output_type -> ypb.ExecResult
-	762,  // 1667: ypb.Yak.ExportsProfileDatabase:output_type -> ypb.ExecResult
-	762,  // 1668: ypb.Yak.ImportsProfileDatabase:output_type -> ypb.ExecResult
-	282,  // 1669: ypb.Yak.QueryCVE:output_type -> ypb.QueryCVEResponse
-	280,  // 1670: ypb.Yak.GetCVE:output_type -> ypb.CVEDetailEx
-	284,  // 1671: ypb.Yak.SaveTextToTemporalFile:output_type -> ypb.SaveTextToTemporalFileResponse
-	276,  // 1672: ypb.Yak.IsScrecorderReady:output_type -> ypb.IsScrecorderReadyResponse
-	762,  // 1673: ypb.Yak.InstallScrecorder:output_type -> ypb.ExecResult
-	762,  // 1674: ypb.Yak.StartScrecorder:output_type -> ypb.ExecResult
-	272,  // 1675: ypb.Yak.QueryScreenRecorders:output_type -> ypb.QueryScreenRecorderResponse
-	4,    // 1676: ypb.Yak.DeleteScreenRecorders:output_type -> ypb.Empty
-	4,    // 1677: ypb.Yak.UploadScreenRecorders:output_type -> ypb.Empty
-	267,  // 1678: ypb.Yak.GetOneScreenRecorders:output_type -> ypb.ScreenRecorder
-	4,    // 1679: ypb.Yak.UpdateScreenRecorders:output_type -> ypb.Empty
-	259,  // 1680: ypb.Yak.IsVulinboxReady:output_type -> ypb.IsVulinboxReadyResponse
-	762,  // 1681: ypb.Yak.InstallVulinbox:output_type -> ypb.ExecResult
-	762,  // 1682: ypb.Yak.StartVulinbox:output_type -> ypb.ExecResult
-	762,  // 1683: ypb.Yak.GenQualityInspectionReport:output_type -> ypb.ExecResult
-	265,  // 1684: ypb.Yak.HTTPRequestBuilder:output_type -> ypb.HTTPRequestBuilderResponse
-	762,  // 1685: ypb.Yak.DebugPlugin:output_type -> ypb.ExecResult
-	257,  // 1686: ypb.Yak.SmokingEvaluatePlugin:output_type -> ypb.SmokingEvaluatePluginResponse
-	775,  // 1687: ypb.Yak.SmokingEvaluatePluginBatch:output_type -> ypb.SmokingEvaluatePluginBatchResponse
-	765,  // 1688: ypb.Yak.GetSystemDefaultDnsServers:output_type -> ypb.DefaultDnsServerResponse
-	251,  // 1689: ypb.Yak.DiagnoseNetwork:output_type -> ypb.DiagnoseNetworkResponse
-	251,  // 1690: ypb.Yak.DiagnoseNetworkDNS:output_type -> ypb.DiagnoseNetworkResponse
-	782,  // 1691: ypb.Yak.TraceRoute:output_type -> ypb.TraceRouteResponse
-	240,  // 1692: ypb.Yak.GetGlobalNetworkConfig:output_type -> ypb.GlobalNetworkConfig
-	4,    // 1693: ypb.Yak.SetGlobalNetworkConfig:output_type -> ypb.Empty
-	4,    // 1694: ypb.Yak.ResetGlobalNetworkConfig:output_type -> ypb.Empty
-	246,  // 1695: ypb.Yak.GetGlobalProxyRulesConfig:output_type -> ypb.GlobalProxyRulesConfig
-	4,    // 1696: ypb.Yak.SetGlobalProxyRulesConfig:output_type -> ypb.Empty
-	244,  // 1697: ypb.Yak.CheckProxyAlive:output_type -> ypb.CheckProxyAliveResponse
-	239,  // 1698: ypb.Yak.ValidP12PassWord:output_type -> ypb.ValidP12PassWordResponse
-	232,  // 1699: ypb.Yak.RequestYakURL:output_type -> ypb.RequestYakURLResponse
-	799,  // 1700: ypb.Yak.ReadFile:output_type -> ypb.ReadFileResponse
-	216,  // 1701: ypb.Yak.GetPcapMetadata:output_type -> ypb.PcapMetadata
-	228,  // 1702: ypb.Yak.PcapX:output_type -> ypb.PcapXResponse
-	220,  // 1703: ypb.Yak.QueryTrafficSession:output_type -> ypb.QueryTrafficSessionResponse
-	222,  // 1704: ypb.Yak.QueryTrafficPacket:output_type -> ypb.QueryTrafficPacketResponse
-	224,  // 1705: ypb.Yak.QueryTrafficTCPReassembled:output_type -> ypb.QueryTrafficTCPReassembledResponse
-	780,  // 1706: ypb.Yak.ParseTraffic:output_type -> ypb.ParseTrafficResponse
-	214,  // 1707: ypb.Yak.DuplexConnection:output_type -> ypb.DuplexConnectionResponse
-	208,  // 1708: ypb.Yak.HybridScan:output_type -> ypb.HybridScanResponse
-	205,  // 1709: ypb.Yak.QueryHybridScanTask:output_type -> ypb.QueryHybridScanTaskResponse
-	4,    // 1710: ypb.Yak.DeleteHybridScanTask:output_type -> ypb.Empty
-	201,  // 1711: ypb.Yak.GetSpaceEngineStatus:output_type -> ypb.SpaceEngineStatus
-	201,  // 1712: ypb.Yak.GetSpaceEngineAccountStatus:output_type -> ypb.SpaceEngineStatus
-	201,  // 1713: ypb.Yak.GetSpaceEngineAccountStatusV2:output_type -> ypb.SpaceEngineStatus
-	762,  // 1714: ypb.Yak.FetchPortAssetFromSpaceEngine:output_type -> ypb.ExecResult
-	784,  // 1715: ypb.Yak.EvaluateExpression:output_type -> ypb.EvaluateExpressionResponse
-	786,  // 1716: ypb.Yak.EvaluateMultiExpression:output_type -> ypb.EvaluateMultiExpressionResponse
-	789,  // 1717: ypb.Yak.GetThirdPartyAppConfigTemplate:output_type -> ypb.GetThirdPartyAppConfigTemplateResponse
-	6,    // 1718: ypb.Yak.CheckHahValidAiConfig:output_type -> ypb.GeneralResponse
-	954,  // 1719: ypb.Yak.ListAiModel:output_type -> ypb.ListAiModelResponse
-	956,  // 1720: ypb.Yak.AIConfigHealthCheck:output_type -> ypb.AIConfigHealthCheckResponse
-	966,  // 1721: ypb.Yak.GetAIGlobalConfig:output_type -> ypb.AIGlobalConfig
-	4,    // 1722: ypb.Yak.SetAIGlobalConfig:output_type -> ypb.Empty
-	961,  // 1723: ypb.Yak.ListAIProviders:output_type -> ypb.ListAIProvidersResponse
-	960,  // 1724: ypb.Yak.QueryAIProvider:output_type -> ypb.QueryAIProvidersResponse
-	963,  // 1725: ypb.Yak.UpsertAIProvider:output_type -> ypb.UpsertAIProviderResponse
-	4,    // 1726: ypb.Yak.DeleteAIProvider:output_type -> ypb.Empty
-	789,  // 1727: ypb.Yak.GetAIThirdPartyAppConfigTemplate:output_type -> ypb.GetThirdPartyAppConfigTemplateResponse
-	791,  // 1728: ypb.Yak.GetApiKeyByOnline:output_type -> ypb.GetApiKeyByOnlineResponse
-	793,  // 1729: ypb.Yak.GetFingerprint:output_type -> ypb.GetFingerprintResponse
-	795,  // 1730: ypb.Yak.AddFingerprint:output_type -> ypb.AddFingerprintResponse
-	797,  // 1731: ypb.Yak.ModifyFingerprint:output_type -> ypb.ModifyFingerprintResponse
-	809,  // 1732: ypb.Yak.QueryFingerprint:output_type -> ypb.QueryFingerprintResponse
-	804,  // 1733: ypb.Yak.DeleteFingerprint:output_type -> ypb.DbOperateMessage
-	804,  // 1734: ypb.Yak.UpdateFingerprint:output_type -> ypb.DbOperateMessage
-	804,  // 1735: ypb.Yak.CreateFingerprint:output_type -> ypb.DbOperateMessage
-	804,  // 1736: ypb.Yak.RecoverBuiltinFingerprint:output_type -> ypb.DbOperateMessage
-	804,  // 1737: ypb.Yak.CreateFingerprintGroup:output_type -> ypb.DbOperateMessage
-	814,  // 1738: ypb.Yak.GetAllFingerprintGroup:output_type -> ypb.FingerprintGroups
-	804,  // 1739: ypb.Yak.RenameFingerprintGroup:output_type -> ypb.DbOperateMessage
-	804,  // 1740: ypb.Yak.DeleteFingerprintGroup:output_type -> ypb.DbOperateMessage
-	804,  // 1741: ypb.Yak.BatchUpdateFingerprintToGroup:output_type -> ypb.DbOperateMessage
-	814,  // 1742: ypb.Yak.GetFingerprintGroupSetByFilter:output_type -> ypb.FingerprintGroups
-	821,  // 1743: ypb.Yak.ExportFingerprint:output_type -> ypb.DataTransferProgress
-	821,  // 1744: ypb.Yak.ImportFingerprint:output_type -> ypb.DataTransferProgress
-	801,  // 1745: ypb.Yak.GetReverseShellProgramList:output_type -> ypb.GetReverseShellProgramListResponse
-	803,  // 1746: ypb.Yak.GenerateReverseShellCommand:output_type -> ypb.GenerateReverseShellCommandResponse
-	841,  // 1747: ypb.Yak.QuerySyntaxFlowRule:output_type -> ypb.QuerySyntaxFlowRuleResponse
-	804,  // 1748: ypb.Yak.CreateSyntaxFlowRule:output_type -> ypb.DbOperateMessage
-	838,  // 1749: ypb.Yak.CreateSyntaxFlowRuleEx:output_type -> ypb.CreateSyntaxFlowRuleResponse
-	804,  // 1750: ypb.Yak.UpdateSyntaxFlowRule:output_type -> ypb.DbOperateMessage
-	840,  // 1751: ypb.Yak.UpdateSyntaxFlowRuleEx:output_type -> ypb.UpdateSyntaxFlowRuleResponse
-	804,  // 1752: ypb.Yak.DeleteSyntaxFlowRule:output_type -> ypb.DbOperateMessage
-	844,  // 1753: ypb.Yak.CheckSyntaxFlowRuleUpdate:output_type -> ypb.CheckSyntaxFlowRuleUpdateResponse
-	846,  // 1754: ypb.Yak.ApplySyntaxFlowRuleUpdate:output_type -> ypb.ApplySyntaxFlowRuleUpdateResponse
-	850,  // 1755: ypb.Yak.QuerySyntaxFlowRuleGroup:output_type -> ypb.QuerySyntaxFlowRuleGroupResponse
-	804,  // 1756: ypb.Yak.DeleteSyntaxFlowRuleGroup:output_type -> ypb.DbOperateMessage
-	804,  // 1757: ypb.Yak.CreateSyntaxFlowRuleGroup:output_type -> ypb.DbOperateMessage
-	804,  // 1758: ypb.Yak.UpdateSyntaxFlowRuleGroup:output_type -> ypb.DbOperateMessage
-	804,  // 1759: ypb.Yak.UpdateSyntaxFlowRuleAndGroup:output_type -> ypb.DbOperateMessage
-	855,  // 1760: ypb.Yak.QuerySyntaxFlowSameGroup:output_type -> ypb.QuerySyntaxFlowSameGroupResponse
-	858,  // 1761: ypb.Yak.SyntaxFlowRuleToOnline:output_type -> ypb.SyntaxFlowRuleOnlineProgress
-	858,  // 1762: ypb.Yak.DownloadSyntaxFlowRule:output_type -> ypb.SyntaxFlowRuleOnlineProgress
-	866,  // 1763: ypb.Yak.SyntaxFlowScan:output_type -> ypb.SyntaxFlowScanResponse
-	863,  // 1764: ypb.Yak.QuerySyntaxFlowScanTask:output_type -> ypb.QuerySyntaxFlowScanTaskResponse
-	804,  // 1765: ypb.Yak.DeleteSyntaxFlowScanTask:output_type -> ypb.DbOperateMessage
-	870,  // 1766: ypb.Yak.QuerySyntaxFlowResult:output_type -> ypb.QuerySyntaxFlowResultResponse
-	873,  // 1767: ypb.Yak.DeleteSyntaxFlowResult:output_type -> ypb.DeleteSyntaxFlowResultResponse
-	836,  // 1768: ypb.Yak.QuerySSAPrograms:output_type -> ypb.QuerySSAProgramResponse
-	804,  // 1769: ypb.Yak.UpdateSSAProgram:output_type -> ypb.DbOperateMessage
-	804,  // 1770: ypb.Yak.DeleteSSAPrograms:output_type -> ypb.DbOperateMessage
-	887,  // 1771: ypb.Yak.QuerySSARisks:output_type -> ypb.QuerySSARisksResponse
-	889,  // 1772: ypb.Yak.QueryNewSSARisks:output_type -> ypb.QueryNewSSARisksResponse
-	804,  // 1773: ypb.Yak.DeleteSSARisks:output_type -> ypb.DbOperateMessage
-	804,  // 1774: ypb.Yak.UpdateSSARiskTags:output_type -> ypb.DbOperateMessage
-	893,  // 1775: ypb.Yak.GetSSARiskFieldGroup:output_type -> ypb.SSARiskFieldGroupResponse
-	893,  // 1776: ypb.Yak.GetSSARiskFieldGroupEx:output_type -> ypb.SSARiskFieldGroupResponse
-	895,  // 1777: ypb.Yak.NewSSARiskRead:output_type -> ypb.NewSSARiskReadResponse
-	897,  // 1778: ypb.Yak.ExportSSARisk:output_type -> ypb.ExportSSARiskResponse
-	899,  // 1779: ypb.Yak.ImportSSARisk:output_type -> ypb.ImportSSARiskResponse
-	830,  // 1780: ypb.Yak.SSARiskDiff:output_type -> ypb.SSARiskDiffResponse
-	904,  // 1781: ypb.Yak.CreateSSARiskDisposals:output_type -> ypb.CreateSSARiskDisposalsResponse
-	906,  // 1782: ypb.Yak.QuerySSARiskDisposals:output_type -> ypb.QuerySSARiskDisposalsResponse
-	908,  // 1783: ypb.Yak.UpdateSSARiskDisposals:output_type -> ypb.UpdateSSARiskDisposalsResponse
-	910,  // 1784: ypb.Yak.DeleteSSARiskDisposals:output_type -> ypb.DeleteSSARiskDisposalsResponse
-	912,  // 1785: ypb.Yak.GetSSARiskDisposal:output_type -> ypb.GetSSARiskDisposalResponse
-	4,    // 1786: ypb.Yak.SSARiskFeedbackToOnline:output_type -> ypb.Empty
-	991,  // 1787: ypb.Yak.GenerateSSAReport:output_type -> ypb.GenerateSSAReportResponse
-	998,  // 1788: ypb.Yak.CreateSSAProject:output_type -> ypb.CreateSSAProjectResponse
-	1000, // 1789: ypb.Yak.UpdateSSAProject:output_type -> ypb.UpdateSSAProjectResponse
-	1002, // 1790: ypb.Yak.DeleteSSAProject:output_type -> ypb.DeleteSSAProjectResponse
-	1004, // 1791: ypb.Yak.QuerySSAProject:output_type -> ypb.QuerySSAProjectResponse
-	1006, // 1792: ypb.Yak.MigrateSSAProject:output_type -> ypb.MigrateSSAProjectResponse
-	1013, // 1793: ypb.Yak.GetSSAWorkbenchDashboard:output_type -> ypb.GetSSAWorkbenchDashboardResponse
-	875,  // 1794: ypb.Yak.GetAllPluginEnv:output_type -> ypb.PluginEnvData
-	875,  // 1795: ypb.Yak.QueryPluginEnv:output_type -> ypb.PluginEnvData
-	4,    // 1796: ypb.Yak.CreatePluginEnv:output_type -> ypb.Empty
-	4,    // 1797: ypb.Yak.SetPluginEnv:output_type -> ypb.Empty
-	4,    // 1798: ypb.Yak.DeletePluginEnv:output_type -> ypb.Empty
-	878,  // 1799: ypb.Yak.GetAllFuzztagInfo:output_type -> ypb.GetAllFuzztagInfoResponse
-	882,  // 1800: ypb.Yak.GenerateFuzztag:output_type -> ypb.GenerateFuzztagResponse
-	915,  // 1801: ypb.Yak.ExportSyntaxFlows:output_type -> ypb.SyntaxflowsProgress
-	915,  // 1802: ypb.Yak.ImportSyntaxFlows:output_type -> ypb.SyntaxflowsProgress
-	920,  // 1803: ypb.Yak.CreateHotPatchTemplate:output_type -> ypb.CreateHotPatchTemplateResponse
-	921,  // 1804: ypb.Yak.DeleteHotPatchTemplate:output_type -> ypb.DeleteHotPatchTemplateResponse
-	922,  // 1805: ypb.Yak.UpdateHotPatchTemplate:output_type -> ypb.UpdateHotPatchTemplateResponse
-	923,  // 1806: ypb.Yak.QueryHotPatchTemplate:output_type -> ypb.QueryHotPatchTemplateResponse
-	925,  // 1807: ypb.Yak.QueryHotPatchTemplateList:output_type -> ypb.QueryHotPatchTemplateListResponse
-	926,  // 1808: ypb.Yak.GetHotPatchTemplateTags:output_type -> ypb.GetHotPatchTemplateTagsResponse
-	928,  // 1809: ypb.Yak.GetGlobalHotPatchConfig:output_type -> ypb.GlobalHotPatchConfig
-	928,  // 1810: ypb.Yak.SetGlobalHotPatchConfig:output_type -> ypb.GlobalHotPatchConfig
-	928,  // 1811: ypb.Yak.ResetGlobalHotPatchConfig:output_type -> ypb.GlobalHotPatchConfig
-	931,  // 1812: ypb.Yak.GroupTableColumn:output_type -> ypb.GroupTableColumnResponse
-	4,    // 1813: ypb.Yak.UploadHotPatchTemplateToOnline:output_type -> ypb.Empty
-	4,    // 1814: ypb.Yak.DownloadHotPatchTemplate:output_type -> ypb.Empty
-	742,  // 1815: ypb.Yak.SetMITMHijackFilter:output_type -> ypb.SetMITMFilterResponse
-	741,  // 1816: ypb.Yak.GetMITMHijackFilter:output_type -> ypb.SetMITMFilterRequest
-	741,  // 1817: ypb.Yak.ResetMITMHijackFilter:output_type -> ypb.SetMITMFilterRequest
-	935,  // 1818: ypb.Yak.ExportHTTPFlowStream:output_type -> ypb.ExportHTTPFlowStreamResponse
-	937,  // 1819: ypb.Yak.ImportHTTPFlowStream:output_type -> ypb.ImportHTTPFlowStreamResponse
-	942,  // 1820: ypb.Yak.CreateNote:output_type -> ypb.CreateNoteResponse
-	804,  // 1821: ypb.Yak.UpdateNote:output_type -> ypb.DbOperateMessage
-	804,  // 1822: ypb.Yak.DeleteNote:output_type -> ypb.DbOperateMessage
-	946,  // 1823: ypb.Yak.QueryNote:output_type -> ypb.QueryNoteResponse
-	948,  // 1824: ypb.Yak.SearchNoteContent:output_type -> ypb.SearchNoteContentResponse
-	950,  // 1825: ypb.Yak.ImportNote:output_type -> ypb.ImportNoteResponse
-	952,  // 1826: ypb.Yak.ExportNote:output_type -> ypb.ExportNoteResponse
-	145,  // 1827: ypb.Yak.StartAIReAct:output_type -> ypb.AIOutputEvent
-	145,  // 1828: ypb.Yak.StartAITask:output_type -> ypb.AIOutputEvent
-	160,  // 1829: ypb.Yak.QueryAITask:output_type -> ypb.AITaskQueryResponse
-	804,  // 1830: ypb.Yak.DeleteAITask:output_type -> ypb.DbOperateMessage
-	157,  // 1831: ypb.Yak.QueryAIEvent:output_type -> ypb.AIEventQueryResponse
-	804,  // 1832: ypb.Yak.DeleteAIEvent:output_type -> ypb.DbOperateMessage
-	168,  // 1833: ypb.Yak.QueryAISession:output_type -> ypb.QueryAISessionResponse
-	804,  // 1834: ypb.Yak.UpdateAISessionTitle:output_type -> ypb.DbOperateMessage
-	804,  // 1835: ypb.Yak.UpdateAISessionIMMeta:output_type -> ypb.DbOperateMessage
-	804,  // 1836: ypb.Yak.DeleteAISession:output_type -> ypb.DbOperateMessage
-	163,  // 1837: ypb.Yak.GetRandomAIMaterials:output_type -> ypb.GetRandomAIMaterialsResponse
-	185,  // 1838: ypb.Yak.ExportAILogs:output_type -> ypb.ExportAILogsResponse
-	4,    // 1839: ypb.Yak.CreateAIMemoryEntity:output_type -> ypb.Empty
-	804,  // 1840: ypb.Yak.UpdateAIMemoryEntity:output_type -> ypb.DbOperateMessage
-	804,  // 1841: ypb.Yak.DeleteAIMemoryEntity:output_type -> ypb.DbOperateMessage
-	189,  // 1842: ypb.Yak.GetAIMemoryEntity:output_type -> ypb.AIMemoryEntity
-	192,  // 1843: ypb.Yak.QueryAIMemoryEntity:output_type -> ypb.QueryAIMemoryEntityResponse
-	196,  // 1844: ypb.Yak.CountAIMemoryEntityTags:output_type -> ypb.CountAIMemoryEntityTagsResponse
-	145,  // 1845: ypb.Yak.StartAITriage:output_type -> ypb.AIOutputEvent
-	804,  // 1846: ypb.Yak.CreateAIForge:output_type -> ypb.DbOperateMessage
-	804,  // 1847: ypb.Yak.UpdateAIForge:output_type -> ypb.DbOperateMessage
-	804,  // 1848: ypb.Yak.DeleteAIForge:output_type -> ypb.DbOperateMessage
-	177,  // 1849: ypb.Yak.QueryAIForge:output_type -> ypb.QueryAIForgeResponse
-	175,  // 1850: ypb.Yak.GetAIForge:output_type -> ypb.AIForge
-	42,   // 1851: ypb.Yak.ExportAIForge:output_type -> ypb.GeneralProgress
-	42,   // 1852: ypb.Yak.ImportAIForge:output_type -> ypb.GeneralProgress
-	183,  // 1853: ypb.Yak.QueryAIFocus:output_type -> ypb.QueryAIFocusResponse
-	198,  // 1854: ypb.Yak.StartMcpServer:output_type -> ypb.StartMcpServerResponse
-	128,  // 1855: ypb.Yak.GetToolSetList:output_type -> ypb.GetToolSetListResponse
-	141,  // 1856: ypb.Yak.GetAIToolList:output_type -> ypb.GetAIToolListResponse
-	804,  // 1857: ypb.Yak.DeleteAITool:output_type -> ypb.DbOperateMessage
-	804,  // 1858: ypb.Yak.SaveAITool:output_type -> ypb.DbOperateMessage
-	134,  // 1859: ypb.Yak.SaveAIToolV2:output_type -> ypb.SaveAIToolV2Response
-	804,  // 1860: ypb.Yak.UpdateAITool:output_type -> ypb.DbOperateMessage
-	138,  // 1861: ypb.Yak.ToggleAIToolFavorite:output_type -> ypb.ToggleAIToolFavoriteResponse
-	132,  // 1862: ypb.Yak.AIToolGenerateMetadata:output_type -> ypb.AIToolGenerateMetadataResponse
-	42,   // 1863: ypb.Yak.ExportAITool:output_type -> ypb.GeneralProgress
-	42,   // 1864: ypb.Yak.ImportAITool:output_type -> ypb.GeneralProgress
-	967,  // 1865: ypb.Yak.IsLlamaServerReady:output_type -> ypb.IsLlamaServerReadyResponse
-	969,  // 1866: ypb.Yak.IsLocalModelReady:output_type -> ypb.IsLocalModelReadyResponse
-	762,  // 1867: ypb.Yak.InstallLlamaServer:output_type -> ypb.ExecResult
-	762,  // 1868: ypb.Yak.StartLocalModel:output_type -> ypb.ExecResult
-	6,    // 1869: ypb.Yak.StopLocalModel:output_type -> ypb.GeneralResponse
-	762,  // 1870: ypb.Yak.DownloadLocalModel:output_type -> ypb.ExecResult
-	974,  // 1871: ypb.Yak.GetSupportedLocalModels:output_type -> ypb.GetSupportedLocalModelsResponse
-	6,    // 1872: ypb.Yak.AddLocalModel:output_type -> ypb.GeneralResponse
-	6,    // 1873: ypb.Yak.DeleteLocalModel:output_type -> ypb.GeneralResponse
-	6,    // 1874: ypb.Yak.UpdateLocalModel:output_type -> ypb.GeneralResponse
-	76,   // 1875: ypb.Yak.GetAllStartedLocalModels:output_type -> ypb.GetAllStartedLocalModelsResponse
-	6,    // 1876: ypb.Yak.ClearAllModels:output_type -> ypb.GeneralResponse
-	126,  // 1877: ypb.Yak.IsSearchVectorDatabaseReady:output_type -> ypb.IsSearchVectorDatabaseReadyResponse
-	762,  // 1878: ypb.Yak.InitSearchVectorDatabase:output_type -> ypb.ExecResult
-	124,  // 1879: ypb.Yak.GetAllVectorStoreCollections:output_type -> ypb.GetAllVectorStoreCollectionsResponse
-	123,  // 1880: ypb.Yak.GetAllVectorStoreCollectionsWithFilter:output_type -> ypb.GetAllVectorStoreCollectionsWithFilterResponse
-	6,    // 1881: ypb.Yak.DeleteSearchVectorDatabase:output_type -> ypb.GeneralResponse
-	6,    // 1882: ypb.Yak.UpdateVectorStoreCollection:output_type -> ypb.GeneralResponse
-	118,  // 1883: ypb.Yak.ListVectorStoreEntries:output_type -> ypb.ListVectorStoreEntriesResponse
-	6,    // 1884: ypb.Yak.CreateVectorStoreEntry:output_type -> ypb.GeneralResponse
-	120,  // 1885: ypb.Yak.GetDocumentByVectorStoreEntryID:output_type -> ypb.GetDocumentByVectorStoreEntryIDResponse
-	84,   // 1886: ypb.Yak.ListThirdPartyBinary:output_type -> ypb.ListThirdPartyBinaryResponse
-	762,  // 1887: ypb.Yak.InstallThirdPartyBinary:output_type -> ypb.ExecResult
-	6,    // 1888: ypb.Yak.UninstallThirdPartyBinary:output_type -> ypb.GeneralResponse
-	88,   // 1889: ypb.Yak.IsThirdPartyBinaryReady:output_type -> ypb.IsThirdPartyBinaryReadyResponse
-	762,  // 1890: ypb.Yak.StartThirdPartyBinary:output_type -> ypb.ExecResult
-	988,  // 1891: ypb.Yak.PluginTrace:output_type -> ypb.PluginTraceResponse
-	94,   // 1892: ypb.Yak.GetKnowledgeBaseNameList:output_type -> ypb.GetKnowledgeBaseNameListResponse
-	99,   // 1893: ypb.Yak.GetKnowledgeBase:output_type -> ypb.GetKnowledgeBaseResponse
-	96,   // 1894: ypb.Yak.GetKnowledgeBaseTypeList:output_type -> ypb.GetKnowledgeBaseTypeListResponse
-	6,    // 1895: ypb.Yak.DeleteKnowledgeBase:output_type -> ypb.GeneralResponse
-	6,    // 1896: ypb.Yak.CreateKnowledgeBase:output_type -> ypb.GeneralResponse
-	39,   // 1897: ypb.Yak.CreateKnowledgeBaseV2:output_type -> ypb.CreateKnowledgeBaseV2Response
-	6,    // 1898: ypb.Yak.UpdateKnowledgeBase:output_type -> ypb.GeneralResponse
-	6,    // 1899: ypb.Yak.DeleteKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
-	6,    // 1900: ypb.Yak.CreateKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
-	6,    // 1901: ypb.Yak.UpdateKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
-	107,  // 1902: ypb.Yak.SearchKnowledgeBaseEntry:output_type -> ypb.SearchKnowledgeBaseEntryResponse
-	106,  // 1903: ypb.Yak.QueryKnowledgeBaseByAI:output_type -> ypb.QueryKnowledgeBaseByAIResponse
-	6,    // 1904: ypb.Yak.BuildVectorIndexForKnowledgeBase:output_type -> ypb.GeneralResponse
-	6,    // 1905: ypb.Yak.BuildVectorIndexForKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
-	91,   // 1906: ypb.Yak.GenerateQuestionIndexForKnowledgeBase:output_type -> ypb.GenerateQuestionIndexForKnowledgeBaseResponse
-	60,   // 1907: ypb.Yak.ListEntityRepository:output_type -> ypb.ListEntityRepositoryResponse
-	64,   // 1908: ypb.Yak.QueryEntity:output_type -> ypb.QueryEntityResponse
-	804,  // 1909: ypb.Yak.CreateEntity:output_type -> ypb.DbOperateMessage
-	804,  // 1910: ypb.Yak.UpdateEntity:output_type -> ypb.DbOperateMessage
-	804,  // 1911: ypb.Yak.DeleteEntity:output_type -> ypb.DbOperateMessage
-	69,   // 1912: ypb.Yak.QueryRelationship:output_type -> ypb.QueryRelationshipResponse
-	804,  // 1913: ypb.Yak.CreateRelationship:output_type -> ypb.DbOperateMessage
-	804,  // 1914: ypb.Yak.UpdateRelationship:output_type -> ypb.DbOperateMessage
-	804,  // 1915: ypb.Yak.DeleteRelationship:output_type -> ypb.DbOperateMessage
-	72,   // 1916: ypb.Yak.QuerySubERM:output_type -> ypb.QuerySubERMResponse
-	74,   // 1917: ypb.Yak.GenerateERMDot:output_type -> ypb.GenerateERMDotResponse
-	42,   // 1918: ypb.Yak.ExportKnowledgeBase:output_type -> ypb.GeneralProgress
-	42,   // 1919: ypb.Yak.ImportKnowledgeBase:output_type -> ypb.GeneralProgress
-	6,    // 1920: ypb.Yak.AddMCPServer:output_type -> ypb.GeneralResponse
-	6,    // 1921: ypb.Yak.DeleteMCPServer:output_type -> ypb.GeneralResponse
-	6,    // 1922: ypb.Yak.UpdateMCPServer:output_type -> ypb.GeneralResponse
-	53,   // 1923: ypb.Yak.GetAllMCPServers:output_type -> ypb.GetAllMCPServersResponse
-	6,    // 1924: ypb.Yak.UpdateMCPServerToolConfig:output_type -> ypb.GeneralResponse
-	56,   // 1925: ypb.Yak.GetMCPToolList:output_type -> ypb.GetMCPToolListResponse
-	54,   // 1926: ypb.Yak.GetMCPToolDetail:output_type -> ypb.MCPClientToolConfig
-	6,    // 1927: ypb.Yak.SetMCPToolEnabled:output_type -> ypb.GeneralResponse
-	44,   // 1928: ypb.Yak.RAGCollectionSearch:output_type -> ypb.RAGCollectionSearchResponse
-	762,  // 1929: ypb.Yak.DownloadRAGs:output_type -> ypb.ExecResult
-	16,   // 1930: ypb.Yak.SaveIMBot:output_type -> ypb.SaveIMBotResponse
-	18,   // 1931: ypb.Yak.ListIMBots:output_type -> ypb.ListIMBotResponse
-	20,   // 1932: ypb.Yak.DeleteIMBot:output_type -> ypb.DeleteIMBotResponse
-	22,   // 1933: ypb.Yak.TestIMBot:output_type -> ypb.TestIMBotResponse
-	24,   // 1934: ypb.Yak.StartIMOnboarding:output_type -> ypb.IMOnboardingEvent
-	27,   // 1935: ypb.Yak.StartIMControl:output_type -> ypb.StartIMControlResponse
-	29,   // 1936: ypb.Yak.StopIMControl:output_type -> ypb.StopIMControlResponse
-	31,   // 1937: ypb.Yak.SubscribeIMControlState:output_type -> ypb.IMControlStateEvent
-	36,   // 1938: ypb.Yak.UpdateIMControlConfig:output_type -> ypb.UpdateIMControlConfigResponse
-	1309, // [1309:1939] is the sub-list for method output_type
-	679,  // [679:1309] is the sub-list for method input_type
-	679,  // [679:679] is the sub-list for extension type_name
-	679,  // [679:679] is the sub-list for extension extendee
-	0,    // [0:679] is the sub-list for field type_name
+	731,  // 439: ypb.HTTPFlow.GetParams:type_name -> ypb.FuzzableParam
+	731,  // 440: ypb.HTTPFlow.PostParams:type_name -> ypb.FuzzableParam
+	731,  // 441: ypb.HTTPFlow.CookieParams:type_name -> ypb.FuzzableParam
+	730,  // 442: ypb.HTTPFlow.MultipartFiles:type_name -> ypb.MultipartFileInfo
+	706,  // 443: ypb.QueryHTTPFlowResponse.Pagination:type_name -> ypb.Paging
+	729,  // 444: ypb.QueryHTTPFlowResponse.Data:type_name -> ypb.HTTPFlow
+	739,  // 445: ypb.HTTPFlowsFieldGroupResponse.Tags:type_name -> ypb.TagsCode
+	739,  // 446: ypb.HTTPFlowsFieldGroupResponse.StatusCode:type_name -> ypb.TagsCode
+	739,  // 447: ypb.HTTPFlowsFieldGroupResponse.Suffixes:type_name -> ypb.TagsCode
+	706,  // 448: ypb.WebsocketFlows.Pagination:type_name -> ypb.Paging
+	741,  // 449: ypb.WebsocketFlows.Data:type_name -> ypb.WebsocketFlow
+	746,  // 450: ypb.SetMITMFilterRequest.FilterData:type_name -> ypb.MITMFilterData
+	746,  // 451: ypb.MITMRequest.FilterData:type_name -> ypb.MITMFilterData
+	761,  // 452: ypb.MITMRequest.yakScriptParams:type_name -> ypb.ExecParamItem
+	750,  // 453: ypb.MITMRequest.removeHookParams:type_name -> ypb.RemoveHookParams
+	749,  // 454: ypb.MITMRequest.replacers:type_name -> ypb.MITMContentReplacer
+	747,  // 455: ypb.MITMRequest.certificates:type_name -> ypb.Certificate
+	698,  // 456: ypb.MITMRequest.hosts:type_name -> ypb.KVPair
+	746,  // 457: ypb.MITMRequest.HijackFilterData:type_name -> ypb.MITMFilterData
+	745,  // 458: ypb.MITMFilterData.IncludeHostnames:type_name -> ypb.FilterDataItem
+	745,  // 459: ypb.MITMFilterData.ExcludeHostnames:type_name -> ypb.FilterDataItem
+	745,  // 460: ypb.MITMFilterData.IncludeSuffix:type_name -> ypb.FilterDataItem
+	745,  // 461: ypb.MITMFilterData.ExcludeSuffix:type_name -> ypb.FilterDataItem
+	745,  // 462: ypb.MITMFilterData.IncludeUri:type_name -> ypb.FilterDataItem
+	745,  // 463: ypb.MITMFilterData.ExcludeUri:type_name -> ypb.FilterDataItem
+	745,  // 464: ypb.MITMFilterData.ExcludeMethods:type_name -> ypb.FilterDataItem
+	745,  // 465: ypb.MITMFilterData.ExcludeMIME:type_name -> ypb.FilterDataItem
+	727,  // 466: ypb.MITMContentReplacer.ExtraHeaders:type_name -> ypb.HTTPHeader
+	561,  // 467: ypb.MITMContentReplacer.ExtraCookies:type_name -> ypb.HTTPCookieSetting
+	748,  // 468: ypb.MITMContentReplacer.SecondaryStages:type_name -> ypb.RegexOutputStage
+	746,  // 469: ypb.MITMResponse.FilterData:type_name -> ypb.MITMFilterData
+	749,  // 470: ypb.MITMResponse.replacers:type_name -> ypb.MITMContentReplacer
+	729,  // 471: ypb.MITMResponse.historyHTTPFlow:type_name -> ypb.HTTPFlow
+	763,  // 472: ypb.MITMResponse.message:type_name -> ypb.ExecResult
+	753,  // 473: ypb.MITMResponse.hooks:type_name -> ypb.YakScriptHooks
+	752,  // 474: ypb.MITMResponse.traceInfo:type_name -> ypb.TraceInfo
+	754,  // 475: ypb.YakScriptHooks.Hooks:type_name -> ypb.YakScriptHookItem
+	761,  // 476: ypb.ExecRequest.Params:type_name -> ypb.ExecParamItem
+	6,    // 477: ypb.ImportHTTPFuzzerTaskFromYamlResponse.Status:type_name -> ypb.GeneralResponse
+	692,  // 478: ypb.ImportHTTPFuzzerTaskFromYamlResponse.Requests:type_name -> ypb.FuzzerRequests
+	692,  // 479: ypb.ExportHTTPFuzzerTaskToYamlRequest.Requests:type_name -> ypb.FuzzerRequests
+	6,    // 480: ypb.ExportHTTPFuzzerTaskToYamlResponse.Status:type_name -> ypb.GeneralResponse
+	698,  // 481: ypb.EvaluateExpressionRequest.Variables:type_name -> ypb.KVPair
+	698,  // 482: ypb.EvaluateMultiExpressionRequest.Variables:type_name -> ypb.KVPair
+	785,  // 483: ypb.EvaluateMultiExpressionResponse.Results:type_name -> ypb.EvaluateExpressionResponse
+	788,  // 484: ypb.GetThirdPartyAppConfigTemplate.Items:type_name -> ypb.ThirdPartyAppConfigItemTemplate
+	789,  // 485: ypb.GetThirdPartyAppConfigTemplateResponse.Templates:type_name -> ypb.GetThirdPartyAppConfigTemplate
+	6,    // 486: ypb.GenerateReverseShellCommandResponse.Status:type_name -> ypb.GeneralResponse
+	806,  // 487: ypb.FingerprintRule.CPE:type_name -> ypb.CPE
+	808,  // 488: ypb.QueryFingerprintRequest.Filter:type_name -> ypb.FingerprintFilter
+	706,  // 489: ypb.QueryFingerprintRequest.Pagination:type_name -> ypb.Paging
+	706,  // 490: ypb.QueryFingerprintResponse.Pagination:type_name -> ypb.Paging
+	807,  // 491: ypb.QueryFingerprintResponse.Data:type_name -> ypb.FingerprintRule
+	808,  // 492: ypb.DeleteFingerprintRequest.Filter:type_name -> ypb.FingerprintFilter
+	807,  // 493: ypb.CreateFingerprintRequest.Rule:type_name -> ypb.FingerprintRule
+	807,  // 494: ypb.UpdateFingerprintRequest.Rule:type_name -> ypb.FingerprintRule
+	814,  // 495: ypb.FingerprintGroups.Data:type_name -> ypb.FingerprintGroup
+	808,  // 496: ypb.BatchUpdateFingerprintToGroupRequest.Filter:type_name -> ypb.FingerprintFilter
+	808,  // 497: ypb.GetFingerprintGroupSetRequest.Filter:type_name -> ypb.FingerprintFilter
+	808,  // 498: ypb.ExportFingerprintRequest.Filter:type_name -> ypb.FingerprintFilter
+	706,  // 499: ypb.QuerySyntaxFlowRuleRequest.Pagination:type_name -> ypb.Paging
+	827,  // 500: ypb.QuerySyntaxFlowRuleRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	1022, // 501: ypb.SyntaxFlowRule.AlertMsg:type_name -> ypb.SyntaxFlowRule.AlertMsgEntry
+	1023, // 502: ypb.AlertMessage.Extra:type_name -> ypb.AlertMessage.ExtraEntry
+	1024, // 503: ypb.SyntaxFlowRuleInput.AlertMsg:type_name -> ypb.SyntaxFlowRuleInput.AlertMsgEntry
+	829,  // 504: ypb.SSARiskDiffRequest.BaseLine:type_name -> ypb.SSARiskDiffItem
+	829,  // 505: ypb.SSARiskDiffRequest.Compare:type_name -> ypb.SSARiskDiffItem
+	885,  // 506: ypb.SSARiskDiffResponse.BaseRisk:type_name -> ypb.SSARisk
+	885,  // 507: ypb.SSARiskDiffResponse.CompareRisk:type_name -> ypb.SSARisk
+	706,  // 508: ypb.QuerySSAProgramRequest.Paging:type_name -> ypb.Paging
+	706,  // 509: ypb.QuerySSAProgramRequest.Pagination:type_name -> ypb.Paging
+	833,  // 510: ypb.QuerySSAProgramRequest.Filter:type_name -> ypb.SSAProgramFilter
+	832,  // 511: ypb.UpdateSSAProgramRequest.ProgramInput:type_name -> ypb.SSAProgramInput
+	833,  // 512: ypb.DeleteSSAProgramRequest.Filter:type_name -> ypb.SSAProgramFilter
+	706,  // 513: ypb.QuerySSAProgramResponse.Paging:type_name -> ypb.Paging
+	706,  // 514: ypb.QuerySSAProgramResponse.Pagination:type_name -> ypb.Paging
+	828,  // 515: ypb.QuerySSAProgramResponse.Programs:type_name -> ypb.SSAProgram
+	828,  // 516: ypb.QuerySSAProgramResponse.Data:type_name -> ypb.SSAProgram
+	826,  // 517: ypb.CreateSyntaxFlowRuleRequest.SyntaxFlowInput:type_name -> ypb.SyntaxFlowRuleInput
+	805,  // 518: ypb.CreateSyntaxFlowRuleResponse.Message:type_name -> ypb.DbOperateMessage
+	824,  // 519: ypb.CreateSyntaxFlowRuleResponse.Rule:type_name -> ypb.SyntaxFlowRule
+	826,  // 520: ypb.UpdateSyntaxFlowRuleRequest.SyntaxFlowInput:type_name -> ypb.SyntaxFlowRuleInput
+	805,  // 521: ypb.UpdateSyntaxFlowRuleResponse.Message:type_name -> ypb.DbOperateMessage
+	824,  // 522: ypb.UpdateSyntaxFlowRuleResponse.Rule:type_name -> ypb.SyntaxFlowRule
+	706,  // 523: ypb.QuerySyntaxFlowRuleResponse.Pagination:type_name -> ypb.Paging
+	805,  // 524: ypb.QuerySyntaxFlowRuleResponse.DbMessage:type_name -> ypb.DbOperateMessage
+	824,  // 525: ypb.QuerySyntaxFlowRuleResponse.Rule:type_name -> ypb.SyntaxFlowRule
+	827,  // 526: ypb.DeleteSyntaxFlowRuleRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	848,  // 527: ypb.QuerySyntaxFlowRuleGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleGroupFilter
+	706,  // 528: ypb.QuerySyntaxFlowRuleGroupRequest.Pagination:type_name -> ypb.Paging
+	849,  // 529: ypb.QuerySyntaxFlowRuleGroupResponse.Group:type_name -> ypb.SyntaxFlowGroup
+	706,  // 530: ypb.QuerySyntaxFlowRuleGroupResponse.Pagination:type_name -> ypb.Paging
+	827,  // 531: ypb.UpdateSyntaxFlowRuleAndGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	827,  // 532: ypb.QuerySyntaxFlowSameGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	849,  // 533: ypb.QuerySyntaxFlowSameGroupResponse.Group:type_name -> ypb.SyntaxFlowGroup
+	848,  // 534: ypb.DeleteSyntaxFlowRuleGroupRequest.Filter:type_name -> ypb.SyntaxFlowRuleGroupFilter
+	706,  // 535: ypb.SyntaxFlowRuleToOnlineRequest.Pagination:type_name -> ypb.Paging
+	827,  // 536: ypb.SyntaxFlowRuleToOnlineRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	827,  // 537: ypb.DownloadSyntaxFlowRuleRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	827,  // 538: ypb.SyntaxFlowScanRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	826,  // 539: ypb.SyntaxFlowScanRequest.RuleInput:type_name -> ypb.SyntaxFlowRuleInput
+	706,  // 540: ypb.QuerySyntaxFlowScanTaskRequest.Pagination:type_name -> ypb.Paging
+	863,  // 541: ypb.QuerySyntaxFlowScanTaskRequest.Filter:type_name -> ypb.SyntaxFlowScanTaskFilter
+	706,  // 542: ypb.QuerySyntaxFlowScanTaskResponse.Pagination:type_name -> ypb.Paging
+	865,  // 543: ypb.QuerySyntaxFlowScanTaskResponse.Data:type_name -> ypb.SyntaxFlowScanTask
+	861,  // 544: ypb.SyntaxFlowScanTask.Config:type_name -> ypb.SyntaxFlowScanRequest
+	863,  // 545: ypb.DeleteSyntaxFlowScanTaskRequest.Filter:type_name -> ypb.SyntaxFlowScanTaskFilter
+	763,  // 546: ypb.SyntaxFlowScanResponse.ExecResult:type_name -> ypb.ExecResult
+	872,  // 547: ypb.SyntaxFlowScanResponse.Result:type_name -> ypb.SyntaxFlowResult
+	516,  // 548: ypb.SyntaxFlowScanResponse.risks:type_name -> ypb.Risk
+	885,  // 549: ypb.SyntaxFlowScanResponse.SSARisks:type_name -> ypb.SSARisk
+	868,  // 550: ypb.SyntaxFlowScanResponse.ActiveTask:type_name -> ypb.SyntaxFlowScanActiveTask
+	706,  // 551: ypb.QuerySyntaxFlowResultRequest.Pagination:type_name -> ypb.Paging
+	869,  // 552: ypb.QuerySyntaxFlowResultRequest.Filter:type_name -> ypb.SyntaxFlowResultFilter
+	706,  // 553: ypb.QuerySyntaxFlowResultResponse.Pagination:type_name -> ypb.Paging
+	805,  // 554: ypb.QuerySyntaxFlowResultResponse.DbMessage:type_name -> ypb.DbOperateMessage
+	872,  // 555: ypb.QuerySyntaxFlowResultResponse.Results:type_name -> ypb.SyntaxFlowResult
+	869,  // 556: ypb.DeleteSyntaxFlowResultRequest.Filter:type_name -> ypb.SyntaxFlowResultFilter
+	805,  // 557: ypb.DeleteSyntaxFlowResultResponse.Message:type_name -> ypb.DbOperateMessage
+	698,  // 558: ypb.PluginEnvData.Env:type_name -> ypb.KVPair
+	881,  // 559: ypb.GetAllFuzztagInfoResponse.Data:type_name -> ypb.FuzztagInfo
+	880,  // 560: ypb.FuzztagInfo.ArgumentTypes:type_name -> ypb.FuzztagArgumentType
+	362,  // 561: ypb.GenerateFuzztagRequest.Range:type_name -> ypb.Range
+	6,    // 562: ypb.GenerateFuzztagResponse.Status:type_name -> ypb.GeneralResponse
+	830,  // 563: ypb.SSARisksFilter.SSARiskDiffRequest:type_name -> ypb.SSARiskDiffRequest
+	706,  // 564: ypb.QuerySSARisksRequest.Pagination:type_name -> ypb.Paging
+	886,  // 565: ypb.QuerySSARisksRequest.Filter:type_name -> ypb.SSARisksFilter
+	706,  // 566: ypb.QuerySSARisksResponse.Pagination:type_name -> ypb.Paging
+	885,  // 567: ypb.QuerySSARisksResponse.Data:type_name -> ypb.SSARisk
+	885,  // 568: ypb.QueryNewSSARisksResponse.Data:type_name -> ypb.SSARisk
+	886,  // 569: ypb.DeleteSSARisksRequest.Filter:type_name -> ypb.SSARisksFilter
+	886,  // 570: ypb.GetSSARiskFieldGroupRequest.Filter:type_name -> ypb.SSARisksFilter
+	523,  // 571: ypb.SSARiskFieldGroupResponse.FileField:type_name -> ypb.FieldGroup
+	465,  // 572: ypb.SSARiskFieldGroupResponse.SeverityField:type_name -> ypb.FieldName
+	465,  // 573: ypb.SSARiskFieldGroupResponse.RiskTypeField:type_name -> ypb.FieldName
+	886,  // 574: ypb.NewSSARiskReadRequest.Filter:type_name -> ypb.SSARisksFilter
+	886,  // 575: ypb.ExportSSARiskRequest.Filter:type_name -> ypb.SSARisksFilter
+	886,  // 576: ypb.SSARiskFeedbackToOnlineRequest.Filter:type_name -> ypb.SSARisksFilter
+	902,  // 577: ypb.CreateSSARiskDisposalsResponse.Data:type_name -> ypb.SSARiskDisposalData
+	706,  // 578: ypb.QuerySSARiskDisposalsRequest.Pagination:type_name -> ypb.Paging
+	903,  // 579: ypb.QuerySSARiskDisposalsRequest.Filter:type_name -> ypb.SSARiskDisposalsFilter
+	706,  // 580: ypb.QuerySSARiskDisposalsResponse.Pagination:type_name -> ypb.Paging
+	902,  // 581: ypb.QuerySSARiskDisposalsResponse.Data:type_name -> ypb.SSARiskDisposalData
+	903,  // 582: ypb.UpdateSSARiskDisposalsRequest.Filter:type_name -> ypb.SSARiskDisposalsFilter
+	902,  // 583: ypb.UpdateSSARiskDisposalsResponse.Data:type_name -> ypb.SSARiskDisposalData
+	903,  // 584: ypb.DeleteSSARiskDisposalsRequest.Filter:type_name -> ypb.SSARiskDisposalsFilter
+	805,  // 585: ypb.DeleteSSARiskDisposalsResponse.Message:type_name -> ypb.DbOperateMessage
+	902,  // 586: ypb.GetSSARiskDisposalResponse.Data:type_name -> ypb.SSARiskDisposalData
+	827,  // 587: ypb.ExportSyntaxFlowsRequest.Filter:type_name -> ypb.SyntaxFlowRuleFilter
+	918,  // 588: ypb.UpdateHotPatchTemplateRequest.Condition:type_name -> ypb.HotPatchTemplateRequest
+	917,  // 589: ypb.UpdateHotPatchTemplateRequest.Data:type_name -> ypb.HotPatchTemplate
+	918,  // 590: ypb.DeleteHotPatchTemplateRequest.Condition:type_name -> ypb.HotPatchTemplateRequest
+	805,  // 591: ypb.CreateHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
+	805,  // 592: ypb.DeleteHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
+	805,  // 593: ypb.UpdateHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
+	805,  // 594: ypb.QueryHotPatchTemplateResponse.Message:type_name -> ypb.DbOperateMessage
+	917,  // 595: ypb.QueryHotPatchTemplateResponse.Data:type_name -> ypb.HotPatchTemplate
+	706,  // 596: ypb.QueryHotPatchTemplateListResponse.Pagination:type_name -> ypb.Paging
+	429,  // 597: ypb.GetHotPatchTemplateTagsResponse.Tags:type_name -> ypb.Tags
+	928,  // 598: ypb.GlobalHotPatchConfig.Items:type_name -> ypb.GlobalHotPatchTemplateRef
+	929,  // 599: ypb.SetGlobalHotPatchConfigRequest.Config:type_name -> ypb.GlobalHotPatchConfig
+	712,  // 600: ypb.ExportHTTPFlowStreamRequest.Filter:type_name -> ypb.QueryHTTPFlowRequest
+	939,  // 601: ypb.NoteContent.Note:type_name -> ypb.Note
+	805,  // 602: ypb.CreateNoteResponse.Message:type_name -> ypb.DbOperateMessage
+	941,  // 603: ypb.UpdateNoteRequest.Filter:type_name -> ypb.NoteFilter
+	941,  // 604: ypb.DeleteNoteRequest.Filter:type_name -> ypb.NoteFilter
+	941,  // 605: ypb.QueryNoteRequest.Filter:type_name -> ypb.NoteFilter
+	706,  // 606: ypb.QueryNoteRequest.Pagination:type_name -> ypb.Paging
+	706,  // 607: ypb.QueryNoteResponse.Pagination:type_name -> ypb.Paging
+	939,  // 608: ypb.QueryNoteResponse.Data:type_name -> ypb.Note
+	706,  // 609: ypb.SearchNoteContentRequest.Pagination:type_name -> ypb.Paging
+	706,  // 610: ypb.SearchNoteContentResponse.Pagination:type_name -> ypb.Paging
+	940,  // 611: ypb.SearchNoteContentResponse.Data:type_name -> ypb.NoteContent
+	941,  // 612: ypb.ExportNoteRequest.Filter:type_name -> ypb.NoteFilter
+	249,  // 613: ypb.AIConfigHealthCheckRequest.Config:type_name -> ypb.ThirdPartyApplicationConfig
+	249,  // 614: ypb.AIConfigHealthCheckResponse.RecommendConfig:type_name -> ypb.ThirdPartyApplicationConfig
+	249,  // 615: ypb.AIProvider.Config:type_name -> ypb.ThirdPartyApplicationConfig
+	959,  // 616: ypb.QueryAIProvidersRequest.Filter:type_name -> ypb.AIProviderFilter
+	706,  // 617: ypb.QueryAIProvidersRequest.Pagination:type_name -> ypb.Paging
+	706,  // 618: ypb.QueryAIProvidersResponse.Pagination:type_name -> ypb.Paging
+	958,  // 619: ypb.QueryAIProvidersResponse.Providers:type_name -> ypb.AIProvider
+	958,  // 620: ypb.ListAIProvidersResponse.Providers:type_name -> ypb.AIProvider
+	958,  // 621: ypb.UpsertAIProviderRequest.Provider:type_name -> ypb.AIProvider
+	958,  // 622: ypb.UpsertAIProviderResponse.Provider:type_name -> ypb.AIProvider
+	249,  // 623: ypb.AIModelConfig.Provider:type_name -> ypb.ThirdPartyApplicationConfig
+	698,  // 624: ypb.AIModelConfig.ExtraParams:type_name -> ypb.KVPair
+	966,  // 625: ypb.AIGlobalConfig.IntelligentModels:type_name -> ypb.AIModelConfig
+	966,  // 626: ypb.AIGlobalConfig.LightweightModels:type_name -> ypb.AIModelConfig
+	966,  // 627: ypb.AIGlobalConfig.VisionModels:type_name -> ypb.AIModelConfig
+	82,   // 628: ypb.LocalModelConfig.Status:type_name -> ypb.LocalModelStatus
+	974,  // 629: ypb.GetSupportedLocalModelsResponse.Models:type_name -> ypb.LocalModelConfig
+	976,  // 630: ypb.WatchProcessRequest.StartParams:type_name -> ypb.WatchProcessStartParams
+	978,  // 631: ypb.WatchProcessResponse.Process:type_name -> ypb.ProcessInfo
+	979,  // 632: ypb.WatchProcessResponse.Connections:type_name -> ypb.ConnectionInfo
+	747,  // 633: ypb.MITMV2Request.Certificates:type_name -> ypb.Certificate
+	698,  // 634: ypb.MITMV2Request.hosts:type_name -> ypb.KVPair
+	698,  // 635: ypb.MITMV2Request.HostsMapping:type_name -> ypb.KVPair
+	746,  // 636: ypb.MITMV2Request.FilterData:type_name -> ypb.MITMFilterData
+	746,  // 637: ypb.MITMV2Request.HijackFilterData:type_name -> ypb.MITMFilterData
+	749,  // 638: ypb.MITMV2Request.Replacers:type_name -> ypb.MITMContentReplacer
+	761,  // 639: ypb.MITMV2Request.YakScriptParams:type_name -> ypb.ExecParamItem
+	750,  // 640: ypb.MITMV2Request.RemoveHookParams:type_name -> ypb.RemoveHookParams
+	983,  // 641: ypb.MITMV2Request.ManualHijackMessage:type_name -> ypb.SingleManualHijackControlMessage
+	698,  // 642: ypb.MITMV2Request.SNIMapping:type_name -> ypb.KVPair
+	746,  // 643: ypb.MITMV2Response.FilterData:type_name -> ypb.MITMFilterData
+	749,  // 644: ypb.MITMV2Response.Replacers:type_name -> ypb.MITMContentReplacer
+	763,  // 645: ypb.MITMV2Response.Message:type_name -> ypb.ExecResult
+	753,  // 646: ypb.MITMV2Response.Hooks:type_name -> ypb.YakScriptHooks
+	984,  // 647: ypb.MITMV2Response.ManualHijackList:type_name -> ypb.SingleManualHijackInfoMessage
+	752,  // 648: ypb.SingleManualHijackInfoMessage.TraceInfo:type_name -> ypb.TraceInfo
+	443,  // 649: ypb.QueryMITMReplacerRulesResponse.Rules:type_name -> ypb.MITMContentReplacers
+	987,  // 650: ypb.PluginTraceResponse.Traces:type_name -> ypb.PluginExecutionTrace
+	990,  // 651: ypb.PluginTraceResponse.Stats:type_name -> ypb.PluginTraceStats
+	886,  // 652: ypb.GenerateSSAReportRequest.Filter:type_name -> ypb.SSARisksFilter
+	994,  // 653: ypb.SSAProject.CompileConfig:type_name -> ypb.SSAProjectCompileConfig
+	995,  // 654: ypb.SSAProject.ScanConfig:type_name -> ypb.SSAProjectScanConfig
+	996,  // 655: ypb.SSAProject.RuleConfig:type_name -> ypb.SSAProjectScanRuleConfig
+	827,  // 656: ypb.SSAProjectScanRuleConfig.RuleFilter:type_name -> ypb.SyntaxFlowRuleFilter
+	993,  // 657: ypb.CreateSSAProjectRequest.Project:type_name -> ypb.SSAProject
+	993,  // 658: ypb.CreateSSAProjectResponse.Project:type_name -> ypb.SSAProject
+	805,  // 659: ypb.CreateSSAProjectResponse.Message:type_name -> ypb.DbOperateMessage
+	993,  // 660: ypb.UpdateSSAProjectRequest.Project:type_name -> ypb.SSAProject
+	993,  // 661: ypb.UpdateSSAProjectResponse.Project:type_name -> ypb.SSAProject
+	805,  // 662: ypb.UpdateSSAProjectResponse.Message:type_name -> ypb.DbOperateMessage
+	997,  // 663: ypb.DeleteSSAProjectRequest.Filter:type_name -> ypb.SSAProjectFilter
+	805,  // 664: ypb.DeleteSSAProjectResponse.Message:type_name -> ypb.DbOperateMessage
+	997,  // 665: ypb.QuerySSAProjectRequest.Filter:type_name -> ypb.SSAProjectFilter
+	706,  // 666: ypb.QuerySSAProjectRequest.Pagination:type_name -> ypb.Paging
+	993,  // 667: ypb.QuerySSAProjectResponse.Projects:type_name -> ypb.SSAProject
+	706,  // 668: ypb.QuerySSAProjectResponse.Pagination:type_name -> ypb.Paging
+	886,  // 669: ypb.GetSSAWorkbenchDashboardRequest.RiskFilter:type_name -> ypb.SSARisksFilter
+	827,  // 670: ypb.GetSSAWorkbenchDashboardRequest.RuleFilter:type_name -> ypb.SyntaxFlowRuleFilter
+	1009, // 671: ypb.GetSSAWorkbenchDashboardResponse.Summary:type_name -> ypb.SSAWorkbenchSummary
+	1010, // 672: ypb.GetSSAWorkbenchDashboardResponse.RiskOverview:type_name -> ypb.SSAWorkbenchRiskLevelItem
+	1011, // 673: ypb.GetSSAWorkbenchDashboardResponse.RiskDistribution:type_name -> ypb.SSAWorkbenchRiskTypeItem
+	1012, // 674: ypb.GetSSAWorkbenchDashboardResponse.TopRuleHits:type_name -> ypb.SSAWorkbenchRuleHitItem
+	1013, // 675: ypb.GetSSAWorkbenchDashboardResponse.RecentProjects:type_name -> ypb.SSAWorkbenchRecentProject
+	442,  // 676: ypb.ExtractDataToFileRequest.DataEntry.value:type_name -> ypb.ExtractableData
+	471,  // 677: ypb.YsoClassGeneraterOptionsWithVerbose.BindOptionsEntry.value:type_name -> ypb.YsoClassOptionsResponseWithVerbose
+	825,  // 678: ypb.SyntaxFlowRule.AlertMsgEntry.value:type_name -> ypb.AlertMessage
+	825,  // 679: ypb.SyntaxFlowRuleInput.AlertMsgEntry.value:type_name -> ypb.AlertMessage
+	4,    // 680: ypb.Yak.Version:input_type -> ypb.Empty
+	779,  // 681: ypb.Yak.YakVersionAtLeast:input_type -> ypb.YakVersionAtLeastRequest
+	755,  // 682: ypb.Yak.Echo:input_type -> ypb.EchoRequest
+	757,  // 683: ypb.Yak.Handshake:input_type -> ypb.HandshakeRequest
+	4,    // 684: ypb.Yak.VerifySystemCertificate:input_type -> ypb.Empty
+	4,    // 685: ypb.Yak.InstallMITMCertificate:input_type -> ypb.Empty
+	744,  // 686: ypb.Yak.MITM:input_type -> ypb.MITMRequest
+	742,  // 687: ypb.Yak.SetMITMFilter:input_type -> ypb.SetMITMFilterRequest
+	4,    // 688: ypb.Yak.GetMITMFilter:input_type -> ypb.Empty
+	4,    // 689: ypb.Yak.ResetMITMFilter:input_type -> ypb.Empty
+	4,    // 690: ypb.Yak.DownloadMITMCert:input_type -> ypb.Empty
+	4,    // 691: ypb.Yak.DownloadMITMGMCert:input_type -> ypb.Empty
+	977,  // 692: ypb.Yak.WatchProcessConnection:input_type -> ypb.WatchProcessRequest
+	981,  // 693: ypb.Yak.MITMV2:input_type -> ypb.MITMV2Request
+	759,  // 694: ypb.Yak.OpenPort:input_type -> ypb.Input
+	762,  // 695: ypb.Yak.Exec:input_type -> ypb.ExecRequest
+	670,  // 696: ypb.Yak.QueryExecHistory:input_type -> ypb.ExecHistoryRequest
+	4,    // 697: ypb.Yak.RemoveExecHistory:input_type -> ypb.Empty
+	673,  // 698: ypb.Yak.SavePluginExecutionHistory:input_type -> ypb.SavePluginExecutionHistoryRequest
+	4,    // 699: ypb.Yak.GetPluginExecutionUsageRanking:input_type -> ypb.Empty
+	4,    // 700: ypb.Yak.LoadNucleiTemplates:input_type -> ypb.Empty
+	4,    // 701: ypb.Yak.AutoUpdateYakModule:input_type -> ypb.Empty
+	762,  // 702: ypb.Yak.ExecYakScript:input_type -> ypb.ExecRequest
+	8,    // 703: ypb.Yak.ExecBatchYakScript:input_type -> ypb.ExecBatchYakScriptRequest
+	4,    // 704: ypb.Yak.GetExecBatchYakScriptUnfinishedTask:input_type -> ypb.Empty
+	408,  // 705: ypb.Yak.GetExecBatchYakScriptUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
+	408,  // 706: ypb.Yak.PopExecBatchYakScriptUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
+	409,  // 707: ypb.Yak.RecoverExecBatchYakScriptUnfinishedTask:input_type -> ypb.RecoverExecBatchYakScriptUnfinishedTaskRequest
+	626,  // 708: ypb.Yak.QueryYakScript:input_type -> ypb.QueryYakScriptRequest
+	626,  // 709: ypb.Yak.QueryYakScriptByYakScriptName:input_type -> ypb.QueryYakScriptRequest
+	630,  // 710: ypb.Yak.SaveYakScript:input_type -> ypb.YakScript
+	7,    // 711: ypb.Yak.DeleteYakScript:input_type -> ypb.DeleteYakScriptRequest
+	10,   // 712: ypb.Yak.GetYakScriptById:input_type -> ypb.GetYakScriptByIdRequest
+	11,   // 713: ypb.Yak.GetYakScriptByName:input_type -> ypb.GetYakScriptByNameRequest
+	12,   // 714: ypb.Yak.GetYakScriptByOnlineID:input_type -> ypb.GetYakScriptByOnlineIDRequest
+	7,    // 715: ypb.Yak.IgnoreYakScript:input_type -> ypb.DeleteYakScriptRequest
+	7,    // 716: ypb.Yak.UnIgnoreYakScript:input_type -> ypb.DeleteYakScriptRequest
+	563,  // 717: ypb.Yak.ExportYakScript:input_type -> ypb.ExportYakScriptRequest
+	564,  // 718: ypb.Yak.ExportYakScriptStream:input_type -> ypb.ExportYakScriptStreamRequest
+	565,  // 719: ypb.Yak.ImportYakScriptStream:input_type -> ypb.ImportYakScriptStreamRequest
+	492,  // 720: ypb.Yak.ExecutePacketYakScript:input_type -> ypb.ExecutePacketYakScriptParams
+	493,  // 721: ypb.Yak.ExecuteBatchPacketYakScript:input_type -> ypb.ExecuteBatchPacketYakScriptParams
+	4,    // 722: ypb.Yak.GetYakScriptTags:input_type -> ypb.Empty
+	430,  // 723: ypb.Yak.QueryYakScriptLocalAndUser:input_type -> ypb.QueryYakScriptLocalAndUserRequest
+	432,  // 724: ypb.Yak.QueryYakScriptByOnlineGroup:input_type -> ypb.QueryYakScriptByOnlineGroupRequest
+	4,    // 725: ypb.Yak.QueryYakScriptLocalAll:input_type -> ypb.Empty
+	433,  // 726: ypb.Yak.QueryYakScriptByNames:input_type -> ypb.QueryYakScriptByNamesRequest
+	434,  // 727: ypb.Yak.QueryYakScriptByIsCore:input_type -> ypb.QueryYakScriptByIsCoreRequest
+	437,  // 728: ypb.Yak.QueryYakScriptRiskDetailByCWE:input_type -> ypb.QueryYakScriptRiskDetailByCWERequest
+	4,    // 729: ypb.Yak.YakScriptRiskTypeList:input_type -> ypb.Empty
+	632,  // 730: ypb.Yak.SaveNewYakScript:input_type -> ypb.SaveNewYakScriptRequest
+	633,  // 731: ypb.Yak.SaveYakScriptToOnline:input_type -> ypb.SaveYakScriptToOnlineRequest
+	636,  // 732: ypb.Yak.ExportLocalYakScript:input_type -> ypb.ExportLocalYakScriptRequest
+	636,  // 733: ypb.Yak.ExportLocalYakScriptStream:input_type -> ypb.ExportLocalYakScriptRequest
+	639,  // 734: ypb.Yak.ImportYakScript:input_type -> ypb.ImportYakScriptRequest
+	641,  // 735: ypb.Yak.SetYakScriptSkipUpdate:input_type -> ypb.SetYakScriptSkipUpdateRequest
+	626,  // 736: ypb.Yak.QueryYakScriptSkipUpdate:input_type -> ypb.QueryYakScriptRequest
+	643,  // 737: ypb.Yak.QueryYakScriptGroup:input_type -> ypb.QueryYakScriptGroupRequest
+	646,  // 738: ypb.Yak.SaveYakScriptGroup:input_type -> ypb.SaveYakScriptGroupRequest
+	647,  // 739: ypb.Yak.RenameYakScriptGroup:input_type -> ypb.RenameYakScriptGroupRequest
+	648,  // 740: ypb.Yak.DeleteYakScriptGroup:input_type -> ypb.DeleteYakScriptGroupRequest
+	626,  // 741: ypb.Yak.GetYakScriptGroup:input_type -> ypb.QueryYakScriptRequest
+	650,  // 742: ypb.Yak.ResetYakScriptGroup:input_type -> ypb.ResetYakScriptGroupRequest
+	651,  // 743: ypb.Yak.SetGroup:input_type -> ypb.SetGroupRequest
+	707,  // 744: ypb.Yak.GetHTTPFlowByHash:input_type -> ypb.GetHTTPFlowByHashRequest
+	708,  // 745: ypb.Yak.GetHTTPFlowById:input_type -> ypb.GetHTTPFlowByIdRequest
+	710,  // 746: ypb.Yak.GetHTTPFlowBodyById:input_type -> ypb.GetHTTPFlowBodyByIdRequest
+	709,  // 747: ypb.Yak.GetHTTPFlowByIds:input_type -> ypb.GetHTTPFlowByIdsRequest
+	712,  // 748: ypb.Yak.QueryHTTPFlows:input_type -> ypb.QueryHTTPFlowRequest
+	724,  // 749: ypb.Yak.DeleteHTTPFlows:input_type -> ypb.DeleteHTTPFlowRequest
+	456,  // 750: ypb.Yak.SetTagForHTTPFlow:input_type -> ypb.SetTagForHTTPFlowRequest
+	725,  // 751: ypb.Yak.QueryHTTPFlowsIds:input_type -> ypb.QueryHTTPFlowsIdsRequest
+	734,  // 752: ypb.Yak.HTTPFlowsFieldGroup:input_type -> ypb.HTTPFlowsFieldGroupRequest
+	736,  // 753: ypb.Yak.HTTPFlowsShare:input_type -> ypb.HTTPFlowsShareRequest
+	738,  // 754: ypb.Yak.HTTPFlowsExtract:input_type -> ypb.HTTPFlowsExtractRequest
+	767,  // 755: ypb.Yak.GetHTTPFlowBare:input_type -> ypb.HTTPFlowBareRequest
+	722,  // 756: ypb.Yak.ExportHTTPFlows:input_type -> ypb.ExportHTTPFlowsRequest
+	713,  // 757: ypb.Yak.HTTPFlowsToOnline:input_type -> ypb.HTTPFlowsToOnlineRequest
+	712,  // 758: ypb.Yak.QueryHTTPFlowsProcessNames:input_type -> ypb.QueryHTTPFlowRequest
+	714,  // 759: ypb.Yak.HTTPFlowsToOnlineBatch:input_type -> ypb.HTTPFlowsToOnlineBatchRequest
+	716,  // 760: ypb.Yak.AnalyzeHTTPFlow:input_type -> ypb.AnalyzeHTTPFlowRequest
+	696,  // 761: ypb.Yak.ExtractUrl:input_type -> ypb.FuzzerRequest
+	486,  // 762: ypb.Yak.GetHistoryHTTPFuzzerTask:input_type -> ypb.GetHistoryHTTPFuzzerTaskRequest
+	4,    // 763: ypb.Yak.QueryHistoryHTTPFuzzerTask:input_type -> ypb.Empty
+	491,  // 764: ypb.Yak.QueryHistoryHTTPFuzzerTaskEx:input_type -> ypb.QueryHistoryHTTPFuzzerTaskExParams
+	462,  // 765: ypb.Yak.DeleteHistoryHTTPFuzzerTask:input_type -> ypb.DeleteHistoryHTTPFuzzerTaskRequest
+	696,  // 766: ypb.Yak.HTTPFuzzer:input_type -> ypb.FuzzerRequest
+	692,  // 767: ypb.Yak.HTTPFuzzerSequence:input_type -> ypb.FuzzerRequests
+	694,  // 768: ypb.Yak.HTTPFuzzerGroup:input_type -> ypb.GroupHTTPFuzzerRequest
+	689,  // 769: ypb.Yak.PreloadHTTPFuzzerParams:input_type -> ypb.PreloadHTTPFuzzerParamsRequest
+	682,  // 770: ypb.Yak.RenderVariables:input_type -> ypb.RenderVariablesRequest
+	684,  // 771: ypb.Yak.MatchHTTPResponse:input_type -> ypb.MatchHTTPResponseParams
+	688,  // 772: ypb.Yak.ExtractHTTPResponse:input_type -> ypb.ExtractHTTPResponseParams
+	700,  // 773: ypb.Yak.RedirectRequest:input_type -> ypb.RedirectRequestParams
+	539,  // 774: ypb.Yak.HTTPRequestMutate:input_type -> ypb.HTTPRequestMutateParams
+	540,  // 775: ypb.Yak.HTTPResponseMutate:input_type -> ypb.HTTPResponseMutateParams
+	421,  // 776: ypb.Yak.FixUploadPacket:input_type -> ypb.FixUploadPacketRequest
+	421,  // 777: ypb.Yak.IsMultipartFormDataRequest:input_type -> ypb.FixUploadPacketRequest
+	351,  // 778: ypb.Yak.GenerateExtractRule:input_type -> ypb.GenerateExtractRuleRequest
+	350,  // 779: ypb.Yak.ExtractData:input_type -> ypb.ExtractDataRequest
+	769,  // 780: ypb.Yak.ImportHTTPFuzzerTaskFromYaml:input_type -> ypb.ImportHTTPFuzzerTaskFromYamlRequest
+	771,  // 781: ypb.Yak.ExportHTTPFuzzerTaskToYaml:input_type -> ypb.ExportHTTPFuzzerTaskToYamlRequest
+	773,  // 782: ypb.Yak.RenderHTTPFuzzerPacket:input_type -> ypb.RenderHTTPFuzzerPacketRequest
+	341,  // 783: ypb.Yak.SaveFuzzerLabel:input_type -> ypb.SaveFuzzerLabelRequest
+	4,    // 784: ypb.Yak.QueryFuzzerLabel:input_type -> ypb.Empty
+	344,  // 785: ypb.Yak.DeleteFuzzerLabel:input_type -> ypb.DeleteFuzzerLabelRequest
+	345,  // 786: ypb.Yak.SaveFuzzerConfig:input_type -> ypb.SaveFuzzerConfigRequest
+	346,  // 787: ypb.Yak.QueryFuzzerConfig:input_type -> ypb.QueryFuzzerConfigRequest
+	349,  // 788: ypb.Yak.DeleteFuzzerConfig:input_type -> ypb.DeleteFuzzerConfigRequest
+	354,  // 789: ypb.Yak.QueryHTTPFuzzerResponseByTaskId:input_type -> ypb.QueryHTTPFuzzerResponseByTaskIdRequest
+	358,  // 790: ypb.Yak.CreateWebsocketFuzzer:input_type -> ypb.ClientWebsocketRequest
+	356,  // 791: ypb.Yak.QueryWebsocketFlowByHTTPFlowWebsocketHash:input_type -> ypb.QueryWebsocketFlowByHTTPFlowWebsocketHashRequest
+	357,  // 792: ypb.Yak.DeleteWebsocketFlowByHTTPFlowWebsocketHash:input_type -> ypb.DeleteWebsocketFlowByHTTPFlowWebsocketHashRequest
+	4,    // 793: ypb.Yak.DeleteWebsocketFlowAll:input_type -> ypb.Empty
+	703,  // 794: ypb.Yak.ConvertFuzzerResponseToHTTPFlow:input_type -> ypb.FuzzerResponse
+	676,  // 795: ypb.Yak.StringFuzzer:input_type -> ypb.StringFuzzerRequest
+	678,  // 796: ypb.Yak.HTTPRequestAnalyzer:input_type -> ypb.HTTPRequestAnalysisMaterial
+	655,  // 797: ypb.Yak.CreateSnippet:input_type -> ypb.SnippetsRequest
+	656,  // 798: ypb.Yak.UpdateSnippet:input_type -> ypb.EditSnippetsRequest
+	657,  // 799: ypb.Yak.DeleteSnippets:input_type -> ypb.QuerySnippetsRequest
+	657,  // 800: ypb.Yak.QuerySnippets:input_type -> ypb.QuerySnippetsRequest
+	659,  // 801: ypb.Yak.Codec:input_type -> ypb.CodecRequest
+	661,  // 802: ypb.Yak.NewCodec:input_type -> ypb.CodecRequestFlow
+	4,    // 803: ypb.Yak.GetAllCodecMethods:input_type -> ypb.Empty
+	662,  // 804: ypb.Yak.SaveCodecFlow:input_type -> ypb.CustomizeCodecFlow
+	663,  // 805: ypb.Yak.UpdateCodecFlow:input_type -> ypb.UpdateCodecFlowRequest
+	664,  // 806: ypb.Yak.DeleteCodecFlow:input_type -> ypb.DeleteCodecFlowRequest
+	4,    // 807: ypb.Yak.GetAllCodecFlow:input_type -> ypb.Empty
+	233,  // 808: ypb.Yak.PacketPrettifyHelper:input_type -> ypb.PacketPrettifyHelperRequest
+	620,  // 809: ypb.Yak.QueryPayload:input_type -> ypb.QueryPayloadRequest
+	618,  // 810: ypb.Yak.QueryPayloadFromFile:input_type -> ypb.QueryPayloadFromFileRequest
+	608,  // 811: ypb.Yak.DeletePayloadByFolder:input_type -> ypb.NameRequest
+	616,  // 812: ypb.Yak.DeletePayloadByGroup:input_type -> ypb.DeletePayloadByGroupRequest
+	617,  // 813: ypb.Yak.DeletePayload:input_type -> ypb.DeletePayloadRequest
+	612,  // 814: ypb.Yak.SavePayload:input_type -> ypb.SavePayloadRequest
+	612,  // 815: ypb.Yak.SavePayloadStream:input_type -> ypb.SavePayloadRequest
+	612,  // 816: ypb.Yak.SavePayloadToFileStream:input_type -> ypb.SavePayloadRequest
+	612,  // 817: ypb.Yak.SaveLargePayloadToFileStream:input_type -> ypb.SavePayloadRequest
+	607,  // 818: ypb.Yak.RenamePayloadFolder:input_type -> ypb.RenameRequest
+	607,  // 819: ypb.Yak.RenamePayloadGroup:input_type -> ypb.RenameRequest
+	613,  // 820: ypb.Yak.UpdatePayload:input_type -> ypb.UpdatePayloadRequest
+	614,  // 821: ypb.Yak.UpdatePayloadToFile:input_type -> ypb.UpdatePayloadToFileRequest
+	615,  // 822: ypb.Yak.BackUpOrCopyPayloads:input_type -> ypb.BackUpOrCopyPayloadsRequest
+	4,    // 823: ypb.Yak.GetAllPayloadGroup:input_type -> ypb.Empty
+	611,  // 824: ypb.Yak.UpdateAllPayloadGroup:input_type -> ypb.UpdateAllPayloadGroupRequest
+	623,  // 825: ypb.Yak.GetAllPayload:input_type -> ypb.GetAllPayloadRequest
+	623,  // 826: ypb.Yak.GetAllPayloadFromFile:input_type -> ypb.GetAllPayloadRequest
+	623,  // 827: ypb.Yak.ExportAllPayload:input_type -> ypb.GetAllPayloadRequest
+	623,  // 828: ypb.Yak.ExportAllPayloadFromFile:input_type -> ypb.GetAllPayloadRequest
+	608,  // 829: ypb.Yak.CreatePayloadFolder:input_type -> ypb.NameRequest
+	608,  // 830: ypb.Yak.RemoveDuplicatePayloads:input_type -> ypb.NameRequest
+	608,  // 831: ypb.Yak.CoverPayloadGroupToDatabase:input_type -> ypb.NameRequest
+	608,  // 832: ypb.Yak.ConvertPayloadGroupToDatabase:input_type -> ypb.NameRequest
+	4,    // 833: ypb.Yak.MigratePayloads:input_type -> ypb.Empty
+	380,  // 834: ypb.Yak.ExportPayloadBatch:input_type -> ypb.ExportPayloadBatchRequest
+	381,  // 835: ypb.Yak.UploadPayloadToOnline:input_type -> ypb.UploadPayloadToOnlineRequest
+	382,  // 836: ypb.Yak.DownloadPayload:input_type -> ypb.DownloadPayloadRequest
+	385,  // 837: ypb.Yak.ExportPayloadDBAndFile:input_type -> ypb.ExportPayloadDBAndFileRequest
+	4,    // 838: ypb.Yak.GetYakitCompletionRaw:input_type -> ypb.Empty
+	603,  // 839: ypb.Yak.GetYakVMBuildInMethodCompletion:input_type -> ypb.GetYakVMBuildInMethodCompletionRequest
+	374,  // 840: ypb.Yak.StaticAnalyzeError:input_type -> ypb.StaticAnalyzeErrorRequest
+	375,  // 841: ypb.Yak.YaklangCompileAndFormat:input_type -> ypb.YaklangCompileAndFormatRequest
+	364,  // 842: ypb.Yak.YaklangLanguageSuggestion:input_type -> ypb.YaklangLanguageSuggestionRequest
+	364,  // 843: ypb.Yak.YaklangLanguageFind:input_type -> ypb.YaklangLanguageSuggestionRequest
+	884,  // 844: ypb.Yak.FuzzTagSuggestion:input_type -> ypb.FuzzTagSuggestionRequest
+	363,  // 845: ypb.Yak.YaklangInspectInformation:input_type -> ypb.YaklangInspectInformationRequest
+	373,  // 846: ypb.Yak.YaklangGetCliCodeFromDatabase:input_type -> ypb.YaklangGetCliCodeFromDatabaseRequest
+	759,  // 847: ypb.Yak.YaklangTerminal:input_type -> ypb.Input
+	597,  // 848: ypb.Yak.PortScan:input_type -> ypb.PortScanRequest
+	4,    // 849: ypb.Yak.ViewPortScanCode:input_type -> ypb.Empty
+	595,  // 850: ypb.Yak.SimpleDetect:input_type -> ypb.RecordPortScanRequest
+	595,  // 851: ypb.Yak.SaveCancelSimpleDetect:input_type -> ypb.RecordPortScanRequest
+	596,  // 852: ypb.Yak.SimpleDetectCreatReport:input_type -> ypb.CreatReportRequest
+	415,  // 853: ypb.Yak.QuerySimpleDetectUnfinishedTask:input_type -> ypb.QueryUnfinishedTaskRequest
+	419,  // 854: ypb.Yak.GetSimpleDetectRecordRequestById:input_type -> ypb.GetUnfinishedTaskDetailByIdRequest
+	416,  // 855: ypb.Yak.DeleteSimpleDetectUnfinishedTask:input_type -> ypb.DeleteUnfinishedTaskRequest
+	420,  // 856: ypb.Yak.RecoverSimpleDetectTask:input_type -> ypb.RecoverUnfinishedTaskRequest
+	4,    // 857: ypb.Yak.GetSimpleDetectUnfinishedTask:input_type -> ypb.Empty
+	408,  // 858: ypb.Yak.GetSimpleDetectUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
+	408,  // 859: ypb.Yak.PopSimpleDetectUnfinishedTaskByUid:input_type -> ypb.GetExecBatchYakScriptUnfinishedTaskByUidRequest
+	409,  // 860: ypb.Yak.RecoverSimpleDetectUnfinishedTask:input_type -> ypb.RecoverExecBatchYakScriptUnfinishedTaskRequest
+	599,  // 861: ypb.Yak.QueryPorts:input_type -> ypb.QueryPortsRequest
+	598,  // 862: ypb.Yak.DeletePorts:input_type -> ypb.DeletePortsRequest
+	542,  // 863: ypb.Yak.QueryHosts:input_type -> ypb.QueryHostsRequest
+	543,  // 864: ypb.Yak.DeleteHosts:input_type -> ypb.DeleteHostsRequest
+	545,  // 865: ypb.Yak.QueryDomains:input_type -> ypb.QueryDomainsRequest
+	546,  // 866: ypb.Yak.DeleteDomains:input_type -> ypb.DeleteDomainsRequest
+	4,    // 867: ypb.Yak.QueryPortsGroup:input_type -> ypb.Empty
+	591,  // 868: ypb.Yak.UpdateFromYakitResource:input_type -> ypb.UpdateFromYakitResourceRequest
+	592,  // 869: ypb.Yak.UpdateFromGithub:input_type -> ypb.UpdateFromGithubRequest
+	579,  // 870: ypb.Yak.AddToMenu:input_type -> ypb.AddToMenuRequest
+	578,  // 871: ypb.Yak.RemoveFromMenu:input_type -> ypb.RemoveFromMenuRequest
+	577,  // 872: ypb.Yak.YakScriptIsInMenu:input_type -> ypb.YakScriptIsInMenuRequest
+	4,    // 873: ypb.Yak.GetAllMenuItem:input_type -> ypb.Empty
+	4,    // 874: ypb.Yak.DeleteAllMenuItem:input_type -> ypb.Empty
+	582,  // 875: ypb.Yak.ImportMenuItem:input_type -> ypb.ImportMenuItemRequest
+	4,    // 876: ypb.Yak.ExportMenuItem:input_type -> ypb.Empty
+	575,  // 877: ypb.Yak.GetMenuItemById:input_type -> ypb.GetMenuItemByIdRequest
+	571,  // 878: ypb.Yak.QueryGroupsByYakScriptId:input_type -> ypb.QueryGroupsByYakScriptIdRequest
+	580,  // 879: ypb.Yak.AddMenus:input_type -> ypb.AddMenuRequest
+	581,  // 880: ypb.Yak.QueryAllMenuItem:input_type -> ypb.QueryAllMenuItemRequest
+	581,  // 881: ypb.Yak.DeleteAllMenu:input_type -> ypb.QueryAllMenuItemRequest
+	584,  // 882: ypb.Yak.AddToNavigation:input_type -> ypb.AddToNavigationRequest
+	587,  // 883: ypb.Yak.GetAllNavigationItem:input_type -> ypb.GetAllNavigationRequest
+	587,  // 884: ypb.Yak.DeleteAllNavigation:input_type -> ypb.GetAllNavigationRequest
+	589,  // 885: ypb.Yak.AddOneNavigation:input_type -> ypb.AddOneNavigationRequest
+	590,  // 886: ypb.Yak.QueryNavigationGroups:input_type -> ypb.QueryNavigationGroupsRequest
+	569,  // 887: ypb.Yak.SaveMarkdownDocument:input_type -> ypb.SaveMarkdownDocumentRequest
+	568,  // 888: ypb.Yak.GetMarkdownDocument:input_type -> ypb.GetMarkdownDocumentRequest
+	568,  // 889: ypb.Yak.DeleteMarkdownDocument:input_type -> ypb.GetMarkdownDocumentRequest
+	560,  // 890: ypb.Yak.StartBasicCrawler:input_type -> ypb.StartBasicCrawlerRequest
+	4,    // 891: ypb.Yak.ViewBasicCrawlerCode:input_type -> ypb.Empty
+	559,  // 892: ypb.Yak.GenerateWebsiteTree:input_type -> ypb.GenerateWebsiteTreeRequest
+	556,  // 893: ypb.Yak.QueryYakScriptExecResult:input_type -> ypb.QueryYakScriptExecResultRequest
+	4,    // 894: ypb.Yak.QueryYakScriptNameInExecResult:input_type -> ypb.Empty
+	554,  // 895: ypb.Yak.DeleteYakScriptExecResult:input_type -> ypb.DeleteYakScriptExecResultRequest
+	4,    // 896: ypb.Yak.DeleteYakScriptExec:input_type -> ypb.Empty
+	538,  // 897: ypb.Yak.StartBrute:input_type -> ypb.StartBruteParams
+	4,    // 898: ypb.Yak.GetAvailableBruteTypes:input_type -> ypb.Empty
+	530,  // 899: ypb.Yak.GetTunnelServerExternalIP:input_type -> ypb.GetTunnelServerExternalIPParams
+	528,  // 900: ypb.Yak.VerifyTunnelServerDomain:input_type -> ypb.VerifyTunnelServerDomainParams
+	532,  // 901: ypb.Yak.StartFacades:input_type -> ypb.StartFacadesParams
+	535,  // 902: ypb.Yak.StartFacadesWithYsoObject:input_type -> ypb.StartFacadesWithYsoParams
+	533,  // 903: ypb.Yak.ApplyClassToFacades:input_type -> ypb.ApplyClassToFacadesParamsWithVerbose
+	480,  // 904: ypb.Yak.BytesToBase64:input_type -> ypb.BytesToBase64Request
+	512,  // 905: ypb.Yak.ConfigGlobalReverse:input_type -> ypb.ConfigGlobalReverseParams
+	4,    // 906: ypb.Yak.AvailableLocalAddr:input_type -> ypb.Empty
+	4,    // 907: ypb.Yak.GetGlobalReverseServer:input_type -> ypb.Empty
+	517,  // 908: ypb.Yak.QueryRisks:input_type -> ypb.QueryRisksRequest
+	514,  // 909: ypb.Yak.QueryRisk:input_type -> ypb.QueryRiskRequest
+	513,  // 910: ypb.Yak.DeleteRisk:input_type -> ypb.DeleteRiskRequest
+	4,    // 911: ypb.Yak.QueryAvailableRiskType:input_type -> ypb.Empty
+	4,    // 912: ypb.Yak.QueryAvailableRiskLevel:input_type -> ypb.Empty
+	4,    // 913: ypb.Yak.QueryRiskTableStats:input_type -> ypb.Empty
+	4,    // 914: ypb.Yak.ResetRiskTableStats:input_type -> ypb.Empty
+	4,    // 915: ypb.Yak.QueryAvailableTarget:input_type -> ypb.Empty
+	519,  // 916: ypb.Yak.QueryNewRisk:input_type -> ypb.QueryNewRiskRequest
+	525,  // 917: ypb.Yak.NewRiskRead:input_type -> ypb.NewRiskReadRequest
+	526,  // 918: ypb.Yak.UploadRiskToOnline:input_type -> ypb.UploadRiskToOnlineRequest
+	527,  // 919: ypb.Yak.SetTagForRisk:input_type -> ypb.SetTagForRiskRequest
+	4,    // 920: ypb.Yak.QueryRiskTags:input_type -> ypb.Empty
+	4,    // 921: ypb.Yak.RiskFieldGroup:input_type -> ypb.Empty
+	526,  // 922: ypb.Yak.RiskFeedbackToOnline:input_type -> ypb.UploadRiskToOnlineRequest
+	454,  // 923: ypb.Yak.QueryReports:input_type -> ypb.QueryReportsRequest
+	451,  // 924: ypb.Yak.QueryReport:input_type -> ypb.QueryReportRequest
+	452,  // 925: ypb.Yak.DeleteReport:input_type -> ypb.DeleteReportRequest
+	4,    // 926: ypb.Yak.QueryAvailableReportFrom:input_type -> ypb.Empty
+	553,  // 927: ypb.Yak.DownloadReport:input_type -> ypb.DownloadReportRequest
+	4,    // 928: ypb.Yak.GetAllYsoGadgetOptions:input_type -> ypb.Empty
+	474,  // 929: ypb.Yak.GetAllYsoClassOptions:input_type -> ypb.YsoOptionsRequerstWithVerbose
+	474,  // 930: ypb.Yak.GetAllYsoClassGeneraterOptions:input_type -> ypb.YsoOptionsRequerstWithVerbose
+	474,  // 931: ypb.Yak.GenerateYsoCode:input_type -> ypb.YsoOptionsRequerstWithVerbose
+	474,  // 932: ypb.Yak.GenerateYsoBytes:input_type -> ypb.YsoOptionsRequerstWithVerbose
+	476,  // 933: ypb.Yak.YsoDump:input_type -> ypb.YsoBytesObject
+	494,  // 934: ypb.Yak.CreateWebShell:input_type -> ypb.WebShell
+	502,  // 935: ypb.Yak.DeleteWebShell:input_type -> ypb.DeleteWebShellRequest
+	494,  // 936: ypb.Yak.UpdateWebShell:input_type -> ypb.WebShell
+	499,  // 937: ypb.Yak.QueryWebShells:input_type -> ypb.QueryWebShellsRequest
+	497,  // 938: ypb.Yak.Ping:input_type -> ypb.WebShellRequest
+	497,  // 939: ypb.Yak.GetBasicInfo:input_type -> ypb.WebShellRequest
+	495,  // 940: ypb.Yak.GenerateWebShell:input_type -> ypb.ShellGenerate
+	503,  // 941: ypb.Yak.SetYakBridgeLogServer:input_type -> ypb.YakDNSLogBridgeAddr
+	4,    // 942: ypb.Yak.GetCurrentYakBridgeLogServer:input_type -> ypb.Empty
+	503,  // 943: ypb.Yak.RequireDNSLogDomain:input_type -> ypb.YakDNSLogBridgeAddr
+	504,  // 944: ypb.Yak.RequireDNSLogDomainByScript:input_type -> ypb.RequireDNSLogDomainByScriptRequest
+	505,  // 945: ypb.Yak.QueryDNSLogByToken:input_type -> ypb.QueryDNSLogByTokenRequest
+	504,  // 946: ypb.Yak.QueryDNSLogTokenByScript:input_type -> ypb.RequireDNSLogDomainByScriptRequest
+	4,    // 947: ypb.Yak.RequireICMPRandomLength:input_type -> ypb.Empty
+	482,  // 948: ypb.Yak.QueryICMPTrigger:input_type -> ypb.QueryICMPTriggerRequest
+	4,    // 949: ypb.Yak.RequireRandomPortToken:input_type -> ypb.Empty
+	460,  // 950: ypb.Yak.QueryRandomPortTrigger:input_type -> ypb.QueryRandomPortTriggerRequest
+	4,    // 951: ypb.Yak.QuerySupportedDnsLogPlatforms:input_type -> ypb.Empty
+	4,    // 952: ypb.Yak.GetAvailableYakScriptTags:input_type -> ypb.Empty
+	4,    // 953: ypb.Yak.ForceUpdateAvailableYakScriptTags:input_type -> ypb.Empty
+	446,  // 954: ypb.Yak.ExecYakitPluginsByYakScriptFilter:input_type -> ypb.ExecYakitPluginsByYakScriptFilterRequest
+	447,  // 955: ypb.Yak.GenerateYakCodeByPacket:input_type -> ypb.GenerateYakCodeByPacketRequest
+	448,  // 956: ypb.Yak.GenerateCSRFPocByPacket:input_type -> ypb.GenerateCSRFPocByPacketRequest
+	4,    // 957: ypb.Yak.ExportMITMReplacerRules:input_type -> ypb.Empty
+	444,  // 958: ypb.Yak.ImportMITMReplacerRules:input_type -> ypb.ImportMITMReplacerRulesRequest
+	4,    // 959: ypb.Yak.GetCurrentRules:input_type -> ypb.Empty
+	443,  // 960: ypb.Yak.SetCurrentRules:input_type -> ypb.MITMContentReplacers
+	985,  // 961: ypb.Yak.QueryMITMReplacerRules:input_type -> ypb.QueryMITMReplacerRulesRequest
+	4,    // 962: ypb.Yak.DeduplicateMITMReplacerRules:input_type -> ypb.Empty
+	777,  // 963: ypb.Yak.GenerateURL:input_type -> ypb.GenerateURLRequest
+	441,  // 964: ypb.Yak.ExtractDataToFile:input_type -> ypb.ExtractDataToFileRequest
+	424,  // 965: ypb.Yak.AutoDecode:input_type -> ypb.AutoDecodeRequest
+	4,    // 966: ypb.Yak.GetSystemProxy:input_type -> ypb.Empty
+	406,  // 967: ypb.Yak.SetSystemProxy:input_type -> ypb.SetSystemProxyRequest
+	402,  // 968: ypb.Yak.GetKey:input_type -> ypb.GetKeyRequest
+	401,  // 969: ypb.Yak.SetKey:input_type -> ypb.SetKeyRequest
+	402,  // 970: ypb.Yak.DelKey:input_type -> ypb.GetKeyRequest
+	4,    // 971: ypb.Yak.GetAllProcessEnvKey:input_type -> ypb.Empty
+	401,  // 972: ypb.Yak.SetProcessEnvKey:input_type -> ypb.SetKeyRequest
+	402,  // 973: ypb.Yak.GetProjectKey:input_type -> ypb.GetKeyRequest
+	401,  // 974: ypb.Yak.SetProjectKey:input_type -> ypb.SetKeyRequest
+	4,    // 975: ypb.Yak.GetOnlineProfile:input_type -> ypb.Empty
+	400,  // 976: ypb.Yak.SetOnlineProfile:input_type -> ypb.OnlineProfile
+	389,  // 977: ypb.Yak.DownloadOnlinePluginById:input_type -> ypb.DownloadOnlinePluginByIdRequest
+	390,  // 978: ypb.Yak.DownloadOnlinePluginByIds:input_type -> ypb.DownloadOnlinePluginByIdsRequest
+	388,  // 979: ypb.Yak.DownloadOnlinePluginAll:input_type -> ypb.DownloadOnlinePluginByTokenRequest
+	384,  // 980: ypb.Yak.DeletePluginByUserID:input_type -> ypb.DeletePluginByUserIDRequest
+	4,    // 981: ypb.Yak.DeleteAllLocalPlugins:input_type -> ypb.Empty
+	4,    // 982: ypb.Yak.GetYakScriptTagsAndType:input_type -> ypb.Empty
+	386,  // 983: ypb.Yak.DeleteLocalPluginsByWhere:input_type -> ypb.DeleteLocalPluginsByWhereRequest
+	393,  // 984: ypb.Yak.DownloadOnlinePluginByScriptNames:input_type -> ypb.DownloadOnlinePluginByScriptNamesRequest
+	391,  // 985: ypb.Yak.DownloadOnlinePlugins:input_type -> ypb.DownloadOnlinePluginsRequest
+	391,  // 986: ypb.Yak.DownloadOnlinePluginBatch:input_type -> ypb.DownloadOnlinePluginsRequest
+	393,  // 987: ypb.Yak.DownloadOnlinePluginByPluginName:input_type -> ypb.DownloadOnlinePluginByScriptNamesRequest
+	396,  // 988: ypb.Yak.DownloadOnlinePluginByUUID:input_type -> ypb.DownloadOnlinePluginByUUIDRequest
+	397,  // 989: ypb.Yak.QueryOnlinePlugins:input_type -> ypb.QueryOnlinePluginsRequest
+	361,  // 990: ypb.Yak.ExecPacketScan:input_type -> ypb.ExecPacketScanRequest
+	4,    // 991: ypb.Yak.GetEngineDefaultProxy:input_type -> ypb.Empty
+	360,  // 992: ypb.Yak.SetEngineDefaultProxy:input_type -> ypb.DefaultProxyResult
+	4,    // 993: ypb.Yak.GetMachineID:input_type -> ypb.Empty
+	4,    // 994: ypb.Yak.GetLicense:input_type -> ypb.Empty
+	765,  // 995: ypb.Yak.CheckLicense:input_type -> ypb.CheckLicenseRequest
+	336,  // 996: ypb.Yak.GetRequestBodyByHTTPFlowID:input_type -> ypb.DownloadBodyByHTTPFlowIDRequest
+	336,  // 997: ypb.Yak.GetResponseBodyByHTTPFlowID:input_type -> ypb.DownloadBodyByHTTPFlowIDRequest
+	335,  // 998: ypb.Yak.GetHTTPPacketBody:input_type -> ypb.GetHTTPPacketBodyRequest
+	337,  // 999: ypb.Yak.EncodeHTTPPacketContent:input_type -> ypb.EncodeHTTPPacketContentRequest
+	333,  // 1000: ypb.Yak.RegisterFacadesHTTP:input_type -> ypb.RegisterFacadesHTTPRequest
+	332,  // 1001: ypb.Yak.ResetAndInvalidUserData:input_type -> ypb.ResetAndInvalidUserDataRequest
+	329,  // 1002: ypb.Yak.CreateYaklangShell:input_type -> ypb.YaklangShellRequest
+	328,  // 1003: ypb.Yak.AttachCombinedOutput:input_type -> ypb.AttachCombinedOutputRequest
+	4,    // 1004: ypb.Yak.IsPrivilegedForNetRaw:input_type -> ypb.Empty
+	4,    // 1005: ypb.Yak.PromotePermissionForUserPcap:input_type -> ypb.Empty
+	322,  // 1006: ypb.Yak.SetCurrentProject:input_type -> ypb.SetCurrentProjectRequest
+	4,    // 1007: ypb.Yak.GetCurrentProject:input_type -> ypb.Empty
+	323,  // 1008: ypb.Yak.GetCurrentProjectEx:input_type -> ypb.GetCurrentProjectExRequest
+	319,  // 1009: ypb.Yak.GetProjects:input_type -> ypb.GetProjectsRequest
+	317,  // 1010: ypb.Yak.NewProject:input_type -> ypb.NewProjectRequest
+	317,  // 1011: ypb.Yak.UpdateProject:input_type -> ypb.NewProjectRequest
+	316,  // 1012: ypb.Yak.IsProjectNameValid:input_type -> ypb.IsProjectNameValidRequest
+	315,  // 1013: ypb.Yak.RemoveProject:input_type -> ypb.RemoveProjectRequest
+	324,  // 1014: ypb.Yak.DeleteProject:input_type -> ypb.DeleteProjectRequest
+	4,    // 1015: ypb.Yak.GetDefaultProject:input_type -> ypb.Empty
+	325,  // 1016: ypb.Yak.GetDefaultProjectEx:input_type -> ypb.GetDefaultProjectExRequest
+	326,  // 1017: ypb.Yak.QueryProjectDetail:input_type -> ypb.QueryProjectDetailRequest
+	4,    // 1018: ypb.Yak.GetTemporaryProject:input_type -> ypb.Empty
+	327,  // 1019: ypb.Yak.GetTemporaryProjectEx:input_type -> ypb.GetTemporaryProjectExRequest
+	311,  // 1020: ypb.Yak.ExportProject:input_type -> ypb.ExportProjectRequest
+	313,  // 1021: ypb.Yak.ImportProject:input_type -> ypb.ImportProjectRequest
+	4,    // 1022: ypb.Yak.MigrateLegacyDatabase:input_type -> ypb.Empty
+	301,  // 1023: ypb.Yak.QueryMITMRuleExtractedData:input_type -> ypb.QueryMITMRuleExtractedDataRequest
+	308,  // 1024: ypb.Yak.QueryMITMExtractedAggregate:input_type -> ypb.QueryMITMExtractedAggregateRequest
+	303,  // 1025: ypb.Yak.ExportMITMRuleExtractedData:input_type -> ypb.ExportMITMRuleExtractedDataRequest
+	305,  // 1026: ypb.Yak.DeleteMITMRuleExtractedData:input_type -> ypb.DeleteMITMRuleExtractedDataRequest
+	306,  // 1027: ypb.Yak.DeduplicateMITMRuleExtractedData:input_type -> ypb.DeduplicateMITMRuleExtractedDataRequest
+	285,  // 1028: ypb.Yak.ImportChaosMakerRules:input_type -> ypb.ImportChaosMakerRulesRequest
+	293,  // 1029: ypb.Yak.QueryChaosMakerRule:input_type -> ypb.QueryChaosMakerRuleRequest
+	292,  // 1030: ypb.Yak.DeleteChaosMakerRuleByID:input_type -> ypb.DeleteChaosMakerRuleByIDRequest
+	289,  // 1031: ypb.Yak.ExecuteChaosMakerRule:input_type -> ypb.ExecuteChaosMakerRuleRequest
+	287,  // 1032: ypb.Yak.IsRemoteAddrAvailable:input_type -> ypb.IsRemoteAddrAvailableRequest
+	287,  // 1033: ypb.Yak.ConnectVulinboxAgent:input_type -> ypb.IsRemoteAddrAvailableRequest
+	253,  // 1034: ypb.Yak.GetRegisteredVulinboxAgent:input_type -> ypb.GetRegisteredAgentRequest
+	252,  // 1035: ypb.Yak.DisconnectVulinboxAgent:input_type -> ypb.DisconnectVulinboxAgentRequest
+	298,  // 1036: ypb.Yak.IsCVEDatabaseReady:input_type -> ypb.IsCVEDatabaseReadyRequest
+	296,  // 1037: ypb.Yak.UpdateCVEDatabase:input_type -> ypb.UpdateCVEDatabaseRequest
+	295,  // 1038: ypb.Yak.ExportsProfileDatabase:input_type -> ypb.ExportsProfileDatabaseRequest
+	294,  // 1039: ypb.Yak.ImportsProfileDatabase:input_type -> ypb.ImportsProfileDatabaseRequest
+	278,  // 1040: ypb.Yak.QueryCVE:input_type -> ypb.QueryCVERequest
+	277,  // 1041: ypb.Yak.GetCVE:input_type -> ypb.GetCVERequest
+	283,  // 1042: ypb.Yak.SaveTextToTemporalFile:input_type -> ypb.SaveTextToTemporalFileRequest
+	275,  // 1043: ypb.Yak.IsScrecorderReady:input_type -> ypb.IsScrecorderReadyRequest
+	274,  // 1044: ypb.Yak.InstallScrecorder:input_type -> ypb.InstallScrecorderRequest
+	273,  // 1045: ypb.Yak.StartScrecorder:input_type -> ypb.StartScrecorderRequest
+	268,  // 1046: ypb.Yak.QueryScreenRecorders:input_type -> ypb.QueryScreenRecorderRequest
+	268,  // 1047: ypb.Yak.DeleteScreenRecorders:input_type -> ypb.QueryScreenRecorderRequest
+	269,  // 1048: ypb.Yak.UploadScreenRecorders:input_type -> ypb.UploadScreenRecorderRequest
+	270,  // 1049: ypb.Yak.GetOneScreenRecorders:input_type -> ypb.GetOneScreenRecorderRequest
+	271,  // 1050: ypb.Yak.UpdateScreenRecorders:input_type -> ypb.UpdateScreenRecorderRequest
+	258,  // 1051: ypb.Yak.IsVulinboxReady:input_type -> ypb.IsVulinboxReadyRequest
+	260,  // 1052: ypb.Yak.InstallVulinbox:input_type -> ypb.InstallVulinboxRequest
+	261,  // 1053: ypb.Yak.StartVulinbox:input_type -> ypb.StartVulinboxRequest
+	262,  // 1054: ypb.Yak.GenQualityInspectionReport:input_type -> ypb.GenQualityInspectionReportRequest
+	266,  // 1055: ypb.Yak.HTTPRequestBuilder:input_type -> ypb.HTTPRequestBuilderParams
+	263,  // 1056: ypb.Yak.DebugPlugin:input_type -> ypb.DebugPluginRequest
+	255,  // 1057: ypb.Yak.SmokingEvaluatePlugin:input_type -> ypb.SmokingEvaluatePluginRequest
+	775,  // 1058: ypb.Yak.SmokingEvaluatePluginBatch:input_type -> ypb.SmokingEvaluatePluginBatchRequest
+	4,    // 1059: ypb.Yak.GetSystemDefaultDnsServers:input_type -> ypb.Empty
+	250,  // 1060: ypb.Yak.DiagnoseNetwork:input_type -> ypb.DiagnoseNetworkRequest
+	235,  // 1061: ypb.Yak.DiagnoseNetworkDNS:input_type -> ypb.DiagnoseNetworkDNSRequest
+	782,  // 1062: ypb.Yak.TraceRoute:input_type -> ypb.TraceRouteRequest
+	237,  // 1063: ypb.Yak.GetGlobalNetworkConfig:input_type -> ypb.GetGlobalNetworkConfigRequest
+	240,  // 1064: ypb.Yak.SetGlobalNetworkConfig:input_type -> ypb.GlobalNetworkConfig
+	236,  // 1065: ypb.Yak.ResetGlobalNetworkConfig:input_type -> ypb.ResetGlobalNetworkConfigRequest
+	4,    // 1066: ypb.Yak.GetGlobalProxyRulesConfig:input_type -> ypb.Empty
+	247,  // 1067: ypb.Yak.SetGlobalProxyRulesConfig:input_type -> ypb.SetGlobalProxyRulesConfigRequest
+	243,  // 1068: ypb.Yak.CheckProxyAlive:input_type -> ypb.CheckProxyAliveRequest
+	238,  // 1069: ypb.Yak.ValidP12PassWord:input_type -> ypb.ValidP12PassWordRequest
+	229,  // 1070: ypb.Yak.RequestYakURL:input_type -> ypb.RequestYakURLParams
+	799,  // 1071: ypb.Yak.ReadFile:input_type -> ypb.ReadFileRequest
+	215,  // 1072: ypb.Yak.GetPcapMetadata:input_type -> ypb.PcapMetadataRequest
+	226,  // 1073: ypb.Yak.PcapX:input_type -> ypb.PcapXRequest
+	225,  // 1074: ypb.Yak.QueryTrafficSession:input_type -> ypb.QueryTrafficSessionRequest
+	217,  // 1075: ypb.Yak.QueryTrafficPacket:input_type -> ypb.QueryTrafficPacketRequest
+	218,  // 1076: ypb.Yak.QueryTrafficTCPReassembled:input_type -> ypb.QueryTrafficTCPReassembledRequest
+	780,  // 1077: ypb.Yak.ParseTraffic:input_type -> ypb.ParseTrafficRequest
+	213,  // 1078: ypb.Yak.DuplexConnection:input_type -> ypb.DuplexConnectionRequest
+	212,  // 1079: ypb.Yak.HybridScan:input_type -> ypb.HybridScanRequest
+	206,  // 1080: ypb.Yak.QueryHybridScanTask:input_type -> ypb.QueryHybridScanTaskRequest
+	203,  // 1081: ypb.Yak.DeleteHybridScanTask:input_type -> ypb.DeleteHybridScanTaskRequest
+	200,  // 1082: ypb.Yak.GetSpaceEngineStatus:input_type -> ypb.GetSpaceEngineStatusRequest
+	199,  // 1083: ypb.Yak.GetSpaceEngineAccountStatus:input_type -> ypb.GetSpaceEngineAccountStatusRequest
+	249,  // 1084: ypb.Yak.GetSpaceEngineAccountStatusV2:input_type -> ypb.ThirdPartyApplicationConfig
+	202,  // 1085: ypb.Yak.FetchPortAssetFromSpaceEngine:input_type -> ypb.FetchPortAssetFromSpaceEngineRequest
+	784,  // 1086: ypb.Yak.EvaluateExpression:input_type -> ypb.EvaluateExpressionRequest
+	786,  // 1087: ypb.Yak.EvaluateMultiExpression:input_type -> ypb.EvaluateMultiExpressionRequest
+	4,    // 1088: ypb.Yak.GetThirdPartyAppConfigTemplate:input_type -> ypb.Empty
+	4,    // 1089: ypb.Yak.CheckHahValidAiConfig:input_type -> ypb.Empty
+	954,  // 1090: ypb.Yak.ListAiModel:input_type -> ypb.ListAiModelRequest
+	956,  // 1091: ypb.Yak.AIConfigHealthCheck:input_type -> ypb.AIConfigHealthCheckRequest
+	4,    // 1092: ypb.Yak.GetAIGlobalConfig:input_type -> ypb.Empty
+	967,  // 1093: ypb.Yak.SetAIGlobalConfig:input_type -> ypb.AIGlobalConfig
+	4,    // 1094: ypb.Yak.ListAIProviders:input_type -> ypb.Empty
+	960,  // 1095: ypb.Yak.QueryAIProvider:input_type -> ypb.QueryAIProvidersRequest
+	963,  // 1096: ypb.Yak.UpsertAIProvider:input_type -> ypb.UpsertAIProviderRequest
+	965,  // 1097: ypb.Yak.DeleteAIProvider:input_type -> ypb.DeleteAIProviderRequest
+	4,    // 1098: ypb.Yak.GetAIThirdPartyAppConfigTemplate:input_type -> ypb.Empty
+	791,  // 1099: ypb.Yak.GetApiKeyByOnline:input_type -> ypb.GetApiKeyByOnlineRequest
+	793,  // 1100: ypb.Yak.GetFingerprint:input_type -> ypb.GetFingerprintRequest
+	795,  // 1101: ypb.Yak.AddFingerprint:input_type -> ypb.AddFingerprintRequest
+	797,  // 1102: ypb.Yak.ModifyFingerprint:input_type -> ypb.ModifyFingerprintRequest
+	809,  // 1103: ypb.Yak.QueryFingerprint:input_type -> ypb.QueryFingerprintRequest
+	811,  // 1104: ypb.Yak.DeleteFingerprint:input_type -> ypb.DeleteFingerprintRequest
+	813,  // 1105: ypb.Yak.UpdateFingerprint:input_type -> ypb.UpdateFingerprintRequest
+	812,  // 1106: ypb.Yak.CreateFingerprint:input_type -> ypb.CreateFingerprintRequest
+	4,    // 1107: ypb.Yak.RecoverBuiltinFingerprint:input_type -> ypb.Empty
+	814,  // 1108: ypb.Yak.CreateFingerprintGroup:input_type -> ypb.FingerprintGroup
+	4,    // 1109: ypb.Yak.GetAllFingerprintGroup:input_type -> ypb.Empty
+	816,  // 1110: ypb.Yak.RenameFingerprintGroup:input_type -> ypb.RenameFingerprintGroupRequest
+	817,  // 1111: ypb.Yak.DeleteFingerprintGroup:input_type -> ypb.DeleteFingerprintGroupRequest
+	818,  // 1112: ypb.Yak.BatchUpdateFingerprintToGroup:input_type -> ypb.BatchUpdateFingerprintToGroupRequest
+	819,  // 1113: ypb.Yak.GetFingerprintGroupSetByFilter:input_type -> ypb.GetFingerprintGroupSetRequest
+	820,  // 1114: ypb.Yak.ExportFingerprint:input_type -> ypb.ExportFingerprintRequest
+	821,  // 1115: ypb.Yak.ImportFingerprint:input_type -> ypb.ImportFingerprintRequest
+	801,  // 1116: ypb.Yak.GetReverseShellProgramList:input_type -> ypb.GetReverseShellProgramListRequest
+	803,  // 1117: ypb.Yak.GenerateReverseShellCommand:input_type -> ypb.GenerateReverseShellCommandRequest
+	823,  // 1118: ypb.Yak.QuerySyntaxFlowRule:input_type -> ypb.QuerySyntaxFlowRuleRequest
+	838,  // 1119: ypb.Yak.CreateSyntaxFlowRule:input_type -> ypb.CreateSyntaxFlowRuleRequest
+	838,  // 1120: ypb.Yak.CreateSyntaxFlowRuleEx:input_type -> ypb.CreateSyntaxFlowRuleRequest
+	840,  // 1121: ypb.Yak.UpdateSyntaxFlowRule:input_type -> ypb.UpdateSyntaxFlowRuleRequest
+	840,  // 1122: ypb.Yak.UpdateSyntaxFlowRuleEx:input_type -> ypb.UpdateSyntaxFlowRuleRequest
+	843,  // 1123: ypb.Yak.DeleteSyntaxFlowRule:input_type -> ypb.DeleteSyntaxFlowRuleRequest
+	844,  // 1124: ypb.Yak.CheckSyntaxFlowRuleUpdate:input_type -> ypb.CheckSyntaxFlowRuleUpdateRequest
+	846,  // 1125: ypb.Yak.ApplySyntaxFlowRuleUpdate:input_type -> ypb.ApplySyntaxFlowRuleUpdateRequest
+	850,  // 1126: ypb.Yak.QuerySyntaxFlowRuleGroup:input_type -> ypb.QuerySyntaxFlowRuleGroupRequest
+	857,  // 1127: ypb.Yak.DeleteSyntaxFlowRuleGroup:input_type -> ypb.DeleteSyntaxFlowRuleGroupRequest
+	852,  // 1128: ypb.Yak.CreateSyntaxFlowRuleGroup:input_type -> ypb.CreateSyntaxFlowGroupRequest
+	853,  // 1129: ypb.Yak.UpdateSyntaxFlowRuleGroup:input_type -> ypb.UpdateSyntaxFlowRuleGroupRequest
+	854,  // 1130: ypb.Yak.UpdateSyntaxFlowRuleAndGroup:input_type -> ypb.UpdateSyntaxFlowRuleAndGroupRequest
+	855,  // 1131: ypb.Yak.QuerySyntaxFlowSameGroup:input_type -> ypb.QuerySyntaxFlowSameGroupRequest
+	858,  // 1132: ypb.Yak.SyntaxFlowRuleToOnline:input_type -> ypb.SyntaxFlowRuleToOnlineRequest
+	860,  // 1133: ypb.Yak.DownloadSyntaxFlowRule:input_type -> ypb.DownloadSyntaxFlowRuleRequest
+	861,  // 1134: ypb.Yak.SyntaxFlowScan:input_type -> ypb.SyntaxFlowScanRequest
+	862,  // 1135: ypb.Yak.QuerySyntaxFlowScanTask:input_type -> ypb.QuerySyntaxFlowScanTaskRequest
+	866,  // 1136: ypb.Yak.DeleteSyntaxFlowScanTask:input_type -> ypb.DeleteSyntaxFlowScanTaskRequest
+	870,  // 1137: ypb.Yak.QuerySyntaxFlowResult:input_type -> ypb.QuerySyntaxFlowResultRequest
+	873,  // 1138: ypb.Yak.DeleteSyntaxFlowResult:input_type -> ypb.DeleteSyntaxFlowResultRequest
+	834,  // 1139: ypb.Yak.QuerySSAPrograms:input_type -> ypb.QuerySSAProgramRequest
+	835,  // 1140: ypb.Yak.UpdateSSAProgram:input_type -> ypb.UpdateSSAProgramRequest
+	836,  // 1141: ypb.Yak.DeleteSSAPrograms:input_type -> ypb.DeleteSSAProgramRequest
+	887,  // 1142: ypb.Yak.QuerySSARisks:input_type -> ypb.QuerySSARisksRequest
+	889,  // 1143: ypb.Yak.QueryNewSSARisks:input_type -> ypb.QueryNewSSARisksRequest
+	891,  // 1144: ypb.Yak.DeleteSSARisks:input_type -> ypb.DeleteSSARisksRequest
+	892,  // 1145: ypb.Yak.UpdateSSARiskTags:input_type -> ypb.UpdateSSARiskTagsRequest
+	4,    // 1146: ypb.Yak.GetSSARiskFieldGroup:input_type -> ypb.Empty
+	893,  // 1147: ypb.Yak.GetSSARiskFieldGroupEx:input_type -> ypb.GetSSARiskFieldGroupRequest
+	895,  // 1148: ypb.Yak.NewSSARiskRead:input_type -> ypb.NewSSARiskReadRequest
+	897,  // 1149: ypb.Yak.ExportSSARisk:input_type -> ypb.ExportSSARiskRequest
+	899,  // 1150: ypb.Yak.ImportSSARisk:input_type -> ypb.ImportSSARiskRequest
+	830,  // 1151: ypb.Yak.SSARiskDiff:input_type -> ypb.SSARiskDiffRequest
+	904,  // 1152: ypb.Yak.CreateSSARiskDisposals:input_type -> ypb.CreateSSARiskDisposalsRequest
+	906,  // 1153: ypb.Yak.QuerySSARiskDisposals:input_type -> ypb.QuerySSARiskDisposalsRequest
+	908,  // 1154: ypb.Yak.UpdateSSARiskDisposals:input_type -> ypb.UpdateSSARiskDisposalsRequest
+	910,  // 1155: ypb.Yak.DeleteSSARiskDisposals:input_type -> ypb.DeleteSSARiskDisposalsRequest
+	912,  // 1156: ypb.Yak.GetSSARiskDisposal:input_type -> ypb.GetSSARiskDisposalRequest
+	901,  // 1157: ypb.Yak.SSARiskFeedbackToOnline:input_type -> ypb.SSARiskFeedbackToOnlineRequest
+	991,  // 1158: ypb.Yak.GenerateSSAReport:input_type -> ypb.GenerateSSAReportRequest
+	998,  // 1159: ypb.Yak.CreateSSAProject:input_type -> ypb.CreateSSAProjectRequest
+	1000, // 1160: ypb.Yak.UpdateSSAProject:input_type -> ypb.UpdateSSAProjectRequest
+	1002, // 1161: ypb.Yak.DeleteSSAProject:input_type -> ypb.DeleteSSAProjectRequest
+	1004, // 1162: ypb.Yak.QuerySSAProject:input_type -> ypb.QuerySSAProjectRequest
+	1006, // 1163: ypb.Yak.MigrateSSAProject:input_type -> ypb.MigrateSSAProjectRequest
+	1008, // 1164: ypb.Yak.GetSSAWorkbenchDashboard:input_type -> ypb.GetSSAWorkbenchDashboardRequest
+	4,    // 1165: ypb.Yak.GetAllPluginEnv:input_type -> ypb.Empty
+	875,  // 1166: ypb.Yak.QueryPluginEnv:input_type -> ypb.QueryPluginEnvRequest
+	876,  // 1167: ypb.Yak.CreatePluginEnv:input_type -> ypb.PluginEnvData
+	876,  // 1168: ypb.Yak.SetPluginEnv:input_type -> ypb.PluginEnvData
+	877,  // 1169: ypb.Yak.DeletePluginEnv:input_type -> ypb.DeletePluginEnvRequest
+	878,  // 1170: ypb.Yak.GetAllFuzztagInfo:input_type -> ypb.GetAllFuzztagInfoRequest
+	882,  // 1171: ypb.Yak.GenerateFuzztag:input_type -> ypb.GenerateFuzztagRequest
+	914,  // 1172: ypb.Yak.ExportSyntaxFlows:input_type -> ypb.ExportSyntaxFlowsRequest
+	915,  // 1173: ypb.Yak.ImportSyntaxFlows:input_type -> ypb.ImportSyntaxFlowsRequest
+	917,  // 1174: ypb.Yak.CreateHotPatchTemplate:input_type -> ypb.HotPatchTemplate
+	920,  // 1175: ypb.Yak.DeleteHotPatchTemplate:input_type -> ypb.DeleteHotPatchTemplateRequest
+	919,  // 1176: ypb.Yak.UpdateHotPatchTemplate:input_type -> ypb.UpdateHotPatchTemplateRequest
+	918,  // 1177: ypb.Yak.QueryHotPatchTemplate:input_type -> ypb.HotPatchTemplateRequest
+	925,  // 1178: ypb.Yak.QueryHotPatchTemplateList:input_type -> ypb.QueryHotPatchTemplateListRequest
+	4,    // 1179: ypb.Yak.GetHotPatchTemplateTags:input_type -> ypb.Empty
+	4,    // 1180: ypb.Yak.GetGlobalHotPatchConfig:input_type -> ypb.Empty
+	930,  // 1181: ypb.Yak.SetGlobalHotPatchConfig:input_type -> ypb.SetGlobalHotPatchConfigRequest
+	4,    // 1182: ypb.Yak.ResetGlobalHotPatchConfig:input_type -> ypb.Empty
+	931,  // 1183: ypb.Yak.GroupTableColumn:input_type -> ypb.GroupTableColumnRequest
+	933,  // 1184: ypb.Yak.UploadHotPatchTemplateToOnline:input_type -> ypb.UploadHotPatchTemplateToOnlineRequest
+	934,  // 1185: ypb.Yak.DownloadHotPatchTemplate:input_type -> ypb.DownloadHotPatchTemplateRequest
+	742,  // 1186: ypb.Yak.SetMITMHijackFilter:input_type -> ypb.SetMITMFilterRequest
+	4,    // 1187: ypb.Yak.GetMITMHijackFilter:input_type -> ypb.Empty
+	4,    // 1188: ypb.Yak.ResetMITMHijackFilter:input_type -> ypb.Empty
+	935,  // 1189: ypb.Yak.ExportHTTPFlowStream:input_type -> ypb.ExportHTTPFlowStreamRequest
+	937,  // 1190: ypb.Yak.ImportHTTPFlowStream:input_type -> ypb.ImportHTTPFlowStreamRequest
+	942,  // 1191: ypb.Yak.CreateNote:input_type -> ypb.CreateNoteRequest
+	944,  // 1192: ypb.Yak.UpdateNote:input_type -> ypb.UpdateNoteRequest
+	945,  // 1193: ypb.Yak.DeleteNote:input_type -> ypb.DeleteNoteRequest
+	946,  // 1194: ypb.Yak.QueryNote:input_type -> ypb.QueryNoteRequest
+	948,  // 1195: ypb.Yak.SearchNoteContent:input_type -> ypb.SearchNoteContentRequest
+	950,  // 1196: ypb.Yak.ImportNote:input_type -> ypb.ImportNoteRequest
+	952,  // 1197: ypb.Yak.ExportNote:input_type -> ypb.ExportNoteRequest
+	147,  // 1198: ypb.Yak.StartAIReAct:input_type -> ypb.AIInputEvent
+	147,  // 1199: ypb.Yak.StartAITask:input_type -> ypb.AIInputEvent
+	159,  // 1200: ypb.Yak.QueryAITask:input_type -> ypb.AITaskQueryRequest
+	161,  // 1201: ypb.Yak.DeleteAITask:input_type -> ypb.AITaskDeleteRequest
+	156,  // 1202: ypb.Yak.QueryAIEvent:input_type -> ypb.AIEventQueryRequest
+	158,  // 1203: ypb.Yak.DeleteAIEvent:input_type -> ypb.AIEventDeleteRequest
+	167,  // 1204: ypb.Yak.QueryAISession:input_type -> ypb.QueryAISessionRequest
+	169,  // 1205: ypb.Yak.UpdateAISessionTitle:input_type -> ypb.UpdateAISessionTitleRequest
+	170,  // 1206: ypb.Yak.UpdateAISessionIMMeta:input_type -> ypb.UpdateAISessionIMMetaRequest
+	173,  // 1207: ypb.Yak.DeleteAISession:input_type -> ypb.DeleteAISessionRequest
+	162,  // 1208: ypb.Yak.GetRandomAIMaterials:input_type -> ypb.GetRandomAIMaterialsRequest
+	184,  // 1209: ypb.Yak.ExportAILogs:input_type -> ypb.ExportAILogsRequest
+	188,  // 1210: ypb.Yak.CreateAIMemoryEntity:input_type -> ypb.CreateAIMemoryEntityRequest
+	189,  // 1211: ypb.Yak.UpdateAIMemoryEntity:input_type -> ypb.AIMemoryEntity
+	194,  // 1212: ypb.Yak.DeleteAIMemoryEntity:input_type -> ypb.DeleteAIMemoryEntityRequest
+	193,  // 1213: ypb.Yak.GetAIMemoryEntity:input_type -> ypb.GetAIMemoryEntityRequest
+	191,  // 1214: ypb.Yak.QueryAIMemoryEntity:input_type -> ypb.QueryAIMemoryEntityRequest
+	195,  // 1215: ypb.Yak.CountAIMemoryEntityTags:input_type -> ypb.CountAIMemoryEntityTagsRequest
+	149,  // 1216: ypb.Yak.StartAITriage:input_type -> ypb.AITriageInputEvent
+	175,  // 1217: ypb.Yak.CreateAIForge:input_type -> ypb.AIForge
+	175,  // 1218: ypb.Yak.UpdateAIForge:input_type -> ypb.AIForge
+	174,  // 1219: ypb.Yak.DeleteAIForge:input_type -> ypb.AIForgeFilter
+	176,  // 1220: ypb.Yak.QueryAIForge:input_type -> ypb.QueryAIForgeRequest
+	180,  // 1221: ypb.Yak.GetAIForge:input_type -> ypb.GetAIForgeRequest
+	178,  // 1222: ypb.Yak.ExportAIForge:input_type -> ypb.ExportAIForgeRequest
+	179,  // 1223: ypb.Yak.ImportAIForge:input_type -> ypb.ImportAIForgeRequest
+	182,  // 1224: ypb.Yak.QueryAIFocus:input_type -> ypb.QueryAIFocusRequest
+	197,  // 1225: ypb.Yak.StartMcpServer:input_type -> ypb.StartMcpServerRequest
+	4,    // 1226: ypb.Yak.GetToolSetList:input_type -> ypb.Empty
+	142,  // 1227: ypb.Yak.GetAIToolList:input_type -> ypb.GetAIToolListRequest
+	136,  // 1228: ypb.Yak.DeleteAITool:input_type -> ypb.DeleteAIToolRequest
+	133,  // 1229: ypb.Yak.SaveAITool:input_type -> ypb.SaveAIToolRequest
+	133,  // 1230: ypb.Yak.SaveAIToolV2:input_type -> ypb.SaveAIToolRequest
+	135,  // 1231: ypb.Yak.UpdateAITool:input_type -> ypb.UpdateAIToolRequest
+	137,  // 1232: ypb.Yak.ToggleAIToolFavorite:input_type -> ypb.ToggleAIToolFavoriteRequest
+	131,  // 1233: ypb.Yak.AIToolGenerateMetadata:input_type -> ypb.AIToolGenerateMetadataRequest
+	143,  // 1234: ypb.Yak.ExportAITool:input_type -> ypb.ExportAIToolRequest
+	144,  // 1235: ypb.Yak.ImportAITool:input_type -> ypb.ImportAIToolRequest
+	4,    // 1236: ypb.Yak.IsLlamaServerReady:input_type -> ypb.Empty
+	969,  // 1237: ypb.Yak.IsLocalModelReady:input_type -> ypb.IsLocalModelReadyRequest
+	971,  // 1238: ypb.Yak.InstallLlamaServer:input_type -> ypb.InstallLlamaServerRequest
+	972,  // 1239: ypb.Yak.StartLocalModel:input_type -> ypb.StartLocalModelRequest
+	81,   // 1240: ypb.Yak.StopLocalModel:input_type -> ypb.StopLocalModelRequest
+	973,  // 1241: ypb.Yak.DownloadLocalModel:input_type -> ypb.DownloadLocalModelRequest
+	4,    // 1242: ypb.Yak.GetSupportedLocalModels:input_type -> ypb.Empty
+	79,   // 1243: ypb.Yak.AddLocalModel:input_type -> ypb.AddLocalModelRequest
+	80,   // 1244: ypb.Yak.DeleteLocalModel:input_type -> ypb.DeleteLocalModelRequest
+	78,   // 1245: ypb.Yak.UpdateLocalModel:input_type -> ypb.UpdateLocalModelRequest
+	4,    // 1246: ypb.Yak.GetAllStartedLocalModels:input_type -> ypb.Empty
+	77,   // 1247: ypb.Yak.ClearAllModels:input_type -> ypb.ClearAllModelsRequest
+	125,  // 1248: ypb.Yak.IsSearchVectorDatabaseReady:input_type -> ypb.IsSearchVectorDatabaseReadyRequest
+	127,  // 1249: ypb.Yak.InitSearchVectorDatabase:input_type -> ypb.InitSearchVectorDatabaseRequest
+	4,    // 1250: ypb.Yak.GetAllVectorStoreCollections:input_type -> ypb.Empty
+	122,  // 1251: ypb.Yak.GetAllVectorStoreCollectionsWithFilter:input_type -> ypb.GetAllVectorStoreCollectionsWithFilterRequest
+	112,  // 1252: ypb.Yak.DeleteSearchVectorDatabase:input_type -> ypb.DeleteSearchVectorDatabaseRequest
+	121,  // 1253: ypb.Yak.UpdateVectorStoreCollection:input_type -> ypb.UpdateVectorStoreCollectionRequest
+	115,  // 1254: ypb.Yak.ListVectorStoreEntries:input_type -> ypb.ListVectorStoreEntriesRequest
+	116,  // 1255: ypb.Yak.CreateVectorStoreEntry:input_type -> ypb.CreateVectorStoreEntryRequest
+	119,  // 1256: ypb.Yak.GetDocumentByVectorStoreEntryID:input_type -> ypb.GetDocumentByVectorStoreEntryIDRequest
+	4,    // 1257: ypb.Yak.ListThirdPartyBinary:input_type -> ypb.Empty
+	85,   // 1258: ypb.Yak.InstallThirdPartyBinary:input_type -> ypb.InstallThirdPartyBinaryRequest
+	86,   // 1259: ypb.Yak.UninstallThirdPartyBinary:input_type -> ypb.UninstallThirdPartyBinaryRequest
+	87,   // 1260: ypb.Yak.IsThirdPartyBinaryReady:input_type -> ypb.IsThirdPartyBinaryReadyRequest
+	89,   // 1261: ypb.Yak.StartThirdPartyBinary:input_type -> ypb.StartThirdPartyBinaryRequest
+	988,  // 1262: ypb.Yak.PluginTrace:input_type -> ypb.PluginTraceRequest
+	4,    // 1263: ypb.Yak.GetKnowledgeBaseNameList:input_type -> ypb.Empty
+	97,   // 1264: ypb.Yak.GetKnowledgeBase:input_type -> ypb.GetKnowledgeBaseRequest
+	4,    // 1265: ypb.Yak.GetKnowledgeBaseTypeList:input_type -> ypb.Empty
+	111,  // 1266: ypb.Yak.DeleteKnowledgeBase:input_type -> ypb.DeleteKnowledgeBaseRequest
+	100,  // 1267: ypb.Yak.CreateKnowledgeBase:input_type -> ypb.CreateKnowledgeBaseRequest
+	38,   // 1268: ypb.Yak.CreateKnowledgeBaseV2:input_type -> ypb.CreateKnowledgeBaseV2Request
+	101,  // 1269: ypb.Yak.UpdateKnowledgeBase:input_type -> ypb.UpdateKnowledgeBaseRequest
+	102,  // 1270: ypb.Yak.DeleteKnowledgeBaseEntry:input_type -> ypb.DeleteKnowledgeBaseEntryRequest
+	108,  // 1271: ypb.Yak.CreateKnowledgeBaseEntry:input_type -> ypb.CreateKnowledgeBaseEntryRequest
+	109,  // 1272: ypb.Yak.UpdateKnowledgeBaseEntry:input_type -> ypb.UpdateKnowledgeBaseEntryRequest
+	104,  // 1273: ypb.Yak.SearchKnowledgeBaseEntry:input_type -> ypb.SearchKnowledgeBaseEntryRequest
+	105,  // 1274: ypb.Yak.QueryKnowledgeBaseByAI:input_type -> ypb.QueryKnowledgeBaseByAIRequest
+	93,   // 1275: ypb.Yak.BuildVectorIndexForKnowledgeBase:input_type -> ypb.BuildVectorIndexForKnowledgeBaseRequest
+	92,   // 1276: ypb.Yak.BuildVectorIndexForKnowledgeBaseEntry:input_type -> ypb.BuildVectorIndexForKnowledgeBaseEntryRequest
+	90,   // 1277: ypb.Yak.GenerateQuestionIndexForKnowledgeBase:input_type -> ypb.GenerateQuestionIndexForKnowledgeBaseRequest
+	4,    // 1278: ypb.Yak.ListEntityRepository:input_type -> ypb.Empty
+	63,   // 1279: ypb.Yak.QueryEntity:input_type -> ypb.QueryEntityRequest
+	61,   // 1280: ypb.Yak.CreateEntity:input_type -> ypb.Entity
+	61,   // 1281: ypb.Yak.UpdateEntity:input_type -> ypb.Entity
+	65,   // 1282: ypb.Yak.DeleteEntity:input_type -> ypb.DeleteEntityRequest
+	68,   // 1283: ypb.Yak.QueryRelationship:input_type -> ypb.QueryRelationshipRequest
+	66,   // 1284: ypb.Yak.CreateRelationship:input_type -> ypb.Relationship
+	66,   // 1285: ypb.Yak.UpdateRelationship:input_type -> ypb.Relationship
+	70,   // 1286: ypb.Yak.DeleteRelationship:input_type -> ypb.DeleteRelationshipRequest
+	71,   // 1287: ypb.Yak.QuerySubERM:input_type -> ypb.QuerySubERMRequest
+	73,   // 1288: ypb.Yak.GenerateERMDot:input_type -> ypb.GenerateERMDotRequest
+	40,   // 1289: ypb.Yak.ExportKnowledgeBase:input_type -> ypb.ExportKnowledgeBaseRequest
+	41,   // 1290: ypb.Yak.ImportKnowledgeBase:input_type -> ypb.ImportKnowledgeBaseRequest
+	45,   // 1291: ypb.Yak.AddMCPServer:input_type -> ypb.AddMCPServerRequest
+	46,   // 1292: ypb.Yak.DeleteMCPServer:input_type -> ypb.DeleteMCPServerRequest
+	47,   // 1293: ypb.Yak.UpdateMCPServer:input_type -> ypb.UpdateMCPServerRequest
+	49,   // 1294: ypb.Yak.GetAllMCPServers:input_type -> ypb.GetAllMCPServersRequest
+	48,   // 1295: ypb.Yak.UpdateMCPServerToolConfig:input_type -> ypb.UpdateMCPServerToolConfigRequest
+	55,   // 1296: ypb.Yak.GetMCPToolList:input_type -> ypb.GetMCPToolListRequest
+	58,   // 1297: ypb.Yak.GetMCPToolDetail:input_type -> ypb.GetMCPToolDetailRequest
+	57,   // 1298: ypb.Yak.SetMCPToolEnabled:input_type -> ypb.SetMCPToolEnabledRequest
+	43,   // 1299: ypb.Yak.RAGCollectionSearch:input_type -> ypb.RAGCollectionSearchRequest
+	37,   // 1300: ypb.Yak.DownloadRAGs:input_type -> ypb.DownloadRAGsRequest
+	15,   // 1301: ypb.Yak.SaveIMBot:input_type -> ypb.SaveIMBotRequest
+	17,   // 1302: ypb.Yak.ListIMBots:input_type -> ypb.ListIMBotRequest
+	19,   // 1303: ypb.Yak.DeleteIMBot:input_type -> ypb.DeleteIMBotRequest
+	21,   // 1304: ypb.Yak.TestIMBot:input_type -> ypb.TestIMBotRequest
+	23,   // 1305: ypb.Yak.StartIMOnboarding:input_type -> ypb.StartIMOnboardingRequest
+	26,   // 1306: ypb.Yak.StartIMControl:input_type -> ypb.StartIMControlRequest
+	28,   // 1307: ypb.Yak.StopIMControl:input_type -> ypb.StopIMControlRequest
+	30,   // 1308: ypb.Yak.SubscribeIMControlState:input_type -> ypb.SubscribeIMControlStateRequest
+	35,   // 1309: ypb.Yak.UpdateIMControlConfig:input_type -> ypb.UpdateIMControlConfigRequest
+	5,    // 1310: ypb.Yak.Version:output_type -> ypb.VersionResponse
+	6,    // 1311: ypb.Yak.YakVersionAtLeast:output_type -> ypb.GeneralResponse
+	756,  // 1312: ypb.Yak.Echo:output_type -> ypb.EchoResposne
+	758,  // 1313: ypb.Yak.Handshake:output_type -> ypb.HandshakeResponse
+	13,   // 1314: ypb.Yak.VerifySystemCertificate:output_type -> ypb.VerifySystemCertificateResponse
+	6,    // 1315: ypb.Yak.InstallMITMCertificate:output_type -> ypb.GeneralResponse
+	751,  // 1316: ypb.Yak.MITM:output_type -> ypb.MITMResponse
+	743,  // 1317: ypb.Yak.SetMITMFilter:output_type -> ypb.SetMITMFilterResponse
+	742,  // 1318: ypb.Yak.GetMITMFilter:output_type -> ypb.SetMITMFilterRequest
+	742,  // 1319: ypb.Yak.ResetMITMFilter:output_type -> ypb.SetMITMFilterRequest
+	464,  // 1320: ypb.Yak.DownloadMITMCert:output_type -> ypb.MITMCert
+	464,  // 1321: ypb.Yak.DownloadMITMGMCert:output_type -> ypb.MITMCert
+	980,  // 1322: ypb.Yak.WatchProcessConnection:output_type -> ypb.WatchProcessResponse
+	982,  // 1323: ypb.Yak.MITMV2:output_type -> ypb.MITMV2Response
+	760,  // 1324: ypb.Yak.OpenPort:output_type -> ypb.Output
+	763,  // 1325: ypb.Yak.Exec:output_type -> ypb.ExecResult
+	671,  // 1326: ypb.Yak.QueryExecHistory:output_type -> ypb.ExecHistoryRecordResponse
+	4,    // 1327: ypb.Yak.RemoveExecHistory:output_type -> ypb.Empty
+	4,    // 1328: ypb.Yak.SavePluginExecutionHistory:output_type -> ypb.Empty
+	674,  // 1329: ypb.Yak.GetPluginExecutionUsageRanking:output_type -> ypb.PluginExecutionUsageRankingResponse
+	4,    // 1330: ypb.Yak.LoadNucleiTemplates:output_type -> ypb.Empty
+	763,  // 1331: ypb.Yak.AutoUpdateYakModule:output_type -> ypb.ExecResult
+	763,  // 1332: ypb.Yak.ExecYakScript:output_type -> ypb.ExecResult
+	9,    // 1333: ypb.Yak.ExecBatchYakScript:output_type -> ypb.ExecBatchYakScriptResult
+	412,  // 1334: ypb.Yak.GetExecBatchYakScriptUnfinishedTask:output_type -> ypb.GetExecBatchYakScriptUnfinishedTaskResponse
+	8,    // 1335: ypb.Yak.GetExecBatchYakScriptUnfinishedTaskByUid:output_type -> ypb.ExecBatchYakScriptRequest
+	8,    // 1336: ypb.Yak.PopExecBatchYakScriptUnfinishedTaskByUid:output_type -> ypb.ExecBatchYakScriptRequest
+	9,    // 1337: ypb.Yak.RecoverExecBatchYakScriptUnfinishedTask:output_type -> ypb.ExecBatchYakScriptResult
+	628,  // 1338: ypb.Yak.QueryYakScript:output_type -> ypb.QueryYakScriptResponse
+	630,  // 1339: ypb.Yak.QueryYakScriptByYakScriptName:output_type -> ypb.YakScript
+	630,  // 1340: ypb.Yak.SaveYakScript:output_type -> ypb.YakScript
+	4,    // 1341: ypb.Yak.DeleteYakScript:output_type -> ypb.Empty
+	630,  // 1342: ypb.Yak.GetYakScriptById:output_type -> ypb.YakScript
+	630,  // 1343: ypb.Yak.GetYakScriptByName:output_type -> ypb.YakScript
+	630,  // 1344: ypb.Yak.GetYakScriptByOnlineID:output_type -> ypb.YakScript
+	4,    // 1345: ypb.Yak.IgnoreYakScript:output_type -> ypb.Empty
+	4,    // 1346: ypb.Yak.UnIgnoreYakScript:output_type -> ypb.Empty
+	566,  // 1347: ypb.Yak.ExportYakScript:output_type -> ypb.ExportYakScriptResponse
+	763,  // 1348: ypb.Yak.ExportYakScriptStream:output_type -> ypb.ExecResult
+	763,  // 1349: ypb.Yak.ImportYakScriptStream:output_type -> ypb.ExecResult
+	763,  // 1350: ypb.Yak.ExecutePacketYakScript:output_type -> ypb.ExecResult
+	9,    // 1351: ypb.Yak.ExecuteBatchPacketYakScript:output_type -> ypb.ExecBatchYakScriptResult
+	428,  // 1352: ypb.Yak.GetYakScriptTags:output_type -> ypb.GetYakScriptTagsResponse
+	431,  // 1353: ypb.Yak.QueryYakScriptLocalAndUser:output_type -> ypb.QueryYakScriptLocalAndUserResponse
+	431,  // 1354: ypb.Yak.QueryYakScriptByOnlineGroup:output_type -> ypb.QueryYakScriptLocalAndUserResponse
+	431,  // 1355: ypb.Yak.QueryYakScriptLocalAll:output_type -> ypb.QueryYakScriptLocalAndUserResponse
+	435,  // 1356: ypb.Yak.QueryYakScriptByNames:output_type -> ypb.QueryYakScriptByNamesResponse
+	436,  // 1357: ypb.Yak.QueryYakScriptByIsCore:output_type -> ypb.QueryYakScriptByIsCoreResponse
+	438,  // 1358: ypb.Yak.QueryYakScriptRiskDetailByCWE:output_type -> ypb.QueryYakScriptRiskDetailByCWEResponse
+	439,  // 1359: ypb.Yak.YakScriptRiskTypeList:output_type -> ypb.YakScriptRiskTypeListResponse
+	630,  // 1360: ypb.Yak.SaveNewYakScript:output_type -> ypb.YakScript
+	634,  // 1361: ypb.Yak.SaveYakScriptToOnline:output_type -> ypb.SaveYakScriptToOnlineResponse
+	637,  // 1362: ypb.Yak.ExportLocalYakScript:output_type -> ypb.ExportLocalYakScriptResponse
+	638,  // 1363: ypb.Yak.ExportLocalYakScriptStream:output_type -> ypb.ExportYakScriptLocalResponse
+	640,  // 1364: ypb.Yak.ImportYakScript:output_type -> ypb.ImportYakScriptResult
+	4,    // 1365: ypb.Yak.SetYakScriptSkipUpdate:output_type -> ypb.Empty
+	642,  // 1366: ypb.Yak.QueryYakScriptSkipUpdate:output_type -> ypb.QueryYakScriptSkipUpdateResponse
+	644,  // 1367: ypb.Yak.QueryYakScriptGroup:output_type -> ypb.QueryYakScriptGroupResponse
+	4,    // 1368: ypb.Yak.SaveYakScriptGroup:output_type -> ypb.Empty
+	4,    // 1369: ypb.Yak.RenameYakScriptGroup:output_type -> ypb.Empty
+	4,    // 1370: ypb.Yak.DeleteYakScriptGroup:output_type -> ypb.Empty
+	649,  // 1371: ypb.Yak.GetYakScriptGroup:output_type -> ypb.GetYakScriptGroupResponse
+	4,    // 1372: ypb.Yak.ResetYakScriptGroup:output_type -> ypb.Empty
+	4,    // 1373: ypb.Yak.SetGroup:output_type -> ypb.Empty
+	729,  // 1374: ypb.Yak.GetHTTPFlowByHash:output_type -> ypb.HTTPFlow
+	729,  // 1375: ypb.Yak.GetHTTPFlowById:output_type -> ypb.HTTPFlow
+	732,  // 1376: ypb.Yak.GetHTTPFlowBodyById:output_type -> ypb.GetHTTPFlowBodyByIdResponse
+	728,  // 1377: ypb.Yak.GetHTTPFlowByIds:output_type -> ypb.HTTPFlows
+	733,  // 1378: ypb.Yak.QueryHTTPFlows:output_type -> ypb.QueryHTTPFlowResponse
+	4,    // 1379: ypb.Yak.DeleteHTTPFlows:output_type -> ypb.Empty
+	4,    // 1380: ypb.Yak.SetTagForHTTPFlow:output_type -> ypb.Empty
+	726,  // 1381: ypb.Yak.QueryHTTPFlowsIds:output_type -> ypb.QueryHTTPFlowsIdsResponse
+	735,  // 1382: ypb.Yak.HTTPFlowsFieldGroup:output_type -> ypb.HTTPFlowsFieldGroupResponse
+	737,  // 1383: ypb.Yak.HTTPFlowsShare:output_type -> ypb.HTTPFlowsShareResponse
+	4,    // 1384: ypb.Yak.HTTPFlowsExtract:output_type -> ypb.Empty
+	768,  // 1385: ypb.Yak.GetHTTPFlowBare:output_type -> ypb.HTTPFlowBareResponse
+	733,  // 1386: ypb.Yak.ExportHTTPFlows:output_type -> ypb.QueryHTTPFlowResponse
+	4,    // 1387: ypb.Yak.HTTPFlowsToOnline:output_type -> ypb.Empty
+	723,  // 1388: ypb.Yak.QueryHTTPFlowsProcessNames:output_type -> ypb.QueryHTTPFlowsProcessNamesResponse
+	715,  // 1389: ypb.Yak.HTTPFlowsToOnlineBatch:output_type -> ypb.HTTPFlowsToOnlineBatchResponse
+	719,  // 1390: ypb.Yak.AnalyzeHTTPFlow:output_type -> ypb.AnalyzeHTTPFlowResponse
+	701,  // 1391: ypb.Yak.ExtractUrl:output_type -> ypb.ExtractedUrl
+	487,  // 1392: ypb.Yak.GetHistoryHTTPFuzzerTask:output_type -> ypb.HistoryHTTPFuzzerTaskDetail
+	489,  // 1393: ypb.Yak.QueryHistoryHTTPFuzzerTask:output_type -> ypb.HistoryHTTPFuzzerTasks
+	490,  // 1394: ypb.Yak.QueryHistoryHTTPFuzzerTaskEx:output_type -> ypb.HistoryHTTPFuzzerTasksResponse
+	4,    // 1395: ypb.Yak.DeleteHistoryHTTPFuzzerTask:output_type -> ypb.Empty
+	703,  // 1396: ypb.Yak.HTTPFuzzer:output_type -> ypb.FuzzerResponse
+	702,  // 1397: ypb.Yak.HTTPFuzzerSequence:output_type -> ypb.FuzzerSequenceResponse
+	695,  // 1398: ypb.Yak.HTTPFuzzerGroup:output_type -> ypb.GroupHTTPFuzzerResponse
+	690,  // 1399: ypb.Yak.PreloadHTTPFuzzerParams:output_type -> ypb.PreloadHTTPFuzzerParamsResponse
+	683,  // 1400: ypb.Yak.RenderVariables:output_type -> ypb.RenderVariablesResponse
+	685,  // 1401: ypb.Yak.MatchHTTPResponse:output_type -> ypb.MatchHTTPResponseResult
+	687,  // 1402: ypb.Yak.ExtractHTTPResponse:output_type -> ypb.ExtractHTTPResponseResult
+	703,  // 1403: ypb.Yak.RedirectRequest:output_type -> ypb.FuzzerResponse
+	541,  // 1404: ypb.Yak.HTTPRequestMutate:output_type -> ypb.MutateResult
+	541,  // 1405: ypb.Yak.HTTPResponseMutate:output_type -> ypb.MutateResult
+	422,  // 1406: ypb.Yak.FixUploadPacket:output_type -> ypb.FixUploadPacketResponse
+	423,  // 1407: ypb.Yak.IsMultipartFormDataRequest:output_type -> ypb.IsMultipartFormDataRequestResult
+	352,  // 1408: ypb.Yak.GenerateExtractRule:output_type -> ypb.GenerateExtractRuleResponse
+	340,  // 1409: ypb.Yak.ExtractData:output_type -> ypb.ExtractDataResponse
+	770,  // 1410: ypb.Yak.ImportHTTPFuzzerTaskFromYaml:output_type -> ypb.ImportHTTPFuzzerTaskFromYamlResponse
+	772,  // 1411: ypb.Yak.ExportHTTPFuzzerTaskToYaml:output_type -> ypb.ExportHTTPFuzzerTaskToYamlResponse
+	774,  // 1412: ypb.Yak.RenderHTTPFuzzerPacket:output_type -> ypb.RenderHTTPFuzzerPacketResponse
+	4,    // 1413: ypb.Yak.SaveFuzzerLabel:output_type -> ypb.Empty
+	342,  // 1414: ypb.Yak.QueryFuzzerLabel:output_type -> ypb.QueryFuzzerLabelResponse
+	4,    // 1415: ypb.Yak.DeleteFuzzerLabel:output_type -> ypb.Empty
+	805,  // 1416: ypb.Yak.SaveFuzzerConfig:output_type -> ypb.DbOperateMessage
+	347,  // 1417: ypb.Yak.QueryFuzzerConfig:output_type -> ypb.QueryFuzzerConfigResponse
+	805,  // 1418: ypb.Yak.DeleteFuzzerConfig:output_type -> ypb.DbOperateMessage
+	355,  // 1419: ypb.Yak.QueryHTTPFuzzerResponseByTaskId:output_type -> ypb.QueryHTTPFuzzerResponseByTaskIdResponse
+	359,  // 1420: ypb.Yak.CreateWebsocketFuzzer:output_type -> ypb.ClientWebsocketResponse
+	740,  // 1421: ypb.Yak.QueryWebsocketFlowByHTTPFlowWebsocketHash:output_type -> ypb.WebsocketFlows
+	4,    // 1422: ypb.Yak.DeleteWebsocketFlowByHTTPFlowWebsocketHash:output_type -> ypb.Empty
+	4,    // 1423: ypb.Yak.DeleteWebsocketFlowAll:output_type -> ypb.Empty
+	729,  // 1424: ypb.Yak.ConvertFuzzerResponseToHTTPFlow:output_type -> ypb.HTTPFlow
+	677,  // 1425: ypb.Yak.StringFuzzer:output_type -> ypb.StringFuzzerResponse
+	680,  // 1426: ypb.Yak.HTTPRequestAnalyzer:output_type -> ypb.HTTPRequestAnalysis
+	4,    // 1427: ypb.Yak.CreateSnippet:output_type -> ypb.Empty
+	4,    // 1428: ypb.Yak.UpdateSnippet:output_type -> ypb.Empty
+	4,    // 1429: ypb.Yak.DeleteSnippets:output_type -> ypb.Empty
+	658,  // 1430: ypb.Yak.QuerySnippets:output_type -> ypb.SnippetsResponse
+	666,  // 1431: ypb.Yak.Codec:output_type -> ypb.CodecResponse
+	666,  // 1432: ypb.Yak.NewCodec:output_type -> ypb.CodecResponse
+	667,  // 1433: ypb.Yak.GetAllCodecMethods:output_type -> ypb.CodecMethods
+	4,    // 1434: ypb.Yak.SaveCodecFlow:output_type -> ypb.Empty
+	4,    // 1435: ypb.Yak.UpdateCodecFlow:output_type -> ypb.Empty
+	4,    // 1436: ypb.Yak.DeleteCodecFlow:output_type -> ypb.Empty
+	665,  // 1437: ypb.Yak.GetAllCodecFlow:output_type -> ypb.GetCodecFlowResponse
+	234,  // 1438: ypb.Yak.PacketPrettifyHelper:output_type -> ypb.PacketPrettifyHelperResponse
+	621,  // 1439: ypb.Yak.QueryPayload:output_type -> ypb.QueryPayloadResponse
+	619,  // 1440: ypb.Yak.QueryPayloadFromFile:output_type -> ypb.QueryPayloadFromFileResponse
+	4,    // 1441: ypb.Yak.DeletePayloadByFolder:output_type -> ypb.Empty
+	4,    // 1442: ypb.Yak.DeletePayloadByGroup:output_type -> ypb.Empty
+	4,    // 1443: ypb.Yak.DeletePayload:output_type -> ypb.Empty
+	4,    // 1444: ypb.Yak.SavePayload:output_type -> ypb.Empty
+	379,  // 1445: ypb.Yak.SavePayloadStream:output_type -> ypb.SavePayloadProgress
+	379,  // 1446: ypb.Yak.SavePayloadToFileStream:output_type -> ypb.SavePayloadProgress
+	379,  // 1447: ypb.Yak.SaveLargePayloadToFileStream:output_type -> ypb.SavePayloadProgress
+	4,    // 1448: ypb.Yak.RenamePayloadFolder:output_type -> ypb.Empty
+	4,    // 1449: ypb.Yak.RenamePayloadGroup:output_type -> ypb.Empty
+	4,    // 1450: ypb.Yak.UpdatePayload:output_type -> ypb.Empty
+	4,    // 1451: ypb.Yak.UpdatePayloadToFile:output_type -> ypb.Empty
+	4,    // 1452: ypb.Yak.BackUpOrCopyPayloads:output_type -> ypb.Empty
+	610,  // 1453: ypb.Yak.GetAllPayloadGroup:output_type -> ypb.GetAllPayloadGroupResponse
+	4,    // 1454: ypb.Yak.UpdateAllPayloadGroup:output_type -> ypb.Empty
+	624,  // 1455: ypb.Yak.GetAllPayload:output_type -> ypb.GetAllPayloadResponse
+	625,  // 1456: ypb.Yak.GetAllPayloadFromFile:output_type -> ypb.GetAllPayloadFromFileResponse
+	624,  // 1457: ypb.Yak.ExportAllPayload:output_type -> ypb.GetAllPayloadResponse
+	624,  // 1458: ypb.Yak.ExportAllPayloadFromFile:output_type -> ypb.GetAllPayloadResponse
+	4,    // 1459: ypb.Yak.CreatePayloadFolder:output_type -> ypb.Empty
+	379,  // 1460: ypb.Yak.RemoveDuplicatePayloads:output_type -> ypb.SavePayloadProgress
+	379,  // 1461: ypb.Yak.CoverPayloadGroupToDatabase:output_type -> ypb.SavePayloadProgress
+	379,  // 1462: ypb.Yak.ConvertPayloadGroupToDatabase:output_type -> ypb.SavePayloadProgress
+	379,  // 1463: ypb.Yak.MigratePayloads:output_type -> ypb.SavePayloadProgress
+	624,  // 1464: ypb.Yak.ExportPayloadBatch:output_type -> ypb.GetAllPayloadResponse
+	383,  // 1465: ypb.Yak.UploadPayloadToOnline:output_type -> ypb.DownloadProgress
+	383,  // 1466: ypb.Yak.DownloadPayload:output_type -> ypb.DownloadProgress
+	624,  // 1467: ypb.Yak.ExportPayloadDBAndFile:output_type -> ypb.GetAllPayloadResponse
+	602,  // 1468: ypb.Yak.GetYakitCompletionRaw:output_type -> ypb.YakitCompletionRawResponse
+	606,  // 1469: ypb.Yak.GetYakVMBuildInMethodCompletion:output_type -> ypb.GetYakVMBuildInMethodCompletionResponse
+	378,  // 1470: ypb.Yak.StaticAnalyzeError:output_type -> ypb.StaticAnalyzeErrorResponse
+	376,  // 1471: ypb.Yak.YaklangCompileAndFormat:output_type -> ypb.YaklangCompileAndFormatResponse
+	367,  // 1472: ypb.Yak.YaklangLanguageSuggestion:output_type -> ypb.YaklangLanguageSuggestionResponse
+	368,  // 1473: ypb.Yak.YaklangLanguageFind:output_type -> ypb.YaklangLanguageFindResponse
+	367,  // 1474: ypb.Yak.FuzzTagSuggestion:output_type -> ypb.YaklangLanguageSuggestionResponse
+	369,  // 1475: ypb.Yak.YaklangInspectInformation:output_type -> ypb.YaklangInspectInformationResponse
+	372,  // 1476: ypb.Yak.YaklangGetCliCodeFromDatabase:output_type -> ypb.YaklangGetCliCodeFromDatabaseResponse
+	760,  // 1477: ypb.Yak.YaklangTerminal:output_type -> ypb.Output
+	763,  // 1478: ypb.Yak.PortScan:output_type -> ypb.ExecResult
+	593,  // 1479: ypb.Yak.ViewPortScanCode:output_type -> ypb.SimpleScript
+	763,  // 1480: ypb.Yak.SimpleDetect:output_type -> ypb.ExecResult
+	4,    // 1481: ypb.Yak.SaveCancelSimpleDetect:output_type -> ypb.Empty
+	763,  // 1482: ypb.Yak.SimpleDetectCreatReport:output_type -> ypb.ExecResult
+	418,  // 1483: ypb.Yak.QuerySimpleDetectUnfinishedTask:output_type -> ypb.QueryUnfinishedTaskResponse
+	595,  // 1484: ypb.Yak.GetSimpleDetectRecordRequestById:output_type -> ypb.RecordPortScanRequest
+	4,    // 1485: ypb.Yak.DeleteSimpleDetectUnfinishedTask:output_type -> ypb.Empty
+	763,  // 1486: ypb.Yak.RecoverSimpleDetectTask:output_type -> ypb.ExecResult
+	413,  // 1487: ypb.Yak.GetSimpleDetectUnfinishedTask:output_type -> ypb.GetSimpleDetectUnfinishedTaskResponse
+	595,  // 1488: ypb.Yak.GetSimpleDetectUnfinishedTaskByUid:output_type -> ypb.RecordPortScanRequest
+	595,  // 1489: ypb.Yak.PopSimpleDetectUnfinishedTaskByUid:output_type -> ypb.RecordPortScanRequest
+	763,  // 1490: ypb.Yak.RecoverSimpleDetectUnfinishedTask:output_type -> ypb.ExecResult
+	600,  // 1491: ypb.Yak.QueryPorts:output_type -> ypb.QueryPortsResponse
+	4,    // 1492: ypb.Yak.DeletePorts:output_type -> ypb.Empty
+	544,  // 1493: ypb.Yak.QueryHosts:output_type -> ypb.QueryHostsResponse
+	4,    // 1494: ypb.Yak.DeleteHosts:output_type -> ypb.Empty
+	547,  // 1495: ypb.Yak.QueryDomains:output_type -> ypb.QueryDomainsResponse
+	4,    // 1496: ypb.Yak.DeleteDomains:output_type -> ypb.Empty
+	549,  // 1497: ypb.Yak.QueryPortsGroup:output_type -> ypb.QueryPortsGroupResponse
+	4,    // 1498: ypb.Yak.UpdateFromYakitResource:output_type -> ypb.Empty
+	4,    // 1499: ypb.Yak.UpdateFromGithub:output_type -> ypb.Empty
+	4,    // 1500: ypb.Yak.AddToMenu:output_type -> ypb.Empty
+	4,    // 1501: ypb.Yak.RemoveFromMenu:output_type -> ypb.Empty
+	4,    // 1502: ypb.Yak.YakScriptIsInMenu:output_type -> ypb.Empty
+	576,  // 1503: ypb.Yak.GetAllMenuItem:output_type -> ypb.MenuByGroup
+	4,    // 1504: ypb.Yak.DeleteAllMenuItem:output_type -> ypb.Empty
+	4,    // 1505: ypb.Yak.ImportMenuItem:output_type -> ypb.Empty
+	583,  // 1506: ypb.Yak.ExportMenuItem:output_type -> ypb.ExportMenuItemResult
+	572,  // 1507: ypb.Yak.GetMenuItemById:output_type -> ypb.MenuItem
+	570,  // 1508: ypb.Yak.QueryGroupsByYakScriptId:output_type -> ypb.GroupNames
+	4,    // 1509: ypb.Yak.AddMenus:output_type -> ypb.Empty
+	576,  // 1510: ypb.Yak.QueryAllMenuItem:output_type -> ypb.MenuByGroup
+	4,    // 1511: ypb.Yak.DeleteAllMenu:output_type -> ypb.Empty
+	4,    // 1512: ypb.Yak.AddToNavigation:output_type -> ypb.Empty
+	588,  // 1513: ypb.Yak.GetAllNavigationItem:output_type -> ypb.GetAllNavigationItemResponse
+	4,    // 1514: ypb.Yak.DeleteAllNavigation:output_type -> ypb.Empty
+	4,    // 1515: ypb.Yak.AddOneNavigation:output_type -> ypb.Empty
+	570,  // 1516: ypb.Yak.QueryNavigationGroups:output_type -> ypb.GroupNames
+	4,    // 1517: ypb.Yak.SaveMarkdownDocument:output_type -> ypb.Empty
+	567,  // 1518: ypb.Yak.GetMarkdownDocument:output_type -> ypb.GetMarkdownDocumentResponse
+	4,    // 1519: ypb.Yak.DeleteMarkdownDocument:output_type -> ypb.Empty
+	763,  // 1520: ypb.Yak.StartBasicCrawler:output_type -> ypb.ExecResult
+	593,  // 1521: ypb.Yak.ViewBasicCrawlerCode:output_type -> ypb.SimpleScript
+	558,  // 1522: ypb.Yak.GenerateWebsiteTree:output_type -> ypb.GenerateWebsiteTreeResponse
+	557,  // 1523: ypb.Yak.QueryYakScriptExecResult:output_type -> ypb.QueryYakScriptExecResultResponse
+	555,  // 1524: ypb.Yak.QueryYakScriptNameInExecResult:output_type -> ypb.YakScriptNames
+	4,    // 1525: ypb.Yak.DeleteYakScriptExecResult:output_type -> ypb.Empty
+	4,    // 1526: ypb.Yak.DeleteYakScriptExec:output_type -> ypb.Empty
+	763,  // 1527: ypb.Yak.StartBrute:output_type -> ypb.ExecResult
+	537,  // 1528: ypb.Yak.GetAvailableBruteTypes:output_type -> ypb.GetAvailableBruteTypesResponse
+	531,  // 1529: ypb.Yak.GetTunnelServerExternalIP:output_type -> ypb.GetTunnelServerExternalIPResponse
+	529,  // 1530: ypb.Yak.VerifyTunnelServerDomain:output_type -> ypb.VerifyTunnelServerDomainResponse
+	763,  // 1531: ypb.Yak.StartFacades:output_type -> ypb.ExecResult
+	763,  // 1532: ypb.Yak.StartFacadesWithYsoObject:output_type -> ypb.ExecResult
+	4,    // 1533: ypb.Yak.ApplyClassToFacades:output_type -> ypb.Empty
+	481,  // 1534: ypb.Yak.BytesToBase64:output_type -> ypb.BytesToBase64Response
+	4,    // 1535: ypb.Yak.ConfigGlobalReverse:output_type -> ypb.Empty
+	510,  // 1536: ypb.Yak.AvailableLocalAddr:output_type -> ypb.AvailableLocalAddrResponse
+	509,  // 1537: ypb.Yak.GetGlobalReverseServer:output_type -> ypb.GetGlobalReverseServerResponse
+	518,  // 1538: ypb.Yak.QueryRisks:output_type -> ypb.QueryRisksResponse
+	516,  // 1539: ypb.Yak.QueryRisk:output_type -> ypb.Risk
+	4,    // 1540: ypb.Yak.DeleteRisk:output_type -> ypb.Empty
+	466,  // 1541: ypb.Yak.QueryAvailableRiskType:output_type -> ypb.Fields
+	466,  // 1542: ypb.Yak.QueryAvailableRiskLevel:output_type -> ypb.Fields
+	463,  // 1543: ypb.Yak.QueryRiskTableStats:output_type -> ypb.RiskTableStats
+	4,    // 1544: ypb.Yak.ResetRiskTableStats:output_type -> ypb.Empty
+	466,  // 1545: ypb.Yak.QueryAvailableTarget:output_type -> ypb.Fields
+	520,  // 1546: ypb.Yak.QueryNewRisk:output_type -> ypb.QueryNewRiskResponse
+	4,    // 1547: ypb.Yak.NewRiskRead:output_type -> ypb.Empty
+	4,    // 1548: ypb.Yak.UploadRiskToOnline:output_type -> ypb.Empty
+	4,    // 1549: ypb.Yak.SetTagForRisk:output_type -> ypb.Empty
+	521,  // 1550: ypb.Yak.QueryRiskTags:output_type -> ypb.QueryRiskTagsResponse
+	522,  // 1551: ypb.Yak.RiskFieldGroup:output_type -> ypb.RiskFieldGroupResponse
+	4,    // 1552: ypb.Yak.RiskFeedbackToOnline:output_type -> ypb.Empty
+	453,  // 1553: ypb.Yak.QueryReports:output_type -> ypb.QueryReportsResponse
+	455,  // 1554: ypb.Yak.QueryReport:output_type -> ypb.Report
+	4,    // 1555: ypb.Yak.DeleteReport:output_type -> ypb.Empty
+	466,  // 1556: ypb.Yak.QueryAvailableReportFrom:output_type -> ypb.Fields
+	4,    // 1557: ypb.Yak.DownloadReport:output_type -> ypb.Empty
+	468,  // 1558: ypb.Yak.GetAllYsoGadgetOptions:output_type -> ypb.YsoOptionsWithVerbose
+	468,  // 1559: ypb.Yak.GetAllYsoClassOptions:output_type -> ypb.YsoOptionsWithVerbose
+	471,  // 1560: ypb.Yak.GetAllYsoClassGeneraterOptions:output_type -> ypb.YsoClassOptionsResponseWithVerbose
+	478,  // 1561: ypb.Yak.GenerateYsoCode:output_type -> ypb.YsoCodeResponse
+	479,  // 1562: ypb.Yak.GenerateYsoBytes:output_type -> ypb.YsoBytesResponse
+	477,  // 1563: ypb.Yak.YsoDump:output_type -> ypb.YsoDumpResponse
+	494,  // 1564: ypb.Yak.CreateWebShell:output_type -> ypb.WebShell
+	4,    // 1565: ypb.Yak.DeleteWebShell:output_type -> ypb.Empty
+	494,  // 1566: ypb.Yak.UpdateWebShell:output_type -> ypb.WebShell
+	500,  // 1567: ypb.Yak.QueryWebShells:output_type -> ypb.QueryWebShellsResponse
+	498,  // 1568: ypb.Yak.Ping:output_type -> ypb.WebShellResponse
+	498,  // 1569: ypb.Yak.GetBasicInfo:output_type -> ypb.WebShellResponse
+	498,  // 1570: ypb.Yak.GenerateWebShell:output_type -> ypb.WebShellResponse
+	4,    // 1571: ypb.Yak.SetYakBridgeLogServer:output_type -> ypb.Empty
+	503,  // 1572: ypb.Yak.GetCurrentYakBridgeLogServer:output_type -> ypb.YakDNSLogBridgeAddr
+	508,  // 1573: ypb.Yak.RequireDNSLogDomain:output_type -> ypb.DNSLogRootDomain
+	508,  // 1574: ypb.Yak.RequireDNSLogDomainByScript:output_type -> ypb.DNSLogRootDomain
+	506,  // 1575: ypb.Yak.QueryDNSLogByToken:output_type -> ypb.QueryDNSLogByTokenResponse
+	506,  // 1576: ypb.Yak.QueryDNSLogTokenByScript:output_type -> ypb.QueryDNSLogByTokenResponse
+	458,  // 1577: ypb.Yak.RequireICMPRandomLength:output_type -> ypb.RequireICMPRandomLengthResponse
+	483,  // 1578: ypb.Yak.QueryICMPTrigger:output_type -> ypb.QueryICMPTriggerResponse
+	461,  // 1579: ypb.Yak.RequireRandomPortToken:output_type -> ypb.RandomPortInfo
+	459,  // 1580: ypb.Yak.QueryRandomPortTrigger:output_type -> ypb.RandomPortTriggerNotification
+	484,  // 1581: ypb.Yak.QuerySupportedDnsLogPlatforms:output_type -> ypb.QuerySupportedDnsLogPlatformsResponse
+	466,  // 1582: ypb.Yak.GetAvailableYakScriptTags:output_type -> ypb.Fields
+	4,    // 1583: ypb.Yak.ForceUpdateAvailableYakScriptTags:output_type -> ypb.Empty
+	763,  // 1584: ypb.Yak.ExecYakitPluginsByYakScriptFilter:output_type -> ypb.ExecResult
+	450,  // 1585: ypb.Yak.GenerateYakCodeByPacket:output_type -> ypb.GenerateYakCodeByPacketResponse
+	449,  // 1586: ypb.Yak.GenerateCSRFPocByPacket:output_type -> ypb.GenerateCSRFPocByPacketResponse
+	445,  // 1587: ypb.Yak.ExportMITMReplacerRules:output_type -> ypb.ExportMITMReplacerRulesResponse
+	4,    // 1588: ypb.Yak.ImportMITMReplacerRules:output_type -> ypb.Empty
+	443,  // 1589: ypb.Yak.GetCurrentRules:output_type -> ypb.MITMContentReplacers
+	4,    // 1590: ypb.Yak.SetCurrentRules:output_type -> ypb.Empty
+	986,  // 1591: ypb.Yak.QueryMITMReplacerRules:output_type -> ypb.QueryMITMReplacerRulesResponse
+	805,  // 1592: ypb.Yak.DeduplicateMITMReplacerRules:output_type -> ypb.DbOperateMessage
+	778,  // 1593: ypb.Yak.GenerateURL:output_type -> ypb.GenerateURLResponse
+	427,  // 1594: ypb.Yak.ExtractDataToFile:output_type -> ypb.ExtractDataToFileResult
+	426,  // 1595: ypb.Yak.AutoDecode:output_type -> ypb.AutoDecodeResponse
+	407,  // 1596: ypb.Yak.GetSystemProxy:output_type -> ypb.GetSystemProxyResult
+	4,    // 1597: ypb.Yak.SetSystemProxy:output_type -> ypb.Empty
+	403,  // 1598: ypb.Yak.GetKey:output_type -> ypb.GetKeyResult
+	4,    // 1599: ypb.Yak.SetKey:output_type -> ypb.Empty
+	4,    // 1600: ypb.Yak.DelKey:output_type -> ypb.Empty
+	405,  // 1601: ypb.Yak.GetAllProcessEnvKey:output_type -> ypb.GetProcessEnvKeyResult
+	4,    // 1602: ypb.Yak.SetProcessEnvKey:output_type -> ypb.Empty
+	403,  // 1603: ypb.Yak.GetProjectKey:output_type -> ypb.GetKeyResult
+	4,    // 1604: ypb.Yak.SetProjectKey:output_type -> ypb.Empty
+	400,  // 1605: ypb.Yak.GetOnlineProfile:output_type -> ypb.OnlineProfile
+	4,    // 1606: ypb.Yak.SetOnlineProfile:output_type -> ypb.Empty
+	4,    // 1607: ypb.Yak.DownloadOnlinePluginById:output_type -> ypb.Empty
+	4,    // 1608: ypb.Yak.DownloadOnlinePluginByIds:output_type -> ypb.Empty
+	387,  // 1609: ypb.Yak.DownloadOnlinePluginAll:output_type -> ypb.DownloadOnlinePluginProgress
+	4,    // 1610: ypb.Yak.DeletePluginByUserID:output_type -> ypb.Empty
+	4,    // 1611: ypb.Yak.DeleteAllLocalPlugins:output_type -> ypb.Empty
+	652,  // 1612: ypb.Yak.GetYakScriptTagsAndType:output_type -> ypb.GetYakScriptTagsAndTypeResponse
+	4,    // 1613: ypb.Yak.DeleteLocalPluginsByWhere:output_type -> ypb.Empty
+	394,  // 1614: ypb.Yak.DownloadOnlinePluginByScriptNames:output_type -> ypb.DownloadOnlinePluginByScriptNamesResponse
+	387,  // 1615: ypb.Yak.DownloadOnlinePlugins:output_type -> ypb.DownloadOnlinePluginProgress
+	4,    // 1616: ypb.Yak.DownloadOnlinePluginBatch:output_type -> ypb.Empty
+	394,  // 1617: ypb.Yak.DownloadOnlinePluginByPluginName:output_type -> ypb.DownloadOnlinePluginByScriptNamesResponse
+	630,  // 1618: ypb.Yak.DownloadOnlinePluginByUUID:output_type -> ypb.YakScript
+	398,  // 1619: ypb.Yak.QueryOnlinePlugins:output_type -> ypb.QueryOnlinePluginsResponse
+	763,  // 1620: ypb.Yak.ExecPacketScan:output_type -> ypb.ExecResult
+	360,  // 1621: ypb.Yak.GetEngineDefaultProxy:output_type -> ypb.DefaultProxyResult
+	4,    // 1622: ypb.Yak.SetEngineDefaultProxy:output_type -> ypb.Empty
+	353,  // 1623: ypb.Yak.GetMachineID:output_type -> ypb.GetMachineIDResponse
+	764,  // 1624: ypb.Yak.GetLicense:output_type -> ypb.GetLicenseResponse
+	4,    // 1625: ypb.Yak.CheckLicense:output_type -> ypb.Empty
+	339,  // 1626: ypb.Yak.GetRequestBodyByHTTPFlowID:output_type -> ypb.Bytes
+	339,  // 1627: ypb.Yak.GetResponseBodyByHTTPFlowID:output_type -> ypb.Bytes
+	339,  // 1628: ypb.Yak.GetHTTPPacketBody:output_type -> ypb.Bytes
+	338,  // 1629: ypb.Yak.EncodeHTTPPacketContent:output_type -> ypb.EncodeHTTPPacketContentResponse
+	334,  // 1630: ypb.Yak.RegisterFacadesHTTP:output_type -> ypb.RegisterFacadesHTTPResponse
+	4,    // 1631: ypb.Yak.ResetAndInvalidUserData:output_type -> ypb.Empty
+	331,  // 1632: ypb.Yak.CreateYaklangShell:output_type -> ypb.YaklangShellResponse
+	763,  // 1633: ypb.Yak.AttachCombinedOutput:output_type -> ypb.ExecResult
+	314,  // 1634: ypb.Yak.IsPrivilegedForNetRaw:output_type -> ypb.IsPrivilegedForNetRawResponse
+	4,    // 1635: ypb.Yak.PromotePermissionForUserPcap:output_type -> ypb.Empty
+	4,    // 1636: ypb.Yak.SetCurrentProject:output_type -> ypb.Empty
+	320,  // 1637: ypb.Yak.GetCurrentProject:output_type -> ypb.ProjectDescription
+	320,  // 1638: ypb.Yak.GetCurrentProjectEx:output_type -> ypb.ProjectDescription
+	321,  // 1639: ypb.Yak.GetProjects:output_type -> ypb.GetProjectsResponse
+	318,  // 1640: ypb.Yak.NewProject:output_type -> ypb.NewProjectResponse
+	318,  // 1641: ypb.Yak.UpdateProject:output_type -> ypb.NewProjectResponse
+	4,    // 1642: ypb.Yak.IsProjectNameValid:output_type -> ypb.Empty
+	4,    // 1643: ypb.Yak.RemoveProject:output_type -> ypb.Empty
+	4,    // 1644: ypb.Yak.DeleteProject:output_type -> ypb.Empty
+	320,  // 1645: ypb.Yak.GetDefaultProject:output_type -> ypb.ProjectDescription
+	320,  // 1646: ypb.Yak.GetDefaultProjectEx:output_type -> ypb.ProjectDescription
+	320,  // 1647: ypb.Yak.QueryProjectDetail:output_type -> ypb.ProjectDescription
+	320,  // 1648: ypb.Yak.GetTemporaryProject:output_type -> ypb.ProjectDescription
+	320,  // 1649: ypb.Yak.GetTemporaryProjectEx:output_type -> ypb.ProjectDescription
+	312,  // 1650: ypb.Yak.ExportProject:output_type -> ypb.ProjectIOProgress
+	312,  // 1651: ypb.Yak.ImportProject:output_type -> ypb.ProjectIOProgress
+	4,    // 1652: ypb.Yak.MigrateLegacyDatabase:output_type -> ypb.Empty
+	300,  // 1653: ypb.Yak.QueryMITMRuleExtractedData:output_type -> ypb.QueryMITMRuleExtractedDataResponse
+	310,  // 1654: ypb.Yak.QueryMITMExtractedAggregate:output_type -> ypb.QueryMITMExtractedAggregateResponse
+	304,  // 1655: ypb.Yak.ExportMITMRuleExtractedData:output_type -> ypb.ExportMITMRuleExtractedDataResponse
+	4,    // 1656: ypb.Yak.DeleteMITMRuleExtractedData:output_type -> ypb.Empty
+	307,  // 1657: ypb.Yak.DeduplicateMITMRuleExtractedData:output_type -> ypb.DeduplicateMITMRuleExtractedDataResponse
+	4,    // 1658: ypb.Yak.ImportChaosMakerRules:output_type -> ypb.Empty
+	291,  // 1659: ypb.Yak.QueryChaosMakerRule:output_type -> ypb.QueryChaosMakerRuleResponse
+	4,    // 1660: ypb.Yak.DeleteChaosMakerRuleByID:output_type -> ypb.Empty
+	763,  // 1661: ypb.Yak.ExecuteChaosMakerRule:output_type -> ypb.ExecResult
+	288,  // 1662: ypb.Yak.IsRemoteAddrAvailable:output_type -> ypb.IsRemoteAddrAvailableResponse
+	288,  // 1663: ypb.Yak.ConnectVulinboxAgent:output_type -> ypb.IsRemoteAddrAvailableResponse
+	254,  // 1664: ypb.Yak.GetRegisteredVulinboxAgent:output_type -> ypb.GetRegisteredAgentResponse
+	4,    // 1665: ypb.Yak.DisconnectVulinboxAgent:output_type -> ypb.Empty
+	297,  // 1666: ypb.Yak.IsCVEDatabaseReady:output_type -> ypb.IsCVEDatabaseReadyResponse
+	763,  // 1667: ypb.Yak.UpdateCVEDatabase:output_type -> ypb.ExecResult
+	763,  // 1668: ypb.Yak.ExportsProfileDatabase:output_type -> ypb.ExecResult
+	763,  // 1669: ypb.Yak.ImportsProfileDatabase:output_type -> ypb.ExecResult
+	282,  // 1670: ypb.Yak.QueryCVE:output_type -> ypb.QueryCVEResponse
+	280,  // 1671: ypb.Yak.GetCVE:output_type -> ypb.CVEDetailEx
+	284,  // 1672: ypb.Yak.SaveTextToTemporalFile:output_type -> ypb.SaveTextToTemporalFileResponse
+	276,  // 1673: ypb.Yak.IsScrecorderReady:output_type -> ypb.IsScrecorderReadyResponse
+	763,  // 1674: ypb.Yak.InstallScrecorder:output_type -> ypb.ExecResult
+	763,  // 1675: ypb.Yak.StartScrecorder:output_type -> ypb.ExecResult
+	272,  // 1676: ypb.Yak.QueryScreenRecorders:output_type -> ypb.QueryScreenRecorderResponse
+	4,    // 1677: ypb.Yak.DeleteScreenRecorders:output_type -> ypb.Empty
+	4,    // 1678: ypb.Yak.UploadScreenRecorders:output_type -> ypb.Empty
+	267,  // 1679: ypb.Yak.GetOneScreenRecorders:output_type -> ypb.ScreenRecorder
+	4,    // 1680: ypb.Yak.UpdateScreenRecorders:output_type -> ypb.Empty
+	259,  // 1681: ypb.Yak.IsVulinboxReady:output_type -> ypb.IsVulinboxReadyResponse
+	763,  // 1682: ypb.Yak.InstallVulinbox:output_type -> ypb.ExecResult
+	763,  // 1683: ypb.Yak.StartVulinbox:output_type -> ypb.ExecResult
+	763,  // 1684: ypb.Yak.GenQualityInspectionReport:output_type -> ypb.ExecResult
+	265,  // 1685: ypb.Yak.HTTPRequestBuilder:output_type -> ypb.HTTPRequestBuilderResponse
+	763,  // 1686: ypb.Yak.DebugPlugin:output_type -> ypb.ExecResult
+	257,  // 1687: ypb.Yak.SmokingEvaluatePlugin:output_type -> ypb.SmokingEvaluatePluginResponse
+	776,  // 1688: ypb.Yak.SmokingEvaluatePluginBatch:output_type -> ypb.SmokingEvaluatePluginBatchResponse
+	766,  // 1689: ypb.Yak.GetSystemDefaultDnsServers:output_type -> ypb.DefaultDnsServerResponse
+	251,  // 1690: ypb.Yak.DiagnoseNetwork:output_type -> ypb.DiagnoseNetworkResponse
+	251,  // 1691: ypb.Yak.DiagnoseNetworkDNS:output_type -> ypb.DiagnoseNetworkResponse
+	783,  // 1692: ypb.Yak.TraceRoute:output_type -> ypb.TraceRouteResponse
+	240,  // 1693: ypb.Yak.GetGlobalNetworkConfig:output_type -> ypb.GlobalNetworkConfig
+	4,    // 1694: ypb.Yak.SetGlobalNetworkConfig:output_type -> ypb.Empty
+	4,    // 1695: ypb.Yak.ResetGlobalNetworkConfig:output_type -> ypb.Empty
+	246,  // 1696: ypb.Yak.GetGlobalProxyRulesConfig:output_type -> ypb.GlobalProxyRulesConfig
+	4,    // 1697: ypb.Yak.SetGlobalProxyRulesConfig:output_type -> ypb.Empty
+	244,  // 1698: ypb.Yak.CheckProxyAlive:output_type -> ypb.CheckProxyAliveResponse
+	239,  // 1699: ypb.Yak.ValidP12PassWord:output_type -> ypb.ValidP12PassWordResponse
+	232,  // 1700: ypb.Yak.RequestYakURL:output_type -> ypb.RequestYakURLResponse
+	800,  // 1701: ypb.Yak.ReadFile:output_type -> ypb.ReadFileResponse
+	216,  // 1702: ypb.Yak.GetPcapMetadata:output_type -> ypb.PcapMetadata
+	228,  // 1703: ypb.Yak.PcapX:output_type -> ypb.PcapXResponse
+	220,  // 1704: ypb.Yak.QueryTrafficSession:output_type -> ypb.QueryTrafficSessionResponse
+	222,  // 1705: ypb.Yak.QueryTrafficPacket:output_type -> ypb.QueryTrafficPacketResponse
+	224,  // 1706: ypb.Yak.QueryTrafficTCPReassembled:output_type -> ypb.QueryTrafficTCPReassembledResponse
+	781,  // 1707: ypb.Yak.ParseTraffic:output_type -> ypb.ParseTrafficResponse
+	214,  // 1708: ypb.Yak.DuplexConnection:output_type -> ypb.DuplexConnectionResponse
+	208,  // 1709: ypb.Yak.HybridScan:output_type -> ypb.HybridScanResponse
+	205,  // 1710: ypb.Yak.QueryHybridScanTask:output_type -> ypb.QueryHybridScanTaskResponse
+	4,    // 1711: ypb.Yak.DeleteHybridScanTask:output_type -> ypb.Empty
+	201,  // 1712: ypb.Yak.GetSpaceEngineStatus:output_type -> ypb.SpaceEngineStatus
+	201,  // 1713: ypb.Yak.GetSpaceEngineAccountStatus:output_type -> ypb.SpaceEngineStatus
+	201,  // 1714: ypb.Yak.GetSpaceEngineAccountStatusV2:output_type -> ypb.SpaceEngineStatus
+	763,  // 1715: ypb.Yak.FetchPortAssetFromSpaceEngine:output_type -> ypb.ExecResult
+	785,  // 1716: ypb.Yak.EvaluateExpression:output_type -> ypb.EvaluateExpressionResponse
+	787,  // 1717: ypb.Yak.EvaluateMultiExpression:output_type -> ypb.EvaluateMultiExpressionResponse
+	790,  // 1718: ypb.Yak.GetThirdPartyAppConfigTemplate:output_type -> ypb.GetThirdPartyAppConfigTemplateResponse
+	6,    // 1719: ypb.Yak.CheckHahValidAiConfig:output_type -> ypb.GeneralResponse
+	955,  // 1720: ypb.Yak.ListAiModel:output_type -> ypb.ListAiModelResponse
+	957,  // 1721: ypb.Yak.AIConfigHealthCheck:output_type -> ypb.AIConfigHealthCheckResponse
+	967,  // 1722: ypb.Yak.GetAIGlobalConfig:output_type -> ypb.AIGlobalConfig
+	4,    // 1723: ypb.Yak.SetAIGlobalConfig:output_type -> ypb.Empty
+	962,  // 1724: ypb.Yak.ListAIProviders:output_type -> ypb.ListAIProvidersResponse
+	961,  // 1725: ypb.Yak.QueryAIProvider:output_type -> ypb.QueryAIProvidersResponse
+	964,  // 1726: ypb.Yak.UpsertAIProvider:output_type -> ypb.UpsertAIProviderResponse
+	4,    // 1727: ypb.Yak.DeleteAIProvider:output_type -> ypb.Empty
+	790,  // 1728: ypb.Yak.GetAIThirdPartyAppConfigTemplate:output_type -> ypb.GetThirdPartyAppConfigTemplateResponse
+	792,  // 1729: ypb.Yak.GetApiKeyByOnline:output_type -> ypb.GetApiKeyByOnlineResponse
+	794,  // 1730: ypb.Yak.GetFingerprint:output_type -> ypb.GetFingerprintResponse
+	796,  // 1731: ypb.Yak.AddFingerprint:output_type -> ypb.AddFingerprintResponse
+	798,  // 1732: ypb.Yak.ModifyFingerprint:output_type -> ypb.ModifyFingerprintResponse
+	810,  // 1733: ypb.Yak.QueryFingerprint:output_type -> ypb.QueryFingerprintResponse
+	805,  // 1734: ypb.Yak.DeleteFingerprint:output_type -> ypb.DbOperateMessage
+	805,  // 1735: ypb.Yak.UpdateFingerprint:output_type -> ypb.DbOperateMessage
+	805,  // 1736: ypb.Yak.CreateFingerprint:output_type -> ypb.DbOperateMessage
+	805,  // 1737: ypb.Yak.RecoverBuiltinFingerprint:output_type -> ypb.DbOperateMessage
+	805,  // 1738: ypb.Yak.CreateFingerprintGroup:output_type -> ypb.DbOperateMessage
+	815,  // 1739: ypb.Yak.GetAllFingerprintGroup:output_type -> ypb.FingerprintGroups
+	805,  // 1740: ypb.Yak.RenameFingerprintGroup:output_type -> ypb.DbOperateMessage
+	805,  // 1741: ypb.Yak.DeleteFingerprintGroup:output_type -> ypb.DbOperateMessage
+	805,  // 1742: ypb.Yak.BatchUpdateFingerprintToGroup:output_type -> ypb.DbOperateMessage
+	815,  // 1743: ypb.Yak.GetFingerprintGroupSetByFilter:output_type -> ypb.FingerprintGroups
+	822,  // 1744: ypb.Yak.ExportFingerprint:output_type -> ypb.DataTransferProgress
+	822,  // 1745: ypb.Yak.ImportFingerprint:output_type -> ypb.DataTransferProgress
+	802,  // 1746: ypb.Yak.GetReverseShellProgramList:output_type -> ypb.GetReverseShellProgramListResponse
+	804,  // 1747: ypb.Yak.GenerateReverseShellCommand:output_type -> ypb.GenerateReverseShellCommandResponse
+	842,  // 1748: ypb.Yak.QuerySyntaxFlowRule:output_type -> ypb.QuerySyntaxFlowRuleResponse
+	805,  // 1749: ypb.Yak.CreateSyntaxFlowRule:output_type -> ypb.DbOperateMessage
+	839,  // 1750: ypb.Yak.CreateSyntaxFlowRuleEx:output_type -> ypb.CreateSyntaxFlowRuleResponse
+	805,  // 1751: ypb.Yak.UpdateSyntaxFlowRule:output_type -> ypb.DbOperateMessage
+	841,  // 1752: ypb.Yak.UpdateSyntaxFlowRuleEx:output_type -> ypb.UpdateSyntaxFlowRuleResponse
+	805,  // 1753: ypb.Yak.DeleteSyntaxFlowRule:output_type -> ypb.DbOperateMessage
+	845,  // 1754: ypb.Yak.CheckSyntaxFlowRuleUpdate:output_type -> ypb.CheckSyntaxFlowRuleUpdateResponse
+	847,  // 1755: ypb.Yak.ApplySyntaxFlowRuleUpdate:output_type -> ypb.ApplySyntaxFlowRuleUpdateResponse
+	851,  // 1756: ypb.Yak.QuerySyntaxFlowRuleGroup:output_type -> ypb.QuerySyntaxFlowRuleGroupResponse
+	805,  // 1757: ypb.Yak.DeleteSyntaxFlowRuleGroup:output_type -> ypb.DbOperateMessage
+	805,  // 1758: ypb.Yak.CreateSyntaxFlowRuleGroup:output_type -> ypb.DbOperateMessage
+	805,  // 1759: ypb.Yak.UpdateSyntaxFlowRuleGroup:output_type -> ypb.DbOperateMessage
+	805,  // 1760: ypb.Yak.UpdateSyntaxFlowRuleAndGroup:output_type -> ypb.DbOperateMessage
+	856,  // 1761: ypb.Yak.QuerySyntaxFlowSameGroup:output_type -> ypb.QuerySyntaxFlowSameGroupResponse
+	859,  // 1762: ypb.Yak.SyntaxFlowRuleToOnline:output_type -> ypb.SyntaxFlowRuleOnlineProgress
+	859,  // 1763: ypb.Yak.DownloadSyntaxFlowRule:output_type -> ypb.SyntaxFlowRuleOnlineProgress
+	867,  // 1764: ypb.Yak.SyntaxFlowScan:output_type -> ypb.SyntaxFlowScanResponse
+	864,  // 1765: ypb.Yak.QuerySyntaxFlowScanTask:output_type -> ypb.QuerySyntaxFlowScanTaskResponse
+	805,  // 1766: ypb.Yak.DeleteSyntaxFlowScanTask:output_type -> ypb.DbOperateMessage
+	871,  // 1767: ypb.Yak.QuerySyntaxFlowResult:output_type -> ypb.QuerySyntaxFlowResultResponse
+	874,  // 1768: ypb.Yak.DeleteSyntaxFlowResult:output_type -> ypb.DeleteSyntaxFlowResultResponse
+	837,  // 1769: ypb.Yak.QuerySSAPrograms:output_type -> ypb.QuerySSAProgramResponse
+	805,  // 1770: ypb.Yak.UpdateSSAProgram:output_type -> ypb.DbOperateMessage
+	805,  // 1771: ypb.Yak.DeleteSSAPrograms:output_type -> ypb.DbOperateMessage
+	888,  // 1772: ypb.Yak.QuerySSARisks:output_type -> ypb.QuerySSARisksResponse
+	890,  // 1773: ypb.Yak.QueryNewSSARisks:output_type -> ypb.QueryNewSSARisksResponse
+	805,  // 1774: ypb.Yak.DeleteSSARisks:output_type -> ypb.DbOperateMessage
+	805,  // 1775: ypb.Yak.UpdateSSARiskTags:output_type -> ypb.DbOperateMessage
+	894,  // 1776: ypb.Yak.GetSSARiskFieldGroup:output_type -> ypb.SSARiskFieldGroupResponse
+	894,  // 1777: ypb.Yak.GetSSARiskFieldGroupEx:output_type -> ypb.SSARiskFieldGroupResponse
+	896,  // 1778: ypb.Yak.NewSSARiskRead:output_type -> ypb.NewSSARiskReadResponse
+	898,  // 1779: ypb.Yak.ExportSSARisk:output_type -> ypb.ExportSSARiskResponse
+	900,  // 1780: ypb.Yak.ImportSSARisk:output_type -> ypb.ImportSSARiskResponse
+	831,  // 1781: ypb.Yak.SSARiskDiff:output_type -> ypb.SSARiskDiffResponse
+	905,  // 1782: ypb.Yak.CreateSSARiskDisposals:output_type -> ypb.CreateSSARiskDisposalsResponse
+	907,  // 1783: ypb.Yak.QuerySSARiskDisposals:output_type -> ypb.QuerySSARiskDisposalsResponse
+	909,  // 1784: ypb.Yak.UpdateSSARiskDisposals:output_type -> ypb.UpdateSSARiskDisposalsResponse
+	911,  // 1785: ypb.Yak.DeleteSSARiskDisposals:output_type -> ypb.DeleteSSARiskDisposalsResponse
+	913,  // 1786: ypb.Yak.GetSSARiskDisposal:output_type -> ypb.GetSSARiskDisposalResponse
+	4,    // 1787: ypb.Yak.SSARiskFeedbackToOnline:output_type -> ypb.Empty
+	992,  // 1788: ypb.Yak.GenerateSSAReport:output_type -> ypb.GenerateSSAReportResponse
+	999,  // 1789: ypb.Yak.CreateSSAProject:output_type -> ypb.CreateSSAProjectResponse
+	1001, // 1790: ypb.Yak.UpdateSSAProject:output_type -> ypb.UpdateSSAProjectResponse
+	1003, // 1791: ypb.Yak.DeleteSSAProject:output_type -> ypb.DeleteSSAProjectResponse
+	1005, // 1792: ypb.Yak.QuerySSAProject:output_type -> ypb.QuerySSAProjectResponse
+	1007, // 1793: ypb.Yak.MigrateSSAProject:output_type -> ypb.MigrateSSAProjectResponse
+	1014, // 1794: ypb.Yak.GetSSAWorkbenchDashboard:output_type -> ypb.GetSSAWorkbenchDashboardResponse
+	876,  // 1795: ypb.Yak.GetAllPluginEnv:output_type -> ypb.PluginEnvData
+	876,  // 1796: ypb.Yak.QueryPluginEnv:output_type -> ypb.PluginEnvData
+	4,    // 1797: ypb.Yak.CreatePluginEnv:output_type -> ypb.Empty
+	4,    // 1798: ypb.Yak.SetPluginEnv:output_type -> ypb.Empty
+	4,    // 1799: ypb.Yak.DeletePluginEnv:output_type -> ypb.Empty
+	879,  // 1800: ypb.Yak.GetAllFuzztagInfo:output_type -> ypb.GetAllFuzztagInfoResponse
+	883,  // 1801: ypb.Yak.GenerateFuzztag:output_type -> ypb.GenerateFuzztagResponse
+	916,  // 1802: ypb.Yak.ExportSyntaxFlows:output_type -> ypb.SyntaxflowsProgress
+	916,  // 1803: ypb.Yak.ImportSyntaxFlows:output_type -> ypb.SyntaxflowsProgress
+	921,  // 1804: ypb.Yak.CreateHotPatchTemplate:output_type -> ypb.CreateHotPatchTemplateResponse
+	922,  // 1805: ypb.Yak.DeleteHotPatchTemplate:output_type -> ypb.DeleteHotPatchTemplateResponse
+	923,  // 1806: ypb.Yak.UpdateHotPatchTemplate:output_type -> ypb.UpdateHotPatchTemplateResponse
+	924,  // 1807: ypb.Yak.QueryHotPatchTemplate:output_type -> ypb.QueryHotPatchTemplateResponse
+	926,  // 1808: ypb.Yak.QueryHotPatchTemplateList:output_type -> ypb.QueryHotPatchTemplateListResponse
+	927,  // 1809: ypb.Yak.GetHotPatchTemplateTags:output_type -> ypb.GetHotPatchTemplateTagsResponse
+	929,  // 1810: ypb.Yak.GetGlobalHotPatchConfig:output_type -> ypb.GlobalHotPatchConfig
+	929,  // 1811: ypb.Yak.SetGlobalHotPatchConfig:output_type -> ypb.GlobalHotPatchConfig
+	929,  // 1812: ypb.Yak.ResetGlobalHotPatchConfig:output_type -> ypb.GlobalHotPatchConfig
+	932,  // 1813: ypb.Yak.GroupTableColumn:output_type -> ypb.GroupTableColumnResponse
+	4,    // 1814: ypb.Yak.UploadHotPatchTemplateToOnline:output_type -> ypb.Empty
+	4,    // 1815: ypb.Yak.DownloadHotPatchTemplate:output_type -> ypb.Empty
+	743,  // 1816: ypb.Yak.SetMITMHijackFilter:output_type -> ypb.SetMITMFilterResponse
+	742,  // 1817: ypb.Yak.GetMITMHijackFilter:output_type -> ypb.SetMITMFilterRequest
+	742,  // 1818: ypb.Yak.ResetMITMHijackFilter:output_type -> ypb.SetMITMFilterRequest
+	936,  // 1819: ypb.Yak.ExportHTTPFlowStream:output_type -> ypb.ExportHTTPFlowStreamResponse
+	938,  // 1820: ypb.Yak.ImportHTTPFlowStream:output_type -> ypb.ImportHTTPFlowStreamResponse
+	943,  // 1821: ypb.Yak.CreateNote:output_type -> ypb.CreateNoteResponse
+	805,  // 1822: ypb.Yak.UpdateNote:output_type -> ypb.DbOperateMessage
+	805,  // 1823: ypb.Yak.DeleteNote:output_type -> ypb.DbOperateMessage
+	947,  // 1824: ypb.Yak.QueryNote:output_type -> ypb.QueryNoteResponse
+	949,  // 1825: ypb.Yak.SearchNoteContent:output_type -> ypb.SearchNoteContentResponse
+	951,  // 1826: ypb.Yak.ImportNote:output_type -> ypb.ImportNoteResponse
+	953,  // 1827: ypb.Yak.ExportNote:output_type -> ypb.ExportNoteResponse
+	145,  // 1828: ypb.Yak.StartAIReAct:output_type -> ypb.AIOutputEvent
+	145,  // 1829: ypb.Yak.StartAITask:output_type -> ypb.AIOutputEvent
+	160,  // 1830: ypb.Yak.QueryAITask:output_type -> ypb.AITaskQueryResponse
+	805,  // 1831: ypb.Yak.DeleteAITask:output_type -> ypb.DbOperateMessage
+	157,  // 1832: ypb.Yak.QueryAIEvent:output_type -> ypb.AIEventQueryResponse
+	805,  // 1833: ypb.Yak.DeleteAIEvent:output_type -> ypb.DbOperateMessage
+	168,  // 1834: ypb.Yak.QueryAISession:output_type -> ypb.QueryAISessionResponse
+	805,  // 1835: ypb.Yak.UpdateAISessionTitle:output_type -> ypb.DbOperateMessage
+	805,  // 1836: ypb.Yak.UpdateAISessionIMMeta:output_type -> ypb.DbOperateMessage
+	805,  // 1837: ypb.Yak.DeleteAISession:output_type -> ypb.DbOperateMessage
+	163,  // 1838: ypb.Yak.GetRandomAIMaterials:output_type -> ypb.GetRandomAIMaterialsResponse
+	185,  // 1839: ypb.Yak.ExportAILogs:output_type -> ypb.ExportAILogsResponse
+	4,    // 1840: ypb.Yak.CreateAIMemoryEntity:output_type -> ypb.Empty
+	805,  // 1841: ypb.Yak.UpdateAIMemoryEntity:output_type -> ypb.DbOperateMessage
+	805,  // 1842: ypb.Yak.DeleteAIMemoryEntity:output_type -> ypb.DbOperateMessage
+	189,  // 1843: ypb.Yak.GetAIMemoryEntity:output_type -> ypb.AIMemoryEntity
+	192,  // 1844: ypb.Yak.QueryAIMemoryEntity:output_type -> ypb.QueryAIMemoryEntityResponse
+	196,  // 1845: ypb.Yak.CountAIMemoryEntityTags:output_type -> ypb.CountAIMemoryEntityTagsResponse
+	145,  // 1846: ypb.Yak.StartAITriage:output_type -> ypb.AIOutputEvent
+	805,  // 1847: ypb.Yak.CreateAIForge:output_type -> ypb.DbOperateMessage
+	805,  // 1848: ypb.Yak.UpdateAIForge:output_type -> ypb.DbOperateMessage
+	805,  // 1849: ypb.Yak.DeleteAIForge:output_type -> ypb.DbOperateMessage
+	177,  // 1850: ypb.Yak.QueryAIForge:output_type -> ypb.QueryAIForgeResponse
+	175,  // 1851: ypb.Yak.GetAIForge:output_type -> ypb.AIForge
+	42,   // 1852: ypb.Yak.ExportAIForge:output_type -> ypb.GeneralProgress
+	42,   // 1853: ypb.Yak.ImportAIForge:output_type -> ypb.GeneralProgress
+	183,  // 1854: ypb.Yak.QueryAIFocus:output_type -> ypb.QueryAIFocusResponse
+	198,  // 1855: ypb.Yak.StartMcpServer:output_type -> ypb.StartMcpServerResponse
+	128,  // 1856: ypb.Yak.GetToolSetList:output_type -> ypb.GetToolSetListResponse
+	141,  // 1857: ypb.Yak.GetAIToolList:output_type -> ypb.GetAIToolListResponse
+	805,  // 1858: ypb.Yak.DeleteAITool:output_type -> ypb.DbOperateMessage
+	805,  // 1859: ypb.Yak.SaveAITool:output_type -> ypb.DbOperateMessage
+	134,  // 1860: ypb.Yak.SaveAIToolV2:output_type -> ypb.SaveAIToolV2Response
+	805,  // 1861: ypb.Yak.UpdateAITool:output_type -> ypb.DbOperateMessage
+	138,  // 1862: ypb.Yak.ToggleAIToolFavorite:output_type -> ypb.ToggleAIToolFavoriteResponse
+	132,  // 1863: ypb.Yak.AIToolGenerateMetadata:output_type -> ypb.AIToolGenerateMetadataResponse
+	42,   // 1864: ypb.Yak.ExportAITool:output_type -> ypb.GeneralProgress
+	42,   // 1865: ypb.Yak.ImportAITool:output_type -> ypb.GeneralProgress
+	968,  // 1866: ypb.Yak.IsLlamaServerReady:output_type -> ypb.IsLlamaServerReadyResponse
+	970,  // 1867: ypb.Yak.IsLocalModelReady:output_type -> ypb.IsLocalModelReadyResponse
+	763,  // 1868: ypb.Yak.InstallLlamaServer:output_type -> ypb.ExecResult
+	763,  // 1869: ypb.Yak.StartLocalModel:output_type -> ypb.ExecResult
+	6,    // 1870: ypb.Yak.StopLocalModel:output_type -> ypb.GeneralResponse
+	763,  // 1871: ypb.Yak.DownloadLocalModel:output_type -> ypb.ExecResult
+	975,  // 1872: ypb.Yak.GetSupportedLocalModels:output_type -> ypb.GetSupportedLocalModelsResponse
+	6,    // 1873: ypb.Yak.AddLocalModel:output_type -> ypb.GeneralResponse
+	6,    // 1874: ypb.Yak.DeleteLocalModel:output_type -> ypb.GeneralResponse
+	6,    // 1875: ypb.Yak.UpdateLocalModel:output_type -> ypb.GeneralResponse
+	76,   // 1876: ypb.Yak.GetAllStartedLocalModels:output_type -> ypb.GetAllStartedLocalModelsResponse
+	6,    // 1877: ypb.Yak.ClearAllModels:output_type -> ypb.GeneralResponse
+	126,  // 1878: ypb.Yak.IsSearchVectorDatabaseReady:output_type -> ypb.IsSearchVectorDatabaseReadyResponse
+	763,  // 1879: ypb.Yak.InitSearchVectorDatabase:output_type -> ypb.ExecResult
+	124,  // 1880: ypb.Yak.GetAllVectorStoreCollections:output_type -> ypb.GetAllVectorStoreCollectionsResponse
+	123,  // 1881: ypb.Yak.GetAllVectorStoreCollectionsWithFilter:output_type -> ypb.GetAllVectorStoreCollectionsWithFilterResponse
+	6,    // 1882: ypb.Yak.DeleteSearchVectorDatabase:output_type -> ypb.GeneralResponse
+	6,    // 1883: ypb.Yak.UpdateVectorStoreCollection:output_type -> ypb.GeneralResponse
+	118,  // 1884: ypb.Yak.ListVectorStoreEntries:output_type -> ypb.ListVectorStoreEntriesResponse
+	6,    // 1885: ypb.Yak.CreateVectorStoreEntry:output_type -> ypb.GeneralResponse
+	120,  // 1886: ypb.Yak.GetDocumentByVectorStoreEntryID:output_type -> ypb.GetDocumentByVectorStoreEntryIDResponse
+	84,   // 1887: ypb.Yak.ListThirdPartyBinary:output_type -> ypb.ListThirdPartyBinaryResponse
+	763,  // 1888: ypb.Yak.InstallThirdPartyBinary:output_type -> ypb.ExecResult
+	6,    // 1889: ypb.Yak.UninstallThirdPartyBinary:output_type -> ypb.GeneralResponse
+	88,   // 1890: ypb.Yak.IsThirdPartyBinaryReady:output_type -> ypb.IsThirdPartyBinaryReadyResponse
+	763,  // 1891: ypb.Yak.StartThirdPartyBinary:output_type -> ypb.ExecResult
+	989,  // 1892: ypb.Yak.PluginTrace:output_type -> ypb.PluginTraceResponse
+	94,   // 1893: ypb.Yak.GetKnowledgeBaseNameList:output_type -> ypb.GetKnowledgeBaseNameListResponse
+	99,   // 1894: ypb.Yak.GetKnowledgeBase:output_type -> ypb.GetKnowledgeBaseResponse
+	96,   // 1895: ypb.Yak.GetKnowledgeBaseTypeList:output_type -> ypb.GetKnowledgeBaseTypeListResponse
+	6,    // 1896: ypb.Yak.DeleteKnowledgeBase:output_type -> ypb.GeneralResponse
+	6,    // 1897: ypb.Yak.CreateKnowledgeBase:output_type -> ypb.GeneralResponse
+	39,   // 1898: ypb.Yak.CreateKnowledgeBaseV2:output_type -> ypb.CreateKnowledgeBaseV2Response
+	6,    // 1899: ypb.Yak.UpdateKnowledgeBase:output_type -> ypb.GeneralResponse
+	6,    // 1900: ypb.Yak.DeleteKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
+	6,    // 1901: ypb.Yak.CreateKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
+	6,    // 1902: ypb.Yak.UpdateKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
+	107,  // 1903: ypb.Yak.SearchKnowledgeBaseEntry:output_type -> ypb.SearchKnowledgeBaseEntryResponse
+	106,  // 1904: ypb.Yak.QueryKnowledgeBaseByAI:output_type -> ypb.QueryKnowledgeBaseByAIResponse
+	6,    // 1905: ypb.Yak.BuildVectorIndexForKnowledgeBase:output_type -> ypb.GeneralResponse
+	6,    // 1906: ypb.Yak.BuildVectorIndexForKnowledgeBaseEntry:output_type -> ypb.GeneralResponse
+	91,   // 1907: ypb.Yak.GenerateQuestionIndexForKnowledgeBase:output_type -> ypb.GenerateQuestionIndexForKnowledgeBaseResponse
+	60,   // 1908: ypb.Yak.ListEntityRepository:output_type -> ypb.ListEntityRepositoryResponse
+	64,   // 1909: ypb.Yak.QueryEntity:output_type -> ypb.QueryEntityResponse
+	805,  // 1910: ypb.Yak.CreateEntity:output_type -> ypb.DbOperateMessage
+	805,  // 1911: ypb.Yak.UpdateEntity:output_type -> ypb.DbOperateMessage
+	805,  // 1912: ypb.Yak.DeleteEntity:output_type -> ypb.DbOperateMessage
+	69,   // 1913: ypb.Yak.QueryRelationship:output_type -> ypb.QueryRelationshipResponse
+	805,  // 1914: ypb.Yak.CreateRelationship:output_type -> ypb.DbOperateMessage
+	805,  // 1915: ypb.Yak.UpdateRelationship:output_type -> ypb.DbOperateMessage
+	805,  // 1916: ypb.Yak.DeleteRelationship:output_type -> ypb.DbOperateMessage
+	72,   // 1917: ypb.Yak.QuerySubERM:output_type -> ypb.QuerySubERMResponse
+	74,   // 1918: ypb.Yak.GenerateERMDot:output_type -> ypb.GenerateERMDotResponse
+	42,   // 1919: ypb.Yak.ExportKnowledgeBase:output_type -> ypb.GeneralProgress
+	42,   // 1920: ypb.Yak.ImportKnowledgeBase:output_type -> ypb.GeneralProgress
+	6,    // 1921: ypb.Yak.AddMCPServer:output_type -> ypb.GeneralResponse
+	6,    // 1922: ypb.Yak.DeleteMCPServer:output_type -> ypb.GeneralResponse
+	6,    // 1923: ypb.Yak.UpdateMCPServer:output_type -> ypb.GeneralResponse
+	53,   // 1924: ypb.Yak.GetAllMCPServers:output_type -> ypb.GetAllMCPServersResponse
+	6,    // 1925: ypb.Yak.UpdateMCPServerToolConfig:output_type -> ypb.GeneralResponse
+	56,   // 1926: ypb.Yak.GetMCPToolList:output_type -> ypb.GetMCPToolListResponse
+	54,   // 1927: ypb.Yak.GetMCPToolDetail:output_type -> ypb.MCPClientToolConfig
+	6,    // 1928: ypb.Yak.SetMCPToolEnabled:output_type -> ypb.GeneralResponse
+	44,   // 1929: ypb.Yak.RAGCollectionSearch:output_type -> ypb.RAGCollectionSearchResponse
+	763,  // 1930: ypb.Yak.DownloadRAGs:output_type -> ypb.ExecResult
+	16,   // 1931: ypb.Yak.SaveIMBot:output_type -> ypb.SaveIMBotResponse
+	18,   // 1932: ypb.Yak.ListIMBots:output_type -> ypb.ListIMBotResponse
+	20,   // 1933: ypb.Yak.DeleteIMBot:output_type -> ypb.DeleteIMBotResponse
+	22,   // 1934: ypb.Yak.TestIMBot:output_type -> ypb.TestIMBotResponse
+	24,   // 1935: ypb.Yak.StartIMOnboarding:output_type -> ypb.IMOnboardingEvent
+	27,   // 1936: ypb.Yak.StartIMControl:output_type -> ypb.StartIMControlResponse
+	29,   // 1937: ypb.Yak.StopIMControl:output_type -> ypb.StopIMControlResponse
+	31,   // 1938: ypb.Yak.SubscribeIMControlState:output_type -> ypb.IMControlStateEvent
+	36,   // 1939: ypb.Yak.UpdateIMControlConfig:output_type -> ypb.UpdateIMControlConfigResponse
+	1310, // [1310:1940] is the sub-list for method output_type
+	680,  // [680:1310] is the sub-list for method input_type
+	680,  // [680:680] is the sub-list for extension type_name
+	680,  // [680:680] is the sub-list for extension extendee
+	0,    // [0:680] is the sub-list for field type_name
 }
 
 func init() { file_yakgrpc_proto_init() }
@@ -82962,13 +83073,14 @@ func file_yakgrpc_proto_init() {
 		return
 	}
 	file_yakgrpc_proto_msgTypes[245].OneofWrappers = []any{}
+	file_yakgrpc_proto_msgTypes[706].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_yakgrpc_proto_rawDesc), len(file_yakgrpc_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   1020,
+			NumMessages:   1021,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
…eton

Oversized multipart/form-data requests now spill each file part to its own disk file under a sidecar directory (large-request-body-<id>-parts/), while the in-DB request keeps only an editable multipart skeleton with placeholder lines for the spilled files. The complete body is rebuilt (streaming file parts back from disk) into TooLargeRequestBodyFile, so GetHTTPFlowBodyById and the list/detail/download contracts are unchanged — no proto, DB schema, or frontend changes.

- spillMultipartFilesIfNeeded: per-part sidecar files + skeleton + rebuilt body
- spillLargeHTTPFlowRequestIfNeeded: tries multipart route before flat spill
- DeleteHTTPFlowByID: cleans up the derived sidecar directory
- fallback to flat spill for non-multipart or text-only multipart bodies