### PR TITLE
fix(ssadb): 清洗非法 UTF-8 字节序列，修复 PG 扫描编译失败

### DIFF
--- a/common/yak/ssa/ssadb/sanitize_for_pg.go
+++ b/common/yak/ssa/ssadb/sanitize_for_pg.go
@@ -3,34 +3,60 @@ package ssadb
 import (
 	"reflect"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/jinzhu/gorm"
 )
 
-// sanitizeStringForPG removes NUL bytes (\x00) from a string.
+// sanitizeStringForPG removes bytes that PostgreSQL rejects at the
+// wire-protocol level from a string. Two classes of bytes are stripped:
 //
-// PostgreSQL rejects NUL bytes at the wire-protocol level — they never reach
-// column validation, triggers, or CHECK constraints. Any Go string that
-// contains a NUL byte and is sent through libpq (e.g. via GORM tx.Save) will
-// fail with: "pq: invalid byte sequence for encoding \"UTF8\": 0x00".
+//  1. NUL bytes (\x00) — PG aborts with
+//     `pq: invalid byte sequence for encoding "UTF8": 0x00`.
+//  2. Invalid UTF-8 byte sequences — PG aborts with the same error family,
+//     e.g. `pq: invalid byte sequence for encoding "UTF8": 0xa0` or
+//     `... 0xe8 0x07 0x10`. A lone continuation byte (0xa0) or a 3-byte
+//     leader (0xe8) followed by non-continuation bytes (0x07 0x10) are not
+//     valid UTF-8 and PG rejects the whole batch.
 //
-// MySQL (utf8mb4) and SQLite tolerate NUL bytes, so this is a PostgreSQL-only
-// concern. SSA string constants derived from source code (e.g. binary resource
-// files parsed as constants) can carry NUL bytes; without stripping, the
-// entire batch write aborts and the scan fails at the compile phase.
+// Both failures abort the entire dbcache save batch, which on a large project
+// compile leaves hundreds of thousands of resident IR items unpersisted and
+// fails the scan at the compile phase with `resident items were not persisted
+// on close`.
 //
-// NUL bytes have no semantic value in SSA IR (they are never part of valid
-// source identifiers, type names, or instruction strings), so stripping is
-// lossless from the perspective of vulnerability detection.
+// MySQL (utf8mb4) and SQLite tolerate these bytes, so this is a
+// PostgreSQL-only concern. SSA string constants derived from source code
+// (e.g. binary resource files parsed as constants, non-UTF-8 source files)
+// can carry these bytes; stripping them is lossless from the perspective of
+// vulnerability detection — invalid bytes are never part of valid source
+// identifiers, type names, or instruction strings, and valid multi-byte UTF-8
+// content (CJK, emoji) is preserved by strings.ToValidUTF8.
+//
+// Invalid bytes are dropped (replaced with the empty string, not U+FFFD) to
+// keep IR string equality stable across re-compiles.
 func sanitizeStringForPG(s string) string {
-	if !strings.ContainsRune(s, 0) {
+	if !strings.ContainsRune(s, 0) && utf8.ValidString(s) {
 		return s
 	}
-	return strings.ReplaceAll(s, "\x00", "")
+	// strings.ToValidUTF8 replaces each invalid byte sequence with the given
+	// replacement; "" drops the invalid bytes entirely. It does NOT remove
+	// NUL bytes (NUL is a valid 1-byte UTF-8 rune), so strip NUL explicitly.
+	cleaned := strings.ToValidUTF8(s, "")
+	if strings.ContainsRune(cleaned, 0) {
+		cleaned = strings.ReplaceAll(cleaned, "\x00", "")
+	}
+	return cleaned
 }
 
-// sanitizeStructStringsForPG uses reflection to strip NUL bytes from every
-// string field (and every element of []string fields) on a struct. This
+// needsSanitize reports whether a string contains bytes PG would reject
+// (NUL or invalid UTF-8). Used as a fast path so clean strings — the common
+// case — are not copied.
+func needsSanitize(s string) bool {
+	return strings.ContainsRune(s, 0) || !utf8.ValidString(s)
+}
+
+// sanitizeStructStringsForPG uses reflection to strip PG-rejected bytes from
+// every string field (and every element of []string fields) on a struct. This
 // automatically covers newly added string fields without manual maintenance.
 //
 // It handles:
@@ -64,7 +90,7 @@ func sanitizeStructFieldsForPG(rv reflect.Value) {
 		switch field.Kind() {
 		case reflect.String:
 			s := field.String()
-			if strings.ContainsRune(s, 0) {
+			if needsSanitize(s) {
 				field.SetString(sanitizeStringForPG(s))
 			}
 		case reflect.Slice:
@@ -86,8 +112,8 @@ func sanitizeStructFieldsForPG(rv reflect.Value) {
 	}
 }
 
-// sanitizeStringSliceForPG strips NUL bytes from every element of a []string
-// slice (including the StringSlice custom type).
+// sanitizeStringSliceForPG strips PG-rejected bytes from every element of a
+// []string slice (including the StringSlice custom type).
 func sanitizeStringSliceForPG(field reflect.Value) {
 	if field.Type().Elem().Kind() != reflect.String {
 		return
@@ -96,7 +122,7 @@ func sanitizeStringSliceForPG(field reflect.Value) {
 	for i := 0; i < n; i++ {
 		elem := field.Index(i)
 		s := elem.String()
-		if strings.ContainsRune(s, 0) {
+		if needsSanitize(s) {
 			elem.SetString(sanitizeStringForPG(s))
 		}
 	}
@@ -106,7 +132,7 @@ func sanitizeStringSliceForPG(field reflect.Value) {
 //
 // These hooks fire on every GORM write path: tx.Save, db.Save, db.Create,
 // and db.Where().Assign().FirstOrCreate() (used by UpsertIrCode). They run
-// before the row is sent to PostgreSQL, stripping NUL bytes that PG would
+// before the row is sent to PostgreSQL, stripping bytes that PG would
 // reject at the protocol level.
 
 func (r *IrCode) BeforeSave(tx *gorm.DB) error {

--- a/common/yak/ssa/ssadb/sanitize_for_pg_test.go
+++ b/common/yak/ssa/ssadb/sanitize_for_pg_test.go
@@ -3,6 +3,7 @@ package ssadb
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
@@ -25,6 +26,32 @@ func TestSanitizeStringForPG(t *testing.T) {
 		{"empty", "", ""},
 		{"tab is preserved", "hello\tworld", "hello\tworld"},
 		{"newline is preserved", "hello\nworld", "hello\nworld"},
+		// Invalid UTF-8 byte sequences — PostgreSQL rejects these at the
+		// wire-protocol level just like NUL bytes. Observed in real scans:
+		//   0xa0               (lone continuation byte, no leading byte)
+		//   0xe8 0x07 0x10     (0xe8 starts a 3-byte seq, but 0x07/0x10 are
+		//                       not valid continuation bytes 0x80-0xBF)
+		// The sanitizer must produce a string PG will accept: valid UTF-8
+		// and no NUL. strings.ToValidUTF8 strips the *invalid* bytes (the
+		// 0xa0, or the 0xe8 leader) but keeps bytes that are valid UTF-8 on
+		// their own (0x07/0x10 are valid ASCII control chars once 0xe8 is
+		// gone). The invariant under test is "PG would accept the result",
+		// not "all suspicious bytes vanished".
+		{"lone 0xa0 stripped", "hello\xa0world", "helloworld"},
+		{"leading 0xa0 stripped", "\xa0start", "start"},
+		{"trailing 0xa0 stripped", "end\xa0", "end"},
+		// 0xe8 is the invalid byte (3-byte leader without valid continuations);
+		// 0x07 0x10 are valid ASCII once 0xe8 is removed.
+		{"invalid 3-byte leader 0xe8 stripped, valid ascii kept", "ab\xe8\x07\x10cd", "ab\x07\x10cd"},
+		{"only invalid 0xa0", "\xa0\xa0\xa0", ""},
+		{"mixed NUL and 0xa0", "a\x00b\xa0c", "abc"},
+		// Valid multi-byte UTF-8 MUST be preserved (regression guard — the
+		// sanitizer must not nuke legitimate CJK / emoji content).
+		{"valid CJK preserved", "你好世界", "你好世界"},
+		{"valid emoji preserved", "hello \xf0\x9f\x98\x80 world", "hello \xf0\x9f\x98\x80 world"},
+		{"valid 2-byte preserved", "caf\xc3\xa9", "caf\xc3\xa9"}, // café
+		// Invalid byte in the middle of an otherwise-valid run
+		{"invalid between valid CJK", "你\xa0好", "你好"},
 	}
 
 	for _, tt := range tests {
@@ -32,10 +59,11 @@ func TestSanitizeStringForPG(t *testing.T) {
 			result := sanitizeStringForPG(tt.input)
 			assert.Equal(t, tt.expected, result)
 			assert.False(t, strings.ContainsRune(result, 0), "result must not contain NUL byte")
+			assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
 		})
 	}
 
-	// Fast path: strings without NUL should be returned as-is (same pointer)
+	// Fast path: clean strings should be returned as-is (same pointer)
 	clean := "no nulls here"
 	result := sanitizeStringForPG(clean)
 	assert.Equal(t, clean, result)
@@ -172,4 +200,89 @@ func TestBeforeSaveHookStripsNUL_UpsertIrCode(t *testing.T) {
 	require.NoError(t, db.Where("program_name = ?", "testupsert").First(&result).Error)
 	assert.Equal(t, "testupsert", result.ProgramName)
 	assert.Equal(t, "funcx", result.Name)
+}
+
+// TestSanitizeStructStringsForPG_InvalidUTF8_IrCode verifies that illegal
+// UTF-8 byte sequences (the 0xa0 / 0xe8 0x07 0x10 patterns observed in real
+// scans) are stripped from every string field on IrCode, while valid multi-byte
+// UTF-8 (CJK, emoji) is preserved.
+func TestSanitizeStructStringsForPG_InvalidUTF8_IrCode(t *testing.T) {
+	ir := &IrCode{
+		ProgramName:       "test\xa0program",
+		Name:              "func\xe8\x07\x10name",
+		VerboseName:       "verbose\xa0name",
+		ShortVerboseName:  "short\xe8\x07\x10name",
+		String:            "const\xa0value",
+		OpcodeName:        "opcode",
+		SourceCodeHash:    "hash\xa0abc",
+		ProgramCompileHash: "compile\xe8\x07\x10hash",
+		ConstType:         "normal",
+		Variable:          StringSlice{"var\xa01", "var2", "var\xe8\x07\x103"},
+	}
+
+	sanitizeStructStringsForPG(ir)
+
+	// 0xa0 is a lone continuation byte → stripped entirely.
+	// 0xe8 0x07 0x10 → 0xe8 is the invalid 3-byte leader, stripped; 0x07 0x10
+	// are valid ASCII control chars once 0xe8 is gone, so they survive.
+	assert.True(t, utf8.ValidString(ir.ProgramName), "ProgramName must be valid UTF-8")
+	assert.Equal(t, "testprogram", ir.ProgramName)
+	assert.True(t, utf8.ValidString(ir.Name), "Name must be valid UTF-8")
+	assert.Equal(t, "func\x07\x10name", ir.Name)
+	assert.Equal(t, "verbosename", ir.VerboseName)
+	assert.Equal(t, "short\x07\x10name", ir.ShortVerboseName)
+	assert.Equal(t, "constvalue", ir.String)
+	assert.Equal(t, "hashabc", ir.SourceCodeHash)
+	assert.Equal(t, "compile\x07\x10hash", ir.ProgramCompileHash)
+	// Non-invalid fields unchanged
+	assert.Equal(t, "opcode", ir.OpcodeName)
+	assert.Equal(t, "normal", ir.ConstType)
+	// StringSlice elements
+	assert.Equal(t, StringSlice{"var1", "var2", "var\x07\x103"}, ir.Variable)
+}
+
+// TestSanitizeStringForPG_PreservesValidUTF8 is a focused regression guard:
+// the sanitizer must only strip *invalid* bytes, never legitimate multi-byte
+// UTF-8 content that source code legitimately contains.
+func TestSanitizeStringForPG_PreservesValidUTF8(t *testing.T) {
+	cases := []string{
+		"你好世界",                                     // 4 CJK chars
+		"hello \xf0\x9f\x98\x80 world",                // emoji
+		"caf\xc3\xa9",                                  // café (2-byte)
+		"日本語テスト",                                  // Japanese
+		"\xe4\xb8\xad\xe6\x96\x87",                     // 中文
+	}
+	for _, s := range cases {
+		result := sanitizeStringForPG(s)
+		assert.Equal(t, s, result, "valid UTF-8 must be preserved: %q", s)
+		assert.True(t, utf8.ValidString(result))
+	}
+}
+
+// TestBeforeSaveHookStripsInvalidUTF8_IrCode verifies the BeforeSave hook
+// fires on the SQLite path and strips invalid UTF-8 bytes (SQLite tolerates
+// them, so without the hook they would be stored as-is).
+func TestBeforeSaveHookStripsInvalidUTF8_IrCode(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&IrCode{}).Error)
+
+	ir := &IrCode{
+		ProgramName: "test\xa0program",
+		Name:        "func\xe8\x07\x10name",
+		String:      "hello\xa0world\xe8\x07\x10!",
+	}
+	require.NoError(t, db.Save(ir).Error)
+
+	var result IrCode
+	require.NoError(t, db.First(&result, ir.ID).Error)
+
+	assert.True(t, utf8.ValidString(result.ProgramName), "ProgramName must be valid UTF-8")
+	assert.True(t, utf8.ValidString(result.Name), "Name must be valid UTF-8")
+	assert.True(t, utf8.ValidString(result.String), "String must be valid UTF-8")
+	assert.Equal(t, "testprogram", result.ProgramName)
+	assert.Equal(t, "func\x07\x10name", result.Name)
+	assert.Equal(t, "helloworld\x07\x10!", result.String)
 }


### PR DESCRIPTION
## 改动摘要

PostgreSQL 在 wire-protocol 层拒绝非法 UTF-8 字节序列（与 NUL 字节同一家族错误）。现有 `sanitize_for_pg.go` 只剥 NUL (0x00)，不处理其他非法序列。远端 PG 部署实测扫描大项目时反复报：

```
pq: invalid byte sequence for encoding "UTF8": 0xa0
pq: invalid byte sequence for encoding "UTF8": 0xe8 0x07 0x10
dbcache save failed: pq: invalid byte sequence ...
编译失败: persist IR to database failed: dbcache: 676969 resident items were not persisted on close
```

根因：lone continuation byte (0xa0) 或 3-byte leader (0xe8) 后跟非 continuation 字节 (0x07 0x10) 不是合法 UTF-8，PG 拒绝整批 dbcache save → 大项目编译时数十万 resident IR item 无法持久化 → 编译阶段失败。

## 修复

扩展 `sanitizeStringForPG`：用 `strings.ToValidUTF8(s, "")` 剥离非法 UTF-8 字节序列（保留合法 CJK/emoji），再剥 NUL。`BeforeSave` hooks（IrCode/IrType/IrNamePool/IrOffset）同时覆盖 NUL 和非法 UTF-8。

非法字节直接丢弃（替换为空串，非 U+FFFD），保持 IR 字符串跨重编译的相等性稳定。

## 改动文件

- `common/yak/ssa/ssadb/sanitize_for_pg.go` — 扩展清洗逻辑 + `needsSanitize` 快速路径
- `common/yak/ssa/ssadb/sanitize_for_pg_test.go` — 新增 4 个测试覆盖非法 UTF-8 场景

## 验证方式

- `go test ./common/yak/ssa/ssadb/` → `ok 0.3s`（含新增测试全绿）

## PR 分流说明

本 PR 为 **main track**（→ `origin/main`），让 main 的扫描引擎快速获得此 fix。

同一 fix 同时提交了 refactor track PR（→ `go0p/refactor/scannode`，PR #4800），因为远端 smoke-node 跑的是 scannode 基线。两个 PR 的 SSA DB 改动相同（同一 commit cherry-pick），最终 main rebase 时由 owner 统一去重——届时 refactor 基线 rebase 到已含此 fix 的 main 上，重复改动自动 drop，保留 reviewed 版本。