### PR TITLE
fix(ssa): 异步 saver 错误冒泡，编译失败时触发 DeleteProgram 清库

### DIFF
--- a/common/utils/dbcache/databasex.go
+++ b/common/utils/dbcache/databasex.go
@@ -127,8 +127,8 @@ func NewCache[T MemoryItem, D any](
 			}, nil
 		})
 
-		cache.saver = NewSave(func(tasks []*saveTask[D]) {
-			cache.handleSaveBatch(tasks, save)
+		cache.saver = NewSave(func(tasks []*saveTask[D]) error {
+			return cache.handleSaveBatch(tasks, save)
 		},
 			WithContext(ctx),
 			WithSaveSize(cfg.saveSize),
@@ -221,7 +221,7 @@ func (c *Cache[T, D]) FlushKeys(keys []int64, reason utils.EvictionReason) {
 	}
 	if len(keys) == 0 {
 		if c.saver != nil {
-			c.saver.Flush()
+			_ = c.saver.Flush()
 		}
 		return
 	}
@@ -235,7 +235,7 @@ func (c *Cache[T, D]) FlushKeys(keys []int64, reason utils.EvictionReason) {
 	defer ticker.Stop()
 	for {
 		if c.saver != nil {
-			c.saver.Flush()
+			_ = c.saver.Flush()
 		}
 		select {
 		case <-done:
@@ -292,7 +292,7 @@ func (c *Cache[T, D]) Close() error {
 	}
 	c.wg.Wait()
 	if c.saver != nil {
-		c.saver.Close()
+		closeErr = utils.JoinErrors(closeErr, c.saver.Close())
 	}
 	remaining := 0
 	if c.resident != nil {
@@ -419,7 +419,7 @@ func (c *Cache[T, D]) CloseWithoutSave() {
 	}
 	c.wg.Wait()
 	if c.saver != nil {
-		c.saver.Close()
+		_ = c.saver.Close()
 	}
 	if c.cancel != nil {
 		c.cancel()
@@ -447,9 +447,9 @@ func (c *Cache[T, D]) IsSaveDisabled() bool {
 	return c.resident.IsSaveDisabled()
 }
 
-func (c *Cache[T, D]) handleSaveBatch(tasks []*saveTask[D], save SaveFunc[D]) {
+func (c *Cache[T, D]) handleSaveBatch(tasks []*saveTask[D], save SaveFunc[D]) error {
 	if c == nil || c.resident == nil {
-		return
+		return nil
 	}
 
 	saveTasks := make([]*saveTask[D], 0, len(tasks))
@@ -468,13 +468,13 @@ func (c *Cache[T, D]) handleSaveBatch(tasks []*saveTask[D], save SaveFunc[D]) {
 	}
 
 	if len(saveTasks) == 0 {
-		return
+		return nil
 	}
 	if save == nil {
 		for _, task := range saveTasks {
 			c.resident.FinishPersist(task.request.key, task.request.generation, false)
 		}
-		return
+		return nil
 	}
 
 	if err := save(saveData); err != nil {
@@ -482,9 +482,10 @@ func (c *Cache[T, D]) handleSaveBatch(tasks []*saveTask[D], save SaveFunc[D]) {
 		for _, task := range saveTasks {
 			c.resident.FinishPersist(task.request.key, task.request.generation, false)
 		}
-		return
+		return err
 	}
 	for _, task := range saveTasks {
 		c.resident.FinishPersist(task.request.key, task.request.generation, true)
 	}
+	return nil
 }

--- a/common/utils/dbcache/save.go
+++ b/common/utils/dbcache/save.go
@@ -14,8 +14,14 @@ import (
 
 // Save provides a way to collect items and save them in batches using a background goroutine.
 // It buffers items and periodically passes them to a save function for processing.
+//
+// Errors returned by the save callback are accumulated and surfaced via Close/Flush.
+// The saver records only the first error (set-once semantics); subsequent errors are
+// logged but do not overwrite the recorded one. This ensures that a batch write failure
+// (e.g. PG rejects a value, connection drop) is not silently swallowed — callers can
+// check the return value of Close/Flush and abort the overall operation.
 type Save[T any] struct {
-	saveToDB func([]T) // Function to save items to the database
+	saveToDB func([]T) error // Function to save items to the database
 
 	buffer *chanx.UnlimitedChan[T] // Channel for buffering items
 	flush  chan flushRequest
@@ -29,6 +35,11 @@ type Save[T any] struct {
 	cancel  context.CancelFunc // Function to cancel the context
 
 	metrics saveMetrics
+
+	// firstErr holds the first error returned by a save callback. Set-once via
+	// CompareAndSwap; subsequent errors are logged but not stored. Read by
+	// Close/Flush to report failures to the caller.
+	firstErr atomic.Pointer[error]
 }
 
 // SaveStats is a compact debug snapshot of the async saver state.
@@ -141,12 +152,20 @@ func resetTimer(timer *time.Timer, duration time.Duration) {
 
 // flushRequest asks the saver goroutine to synchronously drain buffered items;
 // it closes done once all queued items have been handed to the save function.
-type flushRequest struct{ done chan struct{} }
+// err is a pointer so the goroutine can write the result back to the caller's
+// flushRequest copy (the channel passes a struct value, so a non-pointer field
+// would be isolated to the receiver's copy).
+type flushRequest struct {
+	done chan struct{}
+	err  *error
+}
 
 // NewSave creates a new Saver with the specified buffer size and save function.
 // It starts a background goroutine to process items from the buffer.
+// The saveToDB callback must return an error if the batch write fails; this
+// error is accumulated and surfaced via Close/Flush.
 func NewSave[T any](
-	saveToDB func([]T),
+	saveToDB func([]T) error,
 	opt ...Option,
 ) *Save[T] {
 	cfg := NewConfig(opt...)
@@ -154,7 +173,7 @@ func NewSave[T any](
 }
 
 func NewSaveWithConfig[T any](
-	saveToDB func([]T),
+	saveToDB func([]T) error,
 	cfg *config,
 ) *Save[T] {
 	if utils.IsNil(saveToDB) {
@@ -229,6 +248,9 @@ func (s *Save[T]) processBuffer() {
 			items = make([]T, 0, saveSize)
 			resetTimer(timer, saveTime)
 			s.saveWG.Wait()
+			if req.err != nil {
+				*req.err = s.recordedErr()
+			}
 			close(req.done)
 		case item, ok := <-s.buffer.OutputChannel():
 			if !ok {
@@ -297,24 +319,30 @@ func (s *Save[T]) Save(item T) {
 // Flush synchronously persists all items queued so far and returns once they
 // have been handed to the save function. The caller MUST NOT call Save
 // concurrently with Flush. Flush is safe to call after Close returns (it is a
-// no-op once the context is cancelled).
-func (s *Save[T]) Flush() {
+// no-op once the context is cancelled). It returns the first error recorded by
+// any save callback, or nil if all batches succeeded.
+func (s *Save[T]) Flush() error {
 	if s == nil {
-		return
+		return nil
 	}
-	req := flushRequest{done: make(chan struct{})}
+	var flushErr error
+	req := flushRequest{done: make(chan struct{}), err: &flushErr}
 	select {
 	case s.flush <- req:
 		<-req.done
+		return flushErr
 	case <-s.ctx.Done():
+		return s.recordedErr()
 	}
 }
 
 // Close stops the background goroutine and waits for it to finish.
 // It also processes any remaining items in the buffer before returning.
-func (s *Save[T]) Close() {
+// It returns the first error recorded by any save callback, or nil if all
+// batches succeeded.
+func (s *Save[T]) Close() error {
 	if s == nil {
-		return
+		return nil
 	}
 	s.buffer.Close() // Close the buffer
 	s.wg.Wait()      // Wait for the background goroutine to finish
@@ -322,6 +350,7 @@ func (s *Save[T]) Close() {
 	if s.cancel != nil {
 		s.cancel()
 	}
+	return s.recordedErr()
 }
 
 func (s *Save[T]) Stats() SaveStats {
@@ -354,11 +383,36 @@ func (s *Save[T]) dispatchSave(ts []T) {
 func (s *Save[T]) runSave(ts []T) {
 	start := time.Now()
 	defer func() {
-		if err := recover(); err != nil {
-			log.Errorf("dbcache batch save panic: %v", err)
+		if r := recover(); r != nil {
+			log.Errorf("dbcache batch save panic: %v", r)
 			utils.PrintCurrentGoroutineRuntimeStack()
+			s.recordErr(fmt.Errorf("dbcache batch save panic: %v", r))
 		}
 		s.metrics.recordBatch(len(ts), time.Since(start))
 	}()
-	s.saveToDB(ts)
+	if err := s.saveToDB(ts); err != nil {
+		log.Errorf("dbcache batch save failed (%s): %v", s.config.name, err)
+		s.recordErr(err)
+	}
+}
+
+// recordErr stores the first error using set-once semantics. Subsequent calls
+// are no-ops so the earliest failure is preserved.
+func (s *Save[T]) recordErr(err error) {
+	if err == nil {
+		return
+	}
+	// Don't overwrite if we already have a recorded error.
+	if s.firstErr.Load() != nil {
+		return
+	}
+	s.firstErr.CompareAndSwap(nil, &err)
+}
+
+// recordedErr returns the first recorded error, or nil.
+func (s *Save[T]) recordedErr() error {
+	if p := s.firstErr.Load(); p != nil {
+		return *p
+	}
+	return nil
 }

--- a/common/utils/dbcache/save_test.go
+++ b/common/utils/dbcache/save_test.go
@@ -2,6 +2,7 @@ package dbcache_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -21,15 +22,16 @@ type TestItem struct {
 func TestNewSaver(t *testing.T) {
 	// Test with default options
 	savedItems := make([]TestItem, 0)
-	saveFn := func(items []TestItem) {
+	saveFn := func(items []TestItem) error {
 		savedItems = append(savedItems, items...)
+		return nil
 	}
 
 	saver := dbcache.NewSave(saveFn)
 	require.NotNil(t, saver)
 	// We can't directly access internal fields of Saver from the test package
 	// Just verify that the saver is created successfully and can be closed
-	saver.Close()
+	require.NoError(t, saver.Close())
 
 	// Test with custom options
 	ctx := context.Background()
@@ -40,16 +42,17 @@ func TestNewSaver(t *testing.T) {
 	)
 	require.NotNil(t, saver)
 	// Can't access internal field wg
-	saver.Close()
+	require.NoError(t, saver.Close())
 }
 
 func TestSaver_Save(t *testing.T) {
 	savedItems := []TestItem{}
 	saveMutex := &sync.Mutex{}
-	saveFn := func(items []TestItem) {
+	saveFn := func(items []TestItem) error {
 		saveMutex.Lock()
 		defer saveMutex.Unlock()
 		savedItems = append(savedItems, items...)
+		return nil
 	}
 
 	ttl := 100 * time.Millisecond
@@ -107,10 +110,11 @@ func TestSaver_Save(t *testing.T) {
 func TestSaver_Close(t *testing.T) {
 	savedItems := []TestItem{}
 	saveMutex := &sync.Mutex{}
-	saveFn := func(items []TestItem) {
+	saveFn := func(items []TestItem) error {
 		saveMutex.Lock()
 		defer saveMutex.Unlock()
 		savedItems = append(savedItems, items...)
+		return nil
 	}
 
 	saver := dbcache.NewSave(saveFn)
@@ -127,7 +131,7 @@ func TestSaver_Close(t *testing.T) {
 	}
 
 	// Then close, should process remaining items
-	saver.Close()
+	require.NoError(t, saver.Close())
 
 	saveMutex.Lock()
 	require.GreaterOrEqual(t, len(savedItems), 3, "Should have saved at least one item")
@@ -137,10 +141,11 @@ func TestSaver_Close(t *testing.T) {
 func TestSaver_WithCustomContext(t *testing.T) {
 	savedItems := []TestItem{}
 	saveMutex := &sync.Mutex{}
-	saveFn := func(items []TestItem) {
+	saveFn := func(items []TestItem) error {
 		saveMutex.Lock()
 		defer saveMutex.Unlock()
 		savedItems = append(savedItems, items...)
+		return nil
 	}
 
 	// Create a context that can be canceled
@@ -188,11 +193,12 @@ func TestSaveAutoSaveSize(t *testing.T) {
 	var savedItemSize []int
 	var mu sync.Mutex
 
-	saveFn := func(items []int) {
+	saveFn := func(items []int) error {
 		mu.Lock()
 		defer mu.Unlock()
 		savedItemSize = append(savedItemSize, len(items))
 		// Make a copy of the slice
+		return nil
 	}
 
 	save := dbcache.NewSave(saveFn,
@@ -220,7 +226,7 @@ func TestSaver_SaveRunsSerially(t *testing.T) {
 	var active atomic.Int32
 	var maxActive atomic.Int32
 
-	saveFn := func(items []int) {
+	saveFn := func(items []int) error {
 		current := active.Add(1)
 		for {
 			maxSeen := maxActive.Load()
@@ -230,6 +236,7 @@ func TestSaver_SaveRunsSerially(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 		active.Add(-1)
+		return nil
 	}
 
 	saver := dbcache.NewSave(saveFn,
@@ -246,15 +253,16 @@ func TestSaver_SaveRunsSerially(t *testing.T) {
 
 func TestSaver_Stats(t *testing.T) {
 	var batches int
-	saver := dbcache.NewSave(func(items []int) {
+	saver := dbcache.NewSave(func(items []int) error {
 		batches++
 		time.Sleep(10 * time.Millisecond)
+		return nil
 	}, dbcache.WithSaveSize(2), dbcache.WithSaveTimeout(30*time.Millisecond))
 
 	saver.Save(1)
 	saver.Save(2)
 	saver.Save(3)
-	saver.Close()
+	require.NoError(t, saver.Close())
 
 	stats := saver.Stats()
 	require.Equal(t, 3, int(stats.BatchItemsTotal))
@@ -263,4 +271,48 @@ func TestSaver_Stats(t *testing.T) {
 	require.GreaterOrEqual(t, int(stats.MaxBatchSize), 1)
 	require.GreaterOrEqual(t, stats.SaveTimeTotal, 10*time.Millisecond)
 	require.Equal(t, int(stats.BatchCount), batches)
+}
+
+func TestSaver_CloseReturnsError(t *testing.T) {
+	wantErr := errors.New("db write failed")
+	saver := dbcache.NewSave(func(items []TestItem) error {
+		return wantErr
+	}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond))
+
+	saver.Save(TestItem{ID: 1, Data: "trigger"})
+	err := saver.Close()
+	require.Error(t, err)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestSaver_FlushReturnsError(t *testing.T) {
+	wantErr := errors.New("flush write failed")
+	saver := dbcache.NewSave(func(items []TestItem) error {
+		return wantErr
+	}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond))
+
+	saver.Save(TestItem{ID: 1, Data: "trigger"})
+	err := saver.Flush()
+	require.Error(t, err)
+	require.ErrorIs(t, err, wantErr)
+	_ = saver.Close()
+}
+
+func TestSaver_PanicRecordedAsError(t *testing.T) {
+	saver := dbcache.NewSave(func(items []TestItem) error {
+		panic("boom in save callback")
+	}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond))
+
+	saver.Save(TestItem{ID: 1, Data: "trigger"})
+	err := saver.Close()
+	require.Error(t, err)
+}
+
+func TestSaver_CloseNoErrorOnSuccess(t *testing.T) {
+	saver := dbcache.NewSave(func(items []TestItem) error {
+		return nil
+	}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond))
+
+	saver.Save(TestItem{ID: 1, Data: "ok"})
+	require.NoError(t, saver.Close())
 }

--- a/common/yak/ssa/database_cache.go
+++ b/common/yak/ssa/database_cache.go
@@ -176,14 +176,18 @@ func (c *ProgramCache) SaveToDatabase(cb ...func(int)) error {
 	steps := []func() error{
 		func() error {
 			if c.types != nil {
-				c.types.close()
+				if err := c.types.close(); err != nil {
+					return err
+				}
 				log.Infof("Type Cache closed")
 			}
 			return nil
 		},
 		func() error {
 			if c.indexes != nil {
-				c.indexes.Close()
+				if err := c.indexes.Close(); err != nil {
+					return err
+				}
 			}
 			return nil
 		},
@@ -198,7 +202,9 @@ func (c *ProgramCache) SaveToDatabase(cb ...func(int)) error {
 		},
 		func() error {
 			if c.sources != nil {
-				c.sources.Close()
+				if err := c.sources.Close(); err != nil {
+					return err
+				}
 			}
 			return nil
 		},
@@ -284,10 +290,14 @@ func (c *ProgramCache) FlushAuxSavers() {
 		return
 	}
 	if c.indexes != nil {
-		c.indexes.Flush() // indexStore.Flush -> indexSaver.Flush + offsetSaver.Flush
+		if err := c.indexes.Flush(); err != nil {
+			log.Errorf("FlushAuxSavers: index store flush failed: %v", err)
+		}
 	}
 	if c.types != nil {
-		c.types.flush() // typeStore.flush: marshal+batch-INSERT resident types, keeps resident map
+		if err := c.types.flush(); err != nil {
+			log.Errorf("FlushAuxSavers: type store flush failed: %v", err)
+		}
 	}
 }
 

--- a/common/yak/ssa/database_cache_index.go
+++ b/common/yak/ssa/database_cache_index.go
@@ -42,7 +42,7 @@ func newIndexStore(cfg *ssaconfig.Config, prog *Program, mode ProgramCacheKind, 
 		return store
 	}
 
-	store.indexSaver = dbcache.NewSave(func(indices []*ssadb.IrIndex) {
+	store.indexSaver = dbcache.NewSave(func(indices []*ssadb.IrIndex) error {
 		saveStep := func() error {
 			return utils.GormTransaction(db, func(tx *gorm.DB) error {
 				batch := make([]*ssadb.IrIndex, 0, len(indices))
@@ -55,19 +55,19 @@ func newIndexStore(cfg *ssaconfig.Config, prog *Program, mode ProgramCacheKind, 
 				return nil
 			})
 		}
-		store.diagnosticsTrack("ssa.Database.SaveIrIndexBatch", saveStep)
+		return store.diagnosticsTrackErr("ssa.Database.SaveIrIndexBatch", saveStep)
 	},
 		dbcache.WithSaveSize(saveSize),
 		dbcache.WithSaveTimeout(saveTime),
 		dbcache.WithName("IrIndex"),
 	)
-	store.offsetSaver = dbcache.NewSave(func(offsets []*ssadb.IrOffset) {
+	store.offsetSaver = dbcache.NewSave(func(offsets []*ssadb.IrOffset) error {
 		saveStep := func() error {
 			return utils.GormTransaction(db, func(tx *gorm.DB) error {
 				return ssadb.SaveIrOffsetBatch(tx, offsets)
 			})
 		}
-		store.diagnosticsTrack("ssa.Database.SaveIrOffsetBatch", saveStep)
+		return store.diagnosticsTrackErr("ssa.Database.SaveIrOffsetBatch", saveStep)
 	},
 		dbcache.WithSaveSize(saveSize),
 		dbcache.WithSaveTimeout(saveTime),
@@ -76,28 +76,40 @@ func newIndexStore(cfg *ssaconfig.Config, prog *Program, mode ProgramCacheKind, 
 	return store
 }
 
-func (s *indexStore) Close() {
+func (s *indexStore) Close() error {
 	if s == nil {
-		return
+		return nil
 	}
+	var errs []error
 	if s.indexSaver != nil {
-		s.indexSaver.Close()
+		if err := s.indexSaver.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if s.offsetSaver != nil {
-		s.offsetSaver.Close()
+		if err := s.offsetSaver.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
+	return utils.JoinErrors(errs...)
 }
 
-func (s *indexStore) Flush() {
+func (s *indexStore) Flush() error {
 	if s == nil {
-		return
+		return nil
 	}
+	var errs []error
 	if s.indexSaver != nil {
-		s.indexSaver.Flush()
+		if err := s.indexSaver.Flush(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if s.offsetSaver != nil {
-		s.offsetSaver.Flush()
+		if err := s.offsetSaver.Flush(); err != nil {
+			errs = append(errs, err)
+		}
 	}
+	return utils.JoinErrors(errs...)
 }
 
 func (s *indexStore) AddInstructionOffsets(inst Instruction) {
@@ -218,15 +230,21 @@ func (s *indexStore) FindByVariableEx(mod ssadb.MatchMode, checkValue func(strin
 }
 
 func (s *indexStore) diagnosticsTrack(name string, steps ...func() error) {
+	_ = s.diagnosticsTrackErr(name, steps...)
+}
+
+func (s *indexStore) diagnosticsTrackErr(name string, steps ...func() error) error {
 	if s == nil || s.program == nil {
 		for _, step := range steps {
 			if step != nil {
-				_ = step()
+				if err := step(); err != nil {
+					return err
+				}
 			}
 		}
-		return
+		return nil
 	}
-	s.program.DiagnosticsTrack(name, steps...)
+	return s.program.DiagnosticsTrackErr(name, steps...)
 }
 
 func (s *indexStore) SaveVariableOffset(variable *Variable, rng *memedit.Range) {

--- a/common/yak/ssa/database_cache_source.go
+++ b/common/yak/ssa/database_cache_source.go
@@ -170,28 +170,28 @@ func (s *sourceStore) markPersisted(hashes ...string) {
 	}
 }
 
-func (s *sourceStore) Close() {
+func (s *sourceStore) Close() error {
 	if s == nil || s.mode != ProgramCacheDBWrite || s.db == nil {
-		return
+		return nil
 	}
 	defer s.releaseEditors()
-	s.Flush()
+	return s.Flush()
 }
 
-func (s *sourceStore) Flush() {
+func (s *sourceStore) Flush() error {
 	if s == nil || s.mode != ProgramCacheDBWrite || s.db == nil {
-		return
+		return nil
 	}
 
 	sources, hashes := s.collectRegisteredSources()
 	if len(sources) == 0 {
-		return
+		return nil
 	}
 
 	existing, err := s.lookupPersistedHashes(hashes)
 	if err != nil {
 		log.Errorf("DATABASE: lookup ir source in database error: %v", err)
-		return
+		return err
 	}
 	if len(existing) > 0 {
 		s.markPersisted(existing...)
@@ -216,7 +216,7 @@ func (s *sourceStore) Flush() {
 		savedHashes = append(savedHashes, hash)
 	}
 	if len(toSave) == 0 {
-		return
+		return nil
 	}
 
 	saveErr := utils.GormTransaction(s.db, func(tx *gorm.DB) error {
@@ -232,9 +232,10 @@ func (s *sourceStore) Flush() {
 	})
 	if saveErr != nil {
 		log.Errorf("DATABASE: save ir source to database error: %v", saveErr)
-		return
+		return saveErr
 	}
 	s.markPersisted(savedHashes...)
+	return nil
 }
 
 func (s *sourceStore) ReleasePersistedEditors() int {

--- a/common/yak/ssa/database_cache_test.go
+++ b/common/yak/ssa/database_cache_test.go
@@ -1,11 +1,13 @@
 package ssa
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils/dbcache"
 	"github.com/yaklang/yaklang/common/utils/filesys"
 	"github.com/yaklang/yaklang/common/utils/memedit"
 	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
@@ -1139,4 +1141,53 @@ func TestInstructionCache_SaveDeduplicatesSourcesWithinBatch(t *testing.T) {
 		Count(&count).Error
 	require.NoError(t, err)
 	require.Equal(t, 1, count, "same editor hash should only be persisted once per batch")
+}
+
+// TestIndexStore_ClosePropagatesSaverError verifies that indexStore.Close
+// returns the error from a failing index/offset saver, rather than silently
+// swallowing it. This is the regression test for the "async saver swallows
+// errors" bug — a failed batch write must surface so that SaveToDatabase can
+// return an error and trigger DeleteProgram cleanup.
+func TestIndexStore_ClosePropagatesSaverError(t *testing.T) {
+	wantErr := errors.New("simulated db write failure")
+
+	store := &indexStore{
+		mode:    ProgramCacheDBWrite,
+		indexSaver: dbcache.NewSave(func(indices []*ssadb.IrIndex) error {
+			return wantErr
+		}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond)),
+		offsetSaver: dbcache.NewSave(func(offsets []*ssadb.IrOffset) error {
+			return nil
+		}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond)),
+	}
+
+	// Trigger a save batch
+	store.indexSaver.Save(ssadb.CreateIndex("test-prog"))
+	err := store.Close()
+	require.Error(t, err)
+	require.ErrorIs(t, err, wantErr)
+}
+
+// TestIndexStore_FlushPropagatesSaverError verifies Flush also surfaces errors.
+func TestIndexStore_FlushPropagatesSaverError(t *testing.T) {
+	wantErr := errors.New("simulated flush failure")
+
+	store := &indexStore{
+		mode:    ProgramCacheDBWrite,
+		indexSaver: dbcache.NewSave(func(indices []*ssadb.IrIndex) error {
+			return nil
+		}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond)),
+		offsetSaver: dbcache.NewSave(func(offsets []*ssadb.IrOffset) error {
+			return wantErr
+		}, dbcache.WithSaveSize(1), dbcache.WithSaveTimeout(10*time.Millisecond)),
+	}
+
+	store.offsetSaver.Save(&ssadb.IrOffset{})
+	// Wait for the timer-triggered save to record the error before flushing,
+	// so the test is not racy under load.
+	time.Sleep(50 * time.Millisecond)
+	err := store.Flush()
+	require.Error(t, err)
+	require.ErrorIs(t, err, wantErr)
+	_ = store.Close()
 }

--- a/common/yak/ssa/database_cache_type.go
+++ b/common/yak/ssa/database_cache_type.go
@@ -81,13 +81,13 @@ func (s *typeStore) get(id int64) (Type, bool) {
 	return typ, true
 }
 
-func (s *typeStore) close() {
-	s.flush()
+func (s *typeStore) close() error {
+	return s.flush()
 }
 
-func (s *typeStore) flush() {
+func (s *typeStore) flush() error {
 	if s == nil || s.mode != ProgramCacheDBWrite || s.db == nil {
-		return
+		return nil
 	}
 
 	types := make([]Type, 0, s.resident.Count())
@@ -98,17 +98,21 @@ func (s *typeStore) flush() {
 		return true
 	})
 	if len(types) == 0 {
-		return
+		return nil
 	}
 
 	saveBatch := saveIrType(s.program, s.db)
 	batch := make([]*ssadb.IrType, 0, s.saveSize)
+	var firstErr error
 	flush := func() {
 		if len(batch) == 0 {
 			return
 		}
 		if err := saveBatch(batch); err != nil {
 			log.Errorf("save ir type batch failed: %v", err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 		batch = make([]*ssadb.IrType, 0, s.saveSize)
 	}
@@ -117,6 +121,9 @@ func (s *typeStore) flush() {
 		irType, err := marshalIrType(s.programName)(typ, utils.EvictionReasonDeleted)
 		if err != nil {
 			log.Errorf("marshal ir type failed: %v", err)
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
 		if utils.IsNil(irType) {
@@ -128,6 +135,7 @@ func (s *typeStore) flush() {
 		}
 	}
 	flush()
+	return firstErr
 }
 
 func saveTypeWithValue(value Value, typ Type) {

--- a/common/yak/ssaapi/sfreport/stream_import_async.go
+++ b/common/yak/ssaapi/sfreport/stream_import_async.go
@@ -66,7 +66,7 @@ func NewAsyncStreamImporter(db *gorm.DB, programName string, config *StreamImpor
 	}
 
 	importer.fileSaver = dbcache.NewSave(
-		func(files []*File) {
+		func(files []*File) error {
 			start := time.Now()
 			importer.batchSaveFiles(db, files)
 			if len(files) > 0 {
@@ -77,6 +77,7 @@ func NewAsyncStreamImporter(db *gorm.DB, programName string, config *StreamImpor
 				log.Infof("[Perf] Files: saved batch=%d, total=%d, took=%v, rate=%.1f/s",
 					len(files), total, duration, float64(len(files))/duration.Seconds())
 			}
+			return nil
 		},
 		dbcache.WithContext(ctx),
 		dbcache.WithSaveSize(config.BatchSize),
@@ -85,7 +86,7 @@ func NewAsyncStreamImporter(db *gorm.DB, programName string, config *StreamImpor
 	)
 
 	importer.riskSaver = dbcache.NewSave(
-		func(risks []*riskWithDataflow) {
+		func(risks []*riskWithDataflow) error {
 			start := time.Now()
 			importer.batchSaveRisks(db, risks)
 			if len(risks) > 0 {
@@ -96,6 +97,7 @@ func NewAsyncStreamImporter(db *gorm.DB, programName string, config *StreamImpor
 				log.Infof("[Perf] Risks: saved batch=%d, total=%d, took=%v, rate=%.1f/s",
 					len(risks), total, duration, float64(len(risks))/duration.Seconds())
 			}
+			return nil
 		},
 		dbcache.WithContext(ctx),
 		dbcache.WithSaveSize(config.BatchSize),
@@ -178,10 +180,14 @@ func (i *AsyncStreamImporter) recordError(err error) {
 
 func (i *AsyncStreamImporter) Close() error {
 	if i.fileSaver != nil {
-		i.fileSaver.Close()
+		if err := i.fileSaver.Close(); err != nil {
+			i.recordError(utils.Wrap(err, "file saver close failed"))
+		}
 	}
 	if i.riskSaver != nil {
-		i.riskSaver.Close()
+		if err := i.riskSaver.Close(); err != nil {
+			i.recordError(utils.Wrap(err, "risk saver close failed"))
+		}
 	}
 	i.cancel()
 
@@ -189,6 +195,9 @@ func (i *AsyncStreamImporter) Close() error {
 	defer i.mu.Unlock()
 	log.Infof("AsyncStreamImporter closed: files=%d, risks=%d, errors=%d",
 		i.filesWritten, i.risksWritten, len(i.errors))
+	if len(i.errors) > 0 {
+		return utils.JoinErrors(i.errors...)
+	}
 	return nil
 }
 

--- a/common/yak/ssaapi/values_db.go
+++ b/common/yak/ssaapi/values_db.go
@@ -132,7 +132,9 @@ func SaveValue(value *Value, opts ...SaveValueOption) error {
 		database := newAuditDatabase(saveValueConfig.ctx, db, defaultSize)
 		saveValueConfig.database = database
 		defer func() {
-			database.Close()
+			if err := database.Close(); err != nil {
+				log.Errorf("audit database close failed: %v", err)
+			}
 		}()
 	}
 
@@ -301,10 +303,24 @@ func (a *auditDatabase) SaveIrSource(editor *ssadb.IrSource) {
 	a.editorSave.Save(editor)
 }
 
-func (a *auditDatabase) Close() {
-	a.nodeSave.Close()
-	a.edgeSave.Close()
-	a.editorSave.Close()
+func (a *auditDatabase) Close() error {
+	var errs []error
+	if a.nodeSave != nil {
+		if err := a.nodeSave.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if a.edgeSave != nil {
+		if err := a.edgeSave.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if a.editorSave != nil {
+		if err := a.editorSave.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return utils.JoinErrors(errs...)
 }
 
 func newAuditDatabase(ctx context.Context, db *gorm.DB, size int) *auditDatabase {
@@ -312,49 +328,46 @@ func newAuditDatabase(ctx context.Context, db *gorm.DB, size int) *auditDatabase
 
 	saveSize := size * 2
 
-	ret.nodeSave = dbcache.NewSave[*ssadb.AuditNode](func(ae []*ssadb.AuditNode) {
+	ret.nodeSave = dbcache.NewSave[*ssadb.AuditNode](func(ae []*ssadb.AuditNode) error {
 		if len(ae) == 0 {
-			return
+			return nil
 		}
-		utils.GormTransaction(db, func(tx *gorm.DB) error {
+		return utils.GormTransaction(db, func(tx *gorm.DB) error {
 			for _, e := range ae {
-				if ret := tx.Save(e).Error; ret != nil {
-					log.Errorf("save AuditNode failed: %v", ret)
+				if err := tx.Save(e).Error; err != nil {
+					return utils.Errorf("save AuditNode failed: %w", err)
 				}
 			}
 			return nil
 		})
-		return
 	}, dbcache.WithContext(ctx), dbcache.WithSaveSize(saveSize), dbcache.WithName("AuditNode"))
 
-	ret.edgeSave = dbcache.NewSave[*ssadb.AuditEdge](func(ae []*ssadb.AuditEdge) {
+	ret.edgeSave = dbcache.NewSave[*ssadb.AuditEdge](func(ae []*ssadb.AuditEdge) error {
 		if len(ae) == 0 {
-			return
+			return nil
 		}
-		utils.GormTransaction(db, func(tx *gorm.DB) error {
+		return utils.GormTransaction(db, func(tx *gorm.DB) error {
 			for _, e := range ae {
-				if ret := tx.Save(e).Error; ret != nil {
-					log.Errorf("save AuditEdge failed: %v", ret)
+				if err := tx.Save(e).Error; err != nil {
+					return utils.Errorf("save AuditEdge failed: %w", err)
 				}
 			}
 			return nil
 		})
-		return
 	}, dbcache.WithContext(ctx), dbcache.WithSaveSize(saveSize), dbcache.WithName("AuditEdge"))
 
-	ret.editorSave = dbcache.NewSave[*ssadb.IrSource](func(ae []*ssadb.IrSource) {
+	ret.editorSave = dbcache.NewSave[*ssadb.IrSource](func(ae []*ssadb.IrSource) error {
 		if len(ae) == 0 {
-			return
+			return nil
 		}
-		utils.GormTransaction(db, func(tx *gorm.DB) error {
+		return utils.GormTransaction(db, func(tx *gorm.DB) error {
 			for _, e := range ae {
-				if ret := tx.Save(e).Error; ret != nil {
-					log.Errorf("save AuditEdge failed: %v", ret)
+				if err := tx.Save(e).Error; err != nil {
+					return utils.Errorf("save IrSource failed: %w", err)
 				}
 			}
 			return nil
 		})
-		return
 	}, dbcache.WithContext(ctx), dbcache.WithSaveSize(size), dbcache.WithName("SourceFile"))
 
 	return ret


### PR DESCRIPTION
## 问题

`dbcache.Save[T]` 是 fire-and-forget 设计：`saveToDB func([]T)` 不返回 error，`Close()`/`Flush()` 返回 void。当批次写入 PostgreSQL 失败时（PG 拒绝某数据、连接断开、磁盘满），错误被静默吞掉。编译返回成功，但 IR DB 缺少 index/offset/type 行——后续扫描跑在残缺 IR 上，**静默漏报漏洞，无任何告警**。

对安全扫描工具来说，静默漏报是最坏的失效模式：比崩溃更坏。崩溃至少让用户知道"没扫成，重扫"；静默漏报让用户以为"扫过了，没漏洞"，实际漏了一片。

## 根因

错误在多层被吞：
1. `Save[T].runSave` — `saveToDB` 无 error 返回值，`recover()` 只 log panic
2. `Save[T].Close()`/`Flush()` — void，无法向调用方报告失败
3. `indexStore.diagnosticsTrack` — 调用 `DiagnosticsTrack`（无 Err 后缀），内部 `_ = DiagnosticsTrackErr(...)` 丢弃
4. `typeStore.flush()` — `log.Errorf` 吞掉，不走 dbcache.Save
5. `sourceStore.Flush()` — `log.Errorf` 吞掉，不走 dbcache.Save
6. `auditDatabase` savers — `log.Errorf` 在事务回调内，返回 nil

`SaveToDatabase` 已返回 error，编译入口 `ssa_compile_fs.go:500-504` 已在 error 时 `return nil, utils.Errorf(...)` 触发 `parseProject` defer 的 `DeleteProgram`。问题只是 index/offset/type/source 的错误从不到达 `SaveToDatabase` 的返回值。

## 改动

给 `dbcache.Save[T]` 的 `saveToDB` 加 `error` 返回值，让批次写入失败冒泡到 `SaveToDatabase` → 编译 error → `DeleteProgram` 清库。

| 文件 | 改动 |
|------|------|
| `dbcache/save.go` | `saveToDB` → `func([]T) error`；`Close()`/`Flush()` 返回 error；`firstErr atomic.Pointer[error]` set-once 记录第一个错误；panic 也记录为 error；`flushRequest.err` 改 `*error` 指针避免通道值拷贝丢失 |
| `dbcache/databasex.go` | `handleSaveBatch` 返回 error；`Cache.Close()` 合并 saver error |
| `ssa/database_cache_index.go` | saver 回调用 `diagnosticsTrackErr` 替代吞错误的 `diagnosticsTrack`；`Close()`/`Flush()` 返回 error |
| `ssa/database_cache_type.go` | `close()`/`flush()` 返回 error；`saveIrType` error 累积为 `firstErr` 不再 log-and-swallow |
| `ssa/database_cache_source.go` | `Close()`/`Flush()` 返回 error；`GormTransaction` error 传播不再 log-and-swallow |
| `ssa/database_cache.go` | `SaveToDatabase` 所有 store Close steps 返回 error（之前只有 instruction store 做）；`FlushAuxSavers` 记录 flush error |
| `ssaapi/values_db.go` | 3 个 audit saver 回调返回 error 不再 log-and-return-nil；`auditDatabase.Close()` 返回合并 error |
| `ssaapi/sfreport/stream_import_async.go` | saver 回调返回 nil（已有 recordError 机制）；`Close()` 合并 saver error |
| `dbcache/save_test.go` | 4 个新测试：CloseReturnsError、FlushReturnsError、PanicRecordedAsError、CloseNoErrorOnSuccess |
| `ssa/database_cache_test.go` | 2 个新测试：indexStore Close/Flush 错误传播 |

## 不改动的部分

- 异步批处理架构不变（goroutine、batch、timing 保持原样），error 只在 Close/Flush 时冒泡
- 指令存储（instruction store）原本就正确返回 error，未改动
- 没有引入新的事务或原子性保证——per-batch commit 模型不变
- `DeleteProgram` 清理逻辑原本就存在且工作正常——只是之前从未被 index/offset/type 失败触发过

## 验证

```
ok  github.com/yaklang/yaklang/common/utils/dbcache   3.049s
ok  github.com/yaklang/yaklang/common/yak/ssa          8.274s
ok  github.com/yaklang/yaklang/common/yak/ssaapi       2.350s
```

SSA 包连跑 3 次稳定通过。