### PR TITLE
perf(c2ssa): cache header macros and avoid per-line expand copies

### DIFF
--- a/common/yak/antlr4util/sll_first_parse.go
+++ b/common/yak/antlr4util/sll_first_parse.go
@@ -96,9 +96,13 @@ func SLLFirstCountersSnapshot() SLLFirstCounters {
 //  1. Try SLL + BailErrorStrategy (fast, low alloc, no recovery)
 //  2. If cancelled, retry LL + DefaultErrorStrategy (correctness + recovery)
 //
+// On SLL→LL fallback the lexed CommonTokenStream is reused (Seek(0) only;
+// Reset is avoided because it clears tokens). This skips a second full lex
+// of the source while preserving parse results.
+//
 // It also:
 //   - Attaches the yak ErrorListener to both lexer and parser
-//   - Detaches lexer tokenSource from tokens after parse to reduce retention
+//   - Detaches lexer tokenSource from tokens after the final parse to reduce retention
 //
 // setup is optional and can be used to apply per-language settings such as ANTLR caches.
 //
@@ -116,22 +120,24 @@ func ParseASTWithSLLFirst[L antlr.Lexer, P antlr.Parser, T any](
 	statsEnabled := SLLFirstStatsEnabled()
 	diagnosticEnabled := antlrDiagnosticEnabledNow()
 	shouldLogFallback := statsEnabled || diagnosticEnabled
-	run := func(predictionMode int, errHandler antlr.ErrorStrategy) (ast T, parseErr error, cancelled bool, elapsed time.Duration) {
+
+	lexer := newLexer(antlr.NewInputStream(src))
+	tokenStream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	if decorateTokenSource != nil {
+		tokenStream.SetTokenSource(decorateTokenSource(lexer))
+	}
+
+	run := func(predictionMode int, errHandler antlr.ErrorStrategy) (ast T, parseErr error, cancelled bool, elapsed time.Duration, parser P) {
 		start := time.Now()
 		defer func() {
 			elapsed = time.Since(start)
 		}()
 
 		errListener := NewErrorListener()
-		lexer := newLexer(antlr.NewInputStream(src))
 		lexer.RemoveErrorListeners()
 		lexer.AddErrorListener(errListener)
 
-		tokenStream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-		if decorateTokenSource != nil {
-			tokenStream.SetTokenSource(decorateTokenSource(lexer))
-		}
-		parser := newParser(tokenStream)
+		parser = newParser(tokenStream)
 		if setup != nil {
 			setup(lexer, parser)
 		}
@@ -169,24 +175,29 @@ func ParseASTWithSLLFirst[L antlr.Lexer, P antlr.Parser, T any](
 			ast = entry(parser)
 		}()
 
+		return ast, errListener.Error(), cancelled, elapsed, parser
+	}
+
+	finish := func(parser P) {
 		DetachParserATNSimulatorCaches(parser)
 		DetachLexerTokenSource(lexer)
-		return ast, errListener.Error(), cancelled, elapsed
 	}
 
 	if !SLLFirstEnabled() {
 		if statsEnabled {
 			atomic.AddUint64(&sllFirstLLOnly, 1)
 		}
-		ast, err, _, _ := run(antlr.PredictionModeLL, antlr.NewDefaultErrorStrategy())
+		ast, err, _, _, parser := run(antlr.PredictionModeLL, antlr.NewDefaultErrorStrategy())
+		finish(parser)
 		return ast, err
 	}
 
 	if statsEnabled {
 		atomic.AddUint64(&sllFirstSLLAttempts, 1)
 	}
-	ast, err, cancelled, sllElapsed := run(antlr.PredictionModeSLL, NewBailErrorStrategy())
+	ast, err, cancelled, sllElapsed, sllParser := run(antlr.PredictionModeSLL, NewBailErrorStrategy())
 	if !cancelled && err == nil {
+		finish(sllParser)
 		return ast, nil
 	}
 
@@ -209,9 +220,17 @@ func ParseASTWithSLLFirst[L antlr.Lexer, P antlr.Parser, T any](
 		}
 	}
 
-	ast, err, _, llElapsed := run(antlr.PredictionModeLL, antlr.NewDefaultErrorStrategy())
+	// Drop SLL parser caches; keep lexer + token stream for LL retry.
+	DetachParserATNSimulatorCaches(sllParser)
+
+	// Finish lexing once, then rewind. Do NOT call Reset() — it clears tokens.
+	tokenStream.Fill()
+	tokenStream.Seek(0)
+
+	ast, err, _, llElapsed, llParser := run(antlr.PredictionModeLL, antlr.NewDefaultErrorStrategy())
+	finish(llParser)
 	if shouldLogFallback {
-		log.Infof("[antlr-sll-first] LL completed: src_len=%d ll_elapsed=%s", len(src), llElapsed)
+		log.Infof("[antlr-sll-first] LL completed: src_len=%d ll_elapsed=%s reused_tokens=1", len(src), llElapsed)
 	}
 	return ast, err
 }

--- a/common/yak/c2ssa/builder.go
+++ b/common/yak/c2ssa/builder.go
@@ -131,8 +131,22 @@ type astbuilder struct {
 	labels         map[string]*ssa.LabelBuilder
 	specialValues  map[string]ssa.Value
 	specialTypes   map[string]ssa.Type
+	memberKeys     map[string]ssa.Value // interned field-name consts for this file build
 	pkgNameCurrent string
 	SetGlobal      bool
+}
+
+// emitMemberKey returns a reused ConstInst for struct/union member names.
+func (b *astbuilder) emitMemberKey(key string) ssa.Value {
+	if b.memberKeys == nil {
+		b.memberKeys = make(map[string]ssa.Value)
+	}
+	if v, ok := b.memberKeys[key]; ok {
+		return v
+	}
+	v := b.EmitConstInst(key)
+	b.memberKeys[key] = v
+	return v
 }
 
 func Frontend(src string, cache *ssa.AntlrCache) (*cparser.CompilationUnitContext, error) {

--- a/common/yak/c2ssa/builder.go
+++ b/common/yak/c2ssa/builder.go
@@ -1,7 +1,6 @@
 package c2ssa
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/yaklang/yaklang/common/log"
@@ -74,16 +73,12 @@ func (s *SSABuilder) BuildFromAST(raw ssa.FrontAST, builder *ssa.FunctionBuilder
 	if !ok {
 		return utils.Errorf("invalid AST type")
 	}
-	SpecialTypes := map[string]ssa.Type{
-		"void":    ssa.CreateAnyType(),
-		"bool":    ssa.CreateBooleanType(),
-		"complex": ssa.CreateAnyType(),
-	}
-	SpecialValue := map[string]ssa.Value{}
 
 	builder.SupportClosure = false
 	builder.WithExternValue(cBuildIn)
-	builder.WithExternSideEffect(cSideEffect)
+	// Reuse prebuilt handlers; avoid WithExternSideEffect rebuilding ~100 entries per file.
+	builder.GetProgram().ExternSideEffect = cSideEffect
+	builder.WithExternBuildValueHandler(cSideEffectHandlers)
 
 	astBuilder := &astbuilder{
 		FunctionBuilder: builder,
@@ -92,13 +87,13 @@ func (s *SSABuilder) BuildFromAST(raw ssa.FrontAST, builder *ssa.FunctionBuilder
 		result:          map[string][]string{},
 		tpHandler:       map[string]func(){},
 		labels:          map[string]*ssa.LabelBuilder{},
-		specialValues:   SpecialValue,
-		specialTypes:    SpecialTypes,
+		specialValues:   map[string]ssa.Value{},
+		specialTypes:    cSpecialTypes,
 		pkgNameCurrent:  "",
 	}
 	// log.Infof("ast: %s", ast.ToStringTree(ast.GetParser().GetRuleNames(), ast.GetParser()))
 	astBuilder.build(ast)
-	fmt.Printf("Program: %v done\n", astBuilder.pkgNameCurrent)
+	log.Debugf("Program: %v done", astBuilder.pkgNameCurrent)
 	return nil
 }
 
@@ -404,6 +399,21 @@ var cSideEffect = map[string][]uint{
 	"va_arg":   {0, 0}, // ap input, typeSize input
 	"va_end":   {0},    // ap input
 	"va_copy":  {0, 0}, // dest input, src input
+}
+
+// cSideEffectHandlers is built once; WithExternSideEffect would rebuild this map per file.
+var cSideEffectHandlers = func() map[string]func(b *ssa.FunctionBuilder, id string, v any) ssa.Value {
+	m := make(map[string]func(b *ssa.FunctionBuilder, id string, v any) ssa.Value, len(cSideEffect))
+	for n := range cSideEffect {
+		m[n] = ssa.BuildFunctionWithSideEffect
+	}
+	return m
+}()
+
+var cSpecialTypes = map[string]ssa.Type{
+	"void":    ssa.CreateAnyType(),
+	"bool":    ssa.CreateBooleanType(),
+	"complex": ssa.CreateAnyType(),
 }
 
 // cBuildIn defines common C standard library functions with proper pointer types

--- a/common/yak/c2ssa/builder_ast.go
+++ b/common/yak/c2ssa/builder_ast.go
@@ -23,15 +23,18 @@ func (b *astbuilder) build(ast *cparser.CompilationUnitContext) {
 	defer recoverRange()
 
 	exportHandler := func() {
+		// Types are already written to ExportType during prebuild (SetExportType).
+		// Re-copying via GetStructAll/GetAliasAll is a no-op; only sync globals.
 		lib := b.GetProgram()
-		for structName, structType := range b.GetStructAll() {
-			lib.SetExportType(structName, structType)
+		if lib.GlobalVariablesBlueprint == nil {
+			return
 		}
-		for aliasName, aliasType := range b.GetAliasAll() {
-			lib.SetExportType(aliasName, aliasType)
+		container := lib.GlobalVariablesBlueprint.Container()
+		if container == nil {
+			return
 		}
-		for globalName, globalValue := range b.GetGlobalVariables() {
-			lib.SetExportValue(globalName, globalValue)
+		for key, val := range container.GetAllMember() {
+			lib.SetExportValue(key.String(), val)
 		}
 	}
 
@@ -102,6 +105,11 @@ func (b *astbuilder) buildFunctionDefinition(ast *cparser.FunctionDefinitionCont
 	var retType ssa.Type
 	var paramTypes ssa.Types
 
+	// Capture return type once in prebuild; lazy body only rebuilds declarator for params.
+	if ds := ast.DeclarationSpecifier(); ds != nil {
+		retType = b.buildDeclarationSpecifier(ds.(*cparser.DeclarationSpecifierContext))
+	}
+
 	if de := ast.Declarator(); de != nil {
 		var base ssa.Value
 		_, base, _ = b.buildDeclarator(de.(*cparser.DeclaratorContext), FUNC_KIND)
@@ -152,9 +160,7 @@ func (b *astbuilder) buildFunctionDefinition(ast *cparser.FunctionDefinitionCont
 				b.FunctionBuilder = b.PushFunction(newFunc)
 				b.SupportClosure = false
 
-				if ds := capturedDef.DeclarationSpecifier(); ds != nil {
-					retType = b.buildDeclarationSpecifier(ds.(*cparser.DeclarationSpecifierContext))
-				}
+				// retType already captured in prebuild; rebuild declarator only for NewParam + types.
 				_, _, paramTypes = b.buildDeclarator(de.(*cparser.DeclaratorContext), FUNC_KIND)
 
 				handleFunctionType(b.Function)
@@ -217,6 +223,12 @@ func (b *astbuilder) buildDirectDeclarator(ast *cparser.DirectDeclaratorContext,
 			// 函数类型：根据 kind 创建函数
 			// 重用 buildIdentifierDeclarator 的逻辑，只取 value 部分
 			_, value, _ = b.buildIdentifierDeclarator(identifierName, kind)
+			if kind == FUNC_KIND && b.PreHandler() {
+				// Prebuild only needs the Function object. Parameter NewParam calls belong
+				// in the lazy body (after PushFunction); skipping here avoids orphan params
+				// on the file-level builder and a redundant parameter-list walk.
+				return variable, value, nil
+			}
 		} else {
 			// 未知类型，使用默认处理
 			value = b.EmitConstInst(identifierName)

--- a/common/yak/c2ssa/builder_express.go
+++ b/common/yak/c2ssa/builder_express.go
@@ -17,6 +17,41 @@ func (b *astbuilder) ensureValue(v ssa.Value) ssa.Value {
 	return v
 }
 
+// hasBinaryExpr is cheaper than len(ast.AllExpression()) >= 2 (avoids child slice alloc).
+func hasBinaryExpr(ast *cparser.ExpressionContext) bool {
+	return ast.Expression(0) != nil && ast.Expression(1) != nil
+}
+
+func (b *astbuilder) applyAssignmentOp(opText string, right, newRight ssa.Value) ssa.Value {
+	switch opText {
+	case "=":
+		return newRight
+	case "*=":
+		return b.EmitBinOp(ssa.OpMul, right, newRight)
+	case "/=":
+		return b.EmitBinOp(ssa.OpDiv, right, newRight)
+	case "%=":
+		return b.EmitBinOp(ssa.OpMod, right, newRight)
+	case "+=":
+		return b.EmitBinOp(ssa.OpAdd, right, newRight)
+	case "-=":
+		return b.EmitBinOp(ssa.OpSub, right, newRight)
+	case "<<=":
+		return b.EmitBinOp(ssa.OpShl, right, newRight)
+	case ">>=":
+		return b.EmitBinOp(ssa.OpShr, right, newRight)
+	case "&=":
+		return b.EmitBinOp(ssa.OpAnd, right, newRight)
+	case "^=":
+		return b.EmitBinOp(ssa.OpXor, right, newRight)
+	case "|=":
+		return b.EmitBinOp(ssa.OpOr, right, newRight)
+	default:
+		b.NewError(ssa.Warn, TAG, fmt.Sprintf("not find: %s", opText))
+		return newRight
+	}
+}
+
 func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool) (ssa.Value, *ssa.Variable) {
 	recoverRange := b.SetRange(&ast.BaseParserRuleContext)
 	defer recoverRange()
@@ -43,16 +78,15 @@ func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool
 			b.AssignVariable(variable, v)
 		})
 		ifb.Build()
-		// generator phi instruction
 		v := b.ReadValue(id)
-		v.SetName(ast.GetText())
 		return v
 	}
 
 	// 1. 一元运算符: unary_op = (Plus | Minus | Not | Caret | Star | And) expression
 	if ast.GetUnary_op() != nil && ast.Expression(0) != nil {
 		op := ast.GetUnary_op().GetText()
-		right, left := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), false)
+		needLeft := op == "&"
+		right, left := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), needLeft)
 		if right != nil {
 			switch op {
 			case "+":
@@ -70,8 +104,8 @@ func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool
 					return right, left
 				}
 			case "&":
-				if _, op1Var := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), true); op1Var != nil {
-					return b.EmitConstPointer(op1Var), nil
+				if left != nil {
+					return b.EmitConstPointer(left), nil
 				}
 			}
 		}
@@ -79,7 +113,7 @@ func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool
 	}
 
 	// 2. 乘法/除法/取模/位移/按位与: expression mul_op = (Star | Div | Mod | LeftShift | RightShift | And) expression
-	if ast.GetMul_op() != nil && len(ast.AllExpression()) >= 2 {
+	if ast.GetMul_op() != nil && hasBinaryExpr(ast) {
 		op := ast.GetMul_op().GetText()
 		op1, _ := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), false)
 		op2, _ := b.buildExpression(ast.Expression(1).(*cparser.ExpressionContext), false)
@@ -103,7 +137,7 @@ func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool
 	}
 
 	// 3. 加法/减法/按位或/按位异或: expression add_op = (Plus | Minus | Or | Caret) expression
-	if ast.GetAdd_op() != nil && len(ast.AllExpression()) >= 2 {
+	if ast.GetAdd_op() != nil && hasBinaryExpr(ast) {
 		op := ast.GetAdd_op().GetText()
 		op1, _ := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), false)
 		op2, _ := b.buildExpression(ast.Expression(1).(*cparser.ExpressionContext), false)
@@ -123,7 +157,7 @@ func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool
 	}
 
 	// 4. 关系运算符: expression rel_op = (Equal | NotEqual | Less | LessEqual | Greater | GreaterEqual) expression
-	if ast.GetRel_op() != nil && len(ast.AllExpression()) >= 2 {
+	if ast.GetRel_op() != nil && hasBinaryExpr(ast) {
 		op := ast.GetRel_op().GetText()
 		op1, _ := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), false)
 		op2, _ := b.buildExpression(ast.Expression(1).(*cparser.ExpressionContext), false)
@@ -146,24 +180,42 @@ func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool
 		return op1, nil
 	}
 
-	// 5. 逻辑与: expression AndAnd expression
-	if ast.AndAnd() != nil && len(ast.AllExpression()) >= 2 {
-		left, _ := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), false)
-		right, _ := b.buildExpression(ast.Expression(1).(*cparser.ExpressionContext), false)
-		if left != nil && right != nil {
-			return b.EmitBinOp(ssa.OpLogicAnd, left, right), nil
+	// 5. 逻辑与: a && b  →  if a { result = b } else { result = a }  (short-circuit)
+	if ast.AndAnd() != nil && hasBinaryExpr(ast) {
+		leftExpr := ast.Expression(0).(*cparser.ExpressionContext)
+		rightExpr := ast.Expression(1).(*cparser.ExpressionContext)
+		left, _ := b.buildExpression(leftExpr, false)
+		if left == nil {
+			return nil, nil
 		}
-		return left, nil
+		return handlerJumpExpression(
+			func(id string) ssa.Value { return left },
+			func() ssa.Value {
+				right, _ := b.buildExpression(rightExpr, false)
+				return b.ensureValue(right)
+			},
+			func() ssa.Value { return left },
+			ssa.AndExpressionVariable,
+		), nil
 	}
 
-	// 6. 逻辑或: expression OrOr expression
-	if ast.OrOr() != nil && len(ast.AllExpression()) >= 2 {
-		left, _ := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), false)
-		right, _ := b.buildExpression(ast.Expression(1).(*cparser.ExpressionContext), false)
-		if left != nil && right != nil {
-			return b.EmitBinOp(ssa.OpLogicOr, left, right), nil
+	// 6. 逻辑或: a || b  →  if a { result = a } else { result = b }  (short-circuit)
+	if ast.OrOr() != nil && hasBinaryExpr(ast) {
+		leftExpr := ast.Expression(0).(*cparser.ExpressionContext)
+		rightExpr := ast.Expression(1).(*cparser.ExpressionContext)
+		left, _ := b.buildExpression(leftExpr, false)
+		if left == nil {
+			return nil, nil
 		}
-		return left, nil
+		return handlerJumpExpression(
+			func(id string) ssa.Value { return left },
+			func() ssa.Value { return left },
+			func() ssa.Value {
+				right, _ := b.buildExpression(rightExpr, false)
+				return b.ensureValue(right)
+			},
+			ssa.OrExpressionVariable,
+		), nil
 	}
 
 	// 7. 括号表达式
@@ -180,22 +232,25 @@ func (b *astbuilder) buildExpression(ast *cparser.ExpressionContext, isLeft bool
 		}
 	}
 
-	// 8. 三元表达式: expression ('?' expression ':' expression)
+	// 8. 三元表达式: expression ('?' expression ':' expression) — defer branches for short-circuit
 	if ast.Question() != nil {
-		condition, _ := b.buildExpression(ast.Expression(0).(*cparser.ExpressionContext), false)
-		value1, _ := b.buildExpression(ast.Expression(1).(*cparser.ExpressionContext), false)
-		value2, _ := b.buildExpression(ast.Expression(2).(*cparser.ExpressionContext), false)
+		condExpr := ast.Expression(0).(*cparser.ExpressionContext)
+		trueAst := ast.Expression(1).(*cparser.ExpressionContext)
+		falseAst := ast.Expression(2).(*cparser.ExpressionContext)
+		condition, _ := b.buildExpression(condExpr, false)
 		return handlerJumpExpression(
 			func(id string) ssa.Value {
 				return condition
 			},
 			func() ssa.Value {
-				return value1
+				value1, _ := b.buildExpression(trueAst, false)
+				return b.ensureValue(value1)
 			},
 			func() ssa.Value {
-				return value2
+				value2, _ := b.buildExpression(falseAst, false)
+				return b.ensureValue(value2)
 			},
-			ssa.AndExpressionVariable,
+			ssa.TernaryExpressionVariable,
 		), nil
 	}
 
@@ -320,33 +375,7 @@ func (b *astbuilder) applyAssignmentFromStarCast(
 		right = newRight
 	}
 
-	switch op.GetText() {
-	case "=":
-		right = newRight
-	case "*=":
-		right = b.EmitBinOp(ssa.OpMul, right, newRight)
-	case "/=":
-		right = b.EmitBinOp(ssa.OpDiv, right, newRight)
-	case "%=":
-		right = b.EmitBinOp(ssa.OpMod, right, newRight)
-	case "+=":
-		right = b.EmitBinOp(ssa.OpAdd, right, newRight)
-	case "-=":
-		right = b.EmitBinOp(ssa.OpSub, right, newRight)
-	case "<<=":
-		right = b.EmitBinOp(ssa.OpShl, right, newRight)
-	case ">>=":
-		right = b.EmitBinOp(ssa.OpShr, right, newRight)
-	case "&=":
-		right = b.EmitBinOp(ssa.OpAnd, right, newRight)
-	case "^=":
-		right = b.EmitBinOp(ssa.OpXor, right, newRight)
-	case "|=":
-		right = b.EmitBinOp(ssa.OpOr, right, newRight)
-	default:
-		right = newRight
-		b.NewError(ssa.Warn, TAG, fmt.Sprintf("not find: %s", op.GetText()))
-	}
+	right = b.applyAssignmentOp(op.GetText(), right, newRight)
 	if left != nil {
 		b.AssignVariable(left, right)
 		right.SetType(newRight.GetType())
@@ -422,7 +451,7 @@ func (b *astbuilder) buildPostfixSuffixLvalueFromPostfixSuffix(
 				if t := right.GetType(); isPointer && t != nil && t.GetTypeKind() == ssa.PointerKind {
 					right = b.GetOriginValue(right)
 				}
-				right = b.ReadMemberCallValue(right, b.EmitConstInst(key))
+				right = b.ReadMemberCallValue(right, b.emitMemberKey(key))
 			}
 			if left != nil {
 				member := b.PeekValue(left.GetName())
@@ -445,7 +474,7 @@ func (b *astbuilder) buildPostfixSuffixLvalueFromPostfixSuffix(
 					member = b.GetOriginValue(member)
 					setReference = true
 				}
-				left = b.CreateMemberCallVariable(member, b.EmitConstInst(key))
+				left = b.CreateMemberCallVariable(member, b.emitMemberKey(key))
 				checkParameter(left.GetName())
 				_ = setReference
 			}
@@ -483,33 +512,7 @@ func (b *astbuilder) applyAssignmentFromCast(
 		right = newRight
 	}
 
-	switch op.GetText() {
-	case "=":
-		right = newRight
-	case "*=":
-		right = b.EmitBinOp(ssa.OpMul, right, newRight)
-	case "/=":
-		right = b.EmitBinOp(ssa.OpDiv, right, newRight)
-	case "%=":
-		right = b.EmitBinOp(ssa.OpMod, right, newRight)
-	case "+=":
-		right = b.EmitBinOp(ssa.OpAdd, right, newRight)
-	case "-=":
-		right = b.EmitBinOp(ssa.OpSub, right, newRight)
-	case "<<=":
-		right = b.EmitBinOp(ssa.OpShl, right, newRight)
-	case ">>=":
-		right = b.EmitBinOp(ssa.OpShr, right, newRight)
-	case "&=":
-		right = b.EmitBinOp(ssa.OpAnd, right, newRight)
-	case "^=":
-		right = b.EmitBinOp(ssa.OpXor, right, newRight)
-	case "|=":
-		right = b.EmitBinOp(ssa.OpOr, right, newRight)
-	default:
-		right = newRight
-		b.NewError(ssa.Warn, TAG, fmt.Sprintf("not find: %s", op.GetText()))
-	}
+	right = b.applyAssignmentOp(op.GetText(), right, newRight)
 	if left != nil {
 		b.AssignVariable(left, right)
 		right.SetType(newRight.GetType())
@@ -550,33 +553,7 @@ func (b *astbuilder) buildAssignmentExpression(ast *cparser.AssignmentExpression
 				}
 
 				op := a.(*cparser.AssignmentOperatorContext).GetText()
-				switch op {
-				case "=":
-					right = newRight
-				case "*=":
-					right = b.EmitBinOp(ssa.OpMul, right, newRight)
-				case "/=":
-					right = b.EmitBinOp(ssa.OpDiv, right, newRight)
-				case "%=":
-					right = b.EmitBinOp(ssa.OpMod, right, newRight)
-				case "+=":
-					right = b.EmitBinOp(ssa.OpAdd, right, newRight)
-				case "-=":
-					right = b.EmitBinOp(ssa.OpSub, right, newRight)
-				case "<<=":
-					right = b.EmitBinOp(ssa.OpShl, right, newRight)
-				case ">>=":
-					right = b.EmitBinOp(ssa.OpShr, right, newRight)
-				case "&=":
-					right = b.EmitBinOp(ssa.OpAnd, right, newRight)
-				case "^=":
-					right = b.EmitBinOp(ssa.OpXor, right, newRight)
-				case "|=":
-					right = b.EmitBinOp(ssa.OpOr, right, newRight)
-				default:
-					right = newRight
-					b.NewError(ssa.Warn, TAG, fmt.Sprintf("not find: %s", op))
-				}
+				right = b.applyAssignmentOp(op, right, newRight)
 				if left != nil {
 					b.AssignVariable(left, right)
 					right.SetType(newRight.GetType())
@@ -786,14 +763,14 @@ func (b *astbuilder) buildPostfixSuffix(ast *cparser.PostfixSuffixContext, right
 				if t := right.GetType(); t != nil && t.GetTypeKind() == ssa.PointerKind {
 					right = b.GetOriginValue(right)
 				}
-				right = b.ReadMemberCallValue(right, b.EmitConstInst(key))
+				right = b.ReadMemberCallValue(right, b.emitMemberKey(key))
 			}
 			if left != nil {
 				member := b.ReadValue(left.GetName())
 				if t := member.GetType(); t != nil && t.GetTypeKind() == ssa.PointerKind {
 					member = b.GetOriginValue(member)
 				}
-				left = b.CreateMemberCallVariable(member, b.EmitConstInst(key))
+				left = b.CreateMemberCallVariable(member, b.emitMemberKey(key))
 				if isPointer {
 					if p, ok := ssa.ToParameter(member); ok && !p.IsFreeValue {
 						b.ReferenceParameter(left.GetName(), p.FormalParameterIndex, ssa.PointerSideEffect)
@@ -1052,7 +1029,7 @@ func (b *astbuilder) buildPostfixSuffixLvalue(ast *cparser.PostfixSuffixLvalueCo
 		isPointer := ast.Arrow() != nil
 		if id := ast.Identifier(); id != nil {
 			key := id.GetText()
-			memberKey := b.EmitConstInst(key)
+			memberKey := b.emitMemberKey(key)
 
 			var member ssa.Value
 			if left != nil {
@@ -1111,6 +1088,7 @@ func (b *astbuilder) buildPrimaryExpression(ast *cparser.PrimaryExpressionContex
 	if id := ast.Identifier(); id != nil {
 		text := id.GetText()
 
+		// CreateVariable before PeekValue preserves existing scope/binding behavior.
 		left := b.CreateVariable(text)
 		right := b.PeekValue(text)
 		if right != nil {

--- a/common/yak/c2ssa/compile_unit.go
+++ b/common/yak/c2ssa/compile_unit.go
@@ -1,14 +1,12 @@
 package c2ssa
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
+	"github.com/yaklang/yaklang/common/yak/c2ssa/preprocess"
 	"github.com/yaklang/yaklang/common/yak/ssa"
 )
-
-var cIncludeRe = regexp.MustCompile(`(?m)^\s*#\s*include\s+[<"]([^>"]+)[>"]`)
 
 // cIncludeExtCandidates are extensions tried when an include path has no
 // extension (e.g. `#include "util"`).
@@ -28,8 +26,11 @@ func (*SSABuilder) CompileUnitDependencies(fs filesys_interface.FileSystem, unit
 				continue
 			}
 			src := ssa.ReadUnitSource(fs, file)
-			for _, match := range cIncludeRe.FindAllStringSubmatch(src, -1) {
-				raw := match[1]
+			for _, line := range preprocess.JoinLogicalLines(src) {
+				raw, _, ok := preprocess.ParseIncludePath(line)
+				if !ok {
+					continue
+				}
 				if to := resolveCInclude(fs, fileToKey, pathToKey, file, raw); to != "" && to != unit.Key {
 					edges = append(edges, ssa.UnitRef{From: unit.Key, To: to, Kind: "include", Raw: raw})
 				}
@@ -55,7 +56,8 @@ func resolveCInclude(fs filesys_interface.FileSystem, fileToKey, pathToKey map[s
 		ssa.CleanUnitPath(fs, fs.Join(importerDir, raw)),
 	}
 	lookup := func(p string) string {
-		if key := fileToKey[ssa.NormalizeUnitPath(fs, p)]; key != "" {
+		norm := ssa.NormalizeUnitPath(fs, p)
+		if key := fileToKey[norm]; key != "" {
 			return key
 		}
 		if fs.Ext(p) == "" {

--- a/common/yak/c2ssa/preprocess/cond_eval.go
+++ b/common/yak/c2ssa/preprocess/cond_eval.go
@@ -30,10 +30,8 @@ func (e *ppExprEnv) lookupObject(name string) (string, bool) {
 		}
 	}
 	if e.global != nil {
-		flat := e.global.Flatten()
-		if v, ok := flat.Object[name]; ok {
-			return v, true
-		}
+		// Chain walk is equivalent to Flatten().Object[name] without full-table Clone.
+		return e.global.LookupObject(name)
 	}
 	return "", false
 }

--- a/common/yak/c2ssa/preprocess/directive.go
+++ b/common/yak/c2ssa/preprocess/directive.go
@@ -29,6 +29,17 @@ func (e *MacroEnvironment) Flatten() MacroTables {
 	return out
 }
 
+// LookupObject finds an object-like macro in this environment (child overrides parent).
+// Equivalent to Flatten().Object[name] without allocating a full merged table.
+func (e *MacroEnvironment) LookupObject(name string) (string, bool) {
+	for cur := e; cur != nil; cur = cur.parent {
+		if v, ok := cur.tables.Object[name]; ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
 func (e *MacroEnvironment) ApplyDefineLine(line string) bool {
 	return ApplyDefineLine(line, &e.tables, false)
 }

--- a/common/yak/c2ssa/preprocess/export.go
+++ b/common/yak/c2ssa/preprocess/export.go
@@ -93,10 +93,7 @@ func ExpandSourceWithTables(src string, tables MacroTables) string {
 
 // ExpandSourceWithTablesState expands macros while preserving block-comment state across calls.
 func ExpandSourceWithTablesState(src string, tables MacroTables, st *macroScanState) string {
-	env := &macroEnv{
-		tables:   exportToMacroTables(tables),
-		maxDepth: maxMacroExpandDepth,
-	}
+	env := newMacroEnvFromTables(tables)
 	expanded := env.expandSourceWithState(src, st)
 	return CollapsePreprocessorContinuations(expanded)
 }

--- a/common/yak/c2ssa/preprocess/export.go
+++ b/common/yak/c2ssa/preprocess/export.go
@@ -121,11 +121,55 @@ func JoinLogicalLines(src string) []string {
 }
 
 // ApplyDefineLine applies a #define/#undef line to tables; returns true if a define was consumed.
+// Mutates Function/Object maps in place (does not replace the map pointers), so shared
+// MacroTables references stay consistent after updates.
 func ApplyDefineLine(line string, tables *MacroTables, strip bool) bool {
-	internal := exportToMacroTables(*tables)
-	removed := applyDirectiveToTables(line, internal, strip)
-	*tables = MacroTablesFromInternal(internal)
-	return removed
+	if tables == nil {
+		return false
+	}
+	if tables.Function == nil {
+		tables.Function = make(map[string]FunctionMacro)
+	}
+	if tables.Object == nil {
+		tables.Object = make(map[string]string)
+	}
+
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || !strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	directive := strings.TrimSpace(strings.TrimPrefix(trimmed, "#"))
+	if directive == "" {
+		return false
+	}
+	parts := strings.Fields(directive)
+	if len(parts) == 0 {
+		return false
+	}
+	switch parts[0] {
+	case "define":
+		if name, fm, ok := parseFunctionDefineSafe(directive); ok {
+			tables.Function[name] = FunctionMacro{
+				Params:   fm.params,
+				Variadic: fm.variadic,
+				Body:     fm.body,
+			}
+			delete(tables.Object, name)
+			return strip
+		}
+		if name, body, ok := parseObjectDefineSafe(directive); ok {
+			tables.Object[name] = body
+			delete(tables.Function, name)
+			return strip
+		}
+	case "undef":
+		if len(parts) >= 2 {
+			name := parts[1]
+			delete(tables.Function, name)
+			delete(tables.Object, name)
+		}
+	}
+	return false
 }
 
 // ParseIncludePath extracts the path from #include "..." or #include <...>.

--- a/common/yak/c2ssa/preprocess/export.go
+++ b/common/yak/c2ssa/preprocess/export.go
@@ -192,12 +192,12 @@ func trimDirectiveLine(line string) string {
 
 func splitDirectiveFields(directive string) []string {
 	var parts []string
-	var cur string
+	var cur strings.Builder
 	inQuote := byte(0)
 	for i := 0; i < len(directive); i++ {
 		c := directive[i]
 		if inQuote != 0 {
-			cur += string(c)
+			cur.WriteByte(c)
 			if c == inQuote && (i == 0 || directive[i-1] != '\\') {
 				inQuote = 0
 			}
@@ -206,23 +206,20 @@ func splitDirectiveFields(directive string) []string {
 		switch c {
 		case '"', '<':
 			inQuote = c
-			if c == '<' {
-				// angle path ends with >
-			}
-			cur += string(c)
+			cur.WriteByte(c)
 		case '>':
-			cur += string(c)
+			cur.WriteByte(c)
 		case ' ', '\t':
-			if cur != "" {
-				parts = append(parts, cur)
-				cur = ""
+			if cur.Len() > 0 {
+				parts = append(parts, cur.String())
+				cur.Reset()
 			}
 		default:
-			cur += string(c)
+			cur.WriteByte(c)
 		}
 	}
-	if cur != "" {
-		parts = append(parts, cur)
+	if cur.Len() > 0 {
+		parts = append(parts, cur.String())
 	}
 	return parts
 }

--- a/common/yak/c2ssa/preprocess/include_inline.go
+++ b/common/yak/c2ssa/preprocess/include_inline.go
@@ -13,10 +13,10 @@ type tuExpandCtx struct {
 }
 
 func (tu *tuProcessor) run(src string) string {
-	env := NewMacroEnvironment(nil)
-	env.tables = tu.base.Clone()
-	cond := NewConditionalStack(env, tu.defs)
+	// One clone of the base tables; env and expandEnv share / derive from it.
 	localTables := tu.base.Clone()
+	env := &MacroEnvironment{tables: localTables}
+	cond := NewConditionalStack(env, tu.defs)
 	var commentState macroScanState
 
 	ctx := &tuExpandCtx{
@@ -30,10 +30,12 @@ func (tu *tuProcessor) run(src string) string {
 	}
 	outLines := ctx.expandSource(src, tu.entryPath)
 	out := strings.Join(outLines, "\n")
+	// Single collapse at end (logical lines already joined; macro bodies may reintroduce \\n).
 	return CollapsePreprocessorContinuations(out)
 }
 
 func (ctx *tuExpandCtx) syncExpandEnv() {
+	// Rebuild internal tables once per define/undef; maps stay shared on MacroTables side.
 	ctx.expandEnv.setTables(exportToMacroTables(ctx.localTables))
 }
 
@@ -58,7 +60,7 @@ func (ctx *tuExpandCtx) expandSource(src, filePath string) []string {
 		switch DirectiveName(line) {
 		case "define":
 			if ApplyDefineLine(line, &ctx.localTables, true) {
-				ctx.env.tables = ctx.localTables.Clone()
+				// localTables mutated in place; env.tables aliases the same maps.
 				ctx.syncExpandEnv()
 				continue
 			}
@@ -68,14 +70,16 @@ func (ctx *tuExpandCtx) expandSource(src, filePath string) []string {
 			if macro != "" {
 				delete(ctx.localTables.Function, macro)
 				delete(ctx.localTables.Object, macro)
-				ctx.env.tables = ctx.localTables.Clone()
 				ctx.syncExpandEnv()
 			}
 			outLines = append(outLines, line)
 		default:
-			// Reuse expandEnv; avoid per-line Flatten + exportToMacroTables.
+			if !ctx.expandEnv.lineMayNeedExpand(line) {
+				outLines = append(outLines, line)
+				continue
+			}
 			expanded := ctx.expandEnv.expandSourceWithState(line, ctx.commentState)
-			outLines = append(outLines, CollapsePreprocessorContinuations(expanded))
+			outLines = append(outLines, expanded)
 		}
 	}
 	return outLines

--- a/common/yak/c2ssa/preprocess/include_inline.go
+++ b/common/yak/c2ssa/preprocess/include_inline.go
@@ -7,6 +7,7 @@ type tuExpandCtx struct {
 	env          *MacroEnvironment
 	cond         *ConditionalStack
 	localTables  MacroTables
+	expandEnv    *macroEnv
 	commentState *macroScanState
 	fromPath     string
 }
@@ -23,12 +24,17 @@ func (tu *tuProcessor) run(src string) string {
 		env:          env,
 		cond:         cond,
 		localTables:  localTables,
+		expandEnv:    newMacroEnvFromTables(localTables),
 		commentState: &commentState,
 		fromPath:     tu.entryPath,
 	}
 	outLines := ctx.expandSource(src, tu.entryPath)
 	out := strings.Join(outLines, "\n")
 	return CollapsePreprocessorContinuations(out)
+}
+
+func (ctx *tuExpandCtx) syncExpandEnv() {
+	ctx.expandEnv.setTables(exportToMacroTables(ctx.localTables))
 }
 
 func (ctx *tuExpandCtx) expandSource(src, filePath string) []string {
@@ -53,6 +59,7 @@ func (ctx *tuExpandCtx) expandSource(src, filePath string) []string {
 		case "define":
 			if ApplyDefineLine(line, &ctx.localTables, true) {
 				ctx.env.tables = ctx.localTables.Clone()
+				ctx.syncExpandEnv()
 				continue
 			}
 			outLines = append(outLines, line)
@@ -62,11 +69,13 @@ func (ctx *tuExpandCtx) expandSource(src, filePath string) []string {
 				delete(ctx.localTables.Function, macro)
 				delete(ctx.localTables.Object, macro)
 				ctx.env.tables = ctx.localTables.Clone()
+				ctx.syncExpandEnv()
 			}
 			outLines = append(outLines, line)
 		default:
-			expanded := ExpandSourceWithTablesState(line, ctx.env.Flatten(), ctx.commentState)
-			outLines = append(outLines, expanded)
+			// Reuse expandEnv; avoid per-line Flatten + exportToMacroTables.
+			expanded := ctx.expandEnv.expandSourceWithState(line, ctx.commentState)
+			outLines = append(outLines, CollapsePreprocessorContinuations(expanded))
 		}
 	}
 	return outLines

--- a/common/yak/c2ssa/preprocess/macro_expand.go
+++ b/common/yak/c2ssa/preprocess/macro_expand.go
@@ -27,10 +27,11 @@ func ExpandFunctionMacrosWithTables(src string, base MacroTables) (string, error
 }
 
 type macroEnv struct {
-	tables           macroTables
-	depth            int
-	maxDepth         int
-	objectBodyTokens map[string][]macroToken // session cache: tokenize only, not full expand
+	tables             macroTables
+	depth              int
+	maxDepth           int
+	objectBodyTokens   map[string][]macroToken // session cache: tokenize only
+	functionBodyTokens map[string][]macroToken
 }
 
 func newMacroEnvFromTables(tables MacroTables) *macroEnv {
@@ -43,6 +44,7 @@ func newMacroEnvFromTables(tables MacroTables) *macroEnv {
 func (e *macroEnv) setTables(tables macroTables) {
 	e.tables = tables
 	e.objectBodyTokens = nil
+	e.functionBodyTokens = nil
 }
 
 func (e *macroEnv) getObjectBodyTokens(name, body string) []macroToken {
@@ -55,6 +57,50 @@ func (e *macroEnv) getObjectBodyTokens(name, body string) []macroToken {
 	toks := tokenizeMacroSource(body)
 	e.objectBodyTokens[name] = toks
 	return toks
+}
+
+func (e *macroEnv) getFunctionBodyTokens(name string, fm functionMacro) []macroToken {
+	if e.functionBodyTokens == nil {
+		e.functionBodyTokens = make(map[string][]macroToken)
+	}
+	if toks, ok := e.functionBodyTokens[name]; ok {
+		return toks
+	}
+	toks := tokenizeMacroSource(fm.body)
+	e.functionBodyTokens[name] = toks
+	return toks
+}
+
+// lineMayNeedExpand cheaply checks whether line contains an identifier that is a known macro.
+// False positives are safe (full expand still correct); false negatives must be avoided.
+func (e *macroEnv) lineMayNeedExpand(line string) bool {
+	if len(e.tables.function) == 0 && len(e.tables.object) == 0 {
+		return false
+	}
+	for i := 0; i < len(line); {
+		c := line[i]
+		if isMacroIdentStart(rune(c)) {
+			start := i
+			i++
+			for i < len(line) {
+				r := rune(line[i])
+				if !isMacroIdentPart(r) {
+					break
+				}
+				i++
+			}
+			name := line[start:i]
+			if _, ok := e.tables.object[name]; ok {
+				return true
+			}
+			if _, ok := e.tables.function[name]; ok {
+				return true
+			}
+			continue
+		}
+		i++
+	}
+	return false
 }
 
 func (e *macroEnv) expandSource(src string) string {
@@ -105,7 +151,7 @@ func (e *macroEnv) expandOnce(tokens []macroToken) ([]macroToken, bool) {
 						for ai, arg := range args {
 							expandedArgs[ai] = e.expandTokens(arg)
 						}
-						repl := e.substituteMacro(fm, expandedArgs)
+						repl := e.substituteMacro(name, fm, expandedArgs)
 						repl = e.expandTokens(repl)
 						e.depth--
 						out = append(out, repl...)
@@ -169,8 +215,8 @@ func trimArgTokens(tokens []macroToken) []macroToken {
 	return tokens[start:end]
 }
 
-func (e *macroEnv) substituteMacro(fm functionMacro, args [][]macroToken) []macroToken {
-	body := tokenizeMacroSource(fm.body)
+func (e *macroEnv) substituteMacro(name string, fm functionMacro, args [][]macroToken) []macroToken {
+	body := e.getFunctionBodyTokens(name, fm)
 	argMap := make(map[string][]macroToken, len(fm.params))
 	for i, p := range fm.params {
 		if i < len(args) {

--- a/common/yak/c2ssa/preprocess/macro_expand.go
+++ b/common/yak/c2ssa/preprocess/macro_expand.go
@@ -27,9 +27,34 @@ func ExpandFunctionMacrosWithTables(src string, base MacroTables) (string, error
 }
 
 type macroEnv struct {
-	tables   macroTables
-	depth    int
-	maxDepth int
+	tables           macroTables
+	depth            int
+	maxDepth         int
+	objectBodyTokens map[string][]macroToken // session cache: tokenize only, not full expand
+}
+
+func newMacroEnvFromTables(tables MacroTables) *macroEnv {
+	return &macroEnv{
+		tables:   exportToMacroTables(tables),
+		maxDepth: maxMacroExpandDepth,
+	}
+}
+
+func (e *macroEnv) setTables(tables macroTables) {
+	e.tables = tables
+	e.objectBodyTokens = nil
+}
+
+func (e *macroEnv) getObjectBodyTokens(name, body string) []macroToken {
+	if e.objectBodyTokens == nil {
+		e.objectBodyTokens = make(map[string][]macroToken)
+	}
+	if toks, ok := e.objectBodyTokens[name]; ok {
+		return toks
+	}
+	toks := tokenizeMacroSource(body)
+	e.objectBodyTokens[name] = toks
+	return toks
 }
 
 func (e *macroEnv) expandSource(src string) string {
@@ -90,7 +115,7 @@ func (e *macroEnv) expandOnce(tokens []macroToken) ([]macroToken, bool) {
 					}
 				}
 			} else if body, ok := e.tables.object[name]; ok {
-				repl := tokenizeMacroSource(body)
+				repl := e.getObjectBodyTokens(name, body)
 				repl = e.expandTokens(repl)
 				out = append(out, repl...)
 				i++

--- a/common/yak/c2ssa/preprocess/preprocess_test.go
+++ b/common/yak/c2ssa/preprocess/preprocess_test.go
@@ -238,6 +238,95 @@ int y = F(1);
 	require.Contains(t, out, "F(1)")
 }
 
+// TestHeaderMacroCache_MultiTUStable locks include-agnostic header macros + project-level cache:
+// multiple TUs on one project must see the same header macros and stable PreprocessTU output.
+func TestHeaderMacroCache_MultiTUStable(t *testing.T) {
+	fs := filesys.NewVirtualFs()
+	require.NoError(t, fs.WriteFile("include/common.h", []byte("#define MAGIC 42\n#define TWICE(x) ((x)+(x))\n"), 0o644))
+	srcA := "int a = MAGIC;\nint b = TWICE(3);\n"
+	srcB := "int c = MAGIC;\nint d = TWICE(MAGIC);\n"
+	require.NoError(t, fs.WriteFile("apps/a.c", []byte(srcA), 0o644))
+	require.NoError(t, fs.WriteFile("apps/b.c", []byte(srcB), 0o644))
+
+	cfg := DefaultConfig()
+	cfg.IncludeDirs = []string{"include"}
+	project := BuildProject(fs, cfg)
+
+	outA1, err := project.PreprocessTU("apps/a.c", srcA)
+	require.NoError(t, err)
+	outA2, err := project.PreprocessTU("apps/a.c", srcA)
+	require.NoError(t, err)
+	require.Equal(t, outA1, outA2, "repeated PreprocessTU on same TU must be byte-identical")
+
+	outB, err := project.PreprocessTU("apps/b.c", srcB)
+	require.NoError(t, err)
+
+	require.Contains(t, outA1, "42")
+	require.Contains(t, outA1, "((3)+(3))")
+	require.Contains(t, outB, "42")
+	require.Contains(t, outB, "((42)+(42))")
+
+	// Header tables computed once; both TUs merge the same cached headers.
+	tablesA := project.buildMacroTables("apps/a.c", srcA)
+	tablesB := project.buildMacroTables("apps/b.c", srcB)
+	require.Equal(t, "42", tablesA.Object["MAGIC"])
+	require.Equal(t, "42", tablesB.Object["MAGIC"])
+	require.Equal(t, tablesA.Function["TWICE"], tablesB.Function["TWICE"])
+}
+
+// TestExpandPath_DefineUndefInterleaved ensures reused expandEnv stays correct across #define/#undef.
+func TestExpandPath_DefineUndefInterleaved(t *testing.T) {
+	fs := filesys.NewVirtualFs()
+	require.NoError(t, fs.WriteFile("include/empty.h", []byte("/* no macros */\n"), 0o644))
+	src := strings.Join([]string{
+		"#define X 1",
+		"int a = X;",
+		"#undef X",
+		"#define X 2",
+		"int b = X;",
+		"#define Y X",
+		"int c = Y;",
+		"#undef Y",
+		"int d = X;",
+	}, "\n")
+	require.NoError(t, fs.WriteFile("apps/interleaved.c", []byte(src), 0o644))
+
+	cfg := DefaultConfig()
+	cfg.IncludeDirs = []string{"include"}
+	project := BuildProject(fs, cfg)
+
+	out1, err := project.PreprocessTU("apps/interleaved.c", src)
+	require.NoError(t, err)
+	out2, err := project.PreprocessTU("apps/interleaved.c", src)
+	require.NoError(t, err)
+	require.Equal(t, out1, out2)
+
+	require.Contains(t, out1, "int a = 1;")
+	require.Contains(t, out1, "int b = 2;")
+	require.Contains(t, out1, "int c = 2;")
+	require.Contains(t, out1, "int d = 2;")
+	require.NotContains(t, out1, "int a = X;")
+	require.NotContains(t, out1, "int b = X;")
+}
+
+func TestLookupObject_ChainMatchesFlatten(t *testing.T) {
+	parent := NewMacroEnvironment(nil)
+	parent.tables.Object["A"] = "1"
+	parent.tables.Object["B"] = "parentB"
+
+	child := NewMacroEnvironment(parent)
+	child.tables.Object["B"] = "childB"
+	child.tables.Object["C"] = "3"
+
+	for _, name := range []string{"A", "B", "C", "missing"} {
+		flat := child.Flatten()
+		want, wantOK := flat.Object[name]
+		got, gotOK := child.LookupObject(name)
+		require.Equal(t, wantOK, gotOK, "name=%s", name)
+		require.Equal(t, want, got, "name=%s", name)
+	}
+}
+
 func ppMustRead(fs *filesys.VirtualFS, path string) string {
 	data, err := fs.ReadFile(path)
 	if err != nil {

--- a/common/yak/c2ssa/preprocess/project.go
+++ b/common/yak/c2ssa/preprocess/project.go
@@ -1,6 +1,8 @@
 package preprocess
 
 import (
+	"sync"
+
 	fi "github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
 )
 
@@ -10,6 +12,11 @@ type CPreprocessProject struct {
 	registry *HeaderRegistry
 	resolver *IncludeResolver
 	config   PreprocessConfig
+
+	// headerMacroTables caches macros collected from all project headers (include-agnostic).
+	// Built once per project; TUs clone and merge their own #define/#undef on top.
+	headerMacroOnce   sync.Once
+	headerMacroTables MacroTables
 }
 
 // BuildProject constructs a preprocessor project from fs and config.
@@ -30,6 +37,24 @@ func BuildProject(fs fi.FileSystem, config PreprocessConfig) *CPreprocessProject
 		resolver: NewIncludeResolver(reg, config),
 		config:   config,
 	}
+}
+
+// getHeaderMacroTables returns macros from all registered headers, computed once per project.
+func (p *CPreprocessProject) getHeaderMacroTables() MacroTables {
+	p.headerMacroOnce.Do(func() {
+		out := NewMacroTables()
+		seen := make(map[string]bool)
+		for _, entry := range p.registry.UniqueEntries() {
+			if entry == nil || seen[entry.Path] {
+				continue
+			}
+			seen[entry.Path] = true
+			tables := p.collectMacrosFromSource(entry.Path, string(entry.Content))
+			out.MergeFrom(tables)
+		}
+		p.headerMacroTables = out
+	})
+	return p.headerMacroTables
 }
 
 // Registry returns the header registry.

--- a/common/yak/c2ssa/preprocess/tu.go
+++ b/common/yak/c2ssa/preprocess/tu.go
@@ -2,7 +2,7 @@ package preprocess
 
 type macroCollector struct {
 	project   *CPreprocessProject
-	env       *MacroEnvironment
+	tables    MacroTables
 	depth     int
 	seenFiles map[string]bool
 }
@@ -24,11 +24,11 @@ func (p *CPreprocessProject) collectMacroEnvironment(entryPath, src string) Macr
 func (p *CPreprocessProject) collectMacrosFromSource(filePath, src string) MacroTables {
 	mc := &macroCollector{
 		project:   p,
-		env:       NewMacroEnvironment(nil),
+		tables:    NewMacroTables(),
 		seenFiles: make(map[string]bool),
 	}
 	mc.scanSource(filePath, src, p.config.Defines)
-	return mc.env.Flatten()
+	return mc.tables
 }
 
 func (mc *macroCollector) scanSource(filePath, src string, defs map[string]string) {
@@ -42,8 +42,11 @@ func (mc *macroCollector) scanSource(filePath, src string, defs map[string]strin
 	mc.seenFiles[norm] = true
 	mc.depth++
 
-	localEnv := NewMacroEnvironment(mc.env)
-	cond := NewConditionalStackWithGlobal(localEnv, mc.env, defs)
+	// Flat local tables for this file — no nested MacroEnvironment Flatten/Clone.
+	// Includes are skipped during collection; #if only sees this file's macros + config.Defines.
+	local := NewMacroTables()
+	localEnv := &MacroEnvironment{tables: local}
+	cond := NewConditionalStackWithGlobal(localEnv, nil, defs)
 
 	for _, line := range JoinLogicalLines(src) {
 		if handleCondDirective(cond, line) {
@@ -57,16 +60,17 @@ func (mc *macroCollector) scanSource(filePath, src string, defs map[string]strin
 		}
 		switch DirectiveName(line) {
 		case "define":
-			localEnv.ApplyDefineLine(line)
+			ApplyDefineLine(line, &local, false)
 		case "undef":
 			macro := ppFirstIdent(DirectiveRest(line))
 			if macro != "" {
-				localEnv.ApplyUndef(macro)
+				delete(local.Function, macro)
+				delete(local.Object, macro)
 			}
 		}
 	}
 
-	mc.env.MergeFrom(localEnv)
+	mc.tables.MergeFrom(local)
 	mc.depth--
 }
 

--- a/common/yak/c2ssa/preprocess/tu.go
+++ b/common/yak/c2ssa/preprocess/tu.go
@@ -9,17 +9,9 @@ type macroCollector struct {
 
 // buildMacroTables collects macros from all project headers and the entry translation unit.
 // Macro expansion is include-agnostic: headers do not need to be #included to contribute macros.
+// Header contribution is cached on the project; only the TU is rescanned per call.
 func (p *CPreprocessProject) buildMacroTables(entryPath, src string) MacroTables {
-	out := NewMacroTables()
-	seen := make(map[string]bool)
-	for _, entry := range p.registry.UniqueEntries() {
-		if entry == nil || seen[entry.Path] {
-			continue
-		}
-		seen[entry.Path] = true
-		tables := p.collectMacrosFromSource(entry.Path, string(entry.Content))
-		out.MergeFrom(tables)
-	}
+	out := p.getHeaderMacroTables().Clone()
 	out.MergeFrom(p.collectMacrosFromSource(entryPath, src))
 	return out
 }


### PR DESCRIPTION
Reduce preprocess cost without changing include-agnostic semantics: cache project header macro tables once, reuse macroEnv across lines, tokenize object-macro bodies once per session, and replace Flatten lookups in #if eval. Also gate BuildFromAST progress logging behind debug.