### PR TITLE
feat(httpflow): always include builtin tags in HTTPFlowsFieldGroup

### DIFF
--- a/common/yakgrpc/grpc_httpflow.go
+++ b/common/yakgrpc/grpc_httpflow.go
@@ -420,11 +420,10 @@ func (s *Server) HTTPFlowsFieldGroup(ctx context.Context, req *ypb.HTTPFlowsFiel
 		tags []*yakit.TagAndStatusCode
 		err  error
 	)
-	if req.IsAll {
-		// 需要统计所有tag
+	if req.GetIsAll() {
 		tags, err = yakit.QueryHTTPFlowTags()
 	} else {
-		tags, err = yakit.HTTPFlowTags(req.RefreshRequest)
+		tags, err = yakit.HTTPFlowTags(req.GetRefreshRequest())
 	}
 	// statusCode, err := yakit.HTTPFlowStatusCode(req.RefreshRequest)
 	var tagsCode ypb.HTTPFlowsFieldGroupResponse

--- a/common/yakgrpc/grpc_httpflow_test.go
+++ b/common/yakgrpc/grpc_httpflow_test.go
@@ -1561,6 +1561,71 @@ func TestHTTPFlowFieldGroup(t *testing.T) {
 	}
 }
 
+func TestHTTPFlowsFieldGroup_IsAllCountsAndBuiltin(t *testing.T) {
+	client, server, err := NewLocalClientAndServerWithTempDatabase(t)
+	require.NoError(t, err)
+
+	db := server.GetProjectDatabase()
+	oldDB := consts.GetGormProjectDatabase()
+	oldPath := consts.GetCurrentProjectDatabasePath()
+	consts.BindProjectDatabase(db, "httpflow-fieldgroup-temp")
+	t.Cleanup(func() {
+		if oldDB != nil {
+			consts.BindProjectDatabase(oldDB, oldPath)
+		}
+	})
+
+	// 无数据时：全部 builtin 都必须存在，且 Total=0
+	emptyRsp, err := client.HTTPFlowsFieldGroup(context.Background(), &ypb.HTTPFlowsFieldGroupRequest{IsAll: true})
+	require.NoError(t, err)
+	emptyByValue := make(map[string]*ypb.TagsCode, len(emptyRsp.Tags))
+	for _, tag := range emptyRsp.Tags {
+		emptyByValue[tag.Value] = tag
+	}
+	for builtin := range yakit.HTTPFlowBuiltinTags {
+		got, ok := emptyByValue[builtin]
+		require.True(t, ok, "empty IsAll missing builtin %s", builtin)
+		require.True(t, got.Builtin)
+		require.Equal(t, int32(0), got.Total, "empty IsAll builtin %s should be 0", builtin)
+	}
+
+	customTag := "isall-custom-" + uuid.NewString()
+	token := uuid.NewString()
+	insert := func(tags string) {
+		flow, err := yakit.CreateHTTPFlow(
+			yakit.CreateHTTPFlowWithURL(fmt.Sprintf("http://example.com/%s", token)),
+			yakit.CreateHTTPFlowWithTags(tags),
+		)
+		require.NoError(t, err)
+		require.NoError(t, yakit.InsertHTTPFlow(db, flow))
+	}
+	insert(customTag)
+	insert(customTag)
+	insert(yakit.HTTPFlowTagDiscarded)
+	insert(customTag + "|" + yakit.HTTPFlowTagDiscarded)
+
+	rsp, err := client.HTTPFlowsFieldGroup(context.Background(), &ypb.HTTPFlowsFieldGroupRequest{IsAll: true})
+	require.NoError(t, err)
+	byValue := make(map[string]*ypb.TagsCode, len(rsp.Tags))
+	for _, tag := range rsp.Tags {
+		byValue[tag.Value] = tag
+	}
+
+	require.Equal(t, int32(3), byValue[customTag].Total)
+	require.False(t, byValue[customTag].Builtin)
+	require.Equal(t, int32(2), byValue[yakit.HTTPFlowTagDiscarded].Total)
+	require.True(t, byValue[yakit.HTTPFlowTagDiscarded].Builtin)
+
+	for builtin := range yakit.HTTPFlowBuiltinTags {
+		got, ok := byValue[builtin]
+		require.True(t, ok, "IsAll missing builtin %s", builtin)
+		require.True(t, got.Builtin)
+		if builtin != yakit.HTTPFlowTagDiscarded {
+			require.Equal(t, int32(0), got.Total, "unused builtin %s should be 0", builtin)
+		}
+	}
+}
+
 func TestGRPCMUSTPASS_HTTPFFlow_KeyWord_Search(t *testing.T) {
 	client, err := NewLocalClient()
 	require.NoError(t, err)

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -1378,45 +1378,28 @@ func HTTPFlowTags(refreshRequest bool) ([]*TagAndStatusCode, error) {
 	for _, v := range model.GlobalHTTPFlowCache.GetAll() {
 		for _, tag := range strings.Split(v.Tags, "|") {
 			tag = strings.TrimSpace(tag)
-			if tag != "" {
+			if tag != "" && !strings.HasPrefix(tag, schema.COLORPREFIX) {
 				tagCounts[tag]++
 			}
 		}
 	}
-	tags := make([]*TagAndStatusCode, 0)
-	for k, v := range tagCounts {
-		if !strings.HasPrefix(k, schema.COLORPREFIX) {
-			tags = append(tags, &TagAndStatusCode{
-				Value:   k,
-				Count:   v,
-				Builtin: IsHTTPFlowBuiltinTag(k),
-			})
-		}
-	}
-	return tags, nil
+	return HTTPFlowTagsFromCounts(tagCounts), nil
 }
 
 func QueryHTTPFlowTags() ([]*TagAndStatusCode, error) {
-	tagSet := make(map[string]struct{})
+	tagCounts := make(map[string]int)
 	db := consts.GetGormProjectDatabase().Model(&schema.HTTPFlow{}).Select("id, tags").Where("tags IS NOT NULL AND tags != ''")
 	for flow := range YieldHTTPFlows(db, context.Background()) {
 		parts := strings.Split(flow.Tags, "|")
 		for _, part := range parts {
 			part = strings.TrimSpace(part)
 			if part != "" && !strings.HasPrefix(part, schema.COLORPREFIX) {
-				tagSet[part] = struct{}{}
+				// IsAll 只收集出现过的 tag，不统计次数
+				tagCounts[part] = 0
 			}
 		}
 	}
-
-	tags := make([]*TagAndStatusCode, 0)
-	for tag := range tagSet {
-		tags = append(tags, &TagAndStatusCode{
-			Value:   tag,
-			Builtin: IsHTTPFlowBuiltinTag(tag),
-		})
-	}
-	return tags, nil
+	return HTTPFlowTagsFromCounts(tagCounts), nil
 }
 
 func HTTPFlowSuffixes() ([]*TagAndStatusCode, error) {

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -1373,31 +1373,35 @@ const (
 	return statusCode, nil
 }*/
 
+func accumulateHTTPFlowTagField(rawTags string, tagCounts map[string]int) {
+	for _, tag := range strings.Split(rawTags, "|") {
+		tag = strings.TrimSpace(tag)
+		if tag != "" && !strings.HasPrefix(tag, schema.COLORPREFIX) {
+			tagCounts[tag]++
+		}
+	}
+}
+
+// HTTPFlowTags 从内存缓存统计 tag。
+// refreshRequest 为历史兼容参数，当前未使用。
 func HTTPFlowTags(refreshRequest bool) ([]*TagAndStatusCode, error) {
+	_ = refreshRequest
 	tagCounts := make(map[string]int)
 	for _, v := range model.GlobalHTTPFlowCache.GetAll() {
-		for _, tag := range strings.Split(v.Tags, "|") {
-			tag = strings.TrimSpace(tag)
-			if tag != "" && !strings.HasPrefix(tag, schema.COLORPREFIX) {
-				tagCounts[tag]++
-			}
+		if v == nil {
+			continue
 		}
+		accumulateHTTPFlowTagField(v.Tags, tagCounts)
 	}
 	return HTTPFlowTagsFromCounts(tagCounts), nil
 }
 
+// QueryHTTPFlowTags 从项目库全量统计 tag。
 func QueryHTTPFlowTags() ([]*TagAndStatusCode, error) {
 	tagCounts := make(map[string]int)
 	db := consts.GetGormProjectDatabase().Model(&schema.HTTPFlow{}).Select("id, tags").Where("tags IS NOT NULL AND tags != ''")
 	for flow := range YieldHTTPFlows(db, context.Background()) {
-		parts := strings.Split(flow.Tags, "|")
-		for _, part := range parts {
-			part = strings.TrimSpace(part)
-			if part != "" && !strings.HasPrefix(part, schema.COLORPREFIX) {
-				// IsAll 只收集出现过的 tag，不统计次数
-				tagCounts[part] = 0
-			}
-		}
+		accumulateHTTPFlowTagField(flow.Tags, tagCounts)
 	}
 	return HTTPFlowTagsFromCounts(tagCounts), nil
 }

--- a/common/yakgrpc/yakit/httpflow_builtin_tags.go
+++ b/common/yakgrpc/yakit/httpflow_builtin_tags.go
@@ -35,3 +35,26 @@ func IsHTTPFlowBuiltinTag(tag string) bool {
 	}
 	return strings.HasPrefix(tag, HTTPFlowTagResend)
 }
+
+// HTTPFlowTagsFromCounts 从 tag 计数构建返回结果，并补齐全部内置 tag（缺失 Count=0）。
+func HTTPFlowTagsFromCounts(tagCounts map[string]int) []*TagAndStatusCode {
+	tags := make([]*TagAndStatusCode, 0, len(tagCounts)+len(HTTPFlowBuiltinTags))
+	for k, v := range tagCounts {
+		tags = append(tags, &TagAndStatusCode{
+			Value:   k,
+			Count:   v,
+			Builtin: IsHTTPFlowBuiltinTag(k),
+		})
+	}
+	for tag := range HTTPFlowBuiltinTags {
+		if _, ok := tagCounts[tag]; ok {
+			continue
+		}
+		tags = append(tags, &TagAndStatusCode{
+			Value:   tag,
+			Count:   0,
+			Builtin: true,
+		})
+	}
+	return tags
+}

--- a/common/yakgrpc/yakit/httpflow_builtin_tags_test.go
+++ b/common/yakgrpc/yakit/httpflow_builtin_tags_test.go
@@ -16,3 +16,30 @@ func TestIsHTTPFlowBuiltinTag(t *testing.T) {
 	require.False(t, IsHTTPFlowBuiltinTag("webfuzzer"))
 	require.False(t, IsHTTPFlowBuiltinTag("custom-tag"))
 }
+
+func TestHTTPFlowTagsFromCounts(t *testing.T) {
+	tags := HTTPFlowTagsFromCounts(map[string]int{
+		"custom-tag":         3,
+		HTTPFlowTagDiscarded: 2,
+	})
+
+	byValue := make(map[string]*TagAndStatusCode, len(tags))
+	for _, tag := range tags {
+		byValue[tag.Value] = tag
+	}
+
+	require.Equal(t, 3, byValue["custom-tag"].Count)
+	require.False(t, byValue["custom-tag"].Builtin)
+
+	require.Equal(t, 2, byValue[HTTPFlowTagDiscarded].Count)
+	require.True(t, byValue[HTTPFlowTagDiscarded].Builtin)
+
+	for builtin := range HTTPFlowBuiltinTags {
+		got, ok := byValue[builtin]
+		require.True(t, ok, "missing builtin tag %s", builtin)
+		require.True(t, got.Builtin)
+		if builtin != HTTPFlowTagDiscarded {
+			require.Equal(t, 0, got.Count)
+		}
+	}
+}

--- a/common/yakgrpc/yakit/httpflow_builtin_tags_test.go
+++ b/common/yakgrpc/yakit/httpflow_builtin_tags_test.go
@@ -1,9 +1,14 @@
 package yakit
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/yakgrpc/model"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
 
 func TestIsHTTPFlowBuiltinTag(t *testing.T) {
@@ -15,6 +20,24 @@ func TestIsHTTPFlowBuiltinTag(t *testing.T) {
 
 	require.False(t, IsHTTPFlowBuiltinTag("webfuzzer"))
 	require.False(t, IsHTTPFlowBuiltinTag("custom-tag"))
+}
+
+func assertAllBuiltinTagsPresent(t *testing.T, tags []*TagAndStatusCode, expectCount map[string]int) {
+	t.Helper()
+	byValue := make(map[string]*TagAndStatusCode, len(tags))
+	for _, tag := range tags {
+		byValue[tag.Value] = tag
+	}
+	for builtin := range HTTPFlowBuiltinTags {
+		got, ok := byValue[builtin]
+		require.True(t, ok, "missing builtin tag %s", builtin)
+		require.True(t, got.Builtin, "builtin tag %s should have Builtin=true", builtin)
+		if expectCount != nil {
+			if want, has := expectCount[builtin]; has {
+				require.Equal(t, want, got.Count, "builtin tag %s count", builtin)
+			}
+		}
+	}
 }
 
 func TestHTTPFlowTagsFromCounts(t *testing.T) {
@@ -34,12 +57,95 @@ func TestHTTPFlowTagsFromCounts(t *testing.T) {
 	require.Equal(t, 2, byValue[HTTPFlowTagDiscarded].Count)
 	require.True(t, byValue[HTTPFlowTagDiscarded].Builtin)
 
+	expect := make(map[string]int, len(HTTPFlowBuiltinTags))
 	for builtin := range HTTPFlowBuiltinTags {
-		got, ok := byValue[builtin]
-		require.True(t, ok, "missing builtin tag %s", builtin)
-		require.True(t, got.Builtin)
-		if builtin != HTTPFlowTagDiscarded {
-			require.Equal(t, 0, got.Count)
-		}
+		expect[builtin] = 0
 	}
+	expect[HTTPFlowTagDiscarded] = 2
+	assertAllBuiltinTagsPresent(t, tags, expect)
+}
+
+func TestHTTPFlowTagsFromCounts_EmptyAlwaysIncludesBuiltinZero(t *testing.T) {
+	tags := HTTPFlowTagsFromCounts(nil)
+	require.Len(t, tags, len(HTTPFlowBuiltinTags))
+
+	expect := make(map[string]int, len(HTTPFlowBuiltinTags))
+	for builtin := range HTTPFlowBuiltinTags {
+		expect[builtin] = 0
+	}
+	assertAllBuiltinTagsPresent(t, tags, expect)
+}
+
+func TestQueryHTTPFlowTags_CountsAndBuiltin(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	customTag := "fieldgroup-custom-" + uuid.NewString()
+	token := uuid.NewString()
+
+	makeFlow := func(tags string) int64 {
+		flow, err := CreateHTTPFlow(
+			CreateHTTPFlowWithURL(fmt.Sprintf("http://example.com/%s", token)),
+			CreateHTTPFlowWithTags(tags),
+		)
+		require.NoError(t, err)
+		require.NoError(t, InsertHTTPFlow(db, flow))
+		t.Cleanup(func() {
+			_ = DeleteHTTPFlow(db, &ypb.DeleteHTTPFlowRequest{Id: []int64{int64(flow.ID)}})
+		})
+		return int64(flow.ID)
+	}
+
+	makeFlow(customTag)
+	makeFlow(customTag)
+	makeFlow(HTTPFlowTagDiscarded)
+	makeFlow(customTag + "|" + HTTPFlowTagDiscarded)
+
+	tags, err := QueryHTTPFlowTags()
+	require.NoError(t, err)
+
+	byValue := make(map[string]*TagAndStatusCode, len(tags))
+	for _, tag := range tags {
+		byValue[tag.Value] = tag
+	}
+
+	require.Equal(t, 3, byValue[customTag].Count)
+	require.False(t, byValue[customTag].Builtin)
+	require.GreaterOrEqual(t, byValue[HTTPFlowTagDiscarded].Count, 2)
+	require.True(t, byValue[HTTPFlowTagDiscarded].Builtin)
+
+	assertAllBuiltinTagsPresent(t, tags, nil)
+}
+
+func TestHTTPFlowTags_CacheCountsAndBuiltin(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	customTag := "cache-fieldgroup-" + uuid.NewString()
+	token := uuid.NewString()
+
+	flow, err := CreateHTTPFlow(
+		CreateHTTPFlowWithURL(fmt.Sprintf("http://example.com/%s", token)),
+		CreateHTTPFlowWithTags(customTag+"|"+HTTPFlowTagWebFuzzer),
+	)
+	require.NoError(t, err)
+	require.NoError(t, InsertHTTPFlow(db, flow))
+	t.Cleanup(func() {
+		_ = DeleteHTTPFlow(db, &ypb.DeleteHTTPFlowRequest{Id: []int64{int64(flow.ID)}})
+		model.DeleteHTTPFlowCacheGRPCModel(flow)
+	})
+
+	cached, err := model.ToHTTPFlowGRPCModel(flow, false)
+	require.NoError(t, err)
+	model.SetHTTPFlowCacheGRPCModel(flow, false, cached)
+
+	tags, err := HTTPFlowTags(false)
+	require.NoError(t, err)
+
+	byValue := make(map[string]*TagAndStatusCode, len(tags))
+	for _, tag := range tags {
+		byValue[tag.Value] = tag
+	}
+
+	require.GreaterOrEqual(t, byValue[customTag].Count, 1)
+	require.False(t, byValue[customTag].Builtin)
+	require.GreaterOrEqual(t, byValue[HTTPFlowTagWebFuzzer].Count, 1)
+	require.True(t, byValue[HTTPFlowTagWebFuzzer].Builtin)
+	assertAllBuiltinTagsPresent(t, tags, nil)
 }


### PR DESCRIPTION
Ensure FieldGroup returns every builtin tag even when unused, with Total=0, via a single HTTPFlowTagsFromCounts pass.