### PR TITLE
feat(scannode): 任务级 yak 引擎日志隔离（SCANNODE_TASK_LOG_DIR）

### DIFF
--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -81,7 +83,9 @@ func (s *ScanNode) executeScriptTask(
 	if err != nil {
 		return nil, utils.Errorf("fetch node path err: %s", err)
 	}
-	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID, ssaDBEnv); err != nil {
+	taskLogWriter, taskLogClose := openTaskLogWriter(input.TaskID, input.SubTaskID, input.RuntimeID)
+	defer taskLogClose()
+	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID, ssaDBEnv, taskLogWriter); err != nil {
 		logReporterEventError("final progress checkpoint", reporter.flushLatestJobProgress())
 		return nil, s.handleScriptFailure(err, result, taskID)
 	}
@@ -295,6 +299,7 @@ func (s *ScanNode) executeScript(
 	params []string,
 	runtimeID string,
 	extraEnv []string,
+	taskLogWriter io.Writer,
 ) error {
 	baseCmd := []string{"distyak", scriptFile}
 	log.Infof("yak %v %v", scriptFile, params)
@@ -306,9 +311,58 @@ func (s *ScanNode) executeScript(
 	)
 	env = append(env, extraEnv...)
 	cmd.Env = env
+	// 默认子进程 stdout/stderr 直通父进程（维持原行为）。当调用方传入
+	// per-task 日志 writer（开发测试调优：SCANNODE_TASK_LOG_DIR 开启时），
+	// 同时 tee 到该 writer，使单个扫描任务的 yak 引擎执行日志单独落盘，
+	// 便于按任务回溯调优，主日志仍保留完整视图。
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	if taskLogWriter != nil {
+		cmd.Stdout = io.MultiWriter(os.Stdout, taskLogWriter)
+		cmd.Stderr = io.MultiWriter(os.Stderr, taskLogWriter)
+	}
 	return cmd.Run()
+}
+
+// openTaskLogWriter 按环境变量 SCANNODE_TASK_LOG_DIR 为单个扫描任务打开
+// 独立的日志文件，用于开发测试调优场景下的任务级日志隔离。返回的 writer
+// 为 nil 表示未启用（生产默认），调用方应原样传给 executeScript，后者会
+// 走原直通路径。返回的 close 函数保证可安全调用（nil 时为 no-op）。
+//
+// 文件名格式：<JobID>_<SubTaskID>_<AttemptID>.log，缺失字段用 "_" 占位。
+// 任一失败（目录不存在/无权限）均降级为 nil 并打 warn 日志，不阻断扫描。
+func openTaskLogWriter(jobID, subTaskID, runtimeID string) (io.Writer, func()) {
+	dir := os.Getenv("SCANNODE_TASK_LOG_DIR")
+	if strings.TrimSpace(dir) == "" {
+		return nil, func() {}
+	}
+	name := fmt.Sprintf("%s_%s_%s.log",
+		sanitizeLogName(jobID),
+		sanitizeLogName(subTaskID),
+		sanitizeLogName(runtimeID),
+	)
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		log.Warnf("open per-task log file failed (fallback to stdout only): %s: %v", path, err)
+		return nil, func() {}
+	}
+	return f, func() { _ = f.Close() }
+}
+
+// sanitizeLogName 把任务标识里的路径分隔符/空字符等替换为 "_"，避免注入
+// 到 per-task 日志文件名中造成路径穿越或文件名异常。
+func sanitizeLogName(s string) string {
+	if s == "" {
+		return "_"
+	}
+	r := strings.NewReplacer("/", "_", "\\", "_", string(os.PathSeparator), "_", "\x00", "_")
+	out := r.Replace(s)
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "_"
+	}
+	return out
 }
 
 // classifyUploadError maps an upload error message to a structured error code

--- a/scannode/script_execution_task_log_test.go
+++ b/scannode/script_execution_task_log_test.go
@@ -1,0 +1,129 @@
+package scannode
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeThroughTaskLog exercises openTaskLogWriter the way executeScript would:
+// it writes a payload through the returned writer (simulating yak engine stdout
+// being tee'd) and verifies the per-task file receives it.
+func writeThroughTaskLog(t *testing.T, dir, jobID, subTaskID, runtimeID, payload string) string {
+	t.Helper()
+	t.Setenv("SCANNODE_TASK_LOG_DIR", dir)
+	w, closeFn := openTaskLogWriter(jobID, subTaskID, runtimeID)
+	defer closeFn()
+	if w == nil {
+		t.Fatalf("expected non-nil writer when SCANNODE_TASK_LOG_DIR set, got nil")
+	}
+	if _, err := io.WriteString(w, payload); err != nil {
+		t.Fatalf("write to task log writer failed: %v", err)
+	}
+	name := sanitizeLogName(jobID) + "_" + sanitizeLogName(subTaskID) + "_" + sanitizeLogName(runtimeID) + ".log"
+	return filepath.Join(dir, name)
+}
+
+func TestOpenTaskLogWriter_DisabledByDefault(t *testing.T) {
+	t.Setenv("SCANNODE_TASK_LOG_DIR", "")
+	w, closeFn := openTaskLogWriter("job-1", "sub-1", "att-1")
+	defer closeFn()
+	if w != nil {
+		t.Fatalf("expected nil writer when SCANNODE_TASK_LOG_DIR empty, got %T", w)
+	}
+}
+
+func TestOpenTaskLogWriter_CreatesPerTaskFile(t *testing.T) {
+	dir := t.TempDir()
+	payload := "yak engine: scanning\nrule hit: cwe-79\n"
+	path := writeThroughTaskLog(t, dir, "job-42", "sub-7", "att-3", payload)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read per-task log failed: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("per-task log content mismatch\nwant: %q\nhave: %q", payload, string(got))
+	}
+	if !strings.HasSuffix(path, "job-42_sub-7_att-3.log") {
+		t.Fatalf("unexpected per-task log filename: %s", path)
+	}
+}
+
+func TestOpenTaskLogWriter_AppendsAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SCANNODE_TASK_LOG_DIR", dir)
+	// 第一次写
+	w1, close1 := openTaskLogWriter("job-1", "sub-1", "att-1")
+	if w1 == nil {
+		t.Fatal("expected non-nil writer")
+	}
+	if _, err := io.WriteString(w1, "first line\n"); err != nil {
+		t.Fatal(err)
+	}
+	close1()
+	// 同一任务第二次写，应追加而非覆盖
+	w2, close2 := openTaskLogWriter("job-1", "sub-1", "att-1")
+	if w2 == nil {
+		t.Fatal("expected non-nil writer")
+	}
+	if _, err := io.WriteString(w2, "second line\n"); err != nil {
+		t.Fatal(err)
+	}
+	close2()
+
+	name := sanitizeLogName("job-1") + "_" + sanitizeLogName("sub-1") + "_" + sanitizeLogName("att-1") + ".log"
+	got, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	want := "first line\nsecond line\n"
+	if string(got) != want {
+		t.Fatalf("append mismatch\nwant: %q\nhave: %q", want, string(got))
+	}
+}
+
+func TestOpenTaskLogWriter_DegradedOnBadDir(t *testing.T) {
+	// 指向一个不存在的深层路径（父目录不可创建，比如无权限的根下），
+	// 应降级为 nil writer 而非 panic。用一个必然无法创建的路径。
+	t.Setenv("SCANNODE_TASK_LOG_DIR", "/nonexistent-root-dir-for-test/tasks")
+	w, closeFn := openTaskLogWriter("job-1", "sub-1", "att-1")
+	defer closeFn()
+	if w != nil {
+		t.Fatalf("expected nil writer on bad dir, got %T", w)
+	}
+}
+
+func TestSanitizeLogName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "_"},
+		{"job/1", "job_1"},
+		{"sub\\2", "sub_2"},
+		{"att\x00x", "att_x"},
+		{"normal", "normal"},
+		{"   ", "_"},
+	}
+	for _, c := range cases {
+		if got := sanitizeLogName(c.in); got != c.want {
+			t.Errorf("sanitizeLogName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestOpenTaskLogWriter_MissingFieldsUsePlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	path := writeThroughTaskLog(t, dir, "", "", "", "payload\n")
+	// 三个空字段各自 sanitize 为 "_"，用 "_" 连接 + ".log":
+	// fmt.Sprintf("%s_%s_%s.log", "_","_","_") = "_"+"_"+"_"+"_"+"_" = "_____" + ".log"
+	want := filepath.Join(dir, "_____.log")
+	if path != want {
+		t.Errorf("placeholder filename mismatch\nwant: %s\nhave: %s", want, path)
+	}
+	if _, err := os.ReadFile(path); err != nil {
+		t.Fatalf("placeholder file not readable: %v", err)
+	}
+}


### PR DESCRIPTION
## 改动摘要

开发测试调优场景下，扫描任务的 yak 引擎执行日志（distyak 子进程 stdout/stderr）原本与 smoke-node 父进程调度日志混在同一文件，难以按任务回溯调优。新增环境变量开关 `SCANNODE_TASK_LOG_DIR`，开启后每个扫描任务的子进程执行日志单独落盘到 `<dir>/<JobID>_<SubTaskID>_<AttemptID>.log`（append 模式），同时 tee 到主日志，主视图不丢失。留空（默认）维持原行为，生产零影响。

## 改动文件

- `scannode/script_execution.go`：`executeScript` 新增 `taskLogWriter io.Writer` 参数，非 nil 时用 `io.MultiWriter(os.Stdout, taskLogWriter)` 同时写主 stdout 与 per-task 文件；nil 时走原 `os.Stdout` 直通路径。`executeScriptTask` 调用 `openTaskLogWriter` 按 env 创建 per-task 文件，失败降级 nil + warn 不阻断扫描。`sanitizeLogName` 把任务标识里的路径分隔符/空字符替换为 `_` 防路径穿越。
- `scannode/script_execution_task_log_test.go`（新增）：6 个单测覆盖开关关/开、内容正确、追加写、坏目录降级、文件名 sanitize、缺失字段占位。

## 验证方式

- `go vet -tags hids ./scannode/` 通过
- `go build -tags hids ./cmd/legion-smoke-node` 通过
- `go test -tags hids -run 'TestOpenTaskLogWriter|TestSanitizeLogName' ./scannode/`：6/6 PASS
- 端到端：起完整 scan 栈 + 用本分支编译的 smoke-node（设 `SCANNODE_TASK_LOG_DIR=/tmp/e2e-task-logs`），触发真实扫描，确认 per-task 日志文件按 `<JobID>_<SubTaskID>_<AttemptID>.log` 生成，内容是完整 yak 引擎日志（编译/扫描/Scan Summary），主日志仍保留完整视图（tee 生效），扫描成功检出 1 risk。

## 不影响范围

不动 `common/log` 共享库、其它 scannode 文件、`main.go`，不引入新依赖。所有开关默认空=现状。