### PR TITLE
feat(scannode): S3d env-switch driver selection (LEGION_AI_RUNTIME)

### DIFF
--- a/scannode/legion_ai_bridge.go
+++ b/scannode/legion_ai_bridge.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -12,6 +13,19 @@ import (
 
 	aiv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/ai/v1"
 )
+
+// selectAISessionRuntimeDriver picks the AI runtime driver based on the
+// LEGION_AI_RUNTIME env var (S3d). "stateless" → statelessAIEngineRuntimeDriver
+// (S3c, per-turn engine, no persistence); any other value or unset →
+// yakAIEngineRuntimeDriver (legacy stateful). This is the behavior-cutover
+// switch point: rolling back is a sessionmgr config change + container restart,
+// no code revert needed.
+func selectAISessionRuntimeDriver() aiSessionRuntimeDriver {
+	if strings.TrimSpace(os.Getenv("LEGION_AI_RUNTIME")) == "stateless" {
+		return newStatelessAIEngineRuntimeDriver()
+	}
+	return newYakAIEngineRuntimeDriver()
+}
 
 const aiSessionRuntimeEventInput = "ai.session.input"
 const aiSessionRuntimeEventContextUpdated = "ai.session.context_updated"
@@ -511,7 +525,7 @@ func (b *legionJobBridge) ensureAIRuntime() *aiSessionRuntimeManager {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.aiRuntime == nil {
-		b.aiRuntime = newAISessionRuntimeManager(newYakAIEngineRuntimeDriver())
+		b.aiRuntime = newAISessionRuntimeManager(selectAISessionRuntimeDriver())
 	}
 	return b.aiRuntime
 }

--- a/scannode/legion_job_bridge.go
+++ b/scannode/legion_job_bridge.go
@@ -49,7 +49,7 @@ func newLegionJobBridge(agent *ScanNode) *legionJobBridge {
 		hidsDryRunPublisher:    capabilityPublisher,
 		ruleSyncPublisher:      newSSARuleSyncEventPublisher(agent.node),
 		aiPublisher:            newAISessionEventPublisher(agent.node),
-		aiRuntime:              newAISessionRuntimeManager(newYakAIEngineRuntimeDriver()),
+		aiRuntime:              newAISessionRuntimeManager(selectAISessionRuntimeDriver()),
 		aiLocalModelOps:        newAILocalModelOperationManager(),
 		aiKnowledgeBaseQueries: newAIKnowledgeBaseQueryManager(),
 		aiKnowledgeBaseQuestionIndexes: newAIKnowledgeBaseQueryManager(),

--- a/scannode/legion_job_bridge_env_test.go
+++ b/scannode/legion_job_bridge_env_test.go
@@ -1,0 +1,41 @@
+package scannode
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSelectAISessionRuntimeDriverStateless verifies that LEGION_AI_RUNTIME=stateless
+// selects the stateless driver (S3c). Uses %T to identify the concrete type
+// because the driver types are unexported and reflect.TypeOf().Name() is
+// unreliable for them.
+func TestSelectAISessionRuntimeDriverStateless(t *testing.T) {
+	t.Setenv("LEGION_AI_RUNTIME", "stateless")
+	d := selectAISessionRuntimeDriver()
+	got := fmt.Sprintf("%T", d)
+	if got != "scannode.statelessAIEngineRuntimeDriver" {
+		t.Fatalf("LEGION_AI_RUNTIME=stateless: expected statelessAIEngineRuntimeDriver, got %s", got)
+	}
+}
+
+// TestSelectAISessionRuntimeDriverDefaultStateful verifies that the default
+// (env unset or any non-"stateless" value) selects the legacy stateful driver,
+// preserving the rollback path.
+func TestSelectAISessionRuntimeDriverDefaultStateful(t *testing.T) {
+	cases := map[string]string{
+		"unset":        "",
+		"empty":        "   ",
+		"stateful":     "stateful",
+		"garbage":      "something-else",
+	}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("LEGION_AI_RUNTIME", val)
+			d := selectAISessionRuntimeDriver()
+			got := fmt.Sprintf("%T", d)
+			if got != "scannode.yakAIEngineRuntimeDriver" {
+				t.Fatalf("LEGION_AI_RUNTIME=%q: expected yakAIEngineRuntimeDriver, got %s", val, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## S3d: scannode env-switch driver selection（AI SaaS 无状态化第 4 步 - yaklang 侧）

### 改动内容
scannode 读取 `LEGION_AI_RUNTIME` env 选择 AI runtime driver：
- `"stateless"` → `statelessAIEngineRuntimeDriver`（S3c 无状态引擎，每轮建临时 engine）
- 其他/unset → `yakAIEngineRuntimeDriver`（legacy 有状态引擎，rollback 路径）

`newLegionJobBridge` + `ensureAIRuntime` 都用 `selectAISessionRuntimeDriver()` helper。

### 回滚机制
env 开关设计——回滚只需改 sessionmgr 配置 + 重启容器，**无需 code revert**。stateful driver 代码完整保留。

### 测试
5 个单测全通过：
- `TestSelectAISessionRuntimeDriverStateless`：env=stateless → statelessAIEngineRuntimeDriver
- `TestSelectAISessionRuntimeDriverDefaultStateful`（4 subcases：unset/empty/stateful/garbage）→ yakAIEngineRuntimeDriver

### 关联
- Legion companion PR: https://github.com/VillanCh/legion/pull/213
- 依赖 S3c (#4817) 已合并：statelessAIEngineRuntimeDriver 已在 baseline
- Spec: `docs/superpowers/specs/2026-07-27-s3-coordinator-stateless-engine-design.md` §7