### PR TITLE
fix(scannode): 支持无状态会话工具审批

### DIFF
--- a/scannode/legion_ai_runtime_stateless.go
+++ b/scannode/legion_ai_runtime_stateless.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/yaklang/yaklang/common/aiengine"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 	aiv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/ai/v1"
 )
 
 // statelessAIEngineRuntimeDriver is a parallel runtime driver (S3c) that runs
 // a fresh stateless aiengine.AIEngine per turn. Unlike yakAIEngineRuntimeDriver,
-// Bind does NOT create an engine; SendInput creates one per turn, runs SendMsg,
-// and closes it on return. History/tools/user_input come from the S3a
-// ContextPackage carried on aiSessionInput. NOT wired into legionJobBridge —
-// wiring + driver selection is S3d.
+// Bind does NOT create an engine. A normal input creates one engine for that
+// turn, while review/sync inputs are routed into the same live engine. The
+// engine is destroyed when the turn returns, so no state crosses turns.
+// History/tools/user_input come from the ContextPackage carried on aiSessionInput.
 type statelessAIEngineRuntimeDriver struct{}
 
 func newStatelessAIEngineRuntimeDriver() aiSessionRuntimeDriver {
@@ -39,22 +41,59 @@ func (statelessAIEngineRuntimeDriver) Bind(
 		binding:       binding,
 		emitter:       emitter,
 		cachedOptions: cachedOptions,
-		newEngine:     aiengine.NewAIEngine, // overridable in tests
+		newEngine: func(opts ...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+			return aiengine.NewAIEngine(opts...)
+		},
 	}, nil
+}
+
+type statelessTurnEngine interface {
+	SendMsg(string, ...aiengine.AIEngineConfigOption) error
+	SendInputEvent(*ypb.AIInputEvent) error
+	Close()
+}
+
+type statelessAITurn struct {
+	engine    statelessTurnEngine
+	closeOnce sync.Once
+}
+
+func (t *statelessAITurn) close() {
+	if t == nil || t.engine == nil {
+		return
+	}
+	t.closeOnce.Do(t.engine.Close)
 }
 
 type statelessAIEngineRuntimeHandle struct {
 	binding       aiSessionBinding
 	emitter       aiSessionRuntimeEmitter
 	cachedOptions []aiengine.AIEngineConfigOption
-	closed        bool
 
-	// newEngine is the engine constructor, overridable in tests to assert
-	// per-turn lifecycle without needing a real AI provider.
-	newEngine func(opts ...aiengine.AIEngineConfigOption) (*aiengine.AIEngine, error)
+	mu         sync.Mutex
+	activeTurn *statelessAITurn
+	closed     bool
+
+	// newEngine is overridable in tests so lifecycle and control routing can
+	// be verified without a real model provider.
+	newEngine func(opts ...aiengine.AIEngineConfigOption) (statelessTurnEngine, error)
 }
 
 func (h *statelessAIEngineRuntimeHandle) SendInput(ctx context.Context, input aiSessionInput) error {
+	if isInteractiveAISessionInput(input.InputType) {
+		handled, err := h.sendInterventionInput(input)
+		if err != nil || handled {
+			return err
+		}
+		// Session status can remain running until S3e's idle timer fires even
+		// though the prior turn engine has already closed. A free input sent in
+		// that window starts the next turn; a review response never does.
+		input.InputType = "message"
+	}
+	if isSyncAISessionInput(input.InputType) {
+		return h.sendSyncInput(input)
+	}
+
 	// Build a fresh engine per turn with WithStateless(true) + cached options +
 	// ContextPackage-derived history injection.
 	options := append([]aiengine.AIEngineConfigOption{}, h.cachedOptions...)
@@ -73,26 +112,143 @@ func (h *statelessAIEngineRuntimeHandle) SendInput(ctx context.Context, input ai
 	// Prefer ContextPackage.user_input; fall back to the legacy PayloadJSON
 	// content (for compatibility if ContextPackage is nil).
 	userInput := ""
-	if input.ContextPackage != nil && input.ContextPackage.UserInput != "" {
-		userInput = input.ContextPackage.UserInput
-	} else {
-		content, _, _, _, perr := yakAIInputContent(input)
+	var messageOptions []aiengine.AIEngineConfigOption
+	if len(input.PayloadJSON) > 0 {
+		content, interactive, syncEvent, decodedOptions, perr := yakAIInputContent(input)
 		if perr != nil {
 			return fmt.Errorf("stateless sendinput: decode input: %w", perr)
 		}
+		if interactive || syncEvent != nil {
+			return fmt.Errorf("stateless sendinput: unsupported control input type %q", input.InputType)
+		}
 		userInput = content
+		messageOptions = decodedOptions
+	}
+	if input.ContextPackage != nil && input.ContextPackage.UserInput != "" {
+		userInput = input.ContextPackage.UserInput
 	}
 	if userInput == "" {
 		return fmt.Errorf("stateless sendinput: empty user input")
 	}
 
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return fmt.Errorf("stateless sendinput: runtime is closed")
+	}
+	if h.activeTurn != nil {
+		h.mu.Unlock()
+		return fmt.Errorf("stateless sendinput: turn already active")
+	}
 	engine, err := h.newEngine(options...)
 	if err != nil {
+		h.mu.Unlock()
 		return fmt.Errorf("stateless sendinput: new engine: %w", err)
 	}
-	defer engine.Close()
+	if engine == nil {
+		h.mu.Unlock()
+		return fmt.Errorf("stateless sendinput: new engine returned nil")
+	}
+	turn := &statelessAITurn{engine: engine}
+	h.activeTurn = turn
+	h.mu.Unlock()
 
-	return engine.SendMsg(userInput)
+	go h.runTurn(ctx, turn, userInput, messageOptions...)
+	return nil
+}
+
+func isInteractiveAISessionInput(inputType string) bool {
+	switch strings.ToLower(strings.TrimSpace(inputType)) {
+	case "interactive", "interactive_response", "review_response", "user_intervention":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSyncAISessionInput(inputType string) bool {
+	return strings.EqualFold(strings.TrimSpace(inputType), "sync_event")
+}
+
+func (h *statelessAIEngineRuntimeHandle) sendInterventionInput(input aiSessionInput) (bool, error) {
+	event, err := buildYakAIInterventionEvent(input)
+	if err != nil {
+		return true, fmt.Errorf("stateless sendinput: %w", err)
+	}
+	turn, err := h.currentTurn("user intervention")
+	if err != nil {
+		if event.GetIsFreeInput() && h.runtimeOpenWithoutActiveTurn() {
+			return false, nil
+		}
+		return true, err
+	}
+	if err := turn.engine.SendInputEvent(event); err != nil {
+		return true, fmt.Errorf("stateless sendinput: send user intervention: %w", err)
+	}
+	return true, nil
+}
+
+func (h *statelessAIEngineRuntimeHandle) sendSyncInput(input aiSessionInput) error {
+	_, _, syncEvent, _, err := yakAIInputContent(input)
+	if err != nil {
+		return fmt.Errorf("stateless sendinput: decode sync event: %w", err)
+	}
+	if syncEvent == nil {
+		return fmt.Errorf("stateless sendinput: sync event is required")
+	}
+	turn, err := h.currentTurn("sync event")
+	if err != nil {
+		return err
+	}
+	if err := turn.engine.SendInputEvent(&ypb.AIInputEvent{
+		IsSyncMessage: true,
+		SyncType:      syncEvent.SyncType,
+		SyncJsonInput: syncEvent.SyncJSONInput,
+	}); err != nil {
+		return fmt.Errorf("stateless sendinput: send sync event: %w", err)
+	}
+	return nil
+}
+
+func (h *statelessAIEngineRuntimeHandle) currentTurn(inputKind string) (*statelessAITurn, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil, fmt.Errorf("stateless sendinput: runtime is closed")
+	}
+	if h.activeTurn == nil {
+		return nil, fmt.Errorf("stateless sendinput: no active turn for %s", inputKind)
+	}
+	return h.activeTurn, nil
+}
+
+func (h *statelessAIEngineRuntimeHandle) runtimeOpenWithoutActiveTurn() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return !h.closed && h.activeTurn == nil
+}
+
+func (h *statelessAIEngineRuntimeHandle) runTurn(
+	ctx context.Context,
+	turn *statelessAITurn,
+	userInput string,
+	options ...aiengine.AIEngineConfigOption,
+) {
+	err := turn.engine.SendMsg(userInput, options...)
+
+	h.mu.Lock()
+	closed := h.closed
+	if h.activeTurn == turn {
+		h.activeTurn = nil
+	}
+	h.mu.Unlock()
+	turn.close()
+
+	if err != nil && ctx.Err() == nil && !closed {
+		h.emitter.Failed(yakAISendFailureCode(err), err.Error(), mustJSON(map[string]string{
+			"runtime": "stateless_yak_ai_engine",
+		}))
+	}
 }
 
 func (h *statelessAIEngineRuntimeHandle) AppendContext(_ context.Context, _ aiSessionContextUpdate) error {
@@ -102,13 +258,24 @@ func (h *statelessAIEngineRuntimeHandle) AppendContext(_ context.Context, _ aiSe
 }
 
 func (h *statelessAIEngineRuntimeHandle) Cancel(_ string) {
-	// Per-turn engine is already closed after SendMsg; Cancel is a no-op.
-	// If a turn is in flight, the engine's ctx cancel (set in NewAIEngine) handles it.
+	h.closeRuntime()
 }
 
 func (h *statelessAIEngineRuntimeHandle) Close(_ string) {
+	h.closeRuntime()
+}
+
+func (h *statelessAIEngineRuntimeHandle) closeRuntime() {
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return
+	}
 	h.closed = true
-	// No persistent engine to close; resources were per-turn.
+	turn := h.activeTurn
+	h.activeTurn = nil
+	h.mu.Unlock()
+	turn.close()
 }
 
 // buildContextPackageHistoryBlock formats the replayed conversation messages

--- a/scannode/legion_ai_runtime_stateless_test.go
+++ b/scannode/legion_ai_runtime_stateless_test.go
@@ -3,10 +3,13 @@ package scannode
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/yaklang/yaklang/common/aiengine"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 	aiv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/ai/v1"
 )
 
@@ -14,27 +17,61 @@ import (
 // (buildYakAIEngineOptions wires emitter into OnEvent; nil would panic).
 type noopEmitter struct{}
 
-func (noopEmitter) Emit(string, []byte)        {}
-func (noopEmitter) Done([]byte)               {}
+func (noopEmitter) Emit(string, []byte)           {}
+func (noopEmitter) Done([]byte)                   {}
 func (noopEmitter) Failed(string, string, []byte) {}
 
-// fakeEngineFactory records how many engines were created and returns a
-// minimal stub *aiengine.AIEngine. We cannot easily construct a real AIEngine
-// without an AI provider, so the test injects this factory to assert the
-// per-turn lifecycle (creation count, Close calls) without a real LLM call.
-//
-// NOTE: aiengine.AIEngine is a struct, not an interface, so we cannot substitute
-// it directly. Instead, the test asserts via the factory's call counter that
-// SendInput invoked newEngine once per turn. The real engine construction +
-// SendMsg + Close path is exercised in integration (S3d T2). For the unit test,
-// we inject a factory that returns a real AIEngine constructed with a no-op
-// operator setup — but since that still needs an AI callback, the simplest
-// verifiable assertion is the factory call count.
+type recordingStatelessEmitter struct {
+	failed chan string
+}
+
+func (recordingStatelessEmitter) Emit(string, []byte) {}
+func (recordingStatelessEmitter) Done([]byte)         {}
+func (e recordingStatelessEmitter) Failed(code string, _ string, _ []byte) {
+	e.failed <- code
+}
+
+type fakeStatelessTurnEngine struct {
+	started   chan struct{}
+	release   chan struct{}
+	closed    chan struct{}
+	events    chan *ypb.AIInputEvent
+	sendErr   error
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func newFakeStatelessTurnEngine() *fakeStatelessTurnEngine {
+	return &fakeStatelessTurnEngine{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		closed:  make(chan struct{}),
+		events:  make(chan *ypb.AIInputEvent, 4),
+	}
+}
+
+func (f *fakeStatelessTurnEngine) SendMsg(string, ...aiengine.AIEngineConfigOption) error {
+	f.startOnce.Do(func() { close(f.started) })
+	select {
+	case <-f.release:
+	case <-f.closed:
+	}
+	return f.sendErr
+}
+
+func (f *fakeStatelessTurnEngine) SendInputEvent(event *ypb.AIInputEvent) error {
+	f.events <- event
+	return nil
+}
+
+func (f *fakeStatelessTurnEngine) Close() {
+	f.closeOnce.Do(func() { close(f.closed) })
+}
 
 func TestStatelessDriverBindReturnsHandleWithoutEngineField(t *testing.T) {
 	driver := newStatelessAIEngineRuntimeDriver()
 	binding := aiSessionBinding{
-		Ref: aiSessionCommandRef{SessionID: "s-stateless-1", OwnerUserID: "u1"},
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-1", OwnerUserID: "u1"},
 		ProviderPolicySnapshotJSON: []byte(`{}`),
 		RuntimeOptionSnapshotJSON:  []byte(`{}`),
 	}
@@ -61,7 +98,7 @@ func TestStatelessDriverSendInputInvokesEngineFactoryPerTurn(t *testing.T) {
 	var engineCreated int32
 	driver := newStatelessAIEngineRuntimeDriver()
 	binding := aiSessionBinding{
-		Ref: aiSessionCommandRef{SessionID: "s-stateless-2", OwnerUserID: "u1"},
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-2", OwnerUserID: "u1"},
 		ProviderPolicySnapshotJSON: []byte(`{}`),
 		RuntimeOptionSnapshotJSON:  []byte(`{}`),
 	}
@@ -74,7 +111,7 @@ func TestStatelessDriverSendInputInvokesEngineFactoryPerTurn(t *testing.T) {
 	// the real SendMsg (we only want to verify the factory was invoked, not
 	// run a real ReAct loop). The error is expected; we assert the count, not
 	// the error path.
-	sh.newEngine = func(opts ...aiengine.AIEngineConfigOption) (*aiengine.AIEngine, error) {
+	sh.newEngine = func(opts ...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
 		atomic.AddInt32(&engineCreated, 1)
 		// Return nil + error so SendInput exits early after counting.
 		return nil, errFakeEngineFactory
@@ -98,13 +135,13 @@ func TestStatelessDriverSendInputInvokesEngineFactoryPerTurn(t *testing.T) {
 func TestStatelessDriverSendInputEmptyUserInputErrors(t *testing.T) {
 	driver := newStatelessAIEngineRuntimeDriver()
 	binding := aiSessionBinding{
-		Ref: aiSessionCommandRef{SessionID: "s-stateless-3", OwnerUserID: "u1"},
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-3", OwnerUserID: "u1"},
 		ProviderPolicySnapshotJSON: []byte(`{}`),
 		RuntimeOptionSnapshotJSON:  []byte(`{}`),
 	}
 	handle, _ := driver.Bind(context.Background(), binding, noopEmitter{})
 	sh := handle.(*statelessAIEngineRuntimeHandle)
-	sh.newEngine = func(opts ...aiengine.AIEngineConfigOption) (*aiengine.AIEngine, error) {
+	sh.newEngine = func(opts ...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
 		t.Fatal("newEngine should not be called when user input is empty")
 		return nil, nil
 	}
@@ -115,6 +152,380 @@ func TestStatelessDriverSendInputEmptyUserInputErrors(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for empty user input")
+	}
+}
+
+func TestStatelessDriverInteractiveResponseRequiresActiveTurnWithoutCreatingEngine(t *testing.T) {
+	var engineCreated int32
+	driver := newStatelessAIEngineRuntimeDriver()
+	binding := aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-review", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}
+	handle, err := driver.Bind(context.Background(), binding, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	sh.newEngine = func(opts ...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		atomic.AddInt32(&engineCreated, 1)
+		return nil, errFakeEngineFactory
+	}
+
+	err = sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"id":"review-1","suggestion":"continue"}`),
+		ContextPackage: &aiv1.ContextPackage{
+			SessionId: "s-stateless-review",
+			UserInput: `{"id":"review-1","suggestion":"continue"}`,
+		},
+	})
+	if err == nil || !contains(err.Error(), "no active turn") {
+		t.Fatalf("expected no-active-turn error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&engineCreated); got != 0 {
+		t.Fatalf("interactive response must not create a new engine, got %d creations", got)
+	}
+}
+
+func TestStatelessDriverFreeInputWithoutActiveTurnStartsNextTurn(t *testing.T) {
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-idle-free-input", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engine := newFakeStatelessTurnEngine()
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		return engine, nil
+	}
+
+	err = sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"content":"continue with redirect checks"}`),
+		ContextPackage: &aiv1.ContextPackage{
+			SessionId: "s-stateless-idle-free-input",
+			UserInput: "continue with redirect checks",
+		},
+	})
+	if err != nil {
+		t.Fatalf("free input: %v", err)
+	}
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("free input did not start a new turn")
+	}
+	close(engine.release)
+}
+
+func TestStatelessDriverRunsTurnAsyncAndRoutesInteractiveResponseToActiveEngine(t *testing.T) {
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-active-review", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engine := newFakeStatelessTurnEngine()
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		return engine, nil
+	}
+
+	returned := make(chan error, 1)
+	go func() {
+		returned <- sh.SendInput(context.Background(), aiSessionInput{
+			InputType:   "message",
+			PayloadJSON: []byte(`{"content":"run a reviewed tool"}`),
+			ContextPackage: &aiv1.ContextPackage{
+				SessionId: "s-stateless-active-review",
+				UserInput: "run a reviewed tool",
+			},
+		})
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("turn did not start")
+	}
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("SendInput returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SendInput blocked the command consumer while the turn was running")
+	}
+
+	err = sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"id":"review-async-1","suggestion":"continue"}`),
+	})
+	if err != nil {
+		t.Fatalf("interactive response: %v", err)
+	}
+
+	select {
+	case event := <-engine.events:
+		if !event.GetIsInteractiveMessage() {
+			t.Fatal("expected interactive event")
+		}
+		if event.GetInteractiveId() != "review-async-1" {
+			t.Fatalf("unexpected interactive id: %q", event.GetInteractiveId())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("active turn did not receive interactive response")
+	}
+	close(engine.release)
+}
+
+func TestStatelessDriverRoutesFreeInputToActiveEngine(t *testing.T) {
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-free-input", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engine := newFakeStatelessTurnEngine()
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		return engine, nil
+	}
+
+	if err := sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "message",
+		PayloadJSON: []byte(`{"content":"start"}`),
+		ContextPackage: &aiv1.ContextPackage{
+			SessionId: "s-stateless-free-input",
+			UserInput: "start",
+		},
+	}); err != nil {
+		t.Fatalf("start turn: %v", err)
+	}
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("turn did not start")
+	}
+
+	err = sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"content":"also inspect redirects"}`),
+	})
+	if err != nil {
+		t.Fatalf("free input: %v", err)
+	}
+	select {
+	case event := <-engine.events:
+		if !event.GetIsFreeInput() || event.GetFreeInput() != "also inspect redirects" {
+			t.Fatalf("unexpected free input event: %#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("active turn did not receive free input")
+	}
+	close(engine.release)
+}
+
+func TestStatelessDriverStartsFreshEngineAfterTurnCompletes(t *testing.T) {
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-next-turn", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engines := []*fakeStatelessTurnEngine{
+		newFakeStatelessTurnEngine(),
+		newFakeStatelessTurnEngine(),
+	}
+	var engineIndex int
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		engine := engines[engineIndex]
+		engineIndex++
+		return engine, nil
+	}
+
+	send := func(content string) error {
+		return sh.SendInput(context.Background(), aiSessionInput{
+			InputType:   "message",
+			PayloadJSON: []byte(fmt.Sprintf(`{"content":%q}`, content)),
+			ContextPackage: &aiv1.ContextPackage{
+				SessionId: "s-stateless-next-turn",
+				UserInput: content,
+			},
+		})
+	}
+	if err := send("first"); err != nil {
+		t.Fatalf("first turn: %v", err)
+	}
+	select {
+	case <-engines[0].started:
+	case <-time.After(time.Second):
+		t.Fatal("first turn did not start")
+	}
+	close(engines[0].release)
+	select {
+	case <-engines[0].closed:
+	case <-time.After(time.Second):
+		t.Fatal("first turn engine was not closed")
+	}
+
+	if err := send("second"); err != nil {
+		t.Fatalf("second turn: %v", err)
+	}
+	select {
+	case <-engines[1].started:
+	case <-time.After(time.Second):
+		t.Fatal("second turn did not start with a fresh engine")
+	}
+	close(engines[1].release)
+}
+
+func TestStatelessDriverRejectsSecondMessageWhileTurnIsActive(t *testing.T) {
+	var engineCreated int32
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-overlap", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engine := newFakeStatelessTurnEngine()
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		atomic.AddInt32(&engineCreated, 1)
+		return engine, nil
+	}
+
+	if err := sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "message",
+		PayloadJSON: []byte(`{"content":"first"}`),
+		ContextPackage: &aiv1.ContextPackage{
+			SessionId: "s-stateless-overlap",
+			UserInput: "first",
+		},
+	}); err != nil {
+		t.Fatalf("first input: %v", err)
+	}
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("first turn did not start")
+	}
+
+	err = sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "message",
+		PayloadJSON: []byte(`{"content":"second"}`),
+		ContextPackage: &aiv1.ContextPackage{
+			SessionId: "s-stateless-overlap",
+			UserInput: "second",
+		},
+	})
+	if err == nil || !contains(err.Error(), "turn already active") {
+		t.Fatalf("expected active-turn error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&engineCreated); got != 1 {
+		t.Fatalf("overlapping input created %d engines, want 1", got)
+	}
+	close(engine.release)
+}
+
+func TestStatelessDriverCancelClosesActiveTurn(t *testing.T) {
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-cancel", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engine := newFakeStatelessTurnEngine()
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		return engine, nil
+	}
+
+	if err := sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "message",
+		PayloadJSON: []byte(`{"content":"long turn"}`),
+		ContextPackage: &aiv1.ContextPackage{
+			SessionId: "s-stateless-cancel",
+			UserInput: "long turn",
+		},
+	}); err != nil {
+		t.Fatalf("start turn: %v", err)
+	}
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("turn did not start")
+	}
+
+	sh.Cancel("user stopped")
+	select {
+	case <-engine.closed:
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not close active engine")
+	}
+}
+
+func TestStatelessDriverCancelDoesNotReportTurnFailure(t *testing.T) {
+	emitter := recordingStatelessEmitter{failed: make(chan string, 1)}
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-cancel-error", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, emitter)
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engine := newFakeStatelessTurnEngine()
+	engine.sendErr = fmt.Errorf("turn interrupted by close")
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		return engine, nil
+	}
+
+	if err := sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "message",
+		PayloadJSON: []byte(`{"content":"long turn"}`),
+		ContextPackage: &aiv1.ContextPackage{
+			SessionId: "s-stateless-cancel-error",
+			UserInput: "long turn",
+		},
+	}); err != nil {
+		t.Fatalf("start turn: %v", err)
+	}
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("turn did not start")
+	}
+
+	sh.Cancel("user stopped")
+	select {
+	case code := <-emitter.failed:
+		t.Fatalf("cancelled turn emitted failure %q", code)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -142,15 +553,16 @@ func TestBuildContextPackageHistoryBlockEmptyReturnsEmpty(t *testing.T) {
 	}
 }
 
-func TestStatelessDriverCancelAndCloseAreNoop(t *testing.T) {
+func TestStatelessDriverCancelAndCloseAreIdempotentWhenIdle(t *testing.T) {
 	driver := newStatelessAIEngineRuntimeDriver()
 	binding := aiSessionBinding{
-		Ref: aiSessionCommandRef{SessionID: "s-stateless-4", OwnerUserID: "u1"},
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-4", OwnerUserID: "u1"},
 		ProviderPolicySnapshotJSON: []byte(`{}`),
 		RuntimeOptionSnapshotJSON:  []byte(`{}`),
 	}
 	handle, _ := driver.Bind(context.Background(), binding, noopEmitter{})
-	// These must not panic.
+	// Repeated shutdown calls with no active turn must not panic.
+	handle.Cancel("test-reason")
 	handle.Cancel("test-reason")
 	handle.Close("test-reason")
 	sh := handle.(*statelessAIEngineRuntimeHandle)

--- a/scannode/legion_ai_runtime_yak.go
+++ b/scannode/legion_ai_runtime_yak.go
@@ -20,6 +20,7 @@ import (
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
 
 const (
@@ -87,7 +88,11 @@ func (h *yakAIEngineRuntimeHandle) SendInput(ctx context.Context, input aiSessio
 	h.mu.Unlock()
 
 	if interactive {
-		if err := h.engine.SendInteractiveResponse(content); err != nil {
+		event, eventErr := buildYakAIInterventionEvent(input)
+		if eventErr != nil {
+			return eventErr
+		}
+		if err := h.engine.SendInputEvent(event); err != nil {
 			return fmt.Errorf("send yak ai interactive response: %w", err)
 		}
 		return nil
@@ -798,6 +803,68 @@ func yakAIInputContent(input aiSessionInput) (string, bool, *yakAISyncEvent, []a
 		}
 		return content, false, nil, yakAIInputAttachedResourceOptions(payload), nil
 	}
+}
+
+func buildYakAIInterventionEvent(input aiSessionInput) (*ypb.AIInputEvent, error) {
+	var payload map[string]any
+	if err := json.Unmarshal(input.PayloadJSON, &payload); err != nil {
+		return nil, fmt.Errorf("decode ai session intervention payload: %w", err)
+	}
+	interactiveID := interactiveIDFromPayload(payload)
+	interactiveJSON := string(input.PayloadJSON)
+	if interactiveID != "" {
+		if explicitJSON := firstNonEmptyString(payload, "interactive_json_input", "response"); explicitJSON != "" {
+			interactiveJSON = explicitJSON
+		}
+		return &ypb.AIInputEvent{
+			IsInteractiveMessage: true,
+			InteractiveId:        interactiveID,
+			InteractiveJSONInput: interactiveJSON,
+		}, nil
+	}
+
+	content := firstNonEmptyString(payload, "content", "message", "text", "free_input")
+	if content != "" {
+		var nested map[string]any
+		if err := json.Unmarshal([]byte(content), &nested); err == nil {
+			interactiveID = interactiveIDFromPayload(nested)
+			if interactiveID != "" {
+				interactiveJSON = content
+			}
+		}
+	}
+	if interactiveID != "" {
+		return &ypb.AIInputEvent{
+			IsInteractiveMessage: true,
+			InteractiveId:        interactiveID,
+			InteractiveJSONInput: interactiveJSON,
+		}, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(input.InputType), "user_intervention") {
+		return nil, fmt.Errorf("ai session interactive id is required")
+	}
+	if content == "" && input.ContextPackage != nil {
+		content = input.ContextPackage.UserInput
+	}
+	if content == "" {
+		return nil, fmt.Errorf("ai session intervention content is required")
+	}
+	return &ypb.AIInputEvent{
+		IsFreeInput: true,
+		FreeInput:   content,
+	}, nil
+}
+
+func interactiveIDFromPayload(payload map[string]any) string {
+	return firstNonEmptyString(
+		payload,
+		"id",
+		"ID",
+		"interactive_id",
+		"interactiveId",
+		"interactiveID",
+		"InteractiveId",
+	)
 }
 
 func yakAIInputAttachedResourceOptions(payload map[string]any) []aiengine.AIEngineConfigOption {

--- a/scannode/legion_ai_runtime_yak_test.go
+++ b/scannode/legion_ai_runtime_yak_test.go
@@ -261,6 +261,82 @@ func TestYakAIInputContentTreatsUserInterventionAsInteractivePayload(t *testing.
 	assertJSONEqualRuntimeYak(t, []byte(content), string(payload))
 }
 
+func TestBuildYakAIInterventionEventCarriesEndpointID(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"id":"interactive-1","suggestion":"continue","review_type":"tool_use_review_require"}`)
+	event, err := buildYakAIInterventionEvent(aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: payload,
+	})
+	if err != nil {
+		t.Fatalf("buildYakAIInterventionEvent() error = %v", err)
+	}
+	if !event.GetIsInteractiveMessage() {
+		t.Fatal("expected interactive input event")
+	}
+	if event.GetInteractiveId() != "interactive-1" {
+		t.Fatalf("unexpected interactive id: %q", event.GetInteractiveId())
+	}
+	assertJSONEqualRuntimeYak(t, []byte(event.GetInteractiveJSONInput()), string(payload))
+}
+
+func TestBuildYakAIInterventionEventUnwrapsComposerReviewPayload(t *testing.T) {
+	t.Parallel()
+
+	event, err := buildYakAIInterventionEvent(aiSessionInput{
+		InputType: "user_intervention",
+		PayloadJSON: []byte(`{
+			"content":"{\"id\":\"interactive-nested\",\"suggestion\":\"enough-cancel\"}",
+			"showQS":"Stop tool"
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("buildYakAIInterventionEvent() error = %v", err)
+	}
+	if event.GetInteractiveId() != "interactive-nested" {
+		t.Fatalf("unexpected interactive id: %q", event.GetInteractiveId())
+	}
+	assertJSONEqualRuntimeYak(
+		t,
+		[]byte(event.GetInteractiveJSONInput()),
+		`{"id":"interactive-nested","suggestion":"enough-cancel"}`,
+	)
+}
+
+func TestBuildYakAIInterventionEventMapsFreeInputWithoutEndpointID(t *testing.T) {
+	t.Parallel()
+
+	event, err := buildYakAIInterventionEvent(aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"content":"check the authorization path too"}`),
+	})
+	if err != nil {
+		t.Fatalf("buildYakAIInterventionEvent() error = %v", err)
+	}
+	if !event.GetIsFreeInput() {
+		t.Fatal("expected free input event")
+	}
+	if event.GetFreeInput() != "check the authorization path too" {
+		t.Fatalf("unexpected free input: %q", event.GetFreeInput())
+	}
+	if event.GetIsInteractiveMessage() {
+		t.Fatal("free input must not be marked interactive")
+	}
+}
+
+func TestBuildYakAIInterventionEventRejectsReviewWithoutEndpointID(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildYakAIInterventionEvent(aiSessionInput{
+		InputType:   "review_response",
+		PayloadJSON: []byte(`{"content":"continue"}`),
+	})
+	if err == nil || !strings.Contains(err.Error(), "interactive id is required") {
+		t.Fatalf("expected missing interactive id error, got %v", err)
+	}
+}
+
 func TestYakAIInputContentMapsAttachedResources(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 改动摘要

- 将无状态 AI runtime 调整为跨 turn 无状态、单个 turn 内保留短生命周期 engine。
- 普通消息异步执行 ReAct turn，保持 NATS 命令消费线程可继续接收工具审批和用户干预。
- 将审批和自由输入按 `interactive_id` 路由到当前活跃 engine，并拒绝过期审批和重叠普通 turn。
- 修正有状态 runtime 的审批事件转换，保留交互 ID 并兼容扁平及 composer 包装载荷。

## 改动文件

- `scannode/legion_ai_runtime_stateless.go`
- `scannode/legion_ai_runtime_stateless_test.go`
- `scannode/legion_ai_runtime_yak.go`
- `scannode/legion_ai_runtime_yak_test.go`

## 验证方式

- `go test ./scannode -race -count=1`
- `go vet ./scannode`
- `go build -tags hids -o /tmp/legion-smoke-node-s3f-pr ./cmd/legion-smoke-node`
- T2：通过真实 API、NATS、ScanNode 和 ReAct 工具调用链验证审批恢复、自由输入、独立下一 turn 及过期审批失败事件。

## 配套改动

- Legion PR：https://github.com/VillanCh/legion/pull/218