### PR TITLE
feat(yakgrpc): add Platform filter to AI session query/delete

### DIFF
--- a/common/yakgrpc/aihttp/handler_session.go
+++ b/common/yakgrpc/aihttp/handler_session.go
@@ -158,6 +158,9 @@ func hasDeleteAISessionFilterCondition(filter *ypb.DeleteAISessionFilter) bool {
 	if len(filter.GetSource()) > 0 {
 		return true
 	}
+	if len(filter.GetPlatform()) > 0 {
+		return true
+	}
 	return false
 }
 
@@ -168,7 +171,10 @@ func needsAISessionDeleteDBLookup(filter *ypb.DeleteAISessionFilter) bool {
 	if filter.GetAfterTimestamp() > 0 || filter.GetBeforeTimestamp() > 0 {
 		return true
 	}
-	return len(filter.GetSource()) > 0
+	if len(filter.GetSource()) > 0 || len(filter.GetPlatform()) > 0 {
+		return true
+	}
+	return false
 }
 
 func (gw *AIAgentHTTPGateway) cancelAndRemoveDeletedSessions(req *ypb.DeleteAISessionRequest) {

--- a/common/yakgrpc/aihttp/tests/session_test.go
+++ b/common/yakgrpc/aihttp/tests/session_test.go
@@ -135,3 +135,62 @@ func TestDeleteSessionPassthroughDeleteAISessionFilter(t *testing.T) {
 	require.False(t, foundOld)
 	require.True(t, foundNew)
 }
+
+// TestDeleteSessionPlatformFilterAccepted verifies that a delete request
+// carrying only a Platform filter (no SessionID / timestamp / Source) is
+// accepted by the gateway validator and forwarded (not rejected as 400).
+func TestDeleteSessionPlatformFilterAccepted(t *testing.T) {
+	gw := newTestGateway(t, aihttp.WithDatabase(consts.GetGormProjectDatabase()))
+
+	feishuID := "platform-filter-feishu-" + uuid.NewString()
+	dingtalkID := "platform-filter-dingtalk-" + uuid.NewString()
+	for _, sid := range []string{feishuID, dingtalkID} {
+		body, _ := json.Marshal(aihttp.CreateSessionRequest{RunID: sid})
+		req := httptest.NewRequest("POST", "/agent/session", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		require.Equal(t, http.StatusCreated, performRequest(gw, req).Code)
+	}
+	db := consts.GetGormProjectDatabase()
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", feishuID).
+		UpdateColumns(map[string]any{"source": "im", "im_source": `{"platform":"feishu"}`}).Error)
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", dingtalkID).
+		UpdateColumns(map[string]any{"source": "im", "im_source": `{"platform":"dingtalk"}`}).Error)
+
+	filterBody, err := protojson.Marshal(&ypb.DeleteAISessionFilter{
+		// Scope deletion to the two test sessions (AND) so we never touch
+		// unrelated real IM sessions in the project database.
+		SessionID: []string{feishuID, dingtalkID},
+		Source:    []string{"im"},
+		Platform:  []string{"feishu"},
+	})
+	require.NoError(t, err)
+	deleteReq := httptest.NewRequest("POST", "/agent/session/del", bytes.NewReader(filterBody))
+	deleteReq.Header.Set("Content-Type", "application/json")
+	deleteResp := performRequest(gw, deleteReq)
+	require.Equal(t, http.StatusOK, deleteResp.Code, "platform-only filter should not be 400: %s", deleteResp.Body.String())
+
+	// Only dingtalk should remain among the two IM sessions.
+	listReq := httptest.NewRequest("GET", "/agent/session/all", nil)
+	listResp := performRequest(gw, listReq)
+	require.Equal(t, http.StatusOK, listResp.Code)
+	var sessions aihttp.SessionListResponse
+	require.NoError(t, json.Unmarshal(listResp.Body.Bytes(), &sessions))
+	ids := make(map[string]bool)
+	for _, item := range sessions.Sessions {
+		ids[item.RunID] = true
+	}
+	require.False(t, ids[feishuID], "feishu session should be deleted")
+	require.True(t, ids[dingtalkID], "dingtalk session should remain")
+}
+
+// TestDeleteSessionRejectsEmptyFilter ensures an empty filter still 400s.
+func TestDeleteSessionRejectsEmptyFilter(t *testing.T) {
+	gw := newTestGateway(t)
+
+	filterBody, err := protojson.Marshal(&ypb.DeleteAISessionFilter{})
+	require.NoError(t, err)
+	deleteReq := httptest.NewRequest("POST", "/agent/session/del", bytes.NewReader(filterBody))
+	deleteReq.Header.Set("Content-Type", "application/json")
+	deleteResp := performRequest(gw, deleteReq)
+	require.Equal(t, http.StatusBadRequest, deleteResp.Code)
+}

--- a/common/yakgrpc/grpc_ai_session_test.go
+++ b/common/yakgrpc/grpc_ai_session_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
@@ -166,6 +167,104 @@ func TestServer_QueryAISession_FilterBySource(t *testing.T) {
 	for _, row := range resp.GetData() {
 		require.Equal(t, "alpha", row.GetSource())
 	}
+}
+
+// TestServer_QueryAISession_FilterByPlatform verifies that querying with
+// Platform filters IM sessions by the platform stored inside im_source JSON,
+// without mixing up feishu and dingtalk sessions (both have source="im").
+func TestServer_QueryAISession_FilterByPlatform(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.AISession{}).Error)
+
+	srv := &Server{projectDatabase: db}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	marker := "plat-filter-" + uuid.NewString()
+	feishuSession := marker + "-feishu"
+	dingtalkSession := marker + "-dingtalk"
+
+	for _, sid := range []string{feishuSession, dingtalkSession} {
+		_, err = yakit.EnsureAISessionMeta(db, sid, "im")
+		require.NoError(t, err)
+	}
+	// Write IM meta so im_source JSON carries the platform.
+	_, err = srv.UpdateAISessionIMMeta(ctx, &ypb.UpdateAISessionIMMetaRequest{
+		SessionID: feishuSession,
+		Meta:      &ypb.IMSourceMeta{Platform: "feishu", ChatType: "private"},
+	})
+	require.NoError(t, err)
+	_, err = srv.UpdateAISessionIMMeta(ctx, &ypb.UpdateAISessionIMMetaRequest{
+		SessionID: dingtalkSession,
+		Meta:      &ypb.IMSourceMeta{Platform: "dingtalk", ChatType: "group"},
+	})
+	require.NoError(t, err)
+
+	// Query feishu only.
+	resp, err := srv.QueryAISession(ctx, &ypb.QueryAISessionRequest{
+		Filter: &ypb.AISessionFilter{Keyword: marker, Source: []string{"im"}, Platform: []string{"feishu"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), resp.GetTotal())
+	require.Equal(t, feishuSession, resp.GetData()[0].GetSessionID())
+
+	// Query dingtalk only.
+	resp, err = srv.QueryAISession(ctx, &ypb.QueryAISessionRequest{
+		Filter: &ypb.AISessionFilter{Keyword: marker, Source: []string{"im"}, Platform: []string{"dingtalk"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), resp.GetTotal())
+	require.Equal(t, dingtalkSession, resp.GetData()[0].GetSessionID())
+}
+
+// TestServer_DeleteAISession_ByPlatform verifies that deleting by Platform
+// only removes sessions of that platform, leaving the other IM platform intact.
+// Uses the full project database (via consts) so the delete pipeline can reach
+// all related tables (ai_agent_runtimes, rag, memory, ...).
+func TestServer_DeleteAISession_ByPlatform(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	srv := &Server{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	marker := "plat-del-" + uuid.NewString()
+	feishuSession := marker + "-feishu"
+	dingtalkSession := marker + "-dingtalk"
+
+	for _, sid := range []string{feishuSession, dingtalkSession} {
+		_, err := yakit.EnsureAISessionMeta(db, sid, "im")
+		require.NoError(t, err)
+	}
+	_, err := srv.UpdateAISessionIMMeta(ctx, &ypb.UpdateAISessionIMMetaRequest{
+		SessionID: feishuSession,
+		Meta:      &ypb.IMSourceMeta{Platform: "feishu", ChatType: "private"},
+	})
+	require.NoError(t, err)
+	_, err = srv.UpdateAISessionIMMeta(ctx, &ypb.UpdateAISessionIMMetaRequest{
+		SessionID: dingtalkSession,
+		Meta:      &ypb.IMSourceMeta{Platform: "dingtalk", ChatType: "group"},
+	})
+	require.NoError(t, err)
+
+	// Delete feishu only, scoped to the two test sessions (AND with SessionID)
+	// so we never touch unrelated real IM sessions in the project database.
+	_, err = srv.DeleteAISession(ctx, &ypb.DeleteAISessionRequest{
+		Filter: &ypb.DeleteAISessionFilter{
+			SessionID: []string{feishuSession, dingtalkSession},
+			Source:    []string{"im"},
+			Platform:  []string{"feishu"},
+		},
+	})
+	require.NoError(t, err)
+
+	// feishu gone, dingtalk remains (isolated by marker keyword).
+	resp, err := srv.QueryAISession(ctx, &ypb.QueryAISessionRequest{
+		Filter: &ypb.AISessionFilter{Keyword: marker, Source: []string{"im"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), resp.GetTotal())
+	require.Equal(t, dingtalkSession, resp.GetData()[0].GetSessionID())
 }
 
 // UpdateAISessionIMMeta 写入后，QueryAISession 应能返回 IMSourceMeta，

--- a/common/yakgrpc/yakgrpc.proto
+++ b/common/yakgrpc/yakgrpc.proto
@@ -2377,6 +2377,9 @@ message AISessionFilter {
   string Keyword = 2;
   // 按会话来源筛选（OR，与 SessionID / Keyword 条件 AND 组合）
   repeated string Source = 3;
+  // 按 IM 平台筛选（如 feishu / dingtalk），仅当 Source 含 "im" 时有意义；
+  // 匹配 ai_sessions_v1.im_source JSON 内的 platform 字段。
+  repeated string Platform = 4;
 }
 
 message AISession {
@@ -2438,6 +2441,9 @@ message DeleteAISessionFilter {
   int64 BeforeTimestamp = 3;
   // 删除 source 匹配的会话（OR，可与 SessionID / 时间范围 AND 组合）
   repeated string Source = 4;
+  // 按 IM 平台删除（如 feishu / dingtalk），仅当 Source 含 "im" 时有意义；
+  // 匹配 ai_sessions_v1.im_source JSON 内的 platform 字段。
+  repeated string Platform = 5;
 }
 
 message DeleteAISessionRequest {

--- a/common/yakgrpc/yakit/ai_session_query.go
+++ b/common/yakgrpc/yakit/ai_session_query.go
@@ -1,6 +1,7 @@
 package yakit
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -53,6 +54,39 @@ func applyAISessionSourceFilter(db *gorm.DB, sources []string) *gorm.DB {
 	}
 }
 
+// applyAISessionPlatformFilter matches IM platform values stored inside the
+// ai_sessions_v1.im_source JSON column. The JSON is written by protojson
+// (camelCase field names), so the platform is stored as `"platform":"feishu"`.
+// We use LIKE to stay compatible with both SQLite (no JSON1 guarantee) and
+// MySQL. Platform values come from notify.Platform constants (feishu /
+// dingtalk) but are normalized here to lower case to be safe.
+func applyAISessionPlatformFilter(db *gorm.DB, platforms []string) *gorm.DB {
+	platforms = normalizeAISessionFilterStrings(platforms)
+	if len(platforms) == 0 {
+		return db
+	}
+
+	seen := make(map[string]struct{}, len(platforms))
+	wheres := make([]string, 0, len(platforms))
+	args := make([]any, 0, len(platforms))
+	for _, p := range platforms {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		wheres = append(wheres, "im_source LIKE ?")
+		args = append(args, fmt.Sprintf(`%%"platform":"%s"%%`, p))
+	}
+	if len(wheres) == 0 {
+		return db
+	}
+	return db.Where(strings.Join(wheres, " OR "), args...)
+}
+
 func FilterAISessionMeta(db *gorm.DB, filter *ypb.AISessionFilter) *gorm.DB {
 	db = db.Model(&schema.AISession{})
 	if filter == nil {
@@ -65,6 +99,9 @@ func FilterAISessionMeta(db *gorm.DB, filter *ypb.AISessionFilter) *gorm.DB {
 	}
 	if len(filter.GetSource()) > 0 {
 		db = applyAISessionSourceFilter(db, filter.GetSource())
+	}
+	if len(filter.GetPlatform()) > 0 {
+		db = applyAISessionPlatformFilter(db, filter.GetPlatform())
 	}
 	return db
 }
@@ -140,7 +177,11 @@ func QueryAISessionIDsForDelete(db *gorm.DB, filter *ypb.DeleteAISessionFilter, 
 		if len(filter.GetSource()) > 0 {
 			query = applyAISessionSourceFilter(query, filter.GetSource())
 		}
-		if len(sessionIDs) == 0 && filter.GetAfterTimestamp() <= 0 && filter.GetBeforeTimestamp() <= 0 && len(sources) == 0 {
+		platforms := normalizeAISessionFilterStrings(filter.GetPlatform())
+		if len(filter.GetPlatform()) > 0 {
+			query = applyAISessionPlatformFilter(query, filter.GetPlatform())
+		}
+		if len(sessionIDs) == 0 && filter.GetAfterTimestamp() <= 0 && filter.GetBeforeTimestamp() <= 0 && len(sources) == 0 && len(platforms) == 0 {
 			return nil, utils.Errorf("at least one filter condition is required")
 		}
 	}

--- a/common/yakgrpc/yakit/ai_session_query_test.go
+++ b/common/yakgrpc/yakit/ai_session_query_test.go
@@ -1,0 +1,115 @@
+package yakit
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// TestApplyAISessionPlatformFilter verifies the platform filter narrows IM
+// sessions by the platform stored inside the im_source JSON column, and is
+// a no-op when no platforms are provided.
+func TestApplyAISessionPlatformFilter(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.AISession{}).Error)
+
+	feishu := "pf-feishu-" + uuid.NewString()
+	dingtalk := "pf-dingtalk-" + uuid.NewString()
+	for _, sid := range []string{feishu, dingtalk} {
+		_, err = EnsureAISessionMeta(db, sid, "im")
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", feishu).
+		UpdateColumn("im_source", `{"platform":"feishu","chatType":"private"}`).Error)
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", dingtalk).
+		UpdateColumn("im_source", `{"platform":"dingtalk","chatType":"group"}`).Error)
+
+	query := func(platforms []string) []string {
+		var ids []string
+		q := applyAISessionPlatformFilter(db.Model(&schema.AISession{}).Where("source = ?", "im"), platforms)
+		require.NoError(t, q.Pluck("session_id", &ids).Error)
+		return ids
+	}
+
+	// No platform filter: returns both (no-op).
+	ids := query(nil)
+	require.ElementsMatch(t, []string{feishu, dingtalk}, ids)
+
+	// feishu only.
+	ids = query([]string{"feishu"})
+	require.Equal(t, []string{feishu}, ids)
+
+	// dingtalk only.
+	ids = query([]string{"dingtalk"})
+	require.Equal(t, []string{dingtalk}, ids)
+
+	// case-insensitive + dedup.
+	ids = query([]string{"Feishu", "feishu"})
+	require.Equal(t, []string{feishu}, ids)
+
+	// multiple platforms OR.
+	ids = query([]string{"feishu", "dingtalk"})
+	require.ElementsMatch(t, []string{feishu, dingtalk}, ids)
+}
+
+// TestFilterAISessionMeta_Platform exercises the public FilterAISessionMeta
+// entry point combining source + platform.
+func TestFilterAISessionMeta_Platform(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.AISession{}).Error)
+
+	feishu := "fm-feishu-" + uuid.NewString()
+	dingtalk := "fm-dingtalk-" + uuid.NewString()
+	for _, sid := range []string{feishu, dingtalk} {
+		_, err = EnsureAISessionMeta(db, sid, "im")
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", feishu).
+		UpdateColumn("im_source", `{"platform":"feishu"}`).Error)
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", dingtalk).
+		UpdateColumn("im_source", `{"platform":"dingtalk"}`).Error)
+
+	var ids []string
+	q := FilterAISessionMeta(db, &ypb.AISessionFilter{Source: []string{"im"}, Platform: []string{"feishu"}})
+	require.NoError(t, q.Pluck("session_id", &ids).Error)
+	require.Equal(t, []string{feishu}, ids)
+}
+
+// TestQueryAISessionIDsForDelete_Platform verifies deletion lookup narrows by
+// platform so only the matching IM sessions are targeted.
+func TestQueryAISessionIDsForDelete_Platform(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.AISession{}).Error)
+
+	feishu := "pd-feishu-" + uuid.NewString()
+	dingtalk := "pd-dingtalk-" + uuid.NewString()
+	for _, sid := range []string{feishu, dingtalk} {
+		_, err = EnsureAISessionMeta(db, sid, "im")
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", feishu).
+		UpdateColumn("im_source", `{"platform":"feishu"}`).Error)
+	require.NoError(t, db.Model(&schema.AISession{}).Where("session_id = ?", dingtalk).
+		UpdateColumn("im_source", `{"platform":"dingtalk"}`).Error)
+
+	ids, err := QueryAISessionIDsForDelete(db, &ypb.DeleteAISessionFilter{
+		Source:   []string{"im"},
+		Platform: []string{"feishu"},
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{feishu}, ids)
+
+	// Platform-only filter (no source) is accepted as a valid condition.
+	ids, err = QueryAISessionIDsForDelete(db, &ypb.DeleteAISessionFilter{
+		Platform: []string{"dingtalk"},
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{dingtalk}, ids)
+}

--- a/common/yakgrpc/ypb/yakgrpc.pb.go
+++ b/common/yakgrpc/ypb/yakgrpc.pb.go
@@ -11908,7 +11908,10 @@ type AISessionFilter struct {
 	SessionID []string               `protobuf:"bytes,1,rep,name=SessionID,proto3" json:"SessionID,omitempty"`
 	Keyword   string                 `protobuf:"bytes,2,opt,name=Keyword,proto3" json:"Keyword,omitempty"`
 	// 按会话来源筛选（OR，与 SessionID / Keyword 条件 AND 组合）
-	Source        []string `protobuf:"bytes,3,rep,name=Source,proto3" json:"Source,omitempty"`
+	Source []string `protobuf:"bytes,3,rep,name=Source,proto3" json:"Source,omitempty"`
+	// 按 IM 平台筛选（如 feishu / dingtalk），仅当 Source 含 "im" 时有意义；
+	// 匹配 ai_sessions_v1.im_source JSON 内的 platform 字段。
+	Platform      []string `protobuf:"bytes,4,rep,name=Platform,proto3" json:"Platform,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -11960,6 +11963,13 @@ func (x *AISessionFilter) GetKeyword() string {
 func (x *AISessionFilter) GetSource() []string {
 	if x != nil {
 		return x.Source
+	}
+	return nil
+}
+
+func (x *AISessionFilter) GetPlatform() []string {
+	if x != nil {
+		return x.Platform
 	}
 	return nil
 }
@@ -12396,7 +12406,10 @@ type DeleteAISessionFilter struct {
 	AfterTimestamp  int64                  `protobuf:"varint,2,opt,name=AfterTimestamp,proto3" json:"AfterTimestamp,omitempty"`
 	BeforeTimestamp int64                  `protobuf:"varint,3,opt,name=BeforeTimestamp,proto3" json:"BeforeTimestamp,omitempty"`
 	// 删除 source 匹配的会话（OR，可与 SessionID / 时间范围 AND 组合）
-	Source        []string `protobuf:"bytes,4,rep,name=Source,proto3" json:"Source,omitempty"`
+	Source []string `protobuf:"bytes,4,rep,name=Source,proto3" json:"Source,omitempty"`
+	// 按 IM 平台删除（如 feishu / dingtalk），仅当 Source 含 "im" 时有意义；
+	// 匹配 ai_sessions_v1.im_source JSON 内的 platform 字段。
+	Platform      []string `protobuf:"bytes,5,rep,name=Platform,proto3" json:"Platform,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -12455,6 +12468,13 @@ func (x *DeleteAISessionFilter) GetBeforeTimestamp() int64 {
 func (x *DeleteAISessionFilter) GetSource() []string {
 	if x != nil {
 		return x.Source
+	}
+	return nil
+}
+
+func (x *DeleteAISessionFilter) GetPlatform() []string {
+	if x != nil {
+		return x.Platform
 	}
 	return nil
 }
@@ -73835,11 +73855,12 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x04Name\x18\x02 \x01(\tR\x04Name\x12\x10\n" +
 	"\x03Seq\x18\x03 \x01(\x03R\x03Seq\x12\x1c\n" +
 	"\tUserInput\x18\x04 \x01(\tR\tUserInput\x12\x1c\n" +
-	"\tForgeName\x18\x05 \x01(\tR\tForgeName\"a\n" +
+	"\tForgeName\x18\x05 \x01(\tR\tForgeName\"}\n" +
 	"\x0fAISessionFilter\x12\x1c\n" +
 	"\tSessionID\x18\x01 \x03(\tR\tSessionID\x12\x18\n" +
 	"\aKeyword\x18\x02 \x01(\tR\aKeyword\x12\x16\n" +
-	"\x06Source\x18\x03 \x03(\tR\x06Source\"\x8a\x03\n" +
+	"\x06Source\x18\x03 \x03(\tR\x06Source\x12\x1a\n" +
+	"\bPlatform\x18\x04 \x03(\tR\bPlatform\"\x8a\x03\n" +
 	"\tAISession\x12\x0e\n" +
 	"\x02Id\x18\x01 \x01(\x03R\x02Id\x12\x1c\n" +
 	"\tSessionID\x18\x02 \x01(\tR\tSessionID\x12\x14\n" +
@@ -73879,12 +73900,13 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\n" +
 	"SenderName\x18\x04 \x01(\tR\n" +
 	"SenderName\x12\x1a\n" +
-	"\bThreadID\x18\x05 \x01(\tR\bThreadID\"\x9f\x01\n" +
+	"\bThreadID\x18\x05 \x01(\tR\bThreadID\"\xbb\x01\n" +
 	"\x15DeleteAISessionFilter\x12\x1c\n" +
 	"\tSessionID\x18\x01 \x03(\tR\tSessionID\x12&\n" +
 	"\x0eAfterTimestamp\x18\x02 \x01(\x03R\x0eAfterTimestamp\x12(\n" +
 	"\x0fBeforeTimestamp\x18\x03 \x01(\x03R\x0fBeforeTimestamp\x12\x16\n" +
-	"\x06Source\x18\x04 \x03(\tR\x06Source\"j\n" +
+	"\x06Source\x18\x04 \x03(\tR\x06Source\x12\x1a\n" +
+	"\bPlatform\x18\x05 \x03(\tR\bPlatform\"j\n" +
 	"\x16DeleteAISessionRequest\x122\n" +
 	"\x06Filter\x18\x01 \x01(\v2\x1a.ypb.DeleteAISessionFilterR\x06Filter\x12\x1c\n" +
 	"\tDeleteAll\x18\x02 \x01(\bR\tDeleteAll\"\xcd\x01\n" +


### PR DESCRIPTION
选中飞书分组删除会误删全部 IM 会话（飞书+钉钉），因为 DB 里所有 IM
会话 source 列统一为 'im'，平台区分只在 im_source JSON 的 platform 字段， 而删除/查询接口只有粗粒度 Source 过滤。