### PR TITLE
feat(scannode): 增加审批命令去重与运行时隔离

### DIFF
--- a/scannode/gen/legionpb/legion/ai/v1/ai.pb.go
+++ b/scannode/gen/legionpb/legion/ai/v1/ai.pb.go
@@ -354,8 +354,12 @@ type PushAISessionInputCommand struct {
 	// set it produce the same wire bytes as before (proto3 message default).
 	// The stateless engine (S3c) consumes this; the stateful engine ignores it.
 	ContextPackage *ContextPackage `protobuf:"bytes,6,opt,name=context_package,json=contextPackage,proto3" json:"context_package,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// S3g approval fencing. Empty for ordinary user input.
+	ReviewId              string `protobuf:"bytes,7,opt,name=review_id,json=reviewId,proto3" json:"review_id,omitempty"`
+	TurnId                string `protobuf:"bytes,8,opt,name=turn_id,json=turnId,proto3" json:"turn_id,omitempty"`
+	ExpectedNodeSessionId string `protobuf:"bytes,9,opt,name=expected_node_session_id,json=expectedNodeSessionId,proto3" json:"expected_node_session_id,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *PushAISessionInputCommand) Reset() {
@@ -428,6 +432,27 @@ func (x *PushAISessionInputCommand) GetContextPackage() *ContextPackage {
 		return x.ContextPackage
 	}
 	return nil
+}
+
+func (x *PushAISessionInputCommand) GetReviewId() string {
+	if x != nil {
+		return x.ReviewId
+	}
+	return ""
+}
+
+func (x *PushAISessionInputCommand) GetTurnId() string {
+	if x != nil {
+		return x.TurnId
+	}
+	return ""
+}
+
+func (x *PushAISessionInputCommand) GetExpectedNodeSessionId() string {
+	if x != nil {
+		return x.ExpectedNodeSessionId
+	}
+	return ""
 }
 
 // ContextPackage is the per-turn, server-assembled context injected into the
@@ -18859,7 +18884,7 @@ const file_legion_ai_v1_ai_proto_rawDesc = "" +
 	"\x1cruntime_option_snapshot_json\x18\b \x01(\fR\x19runtimeOptionSnapshotJson\x12F\n" +
 	"\vattachments\x18\t \x03(\v2$.legion.ai.v1.AISessionAttachmentRefR\vattachments\x12M\n" +
 	"\x0fcredential_refs\x18\n" +
-	" \x03(\v2$.legion.ai.v1.AISessionCredentialRefR\x0ecredentialRefs\"\xb7\x02\n" +
+	" \x03(\v2$.legion.ai.v1.AISessionCredentialRefR\x0ecredentialRefs\"\xa6\x03\n" +
 	"\x19PushAISessionInputCommand\x12;\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x1f.legion.node.v1.CommandMetadataR\bmetadata\x124\n" +
 	"\asession\x18\x02 \x01(\v2\x1a.legion.ai.v1.AISessionRefR\asession\x12\"\n" +
@@ -18868,7 +18893,10 @@ const file_legion_ai_v1_ai_proto_rawDesc = "" +
 	"input_type\x18\x04 \x01(\tR\tinputType\x12\x1d\n" +
 	"\n" +
 	"input_json\x18\x05 \x01(\fR\tinputJson\x12E\n" +
-	"\x0fcontext_package\x18\x06 \x01(\v2\x1c.legion.ai.v1.ContextPackageR\x0econtextPackage\"\xa6\x03\n" +
+	"\x0fcontext_package\x18\x06 \x01(\v2\x1c.legion.ai.v1.ContextPackageR\x0econtextPackage\x12\x1b\n" +
+	"\treview_id\x18\a \x01(\tR\breviewId\x12\x17\n" +
+	"\aturn_id\x18\b \x01(\tR\x06turnId\x127\n" +
+	"\x18expected_node_session_id\x18\t \x01(\tR\x15expectedNodeSessionId\"\xa6\x03\n" +
 	"\x0eContextPackage\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12#\n" +

--- a/scannode/legion_ai_bridge.go
+++ b/scannode/legion_ai_bridge.go
@@ -3,6 +3,7 @@ package scannode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -29,6 +30,8 @@ func selectAISessionRuntimeDriver() aiSessionRuntimeDriver {
 
 const aiSessionRuntimeEventInput = "ai.session.input"
 const aiSessionRuntimeEventContextUpdated = "ai.session.context_updated"
+
+var errAISessionInputInFlight = errors.New("ai session input command is already in flight")
 
 type aiSessionRuntimeDriver interface {
 	Bind(context.Context, aiSessionBinding, aiSessionRuntimeEmitter) (aiSessionRuntimeHandle, error)
@@ -85,6 +88,8 @@ type aiSessionInput struct {
 	InputType      string
 	PayloadJSON    []byte
 	ContextPackage *aiv1.ContextPackage // S3c: per-turn server-assembled context (history/tools/user_input)
+	ReviewID       string
+	TurnID         string
 }
 
 type aiSessionContextUpdate struct {
@@ -101,6 +106,9 @@ type acceptedAISessionInput struct {
 	payloadJSON    []byte
 	handle         aiSessionRuntimeHandle
 	contextPackage *aiv1.ContextPackage // S3c: carried through to handle.SendInput
+	reviewID       string
+	turnID         string
+	duplicate      bool
 }
 
 type acceptedAISessionContextUpdate struct {
@@ -131,13 +139,16 @@ type aiSessionRuntimeManager struct {
 }
 
 type aiSessionRuntime struct {
-	mu        sync.Mutex
-	ref       aiSessionCommandRef
-	projectID string
-	title     string
-	seq       uint64
-	cancel    context.CancelFunc
-	handle    aiSessionRuntimeHandle
+	mu                     sync.Mutex
+	ref                    aiSessionCommandRef
+	projectID              string
+	title                  string
+	seq                    uint64
+	cancel                 context.CancelFunc
+	handle                 aiSessionRuntimeHandle
+	processedInputCommands map[string]struct{}
+	processedInputOrder    []string
+	inFlightInputCommands  map[string]struct{}
 }
 
 func newAISessionRuntimeManager(driver aiSessionRuntimeDriver) *aiSessionRuntimeManager {
@@ -173,10 +184,12 @@ func (m *aiSessionRuntimeManager) Bind(
 
 	ctx, cancel := context.WithCancel(parent)
 	runtime := &aiSessionRuntime{
-		ref:       ref,
-		projectID: strings.TrimSpace(command.GetProjectId()),
-		title:     strings.TrimSpace(command.GetTitle()),
-		cancel:    cancel,
+		ref:                    ref,
+		projectID:              strings.TrimSpace(command.GetProjectId()),
+		title:                  strings.TrimSpace(command.GetTitle()),
+		cancel:                 cancel,
+		processedInputCommands: make(map[string]struct{}),
+		inFlightInputCommands:  make(map[string]struct{}),
 	}
 	runtime.handle = noopAISessionRuntimeHandle{}
 	handle, err := m.driver.Bind(ctx, aiSessionBinding{
@@ -227,6 +240,16 @@ func (m *aiSessionRuntimeManager) AcceptInput(
 	}
 
 	session.mu.Lock()
+	if _, ok := session.processedInputCommands[ref.CommandID]; ok {
+		ref.RunID = session.ref.RunID
+		session.mu.Unlock()
+		return acceptedAISessionInput{ref: ref, duplicate: true}, nil
+	}
+	if _, ok := session.inFlightInputCommands[ref.CommandID]; ok {
+		session.mu.Unlock()
+		return acceptedAISessionInput{ref: ref}, errAISessionInputInFlight
+	}
+	session.inFlightInputCommands[ref.CommandID] = struct{}{}
 	session.seq++
 	ref.RunID = session.ref.RunID
 	session.ref.CommandID = ref.CommandID
@@ -245,7 +268,36 @@ func (m *aiSessionRuntimeManager) AcceptInput(
 		payloadJSON:    payload,
 		handle:         handle,
 		contextPackage: command.GetContextPackage(),
+		reviewID:       strings.TrimSpace(command.GetReviewId()),
+		turnID:         strings.TrimSpace(command.GetTurnId()),
 	}, nil
+}
+
+func (m *aiSessionRuntimeManager) CompleteInput(sessionID, commandID string, succeeded bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	session, ok := m.sessions[strings.TrimSpace(sessionID)]
+	if !ok {
+		return
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	commandID = strings.TrimSpace(commandID)
+	delete(session.inFlightInputCommands, commandID)
+	if !succeeded || commandID == "" {
+		return
+	}
+	if _, exists := session.processedInputCommands[commandID]; exists {
+		return
+	}
+	session.processedInputCommands[commandID] = struct{}{}
+	session.processedInputOrder = append(session.processedInputOrder, commandID)
+	const processedInputLimit = 1024
+	if len(session.processedInputOrder) > processedInputLimit {
+		oldest := session.processedInputOrder[0]
+		session.processedInputOrder = session.processedInputOrder[1:]
+		delete(session.processedInputCommands, oldest)
+	}
 }
 
 func (m *aiSessionRuntimeManager) AcceptContextUpdate(
@@ -397,11 +449,33 @@ func (b *legionJobBridge) handleAISessionInput(ctx context.Context, raw []byte) 
 	if err := validateAISessionInputCommand(&command); err != nil {
 		return b.publishAISessionCommandFailure(ctx, ref, "invalid_ai_session_input_command", err)
 	}
+	if expected := strings.TrimSpace(command.GetExpectedNodeSessionId()); expected != "" {
+		nodeSession, ok := b.agent.node.GetSessionState()
+		if !ok || strings.TrimSpace(nodeSession.SessionID) != expected {
+			return b.publishAISessionCommandFailure(
+				ctx,
+				ref,
+				"ai_session_review_fenced",
+				fmt.Errorf("ai session review expected node session %s", expected),
+			)
+		}
+	}
 
-	accepted, err := b.ensureAIRuntime().AcceptInput(&command)
+	runtime := b.ensureAIRuntime()
+	accepted, err := runtime.AcceptInput(&command)
 	if err != nil {
+		if errors.Is(err, errAISessionInputInFlight) {
+			return err
+		}
 		return b.publishAISessionCommandFailure(ctx, ref, "ai_session_input_failed", err)
 	}
+	if accepted.duplicate {
+		return nil
+	}
+	succeeded := false
+	defer func() {
+		runtime.CompleteInput(accepted.ref.SessionID, accepted.ref.CommandID, succeeded)
+	}()
 	if err := b.ensureAIPublisher().PublishEvent(
 		ctx,
 		accepted.ref,
@@ -412,6 +486,7 @@ func (b *legionJobBridge) handleAISessionInput(ctx context.Context, raw []byte) 
 		return err
 	}
 	if accepted.handle == nil {
+		succeeded = true
 		return nil
 	}
 	if err := accepted.handle.SendInput(ctx, aiSessionInput{
@@ -419,9 +494,14 @@ func (b *legionJobBridge) handleAISessionInput(ctx context.Context, raw []byte) 
 		InputType:      accepted.inputType,
 		PayloadJSON:    accepted.payloadJSON,
 		ContextPackage: accepted.contextPackage,
+		ReviewID:       accepted.reviewID,
+		TurnID:         accepted.turnID,
 	}); err != nil {
-		return b.publishAISessionCommandFailure(ctx, accepted.ref, "ai_session_runtime_input_failed", err)
+		failureErr := b.publishAISessionCommandFailure(ctx, accepted.ref, "ai_session_runtime_input_failed", err)
+		succeeded = failureErr == nil
+		return failureErr
 	}
+	succeeded = true
 	return nil
 }
 
@@ -618,6 +698,12 @@ func validateAISessionInputCommand(command *aiv1.PushAISessionInputCommand) erro
 		return fmt.Errorf("ai session input session_id is required")
 	case strings.TrimSpace(command.GetOwnerUserId()) == "":
 		return fmt.Errorf("ai session input owner_user_id is required")
+	case strings.TrimSpace(command.GetReviewId()) != "" &&
+		strings.TrimSpace(command.GetTurnId()) == "":
+		return fmt.Errorf("ai session review turn_id is required")
+	case strings.TrimSpace(command.GetReviewId()) != "" &&
+		strings.TrimSpace(command.GetExpectedNodeSessionId()) == "":
+		return fmt.Errorf("ai session review expected_node_session_id is required")
 	default:
 		_, err := normalizeAISessionInputPayload(command.GetInputType(), command.GetInputJson())
 		return err

--- a/scannode/legion_ai_bridge_test.go
+++ b/scannode/legion_ai_bridge_test.go
@@ -264,6 +264,73 @@ func TestHandleAISessionInputPublishesRuntimeEvent(t *testing.T) {
 	driver.assertInput(t, 0, "hello")
 }
 
+func TestHandleAISessionInputDeduplicatesRedeliveredCommand(t *testing.T) {
+	t.Parallel()
+
+	bridge, fakeJS, driver := newTestAISessionBridge(t)
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, validAISessionBindCommand())); err != nil {
+		t.Fatalf("handle ai bind: %v", err)
+	}
+	resetPublishedMessages(fakeJS)
+	raw := mustMarshalProto(t, validAISessionInputCommand())
+	if err := bridge.handleAISessionInput(context.Background(), raw); err != nil {
+		t.Fatalf("handle first input: %v", err)
+	}
+	if err := bridge.handleAISessionInput(context.Background(), raw); err != nil {
+		t.Fatalf("handle duplicate input: %v", err)
+	}
+
+	driver.mu.Lock()
+	inputCount := len(driver.inputs)
+	driver.mu.Unlock()
+	if inputCount != 1 {
+		t.Fatalf("duplicate command reached runtime %d times", inputCount)
+	}
+	fakeJS.mu.Lock()
+	eventCount := len(fakeJS.publish)
+	fakeJS.mu.Unlock()
+	if eventCount != 1 {
+		t.Fatalf("duplicate command published %d input events", eventCount)
+	}
+}
+
+func TestHandleAISessionReviewRejectsStaleNodeSession(t *testing.T) {
+	t.Parallel()
+
+	bridge, fakeJS, driver := newTestAISessionBridge(t)
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, validAISessionBindCommand())); err != nil {
+		t.Fatalf("handle ai bind: %v", err)
+	}
+	resetPublishedMessages(fakeJS)
+	command := validAISessionInputCommand()
+	command.InputType = "user_intervention"
+	command.InputJson = []byte(`{"id":"review-fenced","suggestion":"continue"}`)
+	command.ReviewId = "review-fenced"
+	command.TurnId = "turn-command"
+	command.ExpectedNodeSessionId = "stale-node-session"
+
+	if err := bridge.handleAISessionInput(context.Background(), mustMarshalProto(t, command)); err != nil {
+		t.Fatalf("fenced review should publish a terminal command failure: %v", err)
+	}
+	driver.mu.Lock()
+	inputCount := len(driver.inputs)
+	driver.mu.Unlock()
+	if inputCount != 0 {
+		t.Fatalf("fenced review reached runtime %d times", inputCount)
+	}
+	msg := waitForPublishedMessage(t, fakeJS, 0)
+	if msg.Subject != "legion.event.ai.session.failed" {
+		t.Fatalf("unexpected fenced review event subject: %s", msg.Subject)
+	}
+	var failed aiv1.AISessionFailed
+	if err := proto.Unmarshal(msg.Data, &failed); err != nil {
+		t.Fatalf("unmarshal fenced failure: %v", err)
+	}
+	if failed.GetErrorCode() != "ai_session_review_fenced" {
+		t.Fatalf("unexpected fenced failure: %#v", &failed)
+	}
+}
+
 func TestHandleAISessionInputPublishesSyncEventPayload(t *testing.T) {
 	t.Parallel()
 

--- a/scannode/legion_ai_runtime_stateless.go
+++ b/scannode/legion_ai_runtime_stateless.go
@@ -55,6 +55,7 @@ type statelessTurnEngine interface {
 
 type statelessAITurn struct {
 	engine    statelessTurnEngine
+	turnID    string
 	closeOnce sync.Once
 }
 
@@ -149,7 +150,7 @@ func (h *statelessAIEngineRuntimeHandle) SendInput(ctx context.Context, input ai
 		h.mu.Unlock()
 		return fmt.Errorf("stateless sendinput: new engine returned nil")
 	}
-	turn := &statelessAITurn{engine: engine}
+	turn := &statelessAITurn{engine: engine, turnID: strings.TrimSpace(input.Ref.CommandID)}
 	h.activeTurn = turn
 	h.mu.Unlock()
 
@@ -181,6 +182,20 @@ func (h *statelessAIEngineRuntimeHandle) sendInterventionInput(input aiSessionIn
 			return false, nil
 		}
 		return true, err
+	}
+	if input.ReviewID != "" && event.GetInteractiveId() != input.ReviewID {
+		return true, fmt.Errorf(
+			"stateless sendinput: review id mismatch: expected %s, got %s",
+			input.ReviewID,
+			event.GetInteractiveId(),
+		)
+	}
+	if input.TurnID != "" && turn.turnID != input.TurnID {
+		return true, fmt.Errorf(
+			"stateless sendinput: turn id mismatch: expected %s, active %s",
+			input.TurnID,
+			turn.turnID,
+		)
 	}
 	if err := turn.engine.SendInputEvent(event); err != nil {
 		return true, fmt.Errorf("stateless sendinput: send user intervention: %w", err)

--- a/scannode/legion_ai_runtime_stateless_test.go
+++ b/scannode/legion_ai_runtime_stateless_test.go
@@ -243,6 +243,7 @@ func TestStatelessDriverRunsTurnAsyncAndRoutesInteractiveResponseToActiveEngine(
 	returned := make(chan error, 1)
 	go func() {
 		returned <- sh.SendInput(context.Background(), aiSessionInput{
+			Ref:         aiSessionCommandRef{CommandID: "turn-command-1"},
 			InputType:   "message",
 			PayloadJSON: []byte(`{"content":"run a reviewed tool"}`),
 			ContextPackage: &aiv1.ContextPackage{
@@ -269,6 +270,8 @@ func TestStatelessDriverRunsTurnAsyncAndRoutesInteractiveResponseToActiveEngine(
 	err = sh.SendInput(context.Background(), aiSessionInput{
 		InputType:   "user_intervention",
 		PayloadJSON: []byte(`{"id":"review-async-1","suggestion":"continue"}`),
+		ReviewID:    "review-async-1",
+		TurnID:      "turn-command-1",
 	})
 	if err != nil {
 		t.Fatalf("interactive response: %v", err)
@@ -284,6 +287,60 @@ func TestStatelessDriverRunsTurnAsyncAndRoutesInteractiveResponseToActiveEngine(
 		}
 	case <-time.After(time.Second):
 		t.Fatal("active turn did not receive interactive response")
+	}
+	close(engine.release)
+}
+
+func TestStatelessDriverFencesReviewByTurnAndReviewID(t *testing.T) {
+	driver := newStatelessAIEngineRuntimeDriver()
+	handle, err := driver.Bind(context.Background(), aiSessionBinding{
+		Ref:                        aiSessionCommandRef{SessionID: "s-stateless-fenced-review", OwnerUserID: "u1"},
+		ProviderPolicySnapshotJSON: []byte(`{}`),
+		RuntimeOptionSnapshotJSON:  []byte(`{}`),
+	}, noopEmitter{})
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	sh := handle.(*statelessAIEngineRuntimeHandle)
+	engine := newFakeStatelessTurnEngine()
+	sh.newEngine = func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+		return engine, nil
+	}
+	if err := sh.SendInput(context.Background(), aiSessionInput{
+		Ref:         aiSessionCommandRef{CommandID: "turn-live"},
+		InputType:   "message",
+		PayloadJSON: []byte(`{"content":"start"}`),
+	}); err != nil {
+		t.Fatalf("start turn: %v", err)
+	}
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("turn did not start")
+	}
+
+	err = sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"id":"review-live","suggestion":"continue"}`),
+		ReviewID:    "review-other",
+		TurnID:      "turn-live",
+	})
+	if err == nil || !contains(err.Error(), "review id mismatch") {
+		t.Fatalf("expected review id fence, got %v", err)
+	}
+	err = sh.SendInput(context.Background(), aiSessionInput{
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"id":"review-live","suggestion":"continue"}`),
+		ReviewID:    "review-live",
+		TurnID:      "turn-stale",
+	})
+	if err == nil || !contains(err.Error(), "turn id mismatch") {
+		t.Fatalf("expected turn id fence, got %v", err)
+	}
+	select {
+	case event := <-engine.events:
+		t.Fatalf("fenced review reached active engine: %#v", event)
+	default:
 	}
 	close(engine.release)
 }

--- a/scannode/proto/legion/ai/v1/ai.proto
+++ b/scannode/proto/legion/ai/v1/ai.proto
@@ -51,6 +51,10 @@ message PushAISessionInputCommand {
   // set it produce the same wire bytes as before (proto3 message default).
   // The stateless engine (S3c) consumes this; the stateful engine ignores it.
   ContextPackage context_package = 6;
+  // S3g approval fencing. Empty for ordinary user input.
+  string review_id = 7;
+  string turn_id = 8;
+  string expected_node_session_id = 9;
 }
 
 // ContextPackage is the per-turn, server-assembled context injected into the


### PR DESCRIPTION
## 改动摘要

- 扩展 AI 输入命令协议，携带 `review_id`、`turn_id` 和预期 `node_session_id`。
- ScanNode 校验节点会话，拒绝投递到旧节点会话的审批命令。
- 增加有界命令去重和 in-flight 防重，避免 JetStream 重投递重复执行或重复发布结果。
- Stateless runtime 按 review/turn 绑定审批输入，同时保留普通人工干预的兼容行为。

## 关键文件

- `scannode/proto/legion/ai/v1/ai.proto`
- `scannode/legion_ai_bridge.go`
- `scannode/legion_ai_runtime_stateless.go`
- 对应 bridge/runtime 单元测试

## 验证方式

- `go test ./scannode/...`：通过
- `go test -race ./scannode`：通过
- `go build -tags hids -o /tmp/legion-smoke-node-s3g-pr ./cmd/legion-smoke-node`：通过
- `buf lint`：通过
- T2 验证：过期节点会话、review/turn 不匹配均被隔离；最终 API 边界用例 9/9 通过。

## 协同说明

- 配套 Legion PR：https://github.com/VillanCh/legion/pull/220
- Broker 级强制重投递未在 T2 环境执行，重投递去重由 focused test 覆盖。