### PR TITLE
feat(scannode): 默认启用无状态 AI 运行时

### DIFF
--- a/docker/session-runtime/Dockerfile
+++ b/docker/session-runtime/Dockerfile
@@ -10,7 +10,7 @@
 #
 # sessionmgr 起容器时注入环境变量：
 #   LEGION_NATS_URL, LEGION_API_URL, LEGION_ENROLLMENT_TOKEN,
-#   LEGION_SESSIONMGR_URL, LEGION_AI_SESSION_ID
+#   LEGION_SESSIONMGR_URL, LEGION_AI_SESSION_ID, LEGION_AI_RUNTIME
 # 并通过 -agent-installation-id ai-session-<sessionID> 传 ephemeral identity。
 
 # ---------- 构建阶段 ----------
@@ -20,7 +20,8 @@ WORKDIR /src
 COPY . .
 
 # 编译 legion-smoke-node（ai_session 容器不需要 HIDS tag，精简依赖）。
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /out/legion-session-runtime ./cmd/legion-smoke-node
+# Yaklang's embedded pcre2 and pcap dependencies require CGO.
+RUN CGO_ENABLED=1 go build -ldflags "-s -w" -o /out/legion-session-runtime ./cmd/legion-smoke-node
 
 # ---------- 运行阶段 ----------
 FROM debian:bookworm-slim
@@ -31,6 +32,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/legion-session-runtime /usr/local/bin/legion-session-runtime
+
+# Keep standalone container launches aligned with sessionmgr. Set this to
+# "stateful" only for a temporary rollback.
+ENV LEGION_AI_RUNTIME=stateless
 
 # 默认入口：作为 ai_session 容器 runtime 启动。
 # sessionmgr 起容器时会覆盖 command 注入 -api-url / -enrollment-token /

--- a/scannode/legion_ai_bridge.go
+++ b/scannode/legion_ai_bridge.go
@@ -12,20 +12,46 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/yaklang/yaklang/common/log"
 	aiv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/ai/v1"
 )
 
 // selectAISessionRuntimeDriver picks the AI runtime driver based on the
-// LEGION_AI_RUNTIME env var (S3d). "stateless" → statelessAIEngineRuntimeDriver
-// (S3c, per-turn engine, no persistence); any other value or unset →
-// yakAIEngineRuntimeDriver (legacy stateful). This is the behavior-cutover
-// switch point: rolling back is a sessionmgr config change + container restart,
-// no code revert needed.
+// LEGION_AI_RUNTIME env var. Stateless is the default; stateful remains as an
+// explicit rollback mode that takes effect after the container is restarted.
 func selectAISessionRuntimeDriver() aiSessionRuntimeDriver {
-	if strings.TrimSpace(os.Getenv("LEGION_AI_RUNTIME")) == "stateless" {
-		return newStatelessAIEngineRuntimeDriver()
+	rawMode := os.Getenv("LEGION_AI_RUNTIME")
+	mode, invalid := normalizeAISessionRuntimeMode(rawMode)
+	if invalid {
+		log.Warnf(
+			"unsupported LEGION_AI_RUNTIME=%q; defaulting to %s",
+			rawMode,
+			aiSessionRuntimeModeStateless,
+		)
+	} else {
+		log.Infof("selected AI session runtime: mode=%s", mode)
 	}
-	return newYakAIEngineRuntimeDriver()
+	if mode == aiSessionRuntimeModeStateful {
+		log.Warn("legacy AI session runtime rollback enabled explicitly")
+		return newYakAIEngineRuntimeDriver()
+	}
+	return newStatelessAIEngineRuntimeDriver()
+}
+
+const (
+	aiSessionRuntimeModeStateless = "stateless"
+	aiSessionRuntimeModeStateful  = "stateful"
+)
+
+func normalizeAISessionRuntimeMode(rawMode string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(rawMode)) {
+	case "", aiSessionRuntimeModeStateless:
+		return aiSessionRuntimeModeStateless, false
+	case aiSessionRuntimeModeStateful:
+		return aiSessionRuntimeModeStateful, false
+	default:
+		return aiSessionRuntimeModeStateless, true
+	}
 }
 
 const aiSessionRuntimeEventInput = "ai.session.input"

--- a/scannode/legion_job_bridge_env_test.go
+++ b/scannode/legion_job_bridge_env_test.go
@@ -18,24 +18,30 @@ func TestSelectAISessionRuntimeDriverStateless(t *testing.T) {
 	}
 }
 
-// TestSelectAISessionRuntimeDriverDefaultStateful verifies that the default
-// (env unset or any non-"stateless" value) selects the legacy stateful driver,
-// preserving the rollback path.
-func TestSelectAISessionRuntimeDriverDefaultStateful(t *testing.T) {
+func TestSelectAISessionRuntimeDriverDefaultStateless(t *testing.T) {
 	cases := map[string]string{
-		"unset":        "",
-		"empty":        "   ",
-		"stateful":     "stateful",
-		"garbage":      "something-else",
+		"unset":    "",
+		"empty":    "   ",
+		"explicit": "STATELESS",
+		"invalid":  "something-else",
 	}
 	for name, val := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv("LEGION_AI_RUNTIME", val)
 			d := selectAISessionRuntimeDriver()
 			got := fmt.Sprintf("%T", d)
-			if got != "scannode.yakAIEngineRuntimeDriver" {
-				t.Fatalf("LEGION_AI_RUNTIME=%q: expected yakAIEngineRuntimeDriver, got %s", val, got)
+			if got != "scannode.statelessAIEngineRuntimeDriver" {
+				t.Fatalf("LEGION_AI_RUNTIME=%q: expected statelessAIEngineRuntimeDriver, got %s", val, got)
 			}
 		})
+	}
+}
+
+func TestSelectAISessionRuntimeDriverExplicitStatefulRollback(t *testing.T) {
+	t.Setenv("LEGION_AI_RUNTIME", " STATEFUL ")
+	d := selectAISessionRuntimeDriver()
+	got := fmt.Sprintf("%T", d)
+	if got != "scannode.yakAIEngineRuntimeDriver" {
+		t.Fatalf("explicit stateful rollback: expected yakAIEngineRuntimeDriver, got %s", got)
 	}
 }


### PR DESCRIPTION
## 改动摘要

- 将 `LEGION_AI_RUNTIME` 未设置、为空或为非法值时统一切换到 stateless。
- 保留显式 `stateful` 作为短期回滚路径，并记录运行时选择与回滚告警。
- session runtime 镜像默认注入 stateless，构建阶段启用 CGO 以满足嵌入依赖。

## 改动文件

- `scannode/legion_ai_bridge.go`：运行时模式归一化、默认值与日志。
- `scannode/legion_job_bridge_env_test.go`：默认、非法值和显式回滚覆盖。
- `docker/session-runtime/Dockerfile`：默认环境变量和可用镜像构建。

## 验证方式

- `go test ./scannode/... -count=1`
- `go test -race ./scannode -run TestSelectAISessionRuntimeDriver -count=1`
- `go build -tags hids ./cmd/legion-smoke-node`
- `buf lint`
- 真实 session runtime Docker 镜像构建与容器 E2E 已通过。