### PR TITLE
feat(xlic): 支持 Legion V2 签名许可

### DIFF
--- a/common/utils/license/app.go
+++ b/common/utils/license/app.go
@@ -1,13 +1,17 @@
 package license
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/tlsutils"
 	"io/ioutil"
+	"strings"
 	"time"
 )
+
+const SignedLicenseV2Prefix = "legion-v2"
 
 type Request struct {
 	Timestamp   int64  `json:"timestamp"`
@@ -75,6 +79,69 @@ func (m *Machine) SignLicense(reqRaw string, org string, duration time.Duration,
 		return "", utils.Errorf("marshal response failed: %s", err)
 	}
 	return tlsutils.Encrypt(raw, m.encryptPubPEM)
+}
+
+// SignLicenseV2 issues an authenticated Legion license without changing the
+// legacy license format used by existing yaklang products.
+func (m *Machine) SignLicenseV2(reqRaw string, org string, duration time.Duration, params map[string]string) (string, error) {
+	reqPlaintext, err := tlsutils.Decrypt(reqRaw, m.decryptPriPEM)
+	if err != nil {
+		return "", utils.Errorf("decrypt license request failed: %s", err)
+	}
+	var req Request
+	if err := json.Unmarshal(reqPlaintext, &req); err != nil {
+		return "", utils.Errorf("unmarshal request failed: %s", err)
+	}
+	rsp := Response{
+		Org:               org,
+		NotAfterTimestamp: time.Now().Add(duration).Unix(),
+		Params:            params,
+		MachineCode:       req.MachineCode,
+	}
+	payload, err := json.Marshal(rsp)
+	if err != nil {
+		return "", utils.Errorf("marshal response failed: %s", err)
+	}
+	signature, err := tlsutils.PemSignSha256WithRSA(m.decryptPriPEM, payload)
+	if err != nil {
+		return "", utils.Errorf("sign license failed: %s", err)
+	}
+	return strings.Join([]string{
+		SignedLicenseV2Prefix,
+		base64.RawURLEncoding.EncodeToString(payload),
+		base64.RawURLEncoding.EncodeToString(signature),
+	}, "."), nil
+}
+
+// VerifyLicenseV2 verifies the additive Legion format with the public key.
+// Legacy callers continue to use VerifyLicense unchanged.
+func (m *Machine) VerifyLicenseV2(licenseRaw string) (*Response, error) {
+	parts := strings.Split(licenseRaw, ".")
+	if len(parts) != 3 || parts[0] != SignedLicenseV2Prefix {
+		return nil, utils.Errorf("invalid signed license format")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, utils.Errorf("decode license payload failed: %s", err)
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, utils.Errorf("decode license signature failed: %s", err)
+	}
+	if err := tlsutils.PemVerifySignSha256WithRSA(m.encryptPubPEM, payload, signature); err != nil {
+		return nil, utils.Errorf("license signature verification failed: %s", err)
+	}
+	var rsp Response
+	if err := json.Unmarshal(payload, &rsp); err != nil {
+		return nil, utils.Errorf("unmarshal response failed: %s", err)
+	}
+	if m.MachineCode != rsp.MachineCode {
+		return nil, utils.Errorf("invalid license")
+	}
+	if !time.Unix(rsp.NotAfterTimestamp, 0).After(time.Now()) {
+		return &rsp, utils.Errorf("expired license")
+	}
+	return &rsp, nil
 }
 
 func (m *Machine) GenerateRequest() (string, error) {

--- a/common/utils/license/app_test.go
+++ b/common/utils/license/app_test.go
@@ -1,9 +1,12 @@
 package license
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/yaklang/yaklang/common/utils/tlsutils"
+	"strings"
 	"testing"
 	"time"
 )
@@ -42,4 +45,51 @@ func TestNewMachine(t *testing.T) {
 	}
 
 	spew.Dump(rsp)
+}
+
+func TestSignedLicenseV2RoundTripAndTamper(t *testing.T) {
+	pri, pub, err := tlsutils.GeneratePrivateAndPublicKeyPEM()
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	requester := NewMachine(pub, nil)
+	signer := NewMachine(nil, pri)
+	req, err := requester.GenerateRequest()
+	if err != nil {
+		t.Fatalf("generate request: %v", err)
+	}
+	licenseRaw, err := signer.SignLicenseV2(req, "Test", 24*time.Hour, map[string]string{
+		"entitlements": `{"products":["hids"],"version":1}`,
+	})
+	if err != nil {
+		t.Fatalf("sign v2 license: %v", err)
+	}
+	rsp, err := requester.VerifyLicenseV2(licenseRaw)
+	if err != nil {
+		t.Fatalf("verify v2 license: %v", err)
+	}
+	if rsp.Org != "Test" {
+		t.Fatalf("unexpected org: %q", rsp.Org)
+	}
+
+	parts := strings.Split(licenseRaw, ".")
+	if len(parts) != 3 || parts[0] != SignedLicenseV2Prefix {
+		t.Fatalf("unexpected v2 format: %q", licenseRaw)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if err := json.Unmarshal(payload, &rsp); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	rsp.NotAfterTimestamp = time.Now().Add(10 * 365 * 24 * time.Hour).Unix()
+	payload, err = json.Marshal(rsp)
+	if err != nil {
+		t.Fatalf("marshal tampered payload: %v", err)
+	}
+	parts[1] = base64.RawURLEncoding.EncodeToString(payload)
+	if _, err := requester.VerifyLicenseV2(strings.Join(parts, ".")); err == nil {
+		t.Fatal("tampered v2 payload must fail verification")
+	}
 }

--- a/common/utils/license/cmd/xlic.go
+++ b/common/utils/license/cmd/xlic.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/yaklang/yaklang/common/urfavecli"
 	"github.com/yaklang/yaklang/common/utils"
@@ -74,6 +75,15 @@ func main() {
 		cli.IntFlag{
 			Name: "duration-days,d",
 		},
+		cli.StringFlag{
+			Name:  "format",
+			Value: "legacy",
+			Usage: "license format: legacy or legion-v2",
+		},
+		cli.StringFlag{
+			Name:  "products",
+			Usage: "comma-separated Legion products: scan_center,ssa,hids,memfit",
+		},
 	}
 
 	app.Before = func(context *cli.Context) error {
@@ -96,10 +106,28 @@ func main() {
 			return err
 		}
 
-		resp, err := m.SignLicense(
-			strings.TrimSpace(string(raw)), org,
-			time.Duration(c.Int64("duration-days"))*(time.Hour*24),
-			nil)
+		params, err := buildEntitlementParams(c.String("products"))
+		if err != nil {
+			return err
+		}
+		request := strings.TrimSpace(string(raw))
+		duration := time.Duration(c.Int64("duration-days")) * (time.Hour * 24)
+		if duration <= 0 {
+			return utils.Errorf("duration-days must be greater than zero")
+		}
+		format := strings.TrimSpace(c.String("format"))
+		if params != nil && format != "legion-v2" {
+			return utils.Errorf("--products requires --format legion-v2")
+		}
+		var resp string
+		switch format {
+		case "", "legacy":
+			resp, err = m.SignLicense(request, org, duration, params)
+		case "legion-v2":
+			resp, err = m.SignLicenseV2(request, org, duration, params)
+		default:
+			return utils.Errorf("unknown license format: %s (valid: legacy, legion-v2)", c.String("format"))
+		}
 		if err != nil {
 			return err
 		}
@@ -116,4 +144,46 @@ func main() {
 		fmt.Printf("command: [%v] failed: %v\n", strings.Join(os.Args, " "), err)
 		return
 	}
+}
+
+func buildEntitlementParams(productsFlag string) (map[string]string, error) {
+	productsFlag = strings.TrimSpace(productsFlag)
+	if productsFlag == "" {
+		return nil, nil
+	}
+	validProducts := map[string]bool{
+		"scan_center": true,
+		"ssa":         true,
+		"hids":        true,
+		"memfit":      true,
+	}
+	products := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, raw := range strings.Split(productsFlag, ",") {
+		product := strings.TrimSpace(raw)
+		if product == "" {
+			continue
+		}
+		if !validProducts[product] {
+			return nil, utils.Errorf(
+				"unknown product key: %s (valid: scan_center, ssa, hids, memfit)",
+				product,
+			)
+		}
+		if !seen[product] {
+			products = append(products, product)
+			seen[product] = true
+		}
+	}
+	if len(products) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(map[string]any{
+		"products": products,
+		"version":  1,
+	})
+	if err != nil {
+		return nil, utils.Errorf("marshal entitlements failed: %s", err)
+	}
+	return map[string]string{"entitlements": string(raw)}, nil
 }

--- a/common/utils/license/cmd/xlic_test.go
+++ b/common/utils/license/cmd/xlic_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildEntitlementParams(t *testing.T) {
+	params, err := buildEntitlementParams("hids, ssa")
+	if err != nil {
+		t.Fatalf("build params: %v", err)
+	}
+	var payload struct {
+		Products []string `json:"products"`
+		Version  int      `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(params["entitlements"]), &payload); err != nil {
+		t.Fatalf("unmarshal entitlements: %v", err)
+	}
+	if payload.Version != 1 || len(payload.Products) != 2 {
+		t.Fatalf("unexpected entitlements: %+v", payload)
+	}
+}
+
+func TestBuildEntitlementParamsRejectsUnknownProduct(t *testing.T) {
+	if _, err := buildEntitlementParams("hids,unknown"); err == nil {
+		t.Fatal("unknown product must be rejected")
+	}
+}


### PR DESCRIPTION
### 改动摘要
- 新增 additive `legion-v2` RSA-SHA256 签名格式，保留 legacy 默认格式兼容现有消费者。
- xlic 增加 `--format legion-v2` 与 `--products`，用于 Legion 多产品授权。
- 修正 Legion request 与 tlsutils 的兼容格式并补充签名篡改测试。

### 验证方式
- `go test ./common/utils/license ./common/utils/license/cmd -count=1`
- Legion PR #225 已实测 xlic → Legion request、签发、验签与产品授权链路。