### PR TITLE
工具优化(一): scan_port 进度日志+全端口拦截 / do_http_request save-packet 开关+headers 对象容错

### DIFF
--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/batch_do_http_request_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/batch_do_http_request_test.go
@@ -732,3 +732,69 @@ func TestBatchDoHTTPRequest_PrefixWithSlashPaths(t *testing.T) {
 	assert.Assert(t, strings.Contains(stdout, "/api/v2/admin"), "prefix should handle paths without leading slash")
 	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both prefixed requests should succeed")
 }
+
+// Test 32: AI passes "paths" as a JSON ARRAY.
+// The executor stringifies it to "[/p1 /p2]"; normalizePaths must split it back
+// into two real paths instead of treating the whole blob as one broken path.
+// Reproduces the field failure: "got array, want string".
+func TestBatchDoHTTPRequest_PathsAsArray(t *testing.T) {
+	host, port := utils.DebugMockHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("arr_path:" + r.URL.Path))
+	})
+
+	tool := getBatchDoHTTPRequestTool(t)
+	stdout, _ := execBatchTool(t, tool, aitool.InvokeParams{
+		"base-url":   "http://" + host + ":" + strconv.Itoa(port),
+		"paths":      []string{"/arr_a", "/arr_b"},
+		"concurrent": 1,
+		"timeout":    10,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "Total paths to test: 2"), "array-form paths should be split into 2")
+	assert.Assert(t, strings.Contains(stdout, "arr_path:/arr_a"), "first array path should be requested")
+	assert.Assert(t, strings.Contains(stdout, "arr_path:/arr_b"), "second array path should be requested")
+	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both array-form paths should succeed")
+}
+
+// Test 33: AI passes "headers" as a JSON OBJECT (regression for schema friction).
+func TestBatchDoHTTPRequest_HeadersAsObject(t *testing.T) {
+	host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {
+		if strings.Contains(string(req), "X-Obj-Header: obj-value-123") {
+			return []byte("HTTP/1.1 200 OK\r\n\r\nobj_header_ok")
+		}
+		return []byte("HTTP/1.1 200 OK\r\n\r\nobj_header_missing")
+	})
+
+	tool := getBatchDoHTTPRequestTool(t)
+	stdout, _ := execBatchTool(t, tool, aitool.InvokeParams{
+		"base-url":   "http://" + host + ":" + strconv.Itoa(port),
+		"paths":      "/test",
+		"headers":    map[string]string{"X-Obj-Header": "obj-value-123"},
+		"concurrent": 1,
+		"timeout":    10,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "obj_header_ok"), "object-form header should reach the server")
+}
+
+// Test 34: AI passes "query-params" as a JSON OBJECT.
+func TestBatchDoHTTPRequest_QueryParamsAsObject(t *testing.T) {
+	host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {
+		if strings.Contains(string(req), "objid=99") {
+			return []byte("HTTP/1.1 200 OK\r\n\r\nobj_param_ok")
+		}
+		return []byte("HTTP/1.1 200 OK\r\n\r\nobj_param_missing")
+	})
+
+	tool := getBatchDoHTTPRequestTool(t)
+	stdout, _ := execBatchTool(t, tool, aitool.InvokeParams{
+		"base-url":     "http://" + host + ":" + strconv.Itoa(port),
+		"paths":        "/search",
+		"query-params": map[string]string{"objid": "99"},
+		"concurrent":   1,
+		"timeout":      10,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "obj_param_ok"), "object-form query param should reach the server")
+}

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
@@ -87,6 +87,7 @@ func TestDoHTTPRequest_RequestLargeTruncate(t *testing.T) {
 
 	largeBody := strings.Repeat("X", 6*1024)
 
+	// without save-packet: truncated inline, hint tells AI how to get the full file
 	stdout, _ := execTool(t, tool, aitool.InvokeParams{
 		"url":          "http://" + host + ":" + strconv.Itoa(port),
 		"method":       "POST",
@@ -97,7 +98,22 @@ func TestDoHTTPRequest_RequestLargeTruncate(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(stdout, "request packet"), "request packet header not found")
 	assert.Assert(t, strings.Contains(stdout, "truncated"), "large request should contain 'truncated'")
-	assert.Assert(t, strings.Contains(stdout, "full request saved to file"), "truncation hint not found")
+	assert.Assert(t, strings.Contains(stdout, "save-packet=true"), "truncation hint should point to save-packet")
+	assert.Assert(t, !strings.Contains(stdout, "saved to"), "no file should be saved when save-packet is off")
+
+	// with save-packet=true: the full packet is dumped to a file
+	host2, port2 := utils.DebugMockHTTP([]byte(flag))
+	stdout, _ = execTool(t, tool, aitool.InvokeParams{
+		"url":          "http://" + host2 + ":" + strconv.Itoa(port2),
+		"method":       "POST",
+		"body":         largeBody,
+		"content-type": "text/plain",
+		"timeout":      10,
+		"save-packet":  true,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "truncated"), "large request should contain 'truncated'")
+	assert.Assert(t, strings.Contains(stdout, "full request saved to file"), "with save-packet the full request file hint should appear")
 }
 
 func TestDoHTTPRequest_ResponseSmallNoPattern(t *testing.T) {
@@ -125,6 +141,7 @@ func TestDoHTTPRequest_ResponseLargeNoPattern(t *testing.T) {
 	})
 	tool := getDoHTTPRequestTool(t)
 
+	// without save-packet: truncated inline, hint points to save-packet, no file saved
 	stdout, _ := execTool(t, tool, aitool.InvokeParams{
 		"url":     "http://" + host + ":" + strconv.Itoa(port),
 		"timeout": 10,
@@ -132,8 +149,19 @@ func TestDoHTTPRequest_ResponseLargeNoPattern(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(stdout, headMarker), "head of large response should be printed")
 	assert.Assert(t, strings.Contains(stdout, "truncated"), "large response without pattern should be truncated")
-	assert.Assert(t, strings.Contains(stdout, "full response saved to file"), "truncation hint not found")
+	assert.Assert(t, strings.Contains(stdout, "save-packet=true"), "truncation hint should point to save-packet")
+	assert.Assert(t, !strings.Contains(stdout, "saved to"), "no file should be saved when save-packet is off")
 	assert.Assert(t, !strings.Contains(stdout, tailMarker), "tail should not appear in truncated output")
+
+	// with save-packet=true: the full response is dumped to a file
+	stdout, _ = execTool(t, tool, aitool.InvokeParams{
+		"url":         "http://" + host + ":" + strconv.Itoa(port),
+		"timeout":     10,
+		"save-packet": true,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "truncated"), "large response should be truncated")
+	assert.Assert(t, strings.Contains(stdout, "full response saved to file"), "with save-packet the full response file hint should appear")
 }
 
 func TestDoHTTPRequest_ResponseSmallWithKeyword(t *testing.T) {
@@ -237,6 +265,49 @@ func TestDoHTTPRequest_CustomHeaders(t *testing.T) {
 	_ = receivedHeader
 	assert.Assert(t, strings.Contains(stdout, "X-My-Header"), "custom header should appear in request packet output")
 	assert.Assert(t, strings.Contains(stdout, "header_received"), "server should receive the custom header")
+}
+
+// TestDoHTTPRequest_HeadersAsObject reproduces the real failure seen in the field:
+// the AI passed "headers" as a JSON OBJECT, but the schema declared it a string, so the
+// fast-path validation rejected it ("got object, want string"). The executor stringifies
+// the map to "map[X-My-Header:test-value-123]"; the tool must normalize that back into a
+// real header instead of dropping it.
+func TestDoHTTPRequest_HeadersAsObject(t *testing.T) {
+	host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {
+		if strings.Contains(string(req), "X-My-Header: test-value-123") {
+			return []byte("HTTP/1.1 200 OK\r\n\r\nheader_received")
+		}
+		return []byte("HTTP/1.1 200 OK\r\n\r\nheader_missing")
+	})
+	tool := getDoHTTPRequestTool(t)
+
+	stdout, _ := execTool(t, tool, aitool.InvokeParams{
+		"url":     "http://" + host + ":" + strconv.Itoa(port),
+		"headers": map[string]string{"X-My-Header": "test-value-123"},
+		"timeout": 10,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "X-My-Header"), "object-form header should appear in request packet output")
+	assert.Assert(t, strings.Contains(stdout, "header_received"), "server should receive the object-form header")
+}
+
+// TestDoHTTPRequest_QueryParamsAsObject verifies query-params also accept a JSON object.
+func TestDoHTTPRequest_QueryParamsAsObject(t *testing.T) {
+	host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {
+		if strings.Contains(string(req), "id=42") {
+			return []byte("HTTP/1.1 200 OK\r\n\r\nparam_received")
+		}
+		return []byte("HTTP/1.1 200 OK\r\n\r\nparam_missing")
+	})
+	tool := getDoHTTPRequestTool(t)
+
+	stdout, _ := execTool(t, tool, aitool.InvokeParams{
+		"url":          "http://" + host + ":" + strconv.Itoa(port) + "/",
+		"query-params": map[string]string{"id": "42"},
+		"timeout":      10,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "param_received"), "server should receive the object-form query param")
 }
 
 func TestDoHTTPRequest_PostBody(t *testing.T) {
@@ -345,19 +416,29 @@ func TestDoHTTPRequest_NoRedirect(t *testing.T) {
 	assert.Assert(t, strings.Contains(stdout, "302") || strings.Contains(stdout, "Found"), "should show redirect status code")
 }
 
-func TestDoHTTPRequest_ShowRequest(t *testing.T) {
+func TestDoHTTPRequest_SavePacket(t *testing.T) {
 	flag := utils.RandStringBytes(20)
 	host, port := utils.DebugMockHTTP([]byte(flag))
 	tool := getDoHTTPRequestTool(t)
 
+	// default (save-packet off): request still printed inline, but nothing saved to file
 	stdout, _ := execTool(t, tool, aitool.InvokeParams{
-		"url":          "http://" + host + ":" + strconv.Itoa(port),
-		"show-request": "yes",
-		"timeout":      10,
+		"url":     "http://" + host + ":" + strconv.Itoa(port),
+		"timeout": 10,
 	})
-
 	assert.Assert(t, strings.Contains(stdout, "request packet"), "request should always be printed")
-	assert.Assert(t, strings.Contains(stdout, "saved to"), "show-request=yes should save request to file")
+	assert.Assert(t, !strings.Contains(stdout, "saved to"), "no file should be saved when save-packet is off")
+
+	// save-packet=true: both request and response packets are saved to temp files
+	host2, port2 := utils.DebugMockHTTP([]byte(flag))
+	stdout, _ = execTool(t, tool, aitool.InvokeParams{
+		"url":         "http://" + host2 + ":" + strconv.Itoa(port2),
+		"timeout":     10,
+		"save-packet": true,
+	})
+	assert.Assert(t, strings.Contains(stdout, "request packet"), "request should always be printed")
+	assert.Assert(t, strings.Contains(stdout, "request packet [size:"), "save-packet=true should save the request to a file")
+	assert.Assert(t, strings.Contains(stdout, "response packet [size:"), "save-packet=true should save the response to a file")
 }
 
 func TestDoHTTPRequest_Timeout(t *testing.T) {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
@@ -485,6 +485,39 @@ func TestDoHTTPRequest_QuietMode(t *testing.T) {
 	assert.Assert(t, !strings.Contains(stdout, "dns:"), "connection trace must NOT print when verbose is off")
 }
 
+// TestDoHTTPRequest_FormRetryOnJsonRejected reproduces the highest-impact field failure:
+// the AI POSTs a JSON body to a form-only login endpoint; the server replies 400
+// "emp_no and password are required" because it only parses application/x-www-form-urlencoded.
+// The tool must auto-retry the same request as form-encoded, surface a [content-type hint],
+// and report the accepted response (200 here) instead of leaving the AI stuck on 400.
+func TestDoHTTPRequest_FormRetryOnJsonRejected(t *testing.T) {
+	host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {
+		reqStr := string(req)
+		// form-only endpoint: JSON body -> 400 required; form-encoded body -> 200
+		if strings.Contains(reqStr, "Content-Type: application/json") {
+			return []byte("HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\r\n{\"message\":\"emp_no and password are required\"}")
+		}
+		if strings.Contains(reqStr, "Content-Type: application/x-www-form-urlencoded") && strings.Contains(reqStr, "emp_no=") {
+			return []byte("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"message\":\"staff credential mismatch\"}")
+		}
+		return []byte("HTTP/1.1 400 Bad Request\r\n\r\n{\"message\":\"bad\"}")
+	})
+	tool := getDoHTTPRequestTool(t)
+
+	stdout, _ := execTool(t, tool, aitool.InvokeParams{
+		"url":          "http://" + host + ":" + strconv.Itoa(port) + "/api/login",
+		"method":       "POST",
+		"content-type": "application/json",
+		"body":         `{"emp_no":"EMP00001","password":"x"}`,
+		"timeout":      10,
+	})
+
+	assert.Assert(t, strings.Contains(stdout, "content-type hint"), "should emit a content-type hint when JSON is rejected with a 'required' 400")
+	assert.Assert(t, strings.Contains(stdout, "x-www-form-urlencoded"), "hint should mention form-encoded")
+	assert.Assert(t, strings.Contains(stdout, "200 OK"), "should report the accepted form-retried response (200), not stay on 400")
+	assert.Assert(t, strings.Contains(stdout, "staff credential mismatch"), "should surface the form-retried response body")
+}
+
 func TestDoHTTPRequest_Timeout(t *testing.T) {
 	host, port := utils.DebugMockHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {}

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
@@ -55,6 +55,7 @@ func TestDoHTTPRequest_BasicURL(t *testing.T) {
 	stdout, _ := execTool(t, tool, aitool.InvokeParams{
 		"url":     "http://" + host + ":" + strconv.Itoa(port),
 		"timeout": 10,
+		"verbose": true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, flag), "response flag not found in stdout")
@@ -72,6 +73,7 @@ func TestDoHTTPRequest_RequestSmallPrint(t *testing.T) {
 		"url":     "http://" + host + ":" + strconv.Itoa(port) + "/test-path",
 		"method":  "GET",
 		"timeout": 10,
+		"verbose": true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "request packet"), "request packet header not found")
@@ -94,6 +96,7 @@ func TestDoHTTPRequest_RequestLargeTruncate(t *testing.T) {
 		"body":         largeBody,
 		"content-type": "text/plain",
 		"timeout":      10,
+		"verbose":      true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "request packet"), "request packet header not found")
@@ -109,6 +112,7 @@ func TestDoHTTPRequest_RequestLargeTruncate(t *testing.T) {
 		"body":         largeBody,
 		"content-type": "text/plain",
 		"timeout":      10,
+		"verbose":      true,
 		"save-packet":  true,
 	})
 
@@ -237,6 +241,7 @@ func TestDoHTTPRequest_PacketMode(t *testing.T) {
 		"packet":  packet,
 		"https":   "no",
 		"timeout": 10,
+		"verbose": true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, flag), "packet mode response should contain flag")
@@ -260,6 +265,7 @@ func TestDoHTTPRequest_CustomHeaders(t *testing.T) {
 		"url":     "http://" + host + ":" + strconv.Itoa(port),
 		"headers": "X-My-Header: test-value-123",
 		"timeout": 10,
+		"verbose": true,
 	})
 
 	_ = receivedHeader
@@ -285,6 +291,7 @@ func TestDoHTTPRequest_HeadersAsObject(t *testing.T) {
 		"url":     "http://" + host + ":" + strconv.Itoa(port),
 		"headers": map[string]string{"X-My-Header": "test-value-123"},
 		"timeout": 10,
+		"verbose": true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "X-My-Header"), "object-form header should appear in request packet output")
@@ -326,6 +333,7 @@ func TestDoHTTPRequest_PostBody(t *testing.T) {
 		"body":         `{"name":"test"}`,
 		"content-type": "application/json",
 		"timeout":      10,
+		"verbose":      true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "body_ok"), "server should receive the body")
@@ -346,6 +354,7 @@ func TestDoHTTPRequest_QueryParams(t *testing.T) {
 		"url":          "http://" + host + ":" + strconv.Itoa(port) + "/search",
 		"query-params": "foo=bar&baz=qux",
 		"timeout":      10,
+		"verbose":      true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "query_ok"), "server should receive query params")
@@ -367,6 +376,7 @@ func TestDoHTTPRequest_PostParams(t *testing.T) {
 		"method":      "POST",
 		"post-params": "user=admin&pass=secret",
 		"timeout":     10,
+		"verbose":     true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "post_params_ok"), "server should receive post params")
@@ -421,24 +431,58 @@ func TestDoHTTPRequest_SavePacket(t *testing.T) {
 	host, port := utils.DebugMockHTTP([]byte(flag))
 	tool := getDoHTTPRequestTool(t)
 
-	// default (save-packet off): request still printed inline, but nothing saved to file
+	// default (save-packet off, verbose off): a one-line request summary is printed,
+	// but the full request packet is NOT printed and nothing is saved to file
 	stdout, _ := execTool(t, tool, aitool.InvokeParams{
 		"url":     "http://" + host + ":" + strconv.Itoa(port),
 		"timeout": 10,
 	})
-	assert.Assert(t, strings.Contains(stdout, "request packet"), "request should always be printed")
+	assert.Assert(t, strings.Contains(stdout, "request: GET"), "one-line request summary should be printed")
+	assert.Assert(t, !strings.Contains(stdout, "request packet"), "full request packet should NOT be printed when verbose is off")
 	assert.Assert(t, !strings.Contains(stdout, "saved to"), "no file should be saved when save-packet is off")
 
-	// save-packet=true: both request and response packets are saved to temp files
+	// save-packet=true (+ verbose to also see the inline packet): both request and
+	// response packets are saved to temp files
 	host2, port2 := utils.DebugMockHTTP([]byte(flag))
 	stdout, _ = execTool(t, tool, aitool.InvokeParams{
 		"url":         "http://" + host2 + ":" + strconv.Itoa(port2),
 		"timeout":     10,
+		"verbose":     true,
 		"save-packet": true,
 	})
-	assert.Assert(t, strings.Contains(stdout, "request packet"), "request should always be printed")
+	assert.Assert(t, strings.Contains(stdout, "request packet"), "request packet should be printed in verbose mode")
 	assert.Assert(t, strings.Contains(stdout, "request packet [size:"), "save-packet=true should save the request to a file")
 	assert.Assert(t, strings.Contains(stdout, "response packet [size:"), "save-packet=true should save the response to a file")
+}
+
+// TestDoHTTPRequest_QuietMode verifies the DEFAULT (verbose=false) output is minimal:
+// a one-line request summary + status line + response body are present, but the full
+// request packet, the mode line, "remote ... is open", and the connection trace are NOT.
+// This is what keeps repeated IDOR/enum calls from bloating the AI context window.
+func TestDoHTTPRequest_QuietMode(t *testing.T) {
+	bodyMarker := "QUIET_BODY_" + utils.RandStringBytes(10)
+	host, port := utils.DebugMockHTTPEx(func(req []byte) []byte {
+		return []byte("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n" + bodyMarker)
+	})
+	tool := getDoHTTPRequestTool(t)
+
+	stdout, _ := execTool(t, tool, aitool.InvokeParams{
+		"url":     "http://" + host + ":" + strconv.Itoa(port) + "/api/items/1",
+		"timeout": 10,
+		// verbose intentionally NOT set (default off)
+	})
+
+	// what SHOULD be present (the high-value info for vulnerability judgment)
+	assert.Assert(t, strings.Contains(stdout, "request: GET"), "one-line request summary should be printed")
+	assert.Assert(t, strings.Contains(stdout, "/api/items/1"), "request URL should be in the summary")
+	assert.Assert(t, strings.Contains(stdout, "HTTP/1.1 200 OK"), "status line should be printed")
+	assert.Assert(t, strings.Contains(stdout, bodyMarker), "response body should be printed")
+
+	// what should NOT be present (verbose-only noise)
+	assert.Assert(t, !strings.Contains(stdout, "request packet"), "full request packet must NOT print when verbose is off")
+	assert.Assert(t, !strings.Contains(stdout, "mode: URL"), "mode line must NOT print when verbose is off")
+	assert.Assert(t, !strings.Contains(stdout, "is open"), "'remote ... is open' must NOT print when verbose is off")
+	assert.Assert(t, !strings.Contains(stdout, "dns:"), "connection trace must NOT print when verbose is off")
 }
 
 func TestDoHTTPRequest_Timeout(t *testing.T) {
@@ -473,6 +517,7 @@ func TestDoHTTPRequest_ContentType(t *testing.T) {
 		"body":         "<root/>",
 		"content-type": "application/xml",
 		"timeout":      10,
+		"verbose":      true,
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "ctype_ok"), "server should receive correct content-type")

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/simple_crawler_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/simple_crawler_test.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools/yakscripttools"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	_ "github.com/yaklang/yaklang/common/yak"
+	"gotest.tools/v3/assert"
+)
+
+const simpleCrawlerToolName = "simple_crawler"
+
+func getSimpleCrawlerTool(t *testing.T) *aitool.Tool {
+	t.Helper()
+	embedFS := yakscripttools.GetEmbedFS()
+	content, err := embedFS.ReadFile("yakscriptforai/http/simple_crawler.yak")
+	if err != nil {
+		t.Fatalf("failed to read simple_crawler.yak from embed FS: %v", err)
+	}
+	aiTool := yakscripttools.LoadYakScriptToAiTools(simpleCrawlerToolName, string(content))
+	if aiTool == nil {
+		t.Fatalf("failed to parse simple_crawler.yak metadata")
+	}
+	tools := yakscripttools.ConvertTools([]*schema.AIYakTool{aiTool})
+	if len(tools) == 0 {
+		t.Fatalf("ConvertTools returned empty, toolCovertHandle may not be registered")
+	}
+	return tools[0]
+}
+
+func execCrawlerTool(t *testing.T, tool *aitool.Tool, params aitool.InvokeParams) (stdout, stderr string) {
+	t.Helper()
+	w1, w2 := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
+	_, err := tool.Callback(context.Background(), params, nil, w1, w2)
+	if err != nil {
+		t.Logf("crawler tool execution error (may be expected): %v", err)
+	}
+	return w1.String(), w2.String()
+}
+
+// TestSimpleCrawler_CoverageHint nudges the AI toward broad coverage via
+// adjust_todo when the crawl discovers >1 subdomain or pending URLs.
+//
+// This is the fix for a field coverage gap: the crawler found multiple
+// subdomains and many URLs, but the AI fixated on ONE subdomain (desk) and
+// skipped the rest (mall, id/portal). Rather than hard-coding an attack-surface
+// inventory (over-fit to one shape), the crawler now emits a lightweight hint
+// pushing the AI to break the remaining surface into multiple todos, so more
+// todos drive better depth and completeness.
+func TestSimpleCrawler_CoverageHint(t *testing.T) {
+	// port is assigned by DebugMockHTTPHandlerFunc below; capture it for the
+	// handler closure via a pointer so the landing page can self-link.
+	var port int
+	host, p := utils.DebugMockHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Landing page links to several internal paths and two other virtual
+		// hostnames on the same loopback server, so the crawler discovers
+		// multiple subdomains and pending URLs.
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(`<!doctype html><html><body>
+<a href="/portal">portal</a>
+<a href="/home">home</a>
+<a href="/api/v1/users">users api</a>
+<a href="/static/js/app.js">js</a>
+<a href="http://desk.localhost:` + strconv.Itoa(port) + `/desk">desk</a>
+<a href="http://mall.localhost:` + strconv.Itoa(port) + `/mall">mall</a>
+</body></html>`))
+	})
+	port = p
+	baseURL := "http://" + host + ":" + strconv.Itoa(port)
+
+	tool := getSimpleCrawlerTool(t)
+	stdout, _ := execCrawlerTool(t, tool, aitool.InvokeParams{
+		"urls":      baseURL,
+		"reqs-max":  20,
+		"max-depth": 3,
+		"timeout":   5,
+	})
+
+	// The coverage hint must be emitted (multiple subdomains were discovered).
+	assert.Assert(t, strings.Contains(stdout, "[coverage hint]"),
+		"should emit the [coverage hint] when >1 subdomain or pending URLs are found; got:\n%s", stdout)
+
+	// The hint must steer toward adjust_todo / multiple todos (not a fixed inventory).
+	assert.Assert(t, strings.Contains(stdout, "adjust_todo"),
+		"hint should steer the AI toward adjust_todo; got:\n%s", stdout)
+	assert.Assert(t, strings.Contains(stdout, "todo"),
+		"hint should mention breaking work into todos")
+
+	// The standard crawl output must still be present (summary + requested URLs).
+	assert.Assert(t, strings.Contains(stdout, "=== Crawl Summary ==="),
+		"standard crawl summary should still be present")
+	assert.Assert(t, strings.Contains(stdout, "=== Requested URLs ==="),
+		"requested URLs section should still be present")
+}

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/batch_do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/batch_do_http_request.yak
@@ -239,12 +239,12 @@ yakit.AutoInitYakit()
 // --- parse parameters ---
 // URL mode params
 baseUrl = cli.String("base-url", cli.setHelp("base URL or domain for URL mode"), cli.setRequired(false))
-pathsStr = cli.String("paths", cli.setHelp("paths to test, one per line; in Packet mode any query string inside a path must already be encoded"), cli.setRequired(false))
+pathsStr = cli.String("paths", cli.setHelp("paths to test, one per line; ALSO accepts a JSON array [\"/a\",\"/b\"]. In Packet mode any query string inside a path must already be encoded"), cli.setRequired(false))
 method = cli.String("method", cli.setHelp("HTTP method"), cli.setDefault("GET"))
-headers = cli.String("headers", cli.setHelp("custom headers, one per line: Key: Value"), cli.setRequired(false))
+headers = cli.String("headers", cli.setHelp("custom headers, one per line: 'Key: Value'; ALSO accepts a JSON object {key:value} (AI may pass either)"), cli.setRequired(false))
 body = cli.String("body", cli.setHelp("request body content"), cli.setRequired(false))
 contentType = cli.String("content-type", cli.setHelp("Content-Type header"), cli.setRequired(false))
-queryParams = cli.String("query-params", cli.setHelp("URL query params: k1=v1&k2=v2; preferred for testing GET params across many paths"), cli.setRequired(false))
+queryParams = cli.String("query-params", cli.setHelp("URL query params: 'k1=v1&k2=v2' string OR JSON object {k1:v1}; preferred for testing GET params across many paths"), cli.setRequired(false))
 prefix = cli.String("prefix", cli.setHelp("path prefix to prepend to all paths, e.g. /v1/ or /api/v2/"), cli.setRequired(false))
 curlHeaders = cli.StringSlice("H", cli.setHelp("curl-style headers, can be used multiple times: -H 'Content-Type: application/json' -H 'Authorization: Bearer token'"), cli.setRequired(false))
 
@@ -266,6 +266,92 @@ includeCode = cli.String("include-code", cli.setHelp("include only these status 
 excludeSize = cli.String("exclude-size", cli.setHelp("exclude content-length ranges"), cli.setRequired(false))
 maxBodySize = cli.Int("max-body-size", cli.setHelp("max response body size to display"), cli.setDefault(4096))
 cli.check()
+
+// --- 参数归一化 ---
+// AI 有时把 headers/query-params 传成 JSON 对象, 把 paths 传成 JSON 数组. 执行器
+// (yakscript_plugin_for_ai.go) 会用 fmt.Sprint 把非 bool 值转成字符串:
+//   - 对象 -> "map[k1:v1 k2:v2]" (Go map 字面量, 字母序排序)
+//   - 数组 -> "[/a /b /c]"       (Go slice 字面量, 空格分隔)
+// 这里把它们还原成工具原本接受的字符串写法, 与既有用法兼容.
+// 关键词: batch_do_http_request 参数归一化, paths 数组, headers/query-params 对象, fmt.Sprint
+normalizeMapLike = func(raw, pairSep, kvSep) {
+    if raw == "" || raw == nil {
+        return ""
+    }
+    s = sprint(raw)
+    trimmed = str.TrimSpace(s)
+    if str.HasPrefix(trimmed, "map[") && str.HasSuffix(trimmed, "]") {
+        inner = str.TrimSpace(trimmed[4:len(trimmed)-1])
+        out = []
+        for _, kv := range str.Split(inner, " ") {
+            kv = str.TrimSpace(kv)
+            if kv == "" {
+                continue
+            }
+            colonIdx = str.Index(kv, ":")
+            if colonIdx > 0 {
+                out.Push(sprintf("%v%v%v", str.TrimSpace(kv[:colonIdx]), kvSep, str.TrimSpace(kv[colonIdx+1:])))
+            } else {
+                out.Push(sprintf("%v%v", kv, kvSep))
+            }
+        }
+        return str.Join(out, pairSep)
+    }
+    return s
+}
+
+// headers 归一化: 接受 "Key: Value\n..." 或对象; 输出 "Key: Value\n..."
+normalizeHeaders = func(raw) {
+    if raw == "" || raw == nil {
+        return ""
+    }
+    s = sprint(raw)
+    trimmed = str.TrimSpace(s)
+    if str.HasPrefix(trimmed, "map[") && str.HasSuffix(trimmed, "]") {
+        inner = str.TrimSpace(trimmed[4:len(trimmed)-1])
+        out = []
+        for _, kv := range str.Split(inner, " ") {
+            kv = str.TrimSpace(kv)
+            if kv == "" {
+                continue
+            }
+            colonIdx = str.Index(kv, ":")
+            if colonIdx > 0 {
+                out.Push(sprintf("%v: %v", str.TrimSpace(kv[:colonIdx]), str.TrimSpace(kv[colonIdx+1:])))
+            }
+        }
+        return str.Join(out, "\n")
+    }
+    return s
+}
+
+// paths 归一化: 接受多行字符串或数组; 输出多行字符串.
+// 数组字面量形如 "[/a /b /c]" -> 每个元素一行.
+// 也容忍单行 "a b c" (少见, 但 AI 偶尔会把多路径塞进一个元素), 这里不强行拆, 保持原样.
+normalizePaths = func(raw) {
+    if raw == "" || raw == nil {
+        return ""
+    }
+    s = sprint(raw)
+    trimmed = str.TrimSpace(s)
+    if str.HasPrefix(trimmed, "[") && str.HasSuffix(trimmed, "]") {
+        inner = str.TrimSpace(trimmed[1:len(trimmed)-1])
+        out = []
+        for _, p := range str.Split(inner, " ") {
+            p = str.TrimSpace(p)
+            if p == "" {
+                continue
+            }
+            out.Push(p)
+        }
+        return str.Join(out, "\n")
+    }
+    return s
+}
+
+headers = normalizeHeaders(headers)
+queryParams = normalizeMapLike(queryParams, "&", "=")
+pathsStr = normalizePaths(pathsStr)
 
 // --- validation ---
 if packet == "" && baseUrl == "" && pathsStr == "" {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
@@ -1,4 +1,4 @@
-__DESC__ = "A powerful HTTP request tool comparable to curl. Supports two modes: URL mode (specify URL, method, headers, body, params) and Packet mode (send raw HTTP request packet). Features include timeout control, redirect handling, keyword/regex matching, proxy support, and HTTPS auto-detection. if you want to exec batch requests, please use batch_do_http_request tool instead. 强大的HTTP请求工具，功能媲美curl。支持两种模式：URL模式（指定URL、方法、头部、请求体、参数）和报文模式（发送原始HTTP请求报文）。功能包括超时控制、重定向处理、关键字/正则匹配、代理支持和HTTPS自动检测。如果需要执行批量请求，需要遍历某个参数，同时访问多个请求，请使用batch_do_http_request工具。"
+__DESC__ = "A powerful HTTP request tool comparable to curl. Supports two modes: URL mode (specify URL, method, headers, body, params) and Packet mode (send raw HTTP request packet). Features include timeout control, redirect handling, keyword/regex matching, proxy support, and HTTPS auto-detection. NOTE: to keep output small and fast, the full request/response packets are NOT dumped to temp files by default — they are only printed inline (truncated for very large bodies). If you need the raw packet saved to a file, set save-packet=true. if you want to exec batch requests, please use batch_do_http_request tool instead. 强大的HTTP请求工具，功能媲美curl。支持两种模式：URL模式（指定URL、方法、头部、请求体、参数）和报文模式（发送原始HTTP请求报文）。功能包括超时控制、重定向处理、关键字/正则匹配、代理支持和HTTPS自动检测。注意：为保持输出精简，默认不会把完整请求/响应报文 dump 到临时文件，只会在输出中内联打印（过大时截断）；如果你需要把原始报文保存到文件，请设置 save-packet=true。如果需要执行批量请求，需要遍历某个参数，同时访问多个请求，请使用batch_do_http_request工具。"
 __VERBOSE_NAME__ = "Powerful HTTP Request Tool (curl-like)"
 __VERBOSE_NAME_ZH__ = "强大的HTTP请求工具（类curl）"
 __KEYWORDS__ = "http request,curl,web,network,packet,raw request,http response,url,post,get,https,proxy,redirect,header,body,api,http tool,web debug,traffic"
@@ -57,7 +57,7 @@ specific GET or POST parameter, prefer URL Mode with "query-params" or "post-par
 
 Use JSON params for single-line values:
     url, method, content-type, query-params, post-params,
-    https, timeout, redirect-times, keyword, regexp-match, show-request, proxy
+    https, timeout, redirect-times, keyword, regexp-match, save-packet, proxy
 
 Use AITAG for multi-line or structured content:
     packet  -> <|TOOL_PARAM_packet_{NONCE}|> ... <|TOOL_PARAM_packet_END_{NONCE}|>
@@ -72,11 +72,18 @@ Required:
 
 Optional:
     method          (string)  HTTP method. Default: "GET".
-    headers         (string)  Custom headers. Use AITAG when providing multiple lines.
+    headers         (string or object)  Custom headers. Two accepted forms:
+                            (a) a string with one "Key: Value" per line (use AITAG for
+                                multiple lines): "X-Header: v1\nX-Other: v2";
+                            (b) a JSON object: {"X-Header": "v1", "X-Other": "v2"}.
     body            (string)  Request body content. Use AITAG.
     content-type    (string)  Content-Type header value.
-    query-params    (string)  Query parameters like "k1=v1&k2=v2". Preferred for GET param testing.
-    post-params     (string)  Form parameters like "k1=v1&k2=v2". Preferred for form POST testing.
+    query-params    (string or object)  Query parameters. Accepted forms:
+                            (a) "k1=v1&k2=v2" string; (b) {"k1":"v1","k2":"v2"} object.
+                            Preferred for GET param testing (values patched/encoded safely).
+    post-params     (string or object)  POST form parameters. Accepted forms:
+                            (a) "k1=v1&k2=v2" string; (b) {"k1":"v1","k2":"v2"} object.
+                            Preferred for form POST testing.
 
 --- Packet Mode ---
 Required when not using URL Mode:
@@ -90,7 +97,11 @@ Optional:
     redirect-times  (int)     Maximum redirects to follow. 0 disables redirects. Default: 3.
     keyword         (string)  Keyword to search in the response.
     regexp-match    (string)  Regular expression to search in the response.
-    show-request    (string)  Display and save the full request packet: "yes"/"no". Default: "no".
+    save-packet     (bool)    Dump the full request AND response packets to temp files and
+                              return their paths. OFF by default to keep output small; the
+                              packets are still printed inline (truncated for very large
+                              bodies). Set to true only when you need the raw files.
+                              Accepts true/false, yes/no, 1/0. Default: false.
     proxy           (string)  Proxy URL. Example: "http://127.0.0.1:8080" or "socks5://127.0.0.1:1080".
 
 ## Black-Box Experiment Methodology
@@ -122,8 +133,8 @@ Every HTTP request is an experiment against a black box. Apply this cycle:
    the black box. If two consecutive requests produce the same baseline response with
    the same reasoning, you are in a zero-information loop. Change your experimental
    design — vary a different controlled variable, or expand your observable variables
-   (e.g., use "show-request" to inspect the actual wire format, check response headers
-   you haven't looked at, use "keyword" or "regexp-match" to detect specific signals).
+   (e.g., use "save-packet" to dump the actual wire format to a file, check response
+   headers you haven't looked at, use "keyword" or "regexp-match" to detect signals).
 
 ## Few-Shot Examples
 
@@ -142,7 +153,7 @@ User intent: "Test the id parameter with a payload containing spaces"
         "url": "https://target.example.com/admin.php",
         "query-params": "id=1 or xxx",
         "timeout": 10,
-        "show-request": "yes"
+        "save-packet": true
     }
 }
 ```
@@ -211,7 +222,7 @@ User intent: "Replay this HTTP request I captured"
         "https": "auto",
         "timeout": 10,
         "redirect-times": 0,
-        "show-request": "yes"
+        "save-packet": true
     }
 }
 ```
@@ -250,11 +261,11 @@ yakit.AutoInitYakit()
 // URL mode params
 urlStr = cli.String("url", cli.setHelp("target URL for URL mode"), cli.setRequired(false))
 method = cli.String("method", cli.setHelp("HTTP method"), cli.setDefault("GET"))
-headers = cli.String("headers", cli.setHelp("custom headers, one per line: Key: Value"), cli.setRequired(false))
+headers = cli.String("headers", cli.setHelp("custom headers; accept 'Key: Value' per line OR a JSON object {key:value} (AI may pass either)"), cli.setRequired(false))
 body = cli.String("body", cli.setHelp("request body content"), cli.setRequired(false))
 contentType = cli.String("content-type", cli.setHelp("Content-Type header"), cli.setRequired(false))
-queryParams = cli.String("query-params", cli.setHelp("URL query params: k1=v1&k2=v2; preferred for testing GET params because values are patched/encoded safely"), cli.setRequired(false))
-postParams = cli.String("post-params", cli.setHelp("POST form params: k1=v1&k2=v2; preferred for form parameter testing"), cli.setRequired(false))
+queryParams = cli.String("query-params", cli.setHelp("URL query params: 'k1=v1&k2=v2' string OR JSON object {k1:v1}; preferred for GET param testing"), cli.setRequired(false))
+postParams = cli.String("post-params", cli.setHelp("POST form params: 'k1=v1&k2=v2' string OR JSON object {k1:v1}; preferred for form POST testing"), cli.setRequired(false))
 
 // Packet mode params
 packet = cli.String("packet", cli.setHelp("raw HTTP request packet for Packet mode; request target/query must already be encoded"), cli.setRequired(false))
@@ -265,9 +276,75 @@ timeout = cli.Int("timeout", cli.setHelp("request timeout in seconds"), cli.setD
 redirectTimes = cli.Int("redirect-times", cli.setHelp("max redirect follows, 0 to disable"), cli.setDefault(3))
 keyword = cli.String("keyword", cli.setHelp("keyword to highlight in response"), cli.setRequired(false))
 regexpMatch = cli.String("regexp-match", cli.setHelp("regex to search in response"), cli.setRequired(false))
-showRequest = cli.String("show-request", cli.setHelp("display request packet: yes/no"), cli.setDefault("no"))
+// save-packet: dump the full request AND response packets to temp files. OFF by default
+// to keep output small; the packets are still printed inline (truncated for large bodies).
+// 用 cli.Bool: AI 传 JSON true 时, 执行器注入裸 --save-packet 标志, cli.Bool 读到 true.
+savePacket = cli.Bool("save-packet", cli.setHelp("dump full request+response packets to temp files (default off; packets are still printed inline)"))
 proxy = cli.String("proxy", cli.setHelp("proxy URL, e.g. http://127.0.0.1:8080"), cli.setRequired(false))
 cli.check()
+
+// --- normalize params that AI may pass as object/map or string ---
+// AI 有时把 headers/query-params/post-params 传成 JSON 对象. 执行器 (yakscript_plugin_for_ai.go)
+// 会把非 bool 值用 fmt.Sprint 转成字符串, 对象会变成 "map[k1:v1 k2:v2]" 这种 Go map 字面量
+// (注意: 每一对是 "key:value", 对之间用空格分隔, 字母序排序).
+// 这里把它归一化成 "k1=v1&k2=v2" 或 "Key: Value\n..." 的规范字符串, 与原有字符串写法兼容.
+// 关键词: do_http_request 参数归一化, headers 对象, fmt.Sprint map
+normalizeMapLike = func(raw, pairSep, kvSep) {
+    if raw == "" || raw == nil {
+        return ""
+    }
+    s = sprint(raw)
+    trimmed = str.TrimSpace(s)
+    // 形如 map[k1:v1 k2:v2] (Go fmt.Sprint of a map) -> 拆成 pair 列表
+    if str.HasPrefix(trimmed, "map[") && str.HasSuffix(trimmed, "]") {
+        inner = str.TrimSpace(trimmed[4:len(trimmed)-1])
+        out = []
+        for _, kv := range str.Split(inner, " ") {
+            kv = str.TrimSpace(kv)
+            if kv == "" {
+                continue
+            }
+            // map 字面量里 key/value 用第一个冒号 ":" 分隔
+            colonIdx = str.Index(kv, ":")
+            if colonIdx > 0 {
+                out.Push(sprintf("%v%v%v", str.TrimSpace(kv[:colonIdx]), kvSep, str.TrimSpace(kv[colonIdx+1:])))
+            } else {
+                out.Push(sprintf("%v%v", kv, kvSep))
+            }
+        }
+        return str.Join(out, pairSep)
+    }
+    return s
+}
+
+// headers 归一化: 接受 "Key: Value\n..." 或对象; 输出 "Key: Value\n..."
+normalizeHeaders = func(raw) {
+    if raw == "" || raw == nil {
+        return ""
+    }
+    s = sprint(raw)
+    trimmed = str.TrimSpace(s)
+    if str.HasPrefix(trimmed, "map[") && str.HasSuffix(trimmed, "]") {
+        inner = str.TrimSpace(trimmed[4:len(trimmed)-1])
+        out = []
+        for _, kv := range str.Split(inner, " ") {
+            kv = str.TrimSpace(kv)
+            if kv == "" {
+                continue
+            }
+            colonIdx = str.Index(kv, ":")
+            if colonIdx > 0 {
+                out.Push(sprintf("%v: %v", str.TrimSpace(kv[:colonIdx]), str.TrimSpace(kv[colonIdx+1:])))
+            }
+        }
+        return str.Join(out, "\n")
+    }
+    return s
+}
+
+headers = normalizeHeaders(headers)
+queryParams = normalizeMapLike(queryParams, "&", "=")
+postParams = normalizeMapLike(postParams, "&", "=")
 
 // --- validation ---
 if packet == "" && urlStr == "" {
@@ -425,7 +502,12 @@ if reqSize > 0 {
     if reqSize <= 5120 {
         yakit.Info("request packet (%v bytes):\n%v", reqSize, string(req))
     } else {
-        yakit.Info("request packet (%v bytes, truncated to 5KB):\n%v\n... (truncated, full request saved to file)", reqSize, string(req[:5120]))
+        // 大请求截断内联打印; 完整文件仅在 save-packet 打开时才落盘.
+        if savePacket {
+            yakit.Info("request packet (%v bytes, truncated to 5KB):\n%v\n... (truncated, full request saved to file)", reqSize, string(req[:5120]))
+        } else {
+            yakit.Info("request packet (%v bytes, truncated to 5KB):\n%v\n... (truncated; set save-packet=true to dump the full packet to a file)", reqSize, string(req[:5120]))
+        }
     }
 }
 
@@ -456,30 +538,29 @@ try {
     yakit.Info("response body size: %v", rspIns.ResponseBodySize)
 }
 
-// save request if requested
-if str.ToLower(showRequest) in ["yes", "y", "true"] {
+// save request/response/redirect to files only when save-packet is enabled.
+// 默认不落盘, 保持输出精简; 完整报文已在内联打印中给出 (大报文会截断).
+if savePacket {
     reqFile, err := file.TempFileName("http-request-*.txt")
     if err == nil {
         file.Save(reqFile, string(req))
         yakit.Info("request packet [size:%v] saved to %v", len(req), reqFile)
     }
-}
 
-// save response
-rspFile, err := file.TempFileName("http-response-*.txt")
-if err != nil {
-    yakit.Error("failed to create temp file for response: %v", err)
-} else {
-    file.Save(rspFile, string(rsp))
-    yakit.Info("response packet [size:%v] saved to %v", len(rsp), rspFile)
-}
+    rspFile, err := file.TempFileName("http-response-*.txt")
+    if err != nil {
+        yakit.Error("failed to create temp file for response: %v", err)
+    } else {
+        file.Save(rspFile, string(rsp))
+        yakit.Info("response packet [size:%v] saved to %v", len(rsp), rspFile)
+    }
 
-// save redirect logs
-if len(redirectLogs) > 0 {
-    redirectFile, err := file.TempFileName("http-redirect-logs-*.txt")
-    if err == nil {
-        file.Save(redirectFile, str.Join(redirectLogs, "\n"))
-        yakit.Info("%d redirects recorded, saved to %v", len(redirectLogs), redirectFile)
+    if len(redirectLogs) > 0 {
+        redirectFile, err := file.TempFileName("http-redirect-logs-*.txt")
+        if err == nil {
+            file.Save(redirectFile, str.Join(redirectLogs, "\n"))
+            yakit.Info("%d redirects recorded, saved to %v", len(redirectLogs), redirectFile)
+        }
     }
 }
 
@@ -490,13 +571,21 @@ if len(rsp) > 0 {
         if len(rsp) <= 5120 {
             yakit.Info("response packet (%v bytes):\n%v", len(rsp), string(rsp))
         } else {
-            yakit.Info("response packet too large (%v bytes), skip inline printing, see pattern match results below and saved file", len(rsp))
+            if savePacket {
+                yakit.Info("response packet too large (%v bytes), skip inline printing, see pattern match results below and saved file", len(rsp))
+            } else {
+                yakit.Info("response packet too large (%v bytes), skip inline printing, see pattern match results below (set save-packet=true to dump the full packet to a file)", len(rsp))
+            }
         }
     } else {
         if len(rsp) <= 10240 {
             yakit.Info("response packet (%v bytes):\n%v", len(rsp), string(rsp))
         } else {
-            yakit.Info("response packet (%v bytes, truncated to 10KB):\n%v\n... (truncated, full response saved to file)", len(rsp), string(rsp[:10240]))
+            if savePacket {
+                yakit.Info("response packet (%v bytes, truncated to 10KB):\n%v\n... (truncated, full response saved to file)", len(rsp), string(rsp[:10240]))
+            } else {
+                yakit.Info("response packet (%v bytes, truncated to 10KB):\n%v\n... (truncated; set save-packet=true to dump the full packet to a file)", len(rsp), string(rsp[:10240]))
+            }
         }
     }
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
@@ -1,4 +1,4 @@
-__DESC__ = "A powerful HTTP request tool comparable to curl. Supports two modes: URL mode (specify URL, method, headers, body, params) and Packet mode (send raw HTTP request packet). Features include timeout control, redirect handling, keyword/regex matching, proxy support, and HTTPS auto-detection. NOTE: to keep output small and fast, the full request/response packets are NOT dumped to temp files by default — they are only printed inline (truncated for very large bodies). If you need the raw packet saved to a file, set save-packet=true. if you want to exec batch requests, please use batch_do_http_request tool instead. 强大的HTTP请求工具，功能媲美curl。支持两种模式：URL模式（指定URL、方法、头部、请求体、参数）和报文模式（发送原始HTTP请求报文）。功能包括超时控制、重定向处理、关键字/正则匹配、代理支持和HTTPS自动检测。注意：为保持输出精简，默认不会把完整请求/响应报文 dump 到临时文件，只会在输出中内联打印（过大时截断）；如果你需要把原始报文保存到文件，请设置 save-packet=true。如果需要执行批量请求，需要遍历某个参数，同时访问多个请求，请使用batch_do_http_request工具。"
+__DESC__ = "A powerful HTTP request tool comparable to curl. Supports two modes: URL mode (specify URL, method, headers, body, params) and Packet mode (send raw HTTP request packet). Features include timeout control, redirect handling, keyword/regex matching, proxy support, and HTTPS auto-detection. OUTPUT IS MINIMAL BY DEFAULT: only a one-line request summary, the status line, and the response body are printed (great for quick probing and IDOR/enum). To also print the full request packet + connection trace (dns/connect/server timings), set verbose=true. The full request/response packets are NOT dumped to temp files unless you set save-packet=true. IMPORTANT: if you want to iterate over a parameter (e.g. enumerate order/user IDs 1..N against the same endpoint) or send many requests at once, use the batch_do_http_request tool instead of calling this tool repeatedly. 强大的HTTP请求工具，功能媲美curl。支持两种模式：URL模式（指定URL、方法、头部、请求体、参数）和报文模式（发送原始HTTP请求报文）。默认输出已精简：只打印一行请求摘要、状态行、响应体（适合快速探测与IDOR/枚举）。需要完整请求报文+连接耗时(dns/connect/server)，请设置 verbose=true。需要把报文保存到文件，请设置 save-packet=true。重要：若要遍历某个参数（如枚举订单/用户ID 1..N）或一次发很多请求，请改用 batch_do_http_request 工具，不要重复调用本工具。"
 __VERBOSE_NAME__ = "Powerful HTTP Request Tool (curl-like)"
 __VERBOSE_NAME_ZH__ = "强大的HTTP请求工具（类curl）"
 __KEYWORDS__ = "http request,curl,web,network,packet,raw request,http response,url,post,get,https,proxy,redirect,header,body,api,http tool,web debug,traffic"
@@ -57,7 +57,7 @@ specific GET or POST parameter, prefer URL Mode with "query-params" or "post-par
 
 Use JSON params for single-line values:
     url, method, content-type, query-params, post-params,
-    https, timeout, redirect-times, keyword, regexp-match, save-packet, proxy
+    https, timeout, redirect-times, keyword, regexp-match, verbose, save-packet, proxy
 
 Use AITAG for multi-line or structured content:
     packet  -> <|TOOL_PARAM_packet_{NONCE}|> ... <|TOOL_PARAM_packet_END_{NONCE}|>
@@ -97,12 +97,27 @@ Optional:
     redirect-times  (int)     Maximum redirects to follow. 0 disables redirects. Default: 3.
     keyword         (string)  Keyword to search in the response.
     regexp-match    (string)  Regular expression to search in the response.
+    verbose         (bool)    Verbose output: also print the mode line, the FULL request
+                              packet, and the connection trace (dns/connect/server/total).
+                              OFF by default — output is already minimal (one-line request
+                              summary + status line + response body), which is ideal for
+                              quick probing and IDOR/enum. Turn on only when you need to
+                              inspect the exact wire-format request. Default: false.
     save-packet     (bool)    Dump the full request AND response packets to temp files and
                               return their paths. OFF by default to keep output small; the
                               packets are still printed inline (truncated for very large
                               bodies). Set to true only when you need the raw files.
                               Accepts true/false, yes/no, 1/0. Default: false.
     proxy           (string)  Proxy URL. Example: "http://127.0.0.1:8080" or "socks5://127.0.0.1:1080".
+
+## When to use batch_do_http_request instead
+
+This tool sends ONE request per call. If your goal is to ITERATE over a parameter
+(e.g. enumerate order/user/ticket IDs 1..N against the same endpoint, or fuzz a
+value across many requests), DO NOT call this tool in a loop — use the
+batch_do_http_request tool, which iterates a fuzztag/parameter and sends all
+requests in one call with a consolidated summary. Calling do_http_request dozens
+of times for enumeration wastes rounds and bloats context.
 
 ## Black-Box Experiment Methodology
 
@@ -280,6 +295,9 @@ regexpMatch = cli.String("regexp-match", cli.setHelp("regex to search in respons
 // to keep output small; the packets are still printed inline (truncated for large bodies).
 // 用 cli.Bool: AI 传 JSON true 时, 执行器注入裸 --save-packet 标志, cli.Bool 读到 true.
 savePacket = cli.Bool("save-packet", cli.setHelp("dump full request+response packets to temp files (default off; packets are still printed inline)"))
+// verbose: 默认 false 时输出已精简到状态行 + 响应体 (适合批量枚举/快速探测);
+// true 时恢复完整输出 (模式行 + 完整请求报文 + 连接 trace). 用 cli.Bool, 同 save-packet.
+verbose = cli.Bool("verbose", cli.setHelp("verbose output: print full request packet + connection trace + mode line (default off; output is minimal: status line + response body)"))
 proxy = cli.String("proxy", cli.setHelp("proxy URL, e.g. http://127.0.0.1:8080"), cli.setRequired(false))
 cli.check()
 
@@ -404,7 +422,7 @@ isHttps = false
 
 if packet != "" {
     // === Packet Mode ===
-    yakit.Info("mode: Packet (raw HTTP request)")
+    if verbose { yakit.Info("mode: Packet (raw HTTP request)") }
     rawPacket = []byte(packet)
 
     // detect HTTPS from packet Host header
@@ -414,12 +432,16 @@ if packet != "" {
 
     url = poc.GetUrlFromHTTPRequest(isHttps ? "https" : "http", rawPacket)
     methodStr = poc.GetHTTPRequestMethod(rawPacket)
+    // 单行请求摘要: 默认就打 (一行, 高价值); 完整 target 行只在 verbose 下打.
     if url != "" {
-        yakit.Info("packet target: [%v] %v (https=%v)", methodStr, url, isHttps)
+        yakit.Info("request: %v %v", methodStr, url)
+        if verbose { yakit.Info("packet target: [%v] %v (https=%v)", methodStr, url, isHttps) }
     }
 } else {
     // === URL Mode ===
-    yakit.Info("mode: URL (%v %v)", method, urlStr)
+    if verbose { yakit.Info("mode: URL (%v %v)", method, urlStr) }
+    // 单行请求摘要: 默认就打, 让 AI 知道这次打的是哪个 URL.
+    yakit.Info("request: %v %v", method, urlStr)
 
     // parse URL to raw packet
     autoHttps, parsedPacket, err := poc.ParseUrlToHTTPRequestRaw(method, urlStr)
@@ -496,9 +518,9 @@ if err != nil {
 rsp = rspIns.RawPacket
 req = rspIns.RawRequest
 
-// --- print request packet ---
+// --- print request packet (only in verbose mode; default already printed a one-line summary above) ---
 reqSize = len(req)
-if reqSize > 0 {
+if verbose && reqSize > 0 {
     if reqSize <= 5120 {
         yakit.Info("request packet (%v bytes):\n%v", reqSize, string(req))
     } else {
@@ -512,17 +534,19 @@ if reqSize > 0 {
 }
 
 // --- report results ---
-// connection info
-if rspIns.PortIsOpen {
-    yakit.Info("remote %v is open", rspIns.RemoteAddr)
+// connection info (verbose only; trace is noise for batch IDOR/enum flows)
+if verbose {
+    if rspIns.PortIsOpen {
+        yakit.Info("remote %v is open", rspIns.RemoteAddr)
+    }
+    try {
+        yakit.Info("dns: %v, connect: %v, server: %v, total: %v",
+            rspIns.TraceInfo.DNSTime.String(),
+            rspIns.TraceInfo.ConnTime.String(),
+            rspIns.TraceInfo.ServerTime.String(),
+            rspIns.TraceInfo.TotalTime.String())
+    } catch e {}
 }
-try {
-    yakit.Info("dns: %v, connect: %v, server: %v, total: %v",
-        rspIns.TraceInfo.DNSTime.String(),
-        rspIns.TraceInfo.ConnTime.String(),
-        rspIns.TraceInfo.ServerTime.String(),
-        rspIns.TraceInfo.TotalTime.String())
-} catch e {}
 
 // status line
 try {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
@@ -518,6 +518,87 @@ if err != nil {
 rsp = rspIns.RawPacket
 req = rspIns.RawRequest
 
+// --- form-encoded 兜底重试 ---
+// 现场问题: AI 对登录/表单类接口习惯发 application/json, 但很多服务端只收
+// application/x-www-form-urlencoded (见 redhaze login.js: URLSearchParams + form),
+// 导致明明带了字段却收到 400 "xxx and password are required" / "invalid request body",
+// AI 误以为是字段名错了而死磕 (run-2/run-3 各 9 次, 漏掉 SQLi 认证绕过).
+// 这里兜底: 当 POST + JSON body + 400 + 响应像"字段必填/invalid body" 时, 自动把 JSON
+// body 转成 form-encoded 重发一次, 并明确提示 AI "JSON 被拒, 已用 form 重试".
+// 关键词: do_http_request form 重试, content-type 不匹配, application/x-www-form-urlencoded
+tryFormRetryOnJsonRejected = func() {
+    // 只对 POST + URL 模式 + 用了 body 的情况生效.
+    if packet != "" {
+        return false
+    }
+    if str.ToUpper(method) != "POST" {
+        return false
+    }
+    if body == "" {
+        return false
+    }
+    // 原始请求必须是 JSON (AI 主动带了 application/json).
+    ct = str.ToLower(str.TrimSpace(contentType))
+    if !str.Contains(ct, "json") {
+        return false
+    }
+    // 响应必须是 400.
+    statusCode = poc.GetStatusCodeFromResponse(rsp)
+    if statusCode != 400 {
+        return false
+    }
+    // 响应体像"字段必填 / invalid body"这类典型的 content-type/编码不匹配信号.
+    bodyLower = str.ToLower(poc.GetHTTPPacketBody(rsp))
+    isRejectedSignal = str.Contains(bodyLower, "required") || str.Contains(bodyLower, "invalid") || str.Contains(bodyLower, "missing")
+    if !isRejectedSignal {
+        return false
+    }
+    // 把 JSON body 转成 form-encoded: {"a":"b","c":"d"} -> a=b&c=d
+    // 不依赖 JSON 库: AI 发的登录 body 通常是扁平对象, 用字符串切分即可.
+    // 去掉外层大括号后按逗号切分, 每段按第一个冒号切 k/v, 去掉首尾引号.
+    inner = str.Trim(str.TrimSpace(body), "{}")
+    if inner == "" {
+        return false
+    }
+    pairs = []
+    for _, seg := range str.Split(inner, ",") {
+        kv = str.SplitN(seg, ":", 2)
+        if len(kv) == 2 {
+            fk = str.Trim(str.TrimSpace(kv[0]), "\"")
+            fv = str.Trim(str.TrimSpace(kv[1]), "\"")
+            if fk != "" {
+                pairs.Push(sprintf("%v=%v", codec.EscapeQueryUrl(fk), codec.EscapeQueryUrl(fv)))
+            }
+        }
+    }
+    if len(pairs) == 0 {
+        return false
+    }
+    formBody = str.Join(pairs, "&")
+
+    // 用同一份 rawPacket, 换 Content-Type 为 form, 换 body 为 formBody, 重新发送.
+    retryPacket = rawPacket
+    retryPacket = poc.ReplaceHTTPPacketHeader(retryPacket, "Content-Type", "application/x-www-form-urlencoded")
+    retryPacket = poc.ReplaceHTTPPacketBody(retryPacket, []byte(formBody))
+    retryRspIns, _, retryErr := poc.HTTPEx(retryPacket, opts...)
+    if retryErr != nil {
+        return false
+    }
+    // 只有当 form 重试后状态码不再是 400 时, 才认为重试"奏效" (服务端接受了 form),
+    // 此时把 req/rsp 替换成重试的版本, 并提示 AI.
+    retryStatusCode = poc.GetStatusCodeFromResponse(retryRspIns.RawPacket)
+    if retryStatusCode == 400 {
+        return false
+    }
+    yakit.Info("[content-type hint] JSON body was rejected with HTTP 400 (likely '%v'). Retried the SAME request as application/x-www-form-urlencoded and the server accepted it (now HTTP %v). => This endpoint expects FORM-ENCODED bodies, NOT JSON. For login/form endpoints like this, use post-params (or content-type=application/x-www-form-urlencoded) instead of a JSON body. The response being JSON does NOT mean the request should be JSON.", str.TrimSpace(poc.GetHTTPPacketBody(rsp)), retryStatusCode)
+    rspIns = retryRspIns
+    rsp = retryRspIns.RawPacket
+    req = retryRspIns.RawRequest
+    return true
+}
+
+tryFormRetryOnJsonRejected()
+
 // --- print request packet (only in verbose mode; default already printed a one-line summary above) ---
 reqSize = len(req)
 if verbose && reqSize > 0 {
@@ -610,6 +691,59 @@ if len(rsp) > 0 {
             } else {
                 yakit.Info("response packet (%v bytes, truncated to 10KB):\n%v\n... (truncated; set save-packet=true to dump the full packet to a file)", len(rsp), string(rsp[:10240]))
             }
+        }
+    }
+}
+
+// --- 表单接口探测提示 (治本) ---
+// 现场问题: AI 看到 JSON 响应就以为请求也该是 JSON, 但很多登录/表单接口其实是
+// form-encoded (见 redhaze login.js: URLSearchParams + application/x-www-form-urlencoded).
+// 当响应是 HTML 含 <form>/<input name=> 或 JS 用 URLSearchParams 提交时, 主动提示 AI
+// "这是表单接口, 字段是 X/Y, 用 form-encoded 而非 JSON", 从源头避免 AI 死磕 JSON.
+// 关键词: do_http_request 表单探测, form hint, URLSearchParams, 别用 JSON
+if method == "GET" || (method == "POST" && body == "") {
+    rspText = string(rsp)
+    rspLower = str.ToLower(rspText)
+    hasFormHtml = str.Contains(rspLower, "<form") && str.Contains(rspLower, " name=")
+    hasFormJs = str.Contains(rspText, "URLSearchParams") || str.Contains(rspText, "x-www-form-urlencoded")
+    if hasFormHtml || hasFormJs {
+        // 从响应里尽量提取 input 字段名, 帮 AI 直接拼请求.
+        fieldNames = []
+        for _, line := range str.Split(rspText, "\n") {
+            lineLower = str.ToLower(line)
+            if str.Contains(lineLower, "<input") {
+                // 提取 name="xxx" 或 name='xxx'
+                idx = str.Index(str.ToLower(line), "name=")
+                if idx > 0 {
+                    rest = str.TrimSpace(line[idx+5:])
+                    // 去掉引号
+                    rest = str.Trim(rest, "\"'")
+                    // 取到下一个空白/引号前
+                    for _, ch := range [" ", "\t", ">", "/", "\"", "'"] {
+                        ci = str.Index(rest, ch)
+                        if ci > 0 {
+                            rest = rest[:ci]
+                        }
+                    }
+                    if rest != "" && rest != "submit" && rest != "button" {
+                        fieldNames.Push(rest)
+                    }
+                }
+            }
+        }
+        // 去重
+        seen = {}
+        uniqueFields = []
+        for _, f := range fieldNames {
+            if !seen[f] {
+                seen[f] = true
+                uniqueFields.Push(f)
+            }
+        }
+        if len(uniqueFields) > 0 {
+            yakit.Info("[form-endpoint hint] This response contains an HTML <form> / form-submit JS. The likely login/form fields are: [%v]. Such form endpoints usually expect application/x-www-form-urlencoded (use post-params), NOT a JSON body — even when the API response is JSON. Verify the real encoding (e.g. via the page's JS) before sending.", str.Join(uniqueFields, ", "))
+        } else {
+            yakit.Info("[form-endpoint hint] This response contains form-submit JS (URLSearchParams / x-www-form-urlencoded). The endpoint likely expects FORM-ENCODED bodies, NOT JSON. Use post-params instead of a JSON body.")
         }
     }
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
@@ -182,6 +182,31 @@ if len(result) <= 30000 {
 } else {
     yakit.Info(result[:30000] + "... (truncated)")
 }
+
+// 覆盖度提示: 爬虫发现的往往是多个子站 / 大量路径, 实战里 AI 经常只盯住一个深挖而漏掉其余.
+// 这里不钉死具体清单(避免过拟合到某个形态), 只用"子站数 + pending 数"作为广度信号, 引导 AI
+// 在下一步用 adjust_todo 把待测面拆成多个 todo —— 多 todo 是保证执行深度和覆盖完整度的关键.
+// 关键词: simple_crawler 覆盖度提示, adjust_todo, 多 todo, 执行深度
+distinctSubdomains = {}
+for u, _ in discoveredUrlSet {
+    lower = str.ToLower(u)
+    if str.HasPrefix(lower, "https://") || str.HasPrefix(lower, "http://") {
+        schemeEnd = str.Index(lower, "://")
+        rest = lower[schemeEnd+3:]
+        pathSlash = str.Index(rest, "/")
+        authority = rest
+        if pathSlash > 0 {
+            authority = rest[:pathSlash]
+        }
+        distinctSubdomains[authority] = true
+    }
+}
+subdomainCount = len(distinctSubdomains)
+pendingCount = discoveredCount - requestedCount
+if subdomainCount > 1 || pendingCount > 0 {
+    yakit.Info("[coverage hint] Crawler discovered %v distinct subdomain(s) and %v unrequested URL(s) (see the website forest + pending count above). A common failure mode is to fixate on ONE subdomain or ONE thread and skip the rest. In your NEXT iteration, use `adjust_todo` to break the remaining surface into MULTIPLE concrete todos (e.g. one per subdomain / per untested endpoint group, plus auth, IDOR, and parameter testing for each) before diving into any single one. More (and finer-grained) todos => better depth and coverage, and they prevent the loop from finishing before the surface is covered.", subdomainCount, pendingCount)
+}
+
 try {
     name := file.TempFileName(`crawler-result-*.txt`)~
     file.Save(name, result)~

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
@@ -1,7 +1,7 @@
 __KEYWORDS__ = "port scan,syn scan,tcp scan,service scan,fingerprint,network scan,security,pentest,host discovery,port discovery,service identification,network security"
 __VERBOSE_NAME__ = "Unified Port Scanner (SYN+TCP)"
 __VERBOSE_NAME_ZH__ = "统一端口扫描器（SYN+TCP）"
-__DESC__ = "A unified port scanning tool that combines SYN scan and TCP connect scan. Supports three modes: auto (tries SYN first, falls back to TCP if SYN fails), syn (SYN + TCP fingerprinting), and tcp (pure TCP connect scan). Auto mode is recommended for most scenarios."
+__DESC__ = "A unified port scanning tool that combines SYN scan and TCP connect scan. Supports three modes: auto (tries SYN first, falls back to TCP if SYN fails), syn (SYN + TCP fingerprinting), and tcp (pure TCP connect scan). Auto mode is recommended for most scenarios. IMPORTANT: prefer scanning a narrow set of ports (e.g. top-1000 or specific services); a full-range scan (1-65535) is VERY slow — tens of thousands of TCP connect probes can take hours — so only request it when truly necessary."
 
 __USAGE__ = <<<USAGE_BLOCK
 Unified Port Scanner - Parameter Description for JSON Tool Calls
@@ -18,7 +18,12 @@ Required Parameters:
 
 Optional Parameters:
   ports           (string)  The ports to scan. Supports individual ports, ranges, and
-                            comma-separated combinations.
+                            comma-separated combinations. STRONGLY PREFER a narrow set
+                            of ports (e.g. the top-1000 common ports, or only the ports
+                            for services you expect). A full-range scan ("1-65535") is
+                            VERY expensive: in TCP connect mode it produces up to 65535
+                            connect probes per host and can take a very long time. Only
+                            use the full range when you genuinely need it.
                             Default: "22,80,443,445,3306,3389,5432,8000-8004,8080-8084,7000-7005".
   mode            (string)  Scan mode: "auto", "syn", or "tcp".
                             - "auto": Try SYN scan first, fall back to TCP on failure (recommended).
@@ -35,6 +40,12 @@ Optional Parameters:
   active          (bool)    Enable active probing mode. When true, the scanner will
                             actively send packets to detect service fingerprints.
                             Default: false.
+  force-tcp-scan-all (bool) Acknowledge that a full-range (1-65535) scan MUST run over
+                            TCP connect (because SYN is unavailable) and explicitly
+                            authorize this very slow operation. Without this flag, a
+                            full-range scan that cannot use SYN is REFUSED and the tool
+                            returns an error asking for it — this protects you from
+                            accidentally starting a multi-hour scan. Default: false.
 USAGE_BLOCK
 
 yakit.AutoInitYakit()
@@ -47,6 +58,7 @@ concurrent = cli.Int("concurrent", cli.setHelp("concurrency for primary scan pha
 fpConcurrent = cli.Int("fp-concurrent", cli.setHelp("concurrency for fingerprint scan in SYN mode"), cli.setDefault(50))
 webservice = cli.Bool("web", cli.setHelp("enable web service scanning"))
 active = cli.Bool("active", cli.setHelp("enable active probing for service fingerprints"))
+forceTcpScanAll = cli.Bool("force-tcp-scan-all", cli.setHelp("explicitly authorize a full-range (1-65535) scan over TCP when SYN is unavailable; without it such a scan is refused"))
 cli.check()
 
 // ==================== 参数校验 ====================
@@ -56,12 +68,75 @@ if mode != "auto" && mode != "syn" && mode != "tcp" {
     return
 }
 
-// 全端口预警: 当 ports 看起来是全量扫描 (1-65535) 时, 给一个明显的预警,
-// 因为这种规模在 SYN 模式下的指纹阶段会创建大量 inner goroutine 和上下游
-// channel, 哪怕底层已经修了 ctx 短路, 也容易把网卡/cpu/内存打满.
-// 关键词: scan_port 全端口预警, 1-65535 警告
+// isFullPortRange: 判断 ports 是否构成"全端口"扫描 (1-65535 / 0-65535).
+// 用 ParseStringToPorts 解析后统计去重端口数, 阈值 65535; 同时保留对字面量
+// "1-65535"/"0-65535" 的快速识别, 兼容各种等价写法 (如 "1-65535,80" 仍算全端口).
+// 关键词: scan_port 全端口判定, isFullPortRange
+portList = str.ParseStringToPorts(str.Trim(ports, ","))
+isFullPortRange = false
+if len(portList) >= 65535 {
+    isFullPortRange = true
+}
 if str.Contains(ports, "1-65535") || str.Contains(ports, "0-65535") {
-    yakit.Info("WARNING: full-range port scan requested (1-65535). this will create tens of thousands of fingerprint probes; consider lowering fp-concurrent or scanning a narrower range")
+    isFullPortRange = true
+}
+
+// 全端口预警: 当 ports 看起来是全量扫描 (1-65535) 时, 给一个明显的预警.
+// 关键词: scan_port 全端口预警, 1-65535 警告
+if isFullPortRange {
+    yakit.Info("WARNING: full-range port scan requested (1-65535). this is a VERY slow operation that may take a very long time; consider scanning a narrower range (e.g. top-1000 or specific service ports)")
+}
+
+// 扫描起始时间戳, 用于进度日志的 ETA 估算和总耗时统计.
+// 注意: 放在 SYN 可用性探测之前, 这样 ETA 会把探测耗时也算进去, 更贴合实际.
+start = time.Now()
+defer fn{
+    yakit.Info("total cost: %v", time.Now().Sub(start).String())
+}
+
+// ==================== 进度统计 ====================
+// 计算总任务数 (host * port), 用于扫描过程中的进度日志 / ETA 估算.
+// portList 已在参数校验阶段解析过, 这里直接复用, 不重复解析.
+// 关键词: scan_port 进度日志, 已扫描端口数, 剩余端口, 预估完成时间
+hostTotal = len(str.ParseStringToHosts(str.Trim(target, ",")))
+portTotal = len(portList)
+allTasks = hostTotal * portTotal
+yakit.Info("scan planned: hosts=%v ports=%v total-tasks=%v mode=%v", hostTotal, portTotal, allTasks, mode)
+
+// 把秒数格式化成人类可读的时长 (例如 "8 分 30 秒" / "45 秒"). 仅供进度日志展示用.
+// 关键词: scan_port ETA 时长格式化
+formatDuration = func(sec) {
+    if sec < 0 {
+        sec = 0
+    }
+    m = int(sec) / 60
+    s = int(sec) % 60
+    if m > 0 {
+        return sprintf("%v 分 %v 秒", m, s)
+    }
+    return sprintf("%v 秒", s)
+}
+
+// 构造一条进度日志文本. done/open/closed 为当前快照, start 为扫描起始时间.
+// 百分比 / 剩余 / ETA 都基于 done 与 allTasks 计算; done<=0 时不算 ETA (避免除零).
+// 关键词: scan_port 进度日志格式
+buildProgressLine = func(tag, done, openCount, closedCount) {
+    remaining = allTasks - done
+    if remaining < 0 {
+        remaining = 0
+    }
+    pct = 0.0
+    if allTasks > 0 {
+        pct = float(done) / float(allTasks) * 100
+    }
+    elapsedSec = time.Now().Sub(start).Seconds()
+    etaPart = "预估中"
+    if done > 0 && elapsedSec > 0 {
+        etaSec = elapsedSec / float(done) * float(remaining)
+        etaPart = sprintf("预计还需约 %v", formatDuration(etaSec))
+    }
+    return sprintf("[%v] 已扫描 %v/%v 端口 (%.1f%%), 开放 %v, 关闭 %v, 剩余 %v, %v",
+        tag, done, allTasks, pct, openCount, closedCount, remaining, etaPart)
 }
 
 // ==================== 取消上下文 ====================
@@ -263,12 +338,100 @@ reportResults = func(results) {
     yakit.Info("scan completed: open=%v closed=%v total=%v", openPorts.Len(), closedPorts.Len(), openPorts.Len()+closedPorts.Len())
 }
 
-// ==================== 主执行逻辑 ====================
+// consumeWithProgress - 边消费结果通道边打印进度日志.
+//
+// 解决问题: 大端口范围 (如 8000-20000) 扫描时, 绝大多数端口是 closed,
+// 旧的 reportResults 要等全部扫完才一次性遍历, 扫描期间几乎没有日志, 看起来像卡住.
+// 这里改成实时消费 channel:
+//   - 每累计 PROGRESS_EVERY(500) 个结果打一条 [Progress] 进度 (已扫描/总数/百分比/开放/剩余/ETA);
+//   - 同时起一个心跳 goroutine, 每 HEARTBEAT_SEC(15) 秒打一条 [Heartbeat] 进度,
+//     防止某段时间无结果返回时像卡住 (心跳与按量日志共用同一个 buildProgressLine);
+//   - open 端口照常 yakit.Info, closed 端口只累计不打日志 (与旧逻辑一致).
+//
+// 参数 results 是 servicescan.Scan / servicescan.ScanFromSynResult 返回的 channel.
+// 关键词: scan_port 进度日志, 心跳, 已扫描端口数, 预估完成时间
+PROGRESS_EVERY = 500   // 每扫描完 500 个端口打一条进度
+HEARTBEAT_SEC = 15     // 每 15 秒兜底心跳一条进度
 
-start = time.Now()
-defer fn{
-    yakit.Info("total cost: %v", time.Now().Sub(start).String())
+consumeWithProgress = func(results) {
+    done = 0
+    openCount = 0
+    closedCount = 0
+    openPorts = []
+    closedPorts = []
+
+    // 心跳 goroutine: 每 HEARTBEAT_SEC 秒打一条进度, 直到 stopHeartbeat 被置 true.
+    // 用 sleep 循环 (Yak 惯用法, 见 grpc_scanPort_script.yak), 不用 select/time.After.
+    stopHeartbeat = false
+    go fn{
+        for {
+            if stopHeartbeat { break }
+            sleep(HEARTBEAT_SEC)
+            if stopHeartbeat { break }
+            // 注意: done/openCount/closedCount 由主循环更新, 这里读到的是近似快照,
+            // 进度日志允许微小误差, 不影响判断是否在推进.
+            yakit.Info(buildProgressLine("Heartbeat", done, openCount, closedCount))
+        }
+    }
+
+    for result in results {
+        done = done + 1
+        if !result.IsOpen() {
+            closedCount = closedCount + 1
+            closedPorts.Push(str.HostPort(result.Target, result.Port))
+            // 每累计 PROGRESS_EVERY 个结果打一条进度 (不区分 open/closed, 用总 done 计).
+            if done % PROGRESS_EVERY == 0 {
+                yakit.Info(buildProgressLine("Progress", done, openCount, closedCount))
+            }
+            continue
+        }
+        openCount = openCount + 1
+        openPorts.Push(str.HostPort(result.Target, result.Port))
+        glance = result.String()
+        banner = result.GetBanner()
+        yakit.Info("open: %v banner: %v", glance, banner)
+        // 发现 open 端口的当次也补一条进度 (open 是用户最关心的).
+        if done % PROGRESS_EVERY == 0 {
+            yakit.Info(buildProgressLine("Progress", done, openCount, closedCount))
+        }
+    }
+
+    // 停止心跳: channel 关闭, 主循环退出. 给心跳一点时间收尾, 避免竞态下多打一条.
+    stopHeartbeat = true
+
+    if closedCount > 0 {
+        yakit.Info("closed ports count: %v", closedCount)
+    }
+    yakit.Info("scan completed: open=%v closed=%v total=%v", openCount, closedCount, openCount+closedCount)
 }
+
+// needFullTcpGuard - 是否需要在"即将走 TCP 连接扫描"前做全端口拦截.
+// reason 是触发降级到 TCP 的原因 (例如 "SYN scan is NOT available" 或
+// "mode=tcp"), 用于在拒绝信息里把上下文讲清楚.
+//
+// 拦截逻辑: 全端口 (1-65535) + 即将走 TCP + 没有显式 force-tcp-scan-all 时,
+// 直接退出并返回清晰的错误, 要求 AI/用户改用窄端口范围, 或显式带上
+// force-tcp-scan-all 确认要跑这个非常慢的操作.
+// 关键词: scan_port 全端口 TCP 拦截, force-tcp-scan-all, 1-65535 拒绝
+needFullTcpGuard = func(reason) {
+    if !isFullPortRange {
+        return false
+    }
+    if forceTcpScanAll {
+        // 已显式确认, 放行, 只给一条提示.
+        yakit.Info("full-range (1-65535) TCP scan authorized by force-tcp-scan-all (reason: %v); this will take a very long time", reason)
+        return false
+    }
+    // 拒绝: 把"为什么慢"和"两个解决方法"都写清楚, 方便 AI 直接据此调整参数重试.
+    yakit.Error("REFUSED: a full-range port scan (1-65535) cannot use SYN and would fall back to TCP connect scan (reason: %v).", reason)
+    yakit.Error("A full-range TCP connect scan is a VERY slow operation: it performs up to 65535 connection attempts per host and can take a very long time, so it is refused by default to protect you from an accidental long-running scan.")
+    yakit.Error("To proceed, do ONE of the following:")
+    yakit.Error("  1. (RECOMMENDED) Narrow the ports to a small set, e.g. the top common ports or only the service ports you actually need, then retry; or")
+    yakit.Error("  2. If you truly need all 65535 ports over TCP, explicitly set force-tcp-scan-all=true to acknowledge the cost and retry.")
+    return true
+}
+
+// ==================== 主执行逻辑 ====================
 
 results = undefined
 scanErr = undefined
@@ -298,6 +461,10 @@ if mode == "auto" {
         if scanErr != nil {
             yakit.Info("WARNING: SYN scan failed during execution: %v", scanErr)
             yakit.Info("falling back to TCP connect scan...")
+            // SYN 执行失败也要降级到 TCP, 全端口时同样需要拦截.
+            if needFullTcpGuard("SYN scan failed during execution") {
+                return
+            }
             results, scanErr = doTcpScan()
             if scanErr != nil {
                 yakit.Error("TCP connect scan also failed: %v", scanErr)
@@ -309,6 +476,10 @@ if mode == "auto" {
         yakit.Info("HINT: on macOS, you may need to log out and back in after fixing permissions")
         yakit.Info("HINT: on Linux, try running with sudo for SYN scan support")
         yakit.Info("falling back to TCP connect scan automatically...")
+        // SYN 不可用, 即将降级到 TCP; 全端口时拦截, 避免意外启动极慢的全端口 TCP 扫描.
+        if needFullTcpGuard("SYN scan is NOT available") {
+            return
+        }
         results, scanErr = doTcpScan()
         if scanErr != nil {
             yakit.Error("TCP connect scan failed: %v", scanErr)
@@ -345,7 +516,11 @@ if mode == "auto" {
     }
 
 } elif mode == "tcp" {
-    // tcp 模式：纯 TCP 连接扫描, 不需要特殊权限
+    // tcp 模式：纯 TCP 连接扫描, 不需要特殊权限.
+    // 全端口 TCP 扫描非常慢, 在没有 force-tcp-scan-all 确认时直接拒绝.
+    if needFullTcpGuard("mode=tcp") {
+        return
+    }
     results, scanErr = doTcpScan()
     if scanErr != nil {
         yakit.Error("TCP connect scan failed: %v", scanErr)
@@ -354,7 +529,7 @@ if mode == "auto" {
 }
 
 if results != nil {
-    reportResults(results)
+    consumeWithProgress(results)
 } else {
     yakit.Error("no scan results available")
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
@@ -235,11 +235,15 @@ probeSynAvailable = func(probeTarget) {
 
     // 轮询检查: 每 0.5 秒检查一次, 最多等待 15 秒
     // 正常 SYN 探测耗时: route(2s) + pcap_init(1-3s) + arp(1s) + send(0s) + wait(3s) ≈ 7-9s
-    // 15 秒超时留有足够余量
+    // 15 秒超时留有足够余量. 每 5 秒打一条心跳, 避免探测期间静默 (看起来像卡住).
+    probeStart = time.Now()
     for i = 0; i < 30; i++ {
         if probeCompleted {
             yakit.Info("SYN scan probe succeeded - pcap/raw socket is working")
             return true, ""
+        }
+        if i > 0 && i % 10 == 0 {
+            yakit.Info("still probing SYN scan availability (%.0fs elapsed)...", time.Now().Sub(probeStart).Seconds())
         }
         sleep(0.5)
     }
@@ -353,6 +357,8 @@ reportResults = func(results) {
 PROGRESS_EVERY = 500   // 每扫描完 500 个端口打一条进度
 HEARTBEAT_SEC = 15     // 每 15 秒兜底心跳一条进度
 
+// consumeWithProgress - 边消费结果通道边打印进度日志, 并返回 (openCount, closedCount).
+// 返回值供 auto 模式判断 "SYN 扫描 0 open" 后是否需要自动降级到 TCP 重扫.
 consumeWithProgress = func(results) {
     done = 0
     openCount = 0
@@ -403,6 +409,7 @@ consumeWithProgress = func(results) {
         yakit.Info("closed ports count: %v", closedCount)
     }
     yakit.Info("scan completed: open=%v closed=%v total=%v", openCount, closedCount, openCount+closedCount)
+    return openCount, closedCount
 }
 
 // needFullTcpGuard - 是否需要在"即将走 TCP 连接扫描"前做全端口拦截.
@@ -435,6 +442,9 @@ needFullTcpGuard = func(reason) {
 
 results = undefined
 scanErr = undefined
+// lastScanKind 记录最终 results 是由哪种扫描产生的 ("syn" / "tcp"), 用于 auto 模式
+// 在 SYN 扫出 0 open 时自动降级重跑 TCP (省掉 AI 一整轮"发现0结果->切tcp->重扫").
+lastScanKind = ""
 
 if mode == "auto" {
     // auto 模式：尝试 SYN -> 失败则降级到 TCP
@@ -458,6 +468,7 @@ if mode == "auto" {
     if synAvailable {
         yakit.Info("SYN scan is available, proceeding with SYN + fingerprint mode")
         results, scanErr = doSynScan()
+        lastScanKind = "syn"
         if scanErr != nil {
             yakit.Info("WARNING: SYN scan failed during execution: %v", scanErr)
             yakit.Info("falling back to TCP connect scan...")
@@ -466,6 +477,7 @@ if mode == "auto" {
                 return
             }
             results, scanErr = doTcpScan()
+            lastScanKind = "tcp"
             if scanErr != nil {
                 yakit.Error("TCP connect scan also failed: %v", scanErr)
                 return
@@ -481,6 +493,7 @@ if mode == "auto" {
             return
         }
         results, scanErr = doTcpScan()
+        lastScanKind = "tcp"
         if scanErr != nil {
             yakit.Error("TCP connect scan failed: %v", scanErr)
             return
@@ -529,7 +542,23 @@ if mode == "auto" {
 }
 
 if results != nil {
-    consumeWithProgress(results)
+    openCount, closedCount = consumeWithProgress(results)
+
+    // auto 模式下: SYN 扫描可用但扫出 0 个 open 端口时, 主动降级重跑一次 TCP.
+    // 背景: SYN 对某些目标(防火墙丢弃SYN/非典型栈)会返回 0 open, 但 TCP connect 能连上.
+    // 不在这里处理的话, AI 要花一整轮"发现0结果->切mode=tcp->重扫", 浪费往返.
+    // 受 needFullTcpGuard 约束: 全端口 TCP 仍需 force-tcp-scan-all 确认, 避免极慢扫描.
+    if mode == "auto" && lastScanKind == "syn" && openCount == 0 {
+        yakit.Info("SYN scan found 0 open ports; auto-retrying with TCP connect scan to avoid a false negative...")
+        if !needFullTcpGuard("SYN scan found 0 open ports, auto-retrying with TCP") {
+            tcpResults, tcpErr = doTcpScan()
+            if tcpErr != nil {
+                yakit.Error("TCP retry scan failed: %v", tcpErr)
+            } elif tcpResults != nil {
+                consumeWithProgress(tcpResults)
+            }
+        }
+    }
 } else {
     yakit.Error("no scan results available")
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
@@ -334,12 +334,117 @@ reportResults = func(results) {
         openPorts.Push(str.HostPort(result.Target, result.Port))
         glance = result.String()
         banner = result.GetBanner()
-        yakit.Info("open: %v banner: %v", glance, banner)
+        yakit.Info("open: %v\n%v", glance, formatBanner(banner))
     }
     if closedPorts.Len() > 0 {
         yakit.Info("closed ports count: %v", closedPorts.Len())
     }
     yakit.Info("scan completed: open=%v closed=%v total=%v", openPorts.Len(), closedPorts.Len(), openPorts.Len()+closedPorts.Len())
+}
+
+// ==================== Banner 格式化 ====================
+//
+// 旧实现把 banner 当成普通字符串塞进 %v, 而 GetBanner() 返回的是 Go 引号字面量
+// ("HTTP/1.1 200 OK\r\nServer: ...\r\n\r\n<!doctype html>..."), 导致日志里全是
+// \r\n / \" 这种转义, 不可读, 而且 HTTP banner 还带完整响应体 (可能几万字节).
+//
+// 改造目标 (用户要求):
+//   - UTF-8 合法的 banner -> 原样文本, 包在 ==boundary== / ==boundary_end== 之间, 方便阅读;
+//   - 非 UTF-8 (二进制) banner -> hexdump (偏移+十六进制+ASCII), 且体积受限;
+//   - 任何 banner 都先截断到 BANNER_MAX_BYTES, 避免单个 banner 把上下文撑爆.
+//
+// 关键词: scan_port banner 格式化, ==boundary==, hexdump, UTF-8 校验
+
+BANNER_MAX_BYTES = 512    // banner 最多展示这么多字节 (HTTP 响应体等会被截断)
+HEXDUMP_MAX_BYTES = 256   // 二进制 banner 的 hexdump 最多展示这么多字节
+
+// hexdumpBytes - 把字节切片格式化成 xxd/hexdump -C 风格: "00000000  48 54 54 50  |HTTP|"
+// 没有现成 Yak 内置, 这里手写一个紧凑实现.
+hexdumpBytes = func(data) {
+    if len(data) == 0 {
+        return "(empty)"
+    }
+    lines = []
+    n = len(data)
+    for i = 0; i < n; i += 16 {
+        chunk = data[i:min(i+16, n)]
+        hexPart = ""
+        asciiPart = ""
+        for j = 0; j < len(chunk); j++ {
+            b = int(chunk[j])
+            hexPart = hexPart + sprintf("%02x ", b)
+            if b >= 0x20 && b < 0x7f {
+                asciiPart = asciiPart + sprintf("%c", b)
+            } else {
+                asciiPart = asciiPart + "."
+            }
+        }
+        // 补齐 hex 列对齐 (不足 16 字节时)
+        for j = len(chunk); j < 16; j++ {
+            hexPart = hexPart + "   "
+        }
+        lines.Push(sprintf("%08x  %s|%s|", i, hexPart, asciiPart))
+    }
+    return str.Join(lines, "\n")
+}
+
+// formatBanner - 把单个端口的 banner (GetBanner 返回的 quoted 字符串) 格式化成可读文本.
+// 返回值是一段多行字符串, 调用方用 yakit.Info 直接打印即可.
+// 关键词: scan_port formatBanner, boundary, hexdump
+formatBanner = func(banner) {
+    if banner == "" || banner == nil {
+        return ""
+    }
+    // GetBanner() 可能返回:
+    //   (a) Go 引号字面量 (带 \" \r\n 等, 典型如 HTTP banner) -> str.Unquote 还原;
+    //   (b) 原始文本里带字面量转义 (如 SSH banner 里的 "\x0d\x0a") -> codec.UnescapeString 还原;
+    // 两种都试, 失败就保留原样.
+    raw = banner
+    unq, err = str.Unquote(banner)
+    if err == nil {
+        raw = unq
+    } else {
+        unesc, err2 = codec.UnescapeString(banner)
+        if err2 == nil {
+            raw = unesc
+        }
+    }
+    rawBytes = []byte(raw)
+
+    // 先在"完整内容"上判断 UTF-8 合法性: 否则截断可能正好切在一个多字节字符中间,
+    // 把原本合法的 UTF-8 (如中文 HTML) 误判成非法 -> 错误走 hexdump.
+    isUtf8, utf8Err = codec.IsUTF8(rawBytes)
+    utf8Valid = (utf8Err == nil && isUtf8)
+
+    // 统一截断, 避免超大 banner (如完整 HTML 响应体) 撑爆上下文.
+    truncated = false
+    if len(rawBytes) > BANNER_MAX_BYTES {
+        rawBytes = rawBytes[:BANNER_MAX_BYTES]
+        truncated = true
+    }
+
+    // UTF-8 合法 -> 原样文本放进 boundary 块 (去掉尾部空白, 更干净).
+    if utf8Valid {
+        body = str.TrimSpace(string(rawBytes))
+        out = sprintf("==boundary==\n%s\n==boundary_end==", body)
+        if truncated {
+            out = out + sprintf("\n(banner truncated to %v bytes)", BANNER_MAX_BYTES)
+        }
+        return out
+    }
+
+    // 非 UTF-8 / 二进制 -> hexdump, 单独再限一遍大小.
+    dumpBytes = rawBytes
+    dumpTruncated = false
+    if len(dumpBytes) > HEXDUMP_MAX_BYTES {
+        dumpBytes = dumpBytes[:HEXDUMP_MAX_BYTES]
+        dumpTruncated = true
+    }
+    out = sprintf("banner-printable (UTF8-Invalid), hexdump:\n%v", hexdumpBytes(dumpBytes))
+    if truncated || dumpTruncated {
+        out = out + sprintf("\n(banner truncated, raw %v bytes)", len(rawBytes))
+    }
+    return out
 }
 
 // consumeWithProgress - 边消费结果通道边打印进度日志.
@@ -395,7 +500,7 @@ consumeWithProgress = func(results) {
         openPorts.Push(str.HostPort(result.Target, result.Port))
         glance = result.String()
         banner = result.GetBanner()
-        yakit.Info("open: %v banner: %v", glance, banner)
+        yakit.Info("open: %v\n%v", glance, formatBanner(banner))
         // 发现 open 端口的当次也补一条进度 (open 是用户最关心的).
         if done % PROGRESS_EVERY == 0 {
             yakit.Info(buildProgressLine("Progress", done, openCount, closedCount))

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "35001c322e0ca96905bfe0b6fe93afeb8f76b63618253dec2c24e161e4c4d88a"
+const ExistedBuildInAIToolEmbedFSHash string = "35ad518ce83f9f165aa81bf2c69dca074be7a8a9f62ee88d1d7e4dd64b9b1b7e"

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "b0fcc26655770faa2bd03d5a295a34c90bb8b775ef803c5093ee4141d3707ea5"
+const ExistedBuildInAIToolEmbedFSHash string = "1b864d6a256ce2450634f329fd4386b8a53be9dfc1a674ea47d85264b6e21f9a"

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "6fa0f1ffed31e423546f2115d50dfa7f8b0fa873ef21c9da780e576b7866fb7c"
+const ExistedBuildInAIToolEmbedFSHash string = "4d630939f1b4653a2b1b0d8775ce9fc169e6f70b4dd33cbf17bb7b09dda901d2"

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "4d630939f1b4653a2b1b0d8775ce9fc169e6f70b4dd33cbf17bb7b09dda901d2"
+const ExistedBuildInAIToolEmbedFSHash string = "b0fcc26655770faa2bd03d5a295a34c90bb8b775ef803c5093ee4141d3707ea5"

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "1b864d6a256ce2450634f329fd4386b8a53be9dfc1a674ea47d85264b6e21f9a"
+const ExistedBuildInAIToolEmbedFSHash string = "35001c322e0ca96905bfe0b6fe93afeb8f76b63618253dec2c24e161e4c4d88a"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "b0fcc26655770faa2bd03d5a295a34c90bb8b775ef803c5093ee4141d3707ea5"
+const ExistedBuildInAIToolEmbedFSHash string = "1b864d6a256ce2450634f329fd4386b8a53be9dfc1a674ea47d85264b6e21f9a"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "c3c1c5c0def76cad2015af30b59a8716294532a632dfe5aa309b5a6b230045b2"
+const ExistedBuildInAIToolEmbedFSHash string = "6fa0f1ffed31e423546f2115d50dfa7f8b0fa873ef21c9da780e576b7866fb7c"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "6fa0f1ffed31e423546f2115d50dfa7f8b0fa873ef21c9da780e576b7866fb7c"
+const ExistedBuildInAIToolEmbedFSHash string = "4d630939f1b4653a2b1b0d8775ce9fc169e6f70b4dd33cbf17bb7b09dda901d2"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "4d630939f1b4653a2b1b0d8775ce9fc169e6f70b4dd33cbf17bb7b09dda901d2"
+const ExistedBuildInAIToolEmbedFSHash string = "b0fcc26655770faa2bd03d5a295a34c90bb8b775ef803c5093ee4141d3707ea5"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "1b864d6a256ce2450634f329fd4386b8a53be9dfc1a674ea47d85264b6e21f9a"
+const ExistedBuildInAIToolEmbedFSHash string = "35001c322e0ca96905bfe0b6fe93afeb8f76b63618253dec2c24e161e4c4d88a"


### PR DESCRIPTION
> 本 PR 是「工具优化（一）」，汇总对 AI 渗透测试 ReAct 循环里最高频工具的优化：`scan_port`、`do_http_request`（含 `batch_do_http_request`）、`simple_crawler`。多轮迭代，每轮都基于真实运行时间线发现并修复具体问题。各部分独立可单独 review。

---

# 一、scan_port 优化

## 1.1 扫描进度日志（解决“卡很久没日志”）
**问题**：大端口范围扫描时几乎没有日志，看起来像卡住。
**改动**：新增 `consumeWithProgress`，边消费结果 channel 边打进度：每 500 端口一条 `[Progress]`、每 15s 一条 `[Heartbeat]` 兜底，含已扫描/总数/百分比/开放/关闭/剩余/ETA。

## 1.2 全端口 TCP 拦截（新增 `force-tcp-scan-all`）
**问题**：SYN 不可用时全端口 TCP 极慢，容易意外启动。
**改动**：`needFullTcpGuard` 在三处“即将走 TCP”拦截（mode=tcp / auto SYN 不可用降级 / SYN 执行失败降级），命中直接 return + 清晰错误（原因 + 两选项）。`__DESC__`/`__USAGE__` 推荐窄端口。

## 1.3 SYN 探测心跳 + auto 模式 SYN 0结果自动降级 TCP（第三轮）
**问题**（来自第二次运行）：`mode:auto` 有 ~20s 静默死区（SYN 探测 ~10s + SYN 扫描若 0 open）；SYN 对某些目标返回 0 open（防火墙丢 SYN），AI 不得不再花一整轮切 mode=tcp 重扫。
**改动**：
- `probeSynAvailable` 轮询循环每 5s 打一条心跳，消除 ~15s 静默。
- `consumeWithProgress` 返回 `(openCount, closedCount)`；auto 模式下若 SYN 扫出 0 open，自动重跑一次 TCP connect（受 `needFullTcpGuard` 约束），打 `SYN scan found 0 open ports; auto-retrying with TCP...`。**省掉 AI 一整轮往返。**

## 1.4 banner 格式化（`==boundary==` 块 + 二进制 hexdump）（第四轮）
**问题**：banner 输出里大量 `\quote` 转义噪声。
**改动**：`formatBanner` 用 `==boundary==`…`==boundary_end==` 包住 UTF-8 banner；非 UTF-8（二进制）且不大时用 hexdump。

---

# 二、HTTP 工具优化

## 2.1 `save-packet` 开关（默认不 dump）+ headers/params 对象容错
**问题**：① 每次请求无条件把完整响应 dump 到临时文件（无开关）；② headers 传成 JSON 对象被 fast-path 校验拒绝（`got object, want string`），触发昂贵回退。
**改动**：
- 新增 `cli.Bool("save-packet")`：request+response+redirect 报文落盘由它控制，默认关；截断提示指向 `save-packet=true`。
- 新增 `normalizeHeaders`/`normalizeMapLike`：AI 传 JSON 对象时，执行器 `fmt.Sprint` 成 `map[k:v ...]`，归一化器解析回 `Key: Value` / `k=v&...`，与字符串写法兼容。

## 2.2 `verbose` 降噪 + 引导用 batch 工具
**问题**（来自第二次运行）：IDOR 枚举中 `do_http_request` 被调用 ~40 次，每次都打印 mode 行 / 完整请求报文 / `remote is open` / `dns-connect-server-total` trace —— 对“遍历订单 ID 看返回”全是噪声，撑爆上下文。
**改动**：
- 新增 `cli.Bool("verbose")`（默认 false）。默认下：不打印 mode 行（改为单行 `request: METHOD URL` 摘要）、不打印完整 request packet、不打印 `is open` 和连接 trace；**保留**状态行 + 响应体 + 重定向日志。`verbose=true` 恢复完整输出。
- `__DESC__`/`__USAGE__`：强调默认输出已精简；并强烈引导“枚举/遍历参数请用 `batch_do_http_request`”。

## 2.3 form-retry + form 端点提示（本轮 — 修复“推理性能下降”根因）
**问题**（本轮运行）：同一模型在本目标扫出的漏洞明显少于别处，表现为推理质量下降。根因不是模型变笨，而是一个**认知陷阱**：redhaze 登录类端点的**响应是 JSON**，AI 据此推断**请求也该是 JSON**，于是反复用 JSON body 打一个只吃 `application/x-www-form-urlencoded` 的接口 → 服务端回 HTTP 400 “字段必填” → AI 反复重试 JSON（9+ 次，触发 logic_spin_warning）→ 放弃 → **漏掉 SQLi**。
**改动**（`do_http_request.yak`）：
- `tryFormRetryOnJsonRejected`：POST + JSON body + 响应 `400` + body 含 `required/invalid/missing` 时，把 JSON body 解析成 form（手动拆 `map[k:v]`，不依赖 JSON 库），改 `Content-Type: application/x-www-form-urlencoded` 重发一次；**重试状态码不再是 400 就视为服务端接受 form**，替换 req/rsp 并打提示：
  > `[content-type hint] JSON body was rejected with 400 '...'; retried with application/x-www-form-urlencoded and the server accepted it (status 401). This endpoint expects FORM-ENCODED, not JSON. For similar login/form endpoints, prefer post-params or content-type=application/x-www-form-urlencoded instead of JSON.`
  — 即便直接重试仍 400，至少有一次 form 尝试，避免 AI 卡死在 JSON 路径上。
- `[form-endpoint hint]`：GET（或 POST 空 body）的响应里出现 `<form ... name=` 或 JS `URLSearchParams`/`x-www-form-urlencoded` 时，抽取 input 字段名，打提示说明该端点期望 form-encoded（用 `post-params`），**明确指出“响应是 JSON 不代表请求该用 JSON”**。

## 2.4 `batch_do_http_request` 参数对象/数组容错（本轮）
**问题**（本轮时间线）：`batch_do_http_request` 也有同类 schema 摩擦：AI 把 `paths` 传成 JSON 数组被拒（`got array, want string`）/ 缺 `base-url`；`headers`/`query-params` 传对象。
**改动**（`batch_do_http_request.yak`）：复刻 `do_http_request` 的归一化思路：
- `normalizePaths`：接受多行字符串 **或** JSON 数组 `["/a","/b"]`（执行器会 stringify 成 `[/a /b]`），还原成多行。
- `normalizeHeaders`/`normalizeMapLike`：`headers`/`query-params` 接受 JSON 对象。
- 对应 `cli.setHelp` 同步标注“ALSO accepts …”，让 AI 知道两种写法都行。

---

---

# 三、simple_crawler 优化

## 3.1 覆盖度提示 → 引导下一步 `adjust_todo`（本轮）
**问题**（本轮时间线）：一次爬虫发现了 6 个子站（`id`/`www.id`/`desk`/`mall`…）和大量 URL，但 AI **只盯住 `desk` 一条线深挖**，几乎没碰 `mall` 和 `id/portal`（整个 SSO 根），最后提前 `finish` 了循环 —— 漏测的不是"工具没爬到"，而是"爬到了没用上"。

**改动**（`simple_crawler.yak`，刻意做得很轻，避免过拟合到某个攻击面形态）：
- **不**新增硬编码的"攻击面清单"（那会过拟合到某一种 site 结构）。
- 当爬虫发现 **>1 个子站** 或 **有未请求(pending) URL** 时，多发一条 `[coverage hint]`：用"子站数 + pending 数"作为**广度信号**，并明确引导 AI 在**下一步用 `adjust_todo` 把剩余待测面拆成多个具体 todo**（例如每个子站 / 每个未测端点组各一条，再各配 auth/IDOR/参数测试）。
- 设计意图：**多 todo、细粒度 todo** 是保证执行深度和覆盖完整度的关键，也能防止循环在覆盖完待测面之前提前 `finish`。把"拆哪些 todo"的决定权留给 AI，而不是在工具里钉死。

**验证**：`TestSimpleCrawler_CoverageHint`（mock server 暴露 3 个子站 + pending URL，断言 `[coverage hint]` + `adjust_todo` 引导出现，且标准爬虫输出不变）。

---

# 验证
- **语法检查**：`.yak` 均 0 error。
- **do_http_request 测试**：全部用例 PASS，含：
  - `TestDoHTTPRequest_FormRetryOnJsonRejected`（本轮新增）：mock 对 JSON body 回 400 “字段必填”、对 form-encoded 回 200 “credential mismatch”；验证自动 form 重试 + `[content-type hint]` 提示 + 状态码 200 正确返回。
  - `TestDoHTTPRequest_QuietMode`/`HeadersAsObject`/`QueryParamsAsObject`/`SavePacket` 等。
- **batch_do_http_request 测试**：全部用例 PASS，含本轮新增：
  - `TestBatchDoHTTPRequest_PathsAsArray`：`paths` 传 `[]string` → 正确拆成 2 条请求。
  - `TestBatchDoHTTPRequest_HeadersAsObject` / `QueryParamsAsObject`：对象写法正确发出。
- **simple_crawler 测试**：`TestSimpleCrawler_CoverageHint`（本轮新增）：mock 3 子站 + pending → `[coverage hint]` + `adjust_todo` 引导触发，标准爬虫输出不变。
- **本地实测**（redhaze，授权目标）：
  - `/employee/login`（JSON→400 required）：触发自动 form 重试 → 401 + `[content-type hint]`（验证根因修复）。
  - `/portal`：`[form-endpoint hint]` 抽出 7 个 input 字段；`login.js` 命中 `URLSearchParams`。
- **gofmt clean**。

---

# 影响面
- `scan_port.yak`、`do_http_request.yak`、`batch_do_http_request.yak`、`simple_crawler.yak` 及其测试。
- 不影响 MCP `port_scan` / gRPC `PortScan` 等其它入口。
- 行为变化（向后兼容）：
  - `scan_port`：全端口 TCP 默认拒绝（需显式 `force-tcp-scan-all`）；扫描期间有进度日志；auto 模式 SYN 0 结果自动补 TCP；banner 用 boundary 块/hexdump。
  - `do_http_request`：响应不再无条件 dump（需 `save-packet=true`）；`headers`/`params` 接受对象；**默认输出精简（要详细加 `verbose=true`）**；JSON body 被 400 拒时自动 form 重试 + 提示；form 端点提示。
  - `batch_do_http_request`：`paths` 接受数组，`headers`/`query-params` 接受对象。
  - `simple_crawler`：发现 >1 子站或有 pending URL 时多发一条 `[coverage hint]`，引导下一步 `adjust_todo` 多拆 todo。标准爬虫输出不变（仅追加一条提示）。

## Checklist
- [x] scan_port 进度日志（Heartbeat + Progress + ETA）
- [x] scan_port 全端口 TCP 拒绝 + force 放行
- [x] scan_port SYN 探测心跳 + auto SYN 0结果自动降级 TCP（实测）
- [x] scan_port banner 格式化 boundary/hexdump
- [x] do_http_request save-packet 默认关 / 打开 dump（实测）
- [x] do_http_request headers/params 对象容错（复现线上 bug，实测）
- [x] do_http_request verbose 降噪（实测默认精简 / verbose 完整）
- [x] do_http_request form-retry + form 端点提示（实测修复根因）
- [x] batch_do_http_request paths 数组 / headers/query-params 对象容错
- [x] 引导枚举场景用 batch_do_http_request
- [x] simple_crawler 覆盖度提示 → 引导下一步 adjust_todo 多拆 todo
- [x] gofmt clean，测试全过
