### PR TITLE
feat(ai): 支持 Focus 运行时风险与资产结果回传

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -182,6 +182,7 @@ type Config struct {
 	EventHandler           func(e *schema.AiOutputEvent)
 	DisableOutputEventType []string
 	SaveEvent              bool
+	ResultSink             ResultSink
 
 	// asyncGuardian process special output event
 	Guardian *AsyncGuardian
@@ -1465,6 +1466,21 @@ func WithEmitter(emitter *Emitter) ConfigOption {
 		}
 		return nil
 	}
+}
+
+// WithResultSink installs a run-scoped structured-result backend.
+func WithResultSink(sink ResultSink) ConfigOption {
+	return func(c *Config) error {
+		c.ResultSink = sink
+		return nil
+	}
+}
+
+func (c *Config) GetResultSink() ResultSink {
+	if c == nil {
+		return nil
+	}
+	return c.ResultSink
 }
 
 // Event / output
@@ -4092,6 +4108,9 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 
 	if i.EventHandler != nil {
 		opts = append(opts, WithEventHandler(i.EventHandler))
+	}
+	if i.ResultSink != nil {
+		opts = append(opts, WithResultSink(i.ResultSink))
 	}
 
 	if i.GetUserUsageCallback() != nil {

--- a/common/ai/aid/aicommon/config_test.go
+++ b/common/ai/aid/aicommon/config_test.go
@@ -184,6 +184,27 @@ func TestConfig_ToolManagerPropagation(t *testing.T) {
 	require.True(t, child.GetAiToolManager().IsRecentlyUsedTool("now"))
 }
 
+func TestConfigResultSinkIsRunScoped(t *testing.T) {
+	sink := ResultSinkFunc(func(
+		context.Context,
+		*schema.Risk,
+	) (ResultReceipt, error) {
+		return ResultReceipt{}, nil
+	})
+	config := NewConfig(context.Background(), WithResultSink(sink))
+
+	if ResultSinkFromConfig(config) == nil {
+		t.Fatal("expected result sink to be available from runtime config")
+	}
+	child := NewConfig(context.Background(), ConvertConfigToOptions(config)...)
+	if ResultSinkFromConfig(child) == nil {
+		t.Fatal("expected child runtime config to retain the run-scoped result sink")
+	}
+	if ResultSinkFromConfig(struct{}{}) != nil {
+		t.Fatal("expected configs without ResultSinkProvider to remain compatible")
+	}
+}
+
 func TestConfig_AiForgeManagerPropagation(t *testing.T) {
 	parent := NewConfig(context.Background())
 	require.NotNil(t, parent.GetAIForgeManager())

--- a/common/ai/aid/aicommon/result_sink.go
+++ b/common/ai/aid/aicommon/result_sink.go
@@ -1,0 +1,73 @@
+package aicommon
+
+import (
+	"context"
+
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// ResultReceipt is the platform-neutral acknowledgement returned after a
+// structured result has been accepted by the configured backend.
+type ResultReceipt struct {
+	ResultID  string
+	DedupeKey string
+	BackendID string
+}
+
+// AssetResult is a platform-neutral structured asset produced by a Focus Mode.
+// Payload is an inline JSON document whose schema is owned by Kind.
+type AssetResult struct {
+	Kind        string
+	Title       string
+	Target      string
+	IdentityKey string
+	Payload     []byte
+}
+
+// ResultSink is injected per AI runtime. Desktop runtimes leave it unset and
+// retain their existing local persistence behavior; SaaS runtimes inject a
+// sink that transfers ownership to Legion.
+type ResultSink interface {
+	SubmitRisk(context.Context, *schema.Risk) (ResultReceipt, error)
+}
+
+// AssetResultSink is an optional capability implemented by backends that can
+// take ownership of structured assets. Keeping it separate preserves
+// compatibility with ResultSink implementations that only accept risks.
+type AssetResultSink interface {
+	ResultSink
+	SubmitAsset(context.Context, AssetResult) (ResultReceipt, error)
+}
+
+// ResultSinkProvider is intentionally separate from AICallerConfigIf so
+// existing third-party and test implementations of that broad interface do
+// not need to change.
+type ResultSinkProvider interface {
+	GetResultSink() ResultSink
+}
+
+func ResultSinkFromConfig(config any) ResultSink {
+	provider, ok := config.(ResultSinkProvider)
+	if !ok || provider == nil {
+		return nil
+	}
+	return provider.GetResultSink()
+}
+
+func AssetResultSinkFromConfig(config any) AssetResultSink {
+	sink, ok := ResultSinkFromConfig(config).(AssetResultSink)
+	if !ok {
+		return nil
+	}
+	return sink
+}
+
+// ResultSinkFunc is a compact adapter for tests and lightweight runtimes.
+type ResultSinkFunc func(context.Context, *schema.Risk) (ResultReceipt, error)
+
+func (f ResultSinkFunc) SubmitRisk(
+	ctx context.Context,
+	risk *schema.Risk,
+) (ResultReceipt, error) {
+	return f(ctx, risk)
+}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_generate_risk.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_generate_risk.go
@@ -1,6 +1,7 @@
 package loop_http_fuzztest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -66,14 +67,18 @@ var generateRiskAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, operator *reactloops.LoopActionHandlerOperator) {
 			specs := collectGenerateRiskSpecs(action)
 			riskIDs := make([]string, 0, len(specs))
+			localRiskIDs := make([]string, 0, len(specs))
 			summaries := make([]string, 0, len(specs))
 			for idx, spec := range specs {
-				riskID, summary, err := saveGeneratedRisk(loop, spec)
+				riskID, summary, persistedLocally, err := saveGeneratedRisk(loop, spec)
 				if err != nil {
 					operator.Fail(fmt.Errorf("generate_risk: save risk #%d failed: %w", idx+1, err))
 					return
 				}
 				riskIDs = append(riskIDs, riskID)
+				if persistedLocally {
+					localRiskIDs = append(localRiskIDs, riskID)
+				}
 				summaries = append(summaries, summary)
 			}
 
@@ -96,7 +101,7 @@ var generateRiskAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 				riskFeedbackType = strings.TrimSpace(specs[0].RiskType)
 				riskFeedbackSeverity = strings.TrimSpace(specs[0].Severity)
 			}
-			loop.SubmitRiskFeedback(riskIDs, riskFeedbackType, riskFeedbackSeverity)
+			loop.SubmitRiskFeedback(localRiskIDs, riskFeedbackType, riskFeedbackSeverity)
 
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeGenerateRisk, fmt.Sprintf("生成 %d 个 Risk / Generated %d Risks", len(riskIDs), len(riskIDs)), summary)
 			reactloops.EmitStatus(loop, "完成 / Complete")
@@ -184,7 +189,7 @@ func validateGenerateRiskSpec(loop *reactloops.ReActLoop, spec generateRiskSpec,
 	return nil
 }
 
-func saveGeneratedRisk(loop *reactloops.ReActLoop, spec generateRiskSpec) (string, string, error) {
+func saveGeneratedRisk(loop *reactloops.ReActLoop, spec generateRiskSpec) (string, string, bool, error) {
 	target := inferGenerateRiskTarget(loop, spec.Target)
 	title := strings.TrimSpace(spec.Title)
 	titleVerbose := strings.TrimSpace(spec.TitleVerbose)
@@ -225,17 +230,53 @@ func saveGeneratedRisk(loop *reactloops.ReActLoop, spec generateRiskSpec) (strin
 		opts = append(opts, yakit.WithRiskParam_Response(responseRaw))
 	}
 
-	risk, err := yakit.NewRisk(target, opts...)
-	if err != nil {
-		return "", "", err
-	}
+	risk := yakit.CreateRisk(target, opts...)
 	if risk == nil {
-		return "", "", fmt.Errorf("saved risk is nil")
+		return "", "", false, fmt.Errorf("created risk is nil")
+	}
+
+	if sink := focusResultSink(loop); sink != nil {
+		receipt, err := sink.SubmitRisk(focusResultContext(loop), risk)
+		if err != nil {
+			return "", "", false, err
+		}
+		if strings.TrimSpace(receipt.ResultID) == "" {
+			return "", "", false, fmt.Errorf("focus result sink returned an empty result id")
+		}
+		summary := fmt.Sprintf(
+			"- result_id=%s severity=%s type=%s target=%s title=%s",
+			receipt.ResultID,
+			risk.Severity,
+			risk.RiskType,
+			target,
+			title,
+		)
+		return receipt.ResultID, summary, false, nil
+	}
+
+	if err := yakit.SaveRisk(risk); err != nil {
+		return "", "", false, err
 	}
 
 	riskID := fmt.Sprintf("%d", risk.ID)
 	summary := fmt.Sprintf("- id=%d severity=%s type=%s target=%s title=%s", risk.ID, risk.Severity, risk.RiskType, target, title)
-	return riskID, summary, nil
+	return riskID, summary, true, nil
+}
+
+func focusResultSink(loop *reactloops.ReActLoop) aicommon.ResultSink {
+	if loop == nil {
+		return nil
+	}
+	return aicommon.ResultSinkFromConfig(loop.GetConfig())
+}
+
+func focusResultContext(loop *reactloops.ReActLoop) context.Context {
+	if loop != nil {
+		if config := loop.GetConfig(); config != nil && config.GetContext() != nil {
+			return config.GetContext()
+		}
+	}
+	return context.Background()
 }
 
 func isValidGenerateRiskSeverity(severity string) bool {

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_generate_risk_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_generate_risk_test.go
@@ -1,10 +1,14 @@
 package loop_http_fuzztest
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/schema"
 )
 
 func TestParseGenerateRiskDetails_JSONObject(t *testing.T) {
@@ -61,4 +65,64 @@ func TestValidateGenerateRiskSpec_RequiresFields(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "risk_type is required") {
 		t.Fatalf("expected risk_type validation error, got %v", err)
 	}
+}
+
+func TestSaveGeneratedRiskUsesInjectedResultSink(t *testing.T) {
+	var submitted *schema.Risk
+	sink := aicommon.ResultSinkFunc(func(
+		_ context.Context,
+		risk *schema.Risk,
+	) (aicommon.ResultReceipt, error) {
+		submitted = risk
+		return aicommon.ResultReceipt{
+			ResultID:  "risk-result-1",
+			DedupeKey: "dedupe-1",
+			BackendID: "job-1",
+		}, nil
+	})
+	loop := newTestHTTPFuzzLoopWithResultSink(t, sink)
+
+	resultID, summary, persistedLocally, err := saveGeneratedRisk(loop, generateRiskSpec{
+		Target:       "https://example.com/api/orders?id=2",
+		Title:        "订单接口越权",
+		TitleVerbose: "订单接口存在越权读取",
+		RiskType:     "privilege-escalation",
+		Severity:     "high",
+		Description:  "切换订单 ID 后返回其他用户数据。",
+		Details:      `{"evidence":"id=2"}`,
+		Payload:      "id=2",
+	})
+	if err != nil {
+		t.Fatalf("save generated risk: %v", err)
+	}
+	if persistedLocally {
+		t.Fatal("expected injected result sink to own persistence")
+	}
+	if resultID != "risk-result-1" {
+		t.Fatalf("unexpected result id: %s", resultID)
+	}
+	if submitted == nil {
+		t.Fatal("expected risk to be submitted")
+	}
+	if submitted.ID != 0 {
+		t.Fatalf("expected risk not to be saved in local database, got id=%d", submitted.ID)
+	}
+	if submitted.RiskType != "privilege-escalation" || submitted.Severity != "high" {
+		t.Fatalf("unexpected submitted risk: %#v", submitted)
+	}
+	if !strings.Contains(summary, "result_id=risk-result-1") {
+		t.Fatalf("unexpected summary: %s", summary)
+	}
+}
+
+func newTestHTTPFuzzLoopWithResultSink(
+	t *testing.T,
+	sink aicommon.ResultSink,
+) *reactloops.ReActLoop {
+	t.Helper()
+	config := aicommon.NewConfig(
+		context.Background(),
+		aicommon.WithResultSink(sink),
+	)
+	return reactloops.NewMinimalReActLoop(config, nil)
 }

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_custom.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_custom.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -480,12 +481,85 @@ func probeAPICandidatesAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 				op.Continue()
 				return
 			}
+			submitted, err := submitVerifiedAPIAssets(
+				reconResultContext(loop),
+				aicommon.AssetResultSinkFromConfig(loop.GetConfig()),
+				pool,
+			)
+			if err != nil {
+				op.Fail(fmt.Errorf("publish verified API assets: %w", err))
+				return
+			}
 			_, verified, _, _ := PoolStats(pool)
-			r.AddToTimeline("probe_api", fmt.Sprintf("probed %d entries; verified count=%d", n, verified))
-			op.Feedback(fmt.Sprintf("Probed %d URLs this batch. Verified entries in pool: %d / %d", n, verified, len(pool.Entries)))
+			r.AddToTimeline(
+				"probe_api",
+				fmt.Sprintf(
+					"probed %d entries; verified count=%d; submitted assets=%d",
+					n,
+					verified,
+					submitted,
+				),
+			)
+			op.Feedback(fmt.Sprintf(
+				"Probed %d URLs this batch. Verified entries in pool: %d / %d. Submitted assets: %d",
+				n,
+				verified,
+				len(pool.Entries),
+				submitted,
+			))
 			reactloops.EmitStatus(loop, "完成 / Complete")
 			reactloops.EmitActionLog(loop, infosecAPIPoolNodeID, fmt.Sprintf("完成: probe_api_candidates (%d probed) / Done: probe_api_candidates (%d probed)", n, n))
 			op.Continue()
 		},
 	)
+}
+
+func submitVerifiedAPIAssets(
+	ctx context.Context,
+	sink aicommon.AssetResultSink,
+	pool *APIPool,
+) (int, error) {
+	if sink == nil || pool == nil {
+		return 0, nil
+	}
+
+	submitted := 0
+	for _, entry := range pool.Entries {
+		if !entry.Verified {
+			continue
+		}
+		method := strings.ToUpper(strings.TrimSpace(entry.Method))
+		if method == "" {
+			method = http.MethodGet
+		}
+		target := strings.TrimSpace(entry.NormalizedURL)
+		if target == "" {
+			continue
+		}
+		payload, err := json.Marshal(entry)
+		if err != nil {
+			return submitted, fmt.Errorf("marshal verified API endpoint %s %s: %w", method, target, err)
+		}
+		identityKey := "http_endpoint:" + method + ":" + target
+		if _, err := sink.SubmitAsset(ctx, aicommon.AssetResult{
+			Kind:        "http_endpoint",
+			Title:       method + " " + target,
+			Target:      target,
+			IdentityKey: identityKey,
+			Payload:     payload,
+		}); err != nil {
+			return submitted, fmt.Errorf("submit verified API endpoint %s %s: %w", method, target, err)
+		}
+		submitted++
+	}
+	return submitted, nil
+}
+
+func reconResultContext(loop *reactloops.ReActLoop) context.Context {
+	if loop != nil {
+		if config := loop.GetConfig(); config != nil && config.GetContext() != nil {
+			return config.GetContext()
+		}
+	}
+	return context.Background()
 }

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_custom.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_custom.go
@@ -3,6 +3,7 @@ package loop_infosec_recon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,12 +11,20 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
+)
+
+const (
+	maxInlineReconAssetPayloadBytes = 60 * 1024
+	maxInlineReconAssetURLBytes     = 16 * 1024
+	maxInlineReconAssetSourceBytes  = 4 * 1024
+	maxInlineReconAssetErrorBytes   = 4 * 1024
 )
 
 // infosecRejectUnsafeArgv blocks control characters that must never appear in tool parameters.
@@ -524,6 +533,7 @@ func submitVerifiedAPIAssets(
 	}
 
 	submitted := 0
+	var submitErr error
 	for _, entry := range pool.Entries {
 		if !entry.Verified {
 			continue
@@ -536,9 +546,13 @@ func submitVerifiedAPIAssets(
 		if target == "" {
 			continue
 		}
-		payload, err := json.Marshal(entry)
+		payload, err := marshalVerifiedAPIAssetPayload(entry)
 		if err != nil {
-			return submitted, fmt.Errorf("marshal verified API endpoint %s %s: %w", method, target, err)
+			submitErr = errors.Join(
+				submitErr,
+				fmt.Errorf("marshal verified API endpoint %s %s: %w", method, target, err),
+			)
+			continue
 		}
 		identityKey := "http_endpoint:" + method + ":" + target
 		if _, err := sink.SubmitAsset(ctx, aicommon.AssetResult{
@@ -548,11 +562,83 @@ func submitVerifiedAPIAssets(
 			IdentityKey: identityKey,
 			Payload:     payload,
 		}); err != nil {
-			return submitted, fmt.Errorf("submit verified API endpoint %s %s: %w", method, target, err)
+			submitErr = errors.Join(
+				submitErr,
+				fmt.Errorf("submit verified API endpoint %s %s: %w", method, target, err),
+			)
+			continue
 		}
 		submitted++
 	}
-	return submitted, nil
+	return submitted, submitErr
+}
+
+func marshalVerifiedAPIAssetPayload(entry APIPoolEntry) ([]byte, error) {
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) <= maxInlineReconAssetPayloadBytes {
+		return raw, nil
+	}
+
+	payload := entry
+	originalEvidence := payload.Evidence
+	payload.Evidence = ""
+	payload.NormalizedURL = truncateReconAssetText(
+		payload.NormalizedURL,
+		maxInlineReconAssetURLBytes,
+	)
+	payload.Source = truncateReconAssetText(payload.Source, maxInlineReconAssetSourceBytes)
+	payload.ProbeError = truncateReconAssetText(payload.ProbeError, maxInlineReconAssetErrorBytes)
+	base, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	if len(base) > maxInlineReconAssetPayloadBytes {
+		return nil, fmt.Errorf(
+			"verified API endpoint metadata exceeds %d bytes",
+			maxInlineReconAssetPayloadBytes,
+		)
+	}
+
+	// JSON may expand control characters to six bytes. Use that worst-case
+	// ratio so the reconstructed payload always remains below the Scan Node
+	// inline-result contract while preserving as much evidence as possible.
+	evidenceBudget := (maxInlineReconAssetPayloadBytes - len(base)) / 6
+	payload.Evidence = truncateReconAssetText(originalEvidence, evidenceBudget)
+	raw, err = json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	for len(raw) > maxInlineReconAssetPayloadBytes && payload.Evidence != "" {
+		payload.Evidence = truncateReconAssetText(payload.Evidence, len(payload.Evidence)/2)
+		raw, err = json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(raw) > maxInlineReconAssetPayloadBytes {
+		return nil, fmt.Errorf(
+			"verified API endpoint payload exceeds %d bytes",
+			maxInlineReconAssetPayloadBytes,
+		)
+	}
+	return raw, nil
+}
+
+func truncateReconAssetText(value string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+	truncated := value[:maxBytes]
+	for !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
 }
 
 func reconResultContext(loop *reactloops.ReActLoop) context.Context {

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/api_pool_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/api_pool_test.go
@@ -3,6 +3,7 @@ package loop_infosec_recon
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -17,6 +18,16 @@ import (
 
 type recordingReconAssetSink struct {
 	assets []aicommon.AssetResult
+}
+
+type sizeLimitedReconAssetSink struct {
+	recordingReconAssetSink
+	maxPayloadBytes int
+}
+
+type selectiveFailReconAssetSink struct {
+	recordingReconAssetSink
+	rejectIdentity string
 }
 
 func (s *recordingReconAssetSink) SubmitRisk(
@@ -36,6 +47,29 @@ func (s *recordingReconAssetSink) SubmitAsset(
 		DedupeKey: asset.IdentityKey,
 		BackendID: "job-1",
 	}, nil
+}
+
+func (s *sizeLimitedReconAssetSink) SubmitAsset(
+	ctx context.Context,
+	asset aicommon.AssetResult,
+) (aicommon.ResultReceipt, error) {
+	if len(asset.Payload) > s.maxPayloadBytes {
+		return aicommon.ResultReceipt{}, fmt.Errorf(
+			"payload exceeds %d bytes",
+			s.maxPayloadBytes,
+		)
+	}
+	return s.recordingReconAssetSink.SubmitAsset(ctx, asset)
+}
+
+func (s *selectiveFailReconAssetSink) SubmitAsset(
+	ctx context.Context,
+	asset aicommon.AssetResult,
+) (aicommon.ResultReceipt, error) {
+	if asset.IdentityKey == s.rejectIdentity {
+		return aicommon.ResultReceipt{}, fmt.Errorf("injected asset failure")
+	}
+	return s.recordingReconAssetSink.SubmitAsset(ctx, asset)
 }
 
 func TestNormalizeURL(t *testing.T) {
@@ -205,4 +239,74 @@ func TestSubmitVerifiedAPIAssetsPublishesOnlyVerifiedEndpoints(t *testing.T) {
 	require.True(t, payload.Verified)
 	require.Equal(t, http.StatusOK, payload.StatusCode)
 	require.Equal(t, "js_static_extract_ai", payload.Source)
+}
+
+func TestSubmitVerifiedAPIAssetsBoundsEvidenceAndContinues(t *testing.T) {
+	t.Parallel()
+
+	const maxPayloadBytes = 64 * 1024
+	pool := &APIPool{Entries: []APIPoolEntry{
+		{
+			NormalizedURL: "https://example.com/api/large",
+			Method:        http.MethodGet,
+			Source:        "js_static_extract_ai",
+			Evidence:      strings.Repeat("\x01", maxPayloadBytes),
+			Verified:      true,
+			StatusCode:    http.StatusOK,
+		},
+		{
+			NormalizedURL: "https://example.com/api/after-large",
+			Method:        http.MethodPost,
+			Source:        "js_static_extract_ai",
+			Evidence:      "fetch('/api/after-large')",
+			Verified:      true,
+			StatusCode:    http.StatusCreated,
+		},
+	}}
+	sink := &sizeLimitedReconAssetSink{maxPayloadBytes: maxPayloadBytes}
+
+	submitted, err := submitVerifiedAPIAssets(context.Background(), sink, pool)
+	require.NoError(t, err)
+	require.Equal(t, 2, submitted)
+	require.Len(t, sink.assets, 2)
+	require.LessOrEqual(t, len(sink.assets[0].Payload), maxPayloadBytes)
+
+	var payload APIPoolEntry
+	require.NoError(t, json.Unmarshal(sink.assets[0].Payload, &payload))
+	require.Less(t, len(payload.Evidence), len(pool.Entries[0].Evidence))
+	require.Equal(t, pool.Entries[0].NormalizedURL, payload.NormalizedURL)
+}
+
+func TestSubmitVerifiedAPIAssetsContinuesAfterSingleAssetFailure(t *testing.T) {
+	t.Parallel()
+
+	pool := &APIPool{Entries: []APIPoolEntry{
+		{
+			NormalizedURL: "https://example.com/api/fails",
+			Method:        http.MethodGet,
+			Source:        "test",
+			Verified:      true,
+			StatusCode:    http.StatusOK,
+		},
+		{
+			NormalizedURL: "https://example.com/api/succeeds",
+			Method:        http.MethodPost,
+			Source:        "test",
+			Verified:      true,
+			StatusCode:    http.StatusCreated,
+		},
+	}}
+	sink := &selectiveFailReconAssetSink{
+		rejectIdentity: "http_endpoint:GET:https://example.com/api/fails",
+	}
+
+	submitted, err := submitVerifiedAPIAssets(context.Background(), sink, pool)
+	require.ErrorContains(t, err, "injected asset failure")
+	require.Equal(t, 1, submitted)
+	require.Len(t, sink.assets, 1)
+	require.Equal(
+		t,
+		"http_endpoint:POST:https://example.com/api/succeeds",
+		sink.assets[0].IdentityKey,
+	)
 }

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/api_pool_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/api_pool_test.go
@@ -1,6 +1,8 @@
 package loop_infosec_recon
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,7 +11,32 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/schema"
 )
+
+type recordingReconAssetSink struct {
+	assets []aicommon.AssetResult
+}
+
+func (s *recordingReconAssetSink) SubmitRisk(
+	context.Context,
+	*schema.Risk,
+) (aicommon.ResultReceipt, error) {
+	return aicommon.ResultReceipt{}, nil
+}
+
+func (s *recordingReconAssetSink) SubmitAsset(
+	_ context.Context,
+	asset aicommon.AssetResult,
+) (aicommon.ResultReceipt, error) {
+	s.assets = append(s.assets, asset)
+	return aicommon.ResultReceipt{
+		ResultID:  asset.IdentityKey,
+		DedupeKey: asset.IdentityKey,
+		BackendID: "job-1",
+	}, nil
+}
 
 func TestNormalizeURL(t *testing.T) {
 	u, err := NormalizeURL("https://Example.COM/path#frag", "")
@@ -134,4 +161,48 @@ func TestProbePoolHTTP_RespectsScopeHosts(t *testing.T) {
 	require.NotNil(t, other)
 	require.False(t, other.Verified)
 	require.Zero(t, other.StatusCode)
+}
+
+func TestSubmitVerifiedAPIAssetsPublishesOnlyVerifiedEndpoints(t *testing.T) {
+	t.Parallel()
+
+	pool := &APIPool{Entries: []APIPoolEntry{
+		{
+			NormalizedURL: "https://example.com/api/users",
+			Method:        "get",
+			Source:        "js_static_extract_ai",
+			Confidence:    0.95,
+			Evidence:      "fetch('/api/users')",
+			Verified:      true,
+			StatusCode:    http.StatusOK,
+		},
+		{
+			NormalizedURL: "https://example.com/api/admin",
+			Method:        "GET",
+			Source:        "js_static_extract_ai",
+			Verified:      false,
+			StatusCode:    http.StatusForbidden,
+		},
+	}}
+	sink := &recordingReconAssetSink{}
+
+	submitted, err := submitVerifiedAPIAssets(context.Background(), sink, pool)
+	require.NoError(t, err)
+	require.Equal(t, 1, submitted)
+	require.Len(t, sink.assets, 1)
+
+	asset := sink.assets[0]
+	require.Equal(t, "http_endpoint", asset.Kind)
+	require.Equal(t, "GET https://example.com/api/users", asset.Title)
+	require.Equal(t, "https://example.com/api/users", asset.Target)
+	require.Equal(
+		t,
+		"http_endpoint:GET:https://example.com/api/users",
+		asset.IdentityKey,
+	)
+	var payload APIPoolEntry
+	require.NoError(t, json.Unmarshal(asset.Payload, &payload))
+	require.True(t, payload.Verified)
+	require.Equal(t, http.StatusOK, payload.StatusCode)
+	require.Equal(t, "js_static_extract_ai", payload.Source)
 }

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -631,6 +631,9 @@ func buildReActOptions(ctx context.Context, config *AIEngineConfig, outputChan c
 	if config.UserUsageCallback != nil {
 		options = append(options, aicommon.WithUserUsageCallback(config.UserUsageCallback))
 	}
+	if config.ResultSink != nil {
+		options = append(options, aicommon.WithResultSink(config.ResultSink))
+	}
 
 	// 高级配置
 

--- a/common/aiengine/config.go
+++ b/common/aiengine/config.go
@@ -77,6 +77,7 @@ type AIEngineConfig struct {
 	OnInputRequiredRaw   func(react aicommon.AIEngineOperator, event *schema.AiOutputEvent, question string) string             // 需要用户输入回调
 	OnInputRequired      func(react aicommon.AIEngineOperator, question string) string                                          // 需要用户输入回调
 	OnSessionID          func(sessionID string)                                                                                 // 会话 ID 就绪回调
+	ResultSink           aicommon.ResultSink
 
 	// 高级配置
 	Focus    string // 焦点，用于聚焦某个任务，如 yaklang_code
@@ -663,6 +664,13 @@ func WithOnData(callback func(react aicommon.AIEngineOperator, event *schema.AiO
 func WithOnFinished(callback func(react aicommon.AIEngineOperator)) AIEngineConfigOption {
 	return func(c *AIEngineConfig) {
 		c.OnFinished = callback
+	}
+}
+
+// WithResultSink installs the structured-result backend used by Focus Modes.
+func WithResultSink(sink aicommon.ResultSink) AIEngineConfigOption {
+	return func(c *AIEngineConfig) {
+		c.ResultSink = sink
 	}
 }
 

--- a/common/aiengine/config_callback_test.go
+++ b/common/aiengine/config_callback_test.go
@@ -125,3 +125,26 @@ func TestBuildReActOptionsAppendsTieredCallbackOverrides(t *testing.T) {
 		t.Fatalf("expected speed callback override, got %q", seen["speed"])
 	}
 }
+
+func TestBuildReActOptionsPropagatesResultSink(t *testing.T) {
+	sink := aicommon.ResultSinkFunc(func(
+		context.Context,
+		*schema.Risk,
+	) (aicommon.ResultReceipt, error) {
+		return aicommon.ResultReceipt{}, nil
+	})
+	engineConfig := NewAIEngineConfig(
+		WithResultSink(sink),
+		WithDisableMCPServers(true),
+	)
+	opts := buildReActOptions(
+		context.Background(),
+		engineConfig,
+		make(chan *schema.AiOutputEvent, 1),
+	)
+	config := aicommon.NewConfig(context.Background(), opts...)
+
+	if aicommon.ResultSinkFromConfig(config) == nil {
+		t.Fatal("expected result sink to reach ReAct runtime config")
+	}
+}


### PR DESCRIPTION
## 改动摘要

- 新增运行级 `ResultSink`，使共享 AI 业务层能够把 Focus 风险与资产交给宿主平台接管。
- `http_fuzztest.generate_risk` 优先通过运行时 Sink 发布风险，未配置 Sink 时保持桌面端 `SaveRisk` 兼容行为。
- `infosec_recon` 将已验证端点作为结构化资产提交给运行时 Sink。
- 将 Sink 通过 `aicommon`、`aiengine` 配置链按运行实例传递，避免全局状态和跨会话污染。

## 分流说明

这是共享 AI 业务层的 `main` 快速通道 PR，只包含 `common/ai` 与 `common/aiengine` 代码。

- Scan Node 自包含重构 PR：#4838
- Legion 平台接管 PR：VillanCh/legion#228

共享 AI 改动会在 #4838 中暂时保留一份，以保证 `go0p/refactor/scannode` 分支在未同步 `main` 前仍可独立编译和验证。后续基线重合时按跨基线规则主动去重，不允许两份实现静默分叉。

## 改动文件

- `common/ai/aid/aicommon/result_sink.go`、`config.go`：风险与资产 Sink 契约及运行级配置。
- `common/aiengine/aiengine.go`、`config.go`：向 AI 执行实例传递 ResultSink。
- `common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_generate_risk.go`：风险回传与桌面兼容回退。
- `common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_custom.go`：已验证端点资产回传。
- 对应测试覆盖运行级隔离、风险发布与端点资产发布。

## 验证方式

main-track 独立代码验证：

- `go test ./common/ai/aid/aicommon -run '^TestConfigResultSinkIsRunScoped$' -count=1`：通过。
- `go test ./common/aiengine -count=1`：通过。
- `go test ./common/ai/aid/aireact/reactloops/loop_http_fuzztest -count=1`：通过。
- `go test ./common/ai/aid/aireact/reactloops/loop_infosec_recon -count=1`：通过。

配套重构链路已达到 T2：

- 真实 `http_fuzztest` Focus 风险进入 Legion 统一风险接口。
- 真实 `infosec_recon` Focus 对同一端点重复发布后，Legion 仍只有一条稳定身份的 `http_endpoint` 资产。
- Scan Node 使用无状态运行时，结果不依赖节点本地风险或资产 SQLite。
