### PR TITLE
feat(ai): make scan_port TUN-aware

### DIFF
--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/scan_port_load_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/scan_port_load_test.go
@@ -71,6 +71,42 @@ func TestMUSTPASS_ScanPortTool_RuntimeCTXUsable(t *testing.T) {
 	// 端到端的"取消即快速返回"行为来保证.
 }
 
+// TestMUSTPASS_ScanPortTool_ActivatesTunSafeMode 验证 TUN/Fake-IP 的
+// 198.18.0.0/15 目标不会被整体拒绝，而是把大范围 SYN 计划收缩为
+// 少量 TCP connect 候选验证，并输出 AI TODO 与后续应用层处置指引.
+//
+// 关键词: scan_port TUN safe mode 回归, SCAN_TUN_SAFE_MODE,
+// 198.18.0.0/15 大规模端口误报, AI_TODO_REQUIRED
+func TestMUSTPASS_ScanPortTool_ActivatesTunSafeMode(t *testing.T) {
+	tool := getScanPortTool(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	w1, w2 := &strings.Builder{}, &strings.Builder{}
+	// 短 context 只让脚本完成计划收缩并进入 TCP 路径，避免测试
+	// 对保留网段真正进行外部网络扫描. context canceled 是预期退出.
+	_, _ = tool.Callback(ctx, aitool.InvokeParams{
+		"hosts": "198.18.215.229",
+		"ports": "1-65535",
+		"mode":  "auto",
+	}, nil, w1, w2)
+
+	combined := w1.String() + "\n" + w2.String()
+	assert.Assert(t, strings.Contains(combined, "[SCAN_TUN_SAFE_MODE]"),
+		"expected machine-readable TUN-safe-mode marker:\n%s", combined)
+	assert.Assert(t, strings.Contains(combined, "effective-mode=tcp"),
+		"expected automatic TCP-connect fallback:\n%s", combined)
+	assert.Assert(t, strings.Contains(combined, "effective-ports=22,80,443,445,3306,3389,5432,6379,8000,8080,8443,9000"),
+		"expected broad request to be reduced to compact operational ports:\n%s", combined)
+	assert.Assert(t, strings.Contains(combined, "[AI_TODO_REQUIRED]"),
+		"expected explicit AI TODO instruction:\n%s", combined)
+	assert.Assert(t, !strings.Contains(combined, "starting SYN scan"),
+		"SYN scan must not start for a TUN/Fake-IP target:\n%s", combined)
+	assert.Assert(t, strings.Contains(combined, "starting TCP connect scan"),
+		"compact TCP scan should replace the broad SYN plan:\n%s", combined)
+}
+
 // TestMUSTPASS_ScanPortTool_CancelStopsTcpScanFast 端到端验证: 当 AI 插件 context
 // 被取消时, scan_port 的 TCP 扫描能借助注入的 CTX 迅速停止, 而不是把对一个 tarpit
 // 主机的全部端口扫完.

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
@@ -1,7 +1,7 @@
 __KEYWORDS__ = "port scan,syn scan,tcp scan,service scan,fingerprint,network scan,security,pentest,host discovery,port discovery,service identification,network security"
 __VERBOSE_NAME__ = "Unified Port Scanner (SYN+TCP)"
 __VERBOSE_NAME_ZH__ = "统一端口扫描器（SYN+TCP）"
-__DESC__ = "A unified port scanning tool that combines SYN scan and TCP connect scan. Supports three modes: auto (tries SYN first, falls back to TCP if SYN fails), syn (SYN + TCP fingerprinting), and tcp (pure TCP connect scan). Auto mode is recommended for most scenarios. IMPORTANT: prefer scanning a narrow set of ports (e.g. top-1000 or specific services); a full-range scan (1-65535) is VERY slow — tens of thousands of TCP connect probes can take hours — so only request it when truly necessary."
+__DESC__ = "A unified port scanner with TUN-aware fallback. Normally it combines SYN discovery and TCP service fingerprinting. When target-specific DNS/route evidence shows Clash Verge or another TUN/Fake-IP path, SYN and large-range port discovery are unreliable but real services such as 80/443 can still exist. The tool therefore does NOT reject the target: it automatically restarts the plan in a compact TCP-connect validation mode, keeps at most a small set of relevant ports, prefers web ports for domain targets, suppresses noisy per-packet/banner output, and tells the AI to continue with protocol-level HTTP/browser checks. TUN-safe results are useful candidates, not an exhaustive port inventory."
 
 __USAGE__ = <<<USAGE_BLOCK
 Unified Port Scanner - Parameter Description for JSON Tool Calls
@@ -46,6 +46,15 @@ Optional Parameters:
                             full-range scan that cannot use SYN is REFUSED and the tool
                             returns an error asking for it — this protects you from
                             accidentally starting a multi-hour scan. Default: false.
+TUN / massive false-positive handling (mandatory for the AI):
+  If the tool returns [SCAN_TUN_SAFE_MODE], it has detected target-specific TUN/Fake-IP
+  evidence and has already replaced SYN/large-range discovery with a small TCP-connect
+  validation plan. Do not discard every result: common ports such as 80/443 may be real.
+  Also do not treat the result as an exhaustive open-port inventory. Add a TODO stating
+  that Clash Verge/TUN causes large port-scan false positives while the compact result
+  may contain real services. Continue by validating likely services at the application
+  layer; for a domain, prioritize HTTP/HTTPS requests or browser inspection. Do not
+  launch another broad port scan under the same TUN route.
 USAGE_BLOCK
 
 yakit.AutoInitYakit()
@@ -66,6 +75,176 @@ mode = str.ToLower(mode)
 if mode != "auto" && mode != "syn" && mode != "tcp" {
     yakit.Error("invalid mode '%v', must be one of: auto, syn, tcp", mode)
     return
+}
+
+// ==================== TUN / Fake-IP 目标级检测与策略收缩 ====================
+//
+// 不仅看“本机是否存在 utun”： macOS 长期可能有多张闲置 utun，仅凭存在
+// 网卡会被本地网络环境误导. 这里只使用当前目标的两类无特权证据:
+//   1. DNS 是否把目标域名映射到 Clash 常用的 198.18.0.0/15 Fake-IP 池;
+//   2. 内核为该解析 IP 选择的实际路由是否走 utun/tun/tap/wg 类接口.
+// os.GetRouteInfo 只读取路由表，无需 root；不额外查询公共控制域名，避免
+// 把 DNS 波动或企业内网解析当成 TUN 证据.
+//
+// 命中后不拒绝任务：改为少量端口 TCP connect + 应用层指纹验证.
+// 这保留 80/443 等真实结果，同时不让 SYN 代应答制造数万个伪 open.
+// 关键词: scan_port TUN Fake-IP, target route utun, 无 root TUN 检测,
+// Clash Verge 大规模端口误报, AI TODO, TUN safe mode
+isTunFakeIPv4 = func(raw) {
+    ip = str.TrimSpace(sprintf("%v", raw))
+    return str.StartsWith(ip, "198.18.") || str.StartsWith(ip, "198.19.")
+}
+
+isTunnelInterface = func(raw) {
+    name = str.ToLower(str.TrimSpace(sprintf("%v", raw)))
+    return str.StartsWith(name, "utun") || str.StartsWith(name, "tun") ||
+        str.StartsWith(name, "tap") || str.StartsWith(name, "wg") ||
+        str.Contains(name, "clash") || str.Contains(name, "meta")
+}
+
+detectTargetTunContext = func(rawTarget) {
+    evidence = []
+    detected = false
+    hasDomain = false
+    fakeCIDR = ""
+    expandedTargets = str.ParseStringToHosts(str.Trim(rawTarget, ","))
+    for item in expandedTargets {
+        candidate = str.TrimSpace(item)
+        resolvedList = []
+        if str.IsIPv4(candidate) {
+            resolvedList.Push(candidate)
+        } else {
+            hasDomain = true
+            try {
+                resolvedList = os.LookupIP(candidate)
+            } catch err {
+                // DNS 失败交给后续扫描流程处理，本检测不单独下结论.
+            }
+        }
+
+        // 只看当前目标的解析结果和目标路由. 单目标一般只有 1-2 个地址,
+        // 不会像网段扫描那样扰动本地网络.
+        for resolved in resolvedList {
+            resolvedText = str.TrimSpace(sprintf("%v", resolved))
+            if isTunFakeIPv4(resolvedText) {
+                detected = true
+                fakeCIDR = "198.18.0.0/15"
+                if candidate == resolvedText {
+                    evidence.Push(sprintf("target=%v is in Fake-IP pool %v", candidate, fakeCIDR))
+                } else {
+                    evidence.Push(sprintf("dns=%v->%v (Fake-IP pool %v)", candidate, resolvedText, fakeCIDR))
+                }
+            }
+
+            try {
+                routeInfo = os.GetRouteInfo(resolvedText)
+                routeIface = routeInfo["interface"]
+                if isTunnelInterface(routeIface) {
+                    detected = true
+                    evidence.Push(sprintf("route=%v via interface=%v gateway=%v source=%v",
+                        resolvedText, routeIface, routeInfo["gateway"], routeInfo["source"]))
+                }
+            } catch err {
+                // 路由读取失败不影响 DNS Fake-IP 证据，也不阻断正常扫描.
+            }
+        }
+    }
+
+    // 只在目标 DNS/路由已经给出 TUN 嫌疑时，再查两个 RFC 保留的
+    // .invalid 名字. 正常 DNS 必须返回 NXDOMAIN；如果它们反而命中了地址,
+    // 说明本地 Fake-IP DNS 正在合成结果. 这两次本地 DNS 查询不发送端口探测,
+    // 且不依赖某个公共站点的可用性.
+    if detected {
+        invalidHits = []
+        for invalidName in ["yak-tun-probe-a.invalid", "yak-tun-probe-b.invalid"] {
+            try {
+                invalidResults = os.LookupIP(invalidName)
+                for invalidIP in invalidResults {
+                    invalidText = str.TrimSpace(sprintf("%v", invalidIP))
+                    invalidHits.Push(sprintf("%v->%v", invalidName, invalidText))
+                    if isTunFakeIPv4(invalidText) {
+                        fakeCIDR = "198.18.0.0/15"
+                    }
+                }
+            } catch err {
+                // NXDOMAIN 是正常结果，静默忽略.
+            }
+        }
+        for invalidHit in invalidHits {
+            evidence.Push(sprintf("reserved-name synthetic DNS hit=%v", invalidHit))
+        }
+    }
+    return {
+        "detected": detected,
+        "has-domain": hasDomain,
+        "fake-cidr": fakeCIDR,
+        "evidence": evidence,
+    }
+}
+
+tunContext = detectTargetTunContext(target)
+tunSafeMode = tunContext["detected"]
+if tunSafeMode {
+    originalMode = mode
+    originalPorts = ports
+    requestedPorts = str.ParseStringToPorts(str.Trim(ports, ","))
+
+    // 窄端口请求尊重用户原选择; 宽范围请求收缩到最多 12 个.
+    // 域名优先 Web 端口，IP 目标优先常见运维服务端口. 优先列表
+    // 始终与用户请求取交集，不会擅自扫描用户没要求的端口.
+    TUN_MAX_PORTS = 12
+    if len(requestedPorts) > TUN_MAX_PORTS {
+        preferred = [22, 80, 443, 445, 3306, 3389, 5432, 6379, 8000, 8080, 8443, 9000]
+        if tunContext["has-domain"] {
+            preferred = [80, 443, 3000, 8000, 8008, 8080, 8443, 8888]
+        }
+        selected = []
+        for candidatePort in preferred {
+            for requestedPort in requestedPorts {
+                if candidatePort == requestedPort {
+                    selected.Push(candidatePort)
+                    break
+                }
+            }
+        }
+        // 如果用户请求与常用集完全无交集，保留请求中前 12 个端口,
+        // 避免把一个非 Web 运维任务静默变成另一个任务.
+        if len(selected) == 0 {
+            selected = requestedPorts[:min(TUN_MAX_PORTS, len(requestedPorts))]
+        }
+        selectedText = []
+        for selectedPort in selected {
+            selectedText.Push(sprintf("%v", selectedPort))
+        }
+        ports = str.Join(selectedText, ",")
+    }
+
+    // TUN 下的 raw SYN 发现不可信，改用真正 connect + 应用层指纹.
+    // 限制并发、关闭 active 主动扩展，域名则开启 Web 识别.
+    mode = "tcp"
+    if concurrent <= 0 || concurrent > 20 { concurrent = 20 }
+    if fpConcurrent <= 0 || fpConcurrent > 8 { fpConcurrent = 8 }
+    active = false
+    if tunContext["has-domain"] { webservice = true }
+
+    yakit.Info("[SCAN_TUN_SAFE_MODE] target-specific TUN/Fake-IP evidence detected without root.")
+    if tunContext["fake-cidr"] != "" {
+        yakit.Info("[TUN_FAKE_IP_RANGE] detected synthetic DNS pool=%v", tunContext["fake-cidr"])
+    }
+    for tunEvidence in tunContext["evidence"] {
+        yakit.Info("[TUN_EVIDENCE] %v", tunEvidence)
+    }
+    yakit.Info("[SCAN_TUN_SAFE_MODE] restarting scan plan: requested-mode=%v requested-ports=%v effective-mode=tcp effective-ports=%v concurrent=%v active=false web=%v", originalMode, originalPorts, ports, concurrent, webservice)
+    // 拆成短行，避免 AI 工具流对单条超长日志截断后丢失关键语义.
+    yakit.Info("[AI_TODO_REQUIRED] Clash Verge/TUN makes broad port discovery produce massive false positives.")
+    yakit.Info("[AI_TODO_REQUIRED] Compact TCP results may still contain real services such as 80/443.")
+    yakit.Info("[AI_TODO_REQUIRED] Record both facts; treat this run as candidates, not an exhaustive port inventory.")
+    yakit.Info("[AI_TODO_REQUIRED] Do not launch another broad port scan under the same TUN route.")
+    if tunContext["has-domain"] {
+        yakit.Info("[AI_NEXT_ACTION] Validate HTTP/HTTPS candidates with application-layer web requests or browser inspection against the original domain; prefer protocol evidence over raw open-port state.")
+    } else {
+        yakit.Info("[AI_NEXT_ACTION] Validate each compact TCP candidate with its expected application protocol; prefer banner/protocol evidence over raw open-port state.")
+    }
 }
 
 // isFullPortRange: 判断 ports 是否构成"全端口"扫描 (1-65535 / 0-65535).
@@ -177,9 +356,8 @@ buildServiceScanOpts = func(tcpConcurrency) {
     if webservice {
         opts.Push(servicescan.web())
     }
-    opts.Push(servicescan.onOpen(i => {
-        yakit.Info("%v is open", i.String())
-    }))
+    // 不在 onOpen 回调里打印结果: consumeWithProgress 会统一输出,
+    // 避免每个端口出现两条内容重复的复杂日志.
     opts.Push(servicescan.probeTimeout(5))
     if active {
         opts.Push(servicescan.active(true))
@@ -334,7 +512,15 @@ reportResults = func(results) {
         openPorts.Push(str.HostPort(result.Target, result.Port))
         glance = result.String()
         banner = result.GetBanner()
-        yakit.Info("open: %v\n%v", glance, formatBanner(banner))
+        if tunSafeMode {
+            // TUN safe mode 只输出紧凑的 TCP/服务候选项. 原始 banner 和
+            // 指纹细节容易放大 Fake-IP 噪声，后续由 AI 用 HTTP/具体协议
+            // 工具对这几个候选端口验证.
+            yakit.Info("tcp candidate: %v service=%v (application-layer validation required)",
+                str.HostPort(result.Target, result.Port), result.GetServiceName())
+        } else {
+            yakit.Info("open: %v\n%v", glance, formatBanner(banner))
+        }
     }
     if closedPorts.Len() > 0 {
         yakit.Info("closed ports count: %v", closedPorts.Len())
@@ -500,7 +686,12 @@ consumeWithProgress = func(results) {
         openPorts.Push(str.HostPort(result.Target, result.Port))
         glance = result.String()
         banner = result.GetBanner()
-        yakit.Info("open: %v\n%v", glance, formatBanner(banner))
+        if tunSafeMode {
+            yakit.Info("tcp candidate: %v service=%v (application-layer validation required)",
+                str.HostPort(result.Target, result.Port), result.GetServiceName())
+        } else {
+            yakit.Info("open: %v\n%v", glance, formatBanner(banner))
+        }
         // 发现 open 端口的当次也补一条进度 (open 是用户最关心的).
         if done % PROGRESS_EVERY == 0 {
             yakit.Info(buildProgressLine("Progress", done, openCount, closedCount))

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
@@ -116,7 +116,10 @@ detectTargetTunContext = func(rawTarget) {
         } else {
             hasDomain = true
             try {
-                resolvedList = os.LookupIP(candidate)
+                // 只查询本机当前 resolver，并严格限制耗时。这里要识别的是
+                // Clash/TUN 对本机 DNS 的影响，不应在 NXDOMAIN 后继续遍历
+                // 公共 DNS fallback，否则离线 CI/受限网络会被多轮超时拖住.
+                resolvedList = os.LookupSystemIPWithTimeout(candidate, 0.8)
             } catch err {
                 // DNS 失败交给后续扫描流程处理，本检测不单独下结论.
             }
@@ -154,11 +157,13 @@ detectTargetTunContext = func(rawTarget) {
     // .invalid 名字. 正常 DNS 必须返回 NXDOMAIN；如果它们反而命中了地址,
     // 说明本地 Fake-IP DNS 正在合成结果. 这两次本地 DNS 查询不发送端口探测,
     // 且不依赖某个公共站点的可用性.
-    if detected {
+    // 显式 IP 已有 Fake-IP/路由证据，不需要再做 DNS 探针。只有域名目标
+    // 才用保留名确认“本机 resolver 正在合成地址”，避免无意义的 DNS 流量.
+    if detected && hasDomain {
         invalidHits = []
         for invalidName in ["yak-tun-probe-a.invalid", "yak-tun-probe-b.invalid"] {
             try {
-                invalidResults = os.LookupIP(invalidName)
+                invalidResults = os.LookupSystemIPWithTimeout(invalidName, 0.2)
                 for invalidIP in invalidResults {
                     invalidText = str.TrimSpace(sprintf("%v", invalidIP))
                     invalidHits.Push(sprintf("%v->%v", invalidName, invalidText))

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "a177025c255d1dce69ac009dc653a0fab1e66d7fac313554bcf2524adccf803d"
+const ExistedBuildInAIToolEmbedFSHash string = "5eb832dd93318b95128e5df619ba106bac376ea8060d980337141bf1708a0bff"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "35ad518ce83f9f165aa81bf2c69dca074be7a8a9f62ee88d1d7e4dd64b9b1b7e"
+const ExistedBuildInAIToolEmbedFSHash string = "a177025c255d1dce69ac009dc653a0fab1e66d7fac313554bcf2524adccf803d"

--- a/common/yak/yaklib/system.go
+++ b/common/yak/yaklib/system.go
@@ -1,15 +1,17 @@
 package yaklib
 
 import (
-	"github.com/yaklang/yaklang/common/utils/sysproc"
 	"net"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/yaklang/yaklang/common/netx"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/cli"
+	"github.com/yaklang/yaklang/common/utils/netutil"
 	"github.com/yaklang/yaklang/common/utils/privileged"
+	"github.com/yaklang/yaklang/common/utils/sysproc"
 )
 
 var SystemExports = map[string]interface{}{
@@ -63,9 +65,49 @@ var SystemExports = map[string]interface{}{
 	"GetLocalAddress":      GetLocalAddress,
 	"GetLocalIPv4Address":  GetLocalIPv4Address,
 	"GetLocalIPv6Address":  GetLocalIPv6Address,
+	"GetRouteInfo":         GetRouteInfo,
 
 	"NewConnectionsWatcher": sysproc.NewWatcher,
 	"NewProcessWatcher":     sysproc.NewProcessesWatcher,
+}
+
+// GetRouteInfo 返回当前系统到指定目标的实际路由信息.
+//
+// 该函数只读取内核路由表与网卡信息，不修改路由，因此不需要
+// root/Administrator 权限. 典型用途是让 Yak 脚本判断某个具体目标
+// 是否经过 utun/tun/wg 等隧道，而不是仅因为系统里存在一张隧道
+// 网卡就产生误判.
+//
+// 返回 map 固定包含 target/interface/gateway/source/error 五个键；
+// 成功时 error 为空字符串，失败时其他路由字段可能为空.
+//
+// Example:
+//
+//	os.GetRouteInfo("198.18.1.2") // {"interface":"utun4", ...}
+func GetRouteInfo(target string) map[string]string {
+	result := map[string]string{
+		"target":    target,
+		"interface": "",
+		"gateway":   "",
+		"source":    "",
+		"error":     "",
+	}
+
+	iface, gateway, source, err := netutil.Route(3*time.Second, target)
+	if err != nil {
+		result["error"] = err.Error()
+		return result
+	}
+	if iface != nil {
+		result["interface"] = iface.Name
+	}
+	if gateway != nil {
+		result["gateway"] = gateway.String()
+	}
+	if source != nil {
+		result["source"] = source.String()
+	}
+	return result
 }
 
 // LookupHost 通过DNS服务器，根据域名查找IP

--- a/common/yak/yaklib/system.go
+++ b/common/yak/yaklib/system.go
@@ -1,6 +1,7 @@
 package yaklib
 
 import (
+	"context"
 	"net"
 	"os"
 	"runtime"
@@ -19,6 +20,7 @@ var SystemExports = map[string]interface{}{
 	"IsUDPPortOpen":             IsUDPPortOpen,
 	"LookupHost":                lookupHost,
 	"LookupIP":                  lookupIP,
+	"LookupSystemIPWithTimeout": LookupSystemIPWithTimeout,
 	"IsTCPPortAvailable":        IsTCPPortAvailable,
 	"IsUDPPortAvailable":        IsUDPPortAvailable,
 	"GetRandomAvailableTCPPort": GetRandomAvailableTCPPort,
@@ -138,6 +140,27 @@ func lookupHost(i string) []string {
 // ```
 func lookupIP(i string) []string {
 	return netx.LookupAll(i)
+}
+
+// LookupSystemIPWithTimeout 仅使用操作系统当前配置的 DNS resolver 查询域名，
+// 并用 seconds 限制整个查询耗时。它不会在系统 DNS 返回 NXDOMAIN 后继续遍历
+// Yak 的公共 DNS fallback，因此适合探测本机 DNS/TUN 行为，且不会因外部 DNS
+// 不可达而长时间阻塞。
+func LookupSystemIPWithTimeout(host string, seconds float64) []string {
+	if seconds <= 0 {
+		seconds = 0.5
+	}
+	if seconds > 5 {
+		seconds = 5
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(seconds*float64(time.Second)))
+	defer cancel()
+
+	results, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return nil
+	}
+	return results
 }
 
 // IsTCPPortOpen 检查本地TCP端口是否开放（被占用）

--- a/common/yak/yaklib/system_route_test.go
+++ b/common/yak/yaklib/system_route_test.go
@@ -1,6 +1,9 @@
 package yaklib
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestMUSTPASS_GetRouteInfoLoopbackWithoutPrivilege(t *testing.T) {
 	info := GetRouteInfo("127.0.0.1")
@@ -15,5 +18,19 @@ func TestMUSTPASS_GetRouteInfoLoopbackWithoutPrivilege(t *testing.T) {
 	}
 	if _, ok := SystemExports["GetRouteInfo"]; !ok {
 		t.Fatal("os.GetRouteInfo is not registered in SystemExports")
+	}
+}
+
+func TestMUSTPASS_LookupSystemIPWithTimeoutDoesNotUseSlowFallbacks(t *testing.T) {
+	start := time.Now()
+	results := LookupSystemIPWithTimeout("yak-tun-probe-must-not-exist.invalid", 0.2)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("system-only DNS lookup exceeded its bounded timeout: %v", elapsed)
+	}
+	if len(results) > 0 {
+		t.Logf("system resolver synthesized reserved-name result (expected under Fake-IP DNS): %v", results)
+	}
+	if _, ok := SystemExports["LookupSystemIPWithTimeout"]; !ok {
+		t.Fatal("os.LookupSystemIPWithTimeout is not registered in SystemExports")
 	}
 }

--- a/common/yak/yaklib/system_route_test.go
+++ b/common/yak/yaklib/system_route_test.go
@@ -1,0 +1,19 @@
+package yaklib
+
+import "testing"
+
+func TestMUSTPASS_GetRouteInfoLoopbackWithoutPrivilege(t *testing.T) {
+	info := GetRouteInfo("127.0.0.1")
+	if info == nil {
+		t.Fatal("GetRouteInfo returned nil")
+	}
+	if info["error"] != "" {
+		t.Fatalf("GetRouteInfo loopback failed: %s", info["error"])
+	}
+	if info["interface"] == "" {
+		t.Fatalf("GetRouteInfo returned no interface: %#v", info)
+	}
+	if _, ok := SystemExports["GetRouteInfo"]; !ok {
+		t.Fatal("os.GetRouteInfo is not registered in SystemExports")
+	}
+}


### PR DESCRIPTION
## Summary

- detect target-specific TUN/Fake-IP routing from DNS, reserved-name synthesis, and rootless route inspection
- replace broad SYN discovery with a compact TCP-connect plan while preserving real service candidates such as 80/443
- guide the AI to record the Clash Verge/TUN limitation in TODO and continue with application-layer validation
- suppress duplicate/noisy scan output in TUN-safe mode

## Testing

- `GITHUB_ACTIONS=true go test ./common/ai/aid/aitool/buildinaitools/yakscripttools/test -run "^TestMUSTPASS_ScanPortTool_" -count=1 -timeout=2m`
- `GITHUB_ACTIONS=true go test ./common/yak/yaklib -run "^TestMUSTPASS_GetRouteInfoLoopbackWithoutPrivilege$" -count=1 -timeout=2m`
- live `.invalid` Fake-IP probe confirmed `198.18.0.0/15` detection and automatic domain plan reduction to 8 web-oriented TCP ports