### PR TITLE
fix(crawler): ignore client-side URL fragments

### DIFF
--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/simple_crawler_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/simple_crawler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
@@ -99,4 +100,43 @@ func TestSimpleCrawler_CoverageHint(t *testing.T) {
 		"standard crawl summary should still be present")
 	assert.Assert(t, strings.Contains(stdout, "=== Requested URLs ==="),
 		"requested URLs section should still be present")
+}
+
+func TestSimpleCrawler_HidesAndDoesNotRequestURLFragments(t *testing.T) {
+	var port int
+	var fragmentRequestCount atomic.Int64
+	host, p := utils.DebugMockHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "#") {
+			fragmentRequestCount.Add(1)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if r.URL.Path == "/" {
+			w.Write([]byte(`<a href="#overview">overview</a>
+<a href="/home#section-systems">systems</a>
+<a href="/home#section-energy">energy</a>`))
+			return
+		}
+		w.Write([]byte("ok"))
+	})
+	port = p
+	baseURL := "http://" + host + ":" + strconv.Itoa(port)
+
+	tool := getSimpleCrawlerTool(t)
+	stdout, _ := execCrawlerTool(t, tool, aitool.InvokeParams{
+		"urls":                   baseURL,
+		"reqs-max":               20,
+		"max-depth":              3,
+		"timeout":                5,
+		"forbid-for-parent-path": "yes",
+	})
+
+	assert.Equal(t, fragmentRequestCount.Load(), int64(0), "crawler must not send URL fragments to the server")
+	assert.Assert(t, strings.Contains(stdout, "Requests sent:   2"),
+		"fragment variants should not consume the request budget; got:\n%s", stdout)
+	assert.Assert(t, !strings.Contains(stdout, "#section-"),
+		"fragment URL should not be shown in crawler output; got:\n%s", stdout)
+	assert.Assert(t, !strings.Contains(stdout, "404 Not Found"),
+		"fragment-only 404 should not be shown in crawler output; got:\n%s", stdout)
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
@@ -60,6 +60,14 @@ discoveredUrls = sync.NewLock()
 discoveredUrlSet = {}
 requestedUrlSet = {}
 
+normalizeDisplayUrl = func(rawUrl) {
+    sharpIndex = str.Index(rawUrl, "#")
+    if sharpIndex >= 0 {
+        return rawUrl[:sharpIndex]
+    }
+    return rawUrl
+}
+
 opts = []
 if reqsLimit > 0 {
     opts.Append(crawler.maxRequest(reqsLimit))
@@ -84,6 +92,10 @@ if timeoutSecond > 0 {
 }
 
 opts.Append(crawler.onUrlFound(func(urlStr) {
+    urlStr = normalizeDisplayUrl(urlStr)
+    if urlStr == "" {
+        return
+    }
     discoveredUrls.Lock()
     defer discoveredUrls.Unlock()
     if urlStr in discoveredUrlSet {
@@ -117,7 +129,8 @@ for currentStartUrl in targetCandidates {
     for result in reqCh {
         currentResults++
         totalResults++
-        urlstr := result.Url()
+        rawUrlstr := result.Url()
+        urlstr := normalizeDisplayUrl(rawUrlstr)
 
         discoveredUrls.Lock()
         requestedUrlSet[urlstr] = true
@@ -135,6 +148,14 @@ for currentStartUrl in targetCandidates {
             rspdesc = str.Join(poc.GetHTTPPacketFirstLine(rsp), " ")
         } catch {}
 
+        // A URL fragment is browser-only and must never be sent to the server.
+        // Keep the output quiet if an older/lower-level request path still
+        // returns a misleading 404 for one; the crawler now strips fragments at
+        // request construction time, so this is only a defensive compatibility
+        // guard.
+        if rawUrlstr != urlstr && str.Contains(rspdesc, " 404 ") {
+            continue
+        }
         requestLines.Append(sprintf("[%v] [%v] %v", method, rspdesc, urlstr))
     }
 

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "5eb832dd93318b95128e5df619ba106bac376ea8060d980337141bf1708a0bff"
+const ExistedBuildInAIToolEmbedFSHash string = "44aedcfd37ccb873a3dd05b0d318a4f9c57c5bb6e8986db558b8964aadc3d058"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "a177025c255d1dce69ac009dc653a0fab1e66d7fac313554bcf2524adccf803d"
+const ExistedBuildInAIToolEmbedFSHash string = "5eb832dd93318b95128e5df619ba106bac376ea8060d980337141bf1708a0bff"

--- a/common/crawler/basic_crawler_test.go
+++ b/common/crawler/basic_crawler_test.go
@@ -1,6 +1,11 @@
 package crawler
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,6 +24,52 @@ func TestCrawler_Run(t *testing.T) {
 	err = crawler.Run()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCrawler_StripsURLFragmentsBeforeRequestAndDiscovery(t *testing.T) {
+	var mu sync.Mutex
+	var requestURIs []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestURIs = append(requestURIs, r.RequestURI)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		switch r.URL.Path {
+		case "/":
+			fmt.Fprint(w, `<a href="#overview">overview</a>
+<a href="/home#systems">systems</a>
+<a href="/home#energy">energy</a>`)
+		case "/home":
+			fmt.Fprint(w, `<a href="#details">home details</a>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var foundURLs []string
+	c, err := NewCrawler(
+		server.URL+"/#start",
+		WithForbiddenFromParent(true),
+		WithConcurrent(1),
+		WithMaxDepth(2),
+		WithOnUrlFound(func(rawURL string) {
+			foundURLs = append(foundURLs, rawURL)
+		}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, c.Run())
+
+	mu.Lock()
+	gotRequestURIs := append([]string(nil), requestURIs...)
+	mu.Unlock()
+	require.Equal(t, []string{"/", "/home"}, gotRequestURIs)
+	require.Equal(t, []string{server.URL + "/home"}, foundURLs)
+	for _, rawURL := range foundURLs {
+		require.False(t, strings.Contains(rawURL, "#"), "fragment leaked into discovered URL: %s", rawURL)
 	}
 }
 
@@ -74,6 +125,20 @@ func TestNewHTTPRequest(t *testing.T) {
 			rsp:         nil,
 			expectHttps: true,
 			expectReq:   []byte("GET /abc HTTP/1.1\r\nHost: www.example.com\r\nReferer: https://www.example.com/\r\n\r\n"),
+		},
+		{
+			req:         baseReq,
+			https:       true,
+			urlString:   "/home#section-systems",
+			expectHttps: true,
+			expectReq:   []byte("GET /home HTTP/1.1\r\nHost: www.example.com\r\nReferer: https://www.example.com/\r\n\r\n"),
+		},
+		{
+			req:         []byte("GET /home HTTP/1.1\r\nHost: www.example.com\r\n\r\n"),
+			https:       true,
+			urlString:   "#section-energy",
+			expectHttps: true,
+			expectReq:   []byte("GET /home HTTP/1.1\r\nHost: www.example.com\r\nReferer: https://www.example.com/home\r\n\r\n"),
 		},
 	}
 

--- a/common/crawler/core.go
+++ b/common/crawler/core.go
@@ -383,6 +383,9 @@ func StartCrawler(url string, opt ...ConfigOpt) (chan *Req, error) {
 func NewCrawler(urls string, opts ...ConfigOpt) (*Crawler, error) {
 	urlsRaw := utils.PrettifyListFromStringSplited(urls, ",")
 	urlList := utils.ParseStringToUrlsWith3W(urlsRaw...)
+	for i, rawURL := range urlList {
+		urlList[i] = stripURLFragment(rawURL)
+	}
 	log.Debugf("actual url list: %v", urlList)
 
 	config := &Config{}
@@ -705,15 +708,14 @@ func (c *Crawler) handleReqResult(r *Req) {
 			log.Errorf("create request from bytes error: %s", err.Error())
 			return
 		}
-		if config.onUrlFound != nil {
-			config.onUrlFound(req.Url())
-		}
 		if ret, err := url.Parse(req.Url()); err != nil {
 			if !config.CheckShouldBeHandledURL(ret) {
 				return
 			}
 		}
-		c.submit(req)
+		if c.submit(req) && config.onUrlFound != nil {
+			config.onUrlFound(req.Url())
+		}
 	}
 
 	var jsContents []*JavaScriptContent
@@ -1098,7 +1100,14 @@ func (c *Crawler) submit(r *Req) bool {
 	if c == nil || c.scheduler == nil {
 		return false
 	}
-	return c.scheduler.Submit(r)
+	if _, loaded := c.foundUrls.LoadOrStore(r.Hash(), nil); loaded {
+		return false
+	}
+	if !c.scheduler.Submit(r) {
+		c.foundUrls.Delete(r.Hash())
+		return false
+	}
+	return true
 }
 
 func (c *Crawler) createReqFromUrl(preRequest *Req, u string) (*Req, error) {
@@ -1114,7 +1123,14 @@ func (c *Crawler) createReqFromBytes(preRequest *Req, https bool, req []byte) (*
 	if err != nil {
 		return nil, err
 	}
+	urlIns.Fragment = ""
+	urlIns.RawFragment = ""
 	reqIns.URL = urlIns
+	reqIns.RequestURI = ""
+	req, err = utils.HttpDumpWithBody(reqIns, true)
+	if err != nil {
+		return nil, err
+	}
 	return &Req{
 		depth:      preRequest.depth + 1,
 		https:      https,
@@ -1125,6 +1141,7 @@ func (c *Crawler) createReqFromBytes(preRequest *Req, https bool, req []byte) (*
 }
 
 func createReqFromUrlEx(preqRequest *Req, method, u string, body io.Reader, c *Crawler) (*Req, error) {
+	u = stripURLFragment(u)
 	r, err := http.NewRequest(method, u, body)
 	if err != nil {
 		return nil, utils.Errorf("create request from url[%v] failed: %s", u, err)

--- a/common/crawler/new_request.go
+++ b/common/crawler/new_request.go
@@ -1,11 +1,13 @@
 package crawler
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
 	"golang.org/x/net/html"
-	"strings"
 )
 
 func NewHTTPRequest(https bool, req []byte, rsp []byte, urlString string) (bool, []byte, error) {
@@ -17,6 +19,16 @@ func NewHTTPRequest(https bool, req []byte, rsp []byte, urlString string) (bool,
 		}
 	} else if strings.HasPrefix(urlString, "javascript:") {
 		return https, nil, utils.Errorf("javascript schema url cannot build http request: %s", urlString)
+	}
+	if ref, err := url.Parse(urlString); err == nil && (ref.Fragment != "" || strings.HasSuffix(urlString, "#")) {
+		if !ref.IsAbs() {
+			if base, baseErr := lowhttp.ExtractURLFromHTTPRequestRaw(req, https); baseErr == nil {
+				ref = base.ResolveReference(ref)
+			}
+		}
+		urlString = stripURLFragment(ref.String())
+	} else {
+		urlString = stripURLFragment(urlString)
 	}
 	reqBytes := lowhttp.UrlToRequestPacket(
 		"GET", urlString, req, https,

--- a/common/crawler/utils.go
+++ b/common/crawler/utils.go
@@ -1,6 +1,9 @@
 package crawler
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 var popularJavaScriptLibraryFiles = []string{"react", "vue", "angular", "jquery", "lodash", "bootstrap", "express", "d3", "moment", "axios", "three", "socket.io", "underscore", "ember", "backbone", "redux", "meteor", "next", "nuxt", "gatsby", "svelte", "preact", "material-ui", "ant-design", "bulma", "semantic-ui", "foundation", "tailwind", "styled-components", "apollo", "graphql", "mobx", "knockout", "mithril", "aurelia", "stimulus", "alpine", "inferno", "riot", "cypress", "rxjs", "zone", "hammerjs", "yarn", "npm", "webpack", "babel", "gulp", "grunt", "browserify", "rollup", "eslint", "prettier", "stylelint", "typescript", "coffeescript", "polymer", "lit-element", "lit-html", "stencil", "dojo", "extjs", "raphael", "paper", "fabric", "konva", "anime", "mojs", "velocity", "greensock", "scrollmagic", "popmotion", "lazy", "immutable", "ramda", "bacon", "bluebird", "q", "when", "leaflet", "openlayers", "mapbox-gl", "highcharts", "amcharts", "chart", "echarts", "zrender", "dimple", "c3", "dc", "nvd3", "plottable", "sigma", "vivagraphjs", "jointjs", "cytoscape", "vis", "gojs", "fabric", "paper", "color"}
 
@@ -11,4 +14,21 @@ func isPopularJSLibrary(libraryFileName string) bool {
 		}
 	}
 	return false
+}
+
+// stripURLFragment removes the client-side fragment from a URL before the
+// crawler turns it into an HTTP request or uses it as a deduplication key.
+// Fragments are never sent to an HTTP server, so treating them as part of the
+// request URL creates duplicate requests and misleading status codes.
+func stripURLFragment(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u == nil {
+		return raw
+	}
+	u.Fragment = ""
+	u.RawFragment = ""
+	if (strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https")) && u.Host != "" && u.Path == "" {
+		u.Path = "/"
+	}
+	return u.String()
 }


### PR DESCRIPTION
## Summary

- strip client-side URL fragments at every crawler request-construction boundary
- normalize empty HTTP(S) paths and deduplicate canonical request hashes before queueing, so anchor variants do not consume the request budget
- canonicalize simple_crawler discovery/output and hide defensive fragment-only 404 noise
- add crawler and AI-tool regressions for start URLs, pure anchors, and multiple anchors on one path

## Tests

- go test ./common/crawler -run "Test(NewHTTPRequest|Crawler_StripsURLFragmentsBeforeRequestAndDiscovery)$" -count=10
- go test ./common/ai/aid/aitool/buildinaitools/yakscripttools/test -run "^TestSimpleCrawler_HidesAndDoesNotRequestURLFragments$" -count=5
- coverage-hint regression also passes

A broader local package run also hit two unrelated baseline/environment failures: TestCrawler_ParseForm reproduces unchanged on origin/main, and scan_port expectations differ under the active local TUN route. Repository CI is the definitive full-suite check.