### PR TITLE
feat(ai): 支持服务端 FocusRuntime 注入

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -182,6 +182,7 @@ type Config struct {
 	EventHandler           func(e *schema.AiOutputEvent)
 	DisableOutputEventType []string
 	SaveEvent              bool
+	FocusRuntime           FocusRuntime
 
 	// asyncGuardian process special output event
 	Guardian *AsyncGuardian
@@ -1463,6 +1464,22 @@ func WithEmitter(emitter *Emitter) ConfigOption {
 		}
 		return nil
 	}
+}
+
+// WithFocusRuntime installs the capability boundary used by server-released
+// Yak Focus code. Desktop and client runtimes leave it unset.
+func WithFocusRuntime(runtime FocusRuntime) ConfigOption {
+	return func(c *Config) error {
+		c.FocusRuntime = runtime
+		return nil
+	}
+}
+
+func (c *Config) GetFocusRuntime() FocusRuntime {
+	if c == nil {
+		return nil
+	}
+	return c.FocusRuntime
 }
 
 // Event / output
@@ -4082,6 +4099,9 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 
 	if i.EventHandler != nil {
 		opts = append(opts, WithEventHandler(i.EventHandler))
+	}
+	if i.FocusRuntime != nil {
+		opts = append(opts, WithFocusRuntime(i.FocusRuntime))
 	}
 
 	if i.GetUserUsageCallback() != nil {

--- a/common/ai/aid/aicommon/config_test.go
+++ b/common/ai/aid/aicommon/config_test.go
@@ -184,6 +184,29 @@ func TestConfig_ToolManagerPropagation(t *testing.T) {
 	require.True(t, child.GetAiToolManager().IsRecentlyUsedTool("now"))
 }
 
+type testFocusRuntime struct{}
+
+func (testFocusRuntime) AuthorizedTarget() string { return "https://example.test/" }
+
+func (testFocusRuntime) Execute(string, map[string]any) (map[string]any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+func TestConfigFocusRuntimeIsRunScoped(t *testing.T) {
+	runtime := testFocusRuntime{}
+	config := NewConfig(context.Background(), WithFocusRuntime(runtime))
+	if FocusRuntimeFromConfig(config) == nil {
+		t.Fatal("expected focus runtime on parent config")
+	}
+	child := NewConfig(context.Background(), config.OriginOptions()...)
+	if FocusRuntimeFromConfig(child) == nil {
+		t.Fatal("expected focus runtime to propagate to child config")
+	}
+	if FocusRuntimeFromConfig(struct{}{}) != nil {
+		t.Fatal("expected configs without FocusRuntimeProvider to remain compatible")
+	}
+}
+
 func TestConfig_AiForgeManagerPropagation(t *testing.T) {
 	parent := NewConfig(context.Background())
 	require.NotNil(t, parent.GetAIForgeManager())

--- a/common/ai/aid/aicommon/focus_runtime.go
+++ b/common/ai/aid/aicommon/focus_runtime.go
@@ -1,0 +1,23 @@
+package aicommon
+
+// FocusRuntime is the narrow, run-scoped capability boundary exposed to a
+// server-released Yak Focus. The release owns orchestration while this runtime
+// owns enforcement and side effects.
+type FocusRuntime interface {
+	AuthorizedTarget() string
+	Execute(capability string, params map[string]any) (map[string]any, error)
+}
+
+// FocusRuntimeProvider stays separate from AICallerConfigIf so downstream
+// implementations of the broad caller interface remain source-compatible.
+type FocusRuntimeProvider interface {
+	GetFocusRuntime() FocusRuntime
+}
+
+func FocusRuntimeFromConfig(config any) FocusRuntime {
+	provider, ok := config.(FocusRuntimeProvider)
+	if !ok || provider == nil {
+		return nil
+	}
+	return provider.GetFocusRuntime()
+}

--- a/common/ai/aid/aireact/reactloops/yak_focus_mode_register.go
+++ b/common/ai/aid/aireact/reactloops/yak_focus_mode_register.go
@@ -3,6 +3,7 @@ package reactloops
 import (
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
@@ -31,6 +32,10 @@ type FocusModeBundle struct {
 	// Name 显式指定专注模式名（不填则取 EntryFile 的 basename 作 fallback）
 	Name string
 
+	// FixedName rejects a script-level __NAME__ override. Server-delivered
+	// releases use this to keep the integrity-bound runtime name authoritative.
+	FixedName bool
+
 	// EntryFile 主入口文件相对路径（仅做调试 / log 使用）
 	EntryFile string
 
@@ -57,10 +62,17 @@ type FocusModeSidekick struct {
 
 // yakFocusBundles 保存所有已通过 RegisterYakFocusModeFromBundle 注册的 bundle，
 // run 期 CreateLoopByName 时会回查它生成新引擎。
-var yakFocusBundles = map[string]*FocusModeBundle{}
+var (
+	yakFocusBundlesMu sync.RWMutex
+	yakFocusBundles   = map[string]*FocusModeBundle{}
+)
+
+const serverFocusRuntimeGlobal = "focusRuntime"
 
 // GetYakFocusModeBundle 通过名字查询已注册的 bundle，主要供测试使用。
 func GetYakFocusModeBundle(name string) (*FocusModeBundle, bool) {
+	yakFocusBundlesMu.RLock()
+	defer yakFocusBundlesMu.RUnlock()
 	b, ok := yakFocusBundles[name]
 	return b, ok
 }
@@ -100,6 +112,7 @@ func RegisterYakFocusModeFromBundle(bundle *FocusModeBundle) error {
 		bundle.EntryFile,
 		bundleCode,
 		WithFocusModeCallerCallTimeout(bootCallTimeout),
+		WithFocusModeCallerVars(map[string]any{serverFocusRuntimeGlobal: nil}),
 	)
 	if err != nil {
 		return utils.Wrapf(err, "yak focus mode: boot eval failed for %s", defaultName)
@@ -110,10 +123,15 @@ func RegisterYakFocusModeFromBundle(bundle *FocusModeBundle) error {
 	if resolvedName == "" {
 		resolvedName = defaultName
 	}
+	if bundle.FixedName && resolvedName != defaultName {
+		return utils.Errorf("yak focus mode: fixed name %q cannot be overridden by %q", defaultName, resolvedName)
+	}
 	bundle.Name = resolvedName
 
 	// 缓存 bundle 给 run 期使用（在尝试注册 LoopFactory 之前），方便测试通过名称回查
+	yakFocusBundlesMu.Lock()
 	yakFocusBundles[resolvedName] = bundle
+	yakFocusBundlesMu.Unlock()
 
 	// ---- run 期 LoopFactory ----
 	factory := func(invoker aicommon.AIInvokeRuntime, opts ...ReActLoopOption) (*ReActLoop, error) {
@@ -122,17 +140,7 @@ func RegisterYakFocusModeFromBundle(bundle *FocusModeBundle) error {
 			runCallTimeout = 30 * time.Second
 		}
 
-		callerOpts := []FocusModeCallerOption{
-			WithFocusModeCallerCallTimeout(runCallTimeout),
-		}
-		if invoker != nil {
-			if cfg := invoker.GetConfig(); cfg != nil {
-				if ctx := cfg.GetContext(); ctx != nil {
-					callerOpts = append(callerOpts, WithFocusModeCallerParentContext(ctx))
-				}
-			}
-		}
-
+		callerOpts := focusModeRunCallerOptions(invoker, runCallTimeout)
 		caller, err := NewFocusModeYakHookCaller(bundle.EntryFile, bundleCode, callerOpts...)
 		if err != nil {
 			return nil, utils.Wrapf(err, "yak focus mode[%v]: create run-phase caller failed", resolvedName)
@@ -156,12 +164,36 @@ func RegisterYakFocusModeFromBundle(bundle *FocusModeBundle) error {
 
 	if err := RegisterLoopFactory(resolvedName, factory, metadataOpts...); err != nil {
 		// 注册失败时回滚 bundle 缓存，避免 GetYakFocusModeBundle 给出脏数据
+		yakFocusBundlesMu.Lock()
 		delete(yakFocusBundles, resolvedName)
+		yakFocusBundlesMu.Unlock()
 		return utils.Wrapf(err, "yak focus mode[%v]: register loop factory failed", resolvedName)
 	}
 
 	log.Infof("yak focus mode[%v] registered (entry=%v, sidekicks=%d)", resolvedName, bundle.EntryFile, len(bundle.Sidekicks))
 	return nil
+}
+
+func focusModeRunCallerOptions(
+	invoker aicommon.AIInvokeRuntime,
+	callTimeout time.Duration,
+) []FocusModeCallerOption {
+	callerOpts := []FocusModeCallerOption{
+		WithFocusModeCallerCallTimeout(callTimeout),
+	}
+	if invoker == nil || invoker.GetConfig() == nil {
+		return callerOpts
+	}
+	config := invoker.GetConfig()
+	if ctx := config.GetContext(); ctx != nil {
+		callerOpts = append(callerOpts, WithFocusModeCallerParentContext(ctx))
+	}
+	if runtime := aicommon.FocusRuntimeFromConfig(config); runtime != nil {
+		callerOpts = append(callerOpts, WithFocusModeCallerVars(map[string]any{
+			serverFocusRuntimeGlobal: runtime,
+		}))
+	}
+	return callerOpts
 }
 
 // RegisterYakFocusMode 是 RegisterYakFocusModeFromBundle 的便捷封装，

--- a/common/ai/aid/aireact/reactloops/yak_focus_mode_register_test.go
+++ b/common/ai/aid/aireact/reactloops/yak_focus_mode_register_test.go
@@ -1,12 +1,30 @@
 package reactloops
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	aicommonmock "github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
 	"github.com/yaklang/yaklang/common/utils"
 )
+
+type registerTestFocusRuntime struct{ target string }
+
+func (r registerTestFocusRuntime) AuthorizedTarget() string { return r.target }
+
+func (registerTestFocusRuntime) Execute(string, map[string]any) (map[string]any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+type registerTestFocusConfig struct {
+	aicommon.AICallerConfigIf
+	runtime aicommon.FocusRuntime
+}
+
+func (c *registerTestFocusConfig) GetFocusRuntime() aicommon.FocusRuntime { return c.runtime }
 
 // 验证 RegisterYakFocusModeFromBundle 的 boot/run 双相行为：
 //   - boot 期：从 yak 脚本中提取 metadata，注册到全局表
@@ -71,6 +89,22 @@ __VERBOSE_NAME__ = "Explicit Name Test"
 
 	_, foundDefault := GetLoopFactory(defaultName)
 	require.False(t, foundDefault, "default name should not be used when __NAME__ is set")
+}
+
+func TestRegisterYakFocusMode_FixedNameRejectsScriptOverride(t *testing.T) {
+	defaultName := "yakfm_fixed_" + utils.RandStringBytes(6)
+	overrideName := "yakfm_override_" + utils.RandStringBytes(6)
+	err := RegisterYakFocusModeFromBundle(&FocusModeBundle{
+		Name:      defaultName,
+		FixedName: true,
+		EntryFile: defaultName + FocusModeFileSuffix,
+		EntryCode: `__NAME__ = "` + overrideName + `"`,
+	})
+	require.Error(t, err)
+	_, found := GetLoopFactory(defaultName)
+	require.False(t, found)
+	_, found = GetLoopFactory(overrideName)
+	require.False(t, found)
 }
 
 // 验证同名重复注册失败，且失败时不会污染 yakFocusBundles。
@@ -152,4 +186,28 @@ computeName = func() {
 	meta, ok := GetLoopMetadata(name)
 	require.True(t, ok)
 	require.Equal(t, "computed via sidekick", meta.VerboseName)
+}
+
+func TestRegisterYakFocusMode_InjectsRunScopedFocusRuntime(t *testing.T) {
+	code := `
+readAuthorizedTarget = func() {
+    return focusRuntime.AuthorizedTarget()
+}
+`
+	baseConfig := aicommonmock.NewMockedAIConfig(context.Background())
+	invoker := aicommonmock.NewMockInvoker(context.Background())
+	invoker.SetConfig(&registerTestFocusConfig{
+		AICallerConfigIf: baseConfig,
+		runtime:          registerTestFocusRuntime{target: "https://example.test/authorized"},
+	})
+	caller, err := NewFocusModeYakHookCaller(
+		"runtime.ai-focus.yak",
+		code,
+		focusModeRunCallerOptions(invoker, time.Second)...,
+	)
+	require.NoError(t, err)
+	defer caller.Close()
+	target, err := caller.CallByName("readAuthorizedTarget")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.test/authorized", target)
 }


### PR DESCRIPTION
## 改动摘要

- 增加最小的 run-scoped `FocusRuntime` 接口，使外部发布的 Yak Focus 能调用由运行环境注入的通用能力。
- 在 AI 配置复制链中传播 `FocusRuntime`，保证子运行时仍使用当前会话绑定的能力实例。
- Yak Focus 注册器在 boot 阶段注入空占位，在 run 阶段注入真实 runtime，并支持固定发布名称，阻止脚本通过 `__NAME__` 改写完整性绑定的运行名。
- 为动态 Focus bundle 注册表增加并发保护。

## 分流说明

该 shared-AI 改动最初随 Scan Node PR #4845 合入 `go0p/refactor/scannode`。由于 refactor 基线不会自动把 shared-AI 变更交付到 `main`，本 PR 按跨基线规则从最新 `main` 单独提取同一实现。

本 PR 只包含 `common/ai/aid` 下的通用接口、配置传播和 Yak Focus 注入，不包含 Scan Node、网络执行、结果回传或具体专业场景编排。两个分支中的共享实现保持一致，后续基线协调时删除重复部分。

## 改动文件

- `common/ai/aid/aicommon/focus_runtime.go`
- `common/ai/aid/aicommon/config.go`
- `common/ai/aid/aicommon/config_test.go`
- `common/ai/aid/aireact/reactloops/yak_focus_mode_register.go`
- `common/ai/aid/aireact/reactloops/yak_focus_mode_register_test.go`

## 验证方式

- `go test -run '^$' ./common/ai/aid/aicommon ./common/ai/aid/aireact/reactloops`：通过。
- `go test -run '^TestConfigFocusRuntimeIsRunScoped$' ./common/ai/aid/aicommon`：通过。
- `go test -run '^TestRegisterYakFocusMode_(FixedNameRejectsScriptOverride|InjectsRunScopedFocusRuntime)$' ./common/ai/aid/aireact/reactloops`：通过。
- `git diff --check origin/main...HEAD`：通过。

当前验证等级为 T1；该 PR 只负责 shared-AI 接口，不单独执行 Scan Node 或产品 E2E。
