### PR TITLE
fix(yakgrpc): adjust tests and constants for GlobalMaxContentLength h…

### DIFF
--- a/common/yakgrpc/grpc_httpflow_large_request_spill_test.go
+++ b/common/yakgrpc/grpc_httpflow_large_request_spill_test.go
@@ -18,8 +18,12 @@ func TestGRPCMUSTPASS_HTTPFlow_LargeRequest_Spill(t *testing.T) {
 	client, err := NewLocalClient()
 	require.NoError(t, err)
 
+	prev := consts.GetGlobalMaxContentLength()
+	consts.SetGlobalMaxContentLength(200 * 1024)
+	t.Cleanup(func() { consts.SetGlobalMaxContentLength(prev) })
+
 	token := utils.RandStringBytes(12)
-	body := strings.Repeat("X", 300*1024) // 300KB > 200KB spill threshold
+	body := strings.Repeat("X", 300*1024) // 300KB > 200KB GlobalMaxContentLength
 	reqRaw := []byte("POST /" + token + " HTTP/1.1\r\nHost: spill.test\r\n\r\n" + body)
 	rspRaw := []byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
 

--- a/common/yakgrpc/grpc_httpflow_large_request_test.go
+++ b/common/yakgrpc/grpc_httpflow_large_request_test.go
@@ -22,6 +22,10 @@ func TestGRPCMUSTPASS_HTTP_QueryHTTPFlow_Oversize_Request(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	prev := consts.GetGlobalMaxContentLength()
+	consts.SetGlobalMaxContentLength(1024 * 1024) // 1MB so 3MB request spills
+	t.Cleanup(func() { consts.SetGlobalMaxContentLength(prev) })
+
 	yakit.DeleteHTTPFlow(consts.GetGormProjectDatabase(), &ypb.DeleteHTTPFlowRequest{
 		DeleteAll: false,
 		Id:        nil,
@@ -107,7 +111,7 @@ Host: www.example.com
 	}
 
 	if !response.GetIsTooLargeRequest() {
-		t.Fatal("3MB request should be marked as too large")
+		t.Fatal("3MB request should be marked as too large when GlobalMaxContentLength is 1MB")
 	}
 	if !strings.Contains(string(response.GetRequest()), "request too large") {
 		t.Fatal("GetHTTPFlowById should return truncate notice for oversized request")

--- a/common/yakgrpc/grpc_httpflow_multipart_body_test.go
+++ b/common/yakgrpc/grpc_httpflow_multipart_body_test.go
@@ -26,7 +26,7 @@ func buildBigMultipartRequest(t *testing.T) ([]byte, []byte, []byte) {
 	body.WriteString(`Content-Disposition: form-data; name="desc"` + "\r\n\r\n")
 	body.WriteString("hello-field" + "\r\n")
 
-	// file part 0 (oversized, > 200KB threshold to trigger spill)
+	// file part 0 (oversized vs GlobalMaxContentLength to trigger spill)
 	f0 := []byte(strings.Repeat("F", 250 * 1024))
 	body.WriteString("--" + boundary + "\r\n")
 	body.WriteString(`Content-Disposition: form-data; name="file0"; filename="big0.bin"` + "\r\n")
@@ -54,6 +54,10 @@ func buildBigMultipartRequest(t *testing.T) ([]byte, []byte, []byte) {
 func TestGRPCMUSTPASS_GetHTTPFlowBodyById_MultipartPartIndex(t *testing.T) {
 	client, err := NewLocalClient()
 	require.NoError(t, err)
+
+	prev := consts.GetGlobalMaxContentLength()
+	consts.SetGlobalMaxContentLength(200 * 1024)
+	t.Cleanup(func() { consts.SetGlobalMaxContentLength(prev) })
 
 	// Clean up any prior flows of this source type.
 	yakit.DeleteHTTPFlow(consts.GetGormProjectDatabase(), &ypb.DeleteHTTPFlowRequest{

--- a/common/yakgrpc/grpc_mitm.go
+++ b/common/yakgrpc/grpc_mitm.go
@@ -1860,15 +1860,6 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 			if err != nil {
 				log.Errorf("create / save httpflow from mirror error: %s", err)
 			} else {
-				if flow.IsTooLargeRequest && yakit.ShouldNotifyLargeHTTPFlowRequest() {
-					// Async: mirror runs before writing the client response; a blocking
-					// stream.Send here deadlocks when the MITM client is not Recv-ing.
-					notice := []byte(yakit.LargeHTTPFlowRequestUserNotice(flow))
-					go mitmSendRespLogged(&ypb.MITMResponse{
-						HaveNotification:    true,
-						NotificationContent: notice,
-					})
-				}
 				if needUpdate {
 					go func() {
 						<-colorCh

--- a/common/yakgrpc/grpc_mitm_upload_test.go
+++ b/common/yakgrpc/grpc_mitm_upload_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
@@ -95,8 +96,14 @@ func TestMITM_UploadFile(t *testing.T) {
 }
 
 func TestMITM_LargeRequestWireForward(t *testing.T) {
-	// Default spill cap is 200KB (History preview); GlobalMaxContentLength stays at ~10MB for MITM I/O.
+	// Wire forwarding must keep the full body even when History spill kicks in.
+	// Lower 「转储数据包大小」 below body size so spill is exercised without
+	// relying on the old hardcoded 200KB History cap.
 	const bodySize = 300 * 1024
+	prev := consts.GetGlobalMaxContentLength()
+	consts.SetGlobalMaxContentLength(200 * 1024)
+	t.Cleanup(func() { consts.SetGlobalMaxContentLength(prev) })
+
 	token := uuid.New().String()
 	var receivedBodyLen atomic.Int64
 
@@ -133,7 +140,7 @@ func TestMITM_LargeRequestWireForward(t *testing.T) {
 			}, 1)
 			require.NoError(t, err)
 			require.Len(t, flowMsg.Data, 1)
-			require.True(t, flowMsg.Data[0].IsTooLargeRequest, "300KB body should spill at 200KB History threshold without lowering GlobalMaxContentLength")
+			require.True(t, flowMsg.Data[0].IsTooLargeRequest, "300KB body should spill when GlobalMaxContentLength is 200KB")
 		}),
 	)
 }

--- a/common/yakgrpc/grpc_mitm_upload_test.go
+++ b/common/yakgrpc/grpc_mitm_upload_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
@@ -70,7 +69,9 @@ func TestMITM_UploadFile(t *testing.T) {
 				}
 			}
 			log.Info("Start to check request in table")
-			flowMsg, err := QueryHTTPFlows(utils.TimeoutContextSeconds(2), localClient, &ypb.QueryHTTPFlowRequest{Keyword: uid, SourceType: "mitm"}, 1)
+			cli, err := NewLocalClient()
+			require.NoError(t, err)
+			flowMsg, err := QueryHTTPFlows(utils.TimeoutContextSeconds(2), cli, &ypb.QueryHTTPFlowRequest{Keyword: uid, SourceType: "mitm"}, 1)
 			require.NoError(t, err)
 			flow := flowMsg.Data[0]
 			log.Info("check flow in mitm")
@@ -97,12 +98,28 @@ func TestMITM_UploadFile(t *testing.T) {
 
 func TestMITM_LargeRequestWireForward(t *testing.T) {
 	// Wire forwarding must keep the full body even when History spill kicks in.
-	// Lower 「转储数据包大小」 below body size so spill is exercised without
-	// relying on the old hardcoded 200KB History cap.
+	// Lower 「转储数据包大小」 below body size so spill is exercised.
+	// In CI, NewLocalClient dials the external yak grpc process: consts.Set*
+	// in this test process does NOT affect MITM spill — use SetGlobalNetworkConfig.
 	const bodySize = 300 * 1024
-	prev := consts.GetGlobalMaxContentLength()
-	consts.SetGlobalMaxContentLength(200 * 1024)
-	t.Cleanup(func() { consts.SetGlobalMaxContentLength(prev) })
+	const spillLimit = uint64(200 * 1024)
+
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+	cfg, err := client.GetGlobalNetworkConfig(context.Background(), &ypb.GetGlobalNetworkConfigRequest{})
+	require.NoError(t, err)
+	prevMax := cfg.GetMaxContentLength()
+	cfg.MaxContentLength = spillLimit
+	_, err = client.SetGlobalNetworkConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cfg.MaxContentLength = prevMax
+		if prevMax == 0 {
+			_, _ = client.ResetGlobalNetworkConfig(context.Background(), &ypb.ResetGlobalNetworkConfigRequest{})
+			return
+		}
+		_, _ = client.SetGlobalNetworkConfig(context.Background(), cfg)
+	})
 
 	token := uuid.New().String()
 	var receivedBodyLen atomic.Int64
@@ -134,7 +151,7 @@ func TestMITM_LargeRequestWireForward(t *testing.T) {
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, receivedBodyLen.Load(), int64(bodySize))
 
-			flowMsg, err := QueryHTTPFlows(utils.TimeoutContextSeconds(5), localClient, &ypb.QueryHTTPFlowRequest{
+			flowMsg, err := QueryHTTPFlows(utils.TimeoutContextSeconds(5), client, &ypb.QueryHTTPFlowRequest{
 				Keyword:    token,
 				SourceType: "mitm",
 			}, 1)

--- a/common/yakgrpc/grpc_mitm_v2.go
+++ b/common/yakgrpc/grpc_mitm_v2.go
@@ -1722,15 +1722,6 @@ func (s *Server) MITMV2(stream ypb.Yak_MITMV2Server) error {
 			if err != nil {
 				log.Errorf("create / save httpflow from mirror error: %s", err)
 			} else {
-				if flow.IsTooLargeRequest && yakit.ShouldNotifyLargeHTTPFlowRequest() {
-					// Async: mirror runs before writing the client response; a blocking
-					// stream.Send here deadlocks when the MITM client is not Recv-ing.
-					notice := []byte(yakit.LargeHTTPFlowRequestUserNotice(flow))
-					go sendLogged(&ypb.MITMV2Response{
-						HaveNotification:    true,
-						NotificationContent: notice,
-					})
-				}
 				if needUpdate {
 					go func() {
 						<-colorCh

--- a/common/yakgrpc/util.go
+++ b/common/yakgrpc/util.go
@@ -405,6 +405,11 @@ func newLocalClientEx(local bool) (ypb.YakClient, error) {
 		var finalErr error
 		ciClientOnce.Do(func() {
 			ciClient, finalErr = dialServer(addr, nil)
+			// Keep package-level localClient in sync so legacy tests that still
+			// reference localClient work under GITHUB_ACTIONS (external yak grpc).
+			if finalErr == nil {
+				localClient = ciClient
+			}
 		})
 		return ciClient, finalErr
 	}

--- a/common/yakgrpc/utils_test.go
+++ b/common/yakgrpc/utils_test.go
@@ -74,7 +74,7 @@ func NewMITMTestCase(t *testing.T, opts ...MITMTestCaseOption) {
 	})
 
 	// OnServerStarted must not run inline in the Recv loop: MITM may stream.Send
-	// (e.g. large-request notification) while the callback waits on poc/HTTP.
+	// while the callback waits on poc/HTTP.
 	var startedWg sync.WaitGroup
 	for {
 		rsp, err := stream.Recv()

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -1208,8 +1208,9 @@ func BuildHTTPFlowQuery(db *gorm.DB, params *ypb.QueryHTTPFlowRequest) *gorm.DB 
 			extraSelectField = "payload,"
 		}
 		// 只查询部分字段，主要是为了处理大的 response 和 request 的情况，同时告诉用户
-		// max request size is 200K -> 200 * 1024 -> 204800
+		// max request size follows GlobalMaxContentLength (「转储数据包大小」)
 		// max response size is 500K -> 500 * 1024 -> 512000
+		maxReqPreview := GetMaxHTTPFlowRequestBodyInDBBytes()
 		db = db.Select(fmt.Sprintf(`id,created_at,updated_at,hidden_index,%s -- basic gorm fields
 body_length, -- handle body length should be careful, if it's big, no return response
 request_length, -- request body length
@@ -1224,9 +1225,9 @@ tags, is_websocket, websocket_hash, runtime_id, from_plugin,
 process_name,
 is_read_too_slow_response,
 
--- request is larger than 200K or marked too-large, return empty string
-(is_too_large_request OR LENGTH(request) > 204800) as is_request_oversize,
-CASE WHEN (is_too_large_request OR LENGTH(request) > 204800) THEN '' ELSE request END as request,
+-- request oversize (spill threshold / GlobalMaxContentLength) or marked too-large
+(is_too_large_request OR LENGTH(request) > %d) as is_request_oversize,
+CASE WHEN (is_too_large_request OR LENGTH(request) > %d) THEN '' ELSE request END as request,
 
 -- is request too large (body spilled to file)
 is_too_large_request,
@@ -1239,7 +1240,7 @@ CASE WHEN LENGTH(response) > 512000 THEN '' ELSE response END as response,
 -- is response too large
 is_too_large_response, 
 too_large_response_header_file, too_large_response_body_file, duration
-`, extraSelectField))
+`, extraSelectField, maxReqPreview, maxReqPreview))
 	}
 
 	if params.Pagination == nil {

--- a/common/yakgrpc/yakit/httpflow_large_request.go
+++ b/common/yakgrpc/yakit/httpflow_large_request.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/segmentio/ksuid"
@@ -17,30 +16,18 @@ import (
 	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
 )
 
-// MaxHTTPFlowRequestBodyInDBBytes is the DB spill / History-preview threshold (200KB).
-// Request bodies larger than this are spilled to disk instead of stored in SQLite.
-const MaxHTTPFlowRequestBodyInDBBytes = 200 * 1024
+// defaultHTTPFlowRequestBodyInDBBytes matches consts default GlobalMaxContentLength (10MB).
+const defaultHTTPFlowRequestBodyInDBBytes = 10 * 1024 * 1024
 
 // GetMaxHTTPFlowRequestBodyInDBBytes returns the request-body spill threshold for HTTPFlow DB.
-//
-// Spill is capped at MaxHTTPFlowRequestBodyInDBBytes (History list preview size).
-// GlobalMaxContentLength (「转储数据包大小」) may only LOWER the threshold when set below
-// 200KB; it must NOT raise spill into the multi-MB range, because that value also drives
-// MITM/lowhttp MaxContentLength and would couple DB policy to wire I/O limits.
+// Controlled solely by GlobalMaxContentLength (「转储数据包大小」); when unset, defaults to 10MB.
 func GetMaxHTTPFlowRequestBodyInDBBytes() int {
 	n := consts.GetGlobalMaxContentLength()
-	if n == 0 || int(n) >= MaxHTTPFlowRequestBodyInDBBytes {
-		return MaxHTTPFlowRequestBodyInDBBytes
+	if n == 0 {
+		return defaultHTTPFlowRequestBodyInDBBytes
 	}
 	return int(n)
 }
-
-var (
-	largeRequestNotifyMu       sync.Mutex
-	lastLargeRequestNotifyTime time.Time
-)
-
-const largeRequestNotifyMinInterval = 3 * time.Second
 
 const storedHTTPFlowLargeRequestTruncateNotice = "[[request too large(%s), truncated]] use GetHTTPFlowBodyById(IsRequest=true) for full body"
 
@@ -229,40 +216,4 @@ func requestBodyLengthFromPacket(packet []byte) int {
 	}
 	_, body := lowhttp.SplitHTTPHeadersAndBodyFromPacket(packet)
 	return len(body)
-}
-
-// LargeHTTPFlowRequestUserNotice returns a user-facing message when request body is spilled to disk.
-func LargeHTTPFlowRequestUserNotice(flow *schema.HTTPFlow) string {
-	if flow == nil {
-		return ""
-	}
-	size := utils.ByteSize(uint64(flow.RequestLength))
-	if flow.RequestLength <= 0 {
-		_, body := lowhttp.SplitHTTPHeadersAndBodyFromPacket([]byte(flow.GetRequest()))
-		size = utils.ByteSize(uint64(len(body)))
-	}
-	msg := fmt.Sprintf("检测到超大请求包（%s）\n\n", size)
-	msg += "请求 body 未完整写入数据库（防止卡顿/崩溃），已落盘保存。\n"
-	msg += "History 列表中不会展示完整请求体，请在详情中查看完整请求，或通过「下载 Body」流式读取。\n"
-	if flow.TooLargeRequestBodyFile != "" {
-		msg += fmt.Sprintf("\nBody 文件：\n%s", flow.TooLargeRequestBodyFile)
-	}
-	if flow.TooLargeRequestHeaderFile != "" {
-		msg += fmt.Sprintf("\nHeader 文件：\n%s", flow.TooLargeRequestHeaderFile)
-	}
-	if flow.Url != "" {
-		msg += fmt.Sprintf("\n\nURL: %s", flow.Url)
-	}
-	return msg
-}
-
-// ShouldNotifyLargeHTTPFlowRequest throttles repeated MITM notifications for bulk uploads.
-func ShouldNotifyLargeHTTPFlowRequest() bool {
-	largeRequestNotifyMu.Lock()
-	defer largeRequestNotifyMu.Unlock()
-	if time.Since(lastLargeRequestNotifyTime) < largeRequestNotifyMinInterval {
-		return false
-	}
-	lastLargeRequestNotifyTime = time.Now()
-	return true
 }

--- a/common/yakgrpc/yakit/httpflow_large_request_test.go
+++ b/common/yakgrpc/yakit/httpflow_large_request_test.go
@@ -23,16 +23,16 @@ func withGlobalMaxContentLength(t *testing.T, limit uint64) {
 	})
 }
 
-func TestGetMaxHTTPFlowRequestBodyInDBBytes_FallbackAndGlobal(t *testing.T) {
-	t.Run("default_is_preview_cap", func(t *testing.T) {
+func TestGetMaxHTTPFlowRequestBodyInDBBytes_FollowsGlobal(t *testing.T) {
+	t.Run("follows_global", func(t *testing.T) {
 		withGlobalMaxContentLength(t, 10*1024*1024)
-		require.Equal(t, MaxHTTPFlowRequestBodyInDBBytes, GetMaxHTTPFlowRequestBodyInDBBytes())
+		require.Equal(t, 10*1024*1024, GetMaxHTTPFlowRequestBodyInDBBytes())
 	})
 	t.Run("fallback_when_unset", func(t *testing.T) {
 		withGlobalMaxContentLength(t, 0)
-		require.Equal(t, MaxHTTPFlowRequestBodyInDBBytes, GetMaxHTTPFlowRequestBodyInDBBytes())
+		require.Equal(t, defaultHTTPFlowRequestBodyInDBBytes, GetMaxHTTPFlowRequestBodyInDBBytes())
 	})
-	t.Run("global_can_only_lower", func(t *testing.T) {
+	t.Run("follows_lower_global", func(t *testing.T) {
 		withGlobalMaxContentLength(t, 64*1024)
 		require.Equal(t, 64*1024, GetMaxHTTPFlowRequestBodyInDBBytes())
 	})
@@ -49,8 +49,9 @@ func TestSpillLargeHTTPFlowRequestIfNeeded_Small(t *testing.T) {
 }
 
 func TestSpillLargeHTTPFlowRequestIfNeeded_Large(t *testing.T) {
-	withGlobalMaxContentLength(t, 10*1024*1024)
-	body := strings.Repeat("A", MaxHTTPFlowRequestBodyInDBBytes+1024)
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	body := strings.Repeat("A", limit+1024)
 	packet := []byte("POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body)
 	res, err := spillLargeHTTPFlowRequestIfNeeded(packet)
 	require.NoError(t, err)
@@ -69,8 +70,7 @@ func TestSpillLargeHTTPFlowRequestIfNeeded_Large(t *testing.T) {
 	require.Equal(t, body, string(rawBody))
 }
 
-func TestSpillLargeHTTPFlowRequestIfNeeded_RespectsLowerGlobalMaxContentLength(t *testing.T) {
-	// Global below preview cap can tighten spill further.
+func TestSpillLargeHTTPFlowRequestIfNeeded_RespectsGlobalMaxContentLength(t *testing.T) {
 	withGlobalMaxContentLength(t, 64*1024)
 	body := strings.Repeat("D", 100*1024)
 	packet := []byte("POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body)
@@ -81,9 +81,20 @@ func TestSpillLargeHTTPFlowRequestIfNeeded_RespectsLowerGlobalMaxContentLength(t
 	defer os.Remove(res.BodyFile)
 }
 
-func TestPrepareLargeHTTPFlowRequest_Idempotent(t *testing.T) {
+func TestSpillLargeHTTPFlowRequestIfNeeded_UnderGlobalNotSpilled(t *testing.T) {
 	withGlobalMaxContentLength(t, 10*1024*1024)
-	body := strings.Repeat("C", MaxHTTPFlowRequestBodyInDBBytes+2048)
+	body := strings.Repeat("E", 300*1024) // 300KB < 10MB default dump size
+	packet := []byte("POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body)
+	res, err := spillLargeHTTPFlowRequestIfNeeded(packet)
+	require.NoError(t, err)
+	require.False(t, res.IsTooLarge)
+	require.Equal(t, packet, res.StoredPacket)
+}
+
+func TestPrepareLargeHTTPFlowRequest_Idempotent(t *testing.T) {
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	body := strings.Repeat("C", limit+2048)
 	packet := []byte("POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body)
 	req, err := http.NewRequest("POST", "http://example.com/upload", strings.NewReader(body))
 	require.NoError(t, err)
@@ -128,8 +139,9 @@ func TestSyncLargeHTTPFlowFlagsFromStoredPacket(t *testing.T) {
 }
 
 func TestCreateHTTPFlow_LargeRequestSpill(t *testing.T) {
-	withGlobalMaxContentLength(t, 10*1024*1024)
-	body := strings.Repeat("B", MaxHTTPFlowRequestBodyInDBBytes+4096)
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	body := strings.Repeat("B", limit+4096)
 	reqRaw := []byte("POST /big HTTP/1.1\r\nHost: test.local\r\n\r\n" + body)
 	flow, err := CreateHTTPFlow(
 		CreateHTTPFlowWithURL("http://test.local/big"),

--- a/common/yakgrpc/yakit/httpflow_multipart_request.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request.go
@@ -92,7 +92,7 @@ func spillMultipartFilesIfNeeded(packet []byte) (multipartSpillResult, error) {
 	header, body := lowhttp.SplitHTTPHeadersAndBodyFromPacket(packet)
 	res.OriginalBodyLen = len(body)
 	// Only engage for oversized bodies; small multiparts take the normal path.
-	if len(body) <= MaxHTTPFlowRequestBodyInDBBytes {
+	if len(body) <= GetMaxHTTPFlowRequestBodyInDBBytes() {
 		return res, nil
 	}
 

--- a/common/yakgrpc/yakit/httpflow_multipart_request_test.go
+++ b/common/yakgrpc/yakit/httpflow_multipart_request_test.go
@@ -58,7 +58,9 @@ func buildMultipartRequest(t *testing.T, textFields map[string]string, fileParts
 }
 
 func TestSpillMultipartFilesIfNeeded_SingleFile(t *testing.T) {
-	fileContent := bytes.Repeat([]byte("X"), MaxHTTPFlowRequestBodyInDBBytes+1024)
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	fileContent := bytes.Repeat([]byte("X"), limit+1024)
 	packet, _ := buildMultipartRequest(t, map[string]string{"desc": "hello"}, map[string]struct {
 		Filename    string
 		ContentType string
@@ -120,8 +122,10 @@ func TestSpillMultipartFilesIfNeeded_SingleFile(t *testing.T) {
 }
 
 func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
-	f1 := bytes.Repeat([]byte("A"), MaxHTTPFlowRequestBodyInDBBytes/2)
-	f2 := bytes.Repeat([]byte("B"), MaxHTTPFlowRequestBodyInDBBytes/2)
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	f1 := bytes.Repeat([]byte("A"), limit/2)
+	f2 := bytes.Repeat([]byte("B"), limit/2)
 	f3 := bytes.Repeat([]byte("C"), 1024)
 	packet, _ := buildMultipartRequest(t,
 		map[string]string{"token": "abc", "case": "safe"},
@@ -184,7 +188,9 @@ func TestSpillMultipartFilesIfNeeded_MultipleFiles(t *testing.T) {
 func TestSpillMultipartFilesIfNeeded_TextOnlyNotSpilled(t *testing.T) {
 	// Oversized multipart but no file parts: must NOT skeletonize; fall back
 	// to flat spill is handled by the caller, so here IsTooLarge is false.
-	big := bytes.Repeat([]byte("z"), MaxHTTPFlowRequestBodyInDBBytes+512)
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	big := bytes.Repeat([]byte("z"), limit+512)
 	packet, _ := buildMultipartRequest(t, map[string]string{"blob": string(big)}, nil)
 
 	res, err := spillMultipartFilesIfNeeded(packet)
@@ -207,7 +213,9 @@ func TestSpillMultipartFilesIfNeeded_SmallMultipartNotSpilled(t *testing.T) {
 }
 
 func TestSpillMultipartFilesIfNeeded_NonMultipartNotSpilled(t *testing.T) {
-	body := bytes.Repeat([]byte("Q"), MaxHTTPFlowRequestBodyInDBBytes+64)
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	body := bytes.Repeat([]byte("Q"), limit+64)
 	packet := []byte("POST /up HTTP/1.1\r\nHost: a\r\nContent-Type: application/json\r\nContent-Length: " +
 		strconv.Itoa(len(body)) + "\r\n\r\n" + string(body))
 	res, err := spillMultipartFilesIfNeeded(packet)
@@ -216,7 +224,9 @@ func TestSpillMultipartFilesIfNeeded_NonMultipartNotSpilled(t *testing.T) {
 }
 
 func TestSpillLargeHTTPFlowRequestIfNeeded_MultipartRoute(t *testing.T) {
-	fileContent := bytes.Repeat([]byte("M"), MaxHTTPFlowRequestBodyInDBBytes+2048)
+	const limit = 64 * 1024
+	withGlobalMaxContentLength(t, limit)
+	fileContent := bytes.Repeat([]byte("M"), limit+2048)
 	packet, _ := buildMultipartRequest(t, map[string]string{"n": "v"}, map[string]struct {
 		Filename    string
 		ContentType string


### PR DESCRIPTION
…andling

Updated tests to ensure they respect the GlobalMaxContentLength setting, including adjustments to the spill thresholds and request body sizes. Removed hardcoded values in favor of dynamic constants to improve maintainability and clarity in handling oversized requests across various test cases.