### PR TITLE
Rookie/refactor/midterm memory

### DIFF
--- a/common/ai/aid/aimem/aimemory.go
+++ b/common/ai/aid/aimem/aimemory.go
@@ -66,7 +66,7 @@ func newAIMemory(sessionId string, requireInvoker bool, opts ...Option) (*AIMemo
 
 	// 创建HNSW后端
 	hnswBackendStart := time.Now()
-	hnswBackend, err := NewAIMemoryHNSWBackend(WithHNSWSessionID(sessionId), WithHNSWDatabase(db))
+	hnswBackend, err := NewAIMemoryHNSWBackend(WithHNSWSessionID(sessionId), WithHNSWDatabase(db), WithHNSWMidtermMode(config.midtermArchiveMode))
 	if du := time.Since(hnswBackendStart); du > 500*time.Millisecond {
 		log.Warnf("[AI-Memory(%v)] creating HNSW backend took %v, it's abnormal case.", name, du)
 	}
@@ -86,6 +86,7 @@ func newAIMemory(sessionId string, requireInvoker bool, opts ...Option) (*AIMemo
 		db:                 db,
 		keywordMatcher:     NewKeywordMatcher(), // 初始化关键词匹配器
 		embeddingAvailable: embeddingAvailable,
+		midtermArchiveMode: config.midtermArchiveMode,
 	}
 
 	if requireInvoker && triage.invoker == nil && config.autoReActInvoker {

--- a/common/ai/aid/aimem/aimemory_search_memory.go
+++ b/common/ai/aid/aimem/aimemory_search_memory.go
@@ -215,7 +215,7 @@ func (t *AIMemoryTriage) searchMemoryKeywordOnly(queryText string, tokenLimit in
 		return nil, utils.Errorf("database connection is nil")
 	}
 
-	query := db.Model(&schema.AIMemoryEntity{}).Where("session_id = ?", t.sessionID)
+	query := db.Table(t.entityTableName()).Where("session_id = ?", t.sessionID)
 	query = bizhelper.FuzzSearchEx(query, []string{"content", "tags", "potential_questions"}, queryText, false)
 
 	var dbEntities []schema.AIMemoryEntity

--- a/common/ai/aid/aimem/aimemory_triage_saving.go
+++ b/common/ai/aid/aimem/aimemory_triage_saving.go
@@ -193,7 +193,7 @@ func (t *AIMemoryTriage) checkTagRepetition(entity *aicommon.MemoryEntity, thres
 
 	// 查询所有现有记忆的标签
 	var existingEntities []schema.AIMemoryEntity
-	if err := db.Where("session_id = ?", t.sessionID).Find(&existingEntities).Error; err != nil {
+	if err := db.Table(t.entityTableName()).Where("session_id = ?", t.sessionID).Find(&existingEntities).Error; err != nil {
 		return false, utils.Errorf("failed to query existing entities: %v", err)
 	}
 
@@ -352,7 +352,7 @@ func (t *AIMemoryTriage) findSimilarByTags(entity *aicommon.MemoryEntity, limit 
 	}
 
 	var existingEntities []schema.AIMemoryEntity
-	if err := db.Where("session_id = ? AND memory_id != ?", t.sessionID, entity.Id).
+	if err := db.Table(t.entityTableName()).Where("session_id = ? AND memory_id != ?", t.sessionID, entity.Id).
 		Limit(limit * 2). // 查询更多以便过滤
 		Find(&existingEntities).Error; err != nil {
 		return nil, utils.Errorf("failed to query existing entities: %v", err)
@@ -429,7 +429,7 @@ func (t *AIMemoryTriage) findSimilarByContent(entity *aicommon.MemoryEntity, lim
 		}
 
 		var existing schema.AIMemoryEntity
-		if err := db.Where("memory_id = ? AND session_id = ?", memoryID, t.sessionID).
+		if err := db.Table(t.entityTableName()).Where("memory_id = ? AND session_id = ?", memoryID, t.sessionID).
 			First(&existing).Error; err != nil {
 			continue // 记忆不存在，跳过
 		}

--- a/common/ai/aid/aimem/coordinator_midterm.go
+++ b/common/ai/aid/aimem/coordinator_midterm.go
@@ -20,7 +20,7 @@ func EnsureTimelineMidtermArchiveStore(cfg *aicommon.Config) *AIMemoryTriage {
 		return nil
 	}
 	midtermSessionID := PersistentSessionToMidtermMemorySessionID(persistentSessionID)
-	store, err := NewAIMemoryForQuery(midtermSessionID, WithDatabase(cfg.GetDB()))
+	store, err := NewAIMemoryForQuery(midtermSessionID, WithDatabase(cfg.GetDB()), WithMidtermArchiveMode())
 	if err != nil {
 		log.Warnf("create midterm archive store failed for session %s: %v", persistentSessionID, err)
 		return nil

--- a/common/ai/aid/aimem/hnsw_backend.go
+++ b/common/ai/aid/aimem/hnsw_backend.go
@@ -40,12 +40,16 @@ type AIMemoryHNSWBackend struct {
 
 	// 是否自动保存graph到数据库
 	autoSave bool
+
+	// midtermMode selects independent DB tables for midterm archive storage.
+	midtermMode bool
 }
 
 type HNSWBackendConfig struct {
-	autoSave  bool
-	sessionID string
-	db        *gorm.DB
+	autoSave    bool
+	sessionID   string
+	db          *gorm.DB
+	midtermMode bool
 }
 
 type HNSWOption func(*HNSWBackendConfig)
@@ -65,6 +69,13 @@ func WithHNSWDatabase(db *gorm.DB) HNSWOption {
 func WithHNSWSessionID(sessionID string) HNSWOption {
 	return func(b *HNSWBackendConfig) {
 		b.sessionID = sessionID
+	}
+}
+
+// WithHNSWMidtermMode configures the backend to use independent midterm archive tables.
+func WithHNSWMidtermMode(midtermMode bool) HNSWOption {
+	return func(b *HNSWBackendConfig) {
+		b.midtermMode = midtermMode
 	}
 }
 
@@ -101,8 +112,12 @@ func NewAIMemoryHNSWBackend(options ...HNSWOption) (*AIMemoryHNSWBackend, error)
 	sessionID := config.sessionID
 
 	// 查找或创建collection
+	collectionTable := "ai_memory_collections_v1"
+	if config.midtermMode {
+		collectionTable = "ai_midterm_archive_collections_v1"
+	}
 	var collection schema.AIMemoryCollection
-	err = db.Where("session_id = ?", sessionID).First(&collection).Error
+	err = db.Table(collectionTable).Where("session_id = ?", sessionID).First(&collection).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		// 创建新的collection
 		collection = schema.AIMemoryCollection{
@@ -113,7 +128,7 @@ func NewAIMemoryHNSWBackend(options ...HNSWOption) (*AIMemoryHNSWBackend, error)
 			EfConstruct: 200,
 			Dimension:   7,
 		}
-		if err := db.Create(&collection).Error; err != nil {
+		if err := db.Table(collectionTable).Create(&collection).Error; err != nil {
 			return nil, utils.Errorf("create collection failed: %v", err)
 		}
 	} else if err != nil {
@@ -125,6 +140,7 @@ func NewAIMemoryHNSWBackend(options ...HNSWOption) (*AIMemoryHNSWBackend, error)
 		db:         db,
 		collection: &collection,
 		autoSave:   config.autoSave,
+		midtermMode: config.midtermMode,
 	}
 
 	// 加载或创建HNSW Graph
@@ -181,7 +197,11 @@ func (b *AIMemoryHNSWBackend) loadGraphFromBinary(graphBinary []byte) (*hnsw.Gra
 
 		// 从数据库加载记忆实体
 		var dbEntity schema.AIMemoryEntity
-		if err := b.db.Where("memory_id = ? AND session_id = ?", memoryID, b.sessionID).First(&dbEntity).Error; err != nil {
+		entityTable := "ai_memory_entities_v1"
+		if b.midtermMode {
+			entityTable = "ai_midterm_archive_entities_v1"
+		}
+		if err := b.db.Table(entityTable).Where("memory_id = ? AND session_id = ?", memoryID, b.sessionID).First(&dbEntity).Error; err != nil {
 			return nil, utils.Errorf("load memory entity failed: %v", err)
 		}
 
@@ -240,7 +260,11 @@ func (b *AIMemoryHNSWBackend) SaveGraph() error {
 	// 原子更新数据库 - 使用事务确保原子性
 	return utils.GormTransaction(b.db, func(tx *gorm.DB) error {
 		// 使用Update方法避免主键冲突
-		return tx.Model(&schema.AIMemoryCollection{}).
+		collectionTable := "ai_memory_collections_v1"
+		if b.midtermMode {
+			collectionTable = "ai_midterm_archive_collections_v1"
+		}
+		return tx.Table(collectionTable).
 			Where("session_id = ?", b.sessionID).
 			Update("graph_binary", binaryData).Error
 	})
@@ -384,8 +408,12 @@ func (b *AIMemoryHNSWBackend) Search(queryVector []float32, limit int) ([]Search
 	}
 
 	// 批量查询数据库
+	entityTable := "ai_memory_entities_v1"
+	if b.midtermMode {
+		entityTable = "ai_midterm_archive_entities_v1"
+	}
 	var dbEntities []schema.AIMemoryEntity
-	if err := b.db.Where("memory_id IN (?) AND session_id = ?", memoryIDs, b.sessionID).
+	if err := b.db.Table(entityTable).Where("memory_id IN (?) AND session_id = ?", memoryIDs, b.sessionID).
 		Find(&dbEntities).Error; err != nil {
 		return nil, utils.Errorf("batch query memory entities failed: %v", err)
 	}

--- a/common/ai/aid/aimem/midterm_archive.go
+++ b/common/ai/aid/aimem/midterm_archive.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	midtermSessionPrefix      = "timeline-midterm:"
+	MidtermSessionPrefix     = "timeline-midterm:"
 	midtermMemoryKindTag      = "timeline_midterm"
 	midtermTagArchiveIDPrefix = "archive_id:"
 	midtermTagReasonPrefix    = "reason:"
@@ -56,7 +56,7 @@ func PersistentSessionToMidtermMemorySessionID(sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
-	return midtermSessionPrefix + sessionID
+	return MidtermSessionPrefix + sessionID
 }
 
 func (r *AIMemoryTriage) ArchiveCompressedBatch(ctx context.Context, batch *aicommon.TimelineArchiveBatch) (*aicommon.TimelineArchiveRef, error) {

--- a/common/ai/aid/aimem/midterm_fork.go
+++ b/common/ai/aid/aimem/midterm_fork.go
@@ -77,7 +77,7 @@ func ForkMidtermArchiveStore(parent *AIMemoryTriage, taskIndex, taskName, persis
 		return nil, err
 	}
 
-	branchStore, err := NewAIMemoryForQuery(branchSessionID, WithDatabase(db))
+	branchStore, err := NewAIMemoryForQuery(branchSessionID, WithDatabase(db), WithMidtermArchiveMode())
 	if err != nil {
 		return nil, utils.Errorf("create branch midterm store failed: %v", err)
 	}

--- a/common/ai/aid/aimem/midterm_fork.go
+++ b/common/ai/aid/aimem/midterm_fork.go
@@ -173,7 +173,7 @@ func (f *MidtermMemoryFork) MergeBack() (*MidtermMemoryMergeResult, error) {
 	}
 
 	var branchEntities []schema.AIMemoryEntity
-	if err := db.Where("session_id = ?", f.BranchSessionID).Find(&branchEntities).Error; err != nil {
+	if err := db.Table(f.ParentStore.entityTableName()).Where("session_id = ?", f.BranchSessionID).Find(&branchEntities).Error; err != nil {
 		return nil, utils.Errorf("query branch midterm entities failed: %v", err)
 	}
 
@@ -257,8 +257,10 @@ func cloneAIMemoryCollectionGraph(db *gorm.DB, parentSessionID, branchSessionID 
 	if db == nil {
 		return utils.Error("database connection is nil")
 	}
+	// midterm fork always uses the midterm archive collection table
+	collectionTable := "ai_midterm_archive_collections_v1"
 	var parentCol schema.AIMemoryCollection
-	err := db.Where("session_id = ?", parentSessionID).First(&parentCol).Error
+	err := db.Table(collectionTable).Where("session_id = ?", parentSessionID).First(&parentCol).Error
 	if err == gorm.ErrRecordNotFound {
 		parentCol = schema.AIMemoryCollection{
 			SessionID:   parentSessionID,
@@ -268,7 +270,7 @@ func cloneAIMemoryCollectionGraph(db *gorm.DB, parentSessionID, branchSessionID 
 			EfConstruct: 200,
 			Dimension:   7,
 		}
-		if err := db.Create(&parentCol).Error; err != nil {
+		if err := db.Table(collectionTable).Create(&parentCol).Error; err != nil {
 			return utils.Errorf("create parent midterm collection failed: %v", err)
 		}
 	} else if err != nil {
@@ -289,14 +291,14 @@ func cloneAIMemoryCollectionGraph(db *gorm.DB, parentSessionID, branchSessionID 
 	}
 
 	var existing schema.AIMemoryCollection
-	err = db.Where("session_id = ?", branchSessionID).First(&existing).Error
+	err = db.Table(collectionTable).Where("session_id = ?", branchSessionID).First(&existing).Error
 	switch {
 	case err == gorm.ErrRecordNotFound:
-		return db.Create(&branchCol).Error
+		return db.Table(collectionTable).Create(&branchCol).Error
 	case err != nil:
 		return utils.Errorf("load branch midterm collection failed: %v", err)
 	default:
-		return db.Model(&existing).Updates(map[string]interface{}{
+		return db.Table(collectionTable).Model(&existing).Updates(map[string]interface{}{
 			"graph_binary":  branchCol.GraphBinary,
 			"m":             branchCol.M,
 			"ml":            branchCol.Ml,
@@ -325,7 +327,7 @@ func (r *AIMemoryTriage) adoptForkedMemoryEntity(entity *aicommon.MemoryEntity) 
 	}
 
 	var existing schema.AIMemoryEntity
-	err := db.Where("memory_id = ?", entity.Id).First(&existing).Error
+	err := db.Table(r.entityTableName()).Where("memory_id = ?", entity.Id).First(&existing).Error
 	if err != nil {
 		return utils.Errorf("load fork memory entity failed: %v", err)
 	}
@@ -343,7 +345,7 @@ func (r *AIMemoryTriage) adoptForkedMemoryEntity(entity *aicommon.MemoryEntity) 
 	existing.T_Score = entity.T_Score
 	existing.CorePactVector = schema.FloatArray(entity.CorePactVector)
 
-	if err := db.Save(&existing).Error; err != nil {
+	if err := db.Table(r.entityTableName()).Save(&existing).Error; err != nil {
 		return utils.Errorf("adopt fork memory entity failed: %v", err)
 	}
 

--- a/common/ai/aid/aimem/midterm_fork_test.go
+++ b/common/ai/aid/aimem/midterm_fork_test.go
@@ -11,7 +11,7 @@ import (
 func TestForkMidtermArchiveStore_SharedBaseNodesBranchOnlyWrites(t *testing.T) {
 	db, err := getTestDatabase()
 	require.NoError(t, err)
-	parent, err := NewAIMemoryForQuery("timeline-midterm:test-parent-fork", WithDatabase(db))
+	parent, err := NewAIMemoryForQuery("timeline-midterm:test-parent-fork", WithDatabase(db), WithMidtermArchiveMode())
 	require.NoError(t, err)
 	defer func() {
 		_ = parent.Close()
@@ -66,7 +66,7 @@ func TestForkMidtermArchiveStore_SharedBaseNodesBranchOnlyWrites(t *testing.T) {
 	var row struct {
 		SessionID string
 	}
-	require.NoError(t, parent.GetDB().Table("ai_memory_entities_v1").
+	require.NoError(t, parent.GetDB().Table("ai_midterm_archive_entities_v1").
 		Select("session_id").Where("memory_id = ?", branchEntity.Id).Scan(&row).Error)
 	require.Equal(t, parent.GetSessionID(), row.SessionID)
 }
@@ -74,7 +74,7 @@ func TestForkMidtermArchiveStore_SharedBaseNodesBranchOnlyWrites(t *testing.T) {
 func TestMidtermMemoryFork_SearchIncludesBaseAndBranch(t *testing.T) {
 	db, err := getTestDatabase()
 	require.NoError(t, err)
-	parent, err := NewAIMemoryForQuery("timeline-midterm:test-search-fork", WithDatabase(db))
+	parent, err := NewAIMemoryForQuery("timeline-midterm:test-search-fork", WithDatabase(db), WithMidtermArchiveMode())
 	require.NoError(t, err)
 	defer func() {
 		_ = parent.Close()

--- a/common/ai/aid/aimem/search.go
+++ b/common/ai/aid/aimem/search.go
@@ -95,7 +95,7 @@ func (r *AIMemoryTriage) SearchBySemantics(query string, limit int) ([]*aicommon
 
 		// 从数据库获取完整记忆条目
 		var dbEntity schema.AIMemoryEntity
-		if err := db.Where("memory_id = ? AND session_id = ?", memoryID, r.sessionID).First(&dbEntity).Error; err != nil {
+		if err := db.Table(r.entityTableName()).Where("memory_id = ? AND session_id = ?", memoryID, r.sessionID).First(&dbEntity).Error; err != nil {
 			if err == gorm.ErrRecordNotFound {
 				log.Warnf("memory entity not found in database: %s", memoryID)
 				continue
@@ -136,7 +136,7 @@ func (r *AIMemoryTriage) SearchByScores(filter *aicommon.ScoreFilter, limit int)
 		return nil, utils.Errorf("database connection is nil")
 	}
 
-	query := db.Where("session_id = ?", r.sessionID)
+	query := db.Table(r.entityTableName()).Where("session_id = ?", r.sessionID)
 
 	if filter != nil {
 		if filter.C_Min > 0 || filter.C_Max > 0 {
@@ -289,7 +289,7 @@ func (r *AIMemoryTriage) SearchByTags(tags []string, matchAll bool, limit int) (
 	}
 
 	var dbEntities []schema.AIMemoryEntity
-	if err := db.Where("session_id = ?", r.sessionID).Find(&dbEntities).Error; err != nil {
+	if err := db.Table(r.entityTableName()).Where("session_id = ?", r.sessionID).Find(&dbEntities).Error; err != nil {
 		return nil, utils.Errorf("query memory entities failed: %v", err)
 	}
 

--- a/common/ai/aid/aimem/storage.go
+++ b/common/ai/aid/aimem/storage.go
@@ -61,7 +61,7 @@ func (r *AIMemoryTriage) SaveMemoryEntities(entities ...*aicommon.MemoryEntity) 
 			CorePactVector:     schema.FloatArray(entity.CorePactVector),
 		}
 
-		if err := db.Create(dbEntity).Error; err != nil {
+		if err := db.Table(r.entityTableName()).Create(dbEntity).Error; err != nil {
 			log.Errorf("save memory entity to database failed: %v (entity id=%s)", err, entity.Id)
 			// 记录最后一次 db 错误，继续尝试保存其他 entity。
 			// 关键词: best-effort, 不因单条 db 写入失败丢失整批 memory
@@ -131,7 +131,7 @@ func (r *AIMemoryTriage) GetAllTags() ([]string, error) {
 	}
 
 	var dbEntities []schema.AIMemoryEntity
-	if err := db.Where("session_id = ?", r.sessionID).Find(&dbEntities).Error; err != nil {
+	if err := db.Table(r.entityTableName()).Where("session_id = ?", r.sessionID).Find(&dbEntities).Error; err != nil {
 		return nil, utils.Errorf("query memory entities failed: %v", err)
 	}
 
@@ -181,7 +181,7 @@ func (r *AIMemoryTriage) DeleteMemoryEntity(memoryID string) error {
 	}
 
 	// 从数据库删除
-	if err := db.Where("memory_id = ? AND session_id = ?", memoryID, r.sessionID).
+	if err := db.Table(r.entityTableName()).Where("memory_id = ? AND session_id = ?", memoryID, r.sessionID).
 		Delete(&schema.AIMemoryEntity{}).Error; err != nil {
 		return utils.Errorf("delete memory entity from database failed: %v", err)
 	}
@@ -210,7 +210,7 @@ func (r *AIMemoryTriage) UpdateMemoryEntity(entity *aicommon.MemoryEntity) error
 
 	// 先查询现有实体
 	var existingEntity schema.AIMemoryEntity
-	if err := db.Where("memory_id = ? AND session_id = ?", entity.Id, r.sessionID).
+	if err := db.Table(r.entityTableName()).Where("memory_id = ? AND session_id = ?", entity.Id, r.sessionID).
 		First(&existingEntity).Error; err != nil {
 		return utils.Errorf("find existing memory entity failed: %v", err)
 	}
@@ -229,7 +229,7 @@ func (r *AIMemoryTriage) UpdateMemoryEntity(entity *aicommon.MemoryEntity) error
 	existingEntity.CorePactVector = schema.FloatArray(entity.CorePactVector)
 
 	// 保存更新
-	if err := db.Save(&existingEntity).Error; err != nil {
+	if err := db.Table(r.entityTableName()).Save(&existingEntity).Error; err != nil {
 		return utils.Errorf("update memory entity in database failed: %v", err)
 	}
 
@@ -254,7 +254,7 @@ func (r *AIMemoryTriage) GetMemoryEntity(memoryID string) (*aicommon.MemoryEntit
 	}
 
 	var dbEntity schema.AIMemoryEntity
-	if err := db.Where("memory_id = ? AND session_id = ?", memoryID, r.sessionID).
+	if err := db.Table(r.entityTableName()).Where("memory_id = ? AND session_id = ?", memoryID, r.sessionID).
 		First(&dbEntity).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, utils.Errorf("memory entity not found: %s", memoryID)
@@ -288,7 +288,7 @@ func (r *AIMemoryTriage) ListAllMemories(limit int) ([]*aicommon.MemoryEntity, e
 		return nil, utils.Errorf("database connection is nil")
 	}
 
-	query := db.Where("session_id = ?", r.sessionID).Order("created_at DESC")
+	query := db.Table(r.entityTableName()).Where("session_id = ?", r.sessionID).Order("created_at DESC")
 	if limit > 0 {
 		query = query.Limit(limit)
 	}

--- a/common/ai/aid/aimem/types.go
+++ b/common/ai/aid/aimem/types.go
@@ -23,6 +23,11 @@ type Config struct {
 	// It is intended for trigger/background-only scenarios.
 	autoReActInvoker bool
 	reActOptions     []aicommon.ConfigOption
+
+	// midtermArchiveMode makes this AIMemoryTriage instance use independent DB tables
+	// (ai_midterm_archive_entities_v1 / ai_midterm_archive_collections_v1) instead of
+	// the shared long-term memory tables. Used by timeline midterm archive stores.
+	midtermArchiveMode bool
 }
 
 // Option AIMemoryTriage的配置选项
@@ -48,6 +53,9 @@ type AIMemoryTriage struct {
 
 	// embedding 服务可用标志
 	embeddingAvailable bool
+
+	// midtermArchiveMode makes this instance use independent DB tables for midterm archives.
+	midtermArchiveMode bool
 }
 
 func (a *AIMemoryTriage) SetInvoker(invoker aicommon.AIInvokeRuntime) {
@@ -91,11 +99,38 @@ func WithAutoReActInvoker(opts ...aicommon.ConfigOption) Option {
 	}
 }
 
+// WithMidtermArchiveMode makes the AIMemoryTriage instance use independent DB tables
+// (ai_midterm_archive_entities_v1 / ai_midterm_archive_collections_v1) for midterm
+// archive storage, physically isolating it from normal long-term memory.
+func WithMidtermArchiveMode() Option {
+	return func(config *Config) {
+		config.midtermArchiveMode = true
+	}
+}
+
 func (r *AIMemoryTriage) SafeGetDB() *gorm.DB {
 	if r.db == nil {
 		return consts.GetGormProjectDatabase()
 	}
 	return r.db
+}
+
+// entityTableName returns the DB table name for memory entities, depending on whether
+// this instance is in midterm archive mode.
+func (r *AIMemoryTriage) entityTableName() string {
+	if r.midtermArchiveMode {
+		return "ai_midterm_archive_entities_v1"
+	}
+	return "ai_memory_entities_v1"
+}
+
+// collectionTableName returns the DB table name for HNSW collections, depending on whether
+// this instance is in midterm archive mode.
+func (r *AIMemoryTriage) collectionTableName() string {
+	if r.midtermArchiveMode {
+		return "ai_midterm_archive_collections_v1"
+	}
+	return "ai_memory_collections_v1"
 }
 
 func (r *AIMemoryTriage) GetDB() *gorm.DB {

--- a/common/ai/aid/aimem/vector_cleanup.go
+++ b/common/ai/aid/aimem/vector_cleanup.go
@@ -122,10 +122,13 @@ func getOrCreateHNSWBackend(cache map[string]*AIMemoryHNSWBackend, db *gorm.DB, 
 	if backend := cache[sessionID]; backend != nil {
 		return backend, nil
 	}
+	// Midterm archive sessions use independent HNSW collection tables.
+	midtermMode := strings.HasPrefix(sessionID, MidtermSessionPrefix)
 	backend, err := NewAIMemoryHNSWBackend(
 		WithHNSWSessionID(sessionID),
 		WithHNSWDatabase(db),
 		WithHNSWAutoSave(false),
+		WithHNSWMidtermMode(midtermMode),
 	)
 	if err != nil {
 		return nil, err

--- a/common/ai/aid/aireact/midterm_context_provider.go
+++ b/common/ai/aid/aireact/midterm_context_provider.go
@@ -23,44 +23,68 @@ type midtermTimelineSearchQuery struct {
 	DisableSemanticSearch bool
 }
 
-func buildTimelineDumpWithMidtermMemory(react *ReAct, timeline *aicommon.Timeline) string {
-	baseTimeline := ""
-	if timeline != nil {
-		baseTimeline = timeline.DumpForPrompt()
+// ConsumeAndSearchMidtermMemory consumes any pending perception-snapshot-based
+// midterm recall queries, searches the timeline archive store, and returns the
+// rendered content string. This is the single entry point that the ReActLoop
+// layer calls (via the midtermMemoryProvider interface) to refresh midterm
+// memory — it replaces the old timeline-injection path.
+//
+// The method is safe to call concurrently: consumePendingMidtermTimelineQueries
+// is mutex-guarded and "consume once" semantics prevent duplicate searches.
+func (r *ReAct) ConsumeAndSearchMidtermMemory() string {
+	if r == nil {
+		return ""
 	}
-	queries := react.consumePendingMidtermTimelineQueries()
+	queries := r.consumePendingMidtermTimelineQueries()
 	if len(queries) == 0 {
-		return baseTimeline
+		return ""
 	}
-
-	midtermPrefix, err := buildMidtermTimelinePrefix(react, queries)
-	if err != nil {
-		return baseTimeline
-	}
-	if midtermPrefix == "" {
-		return baseTimeline
-	}
-	if strings.TrimSpace(baseTimeline) == "" {
-		return "timeline:\n" + midtermPrefix
-	}
-	body := strings.TrimPrefix(baseTimeline, "timeline:\n")
-	return "timeline:\n" + midtermPrefix + body
+	return r.searchAndRenderMidtermMemory(queries)
 }
 
-func prependMidtermTimelinePrefixForPrompt(react *ReAct, openBody string) string {
-	queries := react.consumePendingMidtermTimelineQueries()
-	if len(queries) == 0 {
-		return openBody
+// searchAndRenderMidtermMemory runs the given queries against the archive store
+// and renders the results into a single content string suitable for injection
+// into the prompt's InjectedMemory block.
+func (r *ReAct) searchAndRenderMidtermMemory(queries []midtermTimelineSearchQuery) string {
+	if r == nil || r.config == nil || r.config.TimelineArchiveStore == nil {
+		return ""
 	}
 
-	midtermPrefix, err := buildMidtermTimelinePrefix(react, queries)
-	if err != nil || midtermPrefix == "" {
-		return openBody
+	queries = deduplicateMidtermSearchQueries(queries)
+	if len(queries) == 0 {
+		return ""
 	}
-	if strings.TrimSpace(openBody) == "" {
-		return "timeline:\n" + midtermPrefix
+
+	result, err := searchMidtermTimelineQueries(r, queries)
+	if err != nil {
+		log.Debugf("midterm memory search failed: queries=%d err=%v", len(queries), err)
+		return ""
 	}
-	return "timeline:\n" + midtermPrefix + openBody
+	if result == nil || strings.TrimSpace(result.TotalContent) == "" {
+		return ""
+	}
+
+	var buf strings.Builder
+	nowStr := time.Now().Format(utils.DefaultTimeFormat3)
+	buf.WriteString(fmt.Sprintf("--[%s] midterm-memory:\n", nowStr))
+	if len(queries) == 1 {
+		buf.WriteString(fmt.Sprintf("     search-query: %s\n", utils.ShrinkString(queries[0].Query, 240)))
+	} else {
+		buf.WriteString("     search-queries:\n")
+		for _, query := range queries {
+			buf.WriteString(fmt.Sprintf("       - %s\n", utils.ShrinkString(query.Query, 240)))
+		}
+	}
+	for _, line := range utils.ParseStringToRawLines(strings.TrimSpace(result.TotalContent)) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		buf.WriteString("     ")
+		buf.WriteString(line)
+		buf.WriteString("\n")
+	}
+	return strings.TrimSpace(buf.String())
 }
 
 func (r *ReAct) ScheduleMidtermTimelineRecall(summary string) {
@@ -143,81 +167,6 @@ func buildMidtermRecallQueries(snapshot *midtermPerceptionSnapshot) []midtermTim
 		appendQuery(keyword, true)
 	}
 	return result
-}
-
-func buildMidtermTimelinePrefix(react *ReAct, queries []midtermTimelineSearchQuery) (string, error) {
-	if react == nil || react.config == nil || react.config.TimelineArchiveStore == nil {
-		return "", nil
-	}
-
-	queries = deduplicateMidtermSearchQueries(queries)
-	if len(queries) == 0 {
-		return "", nil
-	}
-
-	result, err := searchMidtermTimelineQueries(react, queries)
-	if err != nil {
-		return "", err
-	}
-	if result == nil || strings.TrimSpace(result.TotalContent) == "" {
-		return "", nil
-	}
-
-	var buf strings.Builder
-	nowStr := time.Now().Format(utils.DefaultTimeFormat3)
-	buf.WriteString(fmt.Sprintf("--[%s] midterm-memory:\n", nowStr))
-	if len(queries) == 1 {
-		buf.WriteString(fmt.Sprintf("     search-query: %s\n", utils.ShrinkString(queries[0].Query, 240)))
-	} else {
-		buf.WriteString("     search-queries:\n")
-		for _, query := range queries {
-			buf.WriteString(fmt.Sprintf("       - %s\n", utils.ShrinkString(query.Query, 240)))
-		}
-	}
-	for _, line := range utils.ParseStringToRawLines(strings.TrimSpace(result.TotalContent)) {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		buf.WriteString("     ")
-		buf.WriteString(line)
-		buf.WriteString("\n")
-	}
-	return buf.String(), nil
-}
-
-func buildMidtermRecallQuery(react *ReAct) string {
-	return strings.Join(buildMidtermRecallQueryParts(react), " ")
-}
-
-func buildMidtermRecallQueryParts(react *ReAct) []string {
-	if react == nil {
-		return nil
-	}
-
-	parts := make([]string, 0, 12)
-	if task := react.GetCurrentTask(); task != nil {
-		parts = append(parts,
-			// task.GetIndex(),
-			task.GetName(),
-			task.GetOriginUserInput(),
-			// task.GetUserInput(),
-			// task.GetSummary(),
-		)
-		parts = append(parts, task.GetUserInput())
-		if info := task.GetTaskRetrievalInfo(); info != nil {
-			parts = append(parts, info.Target)
-			parts = append(parts, info.Questions...)
-			parts = append(parts, info.Tags...)
-		}
-	}
-
-	history := react.config.GetUserInputHistory()
-	if n := len(history); n > 0 {
-		parts = append(parts, history[n-1].UserInput)
-	}
-
-	return deduplicateMidtermQueryParts(parts)
 }
 
 func searchMidtermTimelineQueries(react *ReAct, queries []midtermTimelineSearchQuery) (finalResult *aicommon.TimelineArchiveSearchResult, finalErr error) {

--- a/common/ai/aid/aireact/midterm_context_provider_test.go
+++ b/common/ai/aid/aireact/midterm_context_provider_test.go
@@ -2,14 +2,11 @@ package aireact
 
 import (
 	"context"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	aicommonmock "github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
-	"github.com/yaklang/yaklang/common/schema"
 )
 
 type mockMidtermArchiveStore struct {
@@ -59,49 +56,25 @@ func newMidtermQueryTestTask(id, index, name, userInput, origin, summary string,
 	return task
 }
 
-func TestBuildMidtermRecallQuery_IncludesCurrentTaskDetails(t *testing.T) {
+func TestConsumeAndSearchMidtermMemory_NoPendingSnapshot(t *testing.T) {
 	cfg := aicommon.NewConfig(context.Background())
-	cfg.SetUserInputHistory([]schema.AIAgentUserInputRecord{{
-		Round:     1,
-		Timestamp: time.Now(),
-		UserInput: "session level request",
-	}})
+	cfg.TimelineArchiveStore = &mockMidtermArchiveStore{}
 
 	react := &ReAct{config: cfg}
 	react.setCurrentTask(newMidtermQueryTestTask(
-		"task-1",
-		"1-2",
-		"verify http flow",
+		"task-1", "1-2", "verify http flow",
 		"focus on malformed headers",
 		"collect and verify malformed header behavior",
 		"need reproduce with retry",
-		&aicommon.AITaskRetrievalInfo{
-			Target:    "http fuzz regression",
-			Questions: []string{"which malformed headers failed"},
-			Tags:      []string{"http", "fuzz"},
-		},
+		nil,
 	))
 
-	query := buildMidtermRecallQuery(react)
-
-	for _, expected := range []string{
-		"verify http flow",
-		"collect and verify malformed header behavior",
-		"focus on malformed headers",
-		"http fuzz regression",
-		"which malformed headers failed",
-		"http",
-		"fuzz",
-		"session level request",
-	} {
-		if !strings.Contains(query, expected) {
-			t.Fatalf("expected query to contain %q, got: %s", expected, query)
-		}
-	}
+	// No pending perception snapshot → empty result, no searches.
+	result := react.ConsumeAndSearchMidtermMemory()
+	require.Empty(t, result)
 }
 
-func TestBuildTimelineDumpWithMidtermMemory_UsesPendingPerceptionSummaryOnce(t *testing.T) {
-	cfg := aicommon.NewConfig(context.Background())
+func TestConsumeAndSearchMidtermMemory_UsesPendingPerceptionSnapshot(t *testing.T) {
 	store := &mockMidtermArchiveStore{
 		results: map[string]*aicommon.TimelineArchiveSearchResult{
 			"perception summary about malformed headers": {
@@ -118,47 +91,38 @@ func TestBuildTimelineDumpWithMidtermMemory_UsesPendingPerceptionSummaryOnce(t *
 			},
 		},
 	}
+	cfg := aicommon.NewConfig(context.Background())
 	cfg.TimelineArchiveStore = store
-
-	timeline := aicommon.NewTimeline(nil, nil)
-	timeline.PushText(1, "live timeline item")
-	cfg.Timeline = timeline
 
 	react := &ReAct{config: cfg}
 	react.setCurrentTask(newMidtermQueryTestTask(
-		"task-1",
-		"1-2",
-		"verify http flow",
+		"task-1", "1-2", "verify http flow",
 		"focus on malformed headers",
 		"collect and verify malformed header behavior",
 		"need reproduce with retry",
 		nil,
 	))
 
-	dumpWithoutPerception := buildTimelineDumpWithMidtermMemory(react, timeline)
-	require.Equal(t, timeline.Dump(), dumpWithoutPerception)
-	require.Empty(t, store.queries)
+	// Before scheduling: empty.
+	require.Empty(t, react.ConsumeAndSearchMidtermMemory())
 
 	react.ScheduleMidtermTimelineRecallFromPerception(
 		"perception summary about malformed headers",
 		[]string{"http fuzzing", "malformed headers"},
 		[]string{"header", "malformed"},
 	)
-	dump := buildTimelineDumpWithMidtermMemory(react, timeline)
+	result := react.ConsumeAndSearchMidtermMemory()
 
-	require.True(t, strings.HasPrefix(dump, "timeline:\n--["))
-	require.Contains(t, dump, "midterm-memory:")
-	require.Contains(t, dump, "search-queries:")
-	require.Contains(t, dump, "perception summary about malformed headers")
-	require.Contains(t, dump, "http fuzzing malformed headers")
-	require.Contains(t, dump, "header")
-	require.Contains(t, dump, "malformed")
-	require.Contains(t, dump, "topic based memory")
-	require.Contains(t, dump, "keyword based memory from header")
-	require.Contains(t, dump, "keyword based memory from malformed")
-	require.Contains(t, dump, "important archived clue")
-	require.Contains(t, dump, "live timeline item")
-	require.Less(t, strings.Index(dump, "midterm-memory:"), strings.Index(dump, "live timeline item"))
+	require.Contains(t, result, "midterm-memory:")
+	require.Contains(t, result, "search-queries:")
+	require.Contains(t, result, "perception summary about malformed headers")
+	require.Contains(t, result, "http fuzzing malformed headers")
+	require.Contains(t, result, "header")
+	require.Contains(t, result, "malformed")
+	require.Contains(t, result, "topic based memory")
+	require.Contains(t, result, "keyword based memory from header")
+	require.Contains(t, result, "keyword based memory from malformed")
+	require.Contains(t, result, "important archived clue")
 	require.Equal(t, []string{
 		"perception summary about malformed headers",
 		"http fuzzing malformed headers",
@@ -171,86 +135,53 @@ func TestBuildTimelineDumpWithMidtermMemory_UsesPendingPerceptionSummaryOnce(t *
 	require.True(t, store.searchQueries[2].DisableSemanticSearch)
 	require.True(t, store.searchQueries[3].DisableSemanticSearch)
 
-	dumpAfterConsumption := buildTimelineDumpWithMidtermMemory(react, timeline)
-	require.Equal(t, timeline.Dump(), dumpAfterConsumption)
+	// Consume-once: second call returns empty.
+	require.Empty(t, react.ConsumeAndSearchMidtermMemory())
 	require.Len(t, store.queries, 4)
 }
 
-func TestBuildMidtermTimelinePrefix_UsesPerceptionQueries(t *testing.T) {
+func TestConsumeAndSearchMidtermMemory_NoArchiveStore(t *testing.T) {
+	cfg := aicommon.NewConfig(context.Background())
+	// No TimelineArchiveStore set.
+
+	react := &ReAct{config: cfg}
+	react.ScheduleMidtermTimelineRecallFromPerception("summary", nil, nil)
+	result := react.ConsumeAndSearchMidtermMemory()
+	require.Empty(t, result)
+}
+
+func TestConsumeAndSearchMidtermMemory_EmptySnapshot(t *testing.T) {
+	cfg := aicommon.NewConfig(context.Background())
+	cfg.TimelineArchiveStore = &mockMidtermArchiveStore{}
+
+	react := &ReAct{config: cfg}
+	// All empty → pending flag cleared, no search.
+	react.ScheduleMidtermTimelineRecallFromPerception("", nil, nil)
+	require.Empty(t, react.ConsumeAndSearchMidtermMemory())
+}
+
+func TestScheduleMidtermTimelineRecallFromPerception_DeduplicatesTopicsAndKeywords(t *testing.T) {
+	cfg := aicommon.NewConfig(context.Background())
 	store := &mockMidtermArchiveStore{
 		results: map[string]*aicommon.TimelineArchiveSearchResult{
-			"perception summary about malformed headers": {
-				ArchiveRefs:  []*aicommon.TimelineArchiveRef{{ArchiveID: "archive-1"}},
-				TotalContent: "memory from perception summary",
-				SelectedMemory: []*aicommon.MemoryEntity{{
-					Id:      "memory-1",
-					Content: "memory from perception summary",
-				}},
-			},
-			"http fuzzing malformed headers": {
-				ArchiveRefs:  []*aicommon.TimelineArchiveRef{{ArchiveID: "archive-2"}},
-				TotalContent: "memory from topics",
-				SelectedMemory: []*aicommon.MemoryEntity{{
-					Id:      "memory-2",
-					Content: "memory from topics",
-				}},
-			},
-			"header": {
-				ArchiveRefs:  []*aicommon.TimelineArchiveRef{{ArchiveID: "archive-3"}},
-				TotalContent: "memory from keyword header",
-				SelectedMemory: []*aicommon.MemoryEntity{{
-					Id:      "memory-3",
-					Content: "memory from keyword header",
-				}},
-			},
-			"malformed": {
-				ArchiveRefs:  []*aicommon.TimelineArchiveRef{{ArchiveID: "archive-4"}},
-				TotalContent: "memory from keyword malformed",
-				SelectedMemory: []*aicommon.MemoryEntity{{
-					Id:      "memory-4",
-					Content: "memory from keyword malformed",
-				}},
-			},
+			"summary":       {TotalContent: "summary memory"},
+			"topic1 topic2": {TotalContent: "topic memory"},
+			"keyword1":      {TotalContent: "keyword1 memory"},
 		},
 	}
-
-	cfg := aicommon.NewConfig(context.Background())
 	cfg.TimelineArchiveStore = store
 
 	react := &ReAct{config: cfg}
-	react.setCurrentTask(newMidtermQueryTestTask(
-		"task-1",
-		"",
-		"verify http flow",
-		"",
-		"collect and verify malformed header behavior",
-		"",
-		nil,
-	))
+	react.ScheduleMidtermTimelineRecallFromPerception(
+		"summary",
+		[]string{"topic1", "topic2", "topic1"}, // dedup
+		[]string{"keyword1", "keyword1"},       // dedup
+	)
+	result := react.ConsumeAndSearchMidtermMemory()
 
-	prefix, err := buildMidtermTimelinePrefix(react, []midtermTimelineSearchQuery{
-		{Query: "perception summary about malformed headers"},
-		{Query: "http fuzzing malformed headers"},
-		{Query: "header", DisableSemanticSearch: true},
-		{Query: "malformed", DisableSemanticSearch: true},
-	})
-	require.NoError(t, err)
-	require.Contains(t, prefix, "search-queries:")
-	require.Contains(t, prefix, "perception summary about malformed headers")
-	require.Contains(t, prefix, "http fuzzing malformed headers")
-	require.Contains(t, prefix, "header")
-	require.Contains(t, prefix, "malformed")
-	require.Contains(t, prefix, "memory from perception summary")
-	require.Contains(t, prefix, "memory from topics")
-	require.Contains(t, prefix, "memory from keyword header")
-	require.Contains(t, prefix, "memory from keyword malformed")
-	require.Equal(t, []string{
-		"perception summary about malformed headers",
-		"http fuzzing malformed headers",
-		"header",
-		"malformed",
-	}, store.queries)
-	require.Len(t, store.searchQueries, 4)
-	require.True(t, store.searchQueries[2].DisableSemanticSearch)
-	require.True(t, store.searchQueries[3].DisableSemanticSearch)
+	require.Contains(t, result, "summary memory")
+	require.Contains(t, result, "topic memory")
+	require.Contains(t, result, "keyword1 memory")
+	// topic1 appears only once in "topic1 topic2" query
+	require.Equal(t, []string{"summary", "topic1 topic2", "keyword1"}, store.queries)
 }

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -95,10 +95,10 @@ func (pm *PromptManager) GetLoopPromptBaseMaterials(tools []*aitool.Tool, nonce 
 	materials.UserHistory = pm.UserHistoryContextWithNonce(nonce)
 
 	// Timeline frozen/open 与 Session Artifacts frozen/open 必须共享同一轮
-	// FrozenTimeUnix；midterm recall 是 turn 级 open prefix，在统一切分之后追加。
-	// 关键词: BuildPromptFrozenOpenMaterials, artifacts frozen time, midterm open
+	// FrozenTimeUnix；midterm memory 现在随 InjectedMemory 在 dynamic 段底部
+	// 拼接，不再注入 timeline-open 段。
+	// 关键词: BuildPromptFrozenOpenMaterials, artifacts frozen time
 	frozenOpen := aicommon.BuildPromptFrozenOpenMaterials(pm.react.config, nonce)
-	frozenOpen.TimelineOpen = prependMidtermTimelinePrefixForPrompt(pm.react, frozenOpen.TimelineOpen)
 	materials.PromptFrozenOpenMaterials = frozenOpen
 
 	allowPlanAndExec := pm.react.config.GetEnablePlanAndExec() && pm.react.GetCurrentPlanExecutionTask() == nil

--- a/common/ai/aid/aireact/prompts.go
+++ b/common/ai/aid/aireact/prompts.go
@@ -654,7 +654,9 @@ func (pm *PromptManager) timelineDumpForPrompt() string {
 	if timeline == nil {
 		return ""
 	}
-	return buildTimelineDumpWithMidtermMemory(pm.react, timeline)
+	// Midterm archive memory is now appended to InjectedMemory in the dynamic
+	// section, no longer prepended to the timeline dump.
+	return timeline.DumpForPrompt()
 }
 
 // DynamicContext returns the concatenation of auto (provider) context and user

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -264,7 +264,7 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 
 	if cfg.TimelineArchiveStore == nil && strings.TrimSpace(cfg.PersistentSessionId) != "" {
 		midtermSessionID := aimem.PersistentSessionToMidtermMemorySessionID(cfg.PersistentSessionId)
-		midtermStore, err := aimem.NewAIMemoryForQuery(midtermSessionID, aimem.WithDatabase(cfg.GetDB()))
+		midtermStore, err := aimem.NewAIMemoryForQuery(midtermSessionID, aimem.WithDatabase(cfg.GetDB()), aimem.WithMidtermArchiveMode())
 		if err != nil {
 			log.Warnf("create timeline archive store failed for session %s: %v", cfg.PersistentSessionId, err)
 		} else {

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -857,6 +857,12 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 		r.fastLoadSearchMemoryWithoutAI(task.GetUserInput())
 	}
 
+	// When regular memory is updated, also refresh midterm archive memory in
+	// parallel. Both fire at the same trigger point; midterm queries are based
+	// on the perception snapshot, consumed from the invoker.
+	r.refreshMidtermMemoryAsync()
+
+
 	go func() {
 		if !utils.IsNil(r.memoryTriage) {
 			log.Info("start to handle searching memory for ReActLoop with AI")

--- a/common/ai/aid/aireact/reactloops/memory_update.go
+++ b/common/ai/aid/aireact/reactloops/memory_update.go
@@ -20,6 +20,10 @@ func (r *ReActLoop) PushMemory(result *aicommon.SearchMemoryResult) {
 	if utils.IsNil(result) {
 		return
 	}
+	// When regular memory is updated, also refresh midterm archive memory in
+	// parallel. Both fire at the same trigger point; midterm queries are based
+	// on the perception snapshot, consumed from the invoker.
+	r.refreshMidtermMemoryAsync()
 	mems := result.Memories
 	for _, m := range mems {
 		//log.Infof("start to handle memory content bytes: %v", utils.ShrinkString(m.Content, 256))

--- a/common/ai/aid/aireact/reactloops/midterm_memory.go
+++ b/common/ai/aid/aireact/reactloops/midterm_memory.go
@@ -1,0 +1,97 @@
+package reactloops
+
+import (
+	"strings"
+
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// midtermMemoryProvider is implemented by the invoker (typically *aireact.ReAct)
+// to consume pending perception-snapshot-based midterm recall queries and
+// return the rendered content. This interface bridges the reactloops → aireact
+// boundary without a circular import.
+type midtermMemoryProvider interface {
+	ConsumeAndSearchMidtermMemory() string
+}
+
+// refreshMidtermMemoryAsync loads midterm archive content asynchronously,
+// mirroring how regular memory is loaded via a goroutine. It consumes the
+// pending perception snapshot (summary + topics + keywords) to build search
+// queries — exactly the same basis that regular memory uses for its search.
+//
+// It skips launching a new search if one is already in flight, avoiding
+// concurrent duplicate searches from stacking up.
+func (r *ReActLoop) refreshMidtermMemoryAsync() {
+	if r == nil {
+		return
+	}
+	r.midtermMemoryMu.Lock()
+	if r.midtermMemorySearchInFlight {
+		r.midtermMemoryMu.Unlock()
+		return
+	}
+	r.midtermMemorySearchInFlight = true
+	r.midtermMemoryMu.Unlock()
+
+	go func() {
+		defer func() {
+			r.midtermMemoryMu.Lock()
+			r.midtermMemorySearchInFlight = false
+			r.midtermMemoryMu.Unlock()
+		}()
+		r.refreshMidtermMemory()
+	}()
+}
+
+// refreshMidtermMemory consumes the pending perception snapshot from the
+// invoker and stores the rendered midterm archive content on the loop, so it
+// can be appended to InjectedMemory at prompt-build time — exactly like
+// regular memory.
+func (r *ReActLoop) refreshMidtermMemory() {
+	if r == nil {
+		return
+	}
+	invoker := r.GetInvoker()
+	if utils.IsNil(invoker) {
+		return
+	}
+	provider, ok := invoker.(midtermMemoryProvider)
+	if !ok {
+		return
+	}
+
+	content := provider.ConsumeAndSearchMidtermMemory()
+	r.midtermMemoryMu.Lock()
+	r.currentMidtermMemory = content
+	r.midtermMemoryMu.Unlock()
+
+	if strings.TrimSpace(content) != "" {
+		log.Debugf("midterm memory refreshed for loop: %d bytes", len(content))
+	}
+}
+
+// GetCurrentMidtermMemory returns the cached midterm archive content.
+func (r *ReActLoop) GetCurrentMidtermMemory() string {
+	if r == nil {
+		return ""
+	}
+	r.midtermMemoryMu.Lock()
+	defer r.midtermMemoryMu.Unlock()
+	return r.currentMidtermMemory
+}
+
+// appendMidtermToMemory appends midterm archive content to the regular memory
+// string so that both are rendered in the dynamic section's InjectedMemory block,
+// at the bottom of the prompt — exactly like regular memory.
+func appendMidtermToMemory(memory, midterm string) string {
+	memory = strings.TrimSpace(memory)
+	midterm = strings.TrimSpace(midterm)
+	if midterm == "" {
+		return memory
+	}
+	if memory == "" {
+		return midterm
+	}
+	return memory + "\n" + midterm
+}

--- a/common/ai/aid/aireact/reactloops/prompt.go
+++ b/common/ai/aid/aireact/reactloops/prompt.go
@@ -265,7 +265,7 @@ func (r *ReActLoop) generateLoopPrompt(
 		ExtraCapabilities: extraCapabilities,
 		TodoSnapshot:      todoSnapshot,
 		ReactiveData:      reactiveData,
-		InjectedMemory:    memory,
+		InjectedMemory:    appendMidtermToMemory(memory, r.GetCurrentMidtermMemory()),
 		TodoCheckpoint:    todoCheckpoint,
 	})
 	if err != nil {

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -102,6 +102,13 @@ type ReActLoop struct {
 	currentMemories *omap.OrderedMap[string, *aicommon.MemoryEntity]
 	memoryTriage    aicommon.MemoryTriage
 
+	// midterm archive memory: loaded/updated alongside regular memory,
+	// rendered together with InjectedMemory in the dynamic section.
+	currentMidtermMemory string
+	midtermMemoryMu      sync.Mutex
+
+	midtermMemorySearchInFlight bool
+
 	// task status control
 	onTaskCreated         func(task aicommon.AIStatefulTask)
 	onAsyncTaskFinished   func(task aicommon.AIStatefulTask)
@@ -568,6 +575,7 @@ func NewReActLoop(name string, invoker aicommon.AIInvokeRuntime, options ...ReAc
 		taskMutex:                    new(sync.Mutex),
 		currentMemories:              omap.NewEmptyOrderedMap[string, *aicommon.MemoryEntity](),
 		memorySizeLimit:              10 * 1024,
+		currentMidtermMemory:         "",
 		historySatisfactionReasons:   make([]*SatisfactionRecord, 0),
 		actionHistory:                make([]*ActionRecord, 0),
 		actionHistoryMutex:           new(sync.Mutex),

--- a/common/schema/ai_midterm_archive.go
+++ b/common/schema/ai_midterm_archive.go
@@ -1,0 +1,23 @@
+package schema
+
+// AIMidtermArchiveEntity 与 AIMemoryEntity 字段完全一致，仅 TableName 不同。
+// 用于中期记忆（timeline midterm archive）的物理隔离存储，避免与普通长期记忆混表。
+type AIMidtermArchiveEntity struct {
+	AIMemoryEntity
+}
+
+// TableName 覆盖为独立的中期记忆表
+func (a *AIMidtermArchiveEntity) TableName() string {
+	return "ai_midterm_archive_entities_v1"
+}
+
+// AIMidtermArchiveCollection 与 AIMemoryCollection 字段完全一致，仅 TableName 不同。
+// 用于中期记忆 HNSW 索引的物理隔离存储。
+type AIMidtermArchiveCollection struct {
+	AIMemoryCollection
+}
+
+// TableName 覆盖为独立的中期记忆 HNSW collection 表
+func (a *AIMidtermArchiveCollection) TableName() string {
+	return "ai_midterm_archive_collections_v1"
+}

--- a/common/schema/database_schema.go
+++ b/common/schema/database_schema.go
@@ -143,6 +143,8 @@ var ProjectTables = []interface{}{
 	&AiProcessAndAiEvent{},
 	&AIMemoryEntity{},
 	&AIMemoryCollection{},
+	&AIMidtermArchiveEntity{},
+	&AIMidtermArchiveCollection{},
 
 	// project level vector collection
 	&VectorStoreCollection{},

--- a/common/yakgrpc/aisessioncleanup/session_cleanup.go
+++ b/common/yakgrpc/aisessioncleanup/session_cleanup.go
@@ -161,6 +161,17 @@ func DeleteAllSessionArtifacts(db *gorm.DB) (*SessionCleanupResult, error) {
 	} else {
 		result.DeletedMemoryCollections = n
 	}
+	// Also clean up the independent midterm archive tables
+	if n, err := hardDeleteAll(db, &schema.AIMidtermArchiveEntity{}); err != nil {
+		return result, err
+	} else {
+		result.DeletedMemoryEntities += n
+	}
+	if n, err := hardDeleteAll(db, &schema.AIMidtermArchiveCollection{}); err != nil {
+		return result, err
+	} else {
+		result.DeletedMemoryCollections += n
+	}
 
 	log.Infof(
 		"deleted all session artifacts: memory_entities=%d memory_collections=%d rag_collections=%d rag_documents=%d entity_repositories=%d entity_relationships=%d er_model_entities=%d knowledge_bases=%d knowledge_entries=%d",
@@ -214,17 +225,41 @@ func pluckRAGArtifactNames(db *gorm.DB, model interface{}, column, likePattern s
 }
 
 func deleteMemoryEntitiesForSession(db *gorm.DB, persistentSessionID string) (int64, error) {
-	return hardDeleteWhere(db, &schema.AIMemoryEntity{},
+	n1, err := hardDeleteWhere(db, &schema.AIMemoryEntity{},
 		"session_id = ? OR session_id LIKE ?",
 		persistentSessionID, memoryMidtermSessionIDLike(persistentSessionID),
 	)
+	if err != nil {
+		return 0, err
+	}
+	// Also delete from the independent midterm archive table
+	n2, err := hardDeleteWhere(db, &schema.AIMidtermArchiveEntity{},
+		"session_id = ? OR session_id LIKE ?",
+		persistentSessionID, memoryMidtermSessionIDLike(persistentSessionID),
+	)
+	if err != nil {
+		return n1, err
+	}
+	return n1 + n2, nil
 }
 
 func deleteMemoryCollectionsForSession(db *gorm.DB, persistentSessionID string) (int64, error) {
-	return hardDeleteWhere(db, &schema.AIMemoryCollection{},
+	n1, err := hardDeleteWhere(db, &schema.AIMemoryCollection{},
 		"session_id = ? OR session_id LIKE ?",
 		persistentSessionID, memoryMidtermSessionIDLike(persistentSessionID),
 	)
+	if err != nil {
+		return 0, err
+	}
+	// Also delete from the independent midterm archive table
+	n2, err := hardDeleteWhere(db, &schema.AIMidtermArchiveCollection{},
+		"session_id = ? OR session_id LIKE ?",
+		persistentSessionID, memoryMidtermSessionIDLike(persistentSessionID),
+	)
+	if err != nil {
+		return n1, err
+	}
+	return n1 + n2, nil
 }
 
 // deleteRAGCollectionsByName 按 collection 名删除向量文档与 collection 行。

--- a/common/yakgrpc/aisessioncleanup/session_cleanup.go
+++ b/common/yakgrpc/aisessioncleanup/session_cleanup.go
@@ -151,26 +151,19 @@ func DeleteAllSessionArtifacts(db *gorm.DB) (*SessionCleanupResult, error) {
 		return result, err
 	}
 
-	if n, err := hardDeleteAll(db, &schema.AIMemoryEntity{}); err != nil {
-		return result, err
-	} else {
-		result.DeletedMemoryEntities = n
+	// Drop and recreate all memory tables — much faster than DELETE FROM on large tables.
+	// This is safe because DeleteAllSessionArtifacts is only called in the deleteAll=true path,
+	// where every AI session artifact is meant to be wiped.
+	memoryTables := []interface{}{
+		&schema.AIMemoryEntity{},
+		&schema.AIMemoryCollection{},
+		&schema.AIMidtermArchiveEntity{},
+		&schema.AIMidtermArchiveCollection{},
 	}
-	if n, err := hardDeleteAll(db, &schema.AIMemoryCollection{}); err != nil {
-		return result, err
-	} else {
-		result.DeletedMemoryCollections = n
-	}
-	// Also clean up the independent midterm archive tables
-	if n, err := hardDeleteAll(db, &schema.AIMidtermArchiveEntity{}); err != nil {
-		return result, err
-	} else {
-		result.DeletedMemoryEntities += n
-	}
-	if n, err := hardDeleteAll(db, &schema.AIMidtermArchiveCollection{}); err != nil {
-		return result, err
-	} else {
-		result.DeletedMemoryCollections += n
+	for _, model := range memoryTables {
+		if err := schema.DropRecreateTable(db, model); err != nil {
+			return result, err
+		}
 	}
 
 	log.Infof(

--- a/common/yakgrpc/aisessioncleanup/session_cleanup.go
+++ b/common/yakgrpc/aisessioncleanup/session_cleanup.go
@@ -408,3 +408,44 @@ func isMissingTableErr(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "no such table") || strings.Contains(msg, "doesn't exist")
 }
+
+// DeleteAllAIMemoryArtifacts 清空全部 AI 记忆数据（不含会话/runtime/event 等会话元数据）。
+// 供 DeleteAIMemoryEntity 在 filter 全空时调用，快速清空所有记忆相关表。
+//
+// 与 DeleteAllSessionArtifacts 不同，本函数只处理 AI Memory 侧的表和 RAG 集合：
+//   - 用 schema.DropRecreateTable 快速清空 4 张记忆表（entity + collection × 普通/中期归档）
+//   - 用 SQL 批量删除所有 ai-memory-% RAG 集合（向量文档 + collection 行）
+//
+// 不加载 HNSW 图、不走 RAG vectorstore 运行时，性能远优于逐条删除。
+func DeleteAllAIMemoryArtifacts(db *gorm.DB) (*SessionCleanupResult, error) {
+	result := &SessionCleanupResult{}
+	if db == nil {
+		return result, utils.Errorf("database is nil")
+	}
+
+	// 1. 删除所有 ai-memory-% RAG 集合（向量文档 + collection 行）
+	ragLike := "ai-memory-%"
+	if err := deleteRAGCollectionsForSession(db, ragLike, result); err != nil {
+		return result, err
+	}
+
+	// 2. Drop + Recreate 所有记忆表，比 DELETE FROM 快得多
+	memoryTables := []interface{}{
+		&schema.AIMemoryEntity{},
+		&schema.AIMemoryCollection{},
+		&schema.AIMidtermArchiveEntity{},
+		&schema.AIMidtermArchiveCollection{},
+	}
+	for _, model := range memoryTables {
+		if err := schema.DropRecreateTable(db, model); err != nil {
+			return result, err
+		}
+	}
+
+	log.Infof(
+		"deleted all AI memory artifacts: rag_collections=%d rag_documents=%d (memory tables dropped & recreated)",
+		result.DeletedRAGCollections,
+		result.DeletedRAGDocuments,
+	)
+	return result, nil
+}

--- a/common/yakgrpc/aisessioncleanup/session_cleanup.go
+++ b/common/yakgrpc/aisessioncleanup/session_cleanup.go
@@ -12,12 +12,18 @@ import (
 // 中期 timeline 记忆在同一 persistent session id 下使用两套独立命名：
 //
 //  1. RAG 侧 — 向量/实体/知识库表中的 name 类字段
-//     格式：ai-memory-timeline-midterm:{persistentSessionId}[@fork...]
+//     格式：ai-memory-timeline-midterm:{persistentSessionId}[@fork:{taskIndex}]
 //     表：rag_vector_collection_v1、rag_entity_repository_v1、rag_knowledge_base_v1
 //
-//  2. Memory 侧 — ai_memory_* 表中的 session_id 字段
-//     格式：timeline-midterm:{persistentSessionId}[@fork...]
-//     表：ai_memory_entities_v1、ai_memory_collections_v1
+//  2. Memory 侧 — 记忆表中的 session_id 字段
+//     格式：timeline-midterm:{persistentSessionId}[@fork:{taskIndex}]
+//     表：ai_midterm_archive_entities_v1、ai_midterm_archive_collections_v1
+//     （历史数据可能仍存于 ai_memory_entities_v1、ai_memory_collections_v1）
+//
+// 删除策略：RAG 侧三张共享表的 name 类字段均有索引（unique_index / index），
+// LIKE 'prefix%' 走索引 range scan 而非全表扫描，且 "name 以该前缀开头" 本身就是
+// RAG 数据的归属判定（能顺带清掉从未写入记忆的孤儿 collection），因此 RAG 侧
+// 一律按前缀 LIKE 过滤删除；Memory 侧整表可 drop，无需过滤。
 const (
 	ragMidtermTableNamePrefix    = "ai-memory-timeline-midterm:"
 	memoryMidtermSessionIDPrefix = "timeline-midterm:"
@@ -41,12 +47,12 @@ func ragMidtermTableName(persistentSessionID string) string {
 	return ragMidtermTableNamePrefix + persistentSessionID
 }
 
-// ragMidtermTableNameLike 匹配 RAG 侧基础名及 fork 变体。
+// ragMidtermTableNameLike 匹配 RAG 侧基础名及 fork 变体（前缀 LIKE，走索引 range scan）。
 func ragMidtermTableNameLike(persistentSessionID string) string {
 	return ragMidtermTableName(persistentSessionID) + "%"
 }
 
-// memoryMidtermSessionID 返回 Memory 侧写入 ai_memory_* 的 session_id。
+// memoryMidtermSessionID 返回 Memory 侧写入记忆表的 session_id。
 func memoryMidtermSessionID(persistentSessionID string) string {
 	return memoryMidtermSessionIDPrefix + persistentSessionID
 }
@@ -70,7 +76,6 @@ func DeleteSessionArtifacts(db *gorm.DB, sessionID string) (*SessionCleanupResul
 	}
 
 	ragLike := ragMidtermTableNameLike(sessionID)
-
 	if err := deleteRAGCollectionsForSession(db, ragLike, result); err != nil {
 		return result, err
 	}
@@ -109,61 +114,30 @@ func DeleteSessionArtifacts(db *gorm.DB, sessionID string) (*SessionCleanupResul
 
 // DeleteAllSessionArtifacts 删除全部中期 Memory + 所有 ai-memory-timeline-midterm:* RAG 数据。
 // 供 DeleteAISession 的 deleteAll 分支使用。纯 SQL。
+//
+// 中期记忆在 Memory 侧已物理分表（ai_midterm_archive_*），deleteAll 语义下整表
+// 都是待删数据，因此统计行数后直接 drop + recreate，远快于 DELETE FROM。
+// RAG 侧的向量/实体/知识库表与其它用途（如知识库）共享，按
+// ai-memory-timeline-midterm:* 前缀 LIKE 过滤删除（name 字段有索引，走 range scan）。
 func DeleteAllSessionArtifacts(db *gorm.DB) (*SessionCleanupResult, error) {
 	result := &SessionCleanupResult{}
 	if db == nil {
 		return result, utils.Errorf("database is nil")
 	}
 
-	var collectionNames []string
-	if err := db.Model(&schema.VectorStoreCollection{}).
-		Where("name LIKE ?", ragMidtermTableNamePrefix+"%").
-		Pluck("name", &collectionNames).Error; err != nil {
-		if !isMissingTableErr(err) {
-			return result, err
-		}
+	ragLike := ragMidtermTableNamePrefix + "%"
+	if err := deleteRAGCollectionsForSession(db, ragLike, result); err != nil {
+		return result, err
 	}
-	if err := deleteRAGCollectionsByName(db, collectionNames, result); err != nil {
+	if err := deleteEntityRepositoriesForSession(db, ragLike, result); err != nil {
+		return result, err
+	}
+	if err := deleteKnowledgeBasesForSession(db, ragLike, result); err != nil {
 		return result, err
 	}
 
-	var entityRepoNames []string
-	if err := db.Model(&schema.EntityRepository{}).
-		Where("entity_base_name LIKE ?", ragMidtermTableNamePrefix+"%").
-		Pluck("entity_base_name", &entityRepoNames).Error; err != nil {
-		if !isMissingTableErr(err) {
-			return result, err
-		}
-	}
-	if err := deleteEntityRepositoriesByName(db, entityRepoNames, result); err != nil {
+	if err := dropAllMemoryTables(db, result); err != nil {
 		return result, err
-	}
-
-	var knowledgeBaseNames []string
-	if err := db.Model(&schema.KnowledgeBaseInfo{}).
-		Where("knowledge_base_name LIKE ?", ragMidtermTableNamePrefix+"%").
-		Pluck("knowledge_base_name", &knowledgeBaseNames).Error; err != nil {
-		if !isMissingTableErr(err) {
-			return result, err
-		}
-	}
-	if err := deleteKnowledgeBasesByName(db, knowledgeBaseNames, result); err != nil {
-		return result, err
-	}
-
-	// Drop and recreate all memory tables — much faster than DELETE FROM on large tables.
-	// This is safe because DeleteAllSessionArtifacts is only called in the deleteAll=true path,
-	// where every AI session artifact is meant to be wiped.
-	memoryTables := []interface{}{
-		&schema.AIMemoryEntity{},
-		&schema.AIMemoryCollection{},
-		&schema.AIMidtermArchiveEntity{},
-		&schema.AIMidtermArchiveCollection{},
-	}
-	for _, model := range memoryTables {
-		if err := schema.DropRecreateTable(db, model); err != nil {
-			return result, err
-		}
 	}
 
 	log.Infof(
@@ -205,6 +179,8 @@ func deleteKnowledgeBasesForSession(db *gorm.DB, likePattern string, result *Ses
 	return deleteKnowledgeBasesByName(db, names, result)
 }
 
+// pluckRAGArtifactNames 按前缀 LIKE 从 RAG 共享表中取出目标 name 列表。
+// name 类字段均有索引，LIKE 'prefix%' 走 range scan，且能覆盖从未写入记忆的孤儿 collection。
 func pluckRAGArtifactNames(db *gorm.DB, model interface{}, column, likePattern string) ([]string, error) {
 	var names []string
 	q := db.Model(model).Where(column+" LIKE ?", likePattern)
@@ -389,16 +365,31 @@ func hardDeleteWhere(db *gorm.DB, model interface{}, query string, args ...inter
 	return res.RowsAffected, nil
 }
 
-func hardDeleteByColumn(db *gorm.DB, model interface{}, query string, args ...interface{}) (int64, error) {
-	return hardDeleteWhere(db, model, query, args...)
-}
-
-func hardDeleteAll(db *gorm.DB, model interface{}) (int64, error) {
-	res := db.Model(model).Unscoped().Delete(model)
-	if res.Error != nil && !isMissingTableErr(res.Error) {
-		return 0, res.Error
+// dropAllMemoryTables 统计并清空全部记忆表（普通 + 中期归档）。
+// 先 COUNT 记录删除行数到 result，再 drop + recreate 整表。
+func dropAllMemoryTables(db *gorm.DB, result *SessionCleanupResult) error {
+	memoryTables := []struct {
+		model   interface{}
+		counter *int64
+	}{
+		{&schema.AIMemoryEntity{}, &result.DeletedMemoryEntities},
+		{&schema.AIMemoryCollection{}, &result.DeletedMemoryCollections},
+		{&schema.AIMidtermArchiveEntity{}, &result.DeletedMemoryEntities},
+		{&schema.AIMidtermArchiveCollection{}, &result.DeletedMemoryCollections},
 	}
-	return res.RowsAffected, nil
+	for _, item := range memoryTables {
+		var count int64
+		if err := db.Model(item.model).Count(&count).Error; err != nil {
+			if !isMissingTableErr(err) {
+				return err
+			}
+		}
+		*item.counter += count
+		if err := schema.DropRecreateTable(db, item.model); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func isMissingTableErr(err error) bool {
@@ -424,26 +415,19 @@ func DeleteAllAIMemoryArtifacts(db *gorm.DB) (*SessionCleanupResult, error) {
 	}
 
 	// 1. 删除所有 ai-memory-% RAG 集合（向量文档 + collection 行）
-	ragLike := "ai-memory-%"
-	if err := deleteRAGCollectionsForSession(db, ragLike, result); err != nil {
+	if err := deleteRAGCollectionsForSession(db, "ai-memory-%", result); err != nil {
 		return result, err
 	}
 
 	// 2. Drop + Recreate 所有记忆表，比 DELETE FROM 快得多
-	memoryTables := []interface{}{
-		&schema.AIMemoryEntity{},
-		&schema.AIMemoryCollection{},
-		&schema.AIMidtermArchiveEntity{},
-		&schema.AIMidtermArchiveCollection{},
-	}
-	for _, model := range memoryTables {
-		if err := schema.DropRecreateTable(db, model); err != nil {
-			return result, err
-		}
+	if err := dropAllMemoryTables(db, result); err != nil {
+		return result, err
 	}
 
 	log.Infof(
-		"deleted all AI memory artifacts: rag_collections=%d rag_documents=%d (memory tables dropped & recreated)",
+		"deleted all AI memory artifacts: memory_entities=%d memory_collections=%d rag_collections=%d rag_documents=%d (memory tables dropped & recreated)",
+		result.DeletedMemoryEntities,
+		result.DeletedMemoryCollections,
 		result.DeletedRAGCollections,
 		result.DeletedRAGDocuments,
 	)

--- a/common/yakgrpc/aisessioncleanup/session_cleanup_test.go
+++ b/common/yakgrpc/aisessioncleanup/session_cleanup_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/yaklang/gorm"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 )
@@ -19,6 +19,8 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&schema.AIAgentRuntime{},
 		&schema.AIMemoryEntity{},
 		&schema.AIMemoryCollection{},
+		&schema.AIMidtermArchiveEntity{},
+		&schema.AIMidtermArchiveCollection{},
 		&schema.VectorStoreCollection{},
 		&schema.VectorStoreDocument{},
 		&schema.EntityRepository{},
@@ -56,10 +58,11 @@ func TestDeleteSessionArtifacts_RemovesMidtermSessionAndFork(t *testing.T) {
 	require.Equal(t, int64(2), result.DeletedKnowledgeBases)
 	require.Equal(t, int64(2), result.DeletedKnowledgeEntries)
 
-	assertZeroCount(t, db.Model(&schema.AIMemoryEntity{}).Where("session_id IN (?)", []string{persistentSessionID, midtermSessionID, forkSessionID}))
+	assertZeroCount(t, db.Model(&schema.AIMidtermArchiveEntity{}).Where("session_id IN (?)", []string{persistentSessionID, midtermSessionID, forkSessionID}))
+	assertZeroCount(t, db.Model(&schema.AIMidtermArchiveCollection{}).Where("session_id IN (?)", []string{persistentSessionID, midtermSessionID, forkSessionID}))
 	assertZeroCount(t, db.Model(&schema.VectorStoreCollection{}).Where("name IN (?)", []string{baseRAGName, forkRAGName}))
 	assertOneCount(t, db.Model(&schema.VectorStoreCollection{}).Where("name = ?", otherRAGName))
-	assertOneCount(t, db.Model(&schema.AIMemoryEntity{}).Where("session_id = ?", memoryMidtermSessionID(otherPersistentSessionID)))
+	assertOneCount(t, db.Model(&schema.AIMidtermArchiveEntity{}).Where("session_id = ?", memoryMidtermSessionID(otherPersistentSessionID)))
 }
 
 func TestDeleteSessionArtifacts_EmptySessionID(t *testing.T) {
@@ -85,6 +88,12 @@ func TestDeleteAllSessionArtifacts_RemovesAllMidtermRAG(t *testing.T) {
 	seedMidtermSessionArtifacts(t, db, sessA, memoryMidtermSessionID(sessA), ragMidtermTableName(sessA), memoryMidtermSessionID(sessA)+"@fork1-1", ragMidtermTableName(sessA)+"@fork1-1")
 	seedMidtermSessionArtifacts(t, db, sessB, memoryMidtermSessionID(sessB), ragMidtermTableName(sessB), "", "")
 
+	// 历史遗留：分表前写入旧 ai_memory_* 表的中期数据，DeleteAll 也应一并清空
+	require.NoError(t, db.Create(&schema.AIMemoryEntity{
+		MemoryID: uuid.NewString(), SessionID: memoryMidtermSessionID(sessB), Content: "legacy-midterm",
+	}).Error)
+	require.NoError(t, db.Create(&schema.AIMemoryCollection{SessionID: memoryMidtermSessionID(sessB)}).Error)
+
 	unrelatedRepo := &schema.EntityRepository{EntityBaseName: "knowledge-base-keep", Uuid: uuid.NewString()}
 	require.NoError(t, db.Create(unrelatedRepo).Error)
 	require.NoError(t, db.Create(&schema.ERModelRelationship{
@@ -108,8 +117,8 @@ func TestDeleteAllSessionArtifacts_RemovesAllMidtermRAG(t *testing.T) {
 
 	result, err := DeleteAllSessionArtifacts(db)
 	require.NoError(t, err)
-	require.Equal(t, int64(3), result.DeletedMemoryEntities)
-	require.Equal(t, int64(3), result.DeletedMemoryCollections)
+	require.Equal(t, int64(4), result.DeletedMemoryEntities)
+	require.Equal(t, int64(4), result.DeletedMemoryCollections)
 	require.Equal(t, int64(3), result.DeletedRAGCollections)
 	require.Equal(t, int64(3), result.DeletedRAGDocuments)
 	require.Equal(t, int64(3), result.DeletedEntityRepositories)
@@ -119,6 +128,11 @@ func TestDeleteAllSessionArtifacts_RemovesAllMidtermRAG(t *testing.T) {
 	require.Equal(t, int64(3), result.DeletedKnowledgeEntries)
 
 	assertZeroCount(t, db.Model(&schema.VectorStoreCollection{}).Where("name LIKE ?", ragMidtermTableNamePrefix+"%"))
+	// 记忆表被 drop + recreate，中期归档表与旧表都应为空
+	assertZeroCount(t, db.Model(&schema.AIMidtermArchiveEntity{}).Where("session_id LIKE ?", memoryMidtermSessionIDPrefix+"%"))
+	assertZeroCount(t, db.Model(&schema.AIMidtermArchiveCollection{}).Where("session_id LIKE ?", memoryMidtermSessionIDPrefix+"%"))
+	assertZeroCount(t, db.Model(&schema.AIMemoryEntity{}).Where("session_id LIKE ?", memoryMidtermSessionIDPrefix+"%"))
+	assertZeroCount(t, db.Model(&schema.AIMemoryCollection{}).Where("session_id LIKE ?", memoryMidtermSessionIDPrefix+"%"))
 	assertOneCount(t, db.Model(&schema.VectorStoreCollection{}).Where("name = ?", "knowledge-base-keep"))
 	assertOneCount(t, db.Model(&schema.EntityRepository{}).Where("uuid = ?", unrelatedRepo.Uuid))
 	assertOneCount(t, db.Model(&schema.KnowledgeBaseInfo{}).Where("id = ?", unrelatedKB.ID))
@@ -131,9 +145,10 @@ func seedMidtermSessionArtifacts(
 ) {
 	t.Helper()
 
-	require.NoError(t, db.Create(&schema.AIMemoryEntity{
+	// 中期记忆已分表：写入独立的归档表 ai_midterm_archive_entities_v1
+	require.NoError(t, db.Create(&schema.AIMidtermArchiveEntity{AIMemoryEntity: schema.AIMemoryEntity{
 		MemoryID: uuid.NewString(), SessionID: midtermSessionID, Content: "midterm",
-	}).Error)
+	}}).Error)
 
 	baseCol := &schema.VectorStoreCollection{Name: baseRAGName}
 	require.NoError(t, db.Create(baseCol).Error)
@@ -159,16 +174,16 @@ func seedMidtermSessionArtifacts(
 		KnowledgeType: "fact", HiddenIndex: uuid.NewString(),
 	}).Error)
 
-	require.NoError(t, db.Create(&schema.AIMemoryCollection{SessionID: midtermSessionID}).Error)
+	require.NoError(t, db.Create(&schema.AIMidtermArchiveCollection{AIMemoryCollection: schema.AIMemoryCollection{SessionID: midtermSessionID}}).Error)
 
 	if forkSessionID == "" || forkRAGName == "" {
 		return
 	}
 
-	require.NoError(t, db.Create(&schema.AIMemoryEntity{
+	require.NoError(t, db.Create(&schema.AIMidtermArchiveEntity{AIMemoryEntity: schema.AIMemoryEntity{
 		MemoryID: uuid.NewString(), SessionID: forkSessionID, Content: "fork",
-	}).Error)
-	require.NoError(t, db.Create(&schema.AIMemoryCollection{SessionID: forkSessionID}).Error)
+	}}).Error)
+	require.NoError(t, db.Create(&schema.AIMidtermArchiveCollection{AIMemoryCollection: schema.AIMemoryCollection{SessionID: forkSessionID}}).Error)
 
 	forkCol := &schema.VectorStoreCollection{Name: forkRAGName}
 	require.NoError(t, db.Create(forkCol).Error)

--- a/common/yakgrpc/grpc_ai_memory_entity.go
+++ b/common/yakgrpc/grpc_ai_memory_entity.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/aisessioncleanup"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
@@ -88,6 +89,23 @@ func (s *Server) DeleteAIMemoryEntity(ctx context.Context, req *ypb.DeleteAIMemo
 		return nil, utils.Errorf("request is nil")
 	}
 
+	// Fast path: when the filter is completely empty, the caller wants to wipe ALL
+	// AI memory data. Use DropRecreateTable to instantly clear the memory tables
+	// and batch-delete all ai-memory-* RAG collections via SQL, instead of loading
+	// HNSW graphs and deleting row-by-row.
+	if isAIMemoryEntityFilterEmpty(req.GetFilter()) {
+		_, err := aisessioncleanup.DeleteAllAIMemoryArtifacts(db)
+		if err != nil {
+			return nil, err
+		}
+		return &ypb.DbOperateMessage{
+			TableName:  (&schema.AIMemoryEntity{}).TableName(),
+			Operation:  "delete",
+			EffectRows: 0, // rows not counted for DropRecreateTable fast path
+			ExtraMessage: "fast_path=drop_recreate_table",
+		}, nil
+	}
+
 	vecSingleton := s.getAIMemoryVectorSingleton()
 	hook := func(ctx context.Context, _ *gorm.DB, entities []schema.AIMemoryEntity) error {
 		return deleteAIMemoryVectorsBatch(ctx, vecSingleton, entities)
@@ -116,6 +134,45 @@ func (s *Server) DeleteAIMemoryEntity(ctx context.Context, req *ypb.DeleteAIMemo
 		Operation:  "delete",
 		EffectRows: count,
 	}, nil
+}
+
+// isAIMemoryEntityFilterEmpty returns true when the filter carries no meaningful
+// constraint, meaning the caller wants to delete ALL memory entities.
+func isAIMemoryEntityFilterEmpty(filter *ypb.AIMemoryEntityFilter) bool {
+	if filter == nil {
+		return true
+	}
+	if strings.TrimSpace(filter.GetSessionID()) != "" {
+		return false
+	}
+	if len(filter.GetMemoryID()) > 0 {
+		return false
+	}
+	if strings.TrimSpace(filter.GetContentKeyword()) != "" {
+		return false
+	}
+	if len(filter.GetTags()) > 0 {
+		return false
+	}
+	if strings.TrimSpace(filter.GetPotentialQuestionKeyword()) != "" {
+		return false
+	}
+	if filter.GetCScore() != nil || filter.GetOScore() != nil || filter.GetRScore() != nil {
+		return false
+	}
+	if filter.GetEScore() != nil || filter.GetPScore() != nil || filter.GetAScore() != nil || filter.GetTScore() != nil {
+		return false
+	}
+	if filter.GetCreatedAt() != nil || filter.GetUpdatedAt() != nil {
+		return false
+	}
+	if strings.TrimSpace(filter.GetSemanticQuery()) != "" {
+		return false
+	}
+	if len(filter.GetCorePactQueryVector()) > 0 {
+		return false
+	}
+	return true
 }
 
 // aiMemoryVectorSessionSingleton 保证再批量删除的时候同一会话ID的HNSW和RAG实例不会重复创建，减少性能消耗

--- a/common/yakgrpc/grpc_ai_memory_entity.go
+++ b/common/yakgrpc/grpc_ai_memory_entity.go
@@ -89,11 +89,26 @@ func (s *Server) DeleteAIMemoryEntity(ctx context.Context, req *ypb.DeleteAIMemo
 	}
 
 	vecSingleton := s.getAIMemoryVectorSingleton()
-	count, err := yakit.DeleteAIMemoryEntityBatched(ctx, db, req.GetFilter(), 200, func(ctx context.Context, _ *gorm.DB, entities []schema.AIMemoryEntity) error {
+	hook := func(ctx context.Context, _ *gorm.DB, entities []schema.AIMemoryEntity) error {
 		return deleteAIMemoryVectorsBatch(ctx, vecSingleton, entities)
-	})
+	}
+
+	// Delete from the normal long-term memory table
+	count, err := yakit.DeleteAIMemoryEntityBatched(ctx, db, req.GetFilter(), 200, hook)
 	if err != nil {
 		return nil, err
+	}
+
+	// If the filter targets a midterm archive session (timeline-midterm:* prefix),
+	// also delete from the independent midterm archive table.
+	if filter := req.GetFilter(); filter != nil {
+		if sid := strings.TrimSpace(filter.GetSessionID()); sid != "" && strings.HasPrefix(sid, aimem.MidtermSessionPrefix) {
+			midtermCount, err := yakit.DeleteAIMidtermArchiveEntityBatched(ctx, db, filter, 200, hook)
+			if err != nil {
+				return nil, err
+			}
+			count += midtermCount
+		}
 	}
 
 	return &ypb.DbOperateMessage{
@@ -131,10 +146,12 @@ func (s *aiMemoryVectorSessionSingleton) GetHNSWBackend(sessionID string) (*aime
 	}
 	s.mu.Unlock()
 
+	midtermMode := strings.HasPrefix(sessionID, aimem.MidtermSessionPrefix)
 	backend, err := aimem.NewAIMemoryHNSWBackend(
 		aimem.WithHNSWSessionID(sessionID),
 		aimem.WithHNSWDatabase(s.db),
 		aimem.WithHNSWAutoSave(false),
+		aimem.WithHNSWMidtermMode(midtermMode),
 	)
 	if err != nil {
 		return nil, err
@@ -478,7 +495,12 @@ func syncAIMemoryVectors(ctx context.Context, db *gorm.DB, entity *schema.AIMemo
 		return nil
 	}
 
-	hnswBackend, err := aimem.NewAIMemoryHNSWBackend(aimem.WithHNSWSessionID(entity.SessionID), aimem.WithHNSWDatabase(db))
+	midtermMode := strings.HasPrefix(entity.SessionID, aimem.MidtermSessionPrefix)
+	hnswBackend, err := aimem.NewAIMemoryHNSWBackend(
+		aimem.WithHNSWSessionID(entity.SessionID),
+		aimem.WithHNSWDatabase(db),
+		aimem.WithHNSWMidtermMode(midtermMode),
+	)
 	if err == nil {
 		_ = hnswBackend.Update(toAIMemoryEntity(entity))
 	} else {

--- a/common/yakgrpc/yakit/ai_memory.go
+++ b/common/yakgrpc/yakit/ai_memory.go
@@ -191,3 +191,109 @@ func CountAIMemoryEntityTags(ctx context.Context, db *gorm.DB, sessionID string)
 
 	return ret, nil
 }
+
+// DeleteAIMidtermArchiveEntityBatched hard-deletes AIMidtermArchiveEntity rows in small batches.
+// It mirrors DeleteAIMemoryEntityBatched but operates on the independent midterm archive table.
+func DeleteAIMidtermArchiveEntityBatched(ctx context.Context, db *gorm.DB, filter *ypb.AIMemoryEntityFilter, batchSize int, hook DeleteAIMemoryEntityBatchHook) (deletedEntities int64, err error) {
+	if db == nil {
+		return 0, utils.Errorf("database not initialized")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if batchSize <= 0 {
+		batchSize = defaultAIMemoryEntityDeleteBatchSize
+	}
+
+	var lastID uint
+	for {
+		select {
+		case <-ctx.Done():
+			return deletedEntities, ctx.Err()
+		default:
+		}
+
+		var entities []schema.AIMemoryEntity
+		q := filterAIMidtermArchiveEntity(db, filter).
+			Select("id, memory_id, session_id, potential_questions").
+			Order("id asc").
+			Limit(batchSize)
+		if lastID > 0 {
+			q = q.Where("id > ?", lastID)
+		}
+		if err := q.Find(&entities).Error; err != nil {
+			return deletedEntities, err
+		}
+		if len(entities) == 0 {
+			return deletedEntities, nil
+		}
+
+		entityIDs := make([]uint, 0, len(entities))
+		for _, entity := range entities {
+			entityIDs = append(entityIDs, entity.ID)
+			lastID = entity.ID
+		}
+
+		var batchDeletedEntities int64
+		if hook != nil {
+			if err := hook(ctx, db, entities); err != nil {
+				return deletedEntities, err
+			}
+		}
+		if err := utils.GormTransaction(db, func(tx *gorm.DB) error {
+			res := tx.Table((&schema.AIMidtermArchiveEntity{}).TableName()).
+				Where("id IN (?)", entityIDs).
+				Unscoped().
+				Delete(&schema.AIMidtermArchiveEntity{})
+			if res.Error != nil {
+				return res.Error
+			}
+			batchDeletedEntities = res.RowsAffected
+			return nil
+		}); err != nil {
+			return deletedEntities, err
+		}
+
+		deletedEntities += batchDeletedEntities
+	}
+}
+
+// filterAIMidtermArchiveEntity builds a query on the midterm archive table, mirroring FilterAIMemoryEntity.
+func filterAIMidtermArchiveEntity(db *gorm.DB, filter *ypb.AIMemoryEntityFilter) *gorm.DB {
+	db = db.Table((&schema.AIMidtermArchiveEntity{}).TableName())
+	if filter == nil {
+		return db
+	}
+
+	if filter.GetSessionID() != "" {
+		db = db.Where("session_id = ?", filter.GetSessionID())
+	}
+	db = bizhelper.ExactQueryStringArrayOr(db, "memory_id", filter.GetMemoryID())
+
+	if kw := strings.TrimSpace(filter.GetContentKeyword()); kw != "" {
+		db = bizhelper.FuzzSearchEx(db, []string{"content"}, kw, false)
+	}
+
+	if kw := strings.TrimSpace(filter.GetPotentialQuestionKeyword()); kw != "" {
+		db = db.Where("potential_questions LIKE ?", "%"+kw+"%")
+	}
+
+	db = bizhelper.QueryByFloatRange(db, "c_score", filter.GetCScore())
+	db = bizhelper.QueryByFloatRange(db, "o_score", filter.GetOScore())
+	db = bizhelper.QueryByFloatRange(db, "r_score", filter.GetRScore())
+	db = bizhelper.QueryByFloatRange(db, "e_score", filter.GetEScore())
+	db = bizhelper.QueryByFloatRange(db, "p_score", filter.GetPScore())
+	db = bizhelper.QueryByFloatRange(db, "a_score", filter.GetAScore())
+	db = bizhelper.QueryByFloatRange(db, "t_score", filter.GetTScore())
+
+	db = bizhelper.QueryByTimeRangeUnix(db, "created_at", filter.GetCreatedAt())
+	db = bizhelper.QueryByTimeRangeUnix(db, "updated_at", filter.GetUpdatedAt())
+
+	if filter.GetTagMatchAll() {
+		db = bizhelper.FuzzQueryArrayStringAndLike(db, "tags", filter.GetTags())
+	} else {
+		db = bizhelper.FuzzQueryArrayStringOrLike(db, "tags", filter.GetTags())
+	}
+
+	return db
+}


### PR DESCRIPTION
## 概述

将中期记忆（timeline midterm archive）从普通长期记忆中物理分表隔离，并围绕分表重构中期回忆注入路径与会话清理逻辑，解决混表带来的清理复杂度和 fork 隔离问题。

## 主要变更

### 1. 中期记忆物理分表（核心）

- 新增 `schema.AIMidtermArchiveEntity` / `AIMidtermArchiveCollection`（表 `ai_midterm_archive_entities_v1` / `ai_midterm_archive_collections_v1`），与 `ai_memory_*` 字段一致但独立存储，中期归档记忆不再与长期记忆混表。
- `aimem` 新增 `WithMidtermArchiveMode` 选项，HNSW backend 与存储层按模式路由到对应表。

### 2. 修复 fork 分支写错表

- `ForkMidtermArchiveStore` 创建分支 store 时未传 `WithMidtermArchiveMode()`，导致 fork 分支实体写入共享长期记忆表，MergeBack 找不到分支实体、fork 搜索隔离失效。已修复并补齐测试。

### 3. 中期回忆改为 InjectedMemory 注入

- 移除旧的 timeline 注入路径（`buildTimelineDumpWithMidtermMemory` 等死代码）。
- 新增 `ReAct.ConsumeAndSearchMidtermMemory()` 作为 reactloops 层唯一入口：消费感知快照（summary + topics + keywords）检索归档记忆。
- 新增 `reactloops/midterm_memory.go` 的 `midtermMemoryProvider` 接口，桥接 reactloops → aireact 且避免循环依赖；中期记忆与常规记忆在同一触发点刷新，渲染进 prompt 动态段的 InjectedMemory 块。
- 重写 `midterm_context_provider_test.go`（5 个新用例）。

### 4. 会话清理逻辑简化与提速

- `DeleteAllSessionArtifacts`：分表后 deleteAll 语义下记忆表整表都是待删数据，改为 **drop + recreate**（先 COUNT 统计行数），替代按 session_id 的复杂过滤与逐行 DELETE，修复删除计数恒为 0 的问题。
- `DeleteAllAIMemoryArtifacts`：`DeleteAIMemoryEntity` 空 filter 全清时同样走 drop + recreate + SQL 批量删 `ai-memory-%` RAG 集合，不再加载 HNSW 图。
- RAG 侧共享表（向量/实体/知识库）保留按 `ai-memory-timeline-midterm:*` 前缀 LIKE 过滤删除（name 字段有索引走 range scan，且能清理孤儿 collection）。
- 全程纯 SQL，不加载 HNSW 图、不走 vectorstore 运行时。

## 测试

- `common/yakgrpc/aisessioncleanup`：全部通过；测试补齐归档表迁移与新旧两表的数据覆盖。
- `common/ai/aid/aimem`、`common/ai/aid/aireact`：fork 与中期上下文相关测试已更新并通过。