### PR TITLE
ci(scannode): 增加 Linux 产品节点打包流水线

### DIFF
--- a/.github/scripts/build-legion-product-node.sh
+++ b/.github/scripts/build-legion-product-node.sh
@@ -84,7 +84,7 @@ jq -n \
   --arg ci_provider "${GITHUB_ACTIONS:+github-actions}" \
   --arg ci_run_id "${GITHUB_RUN_ID:-local}" \
   --arg ci_run_attempt "${GITHUB_RUN_ATTEMPT:-1}" \
-  --arg ci_workflow "${GITHUB_WORKFLOW:-local}" \
+  --arg ci_workflow "${PRODUCT_NODE_WORKFLOW_NAME:-${GITHUB_WORKFLOW:-local}}" \
   --arg ci_actor "${GITHUB_ACTOR:-local}" \
   '{
     schema_version: "1",

--- a/.github/scripts/build-legion-product-node.sh
+++ b/.github/scripts/build-legion-product-node.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+package_name="${NODE_PACKAGE_NAME:-legion-product-node_linux_amd64}"
+dist_dir="${NODE_DIST_DIR:-$repo_root/dist}"
+package_dir="$dist_dir/$package_name"
+package_path="$dist_dir/$package_name.tar.gz"
+
+die() {
+  printf '[legion-product-node][error] %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '[legion-product-node] %s\n' "$*"
+}
+
+for command in file git go gzip jq readelf sha256sum stat tar; do
+  command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
+done
+
+source_sha="${SOURCE_SHA:-$(git -C "$repo_root" rev-parse HEAD)}"
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid SOURCE_SHA: $source_sha"
+[[ "$(git -C "$repo_root" rev-parse HEAD)" == "$source_sha" ]] || \
+  die "checkout HEAD does not match SOURCE_SHA"
+
+source_dirty=false
+if [[ -n "$(git -C "$repo_root" status --porcelain --untracked-files=all)" ]]; then
+  source_dirty=true
+fi
+if [[ "${CI:-}" == "true" && "$source_dirty" == "true" ]]; then
+  die "CI checkout must be clean"
+fi
+
+version="${NODE_PACKAGE_VERSION:-sha-${source_sha:0:12}}"
+[[ -n "$version" ]] || die "node package version must not be empty"
+[[ ! -e "$package_dir" ]] || die "package directory already exists: $package_dir"
+[[ ! -e "$package_path" ]] || die "package archive already exists: $package_path"
+
+binary="$package_dir/legion-smoke-node"
+build_tags="hids"
+module_go_version="$(awk '$1 == "go" { gsub(/\r/, "", $2); print $2; exit }' "$repo_root/go.mod")"
+[[ -n "$module_go_version" ]] || die "go.mod does not declare a Go version"
+toolchain_version="$(go env GOVERSION)"
+[[ "$toolchain_version" == "go$module_go_version" ]] || \
+  die "Go toolchain $toolchain_version does not match go.mod version go$module_go_version"
+mkdir -p "$package_dir"
+
+log "building Linux amd64 HIDS node from $source_sha with $(go version)"
+(
+  cd "$repo_root"
+  CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+    -trimpath \
+    -buildvcs=true \
+    -tags "$build_tags" \
+    -ldflags '-s -w -buildid= -linkmode external -extldflags "-static"' \
+    -o "$binary" \
+    ./cmd/legion-smoke-node
+)
+
+file_description="$(file "$binary")"
+printf '%s\n' "$file_description"
+grep -q 'statically linked' <<<"$file_description" || die "node binary is not statically linked"
+if readelf -d "$binary" 2>/dev/null | grep -q '(NEEDED)'; then
+  die "node binary declares dynamic library dependencies"
+fi
+
+binary_sha="$(sha256sum "$binary" | awk '{print $1}')"
+binary_size="$(stat -c %s "$binary")"
+built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+jq -n \
+  --arg version "$version" \
+  --arg repository "${GITHUB_REPOSITORY:-yaklang/yaklang}" \
+  --arg source_sha "$source_sha" \
+  --argjson source_dirty "$source_dirty" \
+  --arg module_go_version "$module_go_version" \
+  --arg go_version "$(go version)" \
+  --arg build_tags "$build_tags" \
+  --arg binary_sha "$binary_sha" \
+  --argjson binary_size "$binary_size" \
+  --arg built_at "$built_at" \
+  --arg ci_provider "${GITHUB_ACTIONS:+github-actions}" \
+  --arg ci_run_id "${GITHUB_RUN_ID:-local}" \
+  --arg ci_run_attempt "${GITHUB_RUN_ATTEMPT:-1}" \
+  --arg ci_workflow "${GITHUB_WORKFLOW:-local}" \
+  --arg ci_actor "${GITHUB_ACTOR:-local}" \
+  '{
+    schema_version: "1",
+    artifact_type: "legion-product-node",
+    version: $version,
+    source: {
+      repository: $repository,
+      commit: $source_sha,
+      dirty: $source_dirty
+    },
+    ci: {
+      provider: (if ($ci_provider | length) > 0 then $ci_provider else "local" end),
+      run_id: $ci_run_id,
+      run_attempt: $ci_run_attempt,
+      workflow: $ci_workflow,
+      actor: $ci_actor
+    },
+    recipe: {
+      goos: "linux",
+      goarch: "amd64",
+      cgo_enabled: true,
+      link_mode: "external-static",
+      build_tags: $build_tags,
+      module_go_version: $module_go_version,
+      go_version: $go_version
+    },
+    capabilities: ["hids", "ssa.rule_sync.export", "yak.execute"],
+    binary: {
+      path: "legion-smoke-node",
+      sha256: $binary_sha,
+      size: $binary_size
+    },
+    built_at: $built_at
+  }' >"$package_dir/PRODUCT_NODE_MANIFEST.json"
+
+(
+  cd "$package_dir"
+  sha256sum legion-smoke-node PRODUCT_NODE_MANIFEST.json >SHA256SUMS
+  sha256sum -c SHA256SUMS
+)
+
+source_epoch="$(git -C "$repo_root" show -s --format=%ct "$source_sha")"
+tar \
+  --sort=name \
+  --mtime="@$source_epoch" \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  -C "$package_dir" \
+  -cf - . | gzip -n -1 >"$package_path"
+(
+  cd "$dist_dir"
+  sha256sum "$(basename "$package_path")" >"$(basename "$package_path").sha256"
+)
+
+log "package created: $package_path"
+log "package checksum: $package_path.sha256"

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v*"
+      - "legion-node-v*"
   pull_request:
     paths:
       - ".github/scripts/build-legion-product-node.sh"

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -1,4 +1,4 @@
-name: Build Legion Product Node
+name: Build Trusted Legion Product Node
 
 on:
   workflow_dispatch:
@@ -71,8 +71,20 @@ jobs:
              and .recipe.goos == "linux"
              and .recipe.goarch == "amd64"
              and .recipe.build_tags == "hids"
+             and .ci.workflow == "Build Trusted Legion Product Node"
              and (.capabilities | index("hids") != null)' \
             PRODUCT_NODE_MANIFEST.json >/dev/null
+
+      - name: Stage cross-repository artifact contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/artifact
+          cp "dist/${NODE_PACKAGE_NAME}/legion-smoke-node" dist/artifact/
+          cp "dist/${NODE_PACKAGE_NAME}/PRODUCT_NODE_MANIFEST.json" dist/artifact/
+          cp "dist/${NODE_PACKAGE_NAME}/SHA256SUMS" dist/artifact/
+          cp "dist/${NODE_PACKAGE_NAME}.tar.gz" dist/artifact/
+          cp "dist/${NODE_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
 
       - name: Publish build summary
         shell: bash
@@ -95,8 +107,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.NODE_PACKAGE_NAME }}
-          path: |
-            dist/${{ env.NODE_PACKAGE_NAME }}.tar.gz
-            dist/${{ env.NODE_PACKAGE_NAME }}.tar.gz.sha256
+          path: dist/artifact/*
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 45
     env:
       NODE_PACKAGE_NAME: legion-product-node_linux_amd64
+      PRODUCT_NODE_WORKFLOW_NAME: Build Trusted Legion Product Node
       SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       NODE_PACKAGE_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
     steps:

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -1,0 +1,102 @@
+name: Build Legion Product Node
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - ".github/scripts/build-legion-product-node.sh"
+      - ".github/workflows/build-legion-product-node.yml"
+      - "cmd/legion-smoke-node/**"
+      - "common/hids/**"
+      - "common/node/**"
+      - "common/spec/**"
+      - "scannode/**"
+      - "go.mod"
+      - "go.sum"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: legion-product-node-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-linux-amd64:
+    name: Build Linux amd64 HIDS node
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    env:
+      NODE_PACKAGE_NAME: legion-product-node_linux_amd64
+      SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      NODE_PACKAGE_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+    steps:
+      - name: Check out source commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build product node package
+        run: ./.github/scripts/build-legion-product-node.sh
+
+      - name: Verify package archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum -c "${NODE_PACKAGE_NAME}.tar.gz.sha256"
+          mkdir verify
+          tar -xzf "${NODE_PACKAGE_NAME}.tar.gz" -C verify
+          cd verify
+          sha256sum -c SHA256SUMS
+          file legion-smoke-node | grep -q 'statically linked'
+          if readelf -d legion-smoke-node 2>/dev/null | grep -q '(NEEDED)'; then
+            echo "node binary declares dynamic library dependencies" >&2
+            exit 1
+          fi
+          jq -e \
+            --arg source_sha "$SOURCE_SHA" \
+            '.artifact_type == "legion-product-node"
+             and .source.commit == $source_sha
+             and .source.dirty == false
+             and .recipe.goos == "linux"
+             and .recipe.goarch == "amd64"
+             and .recipe.build_tags == "hids"
+             and (.capabilities | index("hids") != null)' \
+            PRODUCT_NODE_MANIFEST.json >/dev/null
+
+      - name: Publish build summary
+        shell: bash
+        run: |
+          {
+            echo "## Legion product node"
+            echo
+            echo "- Source: \`${SOURCE_SHA}\`"
+            echo "- Package: \`${NODE_PACKAGE_NAME}.tar.gz\`"
+            echo "- Target: \`linux/amd64\`"
+            echo "- Build tags: \`hids\`"
+            echo "- Go: \`$(go version)\`"
+            echo
+            echo '```json'
+            jq . "dist/${NODE_PACKAGE_NAME}/PRODUCT_NODE_MANIFEST.json"
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload node package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NODE_PACKAGE_NAME }}
+          path: |
+            dist/${{ env.NODE_PACKAGE_NAME }}.tar.gz
+            dist/${{ env.NODE_PACKAGE_NAME }}.tar.gz.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -41,8 +41,10 @@ GOOS=linux GOARCH=amd64 go build -tags hids -o ./legion-smoke-node-hids-linux-am
 
 `.github/workflows/build-legion-product-node.yml` produces the deployable
 Linux amd64 product node from the repository's declared Go version. The
-workflow runs for relevant pull requests, manual dispatches, and every `v*`
-tag, including alpha tags.
+workflow runs for relevant pull requests, manual dispatches, and tags in the
+isolated `legion-node-v*` namespace, including alpha tags. This
+namespace does not trigger the repository's existing general `v*` release
+workflows.
 
 The `legion-product-node_linux_amd64` artifact contains:
 

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -48,14 +48,18 @@ workflows.
 
 The `legion-product-node_linux_amd64` artifact contains:
 
+- `legion-smoke-node`
+- `PRODUCT_NODE_MANIFEST.json`
+- `SHA256SUMS`
 - `legion-product-node_linux_amd64.tar.gz`
 - `legion-product-node_linux_amd64.tar.gz.sha256`
 
-The archive contains the statically linked `legion-smoke-node`,
-`PRODUCT_NODE_MANIFEST.json`, and `SHA256SUMS`. The manifest binds the binary
-to the exact Yaklang source commit, Go toolchain, Linux amd64 target, `hids`
-build tag, and advertised capability set. This artifact is an input to the
-Legion deployment packaging pipeline; it is not a complete deployment bundle.
+The direct files are the cross-repository assembly contract. The archive
+contains the same statically linked `legion-smoke-node`, manifest, and inner
+checksums for standalone downloads. The manifest binds the binary to the exact
+Yaklang source commit, Go toolchain, Linux amd64 target, `hids` build tag, and
+advertised capability set. This artifact is an input to the Legion deployment
+packaging pipeline; it is not a complete deployment bundle.
 
 Use `task legion_smoke_node_build_hids` for native debugging when your current host is already Linux. Use `task legion_smoke_node_build_hids_linux_amd64` when you need a deployable Linux artifact from any development host.
 

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -37,6 +37,24 @@ go build -tags hids -o ./legion-smoke-node-hids ./cmd/legion-smoke-node
 GOOS=linux GOARCH=amd64 go build -tags hids -o ./legion-smoke-node-hids-linux-amd64 ./cmd/legion-smoke-node
 ```
 
+## CI Product Node Package
+
+`.github/workflows/build-legion-product-node.yml` produces the deployable
+Linux amd64 product node from the repository's declared Go version. The
+workflow runs for relevant pull requests, manual dispatches, and every `v*`
+tag, including alpha tags.
+
+The `legion-product-node_linux_amd64` artifact contains:
+
+- `legion-product-node_linux_amd64.tar.gz`
+- `legion-product-node_linux_amd64.tar.gz.sha256`
+
+The archive contains the statically linked `legion-smoke-node`,
+`PRODUCT_NODE_MANIFEST.json`, and `SHA256SUMS`. The manifest binds the binary
+to the exact Yaklang source commit, Go toolchain, Linux amd64 target, `hids`
+build tag, and advertised capability set. This artifact is an input to the
+Legion deployment packaging pipeline; it is not a complete deployment bundle.
+
 Use `task legion_smoke_node_build_hids` for native debugging when your current host is already Linux. Use `task legion_smoke_node_build_hids_linux_amd64` when you need a deployable Linux artifact from any development host.
 
 If a future production Legion node entrypoint is added, it must also be built with `-tags hids` before the binary is expected to advertise or run the HIDS capability.


### PR DESCRIPTION
## 背景

Scan Node 基线已通过 #4660 合并到 `main`，但现有 Cross Build 流水线只构建 Yak/Yak Slim，没有产出 Legion 可消费的 `legion-smoke-node` 产品节点包。

## 改动

- 新增 `Build Trusted Legion Product Node` 工作流：相关 PR、手动触发及独立的 `legion-node-v*` Tag（包含 alpha Tag）均可触发；该命名空间不会命中仓库现有的通用 `v*` 发布工作流。
- 使用仓库 `go.mod` 声明的 Go 1.22.12，以 `hids` Build Tag 构建 Linux amd64 静态节点。
- Artifact 根目录直接产出节点二进制、Manifest 与内部 SHA256，供 Legion 跨仓库组装器消费；同时保留 `legion-product-node_linux_amd64.tar.gz` 与外层 SHA256，便于独立下载。
- 包内包含节点二进制、`PRODUCT_NODE_MANIFEST.json` 和 `SHA256SUMS`；Manifest 绑定精确源码提交、工具链、构建配方和能力集合。
- CI 解包复核内外层校验和、静态链接、动态依赖以及 Manifest 来源。
- 补充 HIDS readiness 文档中的 CI 产物边界说明：该节点包是 Legion 部署包的输入，不是完整部署包。

## 本地验证

- `actionlint .github/workflows/build-legion-product-node.yml`
- `bash -n .github/scripts/build-legion-product-node.sh`
- `shellcheck .github/scripts/build-legion-product-node.sh`
- `git diff --check`
- Go 1.22.12 完整打包成功；产物约 70 MB，`file`/`readelf` 确认静态链接且无 `NEEDED` 条目，内外层 SHA256 均通过。
- 使用 Legion 官方 `package_legion_product_deploy.sh` 通过 customer provenance 门禁，成功组装 `ssa + connected` 部署包；独立解压后 `verify-package.sh` 通过。
- `go test ./cmd/legion-smoke-node -count=1`
- `go test -tags hids ./scannode -run '^(TestHIDSCapabilityHooks|TestCapabilityManager.*(HIDS|StructuredDetail)|TestNormalizeCapabilityEventStatus|TestNormalizeScanNodeCapabilityKeys.*)$' -count=1`

## 后续

本 PR 先建立可审计的节点构建与 GitHub Artifact 产出，不直接发布 OSS 或创建 Release。可通过 `legion-node-v0.0.0-alpha.*` Tag 隔离触发节点打包验证。
