### PR TITLE
ci(release): 发布 Legion AI Session Runtime 独立构建产物

### DIFF
--- a/.github/scripts/package-legion-ai-session-runtime.sh
+++ b/.github/scripts/package-legion-ai-session-runtime.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+package_name="${RUNTIME_PACKAGE_NAME:-legion-ai-session-runtime_linux_amd64}"
+dist_dir="${RUNTIME_DIST_DIR:-$repo_root/dist}"
+package_dir="$dist_dir/$package_name"
+package_path="$dist_dir/$package_name.tar.gz"
+dockerfile="${RUNTIME_DOCKERFILE:-$repo_root/docker/session-runtime/Dockerfile}"
+dockerignore="${RUNTIME_DOCKERIGNORE:-${dockerfile}.dockerignore}"
+
+die() {
+  printf '[legion-ai-session-runtime][error] %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '[legion-ai-session-runtime] %s\n' "$*"
+}
+
+for command in file git gzip jq sha256sum stat tar; do
+  command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
+done
+
+source_sha="${SOURCE_SHA:-$(git -C "$repo_root" rev-parse HEAD)}"
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid SOURCE_SHA: $source_sha"
+[[ "$(git -C "$repo_root" rev-parse HEAD)" == "$source_sha" ]] || \
+  die "checkout HEAD does not match SOURCE_SHA"
+
+source_dirty=false
+if [[ -n "$(git -C "$repo_root" status --porcelain --untracked-files=all)" ]]; then
+  source_dirty=true
+fi
+if [[ "${CI:-}" == "true" && "$source_dirty" == "true" ]]; then
+  die "CI checkout must be clean before provenance is generated"
+fi
+
+runtime_binary="${RUNTIME_BINARY:-}"
+runtime_ldd_file="${RUNTIME_LDD_FILE:-}"
+runtime_image_ref="${RUNTIME_IMAGE_REF:-}"
+runtime_image_tag="${RUNTIME_IMAGE_TAG:-}"
+runtime_base_image="${RUNTIME_BASE_IMAGE:-}"
+runtime_builder_image="${RUNTIME_BUILDER_IMAGE:-}"
+runtime_go_version="${RUNTIME_GO_VERSION:-}"
+
+[[ -f "$runtime_binary" ]] || die "RUNTIME_BINARY must reference the binary extracted from the built image"
+[[ -f "$runtime_ldd_file" ]] || die "RUNTIME_LDD_FILE must reference ldd output captured inside the built image"
+[[ -f "$dockerfile" ]] || die "runtime Dockerfile does not exist: $dockerfile"
+[[ -f "$dockerignore" ]] || die "runtime Dockerfile ignore file does not exist: $dockerignore"
+[[ "$runtime_image_ref" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || \
+  die "RUNTIME_IMAGE_REF must be an immutable image@sha256 digest"
+[[ "$runtime_image_tag" =~ ^[^[:space:]@]+:[^[:space:]@]+$ ]] || \
+  die "RUNTIME_IMAGE_TAG must be the human-readable build tag"
+[[ "$runtime_base_image" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || \
+  die "RUNTIME_BASE_IMAGE must be pinned by sha256 digest"
+[[ "$runtime_builder_image" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || \
+  die "RUNTIME_BUILDER_IMAGE must be pinned by sha256 digest"
+[[ -n "$runtime_go_version" ]] || die "RUNTIME_GO_VERSION is required"
+grep -qv '^[[:space:]]*$' "$runtime_ldd_file" || die "runtime ldd output is empty"
+if grep -q 'not found' "$runtime_ldd_file"; then
+  die "runtime binary has unresolved shared libraries in the final image"
+fi
+
+file_description="$(file "$runtime_binary")"
+grep -q 'ELF 64-bit' <<<"$file_description" || die "runtime binary is not a 64-bit ELF file"
+grep -q 'x86-64' <<<"$file_description" || die "runtime binary is not built for linux/amd64"
+
+module_go_version="$(awk '$1 == "go" { gsub(/\r/, "", $2); print $2; exit }' "$repo_root/go.mod")"
+[[ -n "$module_go_version" ]] || die "go.mod does not declare a Go version"
+[[ "$runtime_go_version" == *"go${module_go_version}"* ]] || \
+  die "Runtime Go version does not match go.mod go${module_go_version}: $runtime_go_version"
+
+version="${RUNTIME_PACKAGE_VERSION:-sha-${source_sha:0:12}}"
+[[ -n "$version" ]] || die "runtime package version must not be empty"
+[[ ! -e "$package_dir" ]] || die "package directory already exists: $package_dir"
+[[ ! -e "$package_path" ]] || die "package archive already exists: $package_path"
+
+mkdir -p "$package_dir"
+binary_sha="$(sha256sum "$runtime_binary" | awk '{print $1}')"
+binary_size="$(stat -c %s "$runtime_binary")"
+dockerfile_sha="$(sha256sum "$dockerfile" | awk '{print $1}')"
+dockerignore_sha="$(sha256sum "$dockerignore" | awk '{print $1}')"
+built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+jq -n \
+  --arg version "$version" \
+  --arg repository "${GITHUB_REPOSITORY:-yaklang/yaklang}" \
+  --arg source_sha "$source_sha" \
+  --argjson source_dirty "$source_dirty" \
+  --arg ci_provider "${RUNTIME_CI_PROVIDER:-${GITHUB_ACTIONS:+github-actions}}" \
+  --arg ci_run_id "${GITHUB_RUN_ID:-local}" \
+  --arg ci_run_attempt "${GITHUB_RUN_ATTEMPT:-1}" \
+  --arg ci_workflow "${SESSION_RUNTIME_WORKFLOW_NAME:-${GITHUB_WORKFLOW:-local}}" \
+  --arg ci_actor "${GITHUB_ACTOR:-local}" \
+  --arg runtime_base_image "$runtime_base_image" \
+  --arg runtime_builder_image "$runtime_builder_image" \
+  --arg dockerfile_sha "$dockerfile_sha" \
+  --arg dockerignore_sha "$dockerignore_sha" \
+  --arg module_go_version "$module_go_version" \
+  --arg runtime_go_version "$runtime_go_version" \
+  --arg binary_sha "$binary_sha" \
+  --argjson binary_size "$binary_size" \
+  --rawfile binary_ldd "$runtime_ldd_file" \
+  --arg runtime_image_ref "$runtime_image_ref" \
+  --arg runtime_image_tag "$runtime_image_tag" \
+  --arg built_at "$built_at" \
+  '{
+    schema_version: "1",
+    artifact_type: "legion-ai-session-runtime",
+    version: $version,
+    source: {
+      repository: $repository,
+      commit: $source_sha,
+      dirty: $source_dirty
+    },
+    ci: {
+      provider: (if ($ci_provider | length) > 0 then $ci_provider else "local" end),
+      run_id: $ci_run_id,
+      run_attempt: $ci_run_attempt,
+      workflow: $ci_workflow,
+      actor: $ci_actor
+    },
+    recipe: {
+      version: "session-runtime-v1",
+      base_image: $runtime_base_image,
+      builder_image: $runtime_builder_image,
+      packaging_repository: $repository,
+      packaging_source_sha: $source_sha,
+      packaging_dirty: $source_dirty,
+      dockerfile_sha256: $dockerfile_sha,
+      dockerignore_sha256: $dockerignore_sha,
+      goos: "linux",
+      goarch: "amd64",
+      cgo_enabled: true,
+      link_mode: "dynamic-container",
+      build_tags: "",
+      module_go_version: $module_go_version,
+      go_version: $runtime_go_version
+    },
+    capabilities: ["ai.session.runtime", "yak.execute"],
+    binary: {
+      path: "/usr/local/bin/legion-session-runtime",
+      sha256: $binary_sha,
+      size: $binary_size,
+      ldd: ($binary_ldd | rtrimstr("\n"))
+    },
+    image: {
+      ref: $runtime_image_ref,
+      tag: $runtime_image_tag,
+      revision_label: $source_sha
+    },
+    built_at: $built_at
+  }' >"$package_dir/SESSION_RUNTIME_MANIFEST.json"
+
+(
+  cd "$package_dir"
+  sha256sum SESSION_RUNTIME_MANIFEST.json >SHA256SUMS
+  sha256sum -c SHA256SUMS
+)
+
+source_epoch="$(git -C "$repo_root" show -s --format=%ct "$source_sha")"
+tar \
+  --sort=name \
+  --mtime="@$source_epoch" \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  -C "$package_dir" \
+  -cf - . | gzip -n -1 >"$package_path"
+(
+  cd "$dist_dir"
+  sha256sum "$(basename "$package_path")" >"$(basename "$package_path").sha256"
+)
+
+log "provenance package created: $package_path"
+log "runtime image: $runtime_image_ref"
+log "runtime binary sha256: $binary_sha"

--- a/.github/scripts/test-package-legion-ai-session-runtime.sh
+++ b/.github/scripts/test-package-legion-ai-session-runtime.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+packager="$repo_root/.github/scripts/package-legion-ai-session-runtime.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+
+source_sha="$(git -C "$repo_root" rev-parse HEAD)"
+fake_digest="$(printf 'a%.0s' {1..64})"
+base_digest="$(printf 'b%.0s' {1..64})"
+builder_digest="$(printf 'c%.0s' {1..64})"
+runtime_binary="$test_root/legion-session-runtime"
+runtime_ldd="$test_root/runtime.ldd"
+cp /bin/true "$runtime_binary"
+ldd "$runtime_binary" >"$runtime_ldd"
+
+SOURCE_SHA="$source_sha" \
+RUNTIME_PACKAGE_VERSION="fixture-${source_sha:0:12}" \
+RUNTIME_DIST_DIR="$test_root/dist" \
+RUNTIME_BINARY="$runtime_binary" \
+RUNTIME_LDD_FILE="$runtime_ldd" \
+RUNTIME_IMAGE_REF="registry.example/legion-ai-session-runtime@sha256:$fake_digest" \
+RUNTIME_IMAGE_TAG="registry.example/legion-ai-session-runtime:fixture" \
+RUNTIME_BASE_IMAGE="debian:bookworm-slim@sha256:$base_digest" \
+RUNTIME_BUILDER_IMAGE="golang:1.22.12-bookworm@sha256:$builder_digest" \
+RUNTIME_GO_VERSION="go version go1.22.12 linux/amd64" \
+RUNTIME_CI_PROVIDER="fixture" \
+SESSION_RUNTIME_WORKFLOW_NAME="fixture" \
+"$packager"
+
+package_name="legion-ai-session-runtime_linux_amd64"
+package_dir="$test_root/dist/$package_name"
+manifest="$package_dir/SESSION_RUNTIME_MANIFEST.json"
+
+(
+  cd "$package_dir"
+  sha256sum -c SHA256SUMS
+)
+(
+  cd "$test_root/dist"
+  sha256sum -c "$package_name.tar.gz.sha256"
+)
+
+jq -e \
+  --arg source_sha "$source_sha" \
+  --arg image_ref "registry.example/legion-ai-session-runtime@sha256:$fake_digest" '
+    .schema_version == "1" and
+    .artifact_type == "legion-ai-session-runtime" and
+    .source.commit == $source_sha and
+    .recipe.packaging_source_sha == $source_sha and
+    .recipe.goos == "linux" and
+    .recipe.goarch == "amd64" and
+    .recipe.cgo_enabled == true and
+    .recipe.link_mode == "dynamic-container" and
+    .recipe.module_go_version == "1.22.12" and
+    (.capabilities | index("ai.session.runtime")) != null and
+    (.capabilities | index("yak.execute")) != null and
+    .image.ref == $image_ref and
+    .image.revision_label == $source_sha and
+    (.binary.sha256 | test("^[0-9a-f]{64}$")) and
+    (.recipe.dockerfile_sha256 | test("^[0-9a-f]{64}$")) and
+    (.recipe.dockerignore_sha256 | test("^[0-9a-f]{64}$"))
+  ' "$manifest" >/dev/null
+
+printf '[legion-ai-session-runtime-test] PASS\n'

--- a/.github/workflows/build-legion-ai-session-runtime.yml
+++ b/.github/workflows/build-legion-ai-session-runtime.yml
@@ -1,0 +1,318 @@
+name: Build Trusted Legion AI Session Runtime
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "legion-runtime-v*"
+  pull_request:
+    paths:
+      - ".github/scripts/package-legion-ai-session-runtime.sh"
+      - ".github/scripts/test-package-legion-ai-session-runtime.sh"
+      - ".github/workflows/build-legion-ai-session-runtime.yml"
+      - "docker/session-runtime/**"
+      - "cmd/legion-smoke-node/**"
+      - "common/ai/**"
+      - "common/node/**"
+      - "common/spec/**"
+      - "scannode/**"
+      - "go.mod"
+      - "go.sum"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: legion-ai-session-runtime-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  RUNTIME_PACKAGE_NAME: legion-ai-session-runtime_linux_amd64
+  RUNTIME_IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/legion-ai-session-runtime
+  SESSION_RUNTIME_WORKFLOW_NAME: Build Trusted Legion AI Session Runtime
+  SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  build-linux-amd64:
+    name: Build Linux amd64 AI Session Runtime
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Check out source commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 0
+
+      - name: Validate event and release source
+        id: contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=false
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              ;;
+            workflow_dispatch)
+              [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+                echo "workflow_dispatch publishing is restricted to main" >&2
+                exit 1
+              }
+              publish=true
+              ;;
+            push)
+              [[ "$GITHUB_REF" =~ ^refs/tags/legion-runtime-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
+                echo "unexpected publish tag: $GITHUB_REF" >&2
+                exit 1
+              }
+              publish=true
+              ;;
+            *)
+              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
+          [[ -z "$(git status --porcelain --untracked-files=all)" ]]
+          if [[ "$publish" == true ]]; then
+            git fetch --no-tags origin main:refs/remotes/origin/main
+            git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
+              echo "published Runtime source must already be reachable from origin/main" >&2
+              exit 1
+            }
+          fi
+
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="sha-${SOURCE_SHA:0:12}"
+          fi
+          artifact_name="$RUNTIME_PACKAGE_NAME"
+          ci_provider=github-actions
+          if [[ "$publish" != true ]]; then
+            artifact_name="${RUNTIME_PACKAGE_NAME}-preview"
+            ci_provider=github-actions-preview
+          fi
+          {
+            echo "publish=$publish"
+            echo "version=$version"
+            echo "artifact_name=$artifact_name"
+            echo "ci_provider=$ci_provider"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Verify module Go version
+        shell: bash
+        run: |
+          set -euo pipefail
+          module_go_version="$(awk '$1 == "go" { gsub(/\r/, "", $2); print $2; exit }' go.mod)"
+          [[ "$module_go_version" == "1.22.12" ]] || {
+            echo "Runtime workflow expects go.mod go1.22.12, got go${module_go_version}" >&2
+            exit 1
+          }
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test AI Session Runtime code
+        shell: bash
+        run: |
+          set -euo pipefail
+          export GOTOOLCHAIN=local
+          go test ./cmd/legion-smoke-node ./common/node ./scannode
+          ./.github/scripts/test-package-legion-ai-session-runtime.sh
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Resolve immutable base images
+        id: bases
+        shell: bash
+        run: |
+          set -euo pipefail
+          builder_tag="golang:1.22.12-bookworm"
+          runtime_tag="debian:bookworm-slim"
+          builder_digest="$(docker buildx imagetools inspect "$builder_tag" --format '{{json .Manifest.Digest}}' | jq -r .)"
+          runtime_digest="$(docker buildx imagetools inspect "$runtime_tag" --format '{{json .Manifest.Digest}}' | jq -r .)"
+          [[ "$builder_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$runtime_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          builder_ref="${builder_tag}@${builder_digest}"
+          runtime_ref="${runtime_tag}@${runtime_digest}"
+          go_version="$(docker run --rm --platform linux/amd64 "$builder_ref" go version)"
+          [[ "$go_version" == *"go1.22.12"* ]]
+          {
+            echo "builder_ref=$builder_ref"
+            echo "runtime_ref=$runtime_ref"
+            echo "go_version=$go_version"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Authenticate to GitHub Container Registry
+        if: steps.contract.outputs.publish == 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build AI Session Runtime image
+        id: image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: docker/session-runtime/Dockerfile
+          platforms: linux/amd64
+          push: ${{ steps.contract.outputs.publish == 'true' }}
+          load: ${{ steps.contract.outputs.publish != 'true' }}
+          tags: ${{ env.RUNTIME_IMAGE_REPOSITORY }}:${{ steps.contract.outputs.version }}
+          build-args: |
+            GO_BUILDER_IMAGE=${{ steps.bases.outputs.builder_ref }}
+            RUNTIME_BASE_IMAGE=${{ steps.bases.outputs.runtime_ref }}
+            SOURCE_SHA=${{ env.SOURCE_SHA }}
+            RUNTIME_VERSION=${{ steps.contract.outputs.version }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ env.SOURCE_SHA }}
+            org.opencontainers.image.version=${{ steps.contract.outputs.version }}
+          provenance: ${{ steps.contract.outputs.publish == 'true' && 'mode=max' || 'false' }}
+          sbom: ${{ steps.contract.outputs.publish == 'true' }}
+
+      - name: Inspect built image and extract Runtime binary
+        id: inspect
+        shell: bash
+        env:
+          PUBLISH: ${{ steps.contract.outputs.publish }}
+          PUBLISHED_DIGEST: ${{ steps.image.outputs.digest }}
+          VERSION: ${{ steps.contract.outputs.version }}
+        run: |
+          set -euo pipefail
+          image_tag="${RUNTIME_IMAGE_REPOSITORY}:${VERSION}"
+          image_for_inspection="$image_tag"
+          if [[ "$PUBLISH" == true ]]; then
+            [[ "$PUBLISHED_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+            image_ref="${RUNTIME_IMAGE_REPOSITORY}@${PUBLISHED_DIGEST}"
+            docker pull "$image_ref"
+            image_for_inspection="$image_ref"
+          else
+            local_image_id="$(docker image inspect --format '{{.Id}}' "$image_tag")"
+            [[ "$local_image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
+            image_ref="local.invalid/yaklang/legion-ai-session-runtime@${local_image_id}"
+          fi
+
+          revision="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$image_for_inspection")"
+          [[ "$revision" == "$SOURCE_SHA" ]]
+          mkdir -p "${RUNNER_TEMP}/runtime-inspect"
+          container_id="$(docker create "$image_for_inspection")"
+          trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
+          docker cp "$container_id:/usr/local/bin/legion-session-runtime" \
+            "${RUNNER_TEMP}/runtime-inspect/legion-session-runtime"
+          docker run --rm --entrypoint /bin/sh "$image_for_inspection" -ec \
+            'test -x /usr/local/bin/legion-session-runtime; ldd /usr/local/bin/legion-session-runtime' \
+            >"${RUNNER_TEMP}/runtime-inspect/runtime.ldd"
+          if grep -q 'not found' "${RUNNER_TEMP}/runtime-inspect/runtime.ldd"; then
+            echo "Runtime binary has unresolved shared libraries" >&2
+            exit 1
+          fi
+          {
+            echo "image_ref=$image_ref"
+            echo "image_tag=$image_tag"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Generate Runtime provenance artifact
+        shell: bash
+        env:
+          RUNTIME_PACKAGE_VERSION: ${{ steps.contract.outputs.version }}
+          RUNTIME_CI_PROVIDER: ${{ steps.contract.outputs.ci_provider }}
+          RUNTIME_BINARY: ${{ runner.temp }}/runtime-inspect/legion-session-runtime
+          RUNTIME_LDD_FILE: ${{ runner.temp }}/runtime-inspect/runtime.ldd
+          RUNTIME_IMAGE_REF: ${{ steps.inspect.outputs.image_ref }}
+          RUNTIME_IMAGE_TAG: ${{ steps.inspect.outputs.image_tag }}
+          RUNTIME_BASE_IMAGE: ${{ steps.bases.outputs.runtime_ref }}
+          RUNTIME_BUILDER_IMAGE: ${{ steps.bases.outputs.builder_ref }}
+          RUNTIME_GO_VERSION: ${{ steps.bases.outputs.go_version }}
+        run: ./.github/scripts/package-legion-ai-session-runtime.sh
+
+      - name: Verify and stage cross-repository artifact contract
+        shell: bash
+        env:
+          PUBLISH: ${{ steps.contract.outputs.publish }}
+        run: |
+          set -euo pipefail
+          cd "dist/${RUNTIME_PACKAGE_NAME}"
+          sha256sum -c SHA256SUMS
+          jq -e \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg image_ref "${{ steps.inspect.outputs.image_ref }}" \
+            --arg provider "${{ steps.contract.outputs.ci_provider }}" '
+              .artifact_type == "legion-ai-session-runtime" and
+              .source.repository == "yaklang/yaklang" and
+              .source.commit == $source_sha and
+              .source.dirty == false and
+              .ci.provider == $provider and
+              .ci.workflow == "Build Trusted Legion AI Session Runtime" and
+              .recipe.packaging_source_sha == $source_sha and
+              .recipe.packaging_dirty == false and
+              .recipe.goos == "linux" and
+              .recipe.goarch == "amd64" and
+              .recipe.cgo_enabled == true and
+              .recipe.link_mode == "dynamic-container" and
+              (.recipe.dockerfile_sha256 | test("^[0-9a-f]{64}$")) and
+              (.recipe.dockerignore_sha256 | test("^[0-9a-f]{64}$")) and
+              (.capabilities | index("ai.session.runtime")) != null and
+              (.capabilities | index("yak.execute")) != null and
+              .image.ref == $image_ref and
+              .image.revision_label == $source_sha
+            ' SESSION_RUNTIME_MANIFEST.json >/dev/null
+          if [[ "$PUBLISH" == true ]]; then
+            jq -e '.ci.provider == "github-actions" and (.ci.run_id | test("^[0-9]+$"))' \
+              SESSION_RUNTIME_MANIFEST.json >/dev/null
+          fi
+
+          cd ../..
+          mkdir -p dist/artifact
+          cp "dist/${RUNTIME_PACKAGE_NAME}/SESSION_RUNTIME_MANIFEST.json" dist/artifact/
+          cp "dist/${RUNTIME_PACKAGE_NAME}/SHA256SUMS" dist/artifact/
+          cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz" dist/artifact/
+          cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
+
+      - name: Publish build summary
+        shell: bash
+        run: |
+          {
+            echo "## Legion AI Session Runtime"
+            echo
+            echo "- Source: \`${SOURCE_SHA}\`"
+            echo "- Published: \`${{ steps.contract.outputs.publish }}\`"
+            echo "- Image: \`${{ steps.inspect.outputs.image_ref }}\`"
+            echo "- Artifact: \`${{ steps.contract.outputs.artifact_name }}\`"
+            echo "- Go: \`${{ steps.bases.outputs.go_version }}\`"
+            echo
+            echo '```json'
+            jq . "dist/${RUNTIME_PACKAGE_NAME}/SESSION_RUNTIME_MANIFEST.json"
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Attest published Runtime manifest
+        if: steps.contract.outputs.publish == 'true'
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: |
+            dist/artifact/SESSION_RUNTIME_MANIFEST.json
+            dist/artifact/SHA256SUMS
+            dist/artifact/${{ env.RUNTIME_PACKAGE_NAME }}.tar.gz
+            dist/artifact/${{ env.RUNTIME_PACKAGE_NAME }}.tar.gz.sha256
+
+      - name: Upload Runtime provenance
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.contract.outputs.artifact_name }}
+          path: dist/artifact/*
+          if-no-files-found: error
+          retention-days: ${{ steps.contract.outputs.publish == 'true' && 14 || 7 }}

--- a/docker/session-runtime/Dockerfile
+++ b/docker/session-runtime/Dockerfile
@@ -13,20 +13,43 @@
 #   LEGION_SESSIONMGR_URL, LEGION_AI_SESSION_ID, LEGION_AI_RUNTIME
 # 并通过 -agent-installation-id ai-session-<sessionID> 传 ephemeral identity。
 
+# Trusted CI resolves both image arguments to immutable sha256 references before
+# building. The tag defaults keep local development convenient without weakening
+# the published provenance contract.
+ARG GO_BUILDER_IMAGE=golang:1.22.12-bookworm
+ARG RUNTIME_BASE_IMAGE=debian:bookworm-slim
+
 # ---------- 构建阶段 ----------
-FROM golang:1.24-bookworm AS builder
+FROM ${GO_BUILDER_IMAGE} AS builder
 
 WORKDIR /src
 COPY . .
 
 # 编译 legion-smoke-node（ai_session 容器不需要 HIDS tag，精简依赖）。
 # Yaklang's embedded pcre2 and pcap dependencies require CGO.
-RUN CGO_ENABLED=1 go build -ldflags "-s -w" -o /out/legion-session-runtime ./cmd/legion-smoke-node
+ENV GOTOOLCHAIN=local
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    module_go_version="$(awk '$1 == "go" { gsub(/\r/, "", $2); print $2; exit }' go.mod)" \
+    && test "$(go env GOVERSION)" = "go${module_go_version}" \
+    && CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+      -trimpath \
+      -buildvcs=false \
+      -ldflags "-s -w -buildid=" \
+      -o /out/legion-session-runtime \
+      ./cmd/legion-smoke-node
 
 # ---------- 运行阶段 ----------
-FROM debian:bookworm-slim
+FROM ${RUNTIME_BASE_IMAGE}
 
-# ai_session 容器需要 ca-certificates（调平台 HTTPS bootstrap）+ curl（调试）。
+ARG SOURCE_SHA=unknown
+ARG RUNTIME_VERSION=dev
+LABEL org.opencontainers.image.title="Legion AI Session Runtime" \
+      org.opencontainers.image.source="https://github.com/yaklang/yaklang" \
+      org.opencontainers.image.revision="${SOURCE_SHA}" \
+      org.opencontainers.image.version="${RUNTIME_VERSION}"
+
+# ai_session 容器需要 ca-certificates 调平台 HTTPS bootstrap。
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/session-runtime/Dockerfile.dockerignore
+++ b/docker/session-runtime/Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+docs
+dist
+node_modules
+releases
+vendor
+*.log
+*.out

--- a/docs/legion-ai-session-runtime-release.md
+++ b/docs/legion-ai-session-runtime-release.md
@@ -1,0 +1,54 @@
+# Legion AI Session Runtime Release
+
+The AI Session Runtime is the containerized `legion-smoke-node` execution form
+used for `kind=ai_session`. It is not `legion-sessionmgr`: Legion owns the
+manager process, while Yaklang owns the Runtime image and its producer
+provenance.
+
+## Workflow
+
+`Build Trusted Legion AI Session Runtime` has three entry modes:
+
+| Event | Behavior | Output trust level |
+|---|---|---|
+| Pull request | Build, test, inspect, and upload preview provenance without pushing an image | Preview; rejected by customer packaging |
+| `workflow_dispatch` on `main` | Publish the immutable image and provenance artifact | Trusted producer |
+| SemVer `legion-runtime-v*` tag reachable from `main` | Publish the immutable image and provenance artifact | Trusted producer |
+
+The isolated tag prefix intentionally does not match the repository's generic
+`v*` release workflows. For example, an alpha producer release can use
+`legion-runtime-v0.1.0-alpha.1`.
+
+## Published outputs
+
+The workflow publishes the Runtime image as:
+
+```text
+ghcr.io/yaklang/legion-ai-session-runtime@sha256:<digest>
+```
+
+The `legion-ai-session-runtime_linux_amd64` Actions artifact contains:
+
+```text
+SESSION_RUNTIME_MANIFEST.json
+SHA256SUMS
+legion-ai-session-runtime_linux_amd64.tar.gz
+legion-ai-session-runtime_linux_amd64.tar.gz.sha256
+```
+
+The artifact is provenance for the image; the deployable Runtime binary stays
+inside the OCI image. Customer assembly must consume the exact image digest,
+not its human-readable tag.
+
+`SESSION_RUNTIME_MANIFEST.json` binds the Yaklang source commit, workflow run,
+Dockerfile and its context-ignore policy, immutable builder and runtime base
+images, embedded binary digest, OCI image digest, and the
+`ai.session.runtime` plus `yak.execute` capabilities.
+
+## Release boundary
+
+This workflow does not build Legion, assemble a customer package, deploy a
+host, or prove a real model conversation. Final `memfit,ssa` assembly consumes
+this Runtime provenance together with the Product Node artifact and a trusted
+Legion bundle. Runtime acceptance still requires deployment, License and
+Provider configuration, and the real two-turn AI conversation verifier.


### PR DESCRIPTION
## 背景

Legion 的 AI Session Manager 负责会话编排，Yaklang 负责执行 `kind=ai_session` 的无状态 Runtime。本 PR 为 Runtime 增加独立、可追溯的构建与发布链路，供后续跨仓库组装消费。

## 主要变更

- 新增 `Build Trusted Legion AI Session Runtime` 工作流。
- PR 阶段构建、测试并上传 preview 产物，但不推送镜像。
- `main` 手动触发或从 `main` 可达的 `legion-runtime-v*` 标签发布正式镜像和来源证明。
- 固定 Go 模块版本为 1.22.12，并校验实际工具链版本，避免间接依赖触发 Go 1.25 自动升级。
- 生成 `SESSION_RUNTIME_MANIFEST.json`、SHA256 校验文件和 Runtime provenance。
- 加固 `docker/session-runtime/Dockerfile`，固定构建/运行基础镜像并记录源码版本。
- 新增打包脚本、契约测试和发布边界说明。

## 输出

- OCI 镜像：`ghcr.io/yaklang/legion-ai-session-runtime@sha256:<digest>`
- Actions 产物：`legion-ai-session-runtime_linux_amd64`
- 产物用于跨仓库组装；本工作流不构建 Legion、不组装客户包，也不声明真实模型会话已通过。

## CI 与发布边界

- PR 仅产生 preview 产物，不发布镜像。
- 正式发布只接受 `main` 上的 `workflow_dispatch` 或 `legion-runtime-v<semver>` 标签。
- 独立标签前缀不会触发现有通用 `v*` 发布工作流。
- 真实可用性仍需在组装后完成部署、License、Provider 配置和双轮 AI 会话验证。

## 验证

- 打包脚本契约测试已纳入工作流。
- Go、Docker、镜像能力、非 root 运行、manifest 与摘要一致性均在工作流内校验。
