### PR TITLE
feat(ci): 将 Legion 组件发布到版本化 OSS

### DIFF
--- a/.github/scripts/build-legion-component-oss-index.sh
+++ b/.github/scripts/build-legion-component-oss-index.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+component=""
+version=""
+source_sha=""
+artifact_dir=""
+public_base_url=""
+output=""
+runtime_image_ref=""
+runtime_image_id=""
+
+usage() {
+  cat <<'EOF'
+Usage: build-legion-component-oss-index.sh [options]
+
+Required:
+  --component product-node|session-runtime
+  --version TAG
+  --source-sha SHA
+  --artifact-dir DIR
+  --public-base-url URL
+  --output FILE
+
+Required for session-runtime:
+  --runtime-image-ref IMAGE@sha256:...
+  --runtime-image-id sha256:...
+EOF
+}
+
+die() { printf '[legion-component-oss-index][error] %s\n' "$*" >&2; exit 1; }
+
+while (($#)); do
+  case "$1" in
+    --component) component="$2"; shift 2 ;;
+    --version) version="$2"; shift 2 ;;
+    --source-sha) source_sha="$2"; shift 2 ;;
+    --artifact-dir) artifact_dir="$2"; shift 2 ;;
+    --public-base-url) public_base_url="$2"; shift 2 ;;
+    --output) output="$2"; shift 2 ;;
+    --runtime-image-ref) runtime_image_ref="$2"; shift 2 ;;
+    --runtime-image-id) runtime_image_id="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+for command in jq sha256sum stat; do
+  command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
+done
+
+case "$component" in
+  product-node)
+    [[ "$version" =~ ^legion-node-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || die "invalid Product Node release version"
+    package_name="legion-product-node_linux_amd64.tar.gz"
+    manifest_name="PRODUCT_NODE_MANIFEST.json"
+    checksums_name="SHA256SUMS"
+    binary_name="legion-smoke-node"
+    manifest_type="legion-product-node"
+    ;;
+  session-runtime)
+    [[ "$version" =~ ^legion-runtime-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || die "invalid Session Runtime release version"
+    package_name="legion-ai-session-runtime_linux_amd64.tar.gz"
+    manifest_name="SESSION_RUNTIME_MANIFEST.json"
+    checksums_name="SHA256SUMS"
+    image_archive_name="legion-ai-session-runtime_linux_amd64.docker.tar.gz"
+    manifest_type="legion-ai-session-runtime"
+    [[ "$runtime_image_ref" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || die "invalid Runtime image ref"
+    [[ "$runtime_image_id" =~ ^sha256:[0-9a-f]{64}$ ]] || die "invalid Runtime image ID"
+    [[ "${runtime_image_ref##*@}" == "$runtime_image_id" ]] || die "Runtime logical image ref and image ID differ"
+    ;;
+  *) die "invalid --component" ;;
+esac
+
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid --source-sha"
+[[ -d "$artifact_dir" ]] || die "artifact directory does not exist"
+artifact_dir="$(cd "$artifact_dir" && pwd)"
+expected_public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/$component/$version/$source_sha"
+[[ "$public_base_url" == "$expected_public_base_url" ]] || \
+  die "public base URL does not match the selected component, version, and source"
+[[ -n "$output" ]] || die "--output is required"
+
+manifest="$artifact_dir/$manifest_name"
+package="$artifact_dir/$package_name"
+checksums="$artifact_dir/$checksums_name"
+package_checksum="$artifact_dir/$package_name.sha256"
+for required in "$manifest" "$package" "$checksums" "$package_checksum"; do
+  [[ -f "$required" ]] || die "missing release artifact: $required"
+done
+
+(
+  cd "$artifact_dir"
+  sha256sum -c "$package_name.sha256" >/dev/null
+)
+jq -e \
+  --arg type "$manifest_type" \
+  --arg version "$version" \
+  --arg source_sha "$source_sha" '
+    .schema_version == "1" and
+    .artifact_type == $type and
+    .version == $version and
+    .source.repository == "yaklang/yaklang" and
+    .source.commit == $source_sha and
+    .source.dirty == false and
+    .ci.provider == "github-actions" and
+    (.ci.run_id | test("^[0-9]+$"))
+  ' "$manifest" >/dev/null || die "producer manifest does not match the requested release"
+
+file_record() {
+  local path="$1"
+  jq -cn \
+    --arg path "$(basename "$path")" \
+    --arg sha256 "$(sha256sum "$path" | awk '{print $1}')" \
+    --argjson size "$(stat -c %s "$path")" \
+    '{path:$path,sha256:$sha256,size:$size}'
+}
+
+package_record="$(file_record "$package")"
+manifest_record="$(file_record "$manifest")"
+checksums_record="$(file_record "$checksums")"
+package_checksum_record="$(file_record "$package_checksum")"
+mkdir -p "$(dirname "$output")"
+
+if [[ "$component" == product-node ]]; then
+  binary="$artifact_dir/$binary_name"
+  [[ -f "$binary" ]] || die "missing release artifact: $binary"
+  binary_record="$(file_record "$binary")"
+  binary_sha="$(jq -er .binary.sha256 "$manifest")"
+  [[ "$binary_sha" == "$(sha256sum "$binary" | awk '{print $1}')" ]] || die "Product Node binary digest differs from its manifest"
+  jq -n \
+    --arg version "$version" \
+    --arg source_sha "$source_sha" \
+    --arg base_url "$public_base_url" \
+    --argjson package "$package_record" \
+    --argjson package_checksum "$package_checksum_record" \
+    --argjson manifest "$manifest_record" \
+    --argjson checksums "$checksums_record" \
+    --argjson binary "$binary_record" \
+    '{
+      schema_version:"1",
+      artifact_type:"legion-component-oss-release",
+      component:"product-node",
+      version:$version,
+      source:{repository:"yaklang/yaklang",commit:$source_sha},
+      distribution:{provider:"aliyun-oss",base_url:$base_url},
+      artifacts:{package:$package,package_checksum:$package_checksum,manifest:$manifest,checksums:$checksums,binary:$binary}
+    }' >"$output"
+else
+  image_archive="$artifact_dir/$image_archive_name"
+  [[ -f "$image_archive" ]] || die "missing Runtime image archive: $image_archive"
+  image_archive_record="$(file_record "$image_archive")"
+  [[ "$(jq -er .image.ref "$manifest")" == "$runtime_image_ref" ]] || die "Runtime image ref differs from its manifest"
+  jq -n \
+    --arg version "$version" \
+    --arg source_sha "$source_sha" \
+    --arg base_url "$public_base_url" \
+    --arg runtime_image_ref "$runtime_image_ref" \
+    --arg runtime_image_id "$runtime_image_id" \
+    --argjson package "$package_record" \
+    --argjson package_checksum "$package_checksum_record" \
+    --argjson manifest "$manifest_record" \
+    --argjson checksums "$checksums_record" \
+    --argjson image_archive "$image_archive_record" \
+    '{
+      schema_version:"1",
+      artifact_type:"legion-component-oss-release",
+      component:"session-runtime",
+      version:$version,
+      source:{repository:"yaklang/yaklang",commit:$source_sha},
+      distribution:{provider:"aliyun-oss",base_url:$base_url},
+      runtime:{image_ref:$runtime_image_ref,image_id:$runtime_image_id},
+      artifacts:{package:$package,package_checksum:$package_checksum,manifest:$manifest,checksums:$checksums,image_archive:$image_archive}
+    }' >"$output"
+fi
+
+jq -e . "$output" >/dev/null
+(
+  cd "$(dirname "$output")"
+  sha256sum "$(basename "$output")" >"$(basename "$output").sha256"
+)
+printf '[legion-component-oss-index] created %s\n' "$output"

--- a/.github/scripts/test-build-legion-component-oss-index.sh
+++ b/.github/scripts/test-build-legion-component-oss-index.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+builder="$script_dir/build-legion-component-oss-index.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+source_sha="1111111111111111111111111111111111111111"
+
+make_common() {
+  local dir="$1" package="$2" manifest="$3"
+  mkdir -p "$dir"
+  printf 'package\n' >"$dir/$package"
+  printf 'checksums\n' >"$dir/SHA256SUMS"
+  (cd "$dir" && sha256sum "$package" >"$package.sha256")
+  [[ -f "$dir/$manifest" ]]
+}
+
+node_dir="$test_root/node"
+mkdir -p "$node_dir"
+printf 'node\n' >"$node_dir/legion-smoke-node"
+node_sha="$(sha256sum "$node_dir/legion-smoke-node" | awk '{print $1}')"
+jq -n --arg sha "$source_sha" --arg binary_sha "$node_sha" '{
+  schema_version:"1",artifact_type:"legion-product-node",version:"legion-node-v1.2.3-alpha.1",
+  source:{repository:"yaklang/yaklang",commit:$sha,dirty:false},
+  ci:{provider:"github-actions",run_id:"123"},binary:{sha256:$binary_sha}
+}' >"$node_dir/PRODUCT_NODE_MANIFEST.json"
+make_common "$node_dir" legion-product-node_linux_amd64.tar.gz PRODUCT_NODE_MANIFEST.json
+"$builder" \
+  --component product-node \
+  --version legion-node-v1.2.3-alpha.1 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$node_dir" \
+  --public-base-url "https://yaklang.oss-accelerate.aliyuncs.com/legion/components/product-node/legion-node-v1.2.3-alpha.1/$source_sha" \
+  --output "$node_dir/release-index.json"
+jq -e --arg sha "$source_sha" '
+  .component == "product-node" and .source.commit == $sha and
+  .artifacts.binary.path == "legion-smoke-node" and
+  (.artifacts.binary.sha256 | test("^[0-9a-f]{64}$"))
+' "$node_dir/release-index.json" >/dev/null
+(cd "$node_dir" && sha256sum -c release-index.json.sha256 >/dev/null)
+
+runtime_dir="$test_root/runtime"
+mkdir -p "$runtime_dir"
+image_id="sha256:3333333333333333333333333333333333333333333333333333333333333333"
+image_ref="yaklang-oss.invalid/legion-ai-session-runtime@$image_id"
+printf 'image\n' >"$runtime_dir/legion-ai-session-runtime_linux_amd64.docker.tar.gz"
+jq -n --arg sha "$source_sha" --arg image_ref "$image_ref" '{
+  schema_version:"1",artifact_type:"legion-ai-session-runtime",version:"legion-runtime-v1.2.3",
+  source:{repository:"yaklang/yaklang",commit:$sha,dirty:false},
+  ci:{provider:"github-actions",run_id:"456"},image:{ref:$image_ref}
+}' >"$runtime_dir/SESSION_RUNTIME_MANIFEST.json"
+make_common "$runtime_dir" legion-ai-session-runtime_linux_amd64.tar.gz SESSION_RUNTIME_MANIFEST.json
+"$builder" \
+  --component session-runtime \
+  --version legion-runtime-v1.2.3 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$runtime_dir" \
+  --public-base-url "https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/legion-runtime-v1.2.3/$source_sha" \
+  --runtime-image-ref "$image_ref" \
+  --runtime-image-id "$image_id" \
+  --output "$runtime_dir/release-index.json"
+jq -e --arg ref "$image_ref" --arg id "$image_id" '
+  .component == "session-runtime" and .runtime.image_ref == $ref and .runtime.image_id == $id and
+  .artifacts.image_archive.path == "legion-ai-session-runtime_linux_amd64.docker.tar.gz"
+' "$runtime_dir/release-index.json" >/dev/null
+(cd "$runtime_dir" && sha256sum -c release-index.json.sha256 >/dev/null)
+
+if "$builder" \
+  --component session-runtime \
+  --version legion-runtime-v1.2.3 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$runtime_dir" \
+  --public-base-url "https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/legion-runtime-v1.2.3/$source_sha" \
+  --runtime-image-ref "$image_ref" \
+  --runtime-image-id sha256:4444444444444444444444444444444444444444444444444444444444444444 \
+  --output "$test_root/mismatched-runtime.json"; then
+  echo 'mismatched Runtime logical ref and image ID unexpectedly accepted' >&2
+  exit 1
+fi
+
+if "$builder" \
+  --component product-node \
+  --version bad-tag \
+  --source-sha "$source_sha" \
+  --artifact-dir "$node_dir" \
+  --public-base-url "https://yaklang.oss-accelerate.aliyuncs.com/legion/components/product-node/bad-tag/$source_sha" \
+  --output "$test_root/invalid.json"; then
+  echo 'invalid release tag unexpectedly accepted' >&2
+  exit 1
+fi
+
+echo 'Legion component OSS index tests passed'

--- a/.github/workflows/build-legion-ai-session-runtime.yml
+++ b/.github/workflows/build-legion-ai-session-runtime.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - ".github/scripts/package-legion-ai-session-runtime.sh"
       - ".github/scripts/test-package-legion-ai-session-runtime.sh"
+      - ".github/scripts/build-legion-component-oss-index.sh"
+      - ".github/scripts/test-build-legion-component-oss-index.sh"
       - ".github/workflows/build-legion-ai-session-runtime.yml"
       - "docker/session-runtime/**"
       - "cmd/legion-smoke-node/**"
@@ -28,7 +30,7 @@ concurrency:
 
 env:
   RUNTIME_PACKAGE_NAME: legion-ai-session-runtime_linux_amd64
-  RUNTIME_IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/legion-ai-session-runtime
+  RUNTIME_IMAGE_REPOSITORY: local.invalid/yaklang/legion-ai-session-runtime
   SESSION_RUNTIME_WORKFLOW_NAME: Build Trusted Legion AI Session Runtime
   SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -36,10 +38,9 @@ jobs:
   build-linux-amd64:
     name: Build Linux amd64 AI Session Runtime
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
-      packages: write
       id-token: write
       attestations: write
     steps:
@@ -55,6 +56,7 @@ jobs:
         run: |
           set -euo pipefail
           publish=false
+          publish_oss=false
           case "$GITHUB_EVENT_NAME" in
             pull_request)
               ;;
@@ -71,6 +73,7 @@ jobs:
                 exit 1
               }
               publish=true
+              publish_oss=true
               ;;
             *)
               echo "unsupported event: $GITHUB_EVENT_NAME" >&2
@@ -101,6 +104,7 @@ jobs:
           fi
           {
             echo "publish=$publish"
+            echo "publish_oss=$publish_oss"
             echo "version=$version"
             echo "artifact_name=$artifact_name"
             echo "ci_provider=$ci_provider"
@@ -129,6 +133,7 @@ jobs:
           export GOTOOLCHAIN=local
           go test ./cmd/legion-smoke-node ./common/node ./scannode
           ./.github/scripts/test-package-legion-ai-session-runtime.sh
+          ./.github/scripts/test-build-legion-component-oss-index.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -154,14 +159,6 @@ jobs:
             echo "go_version=$go_version"
           } >>"$GITHUB_OUTPUT"
 
-      - name: Authenticate to GitHub Container Registry
-        if: steps.contract.outputs.publish == 'true'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build AI Session Runtime image
         id: image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -169,8 +166,8 @@ jobs:
           context: .
           file: docker/session-runtime/Dockerfile
           platforms: linux/amd64
-          push: ${{ steps.contract.outputs.publish == 'true' }}
-          load: ${{ steps.contract.outputs.publish != 'true' }}
+          push: false
+          load: true
           tags: ${{ env.RUNTIME_IMAGE_REPOSITORY }}:${{ steps.contract.outputs.version }}
           build-args: |
             GO_BUILDER_IMAGE=${{ steps.bases.outputs.builder_ref }}
@@ -181,30 +178,21 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ env.SOURCE_SHA }}
             org.opencontainers.image.version=${{ steps.contract.outputs.version }}
-          provenance: ${{ steps.contract.outputs.publish == 'true' && 'mode=max' || 'false' }}
-          sbom: ${{ steps.contract.outputs.publish == 'true' }}
+          provenance: false
+          sbom: false
 
       - name: Inspect built image and extract Runtime binary
         id: inspect
         shell: bash
         env:
-          PUBLISH: ${{ steps.contract.outputs.publish }}
-          PUBLISHED_DIGEST: ${{ steps.image.outputs.digest }}
           VERSION: ${{ steps.contract.outputs.version }}
         run: |
           set -euo pipefail
           image_tag="${RUNTIME_IMAGE_REPOSITORY}:${VERSION}"
           image_for_inspection="$image_tag"
-          if [[ "$PUBLISH" == true ]]; then
-            [[ "$PUBLISHED_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
-            image_ref="${RUNTIME_IMAGE_REPOSITORY}@${PUBLISHED_DIGEST}"
-            docker pull "$image_ref"
-            image_for_inspection="$image_ref"
-          else
-            local_image_id="$(docker image inspect --format '{{.Id}}' "$image_tag")"
-            [[ "$local_image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
-            image_ref="local.invalid/yaklang/legion-ai-session-runtime@${local_image_id}"
-          fi
+          local_image_id="$(docker image inspect --format '{{.Id}}' "$image_tag")"
+          [[ "$local_image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image_ref="yaklang-oss.invalid/legion-ai-session-runtime@${local_image_id}"
 
           revision="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$image_for_inspection")"
           [[ "$revision" == "$SOURCE_SHA" ]]
@@ -223,6 +211,7 @@ jobs:
           {
             echo "image_ref=$image_ref"
             echo "image_tag=$image_tag"
+            echo "image_id=$local_image_id"
           } >>"$GITHUB_OUTPUT"
 
       - name: Generate Runtime provenance artifact
@@ -282,6 +271,105 @@ jobs:
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz" dist/artifact/
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
 
+      - name: Build immutable OSS Runtime release
+        if: steps.contract.outputs.publish_oss == 'true'
+        id: oss-release
+        shell: bash
+        env:
+          VERSION: ${{ steps.contract.outputs.version }}
+          RUNTIME_IMAGE_REF: ${{ steps.inspect.outputs.image_ref }}
+          RUNTIME_IMAGE_ID: ${{ steps.inspect.outputs.image_id }}
+        run: |
+          set -euo pipefail
+          oss_release="dist/oss-release"
+          mkdir -p "$oss_release"
+          cp dist/artifact/* "$oss_release/"
+          docker save "$RUNTIME_IMAGE_ID" | gzip -n -1 >"$oss_release/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
+          public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/${VERSION}/${SOURCE_SHA}"
+          ./.github/scripts/build-legion-component-oss-index.sh \
+            --component session-runtime \
+            --version "$VERSION" \
+            --source-sha "$SOURCE_SHA" \
+            --artifact-dir "$oss_release" \
+            --public-base-url "$public_base_url" \
+            --runtime-image-ref "$RUNTIME_IMAGE_REF" \
+            --runtime-image-id "$RUNTIME_IMAGE_ID" \
+            --output "$oss_release/release-index.json"
+          cp "$oss_release/release-index.json" "$oss_release/release-index.json.sha256" dist/artifact/
+          {
+            echo "public_base_url=$public_base_url"
+            echo "index_url=$public_base_url/release-index.json"
+            echo "index_sha256=$(sha256sum "$oss_release/release-index.json" | awk '{print $1}')"
+            echo "remote_prefix=legion/components/session-runtime/${VERSION}/${SOURCE_SHA}"
+            echo "release_dir=$oss_release"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Build repository-owned OSS uploader
+        if: steps.contract.outputs.publish_oss == 'true'
+        shell: bash
+        run: go build -trimpath -o "${RUNNER_TEMP}/yak-oss-upload" ./common/yak/cmd/yak.go
+
+      - name: Publish immutable Runtime release to OSS
+        if: steps.contract.outputs.publish_oss == 'true'
+        shell: bash
+        env:
+          OSS_KEY_ID: ${{ secrets.OSS_KEY_ID }}
+          OSS_KEY_SECRET: ${{ secrets.OSS_KEY_SECRET }}
+          REMOTE_PREFIX: ${{ steps.oss-release.outputs.remote_prefix }}
+          RELEASE_DIR: ${{ steps.oss-release.outputs.release_dir }}
+          INDEX_URL: ${{ steps.oss-release.outputs.index_url }}
+          INDEX_SHA256: ${{ steps.oss-release.outputs.index_sha256 }}
+        run: |
+          set -euo pipefail
+          [[ -n "$OSS_KEY_ID" && -n "$OSS_KEY_SECRET" ]]
+          existing_index="${RUNNER_TEMP}/existing-runtime-index.json"
+          http_status="$(curl --silent --show-error --location --retry 4 --retry-all-errors \
+            --output "$existing_index" --write-out '%{http_code}' "$INDEX_URL")"
+          case "$http_status" in
+            200)
+              [[ "$(sha256sum "$existing_index" | awk '{print $1}')" == "$INDEX_SHA256" ]] || {
+                echo "refusing to replace an existing OSS Runtime release index" >&2
+                exit 1
+              }
+              echo "identical OSS Runtime release already exists; upload is idempotent"
+              exit 0
+              ;;
+            404) ;;
+            *) echo "cannot determine whether OSS Runtime release already exists: HTTP $http_status" >&2; exit 1 ;;
+          esac
+          upload_specs=()
+          for file in "$RELEASE_DIR"/*; do
+            case "$(basename "$file")" in release-index.json|release-index.json.sha256) continue ;; esac
+            upload_specs+=("$file:/$REMOTE_PREFIX/$(basename "$file")")
+          done
+          payloads="$(IFS=';'; echo "${upload_specs[*]}")"
+          "${RUNNER_TEMP}/yak-oss-upload" upload-oss \
+            --endpoint oss-accelerate.aliyuncs.com \
+            --bucket yaklang \
+            --ak "$OSS_KEY_ID" \
+            --sk "$OSS_KEY_SECRET" \
+            --times 5 \
+            --file "$payloads"
+          "${RUNNER_TEMP}/yak-oss-upload" upload-oss \
+            --endpoint oss-accelerate.aliyuncs.com \
+            --bucket yaklang \
+            --ak "$OSS_KEY_ID" \
+            --sk "$OSS_KEY_SECRET" \
+            --times 5 \
+            --file "$RELEASE_DIR/release-index.json.sha256:/$REMOTE_PREFIX/release-index.json.sha256;$RELEASE_DIR/release-index.json:/$REMOTE_PREFIX/release-index.json"
+
+      - name: Verify public Runtime release index
+        if: steps.contract.outputs.publish_oss == 'true'
+        shell: bash
+        env:
+          INDEX_URL: ${{ steps.oss-release.outputs.index_url }}
+          INDEX_SHA256: ${{ steps.oss-release.outputs.index_sha256 }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location --retry 4 --retry-all-errors \
+            "$INDEX_URL" --output "${RUNNER_TEMP}/published-runtime-index.json"
+          [[ "$(sha256sum "${RUNNER_TEMP}/published-runtime-index.json" | awk '{print $1}')" == "$INDEX_SHA256" ]]
+
       - name: Publish build summary
         shell: bash
         run: |
@@ -293,6 +381,10 @@ jobs:
             echo "- Image: \`${{ steps.inspect.outputs.image_ref }}\`"
             echo "- Artifact: \`${{ steps.contract.outputs.artifact_name }}\`"
             echo "- Go: \`${{ steps.bases.outputs.go_version }}\`"
+            if [[ "${{ steps.contract.outputs.publish_oss }}" == true ]]; then
+              echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
+              echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
+            fi
             echo
             echo '```json'
             jq . "dist/${RUNTIME_PACKAGE_NAME}/SESSION_RUNTIME_MANIFEST.json"

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - ".github/scripts/build-legion-product-node.sh"
+      - ".github/scripts/build-legion-component-oss-index.sh"
+      - ".github/scripts/test-build-legion-component-oss-index.sh"
       - ".github/workflows/build-legion-product-node.yml"
       - "cmd/legion-smoke-node/**"
       - "common/hids/**"
@@ -36,17 +38,67 @@ jobs:
       NODE_PACKAGE_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
     steps:
       - name: Check out source commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 0
+
+      - name: Validate event and release source
+        id: contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_oss=false
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              ;;
+            workflow_dispatch)
+              [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+                echo "workflow_dispatch is restricted to main" >&2
+                exit 1
+              }
+              ;;
+            push)
+              [[ "$GITHUB_REF" =~ ^refs/tags/legion-node-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
+                echo "unexpected Product Node release tag: $GITHUB_REF" >&2
+                exit 1
+              }
+              publish_oss=true
+              ;;
+            *)
+              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
+          [[ -z "$(git status --porcelain --untracked-files=all)" ]]
+          if [[ "$publish_oss" == true ]]; then
+            git fetch --no-tags origin main:refs/remotes/origin/main
+            git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
+              echo "published Product Node source must already be reachable from origin/main" >&2
+              exit 1
+            }
+          fi
+          version="sha-${SOURCE_SHA:0:12}"
+          [[ "$GITHUB_REF" != refs/tags/* ]] || version="$GITHUB_REF_NAME"
+          {
+            echo "publish_oss=$publish_oss"
+            echo "version=$version"
+          } >>"$GITHUB_OUTPUT"
 
       - name: Set up Go from go.mod
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
+      - name: Test OSS release index contract
+        run: ./.github/scripts/test-build-legion-component-oss-index.sh
+
       - name: Build product node package
+        env:
+          NODE_PACKAGE_VERSION: ${{ steps.contract.outputs.version }}
         run: ./.github/scripts/build-legion-product-node.sh
 
       - name: Verify package archive
@@ -87,6 +139,94 @@ jobs:
           cp "dist/${NODE_PACKAGE_NAME}.tar.gz" dist/artifact/
           cp "dist/${NODE_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
 
+      - name: Build immutable OSS release index
+        if: steps.contract.outputs.publish_oss == 'true'
+        id: oss-release
+        shell: bash
+        env:
+          VERSION: ${{ steps.contract.outputs.version }}
+        run: |
+          set -euo pipefail
+          public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/product-node/${VERSION}/${SOURCE_SHA}"
+          ./.github/scripts/build-legion-component-oss-index.sh \
+            --component product-node \
+            --version "$VERSION" \
+            --source-sha "$SOURCE_SHA" \
+            --artifact-dir dist/artifact \
+            --public-base-url "$public_base_url" \
+            --output dist/artifact/release-index.json
+          {
+            echo "public_base_url=$public_base_url"
+            echo "index_url=$public_base_url/release-index.json"
+            echo "index_sha256=$(sha256sum dist/artifact/release-index.json | awk '{print $1}')"
+            echo "remote_prefix=legion/components/product-node/${VERSION}/${SOURCE_SHA}"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Build repository-owned OSS uploader
+        if: steps.contract.outputs.publish_oss == 'true'
+        shell: bash
+        run: go build -trimpath -o "${RUNNER_TEMP}/yak-oss-upload" ./common/yak/cmd/yak.go
+
+      - name: Publish immutable Product Node release to OSS
+        if: steps.contract.outputs.publish_oss == 'true'
+        shell: bash
+        env:
+          OSS_KEY_ID: ${{ secrets.OSS_KEY_ID }}
+          OSS_KEY_SECRET: ${{ secrets.OSS_KEY_SECRET }}
+          REMOTE_PREFIX: ${{ steps.oss-release.outputs.remote_prefix }}
+          INDEX_URL: ${{ steps.oss-release.outputs.index_url }}
+          INDEX_SHA256: ${{ steps.oss-release.outputs.index_sha256 }}
+        run: |
+          set -euo pipefail
+          [[ -n "$OSS_KEY_ID" && -n "$OSS_KEY_SECRET" ]]
+          existing_index="${RUNNER_TEMP}/existing-product-node-index.json"
+          http_status="$(curl --silent --show-error --location --retry 4 --retry-all-errors \
+            --output "$existing_index" --write-out '%{http_code}' "$INDEX_URL")"
+          case "$http_status" in
+            200)
+              [[ "$(sha256sum "$existing_index" | awk '{print $1}')" == "$INDEX_SHA256" ]] || {
+                echo "refusing to replace an existing OSS Product Node release index" >&2
+                exit 1
+              }
+              echo "identical OSS Product Node release already exists; upload is idempotent"
+              exit 0
+              ;;
+            404) ;;
+            *) echo "cannot determine whether OSS Product Node release already exists: HTTP $http_status" >&2; exit 1 ;;
+          esac
+          upload_specs=()
+          for file in dist/artifact/*; do
+            case "$(basename "$file")" in release-index.json|release-index.json.sha256) continue ;; esac
+            upload_specs+=("$file:/$REMOTE_PREFIX/$(basename "$file")")
+          done
+          payloads="$(IFS=';'; echo "${upload_specs[*]}")"
+          "${RUNNER_TEMP}/yak-oss-upload" upload-oss \
+            --endpoint oss-accelerate.aliyuncs.com \
+            --bucket yaklang \
+            --ak "$OSS_KEY_ID" \
+            --sk "$OSS_KEY_SECRET" \
+            --times 5 \
+            --file "$payloads"
+          "${RUNNER_TEMP}/yak-oss-upload" upload-oss \
+            --endpoint oss-accelerate.aliyuncs.com \
+            --bucket yaklang \
+            --ak "$OSS_KEY_ID" \
+            --sk "$OSS_KEY_SECRET" \
+            --times 5 \
+            --file "dist/artifact/release-index.json.sha256:/$REMOTE_PREFIX/release-index.json.sha256;dist/artifact/release-index.json:/$REMOTE_PREFIX/release-index.json"
+
+      - name: Verify public Product Node release index
+        if: steps.contract.outputs.publish_oss == 'true'
+        shell: bash
+        env:
+          INDEX_URL: ${{ steps.oss-release.outputs.index_url }}
+          INDEX_SHA256: ${{ steps.oss-release.outputs.index_sha256 }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location --retry 4 --retry-all-errors \
+            "$INDEX_URL" --output "${RUNNER_TEMP}/published-product-node-index.json"
+          [[ "$(sha256sum "${RUNNER_TEMP}/published-product-node-index.json" | awk '{print $1}')" == "$INDEX_SHA256" ]]
+
       - name: Publish build summary
         shell: bash
         run: |
@@ -98,6 +238,10 @@ jobs:
             echo "- Target: \`linux/amd64\`"
             echo "- Build tags: \`hids\`"
             echo "- Go: \`$(go version)\`"
+            if [[ "${{ steps.contract.outputs.publish_oss }}" == true ]]; then
+              echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
+              echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
+            fi
             echo
             echo '```json'
             jq . "dist/${NODE_PACKAGE_NAME}/PRODUCT_NODE_MANIFEST.json"
@@ -105,7 +249,7 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload node package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.NODE_PACKAGE_NAME }}
           path: dist/artifact/*

--- a/docs/legion-ai-session-runtime-release.md
+++ b/docs/legion-ai-session-runtime-release.md
@@ -11,9 +11,9 @@ provenance.
 
 | Event | Behavior | Output trust level |
 |---|---|---|
-| Pull request | Build, test, inspect, and upload preview provenance without pushing an image | Preview; rejected by customer packaging |
-| `workflow_dispatch` on `main` | Publish the immutable image and provenance artifact | Trusted producer |
-| SemVer `legion-runtime-v*` tag reachable from `main` | Publish the immutable image and provenance artifact | Trusted producer |
+| Pull request | Build, test, inspect, and upload preview provenance | Preview; rejected by customer packaging |
+| `workflow_dispatch` on `main` | Build and attest trusted provenance without publishing a distribution object | Trusted producer verification |
+| SemVer `legion-runtime-v*` tag reachable from `main` | Publish the immutable image archive, provenance, and release index to OSS | Trusted producer release |
 
 The isolated tag prefix intentionally does not match the repository's generic
 `v*` release workflows. For example, an alpha producer release can use
@@ -21,34 +21,40 @@ The isolated tag prefix intentionally does not match the repository's generic
 
 ## Published outputs
 
-The workflow publishes the Runtime image as:
+The tag workflow publishes a versioned public OSS directory:
 
 ```text
-ghcr.io/yaklang/legion-ai-session-runtime@sha256:<digest>
+https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/<tag>/<source-sha>/
+├── legion-ai-session-runtime_linux_amd64.docker.tar.gz
+├── legion-ai-session-runtime_linux_amd64.tar.gz
+├── legion-ai-session-runtime_linux_amd64.tar.gz.sha256
+├── SESSION_RUNTIME_MANIFEST.json
+├── SHA256SUMS
+├── release-index.json
+└── release-index.json.sha256
 ```
 
-The `legion-ai-session-runtime_linux_amd64` Actions artifact contains:
+The `legion-ai-session-runtime_linux_amd64` Actions artifact retains the
+provenance files and release index for short-term workflow inspection. It is
+not the cross-repository distribution channel.
 
-```text
-SESSION_RUNTIME_MANIFEST.json
-SHA256SUMS
-legion-ai-session-runtime_linux_amd64.tar.gz
-legion-ai-session-runtime_linux_amd64.tar.gz.sha256
-```
-
-The artifact is provenance for the image; the deployable Runtime binary stays
-inside the OCI image. Customer assembly must consume the exact image digest,
-not its human-readable tag.
+The deployable Runtime binary stays inside the Docker image archive. The
+release index binds every OSS object to its SHA-256 digest and records the
+loaded image ID. Customer assembly supplies the independently approved index
+digest, downloads the archive without repository credentials, and verifies the
+image ID and source revision label before packaging.
 
 `SESSION_RUNTIME_MANIFEST.json` binds the Yaklang source commit, workflow run,
 Dockerfile and its context-ignore policy, immutable builder and runtime base
-images, embedded binary digest, OCI image digest, and the
+images, embedded binary digest, immutable image ID, and the
 `ai.session.runtime` plus `yak.execute` capabilities.
 
 ## Release boundary
 
 This workflow does not build Legion, assemble a customer package, deploy a
-host, or prove a real model conversation. Final `memfit,ssa` assembly consumes
-this Runtime provenance together with the Product Node artifact and a trusted
-Legion bundle. Runtime acceptance still requires deployment, License and
-Provider configuration, and the real two-turn AI conversation verifier.
+host, or prove a real model conversation. Final assembly consumes this Runtime
+release together with the Product Node OSS release and a trusted Legion bundle.
+Because no container registry is part of this release contract, packages
+containing `memfit` use offline delivery and carry the verified image archive.
+Runtime acceptance still requires deployment, License and Provider
+configuration, and the real two-turn AI conversation verifier.

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -61,6 +61,15 @@ Yaklang source commit, Go toolchain, Linux amd64 target, `hids` build tag, and
 advertised capability set. This artifact is an input to the Legion deployment
 packaging pipeline; it is not a complete deployment bundle.
 
+A SemVer `legion-node-v*` tag reachable from `main` also publishes these files
+under the versioned public OSS path
+`/legion/components/product-node/<tag>/<source-sha>/`. The accompanying
+`release-index.json` binds the source commit, producer manifest, archive, raw
+binary, and checksums. Cross-repository assembly consumes the OSS index URL and
+an independently approved index SHA-256 instead of a GitHub Actions run ID or
+repository token. Manual dispatch remains a build verification entry and does
+not publish a formal OSS release.
+
 Use `task legion_smoke_node_build_hids` for native debugging when your current host is already Linux. Use `task legion_smoke_node_build_hids_linux_amd64` when you need a deployable Linux artifact from any development host.
 
 If a future production Legion node entrypoint is added, it must also be built with `-tags hids` before the binary is expected to advertise or run the HIDS capability.


### PR DESCRIPTION
## 变更内容

- `legion-node-v*` tag 将 Product Node 包、清单、校验和与发布索引上传到版本化 OSS 路径。
- `legion-runtime-v*` tag 将 AI Session Runtime 的压缩 Docker archive、清单与发布索引上传到版本化 OSS 路径。
- 发布索引绑定组件、SemVer tag、完整源码 SHA、对象 SHA-256、Runtime 逻辑引用和镜像 ID。
- 索引最后上传；已存在的索引只允许相同 SHA 的幂等重跑，拒绝覆盖不同内容。
- 移除 Runtime 对 GHCR 登录、push 与 Packages 写权限的依赖。

## 原因

Legion 最终组包不应依赖私有容器仓库或跨仓库临时 Actions 产物。Yaklang 作为组件生产者，负责发布可独立下载、可校验、可按版本长期引用的 OSS 组件；Legion 只消费明确批准的索引 URL 与 SHA。

## 使用影响

- Product Node 发布 tag：`legion-node-vX.Y.Z[-prerelease]`
- Session Runtime 发布 tag：`legion-runtime-vX.Y.Z[-prerelease]`
- 正式 tag 必须指向已进入 `main` 的完整提交 SHA。
- Runtime 作为离线 Docker archive 发布，不再提供 GHCR 镜像。

## 验证

- Go 1.22.12 真实静态构建 `legion-smoke-node` 通过。
- `go test ./cmd/legion-smoke-node ./common/node ./scannode` 通过。
- Runtime provenance 打包测试通过。
- OSS 索引正向、篡改、非法 tag、Runtime 引用与镜像 ID 不一致测试通过。
- ShellCheck、Actionlint v1.7.7、YAML 解析和 `git diff --check` 通过。

## 后续

合并后先创建 alpha 组件 tag 验证 OSS 实际上传和公开读取，再由 Legion 的组包 PR 消费索引。
