### PR TITLE
refactor(aid): deduplicate timeline HINT into centralized prompt sect…

### DIFF
--- a/common/ai/aid/aicommon/prompts/prefix/high_static_section.txt
+++ b/common/ai/aid/aicommon/prompts/prefix/high_static_section.txt
@@ -134,6 +134,46 @@ TODO 的形态定义、心智模型、使用方法和文字要求集中在任务
 - 后续行动不越界. 子任务发现指向兄弟任务或父任务的高价值线索时，将证据和建议交回 coordinator；它不阻止当前子任务在自身完成后收口，也不得在子任务内擅自扩张执行范围。
 - 边界即止. 子任务完成立刻按 schema 收口动作收口, 不替系统调度兄弟 / 父节点; 跨节点决策权在 coordinator.
 
+## Timeline 机制
+
+Timeline 是 Agent 的运行日志与短期记忆: 每一步动作 (工具调用 / 文本记录 / 用户交互) 按时间先后追加为条目, 渲染后在 prompt 中以 `HH:MM:SS [type/...]` 行头出现, 供你判断任务进度、确认已尝试路径、避免重复调用. 开放时间线 (Open Tail) 段记录最近若干步; 更早的内容被压缩为摘要.
+
+### 条目类型
+
+Timeline 有三类条目, 由系统自动写入, 你不可伪造或篡改:
+
+- `text/<entryType>`. 文本记录, 来源 `AddToTimeline` / `PushText`. 记录推理片段、参数快照、流程事件等; 头部 `[entryType]` 标注语义类别 (如 `action`, `note`, `[DIRECT_CALL_PARAMS]`, `TODO_DELTA` 等). 部分控制层类别 (如 `TODO_DELTA` / `EVIDENCE_OPS` / `MODEL_THINKING`) 由系统从 prompt 投影中自动过滤, 不出现在你看到的时间线里.
+- `tool/<name> ok|fail`. 工具调用结果, 来源 `PushToolResult`. 包含工具名、成功 / 失败状态及输出预览; 超长输出被截断并落盘为 artifact (见下方).
+- `user/<stage>`. 用户交互, 来源 `PushUserInteraction`. 记录系统与用户的交互阶段 (如 `review`, `free_input`).
+
+### 渲染格式
+
+每条条目渲染为:
+
+```
+HH:MM:SS [type/verbose]
+<content>
+```
+
+- `type/verbose` 由条目类型决定: `tool/do_http_request ok`, `text/note`, `user/review` 等.
+- 同一 task 的连续条目共享 task 头 `# task=<id>`, task 切换时输出新头.
+- 时间线按时间桶分组, 每桶头标注 `# bucket=<start>-<end> interval=<N>m`, 可附带 `task=<id>` 标识该桶首条条目的所属任务.
+
+### 工具输出与 Artifact
+
+工具输出超 token 上限时, 系统将完整内容落盘为 artifact 文件, Timeline 中只保留有界预览 (头尾 + 中段截断标记). 预览末尾以 `ARTIFACT:` 块给出文件路径:
+
+- 路径含义. `combined` = 合并的 stdout+stderr 全量输出; `result` = 结构化结果 (JSON).
+- 按需读取. 不要 `load` / `cat` 完整 artifact; 优先 `grep` 定位关键行, 或用 `read_file(file=<path>, mode="lines", offset=..., lines=...)` 分段读取所需片段.
+- 路径每条 toolcall 独立. 不同工具调用的 artifact 路径不同, 不要跨条目复用路径.
+- 持久化失败. 若 `ARTIFACT:` 缺失而出现 `HINT: artifact_persist_failed`, 完整输出不可恢复, 仅 Timeline 预览可用; 此时不应反复重试同一工具期望产出完整数据.
+
+### 使用纪律
+
+- 事实依据. 时间线是"已发生事件"的权威记录; 判断"做过什么"以时间线为准, 不凭记忆推断.
+- 不复述. 时间线已有内容不在 thought / summary 重复; 需引用时只写 `[16:51:26 tool/do_http_request]` 等行头定位, 不抄 body.
+- 压缩感知. 更早的条目可能被压缩为摘要段; 若需要早期细节, 通过工具重新获取数据, 不假设摘要保留了全部细节.
+
 ## 能力系统
 
 四类能力扩展 ReAct 主循环: 外部工具 / AI 蓝图 / Focus 模式 / Skills 文档. 可用性以本轮 SCHEMA enum 为准, 未列出即禁用, 按字面填写.

--- a/common/ai/aid/aicommon/timeline_groups_render.go
+++ b/common/ai/aid/aicommon/timeline_groups_render.go
@@ -809,6 +809,25 @@ func extractTextEntryType(text string) string {
 	return ""
 }
 
+// extractTextTimelineContent 从 TextTimelineItem.Text 提取 body 内容,
+// 与 parseTextTimelineItem 的内容解析逻辑一致 (含历史格式 removeIndent 兼容).
+// 关键词: TextTimelineItem content 提取, timeline prompt projection
+func extractTextTimelineContent(text string) string {
+	if text == "" {
+		return ""
+	}
+	colonIndex := strings.Index(text, ":\n")
+	if colonIndex != -1 {
+		content := text[colonIndex+2:]
+		return removeIndent(content, "  ")
+	}
+	colonIndex = strings.Index(text, ":")
+	if colonIndex != -1 {
+		return strings.TrimSpace(text[colonIndex+1:])
+	}
+	return text
+}
+
 // selectShrunkContent 优先返回 GetShrinkResult，回退到 GetShrinkSimilarResult，最后回退到 String
 // 用于 token 节省：尽量使用已存在的精简表示
 // 关键词: 优先 ShrinkResult, token 优化

--- a/common/ai/aid/aicommon/timeline_item_human_readable.go
+++ b/common/ai/aid/aicommon/timeline_item_human_readable.go
@@ -124,13 +124,13 @@ func parseTextTimelineItem(result *TimelineItemHumanReadable, text string) {
 		return
 	}
 
-	// 优先匹配有 task 的格式: [entryType] [task:taskId]:
+	// 保留 TaskID 解析: [entryType] [task:taskId]: 格式中的 taskId 仍被
+	// timeline render / fork merge / emitter 等下游依赖 (注释: "ParseTimelineItemHumanReadable
+	// / emitter / marshal 仍能取得逐条 TaskID"). 不再解析 EntryType, 也不做
+	// EntryType -> Type 映射; Type 统一由 ParseTimelineItemHumanReadable 按 value
+	// 类型决定 (TextTimelineItem => "text").
 	if matches := withTaskRegex.FindStringSubmatch(text); len(matches) > 2 {
-		result.EntryType = matches[1]
 		result.TaskID = matches[2]
-	} else if matches := withoutTaskRegex.FindStringSubmatch(text); len(matches) > 1 {
-		// 匹配没有 task 的格式: [entryType]:
-		result.EntryType = matches[1]
 	}
 
 	// 解析内容：找到第一个 ":\n" 之后的内容
@@ -151,9 +151,6 @@ func parseTextTimelineItem(result *TimelineItemHumanReadable, text string) {
 		}
 	}
 
-	if itemType, ok := EntryTypeToTimelineItemType[result.EntryType]; ok {
-		result.Type = itemType
-	}
 }
 
 // removeIndent 移除每行开头的指定前缀

--- a/common/ai/aid/aicommon/timeline_item_human_readable_test.go
+++ b/common/ai/aid/aicommon/timeline_item_human_readable_test.go
@@ -43,7 +43,7 @@ func TestParseTimelineItemHumanReadable_TextTimelineItem_WithTaskID(t *testing.T
 	require.NotNil(t, result)
 	require.Equal(t, "text", result.Type)
 	require.Equal(t, int64(123), result.ID)
-	require.Equal(t, "action", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "task-001", result.TaskID)
 	require.Equal(t, "This is the action content\nwith multiple lines", result.Content)
 	require.Equal(t, text, result.RawText)
@@ -65,7 +65,7 @@ func TestParseTimelineItemHumanReadable_TextTimelineItem_WithoutTaskID(t *testin
 	result := ParseTimelineItemHumanReadable(item)
 	require.NotNil(t, result)
 	require.Equal(t, "text", result.Type)
-	require.Equal(t, "[BLUEPRINT_PROMPT_ERROR]", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Empty(t, result.TaskID)
 	require.Equal(t, "Simple note content", result.Content)
 }
@@ -84,7 +84,7 @@ func TestParseTimelineItemHumanReadable_TextTimelineItem_WithBuildinEntryType(t 
 	result := ParseTimelineItemHumanReadable(item)
 	require.NotNil(t, result)
 	require.Equal(t, "text", result.Type)
-	require.Equal(t, "note", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Empty(t, result.TaskID)
 	require.Equal(t, "Simple note content", result.Content)
 }
@@ -102,7 +102,7 @@ func TestParseTimelineItemHumanReadable_TextTimelineItem_DefaultNote(t *testing.
 
 	result := ParseTimelineItemHumanReadable(item)
 	require.NotNil(t, result)
-	require.Equal(t, "note", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "task-002", result.TaskID)
 	require.Equal(t, "Default note", result.Content)
 }
@@ -139,7 +139,7 @@ func TestParseTimelineItemHumanReadable_TextTimelineItem_WithColonNoNewline(t *t
 
 	result := ParseTimelineItemHumanReadable(item)
 	require.NotNil(t, result)
-	require.Equal(t, "info", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "Some inline content", result.Content)
 }
 
@@ -259,10 +259,10 @@ func TestParseTimelineItemsHumanReadable_Multiple(t *testing.T) {
 	require.Len(t, results, 3)
 
 	require.Equal(t, "text", results[0].Type)
-	require.Equal(t, "note", results[0].EntryType)
+	require.Empty(t, results[0].EntryType)
 
 	require.Equal(t, "text", results[1].Type)
-	require.Equal(t, "action", results[1].EntryType)
+	require.Empty(t, results[1].EntryType)
 	require.Equal(t, "t1", results[1].TaskID)
 
 	require.Equal(t, "user_interaction", results[2].Type)
@@ -324,7 +324,7 @@ func TestParseTextTimelineItem_ComplexTaskID(t *testing.T) {
 	result := &TimelineItemHumanReadable{}
 	parseTextTimelineItem(result, text)
 
-	require.Equal(t, "action", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "plan-1-subtask-2-step-3", result.TaskID)
 	require.Equal(t, "Complex task", result.Content)
 }
@@ -334,7 +334,7 @@ func TestParseTextTimelineItem_MultilineContent(t *testing.T) {
 	result := &TimelineItemHumanReadable{}
 	parseTextTimelineItem(result, text)
 
-	require.Equal(t, "result", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "t1", result.TaskID)
 	require.Equal(t, "Line 1\nLine 2\nLine 3", result.Content)
 }
@@ -344,9 +344,10 @@ func TestParseTextTimelineItem_WithSpecialEntryType(t *testing.T) {
 	result := &TimelineItemHumanReadable{}
 	parseTextTimelineItem(result, text)
 
-	require.Equal(t, "current task user input", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "Special entry type", result.Content)
-	require.Equal(t, "user_input", result.Type)
+	// parseTextTimelineItem 不再设置 Type; Type 由调用方 (ParseTimelineItemHumanReadable) 按 value 类型决定
+	require.Empty(t, result.Type)
 }
 
 // TestParseTimelineItemHumanReadable_TextTimelineItem_NewFormatNoIndent 验证修复
@@ -369,7 +370,7 @@ func TestParseTimelineItemHumanReadable_TextTimelineItem_NewFormatNoIndent(t *te
 	require.NotNil(t, result)
 	require.Equal(t, "text", result.Type)
 	require.Equal(t, int64(600), result.ID)
-	require.Equal(t, "action", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "task-007", result.TaskID)
 	// removeIndent 在 body 没有 "  " 前缀时退化成 no-op, Content 维持原样
 	require.Equal(t, "Line 1\nLine 2\nLine 3", result.Content)
@@ -384,7 +385,7 @@ func TestParseTextTimelineItem_NewFormatNoIndent_NoTask(t *testing.T) {
 	result := &TimelineItemHumanReadable{}
 	parseTextTimelineItem(result, text)
 
-	require.Equal(t, "note", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Empty(t, result.TaskID)
 	require.Equal(t, "flush left line 1\nflush left line 2", result.Content)
 }
@@ -399,7 +400,7 @@ func TestParseTextTimelineItem_HistoricalFormatStillWorks(t *testing.T) {
 	result := &TimelineItemHumanReadable{}
 	parseTextTimelineItem(result, text)
 
-	require.Equal(t, "action", result.EntryType)
+	require.Empty(t, result.EntryType)
 	require.Equal(t, "task-008", result.TaskID)
 	// removeIndent 把每行 "  " 前缀消掉, 让历史数据与新数据产出一致 Content
 	require.Equal(t, "legacy line 1\nlegacy line 2", result.Content)

--- a/common/ai/aid/aicommon/timeline_prompt_projection.go
+++ b/common/ai/aid/aicommon/timeline_prompt_projection.go
@@ -18,22 +18,22 @@ func projectTimelineItemForPrompt(item *TimelineItem) *TimelineItem {
 		return item
 	}
 
-	parsed := ParseTimelineItemHumanReadable(item)
-	if parsed == nil {
-		return item
-	}
-	category := normalizeTimelinePromptCategory(parsed.EntryType)
+	// 直接从原始文本提取 entryType, 不依赖 parseTextTimelineItem
+	// (parseTextTimelineItem 已不再做正则匹配设置 EntryType).
+	entryType := extractTextEntryType(textItem.Text)
+	category := normalizeTimelinePromptCategory(entryType)
 	switch category {
 	case "TODO_DELTA", "EVIDENCE_OPS", "MODEL_THINKING":
 		return nil
 	case "ITERATION":
 		return item
 	case "TODO_DELTA_ERROR":
-		filtered := filterRedundantTodoErrorLines(parsed.Content)
+		content := extractTextTimelineContent(textItem.Text)
+		filtered := filterRedundantTodoErrorLines(content)
 		if filtered == "" {
 			return nil
 		}
-		if filtered == strings.TrimSpace(parsed.Content) {
+		if filtered == strings.TrimSpace(content) {
 			return item
 		}
 		return cloneTextTimelineItemForPrompt(item, textItem, replaceTimelineTextBody(textItem.Text, filtered))

--- a/common/ai/aid/aicommon/toolcall_artifact.go
+++ b/common/ai/aid/aicommon/toolcall_artifact.go
@@ -261,7 +261,7 @@ func (t *ToolCaller) newToolCallArtifactBundle(tool *aitool.Tool, callToolID, id
 // reserveToolArtifactDir never reuses an existing bundle. This matters during
 // checkpoint replay: the caller prepares a bundle before it discovers the
 // stored result, and truncating the original artifact here would make the HINT
-// in the replayed Data point at destroyed files.
+// in the replayed Data point at destroyed files. (ARTIFACT: paths)
 func reserveToolArtifactDir(base string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
 		return base, err
@@ -396,14 +396,11 @@ func fileStats(path string) artifactFileStats {
 
 func toolArtifactHint(b *toolCallArtifactBundle, persistErr error) string {
 	if persistErr != nil || b == nil {
-		return fmt.Sprintf("HINT:\nComplete output could not be persisted (artifact_persist_failed: %v). This is a bounded preview; omitted content is unrecoverable.", persistErr)
+		return fmt.Sprintf("HINT:\nartifact_persist_failed: %v. This is a bounded preview; omitted content is unrecoverable.", persistErr)
 	}
-	return fmt.Sprintf(`HINT:
-Complete tool output is stored in artifacts:
-- combined output: %s
-- result: %s
-Use grep first, or read_file(file=%q, mode="lines", offset=..., lines=...).
-Do not load or cat the complete artifact unless necessary.`, b.combinedPath, b.resultPath, b.combinedPath)
+	// 仅保留 artifact 路径; grep / read_file 等使用纪律由 high_static_section.txt
+	// 的 "Timeline 工具产物 (Artifact)" 段集中说明, 不在每条 toolcall 重复.
+	return fmt.Sprintf("ARTIFACT:\n- combined: %s\n- result: %s", b.combinedPath, b.resultPath)
 }
 
 func shrinkBodyWithStats(body string, budget int) string {
@@ -414,7 +411,7 @@ func shrinkBodyWithStats(body string, budget int) string {
 	if len(tokens) <= budget {
 		return body
 	}
-	marker := fmt.Sprintf("\n\n... [truncated %d tokens, %d bytes and %d lines from the middle; inspect artifacts from HINT] ...\n\n",
+	marker := fmt.Sprintf("\n\n... [truncated %d tokens, %d bytes and %d lines from the middle; inspect artifacts (see ARTIFACT: paths)] ...\n\n",
 		len(tokens)-budget, len(body), strings.Count(body, "\n"))
 	markerTokens := ytoken.CalcTokenCount(marker)
 	available := budget - markerTokens
@@ -503,7 +500,10 @@ func enforceCanonicalToolResultLimit(toolResult *aitool.ToolResult) {
 		if !ok || data == "" {
 			break
 		}
-		hintIndex := strings.LastIndex(data, "\n\nHINT:\n")
+		hintIndex := strings.LastIndex(data, "\n\nARTIFACT:\n")
+		if hintIndex < 0 {
+			hintIndex = strings.LastIndex(data, "\n\nHINT:\n")
+		}
 		if hintIndex < 0 {
 			break
 		}
@@ -528,7 +528,7 @@ func (b *toolCallArtifactBundle) finalize(
 	if toolResult == nil {
 		return nil
 	}
-	if data, ok := toolResult.Data.(string); ok && strings.Contains(data, "COMBINED OUTPUT:\n") && strings.Contains(data, "\n\nRESULT:\n") && strings.Contains(data, "\n\nHINT:\n") {
+	if data, ok := toolResult.Data.(string); ok && strings.Contains(data, "COMBINED OUTPUT:\n") && strings.Contains(data, "\n\nRESULT:\n") && (strings.Contains(data, "\n\nARTIFACT:\n") || strings.Contains(data, "\n\nHINT:\n")) {
 		// A current-format checkpoint already owns stable artifact paths. Do not
 		// wrap the preview again or rewrite its bytes during replay.
 		b.closeStreams()

--- a/common/ai/aid/aicommon/toolcall_artifact_test.go
+++ b/common/ai/aid/aicommon/toolcall_artifact_test.go
@@ -33,7 +33,7 @@ func TestNormalizeToolResultDataHardTokenLimit(t *testing.T) {
 		Param:   map[string]any{"query": "example"},
 		Success: true,
 	}
-	hint := "HINT:\nComplete tool output is stored in artifacts:\n- combined output: /tmp/artifacts/combined_output.txt\n- result: /tmp/artifacts/result.txt"
+	hint := "ARTIFACT:\n- combined: /tmp/artifacts/combined_output.txt\n- result: /tmp/artifacts/result.txt"
 	normalizeToolResultData(toolResult, combined, result, hint)
 
 	data, ok := toolResult.Data.(string)
@@ -51,7 +51,7 @@ func TestNormalizeToolResultDataHardTokenLimit(t *testing.T) {
 func TestToolResultOutputKindsOver200KTokens(t *testing.T) {
 	huge := "KIND-HEAD\n" + strings.Repeat("record-0123456789 alpha beta gamma delta\n", 25000) + "KIND-MIDDLE-SENTINEL\n" + strings.Repeat("record-9876543210 epsilon zeta eta theta\n", 25000) + "KIND-TAIL\n"
 	require.Greater(t, ytoken.CalcTokenCount(huge), 200000)
-	hint := "HINT:\nComplete tool output is stored in artifacts:\n- combined output: /tmp/tool/combined_output.txt\n- stdout: /tmp/tool/stdout.txt\n- stderr: /tmp/tool/stderr.txt\n- result: /tmp/tool/result.txt"
+	hint := "ARTIFACT:\n- combined: /tmp/tool/combined_output.txt\n- result: /tmp/tool/result.txt"
 
 	resultJSON, ext := stableResultText(map[string]any{"records": huge, "count": 50000})
 	require.Equal(t, ".json", ext)
@@ -74,7 +74,7 @@ func TestToolResultOutputKindsOver200KTokens(t *testing.T) {
 			data := toolResult.Data.(string)
 			require.LessOrEqual(t, ytoken.CalcTokenCount(data), ToolResultTokenLimit)
 			require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
-			require.Contains(t, data, "HINT:")
+			require.Contains(t, data, "ARTIFACT:")
 			require.NotContains(t, data, "KIND-MIDDLE-SENTINEL")
 		})
 	}
@@ -96,14 +96,14 @@ func TestNormalizeToolResultDataOmitsHugeTimelineParams(t *testing.T) {
 func TestLateInvocationErrorCannotPushTimelineItemOverLimit(t *testing.T) {
 	combined, result := oversizedToolFixture()
 	toolResult := &aitool.ToolResult{Name: "late-error", Success: true}
-	normalizeToolResultData(toolResult, combined, result, "HINT:\n- combined output: /tmp/late/combined_output.txt")
+	normalizeToolResultData(toolResult, combined, result, "ARTIFACT:\n- combined: /tmp/late/combined_output.txt")
 	toolResult.Success = false
 	toolResult.Error = strings.Repeat("late-checkpoint-error-0123456789 ", 30000)
 
 	enforceCanonicalToolResultLimit(toolResult)
 	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.Data.(string)), ToolResultTokenLimit)
 	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
-	require.Contains(t, toolResult.Data.(string), "HINT:")
+	require.Contains(t, toolResult.Data.(string), "ARTIFACT:")
 }
 
 func TestToolArtifactCombinedOutputPreservesInterleaving(t *testing.T) {
@@ -232,7 +232,7 @@ func TestToolArtifactFinalizeReplacesDataAndPersistsRawFiles(t *testing.T) {
 	require.NoError(t, b.finalize(caller, tool, "call-1", "fixture", toolResult.Param.(aitool.InvokeParams), toolResult, 0, ""))
 
 	require.IsType(t, "", toolResult.Data)
-	require.Contains(t, toolResult.Data.(string), "HINT:")
+	require.Contains(t, toolResult.Data.(string), "ARTIFACT:")
 	require.Contains(t, toolResult.Data.(string), b.combinedPath)
 	raw, err := os.ReadFile(b.combinedPath)
 	require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestToolArtifactFinalizeReplacesDataAndPersistsRawFiles(t *testing.T) {
 func TestNormalizeToolResultDataDeduplicatesExactCombinedAndResult(t *testing.T) {
 	result := strings.Repeat("same-result-line\n", 100)
 	toolResult := &aitool.ToolResult{Name: "dedupe", Success: true}
-	normalizeToolResultData(toolResult, result, result, "HINT:\n/path")
+	normalizeToolResultData(toolResult, result, result, "ARTIFACT:\n/path")
 	data := toolResult.Data.(string)
 	// When combined == result, the RESULT section is omitted entirely (no "RESULT:" tag),
 	// so the result string appears exactly once (only in COMBINED OUTPUT).
@@ -316,7 +316,7 @@ func TestCurrentCheckpointReplayKeepsCompactedDataByteStable(t *testing.T) {
 	require.NoError(t, err)
 	b.stderr, err = os.Create(b.stderrPath)
 	require.NoError(t, err)
-	original := "COMBINED OUTPUT:\npreview\n\nRESULT:\nresult\n\nHINT:\n- combined output: /stable/original/path"
+	original := "COMBINED OUTPUT:\npreview\n\nRESULT:\nresult\n\nARTIFACT:\n- combined: /stable/original/path"
 	toolResult := &aitool.ToolResult{Name: "replay", Success: true, Data: original}
 	tool, err := aitool.New("replay", aitool.WithSimpleCallback(func(aitool.InvokeParams, io.Writer, io.Writer) (any, error) { return nil, nil }))
 	require.NoError(t, err)
@@ -375,7 +375,7 @@ func TestLegacyTimelineToolResultMigratesToArtifactAndCanonicalData(t *testing.T
 	require.True(t, ok)
 	require.Contains(t, data, "COMBINED OUTPUT:\nLEGACY-HEAD")
 	require.Contains(t, data, "result-tail")
-	require.Contains(t, data, "HINT:\nComplete tool output is stored in artifacts:")
+	require.Contains(t, data, "ARTIFACT:\n- combined:")
 	require.NotContains(t, data, "LEGACY-MIDDLE-SENTINEL")
 	require.LessOrEqual(t, ytoken.CalcTokenCount(data), ToolResultTokenLimit)
 	require.LessOrEqual(t, ytoken.CalcTokenCount(result.String()), ToolResultTokenLimit)
@@ -409,6 +409,6 @@ func BenchmarkNormalizeToolResultData200KTokens(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		toolResult := &aitool.ToolResult{Name: fmt.Sprintf("bench-%d", i), Success: true}
-		normalizeToolResultData(toolResult, combined, result, "HINT:\n/tmp/artifact")
+		normalizeToolResultData(toolResult, combined, result, "ARTIFACT:\n/tmp/artifact")
 	}
 }

--- a/common/ai/aid/aireact/invoke_toolcall_directly_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_directly_test.go
@@ -24,9 +24,12 @@ func mockedDirectlyCallTool(i aicommon.AICallerConfigIf, req *aicommon.AIRequest
 
 	if isPrimaryDecisionPrompt(prompt) {
 		// verification 收缩为纯观测角色后, satisfied=true 不再自动退出. 直接
-		// 工具执行后 timeline 会出现 [DIRECT_CALL_PARAMS], 检测到它说明已调
-		// 过工具, 此时主动 finish 收口, 模拟 "AI 判断任务完成后主动调 finish".
-		if strings.Contains(prompt, "[DIRECT_CALL_PARAMS]") {
+		// 工具执行后 timeline 会出现该工具的 DIRECT_CALL_PARAMS 参数快照
+		// ("ToolName <tool> Parameter:"), 检测到它说明已调过工具, 此时主动
+		// finish 收口, 模拟 "AI 判断任务完成后主动调 finish".
+		// 注意: 不能匹配 "[DIRECT_CALL_PARAMS]" 字面量, 静态 prompt 散文
+		// (high_static_section.txt 的 timeline 条目说明) 已包含该字样.
+		if strings.Contains(prompt, "ToolName "+toolName+" Parameter:") {
 			rsp := i.NewAIResponse()
 			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish", "human_readable_thought": "mocked: task done after tool call"}`))
 			rsp.Close()
@@ -61,9 +64,11 @@ func mockedDirectlyCallToolLegacyWrapped(i aicommon.AICallerConfigIf, req *aicom
 	prompt := req.GetPrompt()
 
 	if isPrimaryDecisionPrompt(prompt) {
-		// 同 mockedDirectlyCallTool: 检测到 [DIRECT_CALL_PARAMS] 说明已调过
-		// 工具, 主动 finish 收口 (verification 不再自动退出).
-		if strings.Contains(prompt, "[DIRECT_CALL_PARAMS]") {
+		// 同 mockedDirectlyCallTool: 检测到该工具的 DIRECT_CALL_PARAMS 参数
+		// 快照 ("ToolName <tool> Parameter:") 说明已调过工具, 主动 finish 收口
+		// (verification 不再自动退出). 不能匹配 "[DIRECT_CALL_PARAMS]" 字面量,
+		// 静态 prompt 散文已包含该字样.
+		if strings.Contains(prompt, "ToolName "+toolName+" Parameter:") {
 			rsp := i.NewAIResponse()
 			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish", "human_readable_thought": "mocked: task done after tool call"}`))
 			rsp.Close()
@@ -98,9 +103,11 @@ func mockedDirectlyCallToolWithAITag(i aicommon.AICallerConfigIf, req *aicommon.
 	prompt := req.GetPrompt()
 
 	if isPrimaryDecisionPrompt(prompt) {
-		// 同 mockedDirectlyCallTool: 检测到 [DIRECT_CALL_PARAMS] 说明已调过
-		// 工具, 主动 finish 收口 (verification 不再自动退出).
-		if strings.Contains(prompt, "[DIRECT_CALL_PARAMS]") {
+		// 同 mockedDirectlyCallTool: 检测到该工具的 DIRECT_CALL_PARAMS 参数
+		// 快照 ("ToolName <tool> Parameter:") 说明已调过工具, 主动 finish 收口
+		// (verification 不再自动退出). 不能匹配 "[DIRECT_CALL_PARAMS]" 字面量,
+		// 静态 prompt 散文已包含该字样.
+		if strings.Contains(prompt, "ToolName "+toolName+" Parameter:") {
 			rsp := i.NewAIResponse()
 			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish", "human_readable_thought": "mocked: task done after tool call"}`))
 			rsp.Close()

--- a/common/ai/aid/aireact/invoke_toolcall_directly_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_directly_test.go
@@ -209,7 +209,7 @@ LOOP:
 	require.Equal(t, int32(1), atomic.LoadInt32(&toolCallCount), "tool should be called exactly once")
 	timeline := react.config.Timeline.String()
 	require.Contains(t, timeline, "[DIRECT_CALL_PARAMS]")
-	require.Contains(t, timeline, "[seconds]: 0.1")
+	require.Contains(t, timeline, "seconds: 0.1")
 	require.NotContains(t, timeline, "param:", "direct-call result must not duplicate the params")
 	require.NotContains(t, timeline, "[user/review]", "fast no-op continue must not enter the timeline")
 }

--- a/common/ai/aid/aireact/invoke_toolcall_mcp_wait_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_mcp_wait_test.go
@@ -53,5 +53,5 @@ func TestExecuteToolCallInternal_WaitsForMCPStubBeforeInvoke(t *testing.T) {
 	data, ok := result.Data.(string)
 	require.True(t, ok, "AI orchestration must expose the canonical bounded string Data")
 	assert.Contains(t, data, "COMBINED OUTPUT:\nlive-ok")
-	assert.Contains(t, data, "HINT:\nComplete tool output is stored in artifacts:")
+	assert.Contains(t, data, "ARTIFACT:\n- combined:")
 }

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools"
+	"github.com/yaklang/yaklang/common/go-funk"
 	"io"
 	"sort"
 	"strings"
@@ -60,9 +61,9 @@ func formatDirectlyCallToolParamsTimeline(toolName string, params aitool.InvokeP
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("直接调用工具%s生成的参数为：", toolName))
+	sb.WriteString(fmt.Sprintf("ToolName %s Parameter:", toolName))
 	for _, key := range directlyCallParamKeys(params) {
-		if key == aicommon.ReservedKeyIdentifier || key == aicommon.ReservedKeyCallExpectations {
+		if key == aicommon.ReservedKeyIdentifier || key == aicommon.ReservedKeyCallExpectations || funk.IsEmpty(params[key]) {
 			continue
 		}
 		displayKey := key
@@ -76,7 +77,7 @@ func formatDirectlyCallToolParamsTimeline(toolName string, params aitool.InvokeP
 			sb.WriteString("\n")
 			sb.WriteString(value)
 		} else {
-			sb.WriteString(fmt.Sprintf("[%s]: %s", displayKey, value))
+			sb.WriteString(fmt.Sprintf("%s: %s", displayKey, value))
 		}
 	}
 	return sb.String()
@@ -381,7 +382,7 @@ var loopAction_directlyCallTool = &reactloops.LoopAction{
 			}
 		}
 		reportStatus := func(msg string) {
-			invoker.AddToTimeline("[DIRECT_CALL_PARAMS]", msg)
+			invoker.AddToTimeline("DIRECT_CALL_PARAMS", msg)
 		}
 
 		toolName := loop.Get("directly_call_tool_name")
@@ -411,7 +412,7 @@ Few-shot example 2 (valid directly_call_tool):
 			loopInfraStatus(loop, "缓存工具不可用 / Cached Tool Unavailable")
 			msg := fmt.Sprintf("directly_call_tool cached tool lookup failed for '%s'; switch to @action=require_tool", toolName)
 			operator.Feedback(utils.Error(msg))
-			invoker.AddToTimeline("[DIRECT_CALL_PARAMS]", msg)
+			invoker.AddToTimeline("DIRECT_CALL_PARAMS", msg)
 			operator.Continue()
 			return
 		}

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool_test.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool_test.go
@@ -72,9 +72,9 @@ func TestFormatDirectlyCallToolParamsTimeline(t *testing.T) {
 		"target":  "https://example.com",
 	}
 	got := formatDirectlyCallToolParamsTimeline("cybersecurity-risk", params, nil)
-	assert.Contains(t, got, "直接调用工具cybersecurity-risk生成的参数为：")
-	assert.Contains(t, got, "[title]: test title")
-	assert.Contains(t, got, "[target]: https://example.com")
+	assert.Contains(t, got, "ToolName cybersecurity-risk Parameter:")
+	assert.Contains(t, got, "title: test title")
+	assert.Contains(t, got, "target: https://example.com")
 	assert.Contains(t, got, "[payload]:\nline1\nline2\nline3")
 
 	blockGot := formatDirectlyCallToolParamsTimeline("bash", aitool.InvokeParams{
@@ -82,7 +82,7 @@ func TestFormatDirectlyCallToolParamsTimeline(t *testing.T) {
 		"timeout": 20,
 	}, []string{"command"})
 	assert.Contains(t, blockGot, "[command(BLOCK)]:\n#!/bin/bash\necho hello")
-	assert.Contains(t, blockGot, "[timeout]: 20")
+	assert.Contains(t, blockGot, "timeout: 20")
 }
 
 func TestNormalizeDirectlyCallToolParams_LegacyWrappedString(t *testing.T) {
@@ -158,8 +158,8 @@ func TestDirectlyCallTool_Handler_NormalizesWrappedParamsAndStreamsProgress(t *t
 	assert.Contains(t, op.GetFeedback().String(), "Prepared directly_call_tool params for 'sleep_test': 1 fields [seconds]")
 
 	timeline := invoker.getTimelineString()
-	assert.Contains(t, timeline, "直接调用工具sleep_test生成的参数为：")
-	assert.Contains(t, timeline, "[seconds]: 0.1")
+	assert.Contains(t, timeline, "ToolName sleep_test Parameter:")
+	assert.Contains(t, timeline, "seconds: 0.1")
 	assert.NotContains(t, timeline, "preparing directly_call_tool params")
 	assert.NotContains(t, timeline, "normalized 1 param fields")
 	assert.NotContains(t, timeline, "calling cached tool")
@@ -206,9 +206,9 @@ func TestDirectlyCallTool_Handler_MergesAITagParams(t *testing.T) {
 	assert.Equal(t, "#!/bin/bash\necho hello", invoker.withoutRequiredParams.GetString("command"))
 	assert.Contains(t, op.GetFeedback().String(), "Prepared directly_call_tool params for 'bash_test': 2 fields [command(BLOCK), timeout]")
 	timeline := invoker.getTimelineString()
-	assert.Contains(t, timeline, "直接调用工具bash_test生成的参数为：")
+	assert.Contains(t, timeline, "ToolName bash_test Parameter:")
 	assert.Contains(t, timeline, "[command(BLOCK)]:\n#!/bin/bash\necho hello")
-	assert.Contains(t, timeline, "[timeout]: 20")
+	assert.Contains(t, timeline, "timeout: 20")
 	assert.NotContains(t, timeline, "merged 1 AITAG block params")
 }
 


### PR DESCRIPTION
## 概述

精简 ReAct prompt 中重复冗余的 timeline/artifact 提示，将分散在每次工具调用结果里的使用说明集中到静态 prompt 的「Timeline 机制」章节，降低每轮迭代的 token 消耗；并同步更新受格式变化影响的测试。

## 主要改动

### Prompt 瘦身（refactor）

- **集中 timeline 说明**：`high_static_section.txt` 新增「Timeline 机制」章节，统一说明条目类型（`text/tool/user`）、渲染格式（`HH:MM:SS [type/...]` 行头、task 头、时间桶分组）、artifact 使用纪律（优先 grep / `read_file` 分段读，不整份 cat）与使用规范（事实依据、不复述、压缩感知）。
- **简化 artifact 提示**：`toolArtifactHint` 从每次 toolcall 重复输出 grep/read_file 教学文案，改为只输出 `ARTIFACT:\n- combined: <path>\n- result: <path>` 路径块；持久化失败时保留 `HINT: artifact_persist_failed` 前缀。`enforceCanonicalToolResultLimit` 与 checkpoint replay 检测同时兼容新旧两种前缀。
- **DIRECT_CALL_PARAMS 时间线格式**：标题改为英文 `ToolName <tool> Parameter:`，单行参数不再加方括号（`key: value`，仅多行值保留 `[key]:` 块格式），空参数跳过；entryType 传参去掉冗余的方括号（`AddToTimeline("DIRECT_CALL_PARAMS", ...)`）。

### Timeline 解析简化（refactor）

- `parseTextTimelineItem` 移除 EntryType 正则匹配与 `EntryTypeToTimelineItemType` 映射，条目 `Type` 完全由 value 类型决定；保留 TaskID 解析供下游（fork merge / emitter / render）依赖。
- `timeline_prompt_projection.go` 改用 `extractTextEntryType` 直接提取 entryType；新增 `extractTextTimelineContent` 用于 `TODO_DELTA_ERROR` 内容提取（含历史格式 removeIndent 兼容）。

### 测试修复（test）

- 更新格式断言：`直接调用工具X生成的参数为：` → `ToolName X Parameter:`；`[key]: value` → `key: value`；MCP wait 测试 `HINT: Complete tool output...` → `ARTIFACT: - combined:`。
- 修复 mock 误判：静态 prompt 散文现已包含 `[DIRECT_CALL_PARAMS]` 字面量，导致 mock 的「工具已调用」检测在首轮决策即命中、提前 finish（工具实际未调用）。改为检测真实 timeline 条目内容 `ToolName <tool> Parameter:`。修复 `TestReAct_DirectlyCallTool_Basic` / `_LegacyWrappedParams` / `_AITagBlockParams` / `_PersistentSession`。

## 测试

- `TestReAct_DirectlyCallTool_*`（Basic / LegacyWrappedParams / AITagBlockParams / RequireThenDirect / PersistentSession）全部通过
- `TestExecuteToolCallInternal_WaitsForMCPStubBeforeInvoke` 通过
- `loopinfra` 包 `TestFormatDirectlyCallToolParamsTimeline` / `TestDirectlyCallTool_Handler_*` 通过
- `aicommon` timeline 相关测试（`timeline_item_human_readable_test.go`、`timeline_prompt_projection_test.go`、`toolcall_artifact_test.go`）已同步更新并通过
