### PR TITLE
feat(aid): improve verbose_name for all builtin AI tools

### DIFF
--- a/common/ai/aid/aireact/invoke_toolcall.go
+++ b/common/ai/aid/aireact/invoke_toolcall.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
+	"strings"
 )
 
 func (r *ReAct) withTaskEmitterScope(fn func(currentTask aicommon.AIStatefulTask) (*aitool.ToolResult, bool, error)) (*aitool.ToolResult, bool, error) {
@@ -133,6 +134,41 @@ func (r *ReAct) resolveToolForCall(ctx context.Context, toolName string) (*aitoo
 		}
 	}
 	return tool, nil
+}
+
+// tryFillVerboseNameForPlaceholder fills the VerboseName / VerboseNameZh /
+// Description of a placeholder tool (used by DirectlyCallTool before the real
+// tool is resolved by the loop-layer prepare callback) so the tool-call card
+// emitted via emitStart carries a readable title.
+//
+// It only inspects the in-memory enabled tool list (which already contains MCP
+// pending stubs loaded from DB cache, since AppendTools/EnableTool register
+// them into toolsGetter). It never reads the database, never waits for a live
+// MCP connection, and silently no-ops on any error — the real tool is still
+// resolved later inside the prepare callback for the actual invocation.
+func (r *ReAct) tryFillVerboseNameForPlaceholder(tool *aitool.Tool) {
+	if tool == nil || r == nil || r.config == nil {
+		return
+	}
+	mgr := r.config.GetAiToolManager()
+	if mgr == nil {
+		return
+	}
+	tools, err := mgr.GetEnableTools()
+	if err != nil {
+		return
+	}
+	for _, real := range tools {
+		if real == nil || real.Name != tool.Name {
+			continue
+		}
+		tool.VerboseName = real.VerboseName
+		tool.VerboseNameZh = real.VerboseNameZh
+		if strings.TrimSpace(tool.Description) == "" && strings.TrimSpace(real.Description) != "" {
+			tool.Description = real.Description
+		}
+		return
+	}
 }
 
 // newToolCallerForCall builds a ToolCaller with the shared options (emitter
@@ -312,6 +348,12 @@ func (r *ReAct) DirectlyCallTool(ctx context.Context, toolName string, action *a
 	}
 
 	directlyCallTool := &aitool.Tool{Tool: &mcp.Tool{Name: toolName}}
+	// The placeholder only carries the tool name. Try to fill its verbose
+	// name / description from the in-memory enabled tool list so the
+	// tool-call card (emitStart) shows a readable title immediately. The
+	// real tool used for the actual invocation is still resolved later
+	// inside the prepare callback (loop-layer resolveTool).
+	r.tryFillVerboseNameForPlaceholder(directlyCallTool)
 	result, directlyAnswer, err := toolCaller.DirectlyCallTool(directlyCallTool, action, prepare)
 	if err != nil {
 		return nil, false, utils.Errorf("tool call failed: %v", err)

--- a/common/ai/aid/aitool/buildinaitools/fstools/fileop.go
+++ b/common/ai/aid/aitool/buildinaitools/fstools/fileop.go
@@ -31,6 +31,8 @@ func CreateFSOperator(fsys filesys_interface.FileSystem) ([]*aitool.Tool, error)
 	factory := aitool.NewFactory()
 	err = factory.RegisterTool("ls",
 		aitool.WithDescription("list files in directory or get file info"),
+		aitool.WithVerboseName("List Files"),
+		aitool.WithVerboseNameZh("列目录"),
 		aitool.WithStringParam("path", aitool.WithParam_Required(true)),
 		aitool.WithSimpleCallback(func(params aitool.InvokeParams, stdout io.Writer, stderr io.Writer) (any, error) {
 			pathName := params.GetString("path")
@@ -238,6 +240,8 @@ func CreateFSOperator(fsys filesys_interface.FileSystem) ([]*aitool.Tool, error)
 	err = factory.RegisterTool(
 		"copy_file",
 		aitool.WithDescription("copy file"),
+		aitool.WithVerboseName("Copy File"),
+		aitool.WithVerboseNameZh("复制文件"),
 		aitool.WithStringParam("src",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("source file path"),

--- a/common/ai/aid/aitool/buildinaitools/fstools/jarop.go
+++ b/common/ai/aid/aitool/buildinaitools/fstools/jarop.go
@@ -19,6 +19,8 @@ func CreateJarOperator() ([]*aitool.Tool, error) {
 	// List JAR directory contents
 	err = factory.RegisterTool("jar_list_directory",
 		aitool.WithDescription("list files and directories in a JAR file"),
+		aitool.WithVerboseName("JAR List Dir"),
+		aitool.WithVerboseNameZh("JAR列目录"),
 		aitool.WithStringParam("jar_path",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("path to JAR file"),
@@ -61,6 +63,8 @@ func CreateJarOperator() ([]*aitool.Tool, error) {
 	// Read a class file from JAR
 	err = factory.RegisterTool("jar_read_class",
 		aitool.WithDescription("read and decompile a class file from a JAR"),
+		aitool.WithVerboseName("JAR Read Class"),
+		aitool.WithVerboseNameZh("JAR读取类"),
 		aitool.WithStringParam("jar_path",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("path to JAR file"),
@@ -107,6 +111,8 @@ func CreateJarOperator() ([]*aitool.Tool, error) {
 	// Read a file from JAR (non-class files)
 	err = factory.RegisterTool("jar_read_file",
 		aitool.WithDescription("read a file (non-class) from a JAR"),
+		aitool.WithVerboseName("JAR Read File"),
+		aitool.WithVerboseNameZh("JAR读取文件"),
 		aitool.WithStringParam("jar_path",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("path to JAR file"),
@@ -139,6 +145,8 @@ func CreateJarOperator() ([]*aitool.Tool, error) {
 	// Get JAR manifest
 	err = factory.RegisterTool("jar_get_manifest",
 		aitool.WithDescription("read the manifest file from a JAR"),
+		aitool.WithVerboseName("JAR Manifest"),
+		aitool.WithVerboseNameZh("JAR清单"),
 		aitool.WithStringParam("jar_path",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("path to JAR file"),
@@ -172,6 +180,8 @@ func CreateJarOperator() ([]*aitool.Tool, error) {
 	// Find classes in JAR
 	err = factory.RegisterTool("jar_find_classes",
 		aitool.WithDescription("find all Java classes in a JAR, including nested JARs"),
+		aitool.WithVerboseName("JAR Find Classes"),
+		aitool.WithVerboseNameZh("JAR查找类"),
 		aitool.WithStringParam("jar_path",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("path to JAR file"),
@@ -211,6 +221,8 @@ func CreateJarOperator() ([]*aitool.Tool, error) {
 	// Find a class by name
 	err = factory.RegisterTool("jar_find_class_by_name",
 		aitool.WithDescription("find a class by its name within a JAR file"),
+		aitool.WithVerboseName("JAR Find Class"),
+		aitool.WithVerboseNameZh("JAR查找类名"),
 		aitool.WithStringParam("jar_path",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("path to JAR file"),

--- a/common/ai/aid/aitool/buildinaitools/notifytools/send_message.go
+++ b/common/ai/aid/aitool/buildinaitools/notifytools/send_message.go
@@ -41,6 +41,8 @@ func CreateNotifySendTools() []*aitool.Tool {
 		"send_im_message",
 		aitool.WithDescription(`Send a message to an IM platform (Feishu/Lark or DingTalk). Use this to proactively push results, alerts, or reports to a user or group chat.
 Credentials (app_id/app_secret) must be configured first via the 'configure_im_credentials' tool.`),
+		aitool.WithVerboseName("Send IM Message"),
+		aitool.WithVerboseNameZh("发送IM消息"),
 		aitool.WithStringParam("platform",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("Target IM platform. Currently supported: 'feishu' (Feishu/Lark), 'dingtalk' (DingTalk)."),
@@ -121,6 +123,8 @@ Credentials (app_id/app_secret) must be configured first via the 'configure_im_c
 	credTool, err := aitool.New(
 		"configure_im_credentials",
 		aitool.WithDescription(`Configure the credentials (app_id/app_secret) for an IM platform so that 'send_im_message' can use them. Credentials are kept in memory for the lifetime of this process.`),
+		aitool.WithVerboseName("Configure IM Credentials"),
+		aitool.WithVerboseNameZh("配置IM凭证"),
 		aitool.WithStringParam("platform",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("Platform to configure: 'feishu' or 'dingtalk'."),

--- a/common/ai/aid/aitool/buildinaitools/searchtools/aitools_search.go
+++ b/common/ai/aid/aitool/buildinaitools/searchtools/aitools_search.go
@@ -27,6 +27,8 @@ func CreateAISearchTools[T AISearchable](searcher AISearcher[T], searchListGette
 	err := factory.RegisterTool(
 		toolName,
 		aitool.WithDescription("Search resources or tools that can search the names of all currently supported things"),
+		aitool.WithVerboseName("Tools Search"),
+		aitool.WithVerboseNameZh("工具搜索"),
 		aitool.WithStringParam("query",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("The name of the tool to query, can describe requirements using natural language."),
@@ -127,6 +129,8 @@ func CreateSearchCapabilitiesTool(cfg *SearchCapabilitiesConfig) ([]*aitool.Tool
 				"or locate skills for specialized knowledge. Returns categorized results. "+
 				"IMPORTANT: Each query should only be searched ONCE. Do NOT call this tool repeatedly with the same or similar query.",
 		),
+		aitool.WithVerboseName("Search Capabilities"),
+		aitool.WithVerboseNameZh("能力搜索"),
 		aitool.WithStringParam("query",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("Search keywords. Describe what you need using natural language, e.g. 'port scanning', 'vulnerability detection', 'encode base64'."),

--- a/common/ai/aid/aitool/buildinaitools/ssatools/ssa_tools.go
+++ b/common/ai/aid/aitool/buildinaitools/ssatools/ssa_tools.go
@@ -53,6 +53,8 @@ func CreateSSATools() ([]*aitool.Tool, error) {
 func registerProjectInfoTool(factory *aitool.ToolFactory) error {
 	return factory.RegisterTool(
 		"ssa-project-info",
+		aitool.WithVerboseName("SSA Project Info"),
+		aitool.WithVerboseNameZh("SSA项目信息"),
 		aitool.WithDescription("获取SSA项目的详细信息，包括项目元数据、文件列表、编译配置等。优先从数据库读取源码，如果不可用则尝试从原始编译路径读取"),
 		aitool.WithKeywords([]string{"SSA", "项目信息", "Program", "内存模式", "源码", "project info", "metadata"}),
 		aitool.WithStringParam("program_name",
@@ -227,6 +229,8 @@ func projectInfoCallback(params aitool.InvokeParams, stdout io.Writer, stderr io
 func registerListFilesTool(factory *aitool.ToolFactory) error {
 	return factory.RegisterTool(
 		"ssa-list-files",
+		aitool.WithVerboseName("SSA List Files"),
+		aitool.WithVerboseNameZh("SSA列文件"),
 		aitool.WithDescription("列出SSA项目中的所有源代码文件，优先从数据库读取，fallback到本地文件系统"),
 		aitool.WithKeywords([]string{"SSA", "文件列表", "项目文件", "list files", "source code", "源码文件"}),
 		aitool.WithStringParam("program_name",
@@ -388,6 +392,8 @@ func listFilesCallback(params aitool.InvokeParams, stdout io.Writer, stderr io.W
 func registerReadFileTool(factory *aitool.ToolFactory) error {
 	return factory.RegisterTool(
 		"ssa-read-file",
+		aitool.WithVerboseName("SSA Read File"),
+		aitool.WithVerboseNameZh("SSA读文件"),
 		aitool.WithDescription("读取SSA项目中的指定源代码文件，优先从数据库读取，fallback到本地文件系统，支持按行分页"),
 		aitool.WithKeywords([]string{"SSA", "读取文件", "源代码", "read file", "source code", "按行读取", "分页"}),
 		aitool.WithStringParam("program_name",
@@ -544,6 +550,8 @@ func readFileCallback(params aitool.InvokeParams, stdout io.Writer, stderr io.Wr
 func registerGrepTool(factory *aitool.ToolFactory) error {
 	return factory.RegisterTool(
 		"ssa-grep",
+		aitool.WithVerboseName("SSA Grep"),
+		aitool.WithVerboseNameZh("SSA搜索"),
 		aitool.WithDescription("在SSA项目的源代码中搜索匹配的文本或正则表达式，优先从数据库读取，fallback到本地文件系统"),
 		aitool.WithKeywords([]string{"SSA", "grep", "搜索", "代码搜索", "search", "pattern", "正则表达式", "文本查找"}),
 		aitool.WithStringParam("program_name",

--- a/common/ai/aid/aitool/buildinaitools/ssatools/syntaxflow.go
+++ b/common/ai/aid/aitool/buildinaitools/ssatools/syntaxflow.go
@@ -15,6 +15,8 @@ const SyntaxFlowToolName_SyntaxCheck = "check-syntaxflow-syntax"
 
 func registerSyntaxFlowTool(factory *aitool.ToolFactory) error {
 	return factory.RegisterTool(SyntaxFlowToolName_SyntaxCheck,
+		aitool.WithVerboseName("SyntaxFlow Checker"),
+		aitool.WithVerboseNameZh("SyntaxFlow检查"),
 		aitool.WithDescription("SyntaxFlow 规则语法检查与正例自检（合并）。1) 语法检查：验证 .sf 规则是否符合 SyntaxFlow 语法。2) 正例自检（可选）：当提供 sample_code+language 时，将用户提供的漏洞样例作为正例（file://、UNSAFE）执行规则，若产生告警则 matched=true。有漏洞样例时必须传入 path、sample_code、filename、language 完成正例自检；无样例时仅传 path 或 syntaxflow-code 做语法检查。"),
 		aitool.WithKeywords([]string{
 			"include 必须 as $gin", "正确 include as $gin",

--- a/common/ai/aid/aitool/buildinaitools/tool_manager.go
+++ b/common/ai/aid/aitool/buildinaitools/tool_manager.go
@@ -763,7 +763,8 @@ func buildStubToolFromMCPCache(fullName string, cfg *schema.MCPServerToolConfig)
 		aitool.WithMCPPendingStub(true),
 		aitool.WithDescription(desc),
 		aitool.WithKeywords([]string{"mcp", serverName, toolName, "external", "remote"}),
-		aitool.WithVerboseName(fmt.Sprintf("%s (MCP:%s)", toolName, serverName)),
+		aitool.WithVerboseName(fmt.Sprintf("%s", toolName)),
+		aitool.WithVerboseNameZh(fmt.Sprintf("%s", toolName)),
 		// Callback returns a retryable error so AI can degrade gracefully
 		// instead of crashing when the MCP server is still initializing.
 		aitool.WithSimpleCallback(func(params aitool.InvokeParams, stdout io.Writer, stderr io.Writer) (any, error) {

--- a/common/ai/aid/aitool/buildinaitools/yaklangtools/yaklang.go
+++ b/common/ai/aid/aitool/buildinaitools/yaklangtools/yaklang.go
@@ -20,6 +20,8 @@ func CreateYaklangTools() ([]*aitool.Tool, error) {
 	factory := aitool.NewFactory()
 	err = factory.RegisterTool(YaklangToolName_SyntaxCheck,
 		aitool.WithDescription("run yaklang code syntax check"),
+		aitool.WithVerboseName("Yaklang Checker"),
+		aitool.WithVerboseNameZh("Yaklang检查"),
 		aitool.WithStringParam("content", aitool.WithParam_Description("yaklang code content")),
 		aitool.WithStringParam("path", aitool.WithParam_Description("yaklang code file path")),
 		aitool.WithSimpleCallback(func(params aitool.InvokeParams, stdout io.Writer, stderr io.Writer) (any, error) {
@@ -45,6 +47,8 @@ func CreateYaklangTools() ([]*aitool.Tool, error) {
 
 	err = factory.RegisterTool("yak-document",
 		aitool.WithDescription("query yaklang document"),
+		aitool.WithVerboseName("Yaklang Document"),
+		aitool.WithVerboseNameZh("Yaklang文档"),
 		aitool.WithStringParam("keyword", aitool.WithParam_Description("yaklang code keyword")),
 		aitool.WithStringParam("lib", aitool.WithParam_Description("yaklang code lib name")),
 		aitool.WithSimpleCallback(func(params aitool.InvokeParams, stdout io.Writer, stderr io.Writer) (any, error) {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/batch_do_http_request_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/batch_do_http_request_test.go
@@ -63,8 +63,8 @@ func execBatchTool(t *testing.T, tool *aitool.Tool, params aitool.InvokeParams) 
 func TestBatchDoHTTPRequest_MetadataContainsIntentHints(t *testing.T) {
 	aiTool := loadBatchDoHTTPRequestAITool(t)
 
-	assert.Equal(t, aiTool.VerboseName, "Batch HTTP Request Tool")
-	assert.Equal(t, aiTool.VerboseNameZh, "批量HTTP请求工具")
+	assert.Equal(t, aiTool.VerboseName, "Batch HTTP Request")
+	assert.Equal(t, aiTool.VerboseNameZh, "批量HTTP请求")
 	assert.Assert(t, strings.Contains(aiTool.Description, "接口批量验证"), "description should mention API batch validation")
 	assert.Assert(t, strings.Contains(aiTool.Description, "IDOR"), "description should mention IDOR use case")
 	assert.Assert(t, strings.Contains(aiTool.Keywords, "未授权访问验证"), "keywords should include unauthorized access validation")

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/browser/use_browser.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/browser/use_browser.yak
@@ -43,8 +43,8 @@ The browser instance persists across tool calls via session ID.
 Native alert/confirm/prompt: dialog text is returned to AI; use op=get subop=dialog then
 op=handle_dialog action=accept|dismiss (value for prompt). Do NOT ignore blocking dialogs.
 DESC_BLOCK
-__VERBOSE_NAME__ = "Browser Automation Tool"
-__VERBOSE_NAME_ZH__ = "浏览器自动化工具"
+__VERBOSE_NAME__ = "Browser Automation"
+__VERBOSE_NAME_ZH__ = "浏览器自动化"
 __KEYWORDS__ = "browser,chrome,CDP,headless,screenshot,snapshot,click,fill,form,login,tab,dialog,scroll,DOM-accessibility-ref"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/auto_decode.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/auto_decode.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个自动尝试多种解码方法来处理给定文本的工具，它会遍历所有可能的解码结果并显示原始文本、解码类型和解码后的结果。"
 __VERBOSE_NAME__ = "Auto Decode"
-__VERBOSE_NAME_ZH__ = "文本自动解码"
+__VERBOSE_NAME_ZH__ = "自动解码"
 __KEYWORDS__ = "文本解码,自动解码,编码识别,文本处理,解码工具,数据处理,auto decode,detect encoding,smart decode"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/data_transform.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/data_transform.yak
@@ -1,6 +1,6 @@
 __DESC__ = "A structured data format conversion tool that converts between JSON, YAML, and XML. Supports auto-detection of input format, pretty printing, format validation, and reformatting."
-__VERBOSE_NAME__ = "Data Format Converter (JSON/YAML/XML)"
-__VERBOSE_NAME_ZH__ = "数据格式转换（JSON/YAML/XML）"
+__VERBOSE_NAME__ = "Data Format Converter"
+__VERBOSE_NAME_ZH__ = "数据格式转换"
 __KEYWORDS__ = "json,yaml,xml,convert,transform,format,prettify,validate,data,config,structured data,serialization,deserialization"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/decode.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/decode.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个多功能的解码工具，支持对多种编码格式（如base64, url编码, double url编码, base32, hex, ascii, html实体, unicode等）的文本进行解码，并输出解码结果。"
-__VERBOSE_NAME__ = "Multi-Format Text Decoder"
-__VERBOSE_NAME_ZH__ = "多格式文本解码"
+__VERBOSE_NAME__ = "Text Decoder"
+__VERBOSE_NAME_ZH__ = "文本解码"
 __KEYWORDS__ = "数据处理,格式转换,base64解码,数据解码,解码工具,base32解码,decode,double url,encoding schemes,data transformation,text processing,hex解码,编码转换,文本解码,url解码,base64,url encoding,base32,format conversion,decoding tools"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/encode.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/encode.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个支持多种编码方式的文本编码工具，包括 Base64、Base64URL、Base32、Hex、双重URL编码、ASCII、HTML实体、HTMLHex、URL编码和Unicode编码。"
-__VERBOSE_NAME__ = "Multi-Format Text Encoder"
-__VERBOSE_NAME_ZH__ = "多格式文本编码"
+__VERBOSE_NAME__ = "Text Encoder"
+__VERBOSE_NAME_ZH__ = "文本编码"
 __KEYWORDS__ = "representation,transformation,数据转换,url编码,双重url编码,unicode编码,hex,url encoding,base32,cipher,编码工具,文本处理,base64,double url encoding,conversion,格式转换,encoding,data format"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/jwt_analyze.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/jwt_analyze.yak
@@ -1,6 +1,6 @@
 __DESC__ = "A JWT (JSON Web Token) analysis tool that decodes header/payload, verifies signatures with provided or common weak keys, and performs security analysis including alg:none detection, weak key brute-force, and expiration checks."
-__VERBOSE_NAME__ = "JWT Token Analyzer"
-__VERBOSE_NAME_ZH__ = "JWT Token 分析工具"
+__VERBOSE_NAME__ = "JWT Analyzer"
+__VERBOSE_NAME_ZH__ = "JWT分析"
 __KEYWORDS__ = "jwt,token,json web token,security,authentication,authorization,alg none,weak key,signature,claims,header,payload,decode,analyze,bearer"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/dns/dig.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/dns/dig.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于执行多种DNS查询的工具，包括A、AAAA、NS、AXFR和TXT记录，根据提供的域名进行查询并显示结果。"
-__VERBOSE_NAME__ = "DNS Lookup Tool"
-__VERBOSE_NAME_ZH__ = "DNS查询工具"
+__VERBOSE_NAME__ = "DNS Lookup"
+__VERBOSE_NAME_ZH__ = "DNS查询"
 __KEYWORDS__ = "domain name,域名解析,a记录,dns查询,dns helper,aaaa record,ns record,txt record,network tools,internet protocols,aaaa记录,dns queries,网络工具,ns记录,txt记录,域名信息,dns lookup,a record,axfr记录"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/markdown_to_docx.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/markdown_to_docx.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于将Markdown文件转换为Word文档(.docx)的工具，基于pandoc进行文档格式转换，支持指定输出目录和自定义输出文件名，适用于文档处理、报告生成和格式转换等场景。"
-__VERBOSE_NAME__ = "Markdown to DOCX Converter"
-__VERBOSE_NAME_ZH__ = "Markdown转DOCX工具"
+__VERBOSE_NAME__ = "Markdown to DOCX"
+__VERBOSE_NAME_ZH__ = "Markdown转DOCX"
 __KEYWORDS__ = "markdown转换,docx文档,文档转换,pandoc,word文档,document conversion,markdown to docx,file conversion,报告生成,文档处理,格式转换,文档导出"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/parse_office_to_text.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/parse_office_to_text.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于解析Office文档（PPT、DOC、Excel）为纯文本的工具，支持提取文档内容并转换为可读文本格式，适用于文档内容分析、文本提取和数据处理等场景。"
-__VERBOSE_NAME__ = "Office Document to Text"
-__VERBOSE_NAME_ZH__ = "Office文档解析为文本"
+__VERBOSE_NAME__ = "Office to Text"
+__VERBOSE_NAME_ZH__ = "Office转文本"
 __KEYWORDS__ = "office文档解析,文本提取,ppt解析,doc解析,excel解析,文档内容提取,office parser,document parsing,text extraction,文件解析,内容分析,数据提取"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/query_excel_data.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/query_excel_data.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Excel 数据查询工具，适用于简单的一次性查询：列选择、行过滤、排序、单维度聚合、分页。性能警告：每次调用都会重新解析整个文件（40MB 文件约需 30 秒）。对于需要 3 次以上查询的多步骤分析，如果数据已通过 ExcelCLI 入库，应优先使用 `excelcli query` 命令通过 SQL 进行批量分析。仅当 ExcelCLI 不可用时，才使用 Python pandas 作为兜底方案。"
-__VERBOSE_NAME__ = "Excel Data Query"
-__VERBOSE_NAME_ZH__ = "Excel 数据查询"
+__VERBOSE_NAME__ = "Excel Query"
+__VERBOSE_NAME_ZH__ = "Excel查询"
 __KEYWORDS__ = "excel query,data filter,sort,aggregate,sum,count,avg,group by,xlsx,spreadsheet,data analysis,column select,pagination,excel search,transaction analysis,financial data,excel read,excelcli,query,SQL 分析,excelcli query,数据库查询,批量分析"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_excel_info.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_excel_info.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Excel 文件结构探索工具。读取 Excel 文件并输出工作表列表、列名及推断数据类型、行数和预览行。先用此工具了解数据布局。重要：本工具仅用于结构探索。对于交易数据、银行流水、发票数据、金融记录或任何案件调查数据的多步骤分析（3 次以上查询），应使用 ExcelCLI（excelcli-analysis 技能）进行数据导入入库，然后通过 bash 工具执行结构化 SQL 分析。仅当 ExcelCLI 不可用时，Python pandas 才作为兜底方案。"
-__VERBOSE_NAME__ = "Excel Structure Explorer"
-__VERBOSE_NAME_ZH__ = "Excel 结构探索"
+__VERBOSE_NAME__ = "Excel Explorer"
+__VERBOSE_NAME_ZH__ = "Excel结构"
 __KEYWORDS__ = "excel,xlsx,xls,spreadsheet,data exploration,column names,sheet list,data types,row count,preview,schema,structure,data analysis,excel info,excel schema,transaction data,financial analysis,bank statement,excelcli,数据入库,案件分析,办案数据,银行流水,发票数据"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_word_structure.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/doc/read_word_structure.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Word document structured reader. Extracts and organizes content from .docx files into separate sections: text body, tables, and attachments (images, charts, OLE objects). Provides cleaner output than parse_office_to_text by separating content types and offering optional table-only or text-only extraction."
-__VERBOSE_NAME__ = "Word Document Structure Reader"
-__VERBOSE_NAME_ZH__ = "Word 文档结构读取"
+__VERBOSE_NAME__ = "Word Structure Reader"
+__VERBOSE_NAME_ZH__ = "Word结构读取"
 __KEYWORDS__ = "word,docx,document,text extraction,table extraction,word structure,document analysis,word reader,office document,doc parsing,word tables,word content,document sections"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fp/match_fingerprint_by_packet.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fp/match_fingerprint_by_packet.yak
@@ -1,5 +1,5 @@
 __DESC__ = "一个数据包指纹匹配工具，可以对输入的网络数据包进行指纹识别和匹配，用于识别数据包中包含的服务、协议或应用特征，帮助进行网络流量分析和安全检测。支持直接传入数据包内容或指定文件路径读取文件内容进行匹配。"
-__VERBOSE_NAME__ = "Packet Fingerprint Matcher"
+__VERBOSE_NAME__ = "Packet Fingerprint"
 __VERBOSE_NAME_ZH__ = "数据包指纹匹配"
 __KEYWORDS__ = "数据包分析,指纹匹配,网络分析,协议识别,服务识别,流量分析,安全检测,packet analysis,fingerprint matching,network analysis,protocol identification,service identification,traffic analysis,security detection,response matching,文件读取,file reading"
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/diff_file.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/diff_file.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于比较两个文件内容差异的工具，参数是两个文件名，所以你需要准备好文件之后才使用这个工具，支持生成详细的差异报告。适用于文件版本对比、代码审查等场景。"
-__VERBOSE_NAME__ = "File Diff Tool"
-__VERBOSE_NAME_ZH__ = "文件差异比较工具"
+__VERBOSE_NAME__ = "File Diff"
+__VERBOSE_NAME_ZH__ = "文件差异对比"
 __KEYWORDS__ = "file diff,文件差异,文件比较,diff comparison,文件对比,text comparison,差异分析,版本对比,代码审查"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/find_file.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/find_file.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于在指定目录下递归搜索文件的工具，支持通过模式（子串、正则、Glob）匹配文件路径，并可根据文件类型（文件/目录）进行过滤。支持名称黑白名单和扩展名黑白名单过滤，限制返回结果数量。"
-__VERBOSE_NAME__ = "File Search Tool"
-__VERBOSE_NAME_ZH__ = "文件搜索工具"
+__VERBOSE_NAME__ = "File Search"
+__VERBOSE_NAME_ZH__ = "文件搜索"
 __KEYWORDS__ = "file size,file type,recursive search,模式匹配,正则表达式,文件大小,文件类型,file filtering,glob pattern,file search,directory search,file extension,文件搜索,文件过滤,递归搜索,regular expression,目录搜索,glob模式,文件扩展名,pattern matching,include,exclude"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/grep.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个文本查找工具，用于在指定文件或目录下查找匹配特定模式的文本。支持子串（区分大小写和不区分大小写）和正则表达式模式。支持名称和扩展名黑白名单过滤。可指定查找的路径、模式、最大结果数量、跳过的匹配次数以及显示匹配文本周围的上下文。"
-__VERBOSE_NAME__ = "Text Grep Tool"
-__VERBOSE_NAME_ZH__ = "文本查找工具"
+__VERBOSE_NAME__ = "Text Grep"
+__VERBOSE_NAME_ZH__ = "文本查找"
 __KEYWORDS__ = "pattern matching,regexp,file path,模式匹配,查找替换,文件路径,context text,文本查找,文本工具,directory search,text tool,文件搜索,正则表达式,目录搜索,grep,text finder,file search,include,exclude,extension filter"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/head_file.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/head_file.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于显示指定文件头部内容的工具。支持按字节数或按行数读取，支持显示行号、十六进制转储等功能。"
-__VERBOSE_NAME__ = "File Head Viewer"
-__VERBOSE_NAME_ZH__ = "文件头部内容查看"
+__VERBOSE_NAME__ = "File Head"
+__VERBOSE_NAME_ZH__ = "文件头部查看"
 __KEYWORDS__ = "file,head,bytes,lines,文件读取,文本处理,十六进制转储,行号显示,内容预览,first bytes,first lines"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/modify_file.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/modify_file.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于增量修改现有文件内容的工具，是修改已有文件时优先于 write_file 的首选方案。支持按行号精准插入或替换内容，content 参数支持多行文本，适用于增加注释、修复 bug、插入代码块、调整配置项等高效编辑场景。"
-__VERBOSE_NAME__ = "File Content Modifier"
-__VERBOSE_NAME_ZH__ = "文件内容修改工具"
+__VERBOSE_NAME__ = "File Modifier"
+__VERBOSE_NAME_ZH__ = "文件修改"
 __KEYWORDS__ = "file modify,文件修改,文件编辑,file editing,content modification,行编辑,line editing,字符串替换,string replacement,文件处理,text processing,insert content,replace content,add comments,增加注释,代码注释,edit existing file,修改现有文件,incremental edit,增量编辑"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/query_document.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/query_document.yak
@@ -1,6 +1,6 @@
 __DESC__ = "智能文档阅读和理解工具，支持多种文档格式的深度分析。通过自适应分块和上下文保持技术，能够理解长文档的语义结构，回答复杂问题，生成摘要，提取关键信息。支持个性化阅读策略和多种输出格式。Analyzes a local text-based document to answer a user's specific question. This tool processes the document in chunks, maintaining contextual understanding to handle long-form content. It is ideal for when an AI agent needs to find specific information, extract key details, or get a conclusive answer from within a file's content. If no question is provided, it will summarize the document."
-__VERBOSE_NAME__ = "File Content Analyzer"
-__VERBOSE_NAME_ZH__ = "文件内容分析器"
+__VERBOSE_NAME__ = "File Analyzer"
+__VERBOSE_NAME_ZH__ = "文件内容分析"
 __KEYWORDS__ = "file analysis, document qa, question answering, query, ask, find, search, retrieve, extract, RAG, retrieval augmented generation, contextual analysis, text chunking, semantic search, information extraction, document analysis, local file QA, content comprehension"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/query_file_meta.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/query_file_meta.yak
@@ -1,6 +1,6 @@
 __DESC__ = "获取指定文件的基本元信息，包括判断是否为目录、文件大小、文件权限模式以及最后修改时间。"
-__VERBOSE_NAME__ = "File Metadata Query"
-__VERBOSE_NAME_ZH__ = "文件元信息查询"
+__VERBOSE_NAME__ = "File Metadata"
+__VERBOSE_NAME_ZH__ = "文件元信息"
 __KEYWORDS__ = "修改时间,directory,file size,file metadata,文件大小,文件权限,文件元数据,文件属性,file information,file permissions,modified time,文件信息,目录检查"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/read_file.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/read_file.yak
@@ -1,6 +1,6 @@
 __DESC__ = "A unified text file (Absolute File Path) reader that supports line-based and byte-chunk reading modes. Automatically detects binary file formats via mimetype (magic bytes) and redirects to appropriate built-in tools (read_excel_info, query_excel_data, read_word_structure, parse_office_to_text, zip_viewer, analyze_pcap, etc.) or Python scripts."
-__VERBOSE_NAME__ = "Unified File Reader"
-__VERBOSE_NAME_ZH__ = "统一文件读取工具"
+__VERBOSE_NAME__ = "File Reader"
+__VERBOSE_NAME_ZH__ = "文件读取"
 __KEYWORDS__ = "memory management,file reading,large file,file handling,reading,data processing,buffer,performance,offset,chunk size,streaming,line reading,binary detection,mimetype,excel,xlsx,pdf,docx,zip,pcap,office,read_excel_info,query_excel_data,parse_office_to_text"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/read_file_lines.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/read_file_lines.yak
@@ -1,6 +1,6 @@
 __DESC__ = "A line-based text file (Absolute File Path) reader with pagination support. Automatically detects binary file formats via mimetype (magic bytes) and redirects to appropriate built-in tools (read_excel_info, read_word_structure, parse_office_to_text, zip_viewer, analyze_pcap, etc.)."
-__VERBOSE_NAME__ = "Line-Based File Reader"
-__VERBOSE_NAME_ZH__ = "按行文件读取工具"
+__VERBOSE_NAME__ = "Line File Reader"
+__VERBOSE_NAME_ZH__ = "按行读取文件"
 __KEYWORDS__ = "file reading,line reading,log analysis,text processing,large file,line by line,pagination,streaming read,binary detection,mimetype,read_excel_info,parse_office_to_text"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/tail_file.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/tail_file.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于显示指定文件尾部内容的工具。支持按字节数或按行数读取，支持显示行号、十六进制转储等功能。"
-__VERBOSE_NAME__ = "File Tail Viewer"
-__VERBOSE_NAME_ZH__ = "文件尾部内容查看"
+__VERBOSE_NAME__ = "File Tail"
+__VERBOSE_NAME_ZH__ = "文件尾部查看"
 __KEYWORDS__ = "file,tail,bytes,lines,文件读取,文本处理,十六进制转储,行号显示,内容预览,last bytes,last lines"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/tree.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/tree.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于查看目录树形结构的工具，支持显示目录下的文件和子目录层级关系，默认排除 .git/node_modules 等噪声目录。支持名称黑白名单和扩展名黑白名单过滤。支持 dirs-only 模式只显示目录结构（不显示文件），适用于大型项目的快速结构概览。适用于目录结构分析、项目概览等场景。"
-__VERBOSE_NAME__ = "Directory Tree Viewer"
-__VERBOSE_NAME_ZH__ = "目录树形结构查看工具"
+__VERBOSE_NAME__ = "Directory Tree"
+__VERBOSE_NAME_ZH__ = "目录树"
 __KEYWORDS__ = "directory tree,目录结构,树形结构,文件系统浏览,directory listing,文件夹结构,文件树,file hierarchy,目录浏览,directory navigation,exclude,include,extension filter,dirs-only,仅目录"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/write_file.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/write_file.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于创建和写入文件的工具，支持将指定内容安全地写入到目标文件中，包括创建新文件或覆盖现有文件。适用于文件创建、配置文件生成、日志文件写入等场景。注意：如果只是修改已有文件的局部内容，应优先使用 modify_file 做增量编辑，避免全量覆写。"
 __VERBOSE_NAME__ = "File Writer"
-__VERBOSE_NAME_ZH__ = "文件写入工具"
+__VERBOSE_NAME_ZH__ = "文件写入"
 __KEYWORDS__ = "file write,文件写入,文件创建,file creation,content writing,文件操作,file operations,text file,binary file,file save,保存文件,创建文件,写入内容,文件处理"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-blame.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-blame.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于执行Git blame操作的工具，可以指定目标Git仓库、文件名以及引用名称（如分支、标签或提交）。工具支持指定结果的起始偏移量和限制数量，以便分块读取 blames 信息。"
-__VERBOSE_NAME__ = "Git Blame Tool"
-__VERBOSE_NAME_ZH__ = "Git Blame工具"
+__VERBOSE_NAME__ = "Git Blame"
+__VERBOSE_NAME_ZH__ = "Git Blame"
 __KEYWORDS__ = "git blame,代码溯源,提交记录,代码归属,版本控制,git工具,仓库管理,文件历史"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-branch.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-branch.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个获取Git仓库分支列表的工具，支持指定仓库路径，并可设置偏移量和数量（limit）来分批读取分支信息。"
-__VERBOSE_NAME__ = "Git Branch Lister"
-__VERBOSE_NAME_ZH__ = "Git分支列表工具"
+__VERBOSE_NAME__ = "Git Branch List"
+__VERBOSE_NAME_ZH__ = "Git分支列表"
 __KEYWORDS__ = "git工具,仓库管理,分支列表,代码分支,分批读取,git信息查询,版本控制,代码管理"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-clone.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-clone.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于克隆Git远程仓库的工具，支持指定本地路径、分支、深度等选项。适用于代码下载、仓库同步等场景。"
-__VERBOSE_NAME__ = "Git Clone Tool"
-__VERBOSE_NAME_ZH__ = "Git克隆工具"
+__VERBOSE_NAME__ = "Git Clone"
+__VERBOSE_NAME_ZH__ = "Git克隆"
 __KEYWORDS__ = "git clone,仓库克隆,代码下载,版本控制,git工具,仓库管理,代码同步,分支克隆,深度克隆"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-current-branch.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-current-branch.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于获取指定Git仓库当前HEAD分支名称及其提交范围（起始和结束提交哈希值）的工具，用于查询和显示仓库的当前分支状态和提交历史范围。"
-__VERBOSE_NAME__ = "Git Current Branch & Commit Range"
-__VERBOSE_NAME_ZH__ = "Git当前分支及提交范围工具"
+__VERBOSE_NAME__ = "Git Current Branch"
+__VERBOSE_NAME_ZH__ = "Git当前分支"
 __KEYWORDS__ = "git工具,仓库管理,分支管理,head分支,提交范围,版本控制,代码管理,git信息查询"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-dump-fs-commit.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-dump-fs-commit.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个强大的Git文件系统提取工具，支持从单个提交、提交范围、日期或日期范围中提取文件系统内容并复制到本地临时目录。适用于代码版本分析、历史快照查看、特定时间点代码恢复等场景。"
-__VERBOSE_NAME__ = "Git Filesystem Extractor"
-__VERBOSE_NAME_ZH__ = "Git文件系统提取工具"
+__VERBOSE_NAME__ = "Git FS Extractor"
+__VERBOSE_NAME_ZH__ = "Git文件提取"
 __KEYWORDS__ = "git,文件系统,提交提取,日期范围,版本控制,代码管理,文件快照,git工具,commit range,date range"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-head.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/git/git-head.yak
@@ -1,6 +1,6 @@
 __DESC__ = "获取指定Git仓库的最新提交(HEAD)的哈希值。如果获取失败，则会发出警告。"
-__VERBOSE_NAME__ = "Git HEAD Hash Tool"
-__VERBOSE_NAME_ZH__ = "Git HEAD哈希值工具"
+__VERBOSE_NAME__ = "Git HEAD Hash"
+__VERBOSE_NAME_ZH__ = "Git HEAD哈希"
 __KEYWORDS__ = "git,仓库,head,哈希,提交,版本控制,信息获取"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/batch_do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/batch_do_http_request.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Send multiple HTTP requests for endpoint probing and API batch validation (IDOR included). URL mode requires `base-url` plus newline-separated `paths`; concurrency is `concurrent`. Responses are included automatically. Prefer structured query/form objects with original unescaped values. Use a packet template only for exact bytes or custom encoding. 用于端点探测、接口批量验证（含 IDOR）的批量 HTTP 请求。URL 模式必须传 `base-url` 和换行分隔的 `paths`，并发参数名是 `concurrent`，响应会自动输出；query/form 传原始未转义值。仅在需要精确报文或自定义编码时使用 packet 模板。"
-__VERBOSE_NAME__ = "Batch HTTP Request Tool"
-__VERBOSE_NAME_ZH__ = "批量HTTP请求工具"
+__VERBOSE_NAME__ = "Batch HTTP Request"
+__VERBOSE_NAME_ZH__ = "批量HTTP请求"
 __KEYWORDS__ = "batch http,request multiple,concurrent,batch request,multi path,path scan,batch url,parallel request,mass request,http flood,path enumeration,directory scan,batch get,batch post,api endpoint validation,endpoint probing,api batch testing,request replay,template replay,unauthorized access check,authorization bypass verification,idor validation,horizontal privilege check,batch interface check,批量请求,并发请求,批量HTTP,多路径探测,路径枚举,目录扫描,接口批量验证,API批量测试,接口探测,端点探测,未授权访问验证,越权验证,水平越权验证,IDOR验证,批量验证接口,请求重放,模板请求,多接口测试"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Send one HTTP request. Prefer URL mode with structured query/form objects: pass original unescaped values and the tool URL-encodes them safely. Use body for a raw JSON/XML/text body. Use packet when exact bytes, duplicate parameters, ordering, or custom encoding matter. Use batch_do_http_request for multiple requests. 发送单个 HTTP 请求。优先使用 URL 模式的 query/form 对象，传原始未转义值，由工具安全编码；JSON/XML/文本使用 body；需要精确数据包、重复参数、顺序或自定义编码时使用 packet；多请求使用 batch_do_http_request。"
-__VERBOSE_NAME__ = "Powerful HTTP Request Tool (curl-like)"
-__VERBOSE_NAME_ZH__ = "强大的HTTP请求工具（类curl）"
+__VERBOSE_NAME__ = "HTTP Request"
+__VERBOSE_NAME_ZH__ = "HTTP请求"
 __KEYWORDS__ = "http request,curl,web,network,packet,raw request,http response,url,post,get,https,proxy,redirect,header,body,api,http tool,web debug,traffic"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/http_response_diff.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/http_response_diff.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Compares two HTTP responses to detect differences. Supports URL mode (send GET to two URLs) and Packet mode (send two raw HTTP packets). Shows status code comparison, content-length difference, and unified diff of response content. Essential for auth bypass detection, WAF analysis, and logic vulnerability verification."
 __VERBOSE_NAME__ = "HTTP Response Diff"
-__VERBOSE_NAME_ZH__ = "HTTP响应差异比较"
+__VERBOSE_NAME_ZH__ = "HTTP响应对比"
 __KEYWORDS__ = "http,response,diff,compare,difference,authentication,bypass,waf,security,status code,body,headers,content-length"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/send_http_request_by_url.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/send_http_request_by_url.yak
@@ -1,6 +1,6 @@
 __DESC__ = "发送基础HTTP请求的工具，允许用户指定请求方法（默认为GET）和完整的URL。工具执行请求并打印原始请求和响应数据包。"
-__VERBOSE_NAME__ = "Basic HTTP Request Tool (URL)"
-__VERBOSE_NAME_ZH__ = "基础HTTP请求工具(URL)"
+__VERBOSE_NAME__ = "HTTP Request by URL"
+__VERBOSE_NAME_ZH__ = "URL HTTP请求"
 __KEYWORDS__ = "http请求,网络工具,web通信,请求工具,响应查看,基础请求,网络调试"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/send_http_request_packet.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/send_http_request_packet.yak
@@ -1,6 +1,6 @@
 __DESC__ = "发送原始HTTP请求数据包，并接收完整的HTTP响应。工具支持设置HTTPS、重定向次数、请求超时时间，同时提供基于关键字或正则表达式匹配请求和响应内容的功能，并可选保存请求/响应到临时文件，显示网络连接和响应时间信息。"
-__VERBOSE_NAME__ = "HTTP Packet Sender & Response Analyzer"
-__VERBOSE_NAME_ZH__ = "HTTP请求数据包发送与响应分析"
+__VERBOSE_NAME__ = "HTTP Packet Sender"
+__VERBOSE_NAME_ZH__ = "HTTP数据包发送"
 __KEYWORDS__ = "http请求,网络探测,数据包发送,流量分析,web工具,请求响应,内容匹配,网络测试,抓包"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
@@ -1,6 +1,6 @@
 __DESC__ = "不使用浏览器的基本简易爬虫，开销低，速度快，可控性好，适合初步探查使用"
-__VERBOSE_NAME__ = "Simple Crawler"
-__VERBOSE_NAME_ZH__ = "简易爬虫"
+__VERBOSE_NAME__ = "Crawler"
+__VERBOSE_NAME_ZH__ = "爬虫"
 __KEYWORDS__ = "爬虫,网络抓取,网页采集,http请求,http响应,无头爬虫,数据抓取,轻量级爬虫"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/url_content_summary.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/url_content_summary.yak
@@ -1,8 +1,8 @@
 __DESC__ = <<<EOF
 Retrieves the content of a specified URL via a GET request. Logs the response headers and body size. If the content type indicates HTML, it extracts and logs: 1. The page title found within the <title> tag. 2. All text content stripped from the HTML elements, concatenated together. Essentially, it provides a summary (title and text) of an HTML web page.
 EOF
-__VERBOSE_NAME__ = "URL Content Summary Extractor"
-__VERBOSE_NAME_ZH__ = "URL内容摘要提取工具"
+__VERBOSE_NAME__ = "URL Content Summary"
+__VERBOSE_NAME_ZH__ = "URL内容摘要"
 __KEYWORDS__ = "url retrieval,page title,http,web page,content extraction,web crawling,html parsing,text extraction,get request,内容提取,web scraper,网页抓取,url获取,页面标题,get请求,html解析,网页信息"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/web_search.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/web_search.yak
@@ -1,6 +1,6 @@
 __DESC__ = "互联网搜索与内容精炼工具。搜索互联网获取信息，并发抓取页面内容，通过 AI 蒸馏压缩提取精华，交付高质量结果。Internet search and content refinement tool. Searches the internet, concurrently fetches page content, and uses AI distillation to extract key information."
-__VERBOSE_NAME__ = "Web Search & Content Refiner"
-__VERBOSE_NAME_ZH__ = "互联网搜索与内容精炼工具"
+__VERBOSE_NAME__ = "Web Search"
+__VERBOSE_NAME_ZH__ = "网页搜索"
 __KEYWORDS__ = "web search,internet search,omnisearch,搜索互联网,互联网搜索,网页搜索,搜索引擎,网上搜索,在线搜索,上网搜索,search engine,web research,网页抓取,信息收集,话题调研,实时信息,content extraction,information gathering,百度搜索,谷歌搜索,search online,搜一下,帮我搜,帮我查"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/net/whois.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/net/whois.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个通过向IANA网站发送HTTP请求来查询指定域名的WHOIS信息的工具。它获取页面内容并提取WHOIS数据进行显示。"
-__VERBOSE_NAME__ = "IANA WHOIS Lookup"
-__VERBOSE_NAME_ZH__ = "IANA WHOIS域名信息查询"
+__VERBOSE_NAME__ = "WHOIS Lookup"
+__VERBOSE_NAME_ZH__ = "WHOIS查询"
 __KEYWORDS__ = "whois查询,域名信息,域名管理,网络侦察,信息收集,iana,域名注册信息"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pcap/analyze_challenge_pcap.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pcap/analyze_challenge_pcap.yak
@@ -1,6 +1,6 @@
 __DESC__ = "专门用于分析chall.pcapng等网络安全挑战PCAP文件的工具，支持解密隐蔽通信、提取flag、识别网络工具行为。"
-__VERBOSE_NAME__ = "Challenge PCAP Analyzer"
-__VERBOSE_NAME_ZH__ = "挑战PCAP分析工具"
+__VERBOSE_NAME__ = "PCAP Challenge Analyzer"
+__VERBOSE_NAME_ZH__ = "PCAP挑战分析"
 __KEYWORDS__ = "challenge,ctf,网络安全挑战,隐蔽通信,flag提取,网络工具分析,流量解密,恶意行为检测"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pcap/analyze_pcap.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pcap/analyze_pcap.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个强大的PCAP数据包分析工具，支持解析网络数据包、提取流量信息、分析协议内容。适用于网络流量分析、协议逆向、数据包调试等场景。"
-__VERBOSE_NAME__ = "PCAP Packet Analyzer"
-__VERBOSE_NAME_ZH__ = "PCAP数据包分析工具"
+__VERBOSE_NAME__ = "PCAP Analyzer"
+__VERBOSE_NAME_ZH__ = "PCAP分析"
 __KEYWORDS__ = "pcap,packet analysis,网络分析,数据包,流量分析,协议解析,网络调试,packet capture,网络流量,数据包分析"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pcap/decrypt_pcap.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pcap/decrypt_pcap.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个专门用于解密和分析网络工具相关PCAP数据包的工具，支持数据帧重组、提取隐藏流量、解密加密通信、识别恶意行为等高级功能。"
-__VERBOSE_NAME__ = "PCAP Decrypt Analyzer"
-__VERBOSE_NAME_ZH__ = "PCAP解密分析工具"
+__VERBOSE_NAME__ = "PCAP Decryptor"
+__VERBOSE_NAME_ZH__ = "PCAP解密"
 __KEYWORDS__ = "pcap,decrypt,解密,网络工具,流量分析,加密通信,恶意行为,隐蔽通道,协议逆向,数据包解密,数据帧重组"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/banner_grab.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/banner_grab.yak
@@ -1,5 +1,5 @@
 __DESC__ = "A TCP banner grabbing tool for service identification. Connects to target host:port, optionally sends probe data, and reads the service banner. Supports batch targets and TLS connections. Identifies common services (SSH, SMTP, HTTP, FTP, MySQL, etc.) from banner content."
-__VERBOSE_NAME__ = "TCP Banner Grabber"
+__VERBOSE_NAME__ = "TCP Banner Grab"
 __VERBOSE_NAME_ZH__ = "TCP Banner抓取"
 __KEYWORDS__ = "banner,grab,tcp,service,identification,fingerprint,port,connect,probe,tls,ssl,ssh,smtp,ftp,mysql,redis,pentest,reconnaissance"
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/brute.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/brute.yak
@@ -1,6 +1,6 @@
 __KEYWORDS__ = "brute force,service,weak password,ssh,ftp,mysql,rdp,postgres,tomcat,smb,vnc,redis,mongodb"
-__VERBOSE_NAME__ = "Identified Service Weak Password Brute Force"
-__VERBOSE_NAME_ZH__ = "已识别服务弱口令爆破"
+__VERBOSE_NAME__ = "Weak Password Brute"
+__VERBOSE_NAME_ZH__ = "弱口令爆破"
 __DESC__ = <<<EOF
 Brute force weak password testing for KNOWN and IDENTIFIED network service protocols.
 This tool is protocol-specific: you MUST already know the exact service type (e.g. ssh, mysql, ftp) before calling it. It is NOT a general-purpose scanner.

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/run_yaml_poc.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/run_yaml_poc.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Executes YAML PoC templates(Nuclei formats) against targets. Supports inline raw YAML PoC, template name search, fuzzy keyword search, and tag-based filtering. Returns matched vulnerabilities with severity, target, PoC name, and request/response details."
-__VERBOSE_NAME__ = "YAML PoC Scanner (Nuclei, Yakit formats)"
-__VERBOSE_NAME_ZH__ = "YAML PoC 扫描器（Nuclei、Yakit 格式）"
+__VERBOSE_NAME__ = "YAML PoC Scanner"
+__VERBOSE_NAME_ZH__ = "YAML PoC扫描"
 __KEYWORDS__ = "nuclei,poc,yaml,vulnerability,scan,template,exploit,cve,security,pentest,detection,web vulnerability"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/scan_port.yak
@@ -1,6 +1,6 @@
 __KEYWORDS__ = "port scan,syn scan,tcp scan,service scan,fingerprint,network scan,security,pentest,host discovery,port discovery,service identification,network security"
-__VERBOSE_NAME__ = "Unified Port Scanner (SYN+TCP)"
-__VERBOSE_NAME_ZH__ = "统一端口扫描器（SYN+TCP）"
+__VERBOSE_NAME__ = "Port Scanner"
+__VERBOSE_NAME_ZH__ = "端口扫描"
 __DESC__ = "A unified port scanner with TUN-aware fallback. Normally it combines SYN discovery and TCP service fingerprinting. When target-specific DNS/route evidence shows Clash Verge or another TUN/Fake-IP path, SYN and large-range port discovery are unreliable but real services such as 80/443 can still exist. The tool therefore does NOT reject the target: it automatically restarts the plan in a compact TCP-connect validation mode, keeps at most a small set of relevant ports, prefers web ports for domain targets, suppresses noisy per-packet/banner output, and tells the AI to continue with protocol-level HTTP/browser checks. TUN-safe results are useful candidates, not an exhaustive port inventory."
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/web_fingerprint.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/pentest/web_fingerprint.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Web 指纹识别工具。接收一个 URL，发送带 rememberMe=123 Cookie 的初始请求用于辅助 Shiro 识别，并调用 servicescan 的 Web 指纹库识别站点指纹。"
-__VERBOSE_NAME__ = "Web Fingerprint Detector"
-__VERBOSE_NAME_ZH__ = "Web 指纹识别"
+__VERBOSE_NAME__ = "Web Fingerprint"
+__VERBOSE_NAME_ZH__ = "Web指纹识别"
 __KEYWORDS__ = "web指纹识别,网站指纹,shiro,rememberMe,servicescan,fingerprint,web fingerprint,pentest,reconnaissance"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/recon/ip_info.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/recon/ip_info.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Queries IP address geolocation, ASN, and ISP information using local MMDB databases (GeoIP2). Supports batch IP queries with comma-separated input. Falls back to amap API if MMDB is unavailable. Provides country, city, coordinates, timezone, ASN, and ISP details."
-__VERBOSE_NAME__ = "IP Geolocation & ASN Lookup"
-__VERBOSE_NAME_ZH__ = "IP 地理位置与 ASN 查询"
+__VERBOSE_NAME__ = "IP Info Lookup"
+__VERBOSE_NAME_ZH__ = "IP信息查询"
 __KEYWORDS__ = "ip,geolocation,geoip,asn,isp,location,country,city,mmdb,maxmind,whois,autonomous system,latitude,longitude"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/recon/network_space_search.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/recon/network_space_search.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Searches network assets using space search engines (FOFA, Shodan, ZoomEye, Hunter, Quake, Zone). Discovers hosts, services, and fingerprints matching the query filter. Requires API key configuration in Yakit settings."
-__VERBOSE_NAME__ = "Network Space Search Engine"
-__VERBOSE_NAME_ZH__ = "网络空间搜索引擎"
+__VERBOSE_NAME__ = "Network Space Search"
+__VERBOSE_NAME_ZH__ = "网络空间搜索"
 __KEYWORDS__ = "fofa,shodan,zoomeye,hunter,quake,zone,零零测绘,space engine,network search,asset discovery,fingerprint,reconnaissance,internet scanning"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/risk/cybersecurity-risk.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/risk/cybersecurity-risk.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Create structured security risk records from a compact set of plain string parameters. This tool is for persisting verified or strongly-supported security findings while avoiding title-only records. It keeps the disclosure simple: target, title, summary, optional type/severity, small proof fields, and optional direct raw request/response or file references."
-__VERBOSE_NAME__ = "Cybersecurity Risk Output Tool"
-__VERBOSE_NAME_ZH__ = "网络安全风险输出工具"
+__VERBOSE_NAME__ = "Risk Output"
+__VERBOSE_NAME_ZH__ = "风险输出"
 __KEYWORDS__ = "security risk,vulnerability report,risk output,security audit,risk management,pentest finding,sqli,xss,rce,security finding,evidence,remediation"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/risk/ssa-risk.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/risk/ssa-risk.yak
@@ -1,6 +1,6 @@
 __DESC__ = "接收一个SSA RiskID获取SSA Risk或者SSA RiskID关联的问题代码"
-__VERBOSE_NAME__ = "SSA Risk by ID Lookup"
-__VERBOSE_NAME_ZH__ = "通过SSA Risk ID获取SSA Risk或者SSA RiskID关联的问题代码"
+__VERBOSE_NAME__ = "SSA Risk Lookup"
+__VERBOSE_NAME_ZH__ = "SSA风险查询"
 __KEYWORDS__ = "SSA, Risk, SSA Risk"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/check_syntaxflow_syntax.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/check_syntaxflow_syntax.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Performs a syntax check on SyntaxFlow rule. The rule can be provided directly as a string ('syntaxflow-code') or by specifying a file path ('path')."
-__VERBOSE_NAME__ = "SyntaxFlow Syntax Checker"
-__VERBOSE_NAME_ZH__ = "SyntaxFlow 语法检测"
+__VERBOSE_NAME__ = "SyntaxFlow Checker"
+__VERBOSE_NAME_ZH__ = "SyntaxFlow语法检测"
 __KEYWORDS__ = "syntaxflow, sf, syntax check, rule validation, static analysis, code audit, SyntaxFlow, 语法检测, 规则验证, 静态分析"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/check_yaklang_syntax.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/check_yaklang_syntax.yak
@@ -1,6 +1,6 @@
 __DESC__ = "Performs a syntax check on Yaklang code. The code can be provided directly as a string ('yaklang-code') or by specifying a file path ('path')."
-__VERBOSE_NAME__ = "Yaklang Syntax Checker"
-__VERBOSE_NAME_ZH__ = "Yaklang 语法检查"
+__VERBOSE_NAME__ = "Yaklang Checker"
+__VERBOSE_NAME_ZH__ = "Yaklang语法检查"
 __KEYWORDS__ = "yaklang, syntax check, linter, static analysis, code validation, Yaklang, 语法检查, 静态分析, 代码验证, 脚本检查"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/poc_template_searcher.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/poc_template_searcher.yak
@@ -1,6 +1,6 @@
 __DESC__ = "POC模板搜索工具，根据漏洞类型和攻击向量搜索和提供相应的Python POC模板，为POC生成提供代码框架参考。"
-__VERBOSE_NAME__ = "PoC Template Searcher"
-__VERBOSE_NAME_ZH__ = "POC模板搜索工具"
+__VERBOSE_NAME__ = "PoC Template Search"
+__VERBOSE_NAME_ZH__ = "PoC模板搜索"
 __KEYWORDS__ = "POC模板,漏洞利用模板,Python POC,代码模板,攻击向量,漏洞利用框架,安全测试模板"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/syntaxflow_rule_completion.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/ssa/syntaxflow_rule_completion.yak
@@ -1,6 +1,6 @@
 __DESC__ = "【sf_rule_completion 子任务专用】读规则、liteforge 补全 desc/alert、内存合并并写入 suggested_path（默认 ~/yakit-projects/code/*-completed.sf）。勿在此脚本内 ExecuteForge。推荐外层走 sf_rule_completion 蓝图。"
 __VERBOSE_NAME__ = "SyntaxFlow Rule Completion"
-__VERBOSE_NAME_ZH__ = "SyntaxFlow 规则补全"
+__VERBOSE_NAME_ZH__ = "SyntaxFlow规则补全"
 __KEYWORDS__ = "syntaxflow,规则补全,desc,alert,sf_rule_completion,SyntaxFlow"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
@@ -1,6 +1,6 @@
 __DESC__ = "跨平台Shell命令执行工具，支持bash/cmd/powershell，具备超时控制和输出捕获。bash 默认以登录 shell 执行以加载系统和用户 profile 中的 PATH/环境变量，不额外启用 set -e 或命令追踪，行为更接近原生终端执行。注意：对于文件创建/写入操作，应优先使用 write_file 工具；对于文件局部修改，应优先使用 modify_file 工具。仅当专用工具无法满足需求时，才使用 bash 的 cat/echo 重定向操作文件。对于已通过 ExcelCLI 入库的数据分析任务，应优先使用 `excelcli query` 命令通过 SQL 分析，而非编写 Python 脚本。"
-__VERBOSE_NAME__ = "Cross-Platform Shell Executor"
-__VERBOSE_NAME_ZH__ = "跨平台Shell命令执行工具"
+__VERBOSE_NAME__ = "Shell Executor"
+__VERBOSE_NAME_ZH__ = "Shell执行"
 __KEYWORDS__ = "shell command,bash,cmd,powershell,命令行工具,系统管理,自动化脚本,运维工具,shell script,command execution,系统操作,终端命令,system administration,automation tools,操作系统,跨平台命令,timeout,超时控制,python script,pandas,data analysis,excel analysis,csv cache,data cache,批量分析,write_file优先,文件操作优先,modify_file优先"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/check_command_availability.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/check_command_availability.yak
@@ -1,5 +1,5 @@
 __DESC__ = "检测环境变量PATH中是否存在指定的命令，用于确认系统工具的可用性。支持检测单个命令或多个命令的存在状态，可指定是否显示详细的PATH信息。适用于脚本执行前的环境检查、依赖工具验证和自动化部署。"
-__VERBOSE_NAME__ = "Command Availability Checker"
+__VERBOSE_NAME__ = "Command Checker"
 __VERBOSE_NAME_ZH__ = "命令可用性检测"
 __KEYWORDS__ = "command availability,path检测,环境变量,命令存在性,系统工具,dependency check,依赖检查,环境检查,工具验证,command validation,executable check,PATH环境变量,系统命令,which命令,where命令"
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/cmd.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/cmd.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个强大的Windows CMD命令执行工具，允许用户在受控环境中执行任意Windows命令行指令，支持超时控制和输出捕获，适用于Windows系统管理、自动化脚本执行和运维操作。注意：路径中的反斜杠(\\)需要转义，例如应使用 C:\\\\Users 而不是 C:\\Users。"
-__VERBOSE_NAME__ = "Windows Command Executor"
-__VERBOSE_NAME_ZH__ = "Windows命令执行"
+__VERBOSE_NAME__ = "CMD Executor"
+__VERBOSE_NAME_ZH__ = "Windows CMD执行"
 __KEYWORDS__ = "cmd command,windows命令,命令行工具,系统管理,自动化脚本,运维工具,batch script,command execution,系统操作,cmd脚本,终端命令,system administration,automation tools,操作系统,windows命令"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/ostype.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/ostype.yak
@@ -1,6 +1,6 @@
 __DESC__ = "获取当前运行环境的操作系统类型信息，返回操作系统的名称和版本，用于系统环境识别和后续工具选择。"
 __VERBOSE_NAME__ = "OS Type Detector"
-__VERBOSE_NAME_ZH__ = "操作系统类型识别"
+__VERBOSE_NAME_ZH__ = "系统类型识别"
 __KEYWORDS__ = "操作系统类型,os type,系统识别,system identification,操作系统检测,os detection,系统环境,operating system,platform detection,系统平台,环境检测"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/powershell.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/powershell.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个强大的PowerShell命令执行工具，允许用户在受控环境中执行任意PowerShell脚本和命令，支持超时控制和输出捕获，适用于Windows高级系统管理、自动化脚本执行和DevOps操作。"
-__VERBOSE_NAME__ = "Windows PowerShell Executor"
-__VERBOSE_NAME_ZH__ = "Windows PowerShell命令执行"
+__VERBOSE_NAME__ = "PowerShell Executor"
+__VERBOSE_NAME_ZH__ = "PowerShell执行"
 __KEYWORDS__ = "powershell command,ps1脚本,windows管理,命令行工具,系统管理,自动化脚本,运维工具,powershell script,command execution,系统操作,ps脚本,终端命令,system administration,automation tools,操作系统,windows高级命令,devops工具"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/tls/tls_inspect.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/tls/tls_inspect.yak
@@ -1,5 +1,5 @@
 __DESC__ = "用于检查指定域名的TLS证书信息，尝试不同的协议版本进行扫描，并打印证书详情。"
-__VERBOSE_NAME__ = "TLS Certificate Inspector"
+__VERBOSE_NAME__ = "TLS Inspector"
 __VERBOSE_NAME_ZH__ = "TLS证书检查"
 __KEYWORDS__ = "security,https,ssl,加密,网络安全,证书详情,安全工具,certificate validation,encryption,certificate authority,domain verification,tls证书,域名扫描,tls certificates,domain inspection,network security,web security,证书检查"
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/yakplugin/call_yak_plugin.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/yakplugin/call_yak_plugin.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个Yak插件调用器，可以通过插件名、数据库ID或UUID执行插件，接收请求URL并自动生成GET请求包，提供反馈机制来显示插件执行结果。"
 __VERBOSE_NAME__ = "Yak Plugin Caller"
-__VERBOSE_NAME_ZH__ = "Yak插件调用器"
+__VERBOSE_NAME_ZH__ = "Yak插件调用"
 __KEYWORDS__ = "插件调用,MITM插件,插件执行,HTTP请求,插件管理,反馈机制,plugin caller,mitm plugin,plugin execution,http request,plugin management,feedback mechanism,yak plugin,hook manager"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/yakplugin/query_plugin_by_fp.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/yakplugin/query_plugin_by_fp.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个基于指纹名称查找相关插件的工具，仅返回插件名中包含指纹名称的 Yak 插件，并给出可传给 Yak 插件调用器的调用标识。"
 __VERBOSE_NAME__ = "Plugin Fingerprint Query"
-__VERBOSE_NAME_ZH__ = "插件指纹查询工具"
+__VERBOSE_NAME_ZH__ = "插件指纹查询"
 __KEYWORDS__ = "插件查询,指纹匹配,相似度计算,插件搜索,数据库查询,模糊匹配,plugin query,fingerprint matching,similarity calculation,plugin search,database query,fuzzy matching,yak plugin,script search"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/yakplugin/subdomain_scan.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/yakplugin/subdomain_scan.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个子域名扫描工具，支持递归爆破和泛解析检测。可以扫描指定域名的所有子域名，并解析出对应的IP地址，支持配置是否进行递归扫描和泛解析停止策略。"
 __VERBOSE_NAME__ = "Subdomain Scanner"
-__VERBOSE_NAME_ZH__ = "子域名扫描工具"
+__VERBOSE_NAME_ZH__ = "子域名扫描"
 __KEYWORDS__ = "子域名扫描,域名爆破,递归扫描,泛解析检测,DNS解析,网络侦察,信息收集,subdomain scan,domain brute force,recursive scan,wildcard detection,DNS resolution,network reconnaissance,information gathering"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/zip/zip_viewer.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/zip/zip_viewer.yak
@@ -1,6 +1,6 @@
 __DESC__ = "一个用于查看ZIP压缩包内部文件列表的工具，支持通过设置偏移量(offset)和限制数量(limit)进行分页阅览，适合处理包含大量文件的压缩包。"
-__VERBOSE_NAME__ = "ZIP Archive Lister"
-__VERBOSE_NAME_ZH__ = "ZIP文件列表查看器"
+__VERBOSE_NAME__ = "ZIP Lister"
+__VERBOSE_NAME_ZH__ = "ZIP文件列表"
 __KEYWORDS__ = "file management,限制数量,zip,pagination,data retrieval,view files,文件列表,分页查询,file list,limit,archive,文件阅览,offset,files,zip解压,压缩文件管理,偏移量"
 
 __USAGE__ = <<<USAGE_BLOCK

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "410cc6295a00f43655313d6ce258e8adc0f712b020101bf6199bc305f210b2e3"
+const ExistedBuildInAIToolEmbedFSHash string = "b4b14d12e9c9cdf09f7d39a17b8f8e9d4b8078383ba4ee02b4342640c4181a4e"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "7c4c511c04bf71bca999ba70b5dadce27dd72c5cdfb3ae6fd10f134d96bb5949"
+const ExistedBuildInAIToolEmbedFSHash string = "410cc6295a00f43655313d6ce258e8adc0f712b020101bf6199bc305f210b2e3"


### PR DESCRIPTION
- Add WithVerboseName/WithVerboseNameZh to 16 Go-registered tools that previously had no verbose name (fstools, jarop, ssatools, yaklangtools, notifytools, searchtools)
- Fix 66 .yak script tools' __VERBOSE_NAME__/__VERBOSE_NAME_ZH__ to comply with naming conventions: max 8 chars/words, no parenthetical supplements, no adjectives (e.g. Powerful/Simple/Unified), concise and direct
- Remove parenthetical (MCP:server) suffix from MCP stub verbose name
- Add tryFillVerboseNameForPlaceholder in aireact/invoke_toolcall.go to fill verbose name on the placeholder tool before emitStart so the tool-call card shows a readable title immediately