### PR TITLE
ci(legion): 发布多架构 Legion 组件

### DIFF
--- a/.github/scripts/build-legion-component-oss-index.sh
+++ b/.github/scripts/build-legion-component-oss-index.sh
@@ -9,6 +9,8 @@ public_base_url=""
 output=""
 runtime_image_ref=""
 runtime_image_id=""
+target_os="linux"
+target_arch="amd64"
 
 usage() {
   cat <<'EOF'
@@ -21,6 +23,10 @@ Required:
   --artifact-dir DIR
   --public-base-url URL
   --output FILE
+
+Optional:
+  --goos linux                    Default: linux
+  --goarch amd64|arm64            Default: amd64
 
 Required for session-runtime:
   --runtime-image-ref IMAGE@sha256:...
@@ -40,10 +46,19 @@ while (($#)); do
     --output) output="$2"; shift 2 ;;
     --runtime-image-ref) runtime_image_ref="$2"; shift 2 ;;
     --runtime-image-id) runtime_image_id="$2"; shift 2 ;;
+    --goos) target_os="$2"; shift 2 ;;
+    --goarch) target_arch="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
 done
+
+[[ "$target_os" == "linux" ]] || die "unsupported component target OS: $target_os"
+case "$target_arch" in amd64|arm64) ;; *) die "unsupported component target architecture: $target_arch" ;; esac
+platform_suffix=""
+if [[ "$target_arch" != "amd64" ]]; then
+  platform_suffix="_${target_os}_${target_arch}"
+fi
 
 for command in jq sha256sum stat; do
   command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
@@ -52,18 +67,18 @@ done
 case "$component" in
   product-node)
     [[ "$version" =~ ^legion-node-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || die "invalid Product Node release version"
-    package_name="legion-product-node_linux_amd64.tar.gz"
-    manifest_name="PRODUCT_NODE_MANIFEST.json"
-    checksums_name="SHA256SUMS"
-    binary_name="legion-smoke-node"
+    package_name="legion-product-node_${target_os}_${target_arch}.tar.gz"
+    manifest_name="PRODUCT_NODE_MANIFEST${platform_suffix}.json"
+    checksums_name="SHA256SUMS${platform_suffix}"
+    binary_name="legion-smoke-node${platform_suffix}"
     manifest_type="legion-product-node"
     ;;
   session-runtime)
     [[ "$version" =~ ^legion-runtime-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || die "invalid Session Runtime release version"
-    package_name="legion-ai-session-runtime_linux_amd64.tar.gz"
-    manifest_name="SESSION_RUNTIME_MANIFEST.json"
-    checksums_name="SHA256SUMS"
-    image_archive_name="legion-ai-session-runtime_linux_amd64.docker.tar.gz"
+    package_name="legion-ai-session-runtime_${target_os}_${target_arch}.tar.gz"
+    manifest_name="SESSION_RUNTIME_MANIFEST${platform_suffix}.json"
+    checksums_name="SHA256SUMS${platform_suffix}"
+    image_archive_name="legion-ai-session-runtime_${target_os}_${target_arch}.docker.tar.gz"
     manifest_type="legion-ai-session-runtime"
     [[ "$runtime_image_ref" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || die "invalid Runtime image ref"
     [[ "$runtime_image_id" =~ ^sha256:[0-9a-f]{64}$ ]] || die "invalid Runtime image ID"
@@ -95,13 +110,17 @@ done
 jq -e \
   --arg type "$manifest_type" \
   --arg version "$version" \
-  --arg source_sha "$source_sha" '
+  --arg source_sha "$source_sha" \
+  --arg target_os "$target_os" \
+  --arg target_arch "$target_arch" '
     .schema_version == "1" and
     .artifact_type == $type and
     .version == $version and
     .source.repository == "yaklang/yaklang" and
     .source.commit == $source_sha and
     .source.dirty == false and
+    .recipe.goos == $target_os and
+    .recipe.goarch == $target_arch and
     .ci.provider == "github-actions" and
     (.ci.run_id | test("^[0-9]+$"))
   ' "$manifest" >/dev/null || die "producer manifest does not match the requested release"
@@ -131,6 +150,8 @@ if [[ "$component" == product-node ]]; then
     --arg version "$version" \
     --arg source_sha "$source_sha" \
     --arg base_url "$public_base_url" \
+    --arg target_os "$target_os" \
+    --arg target_arch "$target_arch" \
     --argjson package "$package_record" \
     --argjson package_checksum "$package_checksum_record" \
     --argjson manifest "$manifest_record" \
@@ -142,6 +163,7 @@ if [[ "$component" == product-node ]]; then
       component:"product-node",
       version:$version,
       source:{repository:"yaklang/yaklang",commit:$source_sha},
+      platform:{goos:$target_os,goarch:$target_arch},
       distribution:{provider:"aliyun-oss",base_url:$base_url},
       artifacts:{package:$package,package_checksum:$package_checksum,manifest:$manifest,checksums:$checksums,binary:$binary}
     }' >"$output"
@@ -154,6 +176,8 @@ else
     --arg version "$version" \
     --arg source_sha "$source_sha" \
     --arg base_url "$public_base_url" \
+    --arg target_os "$target_os" \
+    --arg target_arch "$target_arch" \
     --arg runtime_image_ref "$runtime_image_ref" \
     --arg runtime_image_id "$runtime_image_id" \
     --argjson package "$package_record" \
@@ -167,6 +191,7 @@ else
       component:"session-runtime",
       version:$version,
       source:{repository:"yaklang/yaklang",commit:$source_sha},
+      platform:{goos:$target_os,goarch:$target_arch},
       distribution:{provider:"aliyun-oss",base_url:$base_url},
       runtime:{image_ref:$runtime_image_ref,image_id:$runtime_image_id},
       artifacts:{package:$package,package_checksum:$package_checksum,manifest:$manifest,checksums:$checksums,image_archive:$image_archive}

--- a/.github/scripts/build-legion-product-node.sh
+++ b/.github/scripts/build-legion-product-node.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-package_name="${NODE_PACKAGE_NAME:-legion-product-node_linux_amd64}"
+target_os="${NODE_GOOS:-linux}"
+target_arch="${NODE_GOARCH:-amd64}"
+package_name="${NODE_PACKAGE_NAME:-legion-product-node_${target_os}_${target_arch}}"
 dist_dir="${NODE_DIST_DIR:-$repo_root/dist}"
 package_dir="$dist_dir/$package_name"
 package_path="$dist_dir/$package_name.tar.gz"
@@ -19,6 +21,20 @@ log() {
 for command in file git go gzip jq readelf sha256sum stat tar; do
   command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
 done
+
+[[ "$target_os" == "linux" ]] || die "unsupported Product Node target OS: $target_os"
+case "$target_arch" in
+  amd64) expected_machine="x86-64" ;;
+  arm64) expected_machine="ARM aarch64" ;;
+  *) die "unsupported Product Node target architecture: $target_arch" ;;
+esac
+[[ "$package_name" == "legion-product-node_${target_os}_${target_arch}" ]] || \
+  die "NODE_PACKAGE_NAME does not match target platform: $package_name"
+platform_suffix=""
+if [[ "$target_arch" != "amd64" ]]; then
+  platform_suffix="_${target_os}_${target_arch}"
+fi
+binary_name="legion-smoke-node${platform_suffix}"
 
 source_sha="${SOURCE_SHA:-$(git -C "$repo_root" rev-parse HEAD)}"
 [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid SOURCE_SHA: $source_sha"
@@ -38,7 +54,7 @@ version="${NODE_PACKAGE_VERSION:-sha-${source_sha:0:12}}"
 [[ ! -e "$package_dir" ]] || die "package directory already exists: $package_dir"
 [[ ! -e "$package_path" ]] || die "package archive already exists: $package_path"
 
-binary="$package_dir/legion-smoke-node"
+binary="$package_dir/$binary_name"
 build_tags="hids"
 module_go_version="$(awk '$1 == "go" { gsub(/\r/, "", $2); print $2; exit }' "$repo_root/go.mod")"
 [[ -n "$module_go_version" ]] || die "go.mod does not declare a Go version"
@@ -47,10 +63,10 @@ toolchain_version="$(go env GOVERSION)"
   die "Go toolchain $toolchain_version does not match go.mod version go$module_go_version"
 mkdir -p "$package_dir"
 
-log "building Linux amd64 HIDS node from $source_sha with $(go version)"
+log "building ${target_os}/${target_arch} HIDS node from $source_sha with $(go version)"
 (
   cd "$repo_root"
-  CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+  CGO_ENABLED=1 GOOS="$target_os" GOARCH="$target_arch" go build \
     -trimpath \
     -buildvcs=true \
     -tags "$build_tags" \
@@ -61,6 +77,9 @@ log "building Linux amd64 HIDS node from $source_sha with $(go version)"
 
 file_description="$(file "$binary")"
 printf '%s\n' "$file_description"
+grep -q 'ELF 64-bit' <<<"$file_description" || die "node binary is not a 64-bit ELF file"
+grep -q "$expected_machine" <<<"$file_description" || \
+  die "node binary does not match ${target_os}/${target_arch}"
 grep -q 'statically linked' <<<"$file_description" || die "node binary is not statically linked"
 if readelf -d "$binary" 2>/dev/null | grep -q '(NEEDED)'; then
   die "node binary declares dynamic library dependencies"
@@ -77,7 +96,10 @@ jq -n \
   --argjson source_dirty "$source_dirty" \
   --arg module_go_version "$module_go_version" \
   --arg go_version "$(go version)" \
+  --arg target_os "$target_os" \
+  --arg target_arch "$target_arch" \
   --arg build_tags "$build_tags" \
+  --arg binary_name "$binary_name" \
   --arg binary_sha "$binary_sha" \
   --argjson binary_size "$binary_size" \
   --arg built_at "$built_at" \
@@ -103,8 +125,8 @@ jq -n \
       actor: $ci_actor
     },
     recipe: {
-      goos: "linux",
-      goarch: "amd64",
+      goos: $target_os,
+      goarch: $target_arch,
       cgo_enabled: true,
       link_mode: "external-static",
       build_tags: $build_tags,
@@ -113,7 +135,7 @@ jq -n \
     },
     capabilities: ["hids", "ssa.rule_sync.export", "yak.execute"],
     binary: {
-      path: "legion-smoke-node",
+      path: $binary_name,
       sha256: $binary_sha,
       size: $binary_size
     },
@@ -122,7 +144,7 @@ jq -n \
 
 (
   cd "$package_dir"
-  sha256sum legion-smoke-node PRODUCT_NODE_MANIFEST.json >SHA256SUMS
+  sha256sum "$binary_name" PRODUCT_NODE_MANIFEST.json >SHA256SUMS
   sha256sum -c SHA256SUMS
 )
 

--- a/.github/scripts/package-legion-ai-session-runtime.sh
+++ b/.github/scripts/package-legion-ai-session-runtime.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-package_name="${RUNTIME_PACKAGE_NAME:-legion-ai-session-runtime_linux_amd64}"
+target_os="${RUNTIME_GOOS:-linux}"
+target_arch="${RUNTIME_GOARCH:-amd64}"
+package_name="${RUNTIME_PACKAGE_NAME:-legion-ai-session-runtime_${target_os}_${target_arch}}"
 dist_dir="${RUNTIME_DIST_DIR:-$repo_root/dist}"
 package_dir="$dist_dir/$package_name"
 package_path="$dist_dir/$package_name.tar.gz"
@@ -21,6 +23,15 @@ log() {
 for command in file git gzip jq sha256sum stat tar; do
   command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
 done
+
+[[ "$target_os" == "linux" ]] || die "unsupported Runtime target OS: $target_os"
+case "$target_arch" in
+  amd64) expected_machine="x86-64" ;;
+  arm64) expected_machine="ARM aarch64" ;;
+  *) die "unsupported Runtime target architecture: $target_arch" ;;
+esac
+[[ "$package_name" == "legion-ai-session-runtime_${target_os}_${target_arch}" ]] || \
+  die "RUNTIME_PACKAGE_NAME does not match target platform: $package_name"
 
 source_sha="${SOURCE_SHA:-$(git -C "$repo_root" rev-parse HEAD)}"
 [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid SOURCE_SHA: $source_sha"
@@ -63,7 +74,8 @@ fi
 
 file_description="$(file "$runtime_binary")"
 grep -q 'ELF 64-bit' <<<"$file_description" || die "runtime binary is not a 64-bit ELF file"
-grep -q 'x86-64' <<<"$file_description" || die "runtime binary is not built for linux/amd64"
+grep -q "$expected_machine" <<<"$file_description" || \
+  die "runtime binary does not match ${target_os}/${target_arch}"
 
 module_go_version="$(awk '$1 == "go" { gsub(/\r/, "", $2); print $2; exit }' "$repo_root/go.mod")"
 [[ -n "$module_go_version" ]] || die "go.mod does not declare a Go version"
@@ -98,6 +110,8 @@ jq -n \
   --arg dockerignore_sha "$dockerignore_sha" \
   --arg module_go_version "$module_go_version" \
   --arg runtime_go_version "$runtime_go_version" \
+  --arg target_os "$target_os" \
+  --arg target_arch "$target_arch" \
   --arg binary_sha "$binary_sha" \
   --argjson binary_size "$binary_size" \
   --rawfile binary_ldd "$runtime_ldd_file" \
@@ -129,8 +143,8 @@ jq -n \
       packaging_dirty: $source_dirty,
       dockerfile_sha256: $dockerfile_sha,
       dockerignore_sha256: $dockerignore_sha,
-      goos: "linux",
-      goarch: "amd64",
+      goos: $target_os,
+      goarch: $target_arch,
       cgo_enabled: true,
       link_mode: "dynamic-container",
       build_tags: "",

--- a/.github/scripts/test-build-legion-component-oss-index.sh
+++ b/.github/scripts/test-build-legion-component-oss-index.sh
@@ -24,7 +24,8 @@ node_sha="$(sha256sum "$node_dir/legion-smoke-node" | awk '{print $1}')"
 jq -n --arg sha "$source_sha" --arg binary_sha "$node_sha" '{
   schema_version:"1",artifact_type:"legion-product-node",version:"legion-node-v1.2.3-alpha.1",
   source:{repository:"yaklang/yaklang",commit:$sha,dirty:false},
-  ci:{provider:"github-actions",run_id:"123"},binary:{sha256:$binary_sha}
+  ci:{provider:"github-actions",run_id:"123"},recipe:{goos:"linux",goarch:"amd64"},
+  binary:{sha256:$binary_sha}
 }' >"$node_dir/PRODUCT_NODE_MANIFEST.json"
 make_common "$node_dir" legion-product-node_linux_amd64.tar.gz PRODUCT_NODE_MANIFEST.json
 "$builder" \
@@ -41,6 +42,33 @@ jq -e --arg sha "$source_sha" '
 ' "$node_dir/release-index.json" >/dev/null
 (cd "$node_dir" && sha256sum -c release-index.json.sha256 >/dev/null)
 
+node_arm_dir="$test_root/node-arm64"
+mkdir -p "$node_arm_dir"
+printf 'node-arm64\n' >"$node_arm_dir/legion-smoke-node_linux_arm64"
+node_arm_sha="$(sha256sum "$node_arm_dir/legion-smoke-node_linux_arm64" | awk '{print $1}')"
+jq -n --arg sha "$source_sha" --arg binary_sha "$node_arm_sha" '{
+  schema_version:"1",artifact_type:"legion-product-node",version:"legion-node-v1.2.3-alpha.1",
+  source:{repository:"yaklang/yaklang",commit:$sha,dirty:false},
+  ci:{provider:"github-actions",run_id:"124"},recipe:{goos:"linux",goarch:"arm64"},
+  binary:{sha256:$binary_sha}
+}' >"$node_arm_dir/PRODUCT_NODE_MANIFEST_linux_arm64.json"
+make_common "$node_arm_dir" legion-product-node_linux_arm64.tar.gz PRODUCT_NODE_MANIFEST_linux_arm64.json
+mv "$node_arm_dir/SHA256SUMS" "$node_arm_dir/SHA256SUMS_linux_arm64"
+"$builder" \
+  --component product-node \
+  --version legion-node-v1.2.3-alpha.1 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$node_arm_dir" \
+  --public-base-url "https://yaklang.oss-accelerate.aliyuncs.com/legion/components/product-node/legion-node-v1.2.3-alpha.1/$source_sha" \
+  --goarch arm64 \
+  --output "$node_arm_dir/release-index-linux-arm64.json"
+jq -e '
+  .component == "product-node" and .platform == {goos:"linux",goarch:"arm64"} and
+  .artifacts.binary.path == "legion-smoke-node_linux_arm64" and
+  .artifacts.manifest.path == "PRODUCT_NODE_MANIFEST_linux_arm64.json"
+' "$node_arm_dir/release-index-linux-arm64.json" >/dev/null
+(cd "$node_arm_dir" && sha256sum -c release-index-linux-arm64.json.sha256 >/dev/null)
+
 runtime_dir="$test_root/runtime"
 mkdir -p "$runtime_dir"
 image_id="sha256:3333333333333333333333333333333333333333333333333333333333333333"
@@ -49,7 +77,8 @@ printf 'image\n' >"$runtime_dir/legion-ai-session-runtime_linux_amd64.docker.tar
 jq -n --arg sha "$source_sha" --arg image_ref "$image_ref" '{
   schema_version:"1",artifact_type:"legion-ai-session-runtime",version:"legion-runtime-v1.2.3",
   source:{repository:"yaklang/yaklang",commit:$sha,dirty:false},
-  ci:{provider:"github-actions",run_id:"456"},image:{ref:$image_ref}
+  ci:{provider:"github-actions",run_id:"456"},recipe:{goos:"linux",goarch:"amd64"},
+  image:{ref:$image_ref}
 }' >"$runtime_dir/SESSION_RUNTIME_MANIFEST.json"
 make_common "$runtime_dir" legion-ai-session-runtime_linux_amd64.tar.gz SESSION_RUNTIME_MANIFEST.json
 "$builder" \
@@ -67,6 +96,36 @@ jq -e --arg ref "$image_ref" --arg id "$image_id" '
 ' "$runtime_dir/release-index.json" >/dev/null
 (cd "$runtime_dir" && sha256sum -c release-index.json.sha256 >/dev/null)
 
+runtime_arm_dir="$test_root/runtime-arm64"
+mkdir -p "$runtime_arm_dir"
+arm_image_id="sha256:5555555555555555555555555555555555555555555555555555555555555555"
+arm_image_ref="yaklang-oss.invalid/legion-ai-session-runtime@$arm_image_id"
+printf 'image-arm64\n' >"$runtime_arm_dir/legion-ai-session-runtime_linux_arm64.docker.tar.gz"
+jq -n --arg sha "$source_sha" --arg image_ref "$arm_image_ref" '{
+  schema_version:"1",artifact_type:"legion-ai-session-runtime",version:"legion-runtime-v1.2.3",
+  source:{repository:"yaklang/yaklang",commit:$sha,dirty:false},
+  ci:{provider:"github-actions",run_id:"457"},recipe:{goos:"linux",goarch:"arm64"},
+  image:{ref:$image_ref}
+}' >"$runtime_arm_dir/SESSION_RUNTIME_MANIFEST_linux_arm64.json"
+make_common "$runtime_arm_dir" legion-ai-session-runtime_linux_arm64.tar.gz SESSION_RUNTIME_MANIFEST_linux_arm64.json
+mv "$runtime_arm_dir/SHA256SUMS" "$runtime_arm_dir/SHA256SUMS_linux_arm64"
+"$builder" \
+  --component session-runtime \
+  --version legion-runtime-v1.2.3 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$runtime_arm_dir" \
+  --public-base-url "https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/legion-runtime-v1.2.3/$source_sha" \
+  --runtime-image-ref "$arm_image_ref" \
+  --runtime-image-id "$arm_image_id" \
+  --goarch arm64 \
+  --output "$runtime_arm_dir/release-index-linux-arm64.json"
+jq -e '
+  .component == "session-runtime" and .platform == {goos:"linux",goarch:"arm64"} and
+  .artifacts.image_archive.path == "legion-ai-session-runtime_linux_arm64.docker.tar.gz" and
+  .artifacts.manifest.path == "SESSION_RUNTIME_MANIFEST_linux_arm64.json"
+' "$runtime_arm_dir/release-index-linux-arm64.json" >/dev/null
+(cd "$runtime_arm_dir" && sha256sum -c release-index-linux-arm64.json.sha256 >/dev/null)
+
 if "$builder" \
   --component session-runtime \
   --version legion-runtime-v1.2.3 \
@@ -77,6 +136,18 @@ if "$builder" \
   --runtime-image-id sha256:4444444444444444444444444444444444444444444444444444444444444444 \
   --output "$test_root/mismatched-runtime.json"; then
   echo 'mismatched Runtime logical ref and image ID unexpectedly accepted' >&2
+  exit 1
+fi
+
+if "$builder" \
+  --component product-node \
+  --version legion-node-v1.2.3 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$node_dir" \
+  --public-base-url "https://yaklang.oss-accelerate.aliyuncs.com/legion/components/product-node/legion-node-v1.2.3/$source_sha" \
+  --goarch riscv64 \
+  --output "$test_root/unsupported-platform.json"; then
+  echo 'unsupported component architecture unexpectedly accepted' >&2
   exit 1
 fi
 

--- a/.github/scripts/test-legion-component-workflow-contract.sh
+++ b/.github/scripts/test-legion-component-workflow-contract.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+check_release_only_workflow() {
+  local workflow="$1" expected_tag="$2" trigger_block
+  trigger_block="$(awk '/^on:$/ { capture=1 } /^permissions:$/ { capture=0 } capture' "$workflow")"
+
+  grep -Fxq "      - \"$expected_tag\"" <<<"$trigger_block" || {
+    echo "$workflow does not declare the exact $expected_tag tag trigger" >&2
+    exit 1
+  }
+  if grep -Eq '^[[:space:]]+(pull_request|workflow_dispatch|branches):' <<<"$trigger_block"; then
+    echo "$workflow must remain tag-only" >&2
+    exit 1
+  fi
+}
+
+check_release_only_workflow \
+  "$repo_root/.github/workflows/build-legion-product-node.yml" \
+  'legion-node-v*'
+check_release_only_workflow \
+  "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml" \
+  'legion-runtime-v*'
+
+grep -Fq 'ubuntu-24.04-arm' "$repo_root/.github/workflows/build-legion-product-node.yml"
+grep -Fq 'ubuntu-24.04-arm' "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"
+grep -Fq 'release-index-linux-arm64.json' "$repo_root/.github/workflows/build-legion-product-node.yml"
+grep -Fq 'release-index-linux-arm64.json' "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"
+
+echo 'Legion component workflow contract tests passed'

--- a/.github/scripts/test-package-legion-ai-session-runtime.sh
+++ b/.github/scripts/test-package-legion-ai-session-runtime.sh
@@ -7,6 +7,11 @@ test_root="$(mktemp -d)"
 trap 'rm -rf -- "$test_root"' EXIT
 
 source_sha="$(git -C "$repo_root" rev-parse HEAD)"
+case "$(uname -m)" in
+  x86_64) target_arch="amd64" ;;
+  aarch64|arm64) target_arch="arm64" ;;
+  *) echo "unsupported test host architecture: $(uname -m)" >&2; exit 1 ;;
+esac
 fake_digest="$(printf 'a%.0s' {1..64})"
 base_digest="$(printf 'b%.0s' {1..64})"
 builder_digest="$(printf 'c%.0s' {1..64})"
@@ -24,12 +29,13 @@ RUNTIME_IMAGE_REF="registry.example/legion-ai-session-runtime@sha256:$fake_diges
 RUNTIME_IMAGE_TAG="registry.example/legion-ai-session-runtime:fixture" \
 RUNTIME_BASE_IMAGE="debian:bookworm-slim@sha256:$base_digest" \
 RUNTIME_BUILDER_IMAGE="golang:1.22.12-bookworm@sha256:$builder_digest" \
-RUNTIME_GO_VERSION="go version go1.22.12 linux/amd64" \
+RUNTIME_GOARCH="$target_arch" \
+RUNTIME_GO_VERSION="go version go1.22.12 linux/$target_arch" \
 RUNTIME_CI_PROVIDER="fixture" \
 SESSION_RUNTIME_WORKFLOW_NAME="fixture" \
 "$packager"
 
-package_name="legion-ai-session-runtime_linux_amd64"
+package_name="legion-ai-session-runtime_linux_${target_arch}"
 package_dir="$test_root/dist/$package_name"
 manifest="$package_dir/SESSION_RUNTIME_MANIFEST.json"
 
@@ -44,13 +50,14 @@ manifest="$package_dir/SESSION_RUNTIME_MANIFEST.json"
 
 jq -e \
   --arg source_sha "$source_sha" \
-  --arg image_ref "registry.example/legion-ai-session-runtime@sha256:$fake_digest" '
+  --arg image_ref "registry.example/legion-ai-session-runtime@sha256:$fake_digest" \
+  --arg target_arch "$target_arch" '
     .schema_version == "1" and
     .artifact_type == "legion-ai-session-runtime" and
     .source.commit == $source_sha and
     .recipe.packaging_source_sha == $source_sha and
     .recipe.goos == "linux" and
-    .recipe.goarch == "amd64" and
+    .recipe.goarch == $target_arch and
     .recipe.cgo_enabled == true and
     .recipe.link_mode == "dynamic-container" and
     .recipe.module_go_version == "1.22.12" and

--- a/.github/workflows/build-legion-ai-session-runtime.yml
+++ b/.github/workflows/build-legion-ai-session-runtime.yml
@@ -1,114 +1,73 @@
 name: Build Trusted Legion AI Session Runtime
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - "legion-runtime-v*"
-  pull_request:
-    paths:
-      - ".github/scripts/package-legion-ai-session-runtime.sh"
-      - ".github/scripts/test-package-legion-ai-session-runtime.sh"
-      - ".github/scripts/build-legion-component-oss-index.sh"
-      - ".github/scripts/test-build-legion-component-oss-index.sh"
-      - ".github/workflows/build-legion-ai-session-runtime.yml"
-      - "docker/session-runtime/**"
-      - "cmd/legion-smoke-node/**"
-      - "common/ai/**"
-      - "common/node/**"
-      - "common/spec/**"
-      - "scannode/**"
-      - "go.mod"
-      - "go.sum"
 
 permissions:
   contents: read
 
 concurrency:
   group: legion-ai-session-runtime-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 env:
-  RUNTIME_PACKAGE_NAME: legion-ai-session-runtime_linux_amd64
   RUNTIME_IMAGE_REPOSITORY: local.invalid/yaklang/legion-ai-session-runtime
   SESSION_RUNTIME_WORKFLOW_NAME: Build Trusted Legion AI Session Runtime
-  SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  SOURCE_SHA: ${{ github.sha }}
 
 jobs:
-  build-linux-amd64:
-    name: Build Linux amd64 AI Session Runtime
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
+  build-and-publish:
+    name: Build Linux ${{ matrix.goarch }} AI Session Runtime
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     permissions:
       contents: read
       id-token: write
       attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            runner: ubuntu-22.04
+            artifact_suffix: ""
+            index_name: release-index.json
+          - goarch: arm64
+            runner: ubuntu-24.04-arm
+            artifact_suffix: _linux_arm64
+            index_name: release-index-linux-arm64.json
+    env:
+      RUNTIME_GOOS: linux
+      RUNTIME_GOARCH: ${{ matrix.goarch }}
+      RUNTIME_PACKAGE_NAME: legion-ai-session-runtime_linux_${{ matrix.goarch }}
+      RUNTIME_PACKAGE_VERSION: ${{ github.ref_name }}
+      ARTIFACT_SUFFIX: ${{ matrix.artifact_suffix }}
+      INDEX_NAME: ${{ matrix.index_name }}
     steps:
-      - name: Check out source commit
+      - name: Check out tagged source commit
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.SOURCE_SHA }}
           fetch-depth: 0
 
-      - name: Validate event and release source
-        id: contract
+      - name: Validate release tag and source
         shell: bash
         run: |
           set -euo pipefail
-          publish=false
-          publish_oss=false
-          case "$GITHUB_EVENT_NAME" in
-            pull_request)
-              ;;
-            workflow_dispatch)
-              [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
-                echo "workflow_dispatch publishing is restricted to main" >&2
-                exit 1
-              }
-              publish=true
-              ;;
-            push)
-              [[ "$GITHUB_REF" =~ ^refs/tags/legion-runtime-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
-                echo "unexpected publish tag: $GITHUB_REF" >&2
-                exit 1
-              }
-              publish=true
-              publish_oss=true
-              ;;
-            *)
-              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
-              exit 1
-              ;;
-          esac
-
+          [[ "$GITHUB_EVENT_NAME" == push ]]
+          [[ "$GITHUB_REF" =~ ^refs/tags/legion-runtime-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
+            echo "unexpected Runtime release tag: $GITHUB_REF" >&2
+            exit 1
+          }
           [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
           [[ -z "$(git status --porcelain --untracked-files=all)" ]]
-          if [[ "$publish" == true ]]; then
-            git fetch --no-tags origin main:refs/remotes/origin/main
-            git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
-              echo "published Runtime source must already be reachable from origin/main" >&2
-              exit 1
-            }
-          fi
-
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            version="$GITHUB_REF_NAME"
-          else
-            version="sha-${SOURCE_SHA:0:12}"
-          fi
-          artifact_name="$RUNTIME_PACKAGE_NAME"
-          ci_provider=github-actions
-          if [[ "$publish" != true ]]; then
-            artifact_name="${RUNTIME_PACKAGE_NAME}-preview"
-            ci_provider=github-actions-preview
-          fi
-          {
-            echo "publish=$publish"
-            echo "publish_oss=$publish_oss"
-            echo "version=$version"
-            echo "artifact_name=$artifact_name"
-            echo "ci_provider=$ci_provider"
-          } >>"$GITHUB_OUTPUT"
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
+            echo "published Runtime source must already be reachable from origin/main" >&2
+            exit 1
+          }
 
       - name: Verify module Go version
         shell: bash
@@ -126,7 +85,7 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Test AI Session Runtime code
+      - name: Test AI Session Runtime code and release contracts
         shell: bash
         run: |
           set -euo pipefail
@@ -151,8 +110,9 @@ jobs:
           [[ "$runtime_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
           builder_ref="${builder_tag}@${builder_digest}"
           runtime_ref="${runtime_tag}@${runtime_digest}"
-          go_version="$(docker run --rm --platform linux/amd64 "$builder_ref" go version)"
+          go_version="$(docker run --rm --platform "linux/${RUNTIME_GOARCH}" "$builder_ref" go version)"
           [[ "$go_version" == *"go1.22.12"* ]]
+          [[ "$go_version" == *"linux/${RUNTIME_GOARCH}"* ]]
           {
             echo "builder_ref=$builder_ref"
             echo "runtime_ref=$runtime_ref"
@@ -165,46 +125,42 @@ jobs:
         with:
           context: .
           file: docker/session-runtime/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/${{ matrix.goarch }}
           push: false
           load: true
-          tags: ${{ env.RUNTIME_IMAGE_REPOSITORY }}:${{ steps.contract.outputs.version }}
+          tags: ${{ env.RUNTIME_IMAGE_REPOSITORY }}:${{ env.RUNTIME_PACKAGE_VERSION }}-${{ matrix.goarch }}
           build-args: |
             GO_BUILDER_IMAGE=${{ steps.bases.outputs.builder_ref }}
             RUNTIME_BASE_IMAGE=${{ steps.bases.outputs.runtime_ref }}
             SOURCE_SHA=${{ env.SOURCE_SHA }}
-            RUNTIME_VERSION=${{ steps.contract.outputs.version }}
+            RUNTIME_VERSION=${{ env.RUNTIME_PACKAGE_VERSION }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ env.SOURCE_SHA }}
-            org.opencontainers.image.version=${{ steps.contract.outputs.version }}
+            org.opencontainers.image.version=${{ env.RUNTIME_PACKAGE_VERSION }}
           provenance: false
           sbom: false
 
       - name: Inspect built image and extract Runtime binary
         id: inspect
         shell: bash
-        env:
-          VERSION: ${{ steps.contract.outputs.version }}
         run: |
           set -euo pipefail
-          image_tag="${RUNTIME_IMAGE_REPOSITORY}:${VERSION}"
-          image_for_inspection="$image_tag"
+          image_tag="${RUNTIME_IMAGE_REPOSITORY}:${RUNTIME_PACKAGE_VERSION}-${RUNTIME_GOARCH}"
           local_image_id="$(docker image inspect --format '{{.Id}}' "$image_tag")"
           [[ "$local_image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$(docker image inspect --format '{{.Architecture}}' "$image_tag")" == "$RUNTIME_GOARCH" ]]
+          [[ "$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$image_tag")" == "$SOURCE_SHA" ]]
           image_ref="yaklang-oss.invalid/legion-ai-session-runtime@${local_image_id}"
-
-          revision="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$image_for_inspection")"
-          [[ "$revision" == "$SOURCE_SHA" ]]
-          mkdir -p "${RUNNER_TEMP}/runtime-inspect"
-          container_id="$(docker create "$image_for_inspection")"
+          inspect_dir="${RUNNER_TEMP}/runtime-inspect-${RUNTIME_GOARCH}"
+          mkdir -p "$inspect_dir"
+          container_id="$(docker create "$image_tag")"
           trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
-          docker cp "$container_id:/usr/local/bin/legion-session-runtime" \
-            "${RUNNER_TEMP}/runtime-inspect/legion-session-runtime"
-          docker run --rm --entrypoint /bin/sh "$image_for_inspection" -ec \
+          docker cp "$container_id:/usr/local/bin/legion-session-runtime" "$inspect_dir/legion-session-runtime"
+          docker run --rm --entrypoint /bin/sh "$image_tag" -ec \
             'test -x /usr/local/bin/legion-session-runtime; ldd /usr/local/bin/legion-session-runtime' \
-            >"${RUNNER_TEMP}/runtime-inspect/runtime.ldd"
-          if grep -q 'not found' "${RUNNER_TEMP}/runtime-inspect/runtime.ldd"; then
+            >"$inspect_dir/runtime.ldd"
+          if grep -q 'not found' "$inspect_dir/runtime.ldd"; then
             echo "Runtime binary has unresolved shared libraries" >&2
             exit 1
           fi
@@ -212,15 +168,14 @@ jobs:
             echo "image_ref=$image_ref"
             echo "image_tag=$image_tag"
             echo "image_id=$local_image_id"
+            echo "inspect_dir=$inspect_dir"
           } >>"$GITHUB_OUTPUT"
 
-      - name: Generate Runtime provenance artifact
-        shell: bash
+      - name: Generate Runtime provenance package
         env:
-          RUNTIME_PACKAGE_VERSION: ${{ steps.contract.outputs.version }}
-          RUNTIME_CI_PROVIDER: ${{ steps.contract.outputs.ci_provider }}
-          RUNTIME_BINARY: ${{ runner.temp }}/runtime-inspect/legion-session-runtime
-          RUNTIME_LDD_FILE: ${{ runner.temp }}/runtime-inspect/runtime.ldd
+          RUNTIME_CI_PROVIDER: github-actions
+          RUNTIME_BINARY: ${{ steps.inspect.outputs.inspect_dir }}/legion-session-runtime
+          RUNTIME_LDD_FILE: ${{ steps.inspect.outputs.inspect_dir }}/runtime.ldd
           RUNTIME_IMAGE_REF: ${{ steps.inspect.outputs.image_ref }}
           RUNTIME_IMAGE_TAG: ${{ steps.inspect.outputs.image_tag }}
           RUNTIME_BASE_IMAGE: ${{ steps.bases.outputs.runtime_ref }}
@@ -228,89 +183,77 @@ jobs:
           RUNTIME_GO_VERSION: ${{ steps.bases.outputs.go_version }}
         run: ./.github/scripts/package-legion-ai-session-runtime.sh
 
-      - name: Verify and stage cross-repository artifact contract
+      - name: Verify and stage architecture-specific artifact contract
         shell: bash
-        env:
-          PUBLISH: ${{ steps.contract.outputs.publish }}
         run: |
           set -euo pipefail
-          cd "dist/${RUNTIME_PACKAGE_NAME}"
+          package_dir="dist/${RUNTIME_PACKAGE_NAME}"
+          cd "$package_dir"
           sha256sum -c SHA256SUMS
           jq -e \
             --arg source_sha "$SOURCE_SHA" \
             --arg image_ref "${{ steps.inspect.outputs.image_ref }}" \
-            --arg provider "${{ steps.contract.outputs.ci_provider }}" '
+            --arg goarch "$RUNTIME_GOARCH" '
               .artifact_type == "legion-ai-session-runtime" and
               .source.repository == "yaklang/yaklang" and
               .source.commit == $source_sha and
               .source.dirty == false and
-              .ci.provider == $provider and
+              .ci.provider == "github-actions" and
               .ci.workflow == "Build Trusted Legion AI Session Runtime" and
               .recipe.packaging_source_sha == $source_sha and
               .recipe.packaging_dirty == false and
               .recipe.goos == "linux" and
-              .recipe.goarch == "amd64" and
+              .recipe.goarch == $goarch and
               .recipe.cgo_enabled == true and
               .recipe.link_mode == "dynamic-container" and
-              (.recipe.dockerfile_sha256 | test("^[0-9a-f]{64}$")) and
-              (.recipe.dockerignore_sha256 | test("^[0-9a-f]{64}$")) and
               (.capabilities | index("ai.session.runtime")) != null and
               (.capabilities | index("yak.execute")) != null and
               .image.ref == $image_ref and
               .image.revision_label == $source_sha
             ' SESSION_RUNTIME_MANIFEST.json >/dev/null
-          if [[ "$PUBLISH" == true ]]; then
-            jq -e '.ci.provider == "github-actions" and (.ci.run_id | test("^[0-9]+$"))' \
-              SESSION_RUNTIME_MANIFEST.json >/dev/null
-          fi
-
           cd ../..
           mkdir -p dist/artifact
-          cp "dist/${RUNTIME_PACKAGE_NAME}/SESSION_RUNTIME_MANIFEST.json" dist/artifact/
-          cp "dist/${RUNTIME_PACKAGE_NAME}/SHA256SUMS" dist/artifact/
+          cp "$package_dir/SESSION_RUNTIME_MANIFEST.json" \
+            "dist/artifact/SESSION_RUNTIME_MANIFEST${ARTIFACT_SUFFIX}.json"
+          cp "$package_dir/SHA256SUMS" "dist/artifact/SHA256SUMS${ARTIFACT_SUFFIX}"
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz" dist/artifact/
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
 
       - name: Build immutable OSS Runtime release
-        if: steps.contract.outputs.publish_oss == 'true'
         id: oss-release
         shell: bash
         env:
-          VERSION: ${{ steps.contract.outputs.version }}
           RUNTIME_IMAGE_REF: ${{ steps.inspect.outputs.image_ref }}
           RUNTIME_IMAGE_ID: ${{ steps.inspect.outputs.image_id }}
         run: |
           set -euo pipefail
-          oss_release="dist/oss-release"
+          oss_release="dist/oss-release-${RUNTIME_GOARCH}"
           mkdir -p "$oss_release"
           cp dist/artifact/* "$oss_release/"
           docker save "$RUNTIME_IMAGE_ID" | gzip -n -1 >"$oss_release/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
-          public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/${VERSION}/${SOURCE_SHA}"
+          public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/${RUNTIME_PACKAGE_VERSION}/${SOURCE_SHA}"
           ./.github/scripts/build-legion-component-oss-index.sh \
             --component session-runtime \
-            --version "$VERSION" \
+            --version "$RUNTIME_PACKAGE_VERSION" \
             --source-sha "$SOURCE_SHA" \
             --artifact-dir "$oss_release" \
             --public-base-url "$public_base_url" \
             --runtime-image-ref "$RUNTIME_IMAGE_REF" \
             --runtime-image-id "$RUNTIME_IMAGE_ID" \
-            --output "$oss_release/release-index.json"
-          cp "$oss_release/release-index.json" "$oss_release/release-index.json.sha256" dist/artifact/
+            --goarch "$RUNTIME_GOARCH" \
+            --output "$oss_release/$INDEX_NAME"
+          cp "$oss_release/$INDEX_NAME" "$oss_release/$INDEX_NAME.sha256" dist/artifact/
           {
-            echo "public_base_url=$public_base_url"
-            echo "index_url=$public_base_url/release-index.json"
-            echo "index_sha256=$(sha256sum "$oss_release/release-index.json" | awk '{print $1}')"
-            echo "remote_prefix=legion/components/session-runtime/${VERSION}/${SOURCE_SHA}"
+            echo "index_url=$public_base_url/$INDEX_NAME"
+            echo "index_sha256=$(sha256sum "$oss_release/$INDEX_NAME" | awk '{print $1}')"
+            echo "remote_prefix=legion/components/session-runtime/${RUNTIME_PACKAGE_VERSION}/${SOURCE_SHA}"
             echo "release_dir=$oss_release"
           } >>"$GITHUB_OUTPUT"
 
       - name: Build repository-owned OSS uploader
-        if: steps.contract.outputs.publish_oss == 'true'
-        shell: bash
         run: go build -trimpath -o "${RUNNER_TEMP}/yak-oss-upload" ./common/yak/cmd/yak.go
 
       - name: Publish immutable Runtime release to OSS
-        if: steps.contract.outputs.publish_oss == 'true'
         shell: bash
         env:
           OSS_KEY_ID: ${{ secrets.OSS_KEY_ID }}
@@ -322,7 +265,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "$OSS_KEY_ID" && -n "$OSS_KEY_SECRET" ]]
-          existing_index="${RUNNER_TEMP}/existing-runtime-index.json"
+          existing_index="${RUNNER_TEMP}/existing-runtime-${RUNTIME_GOARCH}-index.json"
           http_status="$(curl --silent --show-error --location --retry 4 --retry-all-errors \
             --output "$existing_index" --write-out '%{http_code}' "$INDEX_URL")"
           case "$http_status" in
@@ -339,8 +282,9 @@ jobs:
           esac
           upload_specs=()
           for file in "$RELEASE_DIR"/*; do
-            case "$(basename "$file")" in release-index.json|release-index.json.sha256) continue ;; esac
-            upload_specs+=("$file:/$REMOTE_PREFIX/$(basename "$file")")
+            base="$(basename "$file")"
+            [[ "$base" == "$INDEX_NAME" || "$base" == "$INDEX_NAME.sha256" ]] && continue
+            upload_specs+=("$file:/$REMOTE_PREFIX/$base")
           done
           payloads="$(IFS=';'; echo "${upload_specs[*]}")"
           "${RUNNER_TEMP}/yak-oss-upload" upload-oss \
@@ -356,55 +300,44 @@ jobs:
             --ak "$OSS_KEY_ID" \
             --sk "$OSS_KEY_SECRET" \
             --times 5 \
-            --file "$RELEASE_DIR/release-index.json.sha256:/$REMOTE_PREFIX/release-index.json.sha256;$RELEASE_DIR/release-index.json:/$REMOTE_PREFIX/release-index.json"
+            --file "$RELEASE_DIR/$INDEX_NAME.sha256:/$REMOTE_PREFIX/$INDEX_NAME.sha256;$RELEASE_DIR/$INDEX_NAME:/$REMOTE_PREFIX/$INDEX_NAME"
 
       - name: Verify public Runtime release index
-        if: steps.contract.outputs.publish_oss == 'true'
         shell: bash
         env:
           INDEX_URL: ${{ steps.oss-release.outputs.index_url }}
           INDEX_SHA256: ${{ steps.oss-release.outputs.index_sha256 }}
         run: |
           set -euo pipefail
+          published_index="${RUNNER_TEMP}/published-runtime-${RUNTIME_GOARCH}-index.json"
           curl --fail --silent --show-error --location --retry 4 --retry-all-errors \
-            "$INDEX_URL" --output "${RUNNER_TEMP}/published-runtime-index.json"
-          [[ "$(sha256sum "${RUNNER_TEMP}/published-runtime-index.json" | awk '{print $1}')" == "$INDEX_SHA256" ]]
+            "$INDEX_URL" --output "$published_index"
+          [[ "$(sha256sum "$published_index" | awk '{print $1}')" == "$INDEX_SHA256" ]]
 
       - name: Publish build summary
         shell: bash
         run: |
           {
-            echo "## Legion AI Session Runtime"
+            echo "## Legion AI Session Runtime ${RUNTIME_GOARCH}"
             echo
             echo "- Source: \`${SOURCE_SHA}\`"
-            echo "- Published: \`${{ steps.contract.outputs.publish }}\`"
             echo "- Image: \`${{ steps.inspect.outputs.image_ref }}\`"
-            echo "- Artifact: \`${{ steps.contract.outputs.artifact_name }}\`"
+            echo "- Package: \`${RUNTIME_PACKAGE_NAME}.tar.gz\`"
+            echo "- Target: \`linux/${RUNTIME_GOARCH}\`"
             echo "- Go: \`${{ steps.bases.outputs.go_version }}\`"
-            if [[ "${{ steps.contract.outputs.publish_oss }}" == true ]]; then
-              echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
-              echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
-            fi
-            echo
-            echo '```json'
-            jq . "dist/${RUNTIME_PACKAGE_NAME}/SESSION_RUNTIME_MANIFEST.json"
-            echo '```'
+            echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
+            echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
           } >>"$GITHUB_STEP_SUMMARY"
 
-      - name: Attest published Runtime manifest
-        if: steps.contract.outputs.publish == 'true'
+      - name: Attest published Runtime artifacts
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-path: |
-            dist/artifact/SESSION_RUNTIME_MANIFEST.json
-            dist/artifact/SHA256SUMS
-            dist/artifact/${{ env.RUNTIME_PACKAGE_NAME }}.tar.gz
-            dist/artifact/${{ env.RUNTIME_PACKAGE_NAME }}.tar.gz.sha256
+          subject-path: dist/artifact/*
 
-      - name: Upload Runtime provenance
+      - name: Upload Runtime release package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ steps.contract.outputs.artifact_name }}
+          name: ${{ env.RUNTIME_PACKAGE_NAME }}
           path: dist/artifact/*
           if-no-files-found: error
-          retention-days: ${{ steps.contract.outputs.publish == 'true' && 14 || 7 }}
+          retention-days: 14

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -1,91 +1,69 @@
 name: Build Trusted Legion Product Node
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - "legion-node-v*"
-  pull_request:
-    paths:
-      - ".github/scripts/build-legion-product-node.sh"
-      - ".github/scripts/build-legion-component-oss-index.sh"
-      - ".github/scripts/test-build-legion-component-oss-index.sh"
-      - ".github/workflows/build-legion-product-node.yml"
-      - "cmd/legion-smoke-node/**"
-      - "common/hids/**"
-      - "common/node/**"
-      - "common/spec/**"
-      - "scannode/**"
-      - "go.mod"
-      - "go.sum"
 
 permissions:
   contents: read
 
 concurrency:
   group: legion-product-node-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
-  build-linux-amd64:
-    name: Build Linux amd64 HIDS node
-    runs-on: ubuntu-22.04
-    timeout-minutes: 45
+  build-and-publish:
+    name: Build Linux ${{ matrix.goarch }} HIDS node
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            runner: ubuntu-22.04
+            artifact_suffix: ""
+            index_name: release-index.json
+            file_machine: x86-64
+          - goarch: arm64
+            runner: ubuntu-24.04-arm
+            artifact_suffix: _linux_arm64
+            index_name: release-index-linux-arm64.json
+            file_machine: ARM aarch64
     env:
-      NODE_PACKAGE_NAME: legion-product-node_linux_amd64
+      NODE_GOOS: linux
+      NODE_GOARCH: ${{ matrix.goarch }}
+      NODE_PACKAGE_NAME: legion-product-node_linux_${{ matrix.goarch }}
+      NODE_PACKAGE_VERSION: ${{ github.ref_name }}
       PRODUCT_NODE_WORKFLOW_NAME: Build Trusted Legion Product Node
-      SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      NODE_PACKAGE_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+      SOURCE_SHA: ${{ github.sha }}
+      ARTIFACT_SUFFIX: ${{ matrix.artifact_suffix }}
+      INDEX_NAME: ${{ matrix.index_name }}
+      FILE_MACHINE: ${{ matrix.file_machine }}
     steps:
-      - name: Check out source commit
+      - name: Check out tagged source commit
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.SOURCE_SHA }}
           fetch-depth: 0
 
-      - name: Validate event and release source
-        id: contract
+      - name: Validate release tag and source
         shell: bash
         run: |
           set -euo pipefail
-          publish_oss=false
-          case "$GITHUB_EVENT_NAME" in
-            pull_request)
-              ;;
-            workflow_dispatch)
-              [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
-                echo "workflow_dispatch is restricted to main" >&2
-                exit 1
-              }
-              ;;
-            push)
-              [[ "$GITHUB_REF" =~ ^refs/tags/legion-node-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
-                echo "unexpected Product Node release tag: $GITHUB_REF" >&2
-                exit 1
-              }
-              publish_oss=true
-              ;;
-            *)
-              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
-              exit 1
-              ;;
-          esac
-
+          [[ "$GITHUB_EVENT_NAME" == push ]]
+          [[ "$GITHUB_REF" =~ ^refs/tags/legion-node-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
+            echo "unexpected Product Node release tag: $GITHUB_REF" >&2
+            exit 1
+          }
           [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
           [[ -z "$(git status --porcelain --untracked-files=all)" ]]
-          if [[ "$publish_oss" == true ]]; then
-            git fetch --no-tags origin main:refs/remotes/origin/main
-            git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
-              echo "published Product Node source must already be reachable from origin/main" >&2
-              exit 1
-            }
-          fi
-          version="sha-${SOURCE_SHA:0:12}"
-          [[ "$GITHUB_REF" != refs/tags/* ]] || version="$GITHUB_REF_NAME"
-          {
-            echo "publish_oss=$publish_oss"
-            echo "version=$version"
-          } >>"$GITHUB_OUTPUT"
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
+            echo "published Product Node source must already be reachable from origin/main" >&2
+            exit 1
+          }
 
       - name: Set up Go from go.mod
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -97,8 +75,6 @@ jobs:
         run: ./.github/scripts/test-build-legion-component-oss-index.sh
 
       - name: Build product node package
-        env:
-          NODE_PACKAGE_VERSION: ${{ steps.contract.outputs.version }}
         run: ./.github/scripts/build-legion-product-node.sh
 
       - name: Verify package archive
@@ -111,64 +87,65 @@ jobs:
           tar -xzf "${NODE_PACKAGE_NAME}.tar.gz" -C verify
           cd verify
           sha256sum -c SHA256SUMS
-          file legion-smoke-node | grep -q 'statically linked'
-          if readelf -d legion-smoke-node 2>/dev/null | grep -q '(NEEDED)'; then
+          binary_name="$(jq -er .binary.path PRODUCT_NODE_MANIFEST.json)"
+          file "$binary_name" | grep -q "$FILE_MACHINE"
+          file "$binary_name" | grep -q 'statically linked'
+          if readelf -d "$binary_name" 2>/dev/null | grep -q '(NEEDED)'; then
             echo "node binary declares dynamic library dependencies" >&2
             exit 1
           fi
           jq -e \
             --arg source_sha "$SOURCE_SHA" \
-            '.artifact_type == "legion-product-node"
-             and .source.commit == $source_sha
-             and .source.dirty == false
-             and .recipe.goos == "linux"
-             and .recipe.goarch == "amd64"
-             and .recipe.build_tags == "hids"
-             and .ci.workflow == "Build Trusted Legion Product Node"
-             and (.capabilities | index("hids") != null)' \
-            PRODUCT_NODE_MANIFEST.json >/dev/null
+            --arg goarch "$NODE_GOARCH" '
+              .artifact_type == "legion-product-node" and
+              .source.commit == $source_sha and
+              .source.dirty == false and
+              .recipe.goos == "linux" and
+              .recipe.goarch == $goarch and
+              .recipe.build_tags == "hids" and
+              .ci.workflow == "Build Trusted Legion Product Node" and
+              (.capabilities | index("hids") != null)
+            ' PRODUCT_NODE_MANIFEST.json >/dev/null
 
-      - name: Stage cross-repository artifact contract
+      - name: Stage architecture-specific artifact contract
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p dist/artifact
-          cp "dist/${NODE_PACKAGE_NAME}/legion-smoke-node" dist/artifact/
-          cp "dist/${NODE_PACKAGE_NAME}/PRODUCT_NODE_MANIFEST.json" dist/artifact/
-          cp "dist/${NODE_PACKAGE_NAME}/SHA256SUMS" dist/artifact/
-          cp "dist/${NODE_PACKAGE_NAME}.tar.gz" dist/artifact/
-          cp "dist/${NODE_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
+          artifact_dir=dist/artifact
+          package_dir="dist/${NODE_PACKAGE_NAME}"
+          mkdir -p "$artifact_dir"
+          binary_name="$(jq -er .binary.path "$package_dir/PRODUCT_NODE_MANIFEST.json")"
+          cp "$package_dir/$binary_name" "$artifact_dir/$binary_name"
+          cp "$package_dir/PRODUCT_NODE_MANIFEST.json" \
+            "$artifact_dir/PRODUCT_NODE_MANIFEST${ARTIFACT_SUFFIX}.json"
+          cp "$package_dir/SHA256SUMS" "$artifact_dir/SHA256SUMS${ARTIFACT_SUFFIX}"
+          cp "dist/${NODE_PACKAGE_NAME}.tar.gz" "$artifact_dir/"
+          cp "dist/${NODE_PACKAGE_NAME}.tar.gz.sha256" "$artifact_dir/"
 
       - name: Build immutable OSS release index
-        if: steps.contract.outputs.publish_oss == 'true'
         id: oss-release
         shell: bash
-        env:
-          VERSION: ${{ steps.contract.outputs.version }}
         run: |
           set -euo pipefail
-          public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/product-node/${VERSION}/${SOURCE_SHA}"
+          public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/product-node/${NODE_PACKAGE_VERSION}/${SOURCE_SHA}"
           ./.github/scripts/build-legion-component-oss-index.sh \
             --component product-node \
-            --version "$VERSION" \
+            --version "$NODE_PACKAGE_VERSION" \
             --source-sha "$SOURCE_SHA" \
             --artifact-dir dist/artifact \
             --public-base-url "$public_base_url" \
-            --output dist/artifact/release-index.json
+            --goarch "$NODE_GOARCH" \
+            --output "dist/artifact/$INDEX_NAME"
           {
-            echo "public_base_url=$public_base_url"
-            echo "index_url=$public_base_url/release-index.json"
-            echo "index_sha256=$(sha256sum dist/artifact/release-index.json | awk '{print $1}')"
-            echo "remote_prefix=legion/components/product-node/${VERSION}/${SOURCE_SHA}"
+            echo "index_url=$public_base_url/$INDEX_NAME"
+            echo "index_sha256=$(sha256sum "dist/artifact/$INDEX_NAME" | awk '{print $1}')"
+            echo "remote_prefix=legion/components/product-node/${NODE_PACKAGE_VERSION}/${SOURCE_SHA}"
           } >>"$GITHUB_OUTPUT"
 
       - name: Build repository-owned OSS uploader
-        if: steps.contract.outputs.publish_oss == 'true'
-        shell: bash
         run: go build -trimpath -o "${RUNNER_TEMP}/yak-oss-upload" ./common/yak/cmd/yak.go
 
       - name: Publish immutable Product Node release to OSS
-        if: steps.contract.outputs.publish_oss == 'true'
         shell: bash
         env:
           OSS_KEY_ID: ${{ secrets.OSS_KEY_ID }}
@@ -179,7 +156,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "$OSS_KEY_ID" && -n "$OSS_KEY_SECRET" ]]
-          existing_index="${RUNNER_TEMP}/existing-product-node-index.json"
+          existing_index="${RUNNER_TEMP}/existing-product-node-${NODE_GOARCH}-index.json"
           http_status="$(curl --silent --show-error --location --retry 4 --retry-all-errors \
             --output "$existing_index" --write-out '%{http_code}' "$INDEX_URL")"
           case "$http_status" in
@@ -196,8 +173,9 @@ jobs:
           esac
           upload_specs=()
           for file in dist/artifact/*; do
-            case "$(basename "$file")" in release-index.json|release-index.json.sha256) continue ;; esac
-            upload_specs+=("$file:/$REMOTE_PREFIX/$(basename "$file")")
+            base="$(basename "$file")"
+            [[ "$base" == "$INDEX_NAME" || "$base" == "$INDEX_NAME.sha256" ]] && continue
+            upload_specs+=("$file:/$REMOTE_PREFIX/$base")
           done
           payloads="$(IFS=';'; echo "${upload_specs[*]}")"
           "${RUNNER_TEMP}/yak-oss-upload" upload-oss \
@@ -213,42 +191,35 @@ jobs:
             --ak "$OSS_KEY_ID" \
             --sk "$OSS_KEY_SECRET" \
             --times 5 \
-            --file "dist/artifact/release-index.json.sha256:/$REMOTE_PREFIX/release-index.json.sha256;dist/artifact/release-index.json:/$REMOTE_PREFIX/release-index.json"
+            --file "dist/artifact/$INDEX_NAME.sha256:/$REMOTE_PREFIX/$INDEX_NAME.sha256;dist/artifact/$INDEX_NAME:/$REMOTE_PREFIX/$INDEX_NAME"
 
       - name: Verify public Product Node release index
-        if: steps.contract.outputs.publish_oss == 'true'
         shell: bash
         env:
           INDEX_URL: ${{ steps.oss-release.outputs.index_url }}
           INDEX_SHA256: ${{ steps.oss-release.outputs.index_sha256 }}
         run: |
           set -euo pipefail
+          published_index="${RUNNER_TEMP}/published-product-node-${NODE_GOARCH}-index.json"
           curl --fail --silent --show-error --location --retry 4 --retry-all-errors \
-            "$INDEX_URL" --output "${RUNNER_TEMP}/published-product-node-index.json"
-          [[ "$(sha256sum "${RUNNER_TEMP}/published-product-node-index.json" | awk '{print $1}')" == "$INDEX_SHA256" ]]
+            "$INDEX_URL" --output "$published_index"
+          [[ "$(sha256sum "$published_index" | awk '{print $1}')" == "$INDEX_SHA256" ]]
 
       - name: Publish build summary
         shell: bash
         run: |
           {
-            echo "## Legion product node"
+            echo "## Legion Product Node ${NODE_GOARCH}"
             echo
             echo "- Source: \`${SOURCE_SHA}\`"
             echo "- Package: \`${NODE_PACKAGE_NAME}.tar.gz\`"
-            echo "- Target: \`linux/amd64\`"
+            echo "- Target: \`linux/${NODE_GOARCH}\`"
             echo "- Build tags: \`hids\`"
-            echo "- Go: \`$(go version)\`"
-            if [[ "${{ steps.contract.outputs.publish_oss }}" == true ]]; then
-              echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
-              echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
-            fi
-            echo
-            echo '```json'
-            jq . "dist/${NODE_PACKAGE_NAME}/PRODUCT_NODE_MANIFEST.json"
-            echo '```'
+            echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
+            echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
           } >>"$GITHUB_STEP_SUMMARY"
 
-      - name: Upload node package
+      - name: Upload node release package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.NODE_PACKAGE_NAME }}

--- a/.github/workflows/verify-legion-component-release-contracts.yml
+++ b/.github/workflows/verify-legion-component-release-contracts.yml
@@ -1,0 +1,130 @@
+name: Verify Legion Component Release Contracts
+
+on:
+  pull_request:
+    paths:
+      - ".github/scripts/build-legion-component-oss-index.sh"
+      - ".github/scripts/build-legion-product-node.sh"
+      - ".github/scripts/package-legion-ai-session-runtime.sh"
+      - ".github/scripts/test-build-legion-component-oss-index.sh"
+      - ".github/scripts/test-legion-component-workflow-contract.sh"
+      - ".github/scripts/test-package-legion-ai-session-runtime.sh"
+      - ".github/workflows/build-legion-ai-session-runtime.yml"
+      - ".github/workflows/build-legion-product-node.yml"
+      - ".github/workflows/verify-legion-component-release-contracts.yml"
+      - "docker/session-runtime/**"
+      - "docs/legion-ai-session-runtime-release.md"
+      - "docs/legion-linux-hids-readiness.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-legion-component-release-contracts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    name: Verify release-only multi-architecture contracts
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out source commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Check shell syntax and lint
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts=(
+            .github/scripts/build-legion-component-oss-index.sh
+            .github/scripts/build-legion-product-node.sh
+            .github/scripts/package-legion-ai-session-runtime.sh
+            .github/scripts/test-build-legion-component-oss-index.sh
+            .github/scripts/test-legion-component-workflow-contract.sh
+            .github/scripts/test-package-legion-ai-session-runtime.sh
+          )
+          bash -n "${scripts[@]}"
+          shellcheck "${scripts[@]}"
+
+      - name: Test tag, architecture, and package metadata contracts
+        run: |
+          set -euo pipefail
+          ./.github/scripts/test-legion-component-workflow-contract.sh
+          ./.github/scripts/test-build-legion-component-oss-index.sh
+          ./.github/scripts/test-package-legion-ai-session-runtime.sh
+
+  build-targets:
+    name: Compile Linux ${{ matrix.goarch }} release targets
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            runner: ubuntu-22.04
+            file_machine: x86-64
+          - goarch: arm64
+            runner: ubuntu-24.04-arm
+            file_machine: ARM aarch64
+    steps:
+      - name: Check out source commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Compile Product Node without packaging
+        shell: bash
+        env:
+          TARGET_ARCH: ${{ matrix.goarch }}
+          FILE_MACHINE: ${{ matrix.file_machine }}
+        run: |
+          set -euo pipefail
+          export GOTOOLCHAIN=local
+          binary="${RUNNER_TEMP}/legion-smoke-node-${TARGET_ARCH}"
+          CGO_ENABLED=1 GOOS=linux GOARCH="$TARGET_ARCH" go build \
+            -trimpath \
+            -buildvcs=true \
+            -tags hids \
+            -ldflags '-s -w -buildid= -linkmode external -extldflags "-static"' \
+            -o "$binary" \
+            ./cmd/legion-smoke-node
+          file "$binary" | grep -q "$FILE_MACHINE"
+          file "$binary" | grep -q 'statically linked'
+          if readelf -d "$binary" 2>/dev/null | grep -q '(NEEDED)'; then
+            echo "node binary declares dynamic library dependencies" >&2
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build Runtime image without packaging
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: docker/session-runtime/Dockerfile
+          platforms: linux/${{ matrix.goarch }}
+          push: false
+          load: true
+          tags: local.invalid/yaklang/legion-ai-session-runtime:verify-${{ matrix.goarch }}
+          provenance: false
+          sbom: false
+
+      - name: Inspect Runtime image
+        shell: bash
+        env:
+          TARGET_ARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          image="local.invalid/yaklang/legion-ai-session-runtime:verify-${TARGET_ARCH}"
+          [[ "$(docker image inspect --format '{{.Architecture}}' "$image")" == "$TARGET_ARCH" ]]
+          docker run --rm --entrypoint /bin/sh "$image" -ec \
+            'test -x /usr/local/bin/legion-session-runtime; ldd /usr/local/bin/legion-session-runtime' \
+            >"${RUNNER_TEMP}/runtime-${TARGET_ARCH}.ldd"
+          ! grep -q 'not found' "${RUNNER_TEMP}/runtime-${TARGET_ARCH}.ldd"

--- a/docker/session-runtime/Dockerfile
+++ b/docker/session-runtime/Dockerfile
@@ -22,6 +22,9 @@ ARG RUNTIME_BASE_IMAGE=debian:bookworm-slim
 # ---------- 构建阶段 ----------
 FROM ${GO_BUILDER_IMAGE} AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /src
 COPY . .
 
@@ -32,7 +35,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     module_go_version="$(awk '$1 == "go" { gsub(/\r/, "", $2); print $2; exit }' go.mod)" \
     && test "$(go env GOVERSION)" = "go${module_go_version}" \
-    && CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+    && test "$TARGETOS" = "linux" \
+    && case "$TARGETARCH" in amd64|arm64) ;; *) exit 1 ;; esac \
+    && CGO_ENABLED=1 GOOS="$TARGETOS" GOARCH="$TARGETARCH" go build \
       -trimpath \
       -buildvcs=false \
       -ldflags "-s -w -buildid=" \

--- a/docs/legion-ai-session-runtime-release.md
+++ b/docs/legion-ai-session-runtime-release.md
@@ -7,13 +7,12 @@ provenance.
 
 ## Workflow
 
-`Build Trusted Legion AI Session Runtime` has three entry modes:
+`Build Trusted Legion AI Session Runtime` is a release-only workflow:
 
 | Event | Behavior | Output trust level |
 |---|---|---|
-| Pull request | Build, test, inspect, and upload preview provenance | Preview; rejected by customer packaging |
-| `workflow_dispatch` on `main` | Build and attest trusted provenance without publishing a distribution object | Trusted producer verification |
-| SemVer `legion-runtime-v*` tag reachable from `main` | Publish the immutable image archive, provenance, and release index to OSS | Trusted producer release |
+| Pull request or ordinary branch push | Does not run or produce a Runtime package | No release artifact |
+| SemVer `legion-runtime-v*` tag reachable from `main` | Build amd64 and arm64 variants, then publish immutable image archives, provenance, and release indexes to OSS | Trusted producer release |
 
 The isolated tag prefix intentionally does not match the repository's generic
 `v*` release workflows. For example, an alpha producer release can use
@@ -31,12 +30,21 @@ https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/<t
 ├── SESSION_RUNTIME_MANIFEST.json
 ├── SHA256SUMS
 ├── release-index.json
-└── release-index.json.sha256
+├── release-index.json.sha256
+├── legion-ai-session-runtime_linux_arm64.docker.tar.gz
+├── legion-ai-session-runtime_linux_arm64.tar.gz
+├── legion-ai-session-runtime_linux_arm64.tar.gz.sha256
+├── SESSION_RUNTIME_MANIFEST_linux_arm64.json
+├── SHA256SUMS_linux_arm64
+├── release-index-linux-arm64.json
+└── release-index-linux-arm64.json.sha256
 ```
 
-The `legion-ai-session-runtime_linux_amd64` Actions artifact retains the
-provenance files and release index for short-term workflow inspection. It is
-not the cross-repository distribution channel.
+The separate `legion-ai-session-runtime_linux_amd64` and
+`legion-ai-session-runtime_linux_arm64` Actions artifacts retain provenance
+files and release indexes for short-term workflow inspection. They are not the
+cross-repository distribution channel. The legacy `release-index.json` selects
+amd64; `release-index-linux-arm64.json` selects arm64.
 
 The deployable Runtime binary stays inside the Docker image archive. The
 release index binds every OSS object to its SHA-256 digest and records the

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -40,13 +40,17 @@ GOOS=linux GOARCH=amd64 go build -tags hids -o ./legion-smoke-node-hids-linux-am
 ## CI Product Node Package
 
 `.github/workflows/build-legion-product-node.yml` produces the deployable
-Linux amd64 product node from the repository's declared Go version. The
-workflow runs for relevant pull requests, manual dispatches, and tags in the
-isolated `legion-node-v*` namespace, including alpha tags. This
-namespace does not trigger the repository's existing general `v*` release
-workflows.
+Linux amd64 and arm64 product nodes from the repository's declared Go version.
+The trusted packaging workflow runs only for tags in the isolated
+`legion-node-v*` namespace, including alpha tags. Pull requests and ordinary
+branch pushes do not produce Product Node packages. This namespace does not
+trigger the repository's existing general `v*` release workflows.
 
-The `legion-product-node_linux_amd64` artifact contains:
+The workflow emits separate `legion-product-node_linux_amd64` and
+`legion-product-node_linux_arm64` Actions artifacts. Each architecture package
+contains its executable, `PRODUCT_NODE_MANIFEST.json`, and `SHA256SUMS`. The
+outer release artifact also contains the package archive and its checksum.
+The amd64 artifact retains the legacy direct object names:
 
 - `legion-smoke-node`
 - `PRODUCT_NODE_MANIFEST.json`
@@ -54,21 +58,31 @@ The `legion-product-node_linux_amd64` artifact contains:
 - `legion-product-node_linux_amd64.tar.gz`
 - `legion-product-node_linux_amd64.tar.gz.sha256`
 
+The arm64 direct objects are architecture-qualified so that both variants can
+share one immutable OSS release directory:
+
+- `legion-smoke-node_linux_arm64`
+- `PRODUCT_NODE_MANIFEST_linux_arm64.json`
+- `SHA256SUMS_linux_arm64`
+- `legion-product-node_linux_arm64.tar.gz`
+- `legion-product-node_linux_arm64.tar.gz.sha256`
+
 The direct files are the cross-repository assembly contract. The archive
-contains the same statically linked `legion-smoke-node`, manifest, and inner
-checksums for standalone downloads. The manifest binds the binary to the exact
-Yaklang source commit, Go toolchain, Linux amd64 target, `hids` build tag, and
+contains the same statically linked executable, manifest, and inner checksums
+for standalone downloads. The manifest binds the binary to the exact Yaklang
+source commit, Go toolchain, Linux target architecture, `hids` build tag, and
 advertised capability set. This artifact is an input to the Legion deployment
 packaging pipeline; it is not a complete deployment bundle.
 
 A SemVer `legion-node-v*` tag reachable from `main` also publishes these files
 under the versioned public OSS path
 `/legion/components/product-node/<tag>/<source-sha>/`. The accompanying
-`release-index.json` binds the source commit, producer manifest, archive, raw
-binary, and checksums. Cross-repository assembly consumes the OSS index URL and
-an independently approved index SHA-256 instead of a GitHub Actions run ID or
-repository token. Manual dispatch remains a build verification entry and does
-not publish a formal OSS release.
+`release-index.json` retains the amd64 contract for existing consumers, while
+`release-index-linux-arm64.json` selects the arm64 objects. Each index binds the
+source commit, target platform, producer manifest, archive, raw binary, and
+checksums. Cross-repository assembly consumes the architecture-appropriate OSS
+index URL and an independently approved index SHA-256 instead of a GitHub
+Actions run ID or repository token.
 
 Use `task legion_smoke_node_build_hids` for native debugging when your current host is already Linux. Use `task legion_smoke_node_build_hids_linux_amd64` when you need a deployable Linux artifact from any development host.
 


### PR DESCRIPTION
## 背景

将 Legion Product Node 与 AI Session Runtime 的可信发布改造为多架构(linux/amd64 + linux/arm64)流水线,并分离普通 PR 的校验路径,避免 PR 误传发布包到 OSS。

## 主要改动

### 触发门控分离
- 可信发布工作流只接受 tag 触发:
  - `build-legion-product-node.yml` 仅接受 `legion-node-v*`
  - `build-legion-ai-session-runtime.yml` 仅接受 `legion-runtime-v*`
- 普通 PR 改由独立的 `verify-legion-component-release-contracts.yml` 走只编译、不打包、不上传的校验路径
- 合同测试 `test-legion-component-workflow-contract.sh` 强制发布工作流保持 tag-only,禁止混入 `pull_request` / `workflow_dispatch` / `branches` 触发

### 多架构支持
- Product Node、Session Runtime 均新增 `linux/arm64` 矩阵,使用原生 `ubuntu-24.04-arm` Runner
- `build-legion-product-node.sh`、`package-legion-ai-session-runtime.sh` 参数化 `NODE_GOOS` / `NODE_GOARCH`,按架构生成产物名与二进制后缀
- Runtime `Dockerfile` 改用 BuildKit 的 `TARGETOS` / `TARGETARCH`

### OSS 索引兼容
- amd64 仍写 `release-index.json`,保持 Legion 下游向后兼容
- arm64 写独立的 `release-index-linux-arm64.json`,不污染现有 amd64 索引
- `build-legion-component-oss-index.sh` 按 `--goarch` 选择输出文件名

### 产物校验
- Product Node:校验静态链接、ELF 架构、`file`/`readelf` 结果、manifest 字段
- Session Runtime:校验镜像架构、`ldd` 输出无 `not found`
- OSS 上传做幂等保护:已存在的索引 sha 必须一致才允许跳过,否则拒绝覆盖

## 验证状态(T1)

- actionlint / shellcheck / YAML / 合同测试通过
- 目标 Go 测试通过
- amd64 Product Node 真实静态打包通过
- amd64 Runtime 真实镜像、ELF、ldd、provenance 打包通过
- ARM64 本地 QEMU 构建因耗时主动取消;原生 ARM64 编译需推送后由 PR CI 确认

## 范围说明

- 未创建 Tag、未上传 OSS
- Legion 下游如何根据架构选择 ARM index 不在本次 Yaklang 生产者范围
- 当前未对"正式/测试"node 做 tag 前缀区分,约定靠 `-alpha` 后缀自证身份

## 关联

- 提交:`9c2572d14`
- 验证报告:`.playwright-mcp/reports/verification-20260806-171015.html`