### PR TITLE
fix(aid): skip duplicate final summary after directly_answer in defau…

### DIFF
--- a/common/ai/aid/aireact/reactloops/loop_default/base.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/base.go
@@ -95,7 +95,7 @@ func init() {
 					if !isDone {
 						return
 					}
-					lastAction := loop.GetLastAction()
+					lastAction := loop.GetLastValidAction()
 					if lastAction == nil {
 						log.Warnf("iteration %d: skip final summary because last action is empty", iteration)
 						return

--- a/common/ai/aid/aireact/reactloops/loop_default/base_post_iteration_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/base_post_iteration_test.go
@@ -1,0 +1,165 @@
+package loop_default
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+	_ "github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops/loopinfra"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// postIterationTestInvoker 记录 post-iteration 总结钩子对 invoker 的调用，
+// 用于断言最终总结是否生成。
+type postIterationTestInvoker struct {
+	*mock.MockInvoker
+
+	mu                  sync.Mutex
+	directAnswerQueries []string
+	timelineEntries     map[string][]string
+}
+
+func newPostIterationTestInvoker(cb aicommon.AICallbackType) *postIterationTestInvoker {
+	ctx := context.Background()
+	base := mock.NewMockInvoker(ctx)
+	base.SetConfig(aicommon.NewConfig(
+		ctx,
+		aicommon.WithAICallback(cb),
+		aicommon.WithDisallowMCPServers(true),
+		aicommon.WithDisableSessionTitleGeneration(true),
+		aicommon.WithDisableIntentRecognition(true),
+		aicommon.WithDisableAutoSkills(true),
+		aicommon.WithGenerateReport(false),
+		aicommon.WithDisableDynamicPlanning(true),
+	))
+	return &postIterationTestInvoker{
+		MockInvoker:     base,
+		timelineEntries: make(map[string][]string),
+	}
+}
+
+func (i *postIterationTestInvoker) DirectlyAnswer(ctx context.Context, query string, tools []*aitool.Tool, opts ...any) (string, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.directAnswerQueries = append(i.directAnswerQueries, query)
+	return "mocked final summary", nil
+}
+
+func (i *postIterationTestInvoker) AddToTimeline(entry, content string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.timelineEntries[entry] = append(i.timelineEntries[entry], content)
+}
+
+func (i *postIterationTestInvoker) directAnswerCalls() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return len(i.directAnswerQueries)
+}
+
+func (i *postIterationTestInvoker) timelineValues(entry string) []string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return append([]string(nil), i.timelineEntries[entry]...)
+}
+
+// newPostIterationTestLoop 通过注册的 default loop 工厂构建循环，
+// 关闭与本次断言无关的能力，只保留 post-iteration 总结钩子的行为。
+func newPostIterationTestLoop(t *testing.T, invoker *postIterationTestInvoker, extraOpts ...reactloops.ReActLoopOption) *reactloops.ReActLoop {
+	t.Helper()
+	opts := []reactloops.ReActLoopOption{
+		reactloops.WithAllowRAG(false),
+		reactloops.WithAllowToolCall(false),
+		reactloops.WithAllowAIForge(false),
+		reactloops.WithAllowPlanAndExec(false),
+		reactloops.WithAllowUserInteract(false),
+	}
+	opts = append(opts, extraOpts...)
+	loop, err := reactloops.CreateLoopByName(schema.AI_REACT_LOOP_NAME_DEFAULT, invoker, opts...)
+	require.NoError(t, err)
+	return loop
+}
+
+// scriptedCallback 按调用次序依次返回脚本化的 AI 响应。
+// finish 动作首次触发软 TODO 检查点会继续迭代，因此脚本需要两次 finish 才会退出。
+func scriptedCallback(responses ...string) aicommon.AICallbackType {
+	var mu sync.Mutex
+	callCount := 0
+	return func(i aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+		mu.Lock()
+		idx := callCount
+		callCount++
+		mu.Unlock()
+		if idx >= len(responses) {
+			idx = len(responses) - 1
+		}
+		rsp := i.NewAIResponse()
+		rsp.EmitOutputStream(bytes.NewBufferString(responses[idx]))
+		rsp.Close()
+		return rsp, nil
+	}
+}
+
+// TestDefaultLoop_PostIterationSkipsSummaryAfterDirectlyAnswer 是本次改动的回归测试：
+// 循环以 directly_answer -> finish -> finish 收尾时，post-iteration 钩子必须通过
+// GetLastValidAction 看到 finish 之前的 directly_answer，从而跳过最终总结。
+// 旧实现使用 GetLastAction 只会看到 finish 记录，导致直接回答后仍多余地生成总结。
+func TestDefaultLoop_PostIterationSkipsSummaryAfterDirectlyAnswer(t *testing.T) {
+	invoker := newPostIterationTestInvoker(scriptedCallback(
+		`{"@action": "directly_answer", "answer_payload": "最终答案"}`,
+		`{"@action": "finish", "answer": "done"}`,
+		`{"@action": "finish", "answer": "done"}`,
+	))
+	loop := newPostIterationTestLoop(t, invoker)
+
+	err := loop.Execute("post-iteration-skip-task", context.Background(), "回答一个问题")
+	require.NoError(t, err)
+
+	require.Equal(t, 0, invoker.directAnswerCalls(),
+		"last valid action is directly_answer; post-iteration summary must be skipped")
+	require.Empty(t, invoker.timelineValues("final_summary"),
+		"no final_summary timeline entry should be recorded after directly_answer")
+
+	lastValid := loop.GetLastValidAction()
+	require.NotNil(t, lastValid)
+	require.Equal(t, schema.AI_REACT_LOOP_ACTION_DIRECTLY_ANSWER, lastValid.ActionType)
+}
+
+// TestDefaultLoop_PostIterationGeneratesSummaryAfterOtherAction 是对照场景：
+// 收尾前最后一次有效 action 不是 directly_answer 时，post-iteration 钩子必须
+// 调用 invoker.DirectlyAnswer 生成最终总结，并写入 final_summary 时间线。
+func TestDefaultLoop_PostIterationGeneratesSummaryAfterOtherAction(t *testing.T) {
+	invoker := newPostIterationTestInvoker(scriptedCallback(
+		`{"@action": "record_note", "note": "做了一些工作"}`,
+		`{"@action": "finish", "answer": "done"}`,
+		`{"@action": "finish", "answer": "done"}`,
+	))
+	loop := newPostIterationTestLoop(t, invoker,
+		reactloops.WithRegisterLoopAction(
+			"record_note",
+			"Record a note for testing",
+			nil,
+			nil,
+			func(loop *reactloops.ReActLoop, action *aicommon.Action, operator *reactloops.LoopActionHandlerOperator) {
+				operator.Continue()
+			},
+		),
+	)
+
+	err := loop.Execute("post-iteration-summary-task", context.Background(), "执行一个任务")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, invoker.directAnswerCalls(),
+		"last valid action is not directly_answer; post-iteration summary must be generated")
+	require.Equal(t, reActPostSummary, invoker.directAnswerQueries[0],
+		"summary must use the post-summary prompt")
+	require.Contains(t, invoker.timelineValues("final_summary"), "mocked final summary",
+		"summary result must be recorded to the final_summary timeline entry")
+}

--- a/common/ai/aid/aireact/reactloops/reactloop_action_history_test.go
+++ b/common/ai/aid/aireact/reactloops/reactloop_action_history_test.go
@@ -1,0 +1,120 @@
+package reactloops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+)
+
+func newActionHistoryTestLoop() *ReActLoop {
+	invoker := mock.NewMockInvoker(context.Background())
+	return NewMinimalReActLoop(invoker.GetConfig(), invoker)
+}
+
+// TestGetLastValidAction 覆盖 GetLastValidAction 的边界行为：
+// 它必须从历史尾部向前跳过 finish 记录（和 nil 记录），返回最近一次有效 action。
+// loop_default 的 post-iteration 总结钩子依赖该语义判断收尾 action。
+func TestGetLastValidAction(t *testing.T) {
+	finishType := loopAction_Finish.ActionType
+
+	cases := []struct {
+		name          string
+		history       []*ActionRecord
+		wantNil       bool
+		wantType      string
+		wantIteration int
+	}{
+		{
+			name:    "empty history returns nil",
+			history: nil,
+			wantNil: true,
+		},
+		{
+			name: "only finish records returns nil",
+			history: []*ActionRecord{
+				{ActionType: finishType, IterationIndex: 1},
+				{ActionType: finishType, IterationIndex: 2},
+			},
+			wantNil: true,
+		},
+		{
+			name: "trailing finish is skipped",
+			history: []*ActionRecord{
+				{ActionType: "tool_call", IterationIndex: 1},
+				{ActionType: loopAction_DirectlyAnswer.ActionType, IterationIndex: 2},
+				{ActionType: finishType, IterationIndex: 3},
+			},
+			wantType:      loopAction_DirectlyAnswer.ActionType,
+			wantIteration: 2,
+		},
+		{
+			name: "multiple trailing finishes are skipped",
+			history: []*ActionRecord{
+				{ActionType: "tool_call", IterationIndex: 1},
+				{ActionType: finishType, IterationIndex: 2},
+				{ActionType: finishType, IterationIndex: 3},
+			},
+			wantType:      "tool_call",
+			wantIteration: 1,
+		},
+		{
+			name: "last non-finish record is returned directly",
+			history: []*ActionRecord{
+				{ActionType: finishType, IterationIndex: 1},
+				{ActionType: "tool_call", IterationIndex: 2},
+			},
+			wantType:      "tool_call",
+			wantIteration: 2,
+		},
+		{
+			name: "nil records are skipped",
+			history: []*ActionRecord{
+				{ActionType: "tool_call", IterationIndex: 1},
+				nil,
+				{ActionType: finishType, IterationIndex: 2},
+				nil,
+			},
+			wantType:      "tool_call",
+			wantIteration: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loop := newActionHistoryTestLoop()
+			loop.actionHistory = append(loop.actionHistory, tc.history...)
+
+			got := loop.GetLastValidAction()
+			if tc.wantNil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tc.wantType, got.ActionType)
+			require.Equal(t, tc.wantIteration, got.IterationIndex)
+		})
+	}
+}
+
+// TestGetLastValidAction_VersusGetLastAction 锁定两个 API 的语义差异：
+// 当循环以 finish 收尾时，GetLastAction 返回 finish 记录本身，
+// 而 GetLastValidAction 必须返回 finish 之前的有效 action（如 directly_answer）。
+// 这是 loop_default 最终总结钩子改用 GetLastValidAction 的直接原因。
+func TestGetLastValidAction_VersusGetLastAction(t *testing.T) {
+	loop := newActionHistoryTestLoop()
+	loop.actionHistory = append(loop.actionHistory,
+		&ActionRecord{ActionType: loopAction_DirectlyAnswer.ActionType, IterationIndex: 1},
+		&ActionRecord{ActionType: loopAction_Finish.ActionType, IterationIndex: 2},
+	)
+
+	last := loop.GetLastAction()
+	require.NotNil(t, last)
+	require.Equal(t, loopAction_Finish.ActionType, last.ActionType)
+
+	valid := loop.GetLastValidAction()
+	require.NotNil(t, valid)
+	require.Equal(t, loopAction_DirectlyAnswer.ActionType, valid.ActionType)
+}


### PR DESCRIPTION
…lt loop

The default loop post-iteration hook used GetLastAction, which always returns the trailing finish record when the loop ends, so the directly_answer early-return never matched and a redundant final summary was generated after the answer had already been delivered.

Switch to GetLastValidAction so the hook sees the last meaningful action before finish and correctly skips the summary when it was directly_answer.

Add white-box unit tests for GetLastValidAction edge cases and end-to-end regression tests covering both the skip path and the summary-generation path.