### PR TITLE
fix(scannode): 为受管源码包下载复用节点会话鉴权

### DIFF
--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -59,6 +59,11 @@ func (s *ScanNode) executeScriptTask(
 		s,
 	)
 	keyValues := s.parseScriptParams(input.ScriptJSONParam)
+	cleanupSourcePayload, err := s.prepareManagedSourcePayload(taskCtx, keyValues)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupSourcePayload()
 	reporter.ssaUploadCfg = extractSSAArtifactUploadConfig(keyValues)
 	reporter.ssaCollector = NewSSAArtifactCollector(input.TaskID, input.RuntimeID, input.SubTaskID)
 	if reporter.ssaCollector != nil {

--- a/scannode/source_payload_download.go
+++ b/scannode/source_payload_download.go
@@ -1,0 +1,215 @@
+package scannode
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/yaklang/yaklang/common/node"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+const sourcePayloadDownloadPathPrefix = "/v1/ssa-source-payloads/"
+
+const sourcePayloadDownloadTimeout = 60 * time.Second
+
+var managedSourcePayloadIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// prepareManagedSourcePayload downloads a Legion-managed archive with the
+// Scan Node's current runtime session and rewrites CodeSource to use the local
+// temporary file. The task-provided URL is deliberately ignored: sending the
+// node session token to that URL would allow a forged job input to exfiltrate
+// the credential.
+func (s *ScanNode) prepareManagedSourcePayload(
+	ctx context.Context,
+	params map[string]any,
+) (func(), error) {
+	reference, err := managedCodeSource(params)
+	if err != nil {
+		return nil, err
+	}
+	if reference == nil {
+		return func() {}, nil
+	}
+	if s == nil || s.node == nil {
+		return nil, utils.Errorf("scan node is not ready for source payload download")
+	}
+	session, ok := s.node.GetSessionState()
+	if !ok {
+		return nil, utils.Errorf("node session is unavailable for source payload download")
+	}
+
+	return downloadAndRewriteManagedSourcePayload(
+		ctx,
+		s.httpClient,
+		s.resolvePlatformAPIBaseURL(),
+		session,
+		reference,
+	)
+}
+
+type managedCodeSourceReference struct {
+	codeSource map[string]any
+	payloadID  string
+	persist    func() error
+}
+
+func managedCodeSource(params map[string]any) (*managedCodeSourceReference, error) {
+	if params == nil {
+		return nil, nil
+	}
+	if reference := managedCodeSourceFromRoot(params); reference != nil {
+		reference.persist = func() error { return nil }
+		return reference, nil
+	}
+
+	configJSON, ok := params["config"].(string)
+	if !ok || strings.TrimSpace(configJSON) == "" {
+		return nil, nil
+	}
+	configRoot := make(map[string]any)
+	if err := json.Unmarshal([]byte(configJSON), &configRoot); err != nil {
+		return nil, nil
+	}
+	reference := managedCodeSourceFromRoot(configRoot)
+	if reference == nil {
+		return nil, nil
+	}
+	reference.persist = func() error {
+		raw, err := json.Marshal(configRoot)
+		if err != nil {
+			return utils.Errorf("marshal managed source payload config: %v", err)
+		}
+		params["config"] = string(raw)
+		return nil
+	}
+	return reference, nil
+}
+
+func managedCodeSourceFromRoot(root map[string]any) *managedCodeSourceReference {
+	codeSource, ok := root["CodeSource"].(map[string]any)
+	if !ok || codeSource == nil {
+		return nil
+	}
+	kind, _ := codeSource["kind"].(string)
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "compression", "jar":
+	default:
+		return nil
+	}
+	payloadID, ok := codeSource["payload_id"].(string)
+	payloadID = strings.TrimSpace(payloadID)
+	if !ok || payloadID == "" {
+		return nil
+	}
+	return &managedCodeSourceReference{codeSource: codeSource, payloadID: payloadID}
+}
+
+func downloadAndRewriteManagedSourcePayload(
+	ctx context.Context,
+	client *http.Client,
+	platformAPIBaseURL string,
+	session node.SessionState,
+	reference *managedCodeSourceReference,
+) (func(), error) {
+	localFile, err := downloadManagedSourcePayload(ctx, client, platformAPIBaseURL, session, reference.payloadID)
+	if err != nil {
+		return nil, err
+	}
+	reference.codeSource["local_file"] = localFile
+	delete(reference.codeSource, "url")
+	if err := reference.persist(); err != nil {
+		_ = os.Remove(localFile)
+		return nil, err
+	}
+	return func() { _ = os.Remove(localFile) }, nil
+}
+
+func downloadManagedSourcePayload(
+	ctx context.Context,
+	client *http.Client,
+	platformAPIBaseURL string,
+	session node.SessionState,
+	payloadID string,
+) (localFile string, err error) {
+	payloadID = strings.TrimSpace(payloadID)
+	if !managedSourcePayloadIDPattern.MatchString(payloadID) {
+		return "", utils.Errorf("invalid managed source payload id")
+	}
+	if strings.TrimSpace(session.SessionID) == "" || strings.TrimSpace(session.SessionToken) == "" {
+		return "", utils.Errorf("node session credentials are unavailable for source payload download")
+	}
+
+	baseURL, err := url.Parse(strings.TrimSpace(platformAPIBaseURL))
+	if err != nil ||
+		baseURL.Scheme == "" ||
+		baseURL.Host == "" ||
+		(baseURL.Scheme != "http" && baseURL.Scheme != "https") ||
+		baseURL.User != nil ||
+		baseURL.RawQuery != "" ||
+		baseURL.Fragment != "" {
+		return "", utils.Errorf("invalid platform API base URL for source payload download")
+	}
+	baseURL.Path = strings.TrimRight(baseURL.Path, "/") + sourcePayloadDownloadPathPrefix + url.PathEscape(payloadID) + "/download"
+	baseURL.RawPath = ""
+	query := baseURL.Query()
+	query.Set("node_session_id", strings.TrimSpace(session.SessionID))
+	baseURL.RawQuery = query.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL.String(), nil)
+	if err != nil {
+		return "", utils.Errorf("build source payload download request: %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+strings.TrimSpace(session.SessionToken))
+
+	httpClient := client
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: sourcePayloadDownloadTimeout}
+	}
+	requestClient := *httpClient
+	if requestClient.Timeout <= 0 {
+		requestClient.Timeout = sourcePayloadDownloadTimeout
+	}
+	// Never forward the node session credential through an HTTP redirect. The
+	// configured Legion endpoint streams the payload directly; a redirect is an
+	// unexpected response and must fail closed.
+	requestClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	response, err := requestClient.Do(request)
+	if err != nil {
+		return "", utils.Errorf("download managed source payload: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", utils.Errorf("download managed source payload failed: status=%d", response.StatusCode)
+	}
+
+	tempFile, err := os.CreateTemp("", "yaklang-node-source-payload-*.zip")
+	if err != nil {
+		return "", utils.Errorf("create source payload temp file: %v", err)
+	}
+	tempPath := tempFile.Name()
+	defer func() {
+		closeErr := tempFile.Close()
+		if err == nil && closeErr != nil {
+			err = utils.Errorf("close source payload temp file: %v", closeErr)
+		}
+		if err != nil {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if _, err = io.Copy(tempFile, response.Body); err != nil {
+		return "", utils.Errorf("write source payload temp file: %v", err)
+	}
+	if err = tempFile.Sync(); err != nil {
+		return "", utils.Errorf("sync source payload temp file: %v", err)
+	}
+	return tempPath, nil
+}

--- a/scannode/source_payload_download_test.go
+++ b/scannode/source_payload_download_test.go
@@ -1,0 +1,160 @@
+package scannode
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/node"
+)
+
+func TestDownloadAndRewriteManagedSourcePayloadUsesTrustedNodeBaseAndSession(t *testing.T) {
+	const archive = "PK\x03\x04source-payload"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodGet, request.Method)
+		assert.Equal(t, "/legion/v1/ssa-source-payloads/sourcepayload-123/download", request.URL.Path)
+		assert.Equal(t, "session-123", request.URL.Query().Get("node_session_id"))
+		assert.Equal(t, "Bearer secret-session-token", request.Header.Get("Authorization"))
+		_, _ = io.WriteString(writer, archive)
+	}))
+	defer server.Close()
+
+	params := map[string]any{
+		"config": `{"Mode":127,"CodeSource":{"kind":"compression","url":"http://127.0.0.1:1/forged-token-sink","payload_id":"sourcepayload-123"}}`,
+	}
+	reference, err := managedCodeSource(params)
+	require.NoError(t, err)
+	require.NotNil(t, reference)
+	cleanup, err := downloadAndRewriteManagedSourcePayload(
+		context.Background(),
+		server.Client(),
+		server.URL+"/legion",
+		node.SessionState{SessionID: "session-123", SessionToken: "secret-session-token"},
+		reference,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+
+	var rewrittenConfig map[string]any
+	require.NoError(t, json.Unmarshal([]byte(params["config"].(string)), &rewrittenConfig))
+	rewrittenCodeSource := rewrittenConfig["CodeSource"].(map[string]any)
+	localFile, ok := rewrittenCodeSource["local_file"].(string)
+	require.True(t, ok)
+	contents, err := os.ReadFile(localFile)
+	require.NoError(t, err)
+	assert.Equal(t, archive, string(contents))
+	assert.NotContains(t, rewrittenCodeSource, "url", "the forged task URL must not survive the trusted rewrite")
+
+	cleanup()
+	_, err = os.Stat(localFile)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestManagedCodeSourceLeavesDirectArchiveURLUnchanged(t *testing.T) {
+	codeSource := map[string]any{
+		"kind": "compression",
+		"url":  "https://archives.example.test/source.zip",
+	}
+	params := map[string]any{"CodeSource": codeSource}
+
+	reference, err := managedCodeSource(params)
+	require.NoError(t, err)
+	assert.Nil(t, reference)
+	assert.Equal(t, "https://archives.example.test/source.zip", codeSource["url"])
+}
+
+func TestDownloadManagedSourcePayloadRejectsInvalidInputBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseURL   string
+		session   node.SessionState
+		payloadID string
+	}{
+		{
+			name:      "payload path injection",
+			baseURL:   "https://platform.example.test",
+			session:   node.SessionState{SessionID: "session-123", SessionToken: "token-123"},
+			payloadID: "../../secret",
+		},
+		{
+			name:      "missing session token",
+			baseURL:   "https://platform.example.test",
+			session:   node.SessionState{SessionID: "session-123"},
+			payloadID: "sourcepayload-123",
+		},
+		{
+			name:      "non HTTP platform URL",
+			baseURL:   "file:///tmp/platform",
+			session:   node.SessionState{SessionID: "session-123", SessionToken: "token-123"},
+			payloadID: "sourcepayload-123",
+		},
+		{
+			name:      "platform URL with query",
+			baseURL:   "https://platform.example.test?redirect=other",
+			session:   node.SessionState{SessionID: "session-123", SessionToken: "token-123"},
+			payloadID: "sourcepayload-123",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := downloadManagedSourcePayload(
+				context.Background(),
+				nil,
+				test.baseURL,
+				test.session,
+				test.payloadID,
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDownloadManagedSourcePayloadRejectsUnauthorizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		http.Error(writer, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := downloadManagedSourcePayload(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		node.SessionState{SessionID: "session-123", SessionToken: "token-123"},
+		"sourcepayload-123",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status=401")
+}
+
+func TestDownloadManagedSourcePayloadDoesNotForwardSessionThroughRedirect(t *testing.T) {
+	var redirectTargetCalled atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectTargetCalled.Store(true)
+	}))
+	defer target.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "Bearer token-123", request.Header.Get("Authorization"))
+		http.Redirect(writer, request, target.URL+"/token-sink", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	_, err := downloadManagedSourcePayload(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		node.SessionState{SessionID: "session-123", SessionToken: "token-123"},
+		"sourcepayload-123",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status=307")
+	assert.False(t, redirectTargetCalled.Load(), "node session token must not follow source payload redirects")
+}


### PR DESCRIPTION
## 改动摘要

- Scan Node 在执行带 `payload_id` 的受管 `compression` / `jar` CodeSource 前，使用当前 Node Session 下载源码包。
- 下载地址从节点自身可信的 `PlatformAPIBaseURL` 重建，并附带 `node_session_id` 与 `Authorization: Bearer <session-token>`。
- 忽略任务参数中的受管源码包 URL，避免伪造 URL 获取节点 Session Token。
- 下载内容写入权限受限的临时文件，子脚本执行结束后删除；HTTP 重定向失败关闭，不转发 Session Token。
- 没有 `payload_id` 的普通第三方压缩包 URL 保持现有行为，也不会收到节点凭据。

## 根因

Legion 的受管源码包下载端点需要复用 Node Session 鉴权，但 SSA 通用下载层原先只执行无请求头的 HTTP GET。若直接把 Session Token 附加到任务提供的 URL，还会形成凭据外泄风险。

因此鉴权桥接放在 Scan Node 执行边界：节点从内存读取当前 Session，使用自身可信平台地址下载，再把 CodeSource 临时改写为本地文件，不把明文 Token 写入 Legion Job、Proto 或持久化参数。

## 兼容性与发布顺序

- 配套 Legion PR：VillanCh/legion#293。
- 应先升级所有可能执行上传压缩包任务的 Yaklang Node，再部署 Legion 的强制下载鉴权；旧节点不会发送 Session 凭据，会在新 Legion 上收到 `401`。
- 新节点可以先连接旧 Legion：旧端点在携带 `node_session_id` 时已经会校验对应 Session Token。

## 验证

- `go test ./scannode ./common/node -count=1`
- 覆盖可信 base 重建、真实嵌套 `config.CodeSource` 回写、Session 请求头、伪造 URL、防路径注入、缺失凭据、401、重定向拒绝、临时文件清理和第三方 URL 兼容。

## 验证边界

- 当前为 T1；尚未与 Legion PR #293 的 worktree 组合启动真实 Scan Dev 栈执行 upload → compile → chained scan。
- 原问题部署与原始 ZIP 不在当前环境中，部署侧 T3 仍需单独复验。
