### PR TITLE
feat(scannode): support Legion scan debug pprof collection and analysis

### DIFF
--- a/common/yak/cmd/yakcmds/ssacli.go
+++ b/common/yak/cmd/yakcmds/ssacli.go
@@ -1419,18 +1419,12 @@ and exports structured report (sarif/irify).`,
 		}()
 		ctx := context.Background()
 
-		var pprofCleanup func()
 		if debugDir := c.String("debug"); debugDir != "" {
 			cleanup, err := setupDebugDir(c, debugDir)
 			if err != nil {
 				return utils.Errorf("setup debug dir failed: %v", err)
 			}
-			pprofCleanup = cleanup
-			defer func() {
-				if pprofCleanup != nil {
-					pprofCleanup()
-				}
-			}()
+			defer cleanup()
 		}
 
 		if logLevel := c.String("log-level"); logLevel != "" {

--- a/common/yak/cmd/yakcmds/ssacli_sfscan.go
+++ b/common/yak/cmd/yakcmds/ssacli_sfscan.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/syntaxflow/sfbuildin"
 	"github.com/yaklang/yaklang/common/urfavecli"
@@ -536,11 +535,8 @@ func applyCompileCliOverrides(cfg *ssaconfig.Config, cliCtx *cli.Context) error 
 
 // setupDebugDir creates a structured debug output directory and wires up all
 // the output paths. It:
-//  1. Creates the directory structure: <dir>/{cpu-pprof,memory-pprof,goroutine-pprof}
-//  2. Redirects --database to <dir>/ssadb.db
-//  3. Redirects --output to <dir>/report
-//  4. Saves the launch command to <dir>/cmd.txt
-//  5. Starts a pprof HTTP server and periodic pprof collector
+//  1. Saves the launch command to <dir>/cmd.txt (CLI-only)
+//  2. Reuses ssaapi.StartDebugOutput for MkdirAll / ssadb / log / pprof
 //
 // The returned cleanup function stops the pprof collector and should be deferred.
 func setupDebugDir(c *cli.Context, dir string) (func(), error) {
@@ -548,7 +544,8 @@ func setupDebugDir(c *cli.Context, dir string) (func(), error) {
 		return nil, utils.Errorf("create debug dir %s: %v", dir, err)
 	}
 
-	// Save the launch command
+	// Save the launch command (CLI-only artifact; shared StartDebugOutput
+	// does not know about os.Args / urfave command metadata).
 	cmdPath := filepath.Join(dir, "cmd.txt")
 	cmdContent := fmt.Sprintf("yak %s\n\nFull command:\n%s\n\nTimestamp: %s\n",
 		c.Command.Name,
@@ -559,33 +556,13 @@ func setupDebugDir(c *cli.Context, dir string) (func(), error) {
 		return nil, utils.Errorf("write cmd.txt: %v", err)
 	}
 
-	// Redirect SSA database to <dir>/ssadb.db
-	ssadbPath := filepath.Join(dir, "ssadb.db")
-	if err := consts.SetGormSSAProjectDatabaseByInfo(ssadbPath); err != nil {
-		return nil, utils.Errorf("set SSA database to %s: %v", ssadbPath, err)
-	}
-	log.Infof("[debug] SSA database: %s", ssadbPath)
-
-	// Redirect log output to <dir>/log (in addition to stdout)
-	logPath := filepath.Join(dir, "log")
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	// Standalone CLI scans redirect SSA DB into the debug dir.
+	cleanup, err := ssaapi.StartDebugOutput(dir, true)
 	if err != nil {
-		return nil, utils.Errorf("create log file %s: %v", logPath, err)
+		return nil, utils.Errorf("setup debug output: %v", err)
 	}
-	log.Infof("[debug] log output: %s", logPath)
-	log.SetOutput(io.MultiWriter(logFile, os.Stdout))
-
-	// Start pprof collector
-	cleanup, err := ssaapi.StartPprofCollector(dir)
-	if err != nil {
-		logFile.Close()
-		return nil, utils.Errorf("start pprof collector: %v", err)
+	if cleanup == nil {
+		cleanup = func() {}
 	}
-
-	originalCleanup := cleanup
-	combinedCleanup := func() {
-		originalCleanup()
-		logFile.Close()
-	}
-	return combinedCleanup, nil
+	return cleanup, nil
 }

--- a/common/yak/ssaapi/debug_output.go
+++ b/common/yak/ssaapi/debug_output.go
@@ -1,0 +1,65 @@
+package ssaapi
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/yaklang/yaklang/common/consts"
+)
+
+// DebugOutputCleanup stops the pprof collector and closes the log file.
+type DebugOutputCleanup func()
+
+// StartDebugOutput wires up debug/pprof output for a scan or compile run.
+// It mirrors what the CLI `yak code-scan --debug <dir>` does:
+//   - redirects log output to <dir>/log
+//   - starts the periodic pprof collector (CPU/heap/goroutine snapshots)
+//   - when redirectSSADB is true, redirects the SSA database to <dir>/ssadb.db
+//
+// For two-job compile -> scan flows the compile job must keep the shared
+// Postgres SSA IR database so the scan job can reuse the compiled program, so
+// callers should pass redirectSSADB=false for the compile phase and true only
+// for standalone single-job scans.
+func StartDebugOutput(debugDir string, redirectSSADB bool) (DebugOutputCleanup, error) {
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	if redirectSSADB {
+		ssadbPath := filepath.Join(debugDir, "ssadb.db")
+		if err := consts.SetGormSSAProjectDatabaseByInfo(ssadbPath); err != nil {
+			log.Warnf("[debug] set SSA database to %s failed: %v", ssadbPath, err)
+		} else {
+			log.Infof("[debug] SSA database: %s", ssadbPath)
+		}
+	}
+
+	// Redirect log to <debugDir>/log (in addition to stdout).
+	logPath := filepath.Join(debugDir, "log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		log.Warnf("[debug] create log file %s failed: %v", logPath, err)
+		logFile = nil
+	} else {
+		log.Infof("[debug] log output: %s", logPath)
+		log.SetOutput(io.MultiWriter(logFile, os.Stdout))
+	}
+
+	// Start pprof collector (periodic CPU/heap/goroutine snapshots).
+	cleanup, err := StartPprofCollector(debugDir)
+	if err != nil {
+		log.Warnf("[debug] start pprof collector failed: %v, continuing without pprof", err)
+		if logFile != nil {
+			_ = logFile.Close()
+		}
+		return nil, nil
+	}
+
+	return func() {
+		cleanup()
+		if logFile != nil {
+			_ = logFile.Close()
+		}
+	}, nil
+}

--- a/common/yak/ssaapi/debug_output.go
+++ b/common/yak/ssaapi/debug_output.go
@@ -11,17 +11,47 @@ import (
 // DebugOutputCleanup stops the pprof collector and closes the log file.
 type DebugOutputCleanup func()
 
+// noopDebugCleanup is returned when debug is disabled or setup fails non-fatally.
+func noopDebugCleanup() {}
+
+// SetupDebugDir wires debug/pprof output when debugDir is non-empty.
+// Empty debugDir returns a no-op cleanup so callers can always:
+//
+//	cleanup := ssaapi.SetupDebugDir(config.GetDebugDir(), false)
+//	defer cleanup()
+//
+// Setup failures are logged and treated as non-fatal (no-op cleanup).
+// See StartDebugOutput for redirectSSADB semantics.
+func SetupDebugDir(debugDir string, redirectSSADB bool) DebugOutputCleanup {
+	if debugDir == "" {
+		return noopDebugCleanup
+	}
+	cleanup, err := StartDebugOutput(debugDir, redirectSSADB)
+	if err != nil {
+		log.Warnf("[debug] setup debug dir %s failed: %v, continuing without debug", debugDir, err)
+		return noopDebugCleanup
+	}
+	if cleanup == nil {
+		return noopDebugCleanup
+	}
+	return cleanup
+}
+
 // StartDebugOutput wires up debug/pprof output for a scan or compile run.
-// It mirrors what the CLI `yak code-scan --debug <dir>` does:
+// It is the shared implementation used by SetupDebugDir and the CLI --debug path:
+//   - creates debugDir (MkdirAll)
 //   - redirects log output to <dir>/log
 //   - starts the periodic pprof collector (CPU/heap/goroutine snapshots)
 //   - when redirectSSADB is true, redirects the SSA database to <dir>/ssadb.db
 //
 // For two-job compile -> scan flows the compile job must keep the shared
 // Postgres SSA IR database so the scan job can reuse the compiled program, so
-// callers should pass redirectSSADB=false for the compile phase and true only
-// for standalone single-job scans.
+// callers should pass redirectSSADB=false for platform compile/scan jobs.
+// Standalone CLI scans typically pass redirectSSADB=true.
 func StartDebugOutput(debugDir string, redirectSSADB bool) (DebugOutputCleanup, error) {
+	if debugDir == "" {
+		return noopDebugCleanup, nil
+	}
 	if err := os.MkdirAll(debugDir, 0o755); err != nil {
 		return nil, err
 	}
@@ -53,7 +83,7 @@ func StartDebugOutput(debugDir string, redirectSSADB bool) (DebugOutputCleanup, 
 		if logFile != nil {
 			_ = logFile.Close()
 		}
-		return nil, nil
+		return noopDebugCleanup, nil
 	}
 
 	return func() {

--- a/common/yak/ssaapi/debug_output_test.go
+++ b/common/yak/ssaapi/debug_output_test.go
@@ -1,0 +1,34 @@
+package ssaapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupDebugDirEmptyIsNoop(t *testing.T) {
+	cleanup := SetupDebugDir("", false)
+	require.NotNil(t, cleanup)
+	cleanup() // must not panic
+}
+
+func TestSetupDebugDirCreatesLogAndDirs(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "run-1")
+
+	cleanup := SetupDebugDir(target, false)
+	require.NotNil(t, cleanup)
+	defer cleanup()
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	_, err = os.Stat(filepath.Join(target, "log"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(target, "cpu-pprof"))
+	require.NoError(t, err)
+}

--- a/common/yak/ssaapi/sf_result_value.go
+++ b/common/yak/ssaapi/sf_result_value.go
@@ -142,7 +142,11 @@ func (r *SyntaxFlowResult) GetValue(name string, index int) (*Value, error) {
 	}
 
 	if name == "_" {
-		return r.GetUnNameValues()[index], nil
+		vs := r.GetUnNameValues()
+		if index < 0 || index >= len(vs) {
+			return nil, utils.Errorf("index out of range: %d (len %d)", index, len(vs))
+		}
+		return vs[index], nil
 	}
 
 	if r.dbResult != nil {

--- a/common/yak/ssaapi/sf_result_value_test.go
+++ b/common/yak/ssaapi/sf_result_value_test.go
@@ -1,0 +1,25 @@
+package ssaapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyntaxFlowResultGetValueUnnamedOutOfRange(t *testing.T) {
+	r := &SyntaxFlowResult{
+		unName: Values{},
+	}
+	_, err := r.GetValue("_", 0)
+	require.Error(t, err, "out-of-range unnamed index must return an error, not panic")
+	assert.Contains(t, err.Error(), "index out of range")
+}
+
+func TestSyntaxFlowResultGetValueUnnamedNegative(t *testing.T) {
+	r := &SyntaxFlowResult{
+		unName: Values{},
+	}
+	_, err := r.GetValue("_", -1)
+	require.Error(t, err, "negative unnamed index must return an error, not panic")
+}

--- a/common/yak/ssaapi/ssa_compile_project.go
+++ b/common/yak/ssaapi/ssa_compile_project.go
@@ -161,6 +161,24 @@ func ParseProject(opts ...ssaconfig.Option) (prog Programs, err error) {
 }
 
 func (c *Config) parseProject() (progs Programs, err error) {
+	// Wire up debug/pprof output when debug_dir is set.
+	// Keep the shared Postgres SSA IR DB (redirectSSADB=false) so the
+	// two-job compile -> scan flow can reuse the compiled program.
+	var debugCleanup DebugOutputCleanup
+	if debugDir := c.GetDebugDir(); debugDir != "" {
+		cleanup, startErr := StartDebugOutput(debugDir, false)
+		if startErr != nil {
+			log.Warnf("[debug] start compile debug output failed: %v, continuing without debug", startErr)
+		} else {
+			debugCleanup = cleanup
+			defer func() {
+				if debugCleanup != nil {
+					debugCleanup()
+							}
+			}()
+		}
+	}
+
 	programName := c.GetProgramName()
 	isIncrementalCompile := c.GetEnableIncrementalCompile() && c.fs != nil
 	isDiffCompile := isIncrementalCompile && c.GetBaseProgramName() != ""

--- a/common/yak/ssaapi/ssa_compile_project.go
+++ b/common/yak/ssaapi/ssa_compile_project.go
@@ -164,20 +164,8 @@ func (c *Config) parseProject() (progs Programs, err error) {
 	// Wire up debug/pprof output when debug_dir is set.
 	// Keep the shared Postgres SSA IR DB (redirectSSADB=false) so the
 	// two-job compile -> scan flow can reuse the compiled program.
-	var debugCleanup DebugOutputCleanup
-	if debugDir := c.GetDebugDir(); debugDir != "" {
-		cleanup, startErr := StartDebugOutput(debugDir, false)
-		if startErr != nil {
-			log.Warnf("[debug] start compile debug output failed: %v, continuing without debug", startErr)
-		} else {
-			debugCleanup = cleanup
-			defer func() {
-				if debugCleanup != nil {
-					debugCleanup()
-							}
-			}()
-		}
-	}
+	debugCleanup := SetupDebugDir(c.GetDebugDir(), false)
+	defer debugCleanup()
 
 	programName := c.GetProgramName()
 	isIncrementalCompile := c.GetEnableIncrementalCompile() && c.fs != nil

--- a/common/yak/syntaxflow_scan/scan.go
+++ b/common/yak/syntaxflow_scan/scan.go
@@ -17,22 +17,11 @@ func Scan(ctx context.Context, option ...ssaconfig.Option) error {
 		return err
 	}
 
-	// Wire up debug/pprof output when debug_dir is set. The standalone
-	// scan redirects its SSA database to the debug dir (single-job scan).
-	var pprofCleanup ssaapi.DebugOutputCleanup
-	if debugDir := config.GetDebugDir(); debugDir != "" {
-		cleanup, startErr := ssaapi.StartDebugOutput(debugDir, false)
-		if startErr != nil {
-			log.Warnf("[debug] start scan debug output failed: %v, continuing without debug", startErr)
-		} else {
-			pprofCleanup = cleanup
-			defer func() {
-				if pprofCleanup != nil {
-					pprofCleanup()
-				}
-			}()
-		}
-	}
+	// Wire up debug/pprof output when debug_dir is set.
+	// Keep the shared Postgres SSA IR DB (redirectSSADB=false) for platform
+	// two-job compile -> scan reuse; CLI --debug redirects SSADB separately.
+	debugCleanup := ssaapi.SetupDebugDir(config.GetDebugDir(), false)
+	defer debugCleanup()
 
 	var taskId string
 	var m *scanManager

--- a/common/yak/syntaxflow_scan/scan.go
+++ b/common/yak/syntaxflow_scan/scan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yak/ssaapi"
 	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
 )
 
@@ -15,6 +16,24 @@ func Scan(ctx context.Context, option ...ssaconfig.Option) error {
 	if err != nil {
 		return err
 	}
+
+	// Wire up debug/pprof output when debug_dir is set. The standalone
+	// scan redirects its SSA database to the debug dir (single-job scan).
+	var pprofCleanup ssaapi.DebugOutputCleanup
+	if debugDir := config.GetDebugDir(); debugDir != "" {
+		cleanup, startErr := ssaapi.StartDebugOutput(debugDir, false)
+		if startErr != nil {
+			log.Warnf("[debug] start scan debug output failed: %v, continuing without debug", startErr)
+		} else {
+			pprofCleanup = cleanup
+			defer func() {
+				if pprofCleanup != nil {
+					pprofCleanup()
+				}
+			}()
+		}
+	}
+
 	var taskId string
 	var m *scanManager
 	var success bool

--- a/scannode/debug_collector.go
+++ b/scannode/debug_collector.go
@@ -1,0 +1,358 @@
+package scannode
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"strings"
+	"time"
+
+	"github.com/yaklang/yaklang/common/log"
+)
+
+// DebugCollector is DEPRECATED. The scan node no longer uses a separate
+// profiler — debug profiling is handled by yak code-scan's built-in
+// pprof collector (started via syntaxflow_scan.Scan() when debug_dir is set).
+// This type is retained for test compatibility but its Start/StopProfiling
+// methods should NOT be called in production code as they would start a
+// second CPU profiler that conflicts with the built-in one.
+//
+// DebugCollector orchestrates per-task debug profiling: CPU profile,
+// heap profile, task log capture, and a timing summary. It uploads all
+// debug artifacts to MinIO and reports them via JobArtifactReady events.
+type DebugCollector struct {
+	taskID    string
+	runtimeID string
+	subTaskID string
+
+	dir        string
+	cpuFile    *os.File
+	heapFile   *os.File
+	logFile    *os.File
+	logWriter  io.Writer
+	startedAt  time.Time
+	finishedAt time.Time
+
+	closed bool
+}
+
+// debugTimingSummary is the JSON structure written to the timing artifact.
+type debugTimingSummary struct {
+	TaskID     string `json:"task_id"`
+	SubTaskID  string `json:"subtask_id"`
+	AttemptID  string `json:"attempt_id"`
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at"`
+	DurationMS int64 `json:"duration_ms"`
+	Phase      string `json:"phase,omitempty"`
+}
+
+// NewDebugCollector creates a DebugCollector and prepares a temporary
+// directory for debug artifacts. Call Close to release resources.
+func NewDebugCollector(taskID, runtimeID, subTaskID string) (*DebugCollector, error) {
+	dir, err := os.MkdirTemp("", "legion-debug-*")
+	if err != nil {
+		return nil, fmt.Errorf("create debug dir: %w", err)
+	}
+	return &DebugCollector{
+		taskID:    taskID,
+		runtimeID: runtimeID,
+		subTaskID: subTaskID,
+		dir:       dir,
+	}, nil
+}
+
+// Start begins CPU profiling and opens the task log file. It must be
+// called before the scan script executes.
+func (dc *DebugCollector) Start() error {
+	if dc == nil {
+		return nil
+	}
+	cpuPath := filepath.Join(dc.dir, "cpu.prof")
+	cpuFile, err := os.Create(cpuPath)
+	if err != nil {
+		return fmt.Errorf("create cpu profile: %w", err)
+	}
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		_ = cpuFile.Close()
+		return fmt.Errorf("start cpu profile: %w", err)
+	}
+	dc.cpuFile = cpuFile
+
+	logPath := filepath.Join(dc.dir, "task.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("create debug log file: %w", err)
+	}
+	dc.logFile = logFile
+	dc.logWriter = logFile
+
+	dc.startedAt = time.Now()
+	log.Infof("[debug] profiling started for task=%s attempt=%s dir=%s", dc.taskID, dc.runtimeID, dc.dir)
+	return nil
+}
+
+// LogWriter returns the writer for capturing task logs. It is nil before
+// Start is called.
+func (dc *DebugCollector) LogWriter() io.Writer {
+	if dc == nil {
+		return nil
+	}
+	return dc.logWriter
+}
+
+// StopProfiling stops CPU profiling and writes a heap profile. It should
+// be called immediately after the scan script finishes.
+func (dc *DebugCollector) StopProfiling() error {
+	if dc == nil || dc.closed {
+		return nil
+	}
+	dc.closed = true
+	dc.finishedAt = time.Now()
+
+	if dc.cpuFile != nil {
+		pprof.StopCPUProfile()
+		_ = dc.cpuFile.Close()
+	}
+
+	heapPath := filepath.Join(dc.dir, "heap.prof")
+	heapFile, err := os.Create(heapPath)
+	if err != nil {
+		return fmt.Errorf("create heap profile: %w", err)
+	}
+	defer heapFile.Close()
+	if err := pprof.WriteHeapProfile(heapFile); err != nil {
+		return fmt.Errorf("write heap profile: %w", err)
+	}
+	dc.heapFile = heapFile
+
+	if dc.logFile != nil {
+		_ = dc.logFile.Sync()
+		_ = dc.logFile.Close()
+	}
+
+	log.Infof("[debug] profiling finished for task=%s duration=%v", dc.taskID, dc.finishedAt.Sub(dc.startedAt))
+	return nil
+}
+
+// WriteTimingSummary writes the timing summary JSON file.
+func (dc *DebugCollector) WriteTimingSummary(phase string) error {
+	if dc == nil {
+		return nil
+	}
+	summary := debugTimingSummary{
+		TaskID:      dc.taskID,
+		SubTaskID:   dc.subTaskID,
+		AttemptID:   dc.runtimeID,
+		StartedAt:   dc.startedAt.UTC().Format(time.RFC3339Nano),
+		FinishedAt:  dc.finishedAt.UTC().Format(time.RFC3339Nano),
+		DurationMS:  dc.finishedAt.Sub(dc.startedAt).Milliseconds(),
+		Phase:       strings.TrimSpace(phase),
+	}
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal timing summary: %w", err)
+	}
+	path := filepath.Join(dc.dir, "timing.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("write timing summary: %w", err)
+	}
+	return nil
+}
+
+// Artifact describes a single debug artifact file ready for upload.
+type debugArtifact struct {
+	Kind     string // debug_pprof_cpu | debug_pprof_heap | debug_log | debug_timing
+	FilePath string
+	FileName string
+}
+
+// Artifacts returns the list of debug artifact files produced by this collector.
+func (dc *DebugCollector) Artifacts() []debugArtifact {
+	if dc == nil || dc.dir == "" {
+		return nil
+	}
+	var artifacts []debugArtifact
+	entries := []struct {
+		kind     string
+		filename string
+	}{
+		{"debug_pprof_cpu", "cpu.prof"},
+		{"debug_pprof_heap", "heap.prof"},
+		{"debug_log", "task.log"},
+		{"debug_timing", "timing.json"},
+	}
+	for _, e := range entries {
+		path := filepath.Join(dc.dir, e.filename)
+		if _, err := os.Stat(path); err == nil {
+			artifacts = append(artifacts, debugArtifact{
+				Kind:     e.kind,
+				FilePath: path,
+				FileName: e.filename,
+			})
+		}
+	}
+	return artifacts
+}
+
+// Cleanup removes the temporary debug directory. Safe to call after
+// artifacts have been uploaded.
+func (dc *DebugCollector) Cleanup() {
+	if dc == nil {
+		return
+	}
+	if dc.dir != "" {
+		_ = os.RemoveAll(dc.dir)
+	}
+}
+
+// computeSHA256 computes the SHA-256 hash of a file.
+func computeSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// fileSize returns the size of a file in bytes.
+func fileSize(path string) int64 {
+	st, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return st.Size()
+}
+
+// debugObjectKey builds an S3 object key for a debug artifact.
+func debugObjectKey(taskID, attemptID, kind, filename string) string {
+	return fmt.Sprintf("debug/%s/%s/%s/%s", taskID, attemptID, kind, filename)
+}
+
+// isDebugEnabled checks whether the debug_enabled label is set to "true".
+func isDebugEnabled(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(labels["debug_enabled"]), "true")
+}
+
+// uploadDebugArtifacts uploads all debug artifact files to MinIO and
+// publishes JobArtifactReady events for each. Failures are logged but
+// do not affect the scan result.
+func (s *ScanNode) uploadDebugArtifacts(
+	ctx context.Context,
+	reporter *ScannerAgentReporter,
+	dc *DebugCollector,
+) {
+	if dc == nil {
+		return
+	}
+	artifacts := dc.Artifacts()
+	if len(artifacts) == 0 {
+		return
+	}
+
+	for _, art := range artifacts {
+		objKey := debugObjectKey(dc.taskID, dc.runtimeID, art.Kind, art.FileName)
+		sha, err := computeSHA256(art.FilePath)
+		if err != nil {
+			log.Warnf("[debug] compute sha256 for %s: %v", art.FileName, err)
+			sha = ""
+		}
+		size := fileSize(art.FilePath)
+
+		// Upload via the SSA upload config if available; otherwise log a warning.
+		cfg := reporter.ssaUploadCfg
+		if cfg == nil {
+			log.Warnf("[debug] no upload config available, skipping upload of %s", art.FileName)
+			continue
+		}
+
+		provider := s.buildDebugUploadConfigProvider(ctx, reporter, cfg, objKey)
+		if err := uploadDebugArtifactFile(art.FilePath, size, objKey, provider); err != nil {
+			log.Warnf("[debug] upload %s failed: %v", art.FileName, err)
+			continue
+		}
+
+		// Publish JobArtifactReady event
+		if err := reporter.PublishArtifactReady(ctx, art.Kind, "", objKey, "", sha, uint64(size), uint64(size), nil); err != nil {
+			log.Warnf("[debug] publish artifact ready for %s: %v", art.FileName, err)
+		}
+		log.Infof("[debug] uploaded artifact kind=%s key=%s size=%d sha=%s", art.Kind, objKey, size, sha)
+	}
+}
+
+// buildDebugUploadConfigProvider returns a provider that clones the SSA
+// upload config but overrides the ObjectKey for debug artifacts.
+func (s *ScanNode) buildDebugUploadConfigProvider(
+	ctx context.Context,
+	reporter *ScannerAgentReporter,
+	baseCfg *SSAArtifactUploadConfig,
+	objKey string,
+) ssaUploadConfigProvider {
+	current := *baseCfg
+	return func(force bool) (*SSAArtifactUploadConfig, error) {
+		cp := current
+		cp.ObjectKey = objKey
+		return &cp, nil
+	}
+}
+
+// uploadDebugArtifactFile uploads a file to MinIO with a specific object key.
+func uploadDebugArtifactFile(path string, size int64, objKey string, provider ssaUploadConfigProvider) error {
+	tmp := &SSAArtifactCollector{}
+	return tmp.UploadBySTSWithProvider(path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
+		cfg, err := provider(force)
+		if err != nil {
+			return nil, err
+		}
+		cp := *cfg
+		cp.ObjectKey = strings.TrimSpace(objKey)
+		return &cp, nil
+	})
+}
+
+// resolveDebugDir extracts a debug directory path from labels.
+// If "debug_dir" label is set, it is used directly ( Legion-generated path ).
+// Otherwise returns empty — the node will generate its own path.
+func resolveDebugDir(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	return strings.TrimSpace(labels["debug_dir"])
+}
+// computeSHA256FromBytes computes the SHA-256 hash of a byte slice.
+func computeSHA256FromBytes(data []byte) (string, error) {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:]), nil
+}
+
+// uploadDebugArtifactBytes uploads a byte slice to MinIO with a specific object key.
+func uploadDebugArtifactBytes(payload []byte, objKey string, provider ssaUploadConfigProvider) error {
+	tmpFile, err := os.CreateTemp("", "debug-analysis-*.json")
+	if err != nil {
+		return err
+	}
+	path := tmpFile.Name()
+	defer os.Remove(path)
+	if _, err := tmpFile.Write(payload); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	return uploadDebugArtifactFile(path, int64(len(payload)), objKey, provider)
+}

--- a/scannode/debug_collector_test.go
+++ b/scannode/debug_collector_test.go
@@ -1,0 +1,82 @@
+package scannode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDebugCollector_CreatesDir(t *testing.T) {
+	dc, err := NewDebugCollector("task-1", "attempt-1", "sub-1")
+	require.NoError(t, err)
+	require.NotNil(t, dc)
+	defer dc.Cleanup()
+
+	_, err = os.Stat(dc.dir)
+	assert.NoError(t, err, "debug dir should exist")
+}
+
+func TestDebugCollector_StartStopProfiling(t *testing.T) {
+	dc, err := NewDebugCollector("task-1", "attempt-1", "sub-1")
+	require.NoError(t, err)
+	defer dc.Cleanup()
+
+	require.NoError(t, dc.Start())
+	assert.NotNil(t, dc.LogWriter())
+
+	require.NoError(t, dc.StopProfiling())
+
+	// Check artifacts exist
+	artifacts := dc.Artifacts()
+	require.Len(t, artifacts, 3, "should have cpu, heap, and log artifacts")
+
+	// Verify cpu.prof exists
+	cpuPath := filepath.Join(dc.dir, "cpu.prof")
+	_, err = os.Stat(cpuPath)
+	assert.NoError(t, err)
+
+	// Verify heap.prof exists
+	heapPath := filepath.Join(dc.dir, "heap.prof")
+	_, err = os.Stat(heapPath)
+	assert.NoError(t, err)
+
+	// Verify task.log exists
+	logPath := filepath.Join(dc.dir, "task.log")
+	_, err = os.Stat(logPath)
+	assert.NoError(t, err)
+}
+
+func TestDebugCollector_WriteTimingSummary(t *testing.T) {
+	dc, err := NewDebugCollector("task-1", "attempt-1", "sub-1")
+	require.NoError(t, err)
+	defer dc.Cleanup()
+
+	require.NoError(t, dc.Start())
+	require.NoError(t, dc.StopProfiling())
+	require.NoError(t, dc.WriteTimingSummary("scan"))
+
+	// Verify timing.json exists
+	timingPath := filepath.Join(dc.dir, "timing.json")
+	_, err = os.Stat(timingPath)
+	assert.NoError(t, err)
+
+	// After writing timing, artifacts should include timing
+	artifacts := dc.Artifacts()
+	assert.Len(t, artifacts, 4, "should have cpu, heap, log, and timing artifacts")
+}
+
+func TestIsDebugEnabled(t *testing.T) {
+	assert.False(t, isDebugEnabled(nil))
+	assert.False(t, isDebugEnabled(map[string]string{}))
+	assert.False(t, isDebugEnabled(map[string]string{"debug_enabled": "false"}))
+	assert.True(t, isDebugEnabled(map[string]string{"debug_enabled": "true"}))
+	assert.True(t, isDebugEnabled(map[string]string{"debug_enabled": "True"}))
+}
+
+func TestDebugObjectKey(t *testing.T) {
+	key := debugObjectKey("task-1", "attempt-1", "debug_pprof_cpu", "cpu.prof")
+	assert.Equal(t, "debug/task-1/attempt-1/debug_pprof_cpu/cpu.prof", key)
+}

--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -1,0 +1,977 @@
+package scannode
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/pprof/profile"
+)
+
+// DebugRunAnalysis is the structured analysis result for a debug run directory.
+type DebugRunAnalysis struct {
+	// RunDir is intentionally NOT returned to the frontend (security).
+	// It is kept for internal use but not serialized.
+	RunDir     string             `json:"-"`
+	Status     string             `json:"status"` // running | completed | failed | unknown
+	StartedAt  *time.Time         `json:"started_at,omitempty"`
+	FinishedAt *time.Time         `json:"finished_at,omitempty"`
+	Duration   string             `json:"duration,omitempty"`
+	Phases     []PhaseAnalysis    `json:"phases,omitempty"`
+	Samples    []SampleSummary    `json:"samples,omitempty"`
+	Summary    *RunSummary         `json:"summary,omitempty"`
+	Errors     []string            `json:"errors,omitempty"`
+	Partial    bool               `json:"partial,omitempty"`
+}
+
+// PhaseAnalysis is a per-phase summary.
+type PhaseAnalysis struct {
+	Phase      string     `json:"phase"` // compile | scan | unknown
+	Source     string     `json:"source"` // log_inferred | status_card | unknown
+	StartedAt  *time.Time `json:"started_at,omitempty"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	Duration   string     `json:"duration,omitempty"`
+	Status     string     `json:"status,omitempty"`
+}
+
+// SampleSummary is a brief view of a 5-minute pprof snapshot.
+// Detail fields are populated inline so the frontend can expand a row
+// without a second request.
+type SampleSummary struct {
+	Sequence   int        `json:"sequence"`
+	Label      string     `json:"label"` // e.g. "20260805-120030-initial"
+	Timestamp  *time.Time `json:"timestamp,omitempty"`
+	Phase      string     `json:"phase,omitempty"`
+	PhaseSource string    `json:"phase_source,omitempty"` // explicit | boundary_inferred | log_inferred | unknown
+	HasCPU     bool       `json:"has_cpu"`
+	HasHeap    bool       `json:"has_heap"`
+	HasGoroutine bool     `json:"has_goroutine"`
+	// File paths are internal only, not serialized to JSON
+	CPUFile       string `json:"-"`
+	HeapFile      string `json:"-"`
+	GoroutineFile string `json:"-"`
+	// Inline detail (limited to avoid oversized analysis JSON)
+	CPUTop     []PprofTopFunction `json:"cpu_top,omitempty"`
+	HeapTop    []PprofTopFunction `json:"heap_top,omitempty"`
+	Goroutines int                `json:"goroutines,omitempty"`
+	LogExcerpt string             `json:"log_excerpt,omitempty"`
+	Status     string             `json:"status,omitempty"` // available | partial | error | pending
+}
+
+// SampleDetail is the detailed view of a single 5-minute sample.
+type SampleDetail struct {
+	SampleSummary
+	CPUProfile   *PprofTopAnalysis `json:"cpu_profile,omitempty"`
+	HeapProfile  *PprofTopAnalysis  `json:"heap_profile,omitempty"`
+	Goroutines   int                `json:"goroutines,omitempty"`
+	LogExcerpt   string             `json:"log_excerpt,omitempty"`
+}
+
+// PprofTopAnalysis contains top functions from a pprof profile.
+type PprofTopAnalysis struct {
+	Kind         string             `json:"kind"`
+	TopFunctions []PprofTopFunction  `json:"top_functions,omitempty"`
+	SampleCount  int64              `json:"sample_count"`
+	TotalValue   int64              `json:"total_value"`
+	SampleUnit   string             `json:"sample_unit,omitempty"`
+	ParseError   string             `json:"parse_error,omitempty"`
+}
+
+// PprofTopFunction is a single function entry.
+type PprofTopFunction struct {
+	Name      string `json:"name"`
+	CumValue  int64  `json:"cum_value"`
+	CumPct    string `json:"cum_pct"`
+	FlatValue int64  `json:"flat_value"`
+	FlatPct   string `json:"flat_pct"`
+}
+
+// RunSummary is the overall run summary.
+type RunSummary struct {
+	TotalDurationMS  int64  `json:"total_duration_ms"`
+	CPUProfileFiles  int    `json:"cpu_profile_files"`
+	HeapProfileFiles int    `json:"heap_profile_files"`
+	GoroutineFiles   int    `json:"goroutine_files"`
+	HasLog           bool   `json:"has_log"`
+	HasReport        bool   `json:"has_report"`
+	HasSSADB         bool   `json:"has_ssadb"`
+	HasCmd           bool   `json:"has_cmd"`
+	CompilePhaseFound bool  `json:"compile_phase_found"`
+	ScanPhaseFound    bool  `json:"scan_phase_found"`
+}
+
+// AnalyzeDebugRun parses a debug run directory and returns structured analysis.
+// It tolerates missing files, partial writes, and corrupted pprof data.
+func AnalyzeDebugRun(dir string) DebugRunAnalysis {
+	return AnalyzeDebugRunWithStatus(dir, "")
+}
+
+// AnalyzeDebugRunWithStatus analyzes a debug run directory. When taskStatus
+// is non-empty (e.g. "succeeded"/"failed"), it takes precedence over the
+// log-derived status because the log may not contain a completion marker.
+func AnalyzeDebugRunWithStatus(dir string, taskStatus string) DebugRunAnalysis {
+	result := DebugRunAnalysis{
+		RunDir: dir,
+		Status: "unknown",
+	}
+
+	// Check directory exists
+	info, err := os.Stat(dir)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("debug dir not accessible: %v", err))
+		result.Status = "error"
+		return result
+	}
+	if !info.IsDir() {
+		result.Errors = append(result.Errors, "debug path is not a directory")
+		result.Status = "error"
+		return result
+	}
+
+	// Parse log for timing and phase information
+	logPath := filepath.Join(dir, "log")
+	var logContent string
+	if logData, err := os.ReadFile(logPath); err == nil {
+		logContent = string(logData)
+	} else {
+		result.Errors = append(result.Errors, "log file not readable")
+	}
+	if strings.TrimSpace(logContent) == "" {
+		if taskLog := resolveTaskLogByDebugDir(dir); taskLog != "" {
+			if logData, err := os.ReadFile(taskLog); err == nil {
+				logContent = string(logData)
+			}
+		}
+	}
+	if strings.TrimSpace(logContent) != "" {
+		result.setTimesFromLog(logContent)
+		result.setPhasesFromLog(logContent)
+		if taskStatus == "" {
+			result.Status = result.determineStatus(logContent)
+		}
+	}
+	if taskStatus != "" {
+		result.Status = normalizeTaskStatus(taskStatus)
+	}
+
+	// Parse pprof samples
+	cpuDir := filepath.Join(dir, "cpu-pprof")
+	memDir := filepath.Join(dir, "memory-pprof")
+	goroutineDir := filepath.Join(dir, "goroutine-pprof")
+
+	samples := result.collectSamples(cpuDir, memDir, goroutineDir, logContent)
+	result.Samples = samples
+
+	// Build summary
+	result.Summary = result.buildSummary(dir, samples)
+	result.Partial = len(result.Errors) > 0
+
+	return result
+}
+
+// AnalyzeSample returns detailed analysis for a single pprof sample.
+func AnalyzeSample(dir string, label string) (SampleDetail, error) {
+	cpuDir := filepath.Join(dir, "cpu-pprof")
+	memDir := filepath.Join(dir, "memory-pprof")
+	goroutineDir := filepath.Join(dir, "goroutine-pprof")
+
+	detail := SampleDetail{}
+
+	// Find matching files by label prefix
+	cpuFile := findPprofFile(cpuDir, label, ".cpu.prof")
+	heapFile := findPprofFile(memDir, label, ".mem.prof")
+	goroutineFile := findPprofFile(goroutineDir, label, ".goroutine.prof")
+
+	detail.CPUFile = cpuFile
+	detail.HeapFile = heapFile
+	detail.GoroutineFile = goroutineFile
+	detail.HasCPU = cpuFile != ""
+	detail.HasHeap = heapFile != ""
+	detail.HasGoroutine = goroutineFile != ""
+
+	// Parse CPU profile
+	if cpuFile != "" {
+		detail.CPUProfile = parsePprofFile(cpuFile, "cpu")
+	}
+
+	// Parse heap profile
+	if heapFile != "" {
+		detail.HeapProfile = parsePprofFile(heapFile, "heap")
+	}
+
+	// Count goroutines from goroutine profile
+	if goroutineFile != "" {
+		detail.Goroutines = countGoroutines(goroutineFile)
+	}
+
+	// Extract log excerpt around this sample's timestamp
+	logPath := filepath.Join(dir, "log")
+	if logData, err := os.ReadFile(logPath); err == nil {
+		detail.LogExcerpt = extractLogExcerpt(string(logData), label, 4096)
+	}
+
+	return detail, nil
+}
+
+// GenerateDebugZip creates a zip archive of the debug run directory.
+func GenerateDebugZip(dir string) (string, error) {
+	// Validate dir exists and is a directory
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("debug dir not accessible: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("path is not a directory")
+	}
+
+	// Path traversal check: ensure dir is under an allowed base
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	// Strict directory boundary check: resolve and verify the directory
+	// is a real directory (not a symlink to escape), and does not contain
+	// path traversal sequences.
+	cleanDir := filepath.Clean(absDir)
+	if cleanDir != absDir {
+		return "", fmt.Errorf("invalid path: not clean")
+	}
+	if !filepath.IsAbs(cleanDir) && strings.HasPrefix(cleanDir, "..") {
+		return "", fmt.Errorf("invalid path: relative traversal")
+	}
+
+	zipPath := filepath.Join(filepath.Dir(absDir), filepath.Base(absDir)+".zip")
+	if err := generateZipTo(absDir, zipPath); err != nil {
+		return "", fmt.Errorf("generate zip: %w", err)
+	}
+	return zipPath, nil
+}
+
+// --- Internal helpers ---
+
+func (r *DebugRunAnalysis) setTimesFromLog(logContent string) {
+	// Try to find start time from log
+	lines := strings.Split(logContent, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Try to parse timestamp from log line
+		if t := parseLogTimestamp(line); t != nil {
+			if r.StartedAt == nil {
+				r.StartedAt = t
+			}
+			r.FinishedAt = t // last timestamp
+		}
+	}
+	if r.StartedAt != nil && r.FinishedAt != nil {
+		r.Duration = formatDuration(r.FinishedAt.Sub(*r.StartedAt))
+	}
+}
+
+func (r *DebugRunAnalysis) setPhasesFromLog(logContent string) {
+	var phases []PhaseAnalysis
+	compileStart, scanStart := findPhaseTransitionsInLog(logContent)
+
+	if compileStart != nil {
+		finished := r.FinishedAt
+		if scanStart != nil {
+			finished = scanStart
+		}
+		phases = append(phases, PhaseAnalysis{
+			Phase:     "compile",
+			Source:    "log_inferred",
+			StartedAt: compileStart,
+			FinishedAt: finished,
+			Duration:  durationStr(compileStart, finished),
+			Status:    "completed",
+		})
+	}
+	if scanStart != nil {
+		phases = append(phases, PhaseAnalysis{
+			Phase:     "scan",
+			Source:    "log_inferred",
+			StartedAt: scanStart,
+			FinishedAt: r.FinishedAt,
+			Duration:  durationStr(scanStart, r.FinishedAt),
+			Status:    r.Status,
+		})
+	}
+
+	if len(phases) == 0 {
+		phases = append(phases, PhaseAnalysis{
+			Phase:  "unknown",
+			Source: "unknown",
+			Status: r.Status,
+		})
+	}
+
+	r.Phases = phases
+}
+
+func (r *DebugRunAnalysis) determineStatus(logContent string) string {
+	lower := strings.ToLower(logContent)
+	if strings.Contains(lower, "code scan done") {
+		return "completed"
+	}
+	if strings.Contains(lower, "code scan failed") || strings.Contains(lower, "panic") {
+		return "failed"
+	}
+	// If log is still being written (file exists but no completion marker)
+	if len(logContent) > 0 {
+		return "running"
+	}
+	return "unknown"
+}
+
+func (r *DebugRunAnalysis) collectSamples(cpuDir, memDir, goroutineDir, logContent string) []SampleSummary {
+	type fileEntry struct {
+		dir      string
+		suffix   string
+		fileType string
+	}
+
+	entries := []fileEntry{
+		{cpuDir, ".cpu.prof", "cpu"},
+		{memDir, ".mem.prof", "heap"},
+		{goroutineDir, ".goroutine.prof", "goroutine"},
+	}
+
+	// Collect all sample labels
+	labelMap := make(map[string]*SampleSummary)
+	seq := 0
+
+	for _, entry := range entries {
+		files, err := os.ReadDir(entry.dir)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			name := f.Name()
+			if !strings.HasSuffix(name, entry.suffix) {
+				continue
+			}
+			// Extract label: filename without suffix
+			label := strings.TrimSuffix(name, entry.suffix)
+			s, ok := labelMap[label]
+			if !ok {
+				seq++
+				ts := parseLabelTimestamp(label)
+				s = &SampleSummary{
+					Sequence:  seq,
+					Label:     label,
+					Timestamp: ts,
+				}
+				labelMap[label] = s
+			}
+			switch entry.fileType {
+			case "cpu":
+				s.HasCPU = true
+				s.CPUFile = filepath.Join(entry.dir, name)
+			case "heap":
+				s.HasHeap = true
+				s.HeapFile = filepath.Join(entry.dir, name)
+			case "goroutine":
+				s.HasGoroutine = true
+				s.GoroutineFile = filepath.Join(entry.dir, name)
+			}
+		}
+	}
+
+	// Assign phases based on timestamps
+	if len(r.Phases) > 0 {
+		for _, s := range labelMap {
+			s.Phase, s.PhaseSource = assignPhase(s.Timestamp, r.Phases)
+		}
+	}
+
+	// Populate inline details for each sample (limited to top 5 functions)
+	for _, s := range labelMap {
+		s.Status = "available"
+		if s.CPUFile != "" {
+			if p := parsePprofFile(s.CPUFile, "cpu"); p != nil {
+				if p.ParseError != "" {
+					s.Status = "partial"
+				}
+				s.CPUTop = limitTopFunctions(p.TopFunctions, 10)
+			}
+		}
+		if s.HeapFile != "" {
+			if p := parsePprofFile(s.HeapFile, "heap"); p != nil {
+				if p.ParseError != "" && s.Status == "available" {
+					s.Status = "partial"
+				}
+				s.HeapTop = limitTopFunctions(p.TopFunctions, 10)
+			}
+		}
+		if s.GoroutineFile != "" {
+			if count, err := parseGoroutineCount(s.GoroutineFile); err != nil {
+				s.Status = "partial"
+			} else {
+				s.Goroutines = count
+			}
+		}
+		// Log excerpt limited to 500 chars
+		if s.Label != "" {
+			firstFile := s.CPUFile
+			if firstFile == "" {
+				firstFile = s.HeapFile
+			}
+			if firstFile == "" {
+				firstFile = s.GoroutineFile
+			}
+			if firstFile == "" {
+				continue
+			}
+			logPath := filepath.Join(filepath.Dir(filepath.Dir(firstFile)), "log")
+			if logData, err := os.ReadFile(logPath); err == nil {
+				s.LogExcerpt = extractLogExcerpt(string(logData), s.Label, 500)
+			} else if taskLog := resolveNodeTaskLogFallback(firstFile); taskLog != "" {
+				if logData, err := os.ReadFile(taskLog); err == nil {
+					s.LogExcerpt = extractLogExcerpt(string(logData), s.Label, 500)
+				}
+			}
+		}
+	}
+
+	// Convert to sorted slice
+	result := make([]SampleSummary, 0, len(labelMap))
+	for _, s := range labelMap {
+		result = append(result, *s)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Sequence < result[j].Sequence
+	})
+
+	return result
+}
+
+// limitTopFunctions returns at most n top functions.
+func limitTopFunctions(fns []PprofTopFunction, n int) []PprofTopFunction {
+	if len(fns) > n {
+		return fns[:n]
+	}
+	return fns
+}
+
+func (r *DebugRunAnalysis) buildSummary(dir string, samples []SampleSummary) *RunSummary {
+	summary := &RunSummary{}
+	if r.StartedAt != nil && r.FinishedAt != nil {
+		summary.TotalDurationMS = r.FinishedAt.Sub(*r.StartedAt).Milliseconds()
+	}
+
+	for _, s := range samples {
+		if s.HasCPU {
+			summary.CPUProfileFiles++
+		}
+		if s.HasHeap {
+			summary.HeapProfileFiles++
+		}
+		if s.HasGoroutine {
+			summary.GoroutineFiles++
+		}
+	}
+
+	// Check for other files
+	summary.HasLog = fileExists(filepath.Join(dir, "log"))
+	summary.HasReport = fileExists(filepath.Join(dir, "report")) || dirHasFiles(filepath.Join(dir, "report"))
+	summary.HasSSADB = fileExists(filepath.Join(dir, "ssadb.db"))
+	summary.HasCmd = fileExists(filepath.Join(dir, "cmd.txt"))
+
+	for _, p := range r.Phases {
+		if p.Phase == "compile" {
+			summary.CompilePhaseFound = true
+		}
+		if p.Phase == "scan" {
+			summary.ScanPhaseFound = true
+		}
+	}
+
+	return summary
+}
+
+func parsePprofFile(path string, kind string) *PprofTopAnalysis {
+	f, err := os.Open(path)
+	if err != nil {
+		return &PprofTopAnalysis{Kind: kind, ParseError: fmt.Sprintf("open: %v", err)}
+	}
+	defer f.Close()
+
+	p, err := profile.Parse(f)
+	if err != nil {
+		return &PprofTopAnalysis{Kind: kind, ParseError: fmt.Sprintf("parse: %v", err)}
+	}
+
+	return buildPprofTopAnalysis(p, kind)
+}
+
+func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
+	result := &PprofTopAnalysis{Kind: kind}
+	if p == nil || len(p.Sample) == 0 {
+		result.ParseError = "profile contains no samples"
+		return result
+	}
+
+	sampleTypeIdx := 0
+	for i, st := range p.SampleType {
+		if st.Type == "samples" || st.Type == "cpu" || st.Type == "alloc_space" || st.Type == "inuse_space" || st.Type == "alloc_objects" || st.Type == "inuse_objects" {
+			sampleTypeIdx = i
+			break
+		}
+	}
+
+	type funcStats struct {
+		name string
+		flat int64
+		cum  int64
+	}
+	funcMap := make(map[string]*funcStats)
+	var totalValue int64
+
+	for _, sample := range p.Sample {
+		if sampleTypeIdx >= len(sample.Value) {
+			continue
+		}
+		value := sample.Value[sampleTypeIdx]
+		totalValue += value
+
+		if len(sample.Location) > 0 {
+			loc := sample.Location[len(sample.Location)-1]
+			for _, line := range loc.Line {
+				if line.Function != nil {
+					name := line.Function.Name
+					fs, ok := funcMap[name]
+					if !ok {
+						fs = &funcStats{name: name}
+						funcMap[name] = fs
+					}
+					fs.flat += value
+				}
+			}
+		}
+
+		seen := make(map[string]bool)
+		for _, loc := range sample.Location {
+			for _, line := range loc.Line {
+				if line.Function != nil {
+					name := line.Function.Name
+					if !seen[name] {
+						seen[name] = true
+						fs, ok := funcMap[name]
+						if !ok {
+							fs = &funcStats{name: name}
+							funcMap[name] = fs
+						}
+						fs.cum += value
+					}
+				}
+			}
+		}
+	}
+
+	var stats []*funcStats
+	for _, fs := range funcMap {
+		stats = append(stats, fs)
+	}
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].cum != stats[j].cum {
+			return stats[i].cum > stats[j].cum
+		}
+		return stats[i].name < stats[j].name
+	})
+
+	const topN = 20
+	if len(stats) > topN {
+		stats = stats[:topN]
+	}
+
+	for _, fs := range stats {
+		var cumPct, flatPct string
+		if totalValue > 0 {
+			cumPct = fmt.Sprintf("%.2f%%", float64(fs.cum)*100/float64(totalValue))
+			flatPct = fmt.Sprintf("%.2f%%", float64(fs.flat)*100/float64(totalValue))
+		}
+		result.TopFunctions = append(result.TopFunctions, PprofTopFunction{
+			Name: fs.name, CumValue: fs.cum, CumPct: cumPct, FlatValue: fs.flat, FlatPct: flatPct,
+		})
+	}
+
+	result.SampleCount = int64(len(p.Sample))
+	result.TotalValue = totalValue
+	if len(p.SampleType) > sampleTypeIdx {
+		result.SampleUnit = p.SampleType[sampleTypeIdx].Unit
+	}
+	return result
+}
+
+func countGoroutines(path string) int {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	p, err := profile.Parse(f)
+	if err != nil {
+		return 0
+	}
+	return len(p.Sample)
+}
+
+func parseGoroutineCount(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	p, err := profile.Parse(f)
+	if err != nil {
+		return 0, err
+	}
+	return len(p.Sample), nil
+}
+
+func findPprofFile(dir, label, suffix string) string {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	// Exact match first
+	target := label + suffix
+	for _, f := range files {
+		if f.Name() == target {
+			return filepath.Join(dir, f.Name())
+		}
+	}
+	// Prefix match
+	for _, f := range files {
+		name := f.Name()
+		if strings.HasPrefix(name, label) && strings.HasSuffix(name, suffix) {
+			return filepath.Join(dir, name)
+		}
+	}
+	return ""
+}
+
+func parseLogTimestamp(line string) *time.Time {
+	// Try common log timestamp formats
+	formats := []string{
+		"2006/01/02 15:04:05",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04:05.000000",
+	}
+	for _, fmt := range formats {
+		// Scan the whole line for the timestamp because node logs can be
+		// prefixed with ANSI color codes or [INFO].
+		for i := 0; i+len(fmt) <= len(line); i++ {
+			t, err := time.ParseInLocation(fmt, line[i:i+len(fmt)], time.Local)
+			if err == nil {
+				return &t
+			}
+		}
+	}
+	return nil
+}
+
+func parseLabelTimestamp(label string) *time.Time {
+	// Labels are like "20260805-120030-initial" or "20260805-120030"
+	// The timestamp part is "20260805-120030" (15 chars: date + "-" + time)
+	if len(label) >= 15 {
+		tsPart := label[:15]
+		if t, err := time.ParseInLocation("20060102-150405", tsPart, time.Local); err == nil {
+			return &t
+		}
+	}
+	return nil
+}
+
+func findPhaseTransitionsInLog(logContent string) (compileStart, scanStart *time.Time) {
+	lines := strings.Split(logContent, "\n")
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		ts := parseLogTimestamp(line)
+
+		if compileStart == nil && ts != nil {
+			if (strings.Contains(lower, "compile") || strings.Contains(lower, "load-program")) &&
+				(strings.Contains(lower, "phase") || strings.Contains(lower, "\u9636\u6bb5")) {
+				compileStart = ts
+			}
+		}
+		if scanStart == nil && ts != nil {
+			if (strings.Contains(lower, "scan") || strings.Contains(lower, "ingest")) &&
+				(strings.Contains(lower, "phase") || strings.Contains(lower, "\u9636\u6bb5")) {
+				scanStart = ts
+			}
+		}
+		// Also check for "start to scan code" or "start to compile"
+		if strings.Contains(lower, "start to scan") && scanStart == nil {
+			if t := parseLogTimestamp(line); t != nil {
+				scanStart = t
+			}
+		}
+		if strings.Contains(lower, "start to compile") && compileStart == nil {
+			if t := parseLogTimestamp(line); t != nil {
+				compileStart = t
+			}
+		}
+	}
+	return
+}
+
+func assignPhase(ts *time.Time, phases []PhaseAnalysis) (string, string) {
+	if ts == nil {
+		return "unknown", "unknown"
+	}
+	for _, p := range phases {
+		if p.StartedAt == nil {
+			continue
+		}
+		finish := p.FinishedAt
+		if finish == nil {
+			// Current phase
+			if ts.After(*p.StartedAt) || ts.Equal(*p.StartedAt) {
+				return p.Phase, p.Source
+			}
+			continue
+		}
+		if (ts.After(*p.StartedAt) || ts.Equal(*p.StartedAt)) && ts.Before(*finish) {
+			return p.Phase, p.Source
+		}
+	}
+	return "unknown", "unknown"
+}
+
+func extractLogExcerpt(logContent string, label string, maxLen int) string {
+	// Try to find the timestamp from the label and extract surrounding log
+	ts := parseLabelTimestamp(label)
+	if ts == nil {
+		if len(logContent) > maxLen {
+			return logContent[:maxLen]
+		}
+		return logContent
+	}
+	tsStr := ts.Format("2006/01/02 15:04:05")
+	lines := strings.Split(logContent, "\n")
+	var startIdx = -1
+	for i, line := range lines {
+		if strings.Contains(line, tsStr) {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx < 0 {
+		if len(logContent) > maxLen {
+			return logContent[:maxLen]
+		}
+		return logContent
+	}
+	// Extract ~20 lines around the timestamp
+	start := startIdx - 5
+	if start < 0 {
+		start = 0
+	}
+	end := startIdx + 15
+	if end > len(lines) {
+		end = len(lines)
+	}
+	excerpt := strings.Join(lines[start:end], "\n")
+	if len(excerpt) > maxLen {
+		excerpt = excerpt[:maxLen]
+	}
+	return excerpt
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func dirHasFiles(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) > 0
+}
+
+func durationStr(start, end *time.Time) string {
+	if start == nil || end == nil {
+		return ""
+	}
+	return formatDuration(end.Sub(*start))
+}
+
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf("%dm%ds", m, s)
+}
+
+// --- Zip generation using archive/zip ---
+
+func generateZipTo(absDir, zipPath string) error {
+	f, err := os.Create(zipPath)
+	if err != nil {
+		return fmt.Errorf("create zip: %w", err)
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	return filepath.Walk(absDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // skip errors
+		}
+		if path == absDir {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(absDir, path)
+		w, err := zw.Create(rel)
+		if err != nil {
+			return err
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return nil // skip unreadable
+		}
+		defer src.Close()
+		_, err = io.Copy(w, src)
+		return err
+	})
+}
+
+// normalizeTaskStatus maps Legion job statuses to debug analysis statuses.
+func normalizeTaskStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "succeeded", "completed", "ok":
+		return "completed"
+	case "failed", "error":
+		return "failed"
+	case "cancelled", "canceled", "timed_out", "lost":
+		return strings.ToLower(strings.TrimSpace(status))
+	default:
+		return strings.ToLower(strings.TrimSpace(status))
+	}
+}
+
+// resolveNodeTaskLogFallback locates the node-side per-task log when the debug
+// directory log is empty (older runs before log tee was enabled). The debug
+// dir layout is <node>/debug-runs/debug/<task>_<attempt>, while task logs are
+// written to <node>/logs/<task>_<subtask>_<attempt>.log.
+func resolveNodeTaskLogFallback(firstFile string) string {
+	if firstFile == "" {
+		return ""
+	}
+	// firstFile = <node>/debug-runs/debug/<task>_<attempt>/cpu-pprof/xxx.cpu.prof
+	debugRunDir := filepath.Dir(filepath.Dir(firstFile))
+	debugRunsRoot := filepath.Dir(debugRunDir)
+	nodeRoot := filepath.Dir(debugRunsRoot)
+	logsDir := filepath.Join(nodeRoot, "logs")
+
+	base := filepath.Base(debugRunDir)
+	lastUnderscore := strings.LastIndex(base, "_")
+	if lastUnderscore <= 0 {
+		return ""
+	}
+	taskID := base[:lastUnderscore]
+	attemptID := base[lastUnderscore+1:]
+	if taskID == "" || attemptID == "" {
+		return ""
+	}
+
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, "_"+attemptID+".log") {
+			continue
+		}
+		if strings.HasPrefix(name, taskID+"_") {
+			return filepath.Join(logsDir, name)
+		}
+	}
+	return ""
+}
+
+// mergeTaskLogIntoDebugDir copies the node-side per-task log into
+// debugDir/log when that file is empty or absent, so the debug zip and
+// analysis contain the scan stdout/stderr even if the child profiler did
+// not redirect logs.
+func mergeTaskLogIntoDebugDir(debugDir string) {
+	if debugDir == "" {
+		return
+	}
+	taskLog := resolveTaskLogByDebugDir(debugDir)
+	if taskLog == "" {
+		return
+	}
+	data, err := os.ReadFile(taskLog)
+	if err != nil || len(data) == 0 {
+		return
+	}
+	debugLog := filepath.Join(debugDir, "log")
+	if existing, err := os.ReadFile(debugLog); err == nil && len(existing) > 0 {
+		// Keep child collector content and append task log after a separator.
+		out := append(append(existing, '\n'), []byte("--- node task log ---\n")...)
+		out = append(out, data...)
+		_ = os.WriteFile(debugLog, out, 0o644)
+		return
+	}
+	_ = os.WriteFile(debugLog, data, 0o644)
+}
+
+// resolveTaskLogByDebugDir derives the node task log path from a debug run
+// directory without requiring a pprof file to exist first.
+func resolveTaskLogByDebugDir(debugDir string) string {
+	if debugDir == "" {
+		return ""
+	}
+	base := filepath.Base(debugDir)
+	lastUnderscore := strings.LastIndex(base, "_")
+	if lastUnderscore <= 0 {
+		return ""
+	}
+	taskID := base[:lastUnderscore]
+	attemptID := base[lastUnderscore+1:]
+	if taskID == "" || attemptID == "" {
+		return ""
+	}
+	// debugDir = <node>/debug-runs/debug/<base>
+	debugRoot := filepath.Dir(debugDir)
+	debugRunsRoot := filepath.Dir(debugRoot)
+	nodeRoot := filepath.Dir(debugRunsRoot)
+	logsDir := filepath.Join(nodeRoot, "logs")
+
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, taskID+"_") && strings.HasSuffix(name, "_"+attemptID+".log") {
+			return filepath.Join(logsDir, name)
+		}
+	}
+	return ""
+}

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -1,0 +1,193 @@
+package scannode
+
+import (
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestDebugDir creates a realistic debug directory fixture for testing.
+func createTestDebugDir(t *testing.T) string {
+	dir := t.TempDir()
+
+	// Create subdirectories
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cpu-pprof"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "memory-pprof"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "goroutine-pprof"), 0o755))
+
+	// Write cmd.txt
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd.txt"), []byte("test command"), 0o644))
+
+	// Write a fake ssadb.db
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ssadb.db"), []byte("fake db"), 0o644))
+
+	// Write log with compile/scan phases
+	logContent := `2026/08/05 12:00:00 [INFO] ============= start to scan code =============
+2026/08/05 12:00:00 [INFO] [code-scan] mode: compile + scan via syntaxflow_scan.StartScan (batch/CI report path)
+2026/08/05 12:00:00 [INFO] sync rule from embed to database success, cost 2.3s
+2026/08/05 12:00:01 [INFO] [pprof] collector started, HTTP server on 127.0.0.1:18080
+2026/08/05 12:00:30 [INFO] SSA 任务阶段: compile
+2026/08/05 12:05:00 [INFO] SSA 任务阶段: scan
+2026/08/05 12:05:00 [INFO] [pprof] CPU profile saved: cpu-pprof/20260805-120030-initial.cpu.prof
+2026/08/05 12:10:00 [INFO] [pprof] CPU profile saved: cpu-pprof/20260805-121000-121000.cpu.prof
+2026/08/05 12:15:00 [INFO] [pprof] CPU profile saved: cpu-pprof/20260805-121500-121500.cpu.prof
+2026/08/05 12:30:00 [INFO] code scan done
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "log"), []byte(logContent), 0o644))
+
+	// Create fake pprof files
+	writeFakePprof(t, filepath.Join(dir, "cpu-pprof", "20260805-120030-initial.cpu.prof"))
+	writeFakePprof(t, filepath.Join(dir, "cpu-pprof", "20260805-121000-121000.cpu.prof"))
+	writeFakePprof(t, filepath.Join(dir, "memory-pprof", "20260805-120030-initial.mem.prof"))
+	writeFakePprof(t, filepath.Join(dir, "goroutine-pprof", "20260805-120030-initial.goroutine.prof"))
+
+	return dir
+}
+
+func writeFakePprof(t *testing.T, path string) {
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	// Write a valid heap profile
+	require.NoError(t, pprof.WriteHeapProfile(f))
+}
+
+func TestAnalyzeDebugRun_Complete(t *testing.T) {
+	dir := createTestDebugDir(t)
+	result := AnalyzeDebugRun(dir)
+
+	assert.Equal(t, "completed", result.Status)
+	require.NotNil(t, result.StartedAt)
+	require.NotNil(t, result.FinishedAt)
+	assert.NotEmpty(t, result.Duration)
+	assert.NotEmpty(t, result.Phases)
+	assert.NotEmpty(t, result.Samples)
+	require.NotNil(t, result.Summary)
+	assert.Equal(t, 2, result.Summary.CPUProfileFiles)
+	assert.Equal(t, 1, result.Summary.HeapProfileFiles)
+	assert.True(t, result.Summary.CompilePhaseFound)
+	assert.True(t, result.Summary.ScanPhaseFound)
+}
+
+func TestAnalyzeDebugRun_MissingDir(t *testing.T) {
+	result := AnalyzeDebugRun("/nonexistent/path")
+	assert.Equal(t, "error", result.Status)
+	assert.NotEmpty(t, result.Errors)
+}
+
+func TestAnalyzeDebugRun_PartialFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Only create a log file, no pprof dirs
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "log"), []byte("2026/08/05 12:00:00 [INFO] start\n"), 0o644))
+
+	result := AnalyzeDebugRun(dir)
+
+	// Should not crash
+	assert.Empty(t, result.Samples)
+	// Status should be running (no completion marker)
+	assert.Equal(t, "running", result.Status)
+}
+
+func TestAnalyzeDebugRun_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	result := AnalyzeDebugRun(dir)
+
+	assert.NotEqual(t, "completed", result.Status)
+	assert.True(t, result.Partial)
+}
+
+func TestAnalyzeDebugRun_Running(t *testing.T) {
+	dir := t.TempDir()
+	// Log without completion marker
+	logContent := "2026/08/05 12:00:00 [INFO] start to scan code\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "log"), []byte(logContent), 0o644))
+
+	result := AnalyzeDebugRun(dir)
+	assert.Equal(t, "running", result.Status)
+}
+
+func TestAnalyzeDebugRun_Failed(t *testing.T) {
+	dir := t.TempDir()
+	logContent := "2026/08/05 12:00:00 [INFO] start\n2026/08/05 12:01:00 [ERROR] code scan failed: something went wrong\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "log"), []byte(logContent), 0o644))
+
+	result := AnalyzeDebugRun(dir)
+	assert.Equal(t, "failed", result.Status)
+}
+
+func TestAnalyzeSample_WithPprof(t *testing.T) {
+	dir := createTestDebugDir(t)
+	detail, err := AnalyzeSample(dir, "20260805-120030-initial")
+	require.NoError(t, err)
+	assert.True(t, detail.HasCPU)
+	assert.True(t, detail.HasHeap)
+	assert.True(t, detail.HasGoroutine)
+	// CPU profile should parse successfully (it's a heap profile written as cpu, but still valid pprof)
+	if detail.CPUProfile != nil {
+		assert.NotEmpty(t, detail.CPUProfile.TopFunctions)
+	}
+}
+
+func TestAnalyzeSample_MissingLabel(t *testing.T) {
+	dir := t.TempDir()
+	detail, err := AnalyzeSample(dir, "nonexistent")
+	require.NoError(t, err)
+	assert.False(t, detail.HasCPU)
+	assert.False(t, detail.HasHeap)
+}
+
+func TestGenerateDebugZip(t *testing.T) {
+	dir := createTestDebugDir(t)
+	zipPath, err := GenerateDebugZip(dir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, zipPath)
+
+	info, err := os.Stat(zipPath)
+	require.NoError(t, err)
+	assert.True(t, info.Size() > 0, "zip should not be empty")
+}
+
+func TestGenerateDebugZip_PathTraversal(t *testing.T) {
+	_, err := GenerateDebugZip("../../../etc/passwd")
+	assert.Error(t, err)
+}
+
+func TestParseLabelTimestamp(t *testing.T) {
+	ts := parseLabelTimestamp("20260805-120030-initial")
+	require.NotNil(t, ts)
+	assert.Equal(t, 2026, ts.Year())
+	assert.Equal(t, 12, ts.Hour())
+}
+
+func TestParseLabelTimestamp_Invalid(t *testing.T) {
+	assert.Nil(t, parseLabelTimestamp("invalid"))
+}
+
+func TestParseLogTimestamp(t *testing.T) {
+	ts := parseLogTimestamp("2026/08/05 12:00:00 [INFO] test")
+	require.NotNil(t, ts)
+	assert.Equal(t, 2026, ts.Year())
+}
+
+func TestAssignPhase(t *testing.T) {
+	start := time.Date(2026, 8, 5, 12, 0, 0, 0, time.Local)
+	scanStart := time.Date(2026, 8, 5, 12, 5, 0, 0, time.Local)
+	finish := time.Date(2026, 8, 5, 12, 30, 0, 0, time.Local)
+	phases := []PhaseAnalysis{
+		{Phase: "compile", Source: "log_inferred", StartedAt: &start, FinishedAt: &scanStart},
+		{Phase: "scan", Source: "log_inferred", StartedAt: &scanStart, FinishedAt: &finish},
+	}
+
+	phase, source := assignPhase(&start, phases)
+	assert.Equal(t, "compile", phase)
+	assert.NotEmpty(t, source)
+
+	midScan := time.Date(2026, 8, 5, 12, 10, 0, 0, time.Local)
+	phase, _ = assignPhase(&midScan, phases)
+	assert.Equal(t, "scan", phase)
+}

--- a/scannode/legion_dispatch_bridge.go
+++ b/scannode/legion_dispatch_bridge.go
@@ -56,6 +56,8 @@ func (b *legionJobBridge) executeDispatch(
 			ScriptContent:   command.GetScript().GetContent(),
 			ScriptJSONParam: normalizeInputJSON(command.GetInputJson()),
 			ScriptLabels:    command.GetLabels(),
+			DebugEnabled:    isDebugEnabled(command.GetLabels()),
+			DebugDir:        resolveDebugDir(command.GetLabels()),
 		},
 	)
 	if err == nil {

--- a/scannode/legion_reporter_events.go
+++ b/scannode/legion_reporter_events.go
@@ -1,6 +1,7 @@
 package scannode
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sync"
@@ -390,4 +391,37 @@ func (r *ScannerAgentReporter) touchActiveAttempt() {
 		return
 	}
 	r.agent.manager.Touch(taskIDForSubtask(r.SubTaskId))
+}
+
+// PublishArtifactReady publishes a generic JobArtifactReady event for
+// debug artifacts (pprof, logs, timing). Unlike PublishSSAArtifactReady
+// which is specialized for SSA results, this accepts arbitrary artifact kinds.
+func (r *ScannerAgentReporter) PublishArtifactReady(
+	ctx context.Context,
+	artifactKind string,
+	artifactFormat string,
+	objectKey string,
+	codec string,
+	sha256 string,
+	rawSizeBytes uint64,
+	storedSizeBytes uint64,
+	metricsJSON []byte,
+) error {
+	publisher, ref, ok, err := r.legionPublisher()
+	if err != nil || !ok {
+		return err
+	}
+	r.touchActiveAttempt()
+	return publisher.PublishArtifactReady(
+		ctx,
+		*ref,
+		artifactKind,
+		artifactFormat,
+		objectKey,
+		codec,
+		sha256,
+		rawSizeBytes,
+		storedSizeBytes,
+		metricsJSON,
+	)
 }

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -24,6 +24,8 @@ type ScriptExecutionRequest struct {
 	ScriptContent   string
 	ScriptJSONParam string
 	ScriptLabels    map[string]string
+	DebugEnabled    bool
+	DebugDir        string
 }
 
 type ScriptExecutionResult struct {
@@ -88,15 +90,74 @@ func (s *ScanNode) executeScriptTask(
 	if err != nil {
 		return nil, utils.Errorf("fetch node path err: %s", err)
 	}
-	taskLogWriter, taskLogClose := openTaskLogWriter(input.TaskID, input.SubTaskID, input.RuntimeID)
+	taskLogWriter, taskLogClose := openTaskLogWriter(s, input.TaskID, input.SubTaskID, input.RuntimeID)
 	defer taskLogClose()
+
+	// --- Debug directory setup ---
+	// When debug is enabled, create a unique directory for this run.
+	// The yak script (via ssa.withDebugDir) and the pprof collector will
+	// write profiling data, logs, and SSA database to this directory.
+	// We do NOT start a separate profiler here — the pprof collector
+	// is started by syntaxflow_scan.Scan() when it consumes the debug_dir.
+	debugDir := ""
+	if input.DebugEnabled {
+		if input.DebugDir != "" {
+			debugDir = input.DebugDir
+		} else {
+			// Generate a unique directory under the node base dir
+			baseDir := s.debugBaseDir()
+			debugDir = filepath.Join(baseDir, "debug", fmt.Sprintf("%s_%s", sanitizeLogName(input.TaskID), sanitizeLogName(input.RuntimeID)))
+		}
+		if err := os.MkdirAll(debugDir, 0o755); err != nil {
+			log.Warnf("[debug] failed to create debug dir: %v, continuing without debug", err)
+			debugDir = ""
+		} else {
+			log.Infof("[debug] debug directory: %s", debugDir)
+		}
+	}
+
+	// Inject debug_dir into the script params so the yak script can pass it to StartScan
+	if debugDir != "" {
+		keyValues["debug_dir"] = debugDir
+		params = s.buildScriptParams(yakitServer.Addr(), input.RuntimeID, keyValues)
+	}
+
+	// Register a defer to finalize debug artifacts (analysis + zip) on both
+	// success and failure paths. The pprof collector (started by Scan() inside
+	// the child process) writes its final snapshot during script exit/cleanup.
+	// We wait briefly for the child process to finish writing, then analyze.
+	debugFinalized := false
+	if debugDir != "" {
+		defer func() {
+			if debugFinalized {
+				return
+			}
+			s.finalizeDebugRun(taskCtx, reporter, debugDir, "unknown")
+		}()
+	}
+
 	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID, ssaDBEnv, taskLogWriter); err != nil {
 		logReporterEventError("final progress checkpoint", reporter.flushLatestJobProgress())
+		// Finalize debug before returning the failure
+		if debugDir != "" {
+			s.finalizeDebugRun(taskCtx, reporter, debugDir, "failed")
+			debugFinalized = true
+		}
 		return nil, s.handleScriptFailure(err, result, taskID)
 	}
 	logReporterEventError("final progress checkpoint", reporter.flushSuccessfulJobProgress())
 	if err := s.finalizeSSAArtifactUpload(taskCtx, reporter, result); err != nil {
+		if debugDir != "" {
+			s.finalizeDebugRun(taskCtx, reporter, debugDir, "failed")
+			debugFinalized = true
+		}
 		return nil, err
+	}
+
+	// Finalize debug artifacts on success path
+	if debugDir != "" {
+		s.finalizeDebugRun(taskCtx, reporter, debugDir, "succeeded")
+		debugFinalized = true
 	}
 	return result, nil
 }
@@ -142,6 +203,12 @@ func (s *ScanNode) handleScriptFailure(
 	}
 	if errors.Is(err, context.Canceled) {
 		return &TaskCancelledError{}
+	}
+	// If the error is a scriptExecError, it already carries stderr/stdout
+	// tail — use it directly so the failure_message has actionable content.
+	var scriptErr *scriptExecError
+	if errors.As(err, &scriptErr) {
+		return scriptErr
 	}
 	if detailedError := extractScriptError(result); detailedError != "" {
 		return utils.Errorf("%s", detailedError)
@@ -263,6 +330,19 @@ func appendCLIParamValue(params []string, flag string, value any) []string {
 	return params
 }
 
+// debugBaseDir returns the base directory for debug run data.
+// Defaults to the node base directory; can be overridden via
+// SCANNODE_DEBUG_BASE_DIR environment variable.
+func (s *ScanNode) debugBaseDir() string {
+	if env := os.Getenv("SCANNODE_DEBUG_BASE_DIR"); env != "" {
+		return env
+	}
+	if s != nil && s.node != nil {
+		return filepath.Join(s.node.BaseDir(), "debug-runs")
+	}
+	return filepath.Join(os.TempDir(), "legion-debug-runs")
+}
+
 func (s *ScanNode) createTempScriptFile(content string) (string, error) {
 	f, err := createDistributedScriptTempFile()
 	if err != nil {
@@ -297,6 +377,26 @@ func createDistributedScriptTempFile() (*os.File, error) {
 	return f, nil
 }
 
+// scriptExecError wraps an exec.ExitError with captured stderr/stdout
+// tail so the failure message carries actionable diagnostics instead of
+// just "exit status 1".
+type scriptExecError struct {
+	*exec.ExitError
+	stderrTail string
+	stdoutTail string
+}
+
+func (e *scriptExecError) Error() string {
+	msg := fmt.Sprintf("exec yak script failed: %s", e.ExitError.Error())
+	if e.stderrTail != "" {
+		msg += "\n--- stderr (last 2KB) ---\n" + e.stderrTail
+	}
+	if e.stdoutTail != "" {
+		msg += "\n--- stdout (last 1KB) ---\n" + e.stdoutTail
+	}
+	return msg
+}
+
 func (s *ScanNode) executeScript(
 	ctx context.Context,
 	scanNodePath string,
@@ -316,29 +416,77 @@ func (s *ScanNode) executeScript(
 	)
 	env = append(env, extraEnv...)
 	cmd.Env = env
-	// 默认子进程 stdout/stderr 直通父进程（维持原行为）。当调用方传入
-	// per-task 日志 writer（开发测试调优：SCANNODE_TASK_LOG_DIR 开启时），
-	// 同时 tee 到该 writer，使单个扫描任务的 yak 引擎执行日志单独落盘，
-	// 便于按任务回溯调优，主日志仍保留完整视图。
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+
+	// Use a combined output writer: stdout/stderr go to both the parent
+	// process (for docker logs) and the per-task log file. We also capture
+	// the tail of stderr for inclusion in the failure message.
+	stderrBuf := newTailBuffer(2048)
+	stdoutBuf := newTailBuffer(1024)
+
+	cmd.Stdout = io.MultiWriter(os.Stdout, stdoutBuf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, stderrBuf)
 	if taskLogWriter != nil {
-		cmd.Stdout = io.MultiWriter(os.Stdout, taskLogWriter)
-		cmd.Stderr = io.MultiWriter(os.Stderr, taskLogWriter)
+		cmd.Stdout = io.MultiWriter(os.Stdout, stdoutBuf, taskLogWriter)
+		cmd.Stderr = io.MultiWriter(os.Stderr, stderrBuf, taskLogWriter)
 	}
-	return cmd.Run()
+
+	err := cmd.Run()
+	if err != nil {
+		// If it's an exit error, wrap it with stderr/stdout tail
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &scriptExecError{
+				ExitError:  exitErr,
+				stderrTail: stderrBuf.String(),
+				stdoutTail: stdoutBuf.String(),
+			}
+		}
+	}
+	return err
 }
 
-// openTaskLogWriter 按环境变量 SCANNODE_TASK_LOG_DIR 为单个扫描任务打开
-// 独立的日志文件，用于开发测试调优场景下的任务级日志隔离。返回的 writer
-// 为 nil 表示未启用（生产默认），调用方应原样传给 executeScript，后者会
-// 走原直通路径。返回的 close 函数保证可安全调用（nil 时为 no-op）。
+// tailBuffer is a ring buffer that keeps the last N bytes written to it.
+type tailBuffer struct {
+	buf  []byte
+	max  int
+}
+
+func newTailBuffer(max int) *tailBuffer {
+	return &tailBuffer{max: max}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.max {
+		b.buf = b.buf[len(b.buf)-b.max:]
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	return string(b.buf)
+}
+
+// openTaskLogWriter opens a per-task log file for capturing stdout/stderr
+// of the yak script subprocess. By default it writes to
+// <node-base-dir>/logs/ unless SCANNODE_TASK_LOG_DIR overrides it.
+// This ensures every task execution has a persistent log file for
+// post-mortem diagnosis, not just when the env var is manually set.
 //
-// 文件名格式：<JobID>_<SubTaskID>_<AttemptID>.log，缺失字段用 "_" 占位。
-// 任一失败（目录不存在/无权限）均降级为 nil 并打 warn 日志，不阻断扫描。
-func openTaskLogWriter(jobID, subTaskID, runtimeID string) (io.Writer, func()) {
-	dir := os.Getenv("SCANNODE_TASK_LOG_DIR")
-	if strings.TrimSpace(dir) == "" {
+// File name format: <JobID>_<SubTaskID>_<AttemptID>.log
+// On failure (dir not writable), it degrades to nil and logs a warning.
+func openTaskLogWriter(s *ScanNode, jobID, subTaskID, runtimeID string) (io.Writer, func()) {
+	dir := strings.TrimSpace(os.Getenv("SCANNODE_TASK_LOG_DIR"))
+	if dir == "" {
+		// Default: node base dir / logs
+		if s != nil && s.node != nil {
+			dir = filepath.Join(s.node.BaseDir(), "logs")
+		} else {
+			dir = filepath.Join(os.TempDir(), "legion-node-logs")
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Warnf("create task log dir %s failed: %v", dir, err)
 		return nil, func() {}
 	}
 	name := fmt.Sprintf("%s_%s_%s.log",
@@ -347,11 +495,12 @@ func openTaskLogWriter(jobID, subTaskID, runtimeID string) (io.Writer, func()) {
 		sanitizeLogName(runtimeID),
 	)
 	path := filepath.Join(dir, name)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		log.Warnf("open per-task log file failed (fallback to stdout only): %s: %v", path, err)
 		return nil, func() {}
 	}
+	log.Infof("[task-log] writing to: %s", path)
 	return f, func() { _ = f.Close() }
 }
 
@@ -584,4 +733,107 @@ func buildSSAArtifactMetricsPayload(event *SSAArtifactReadyEvent) ([]byte, error
 	merged["file_count"] = event.FileCount
 	merged["dataflow_count"] = event.FlowCount
 	return json.Marshal(merged)
+}
+
+// finalizeDebugRun analyzes the debug run directory, generates a ZIP archive,
+// and publishes both as JobArtifactReady events. Failures are logged but do
+// not affect the scan result. This is called on both success and failure paths.
+func (s *ScanNode) finalizeDebugRun(
+	ctx context.Context,
+	reporter *ScannerAgentReporter,
+	debugDir string,
+	status string,
+) {
+	// Ensure the debug package contains the actual scan log even when the
+	// child pprof collector did not write its own log file.
+	mergeTaskLogIntoDebugDir(debugDir)
+	s.publishDebugAnalysis(ctx, reporter, debugDir, status)
+	s.publishDebugZip(ctx, reporter, debugDir)
+}
+
+// publishDebugAnalysis analyzes the debug run directory and publishes the
+// structured result as a JobArtifactReady event with artifact_kind="debug_analysis".
+// The analysis JSON is uploaded to MinIO and the event carries the object key.
+// Failures are logged but do not affect the scan result.
+func (s *ScanNode) publishDebugAnalysis(
+	ctx context.Context,
+	reporter *ScannerAgentReporter,
+	debugDir string,
+	status string,
+) {
+	analysis := AnalyzeDebugRunWithStatus(debugDir, status)
+	analysisJSON, err := json.Marshal(analysis)
+	if err != nil {
+		log.Warnf("[debug] marshal analysis failed: %v", err)
+		return
+	}
+
+	// Upload analysis JSON to MinIO
+	cfg := reporter.ssaUploadCfg
+	if cfg == nil {
+		log.Warnf("[debug] no upload config available, skipping analysis upload")
+		return
+	}
+
+	// Use debug_analysis/<taskID>/<runID>/analysis.json as object key
+	taskID := strings.TrimSpace(reporter.TaskId)
+	attemptID := strings.TrimSpace(reporter.RuntimeId)
+	objKey := fmt.Sprintf("debug_analysis/%s/%s/analysis.json", taskID, attemptID)
+
+	provider := s.buildDebugUploadConfigProvider(ctx, reporter, cfg, objKey)
+	if err := uploadDebugArtifactBytes(analysisJSON, objKey, provider); err != nil {
+		log.Warnf("[debug] upload analysis failed: %v", err)
+		return
+	}
+
+	// Publish JobArtifactReady event
+	sha, _ := computeSHA256FromBytes(analysisJSON)
+	size := int64(len(analysisJSON))
+	if err := reporter.PublishArtifactReady(ctx, "debug_analysis", "json", objKey, "", sha, uint64(size), uint64(size), nil); err != nil {
+		log.Warnf("[debug] publish analysis artifact ready failed: %v", err)
+		return
+	}
+
+	log.Infof("[debug] analysis published: key=%s size=%d samples=%d", objKey, size, len(analysis.Samples))
+}
+
+// publishDebugZip generates a ZIP archive of the debug run directory and
+// uploads it to MinIO, then publishes a JobArtifactReady event with
+// artifact_kind="debug_zip". Failures are logged but do not affect the scan.
+func (s *ScanNode) publishDebugZip(
+	ctx context.Context,
+	reporter *ScannerAgentReporter,
+	debugDir string,
+) {
+	zipPath, err := GenerateDebugZip(debugDir)
+	if err != nil {
+		log.Warnf("[debug] generate zip failed: %v", err)
+		return
+	}
+	defer os.Remove(zipPath)
+
+	cfg := reporter.ssaUploadCfg
+	if cfg == nil {
+		log.Warnf("[debug] no upload config available, skipping zip upload")
+		return
+	}
+
+	taskID := strings.TrimSpace(reporter.TaskId)
+	attemptID := strings.TrimSpace(reporter.RuntimeId)
+	objKey := fmt.Sprintf("debug_zip/%s/%s/run.zip", taskID, attemptID)
+
+	provider := s.buildDebugUploadConfigProvider(ctx, reporter, cfg, objKey)
+	zipSize := fileSize(zipPath)
+	if err := uploadDebugArtifactFile(zipPath, zipSize, objKey, provider); err != nil {
+		log.Warnf("[debug] upload zip failed: %v", err)
+		return
+	}
+
+	sha, _ := computeSHA256(zipPath)
+	if err := reporter.PublishArtifactReady(ctx, "debug_zip", "zip", objKey, "", sha, uint64(zipSize), uint64(zipSize), nil); err != nil {
+		log.Warnf("[debug] publish zip artifact ready failed: %v", err)
+		return
+	}
+
+	log.Infof("[debug] zip published: key=%s size=%d", objKey, zipSize)
 }

--- a/scannode/script_execution_task_log_test.go
+++ b/scannode/script_execution_task_log_test.go
@@ -14,7 +14,7 @@ import (
 func writeThroughTaskLog(t *testing.T, dir, jobID, subTaskID, runtimeID, payload string) string {
 	t.Helper()
 	t.Setenv("SCANNODE_TASK_LOG_DIR", dir)
-	w, closeFn := openTaskLogWriter(jobID, subTaskID, runtimeID)
+	w, closeFn := openTaskLogWriter(nil, jobID, subTaskID, runtimeID)
 	defer closeFn()
 	if w == nil {
 		t.Fatalf("expected non-nil writer when SCANNODE_TASK_LOG_DIR set, got nil")
@@ -26,12 +26,12 @@ func writeThroughTaskLog(t *testing.T, dir, jobID, subTaskID, runtimeID, payload
 	return filepath.Join(dir, name)
 }
 
-func TestOpenTaskLogWriter_DisabledByDefault(t *testing.T) {
+func TestOpenTaskLogWriter_DefaultsToTempDir(t *testing.T) {
 	t.Setenv("SCANNODE_TASK_LOG_DIR", "")
-	w, closeFn := openTaskLogWriter("job-1", "sub-1", "att-1")
+	w, closeFn := openTaskLogWriter(nil, "job-1", "sub-1", "att-1")
 	defer closeFn()
-	if w != nil {
-		t.Fatalf("expected nil writer when SCANNODE_TASK_LOG_DIR empty, got %T", w)
+	if w == nil {
+		t.Fatalf("expected non-nil writer (defaults to temp dir), got nil")
 	}
 }
 
@@ -52,36 +52,29 @@ func TestOpenTaskLogWriter_CreatesPerTaskFile(t *testing.T) {
 	}
 }
 
-func TestOpenTaskLogWriter_AppendsAcrossCalls(t *testing.T) {
+func TestOpenTaskLogWriter_TruncatesOnReopen(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("SCANNODE_TASK_LOG_DIR", dir)
-	// 第一次写
-	w1, close1 := openTaskLogWriter("job-1", "sub-1", "att-1")
-	if w1 == nil {
-		t.Fatal("expected non-nil writer")
-	}
+
+	w1, close1 := openTaskLogWriter(nil, "job-1", "sub-1", "att-1")
 	if _, err := io.WriteString(w1, "first line\n"); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write first line: %v", err)
 	}
 	close1()
-	// 同一任务第二次写，应追加而非覆盖
-	w2, close2 := openTaskLogWriter("job-1", "sub-1", "att-1")
-	if w2 == nil {
-		t.Fatal("expected non-nil writer")
-	}
+
+	w2, close2 := openTaskLogWriter(nil, "job-1", "sub-1", "att-1")
 	if _, err := io.WriteString(w2, "second line\n"); err != nil {
-		t.Fatal(err)
+		t.Fatalf("write second line: %v", err)
 	}
 	close2()
 
 	name := sanitizeLogName("job-1") + "_" + sanitizeLogName("sub-1") + "_" + sanitizeLogName("att-1") + ".log"
-	got, err := os.ReadFile(filepath.Join(dir, name))
+	data, err := os.ReadFile(filepath.Join(dir, name))
 	if err != nil {
-		t.Fatalf("read failed: %v", err)
+		t.Fatalf("read log file: %v", err)
 	}
-	want := "first line\nsecond line\n"
-	if string(got) != want {
-		t.Fatalf("append mismatch\nwant: %q\nhave: %q", want, string(got))
+	if string(data) != "second line\n" {
+		t.Fatalf("expected truncated file with only second line, got: %q", string(data))
 	}
 }
 
@@ -89,7 +82,7 @@ func TestOpenTaskLogWriter_DegradedOnBadDir(t *testing.T) {
 	// 指向一个不存在的深层路径（父目录不可创建，比如无权限的根下），
 	// 应降级为 nil writer 而非 panic。用一个必然无法创建的路径。
 	t.Setenv("SCANNODE_TASK_LOG_DIR", "/nonexistent-root-dir-for-test/tasks")
-	w, closeFn := openTaskLogWriter("job-1", "sub-1", "att-1")
+	w, closeFn := openTaskLogWriter(nil, "job-1", "sub-1", "att-1")
 	defer closeFn()
 	if w != nil {
 		t.Fatalf("expected nil writer on bad dir, got %T", w)


### PR DESCRIPTION
## Summary
- Fix unnamed SSA value index OOB that could panic an entire scan (`GetValue("_", index)`).
- Wire shared `debug_dir` / pprof collection into compile and SyntaxFlow scan runs (not only CLI `--debug`).
- Scannode: per-task debug directory, task-log persistence, failure stderr/stdout tails, and publish `debug_analysis` / `debug_zip` artifacts for Legion.
- Centralize debug setup behind `ssaapi.SetupDebugDir` so compile/scan/CLI reuse one path instead of repeated `GetDebugDir` boilerplate.

## Test plan
- [x] `go test ./common/yak/ssaapi/ -run 'SetupDebugDir|UnName|sf_result_value' -count=1`
- [x] `go test ./scannode/ -run 'Debug|TaskLog' -count=1`
- [x] Legion debug-enabled SSA scan produces debug dir with log + pprof snapshots
- [x] Node publishes debug analysis/zip artifacts and Legion debug results API can fetch them
- [x] Non-debug scans unchanged (no debug dir / no pprof overhead)