### PR TITLE
ci(legion): 支持通过 alpha tag 构建 Node 和 Runtime

### DIFF
--- a/.github/scripts/test-legion-component-workflow-contract.sh
+++ b/.github/scripts/test-legion-component-workflow-contract.sh
@@ -24,6 +24,31 @@ check_release_only_workflow \
   "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml" \
   'legion-runtime-v*'
 
+runtime_workflow="$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"
+runtime_alpha_workflow="$repo_root/.github/workflows/build-legion-ai-session-runtime-alpha.yml"
+check_release_only_workflow "$runtime_alpha_workflow" 'legion-runtime-alpha-*'
+grep -Fq 'workflow_call:' "$runtime_workflow"
+grep -Fq 'source_mode: alpha' "$runtime_alpha_workflow"
+grep -Fq 'retention_days: 7' "$runtime_alpha_workflow"
+grep -Fq 'uses: ./.github/workflows/build-legion-ai-session-runtime.yml' "$runtime_alpha_workflow"
+grep -Fq 'PUBLISH_OSS' "$runtime_workflow"
+grep -Fq 'if: env.PUBLISH_OSS == '\''true'\''' "$runtime_workflow"
+[[ "$(grep -Fc "if: env.PUBLISH_OSS == 'true'" "$runtime_workflow")" -eq 4 ]]
+grep -Fq '.docker.tar.gz' "$runtime_workflow"
+grep -Fq 'contents: read' "$runtime_alpha_workflow"
+if grep -Eq 'secrets: inherit|OSS_KEY_(ID|SECRET)|upload-oss' "$runtime_alpha_workflow"; then
+  echo "$runtime_alpha_workflow must not receive Runtime release secrets or publish to OSS" >&2
+  exit 1
+fi
+if grep -Eq 'id-token:|attestations:' "$runtime_alpha_workflow"; then
+  echo "$runtime_alpha_workflow must remain a read-only Runtime candidate caller" >&2
+  exit 1
+fi
+
+runtime_alpha_tag='legion-runtime-alpha-0212'
+[[ "$runtime_alpha_tag" == legion-runtime-alpha-* ]]
+[[ "$runtime_alpha_tag" != legion-runtime-v* ]]
+
 alpha_workflow="$repo_root/.github/workflows/build-legion-node-alpha.yml"
 check_release_only_workflow "$alpha_workflow" 'legion-node-alpha-*'
 
@@ -56,8 +81,8 @@ grep -Fq 'uses: ./.github/workflows/build-legion-node-alpha.yml' "$product_workf
 grep -Fq 'source_mode: release' "$product_workflow"
 grep -Fq 'production_release: true' "$product_workflow"
 grep -Fq 'ubuntu-24.04-arm' "$product_workflow"
-grep -Fq 'ubuntu-24.04-arm' "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"
+grep -Fq 'ubuntu-24.04-arm' "$runtime_workflow"
 grep -Fq 'release-index-linux-arm64.json' "$product_workflow"
-grep -Fq 'release-index-linux-arm64.json' "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"
+grep -Fq 'release-index-linux-arm64.json' "$runtime_workflow"
 
 echo 'Legion component workflow contract tests passed'

--- a/.github/scripts/test-legion-component-workflow-contract.sh
+++ b/.github/scripts/test-legion-component-workflow-contract.sh
@@ -27,12 +27,15 @@ check_release_only_workflow \
 alpha_workflow="$repo_root/.github/workflows/build-legion-node-alpha.yml"
 check_release_only_workflow "$alpha_workflow" 'legion-node-alpha-*'
 
+grep -Fq 'workflow_call:' "$alpha_workflow"
 grep -Fq 'macos-15-intel' "$alpha_workflow"
 grep -Fq 'macos-15' "$alpha_workflow"
 grep -Fq 'ubuntu-22.04' "$alpha_workflow"
 grep -Fq 'ubuntu-24.04-arm' "$alpha_workflow"
 grep -Fq './cmd/legion-smoke-node' "$alpha_workflow"
-grep -Fq 'retention-days: 7' "$alpha_workflow"
+grep -Fq 'default: 7' "$alpha_workflow"
+grep -Fq 'retention-days:' "$alpha_workflow"
+grep -Fq 'inputs.retention_days || 7' "$alpha_workflow"
 grep -Fq 'Actions artifact only; not published to OSS or a stable channel' "$alpha_workflow"
 if grep -Eq 'pull-requests: read|/pulls/|OSS_KEY_(ID|SECRET)|upload-oss|build-legion-component-oss-index' "$alpha_workflow"; then
   echo "$alpha_workflow must not resolve PR metadata or publish alpha artifacts to OSS" >&2
@@ -47,9 +50,14 @@ alpha_tag='legion-node-alpha-0212'
 [[ "$alpha_tag" == legion-node-alpha-* ]]
 [[ "$alpha_tag" != legion-node-v* ]]
 
-grep -Fq 'ubuntu-24.04-arm' "$repo_root/.github/workflows/build-legion-product-node.yml"
+product_workflow="$repo_root/.github/workflows/build-legion-product-node.yml"
+grep -Fq 'build-portable-nodes:' "$product_workflow"
+grep -Fq 'uses: ./.github/workflows/build-legion-node-alpha.yml' "$product_workflow"
+grep -Fq 'source_mode: release' "$product_workflow"
+grep -Fq 'production_release: true' "$product_workflow"
+grep -Fq 'ubuntu-24.04-arm' "$product_workflow"
 grep -Fq 'ubuntu-24.04-arm' "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"
-grep -Fq 'release-index-linux-arm64.json' "$repo_root/.github/workflows/build-legion-product-node.yml"
+grep -Fq 'release-index-linux-arm64.json' "$product_workflow"
 grep -Fq 'release-index-linux-arm64.json' "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"
 
 echo 'Legion component workflow contract tests passed'

--- a/.github/scripts/test-legion-component-workflow-contract.sh
+++ b/.github/scripts/test-legion-component-workflow-contract.sh
@@ -5,7 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 check_release_only_workflow() {
   local workflow="$1" expected_tag="$2" trigger_block
-  trigger_block="$(awk '/^on:$/ { capture=1 } /^permissions:$/ { capture=0 } capture' "$workflow")"
+  trigger_block="$(tr -d '\r' <"$workflow" | awk '/^on:$/ { capture=1 } /^permissions:$/ { capture=0 } capture')"
 
   grep -Fxq "      - \"$expected_tag\"" <<<"$trigger_block" || {
     echo "$workflow does not declare the exact $expected_tag tag trigger" >&2
@@ -23,6 +23,29 @@ check_release_only_workflow \
 check_release_only_workflow \
   "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml" \
   'legion-runtime-v*'
+
+alpha_workflow="$repo_root/.github/workflows/build-legion-node-alpha.yml"
+check_release_only_workflow "$alpha_workflow" 'legion-node-alpha-*'
+
+grep -Fq 'macos-15-intel' "$alpha_workflow"
+grep -Fq 'macos-15' "$alpha_workflow"
+grep -Fq 'ubuntu-22.04' "$alpha_workflow"
+grep -Fq 'ubuntu-24.04-arm' "$alpha_workflow"
+grep -Fq './cmd/legion-smoke-node' "$alpha_workflow"
+grep -Fq 'retention-days: 7' "$alpha_workflow"
+grep -Fq 'Actions artifact only; not published to OSS or a stable channel' "$alpha_workflow"
+if grep -Eq 'pull-requests: read|/pulls/|OSS_KEY_(ID|SECRET)|upload-oss|build-legion-component-oss-index' "$alpha_workflow"; then
+  echo "$alpha_workflow must not resolve PR metadata or publish alpha artifacts to OSS" >&2
+  exit 1
+fi
+if grep -Fq -- '-tags hids' "$alpha_workflow"; then
+  echo "$alpha_workflow must build the portable non-HIDS node" >&2
+  exit 1
+fi
+
+alpha_tag='legion-node-alpha-0212'
+[[ "$alpha_tag" == legion-node-alpha-* ]]
+[[ "$alpha_tag" != legion-node-v* ]]
 
 grep -Fq 'ubuntu-24.04-arm' "$repo_root/.github/workflows/build-legion-product-node.yml"
 grep -Fq 'ubuntu-24.04-arm' "$repo_root/.github/workflows/build-legion-ai-session-runtime.yml"

--- a/.github/workflows/build-legion-ai-session-runtime-alpha.yml
+++ b/.github/workflows/build-legion-ai-session-runtime-alpha.yml
@@ -1,0 +1,22 @@
+name: Build Legion AI Session Runtime Alpha
+
+on:
+  push:
+    tags:
+      - "legion-runtime-alpha-*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: legion-ai-session-runtime-alpha-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build short-lived Runtime artifacts
+    uses: ./.github/workflows/build-legion-ai-session-runtime.yml
+    with:
+      source_mode: alpha
+      retention_days: 7
+      producer_workflow_name: Build Legion AI Session Runtime Alpha

--- a/.github/workflows/build-legion-ai-session-runtime.yml
+++ b/.github/workflows/build-legion-ai-session-runtime.yml
@@ -1,6 +1,28 @@
 name: Build Trusted Legion AI Session Runtime
 
 on:
+  workflow_call:
+    inputs:
+      source_mode:
+        description: "Source validation mode: alpha or release"
+        required: false
+        type: string
+        default: release
+      retention_days:
+        description: "GitHub Actions artifact retention"
+        required: false
+        type: number
+        default: 14
+      producer_workflow_name:
+        description: "Workflow name recorded in Runtime provenance"
+        required: false
+        type: string
+        default: Build Trusted Legion AI Session Runtime
+    secrets:
+      OSS_KEY_ID:
+        required: false
+      OSS_KEY_SECRET:
+        required: false
   push:
     tags:
       - "legion-runtime-v*"
@@ -14,7 +36,10 @@ concurrency:
 
 env:
   RUNTIME_IMAGE_REPOSITORY: local.invalid/yaklang/legion-ai-session-runtime
-  SESSION_RUNTIME_WORKFLOW_NAME: Build Trusted Legion AI Session Runtime
+  SESSION_RUNTIME_WORKFLOW_NAME: ${{ inputs.producer_workflow_name || 'Build Trusted Legion AI Session Runtime' }}
+  RUNTIME_SOURCE_MODE: ${{ inputs.source_mode || 'release' }}
+  RUNTIME_RETENTION_DAYS: ${{ inputs.retention_days || 14 }}
+  PUBLISH_OSS: ${{ (inputs.source_mode || 'release') == 'release' }}
   SOURCE_SHA: ${{ github.sha }}
 
 jobs:
@@ -52,22 +77,38 @@ jobs:
           ref: ${{ env.SOURCE_SHA }}
           fetch-depth: 0
 
-      - name: Validate release tag and source
+      - name: Validate tag and source
         shell: bash
         run: |
           set -euo pipefail
           [[ "$GITHUB_EVENT_NAME" == push ]]
-          [[ "$GITHUB_REF" =~ ^refs/tags/legion-runtime-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
-            echo "unexpected Runtime release tag: $GITHUB_REF" >&2
-            exit 1
-          }
           [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
           [[ -z "$(git status --porcelain --untracked-files=all)" ]]
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
-            echo "published Runtime source must already be reachable from origin/main" >&2
-            exit 1
-          }
+          case "$RUNTIME_SOURCE_MODE" in
+            alpha)
+              [[ "$GITHUB_REF" =~ ^refs/tags/legion-runtime-alpha-[0-9A-Za-z][0-9A-Za-z._-]*$ ]] || {
+                echo "unexpected Runtime alpha tag: $GITHUB_REF" >&2
+                exit 1
+              }
+              [[ "$PUBLISH_OSS" == false ]]
+              ;;
+            release)
+              [[ "$GITHUB_REF" =~ ^refs/tags/legion-runtime-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
+                echo "unexpected Runtime release tag: $GITHUB_REF" >&2
+                exit 1
+              }
+              [[ "$PUBLISH_OSS" == true ]]
+              git fetch --no-tags origin main:refs/remotes/origin/main
+              git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
+                echo "published Runtime source must already be reachable from origin/main" >&2
+                exit 1
+              }
+              ;;
+            *)
+              echo "unsupported Runtime source validation mode: $RUNTIME_SOURCE_MODE" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Verify module Go version
         shell: bash
@@ -193,13 +234,14 @@ jobs:
           jq -e \
             --arg source_sha "$SOURCE_SHA" \
             --arg image_ref "${{ steps.inspect.outputs.image_ref }}" \
-            --arg goarch "$RUNTIME_GOARCH" '
+            --arg goarch "$RUNTIME_GOARCH" \
+            --arg workflow_name "$SESSION_RUNTIME_WORKFLOW_NAME" '
               .artifact_type == "legion-ai-session-runtime" and
               .source.repository == "yaklang/yaklang" and
               .source.commit == $source_sha and
               .source.dirty == false and
               .ci.provider == "github-actions" and
-              .ci.workflow == "Build Trusted Legion AI Session Runtime" and
+              .ci.workflow == $workflow_name and
               .recipe.packaging_source_sha == $source_sha and
               .recipe.packaging_dirty == false and
               .recipe.goos == "linux" and
@@ -219,7 +261,7 @@ jobs:
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz" dist/artifact/
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
 
-      - name: Build immutable OSS Runtime release
+      - name: Build Runtime image archive and optional OSS release
         id: oss-release
         shell: bash
         env:
@@ -227,10 +269,15 @@ jobs:
           RUNTIME_IMAGE_ID: ${{ steps.inspect.outputs.image_id }}
         run: |
           set -euo pipefail
+          docker save "$RUNTIME_IMAGE_ID" | gzip -n -1 \
+            >"dist/artifact/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
+          if [[ "$PUBLISH_OSS" != true ]]; then
+            echo "alpha Runtime archive staged for Actions artifact only"
+            exit 0
+          fi
           oss_release="dist/oss-release-${RUNTIME_GOARCH}"
           mkdir -p "$oss_release"
           cp dist/artifact/* "$oss_release/"
-          docker save "$RUNTIME_IMAGE_ID" | gzip -n -1 >"$oss_release/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
           public_base_url="https://yaklang.oss-accelerate.aliyuncs.com/legion/components/session-runtime/${RUNTIME_PACKAGE_VERSION}/${SOURCE_SHA}"
           ./.github/scripts/build-legion-component-oss-index.sh \
             --component session-runtime \
@@ -251,9 +298,11 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Build repository-owned OSS uploader
+        if: env.PUBLISH_OSS == 'true'
         run: go build -trimpath -o "${RUNNER_TEMP}/yak-oss-upload" ./common/yak/cmd/yak.go
 
       - name: Publish immutable Runtime release to OSS
+        if: env.PUBLISH_OSS == 'true'
         shell: bash
         env:
           OSS_KEY_ID: ${{ secrets.OSS_KEY_ID }}
@@ -303,6 +352,7 @@ jobs:
             --file "$RELEASE_DIR/$INDEX_NAME.sha256:/$REMOTE_PREFIX/$INDEX_NAME.sha256;$RELEASE_DIR/$INDEX_NAME:/$REMOTE_PREFIX/$INDEX_NAME"
 
       - name: Verify public Runtime release index
+        if: env.PUBLISH_OSS == 'true'
         shell: bash
         env:
           INDEX_URL: ${{ steps.oss-release.outputs.index_url }}
@@ -317,6 +367,11 @@ jobs:
       - name: Publish build summary
         shell: bash
         run: |
+          if [[ "$PUBLISH_OSS" == true ]]; then
+            distribution="OSS + Actions"
+          else
+            distribution="Actions only"
+          fi
           {
             echo "## Legion AI Session Runtime ${RUNTIME_GOARCH}"
             echo
@@ -325,11 +380,16 @@ jobs:
             echo "- Package: \`${RUNTIME_PACKAGE_NAME}.tar.gz\`"
             echo "- Target: \`linux/${RUNTIME_GOARCH}\`"
             echo "- Go: \`${{ steps.bases.outputs.go_version }}\`"
-            echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
-            echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
+            echo "- Distribution: \`${distribution}\`"
+            echo "- Retention: \`${RUNTIME_RETENTION_DAYS} days\`"
+            if [[ "$PUBLISH_OSS" == true ]]; then
+              echo "- OSS index: \`${{ steps.oss-release.outputs.index_url }}\`"
+              echo "- OSS index SHA256: \`${{ steps.oss-release.outputs.index_sha256 }}\`"
+            fi
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Attest published Runtime artifacts
+        if: env.PUBLISH_OSS == 'true'
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: dist/artifact/*
@@ -340,4 +400,4 @@ jobs:
           name: ${{ env.RUNTIME_PACKAGE_NAME }}
           path: dist/artifact/*
           if-no-files-found: error
-          retention-days: 14
+          retention-days: ${{ inputs.retention_days || 14 }}

--- a/.github/workflows/build-legion-node-alpha.yml
+++ b/.github/workflows/build-legion-node-alpha.yml
@@ -1,6 +1,23 @@
-name: Build Legion Node Alpha
+name: Build Portable Legion Node
 
 on:
+  workflow_call:
+    inputs:
+      source_mode:
+        description: "Source validation mode: alpha or release"
+        required: false
+        type: string
+        default: alpha
+      retention_days:
+        description: "GitHub Actions artifact retention"
+        required: false
+        type: number
+        default: 7
+      production_release:
+        description: "Whether the portable artifact belongs to a formal version tag"
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - "legion-node-alpha-*"
@@ -9,12 +26,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: legion-node-alpha-${{ github.ref }}
+  group: legion-portable-node-${{ github.ref }}
   cancel-in-progress: false
 
 env:
   SOURCE_SHA: ${{ github.sha }}
   NODE_VERSION: ${{ github.ref_name }}
+  SOURCE_MODE: ${{ inputs.source_mode || 'alpha' }}
+  RETENTION_DAYS: ${{ inputs.retention_days || 7 }}
+  PRODUCTION_RELEASE: ${{ inputs.production_release || false }}
 
 jobs:
   source-contract:
@@ -28,17 +48,36 @@ jobs:
           ref: ${{ env.SOURCE_SHA }}
           fetch-depth: 0
 
-      - name: Validate alpha tag and source
+      - name: Validate tag and source
         shell: bash
         run: |
           set -euo pipefail
           [[ "$GITHUB_EVENT_NAME" == push ]]
-          [[ "$GITHUB_REF" =~ ^refs/tags/legion-node-alpha-[0-9A-Za-z][0-9A-Za-z._-]*$ ]] || {
-            echo "unexpected Legion Node alpha tag: $GITHUB_REF" >&2
-            exit 1
-          }
           [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
           [[ -z "$(git status --porcelain --untracked-files=all)" ]]
+          case "$SOURCE_MODE" in
+            alpha)
+              [[ "$GITHUB_REF" =~ ^refs/tags/legion-node-alpha-[0-9A-Za-z][0-9A-Za-z._-]*$ ]] || {
+                echo "unexpected Legion Node alpha tag: $GITHUB_REF" >&2
+                exit 1
+              }
+              ;;
+            release)
+              [[ "$GITHUB_REF" =~ ^refs/tags/legion-node-v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || {
+                echo "unexpected Legion Node release tag: $GITHUB_REF" >&2
+                exit 1
+              }
+              git fetch --no-tags origin main:refs/remotes/origin/main
+              git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main || {
+                echo "published portable Node source must already be reachable from origin/main" >&2
+                exit 1
+              }
+              ;;
+            *)
+              echo "unsupported source validation mode: $SOURCE_MODE" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Test Legion Node entrypoint
         shell: bash
@@ -90,13 +129,13 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Build native Legion Node alpha artifact
+      - name: Build native portable Legion Node artifact
         shell: bash
         run: |
           set -euo pipefail
           export GOTOOLCHAIN=local
-          mkdir -p dist/legion-node-alpha
-          binary="dist/legion-node-alpha/${BINARY_NAME}"
+          mkdir -p dist/legion-node-portable
+          binary="dist/legion-node-portable/${BINARY_NAME}"
           CGO_ENABLED=1 GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" go build \
             -trimpath \
             -buildvcs=true \
@@ -104,9 +143,9 @@ jobs:
             -o "$binary" \
             ./cmd/legion-smoke-node
 
-          file "$binary" | tee dist/legion-node-alpha/FILE.txt
-          grep -Fq "$EXPECTED_FILE_FRAGMENT" dist/legion-node-alpha/FILE.txt
-          go version -m "$binary" >dist/legion-node-alpha/GO_VERSION.txt
+          file "$binary" | tee dist/legion-node-portable/FILE.txt
+          grep -Fq "$EXPECTED_FILE_FRAGMENT" dist/legion-node-portable/FILE.txt
+          go version -m "$binary" >dist/legion-node-portable/GO_VERSION.txt
 
           if command -v sha256sum >/dev/null 2>&1; then
             binary_sha="$(sha256sum "$binary" | awk '{print $1}')"
@@ -119,7 +158,7 @@ jobs:
             binary_size="$(stat -f %z "$binary")"
           fi
           printf '%s  %s\n' "$binary_sha" "$BINARY_NAME" \
-            >dist/legion-node-alpha/SHA256SUMS
+            >dist/legion-node-portable/SHA256SUMS
 
           jq -n \
             --arg version "$NODE_VERSION" \
@@ -131,10 +170,12 @@ jobs:
             --arg binary_name "$BINARY_NAME" \
             --arg binary_sha "$binary_sha" \
             --argjson binary_size "$binary_size" \
+            --argjson retention_days "$RETENTION_DAYS" \
+            --argjson production_release "$PRODUCTION_RELEASE" \
             --arg built_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
               {
                 schema_version: "1",
-                artifact_type: "legion-node-alpha",
+                artifact_type: "legion-node-portable",
                 version: $version,
                 source: {
                   repository: $repository,
@@ -156,31 +197,32 @@ jobs:
                 },
                 distribution: {
                   channel: "github-actions",
-                  retention_days: 7,
-                  production_release: false
+                  retention_days: $retention_days,
+                  production_release: $production_release
                 },
                 built_at: $built_at
               }
-            ' >dist/legion-node-alpha/LEGION_NODE_ALPHA_MANIFEST.json
+            ' >dist/legion-node-portable/LEGION_NODE_MANIFEST.json
 
-      - name: Upload short-lived Legion Node artifact
+      - name: Upload portable Legion Node artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.NODE_VERSION }}-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/legion-node-alpha/*
+          path: dist/legion-node-portable/*
           if-no-files-found: error
-          retention-days: 7
+          retention-days: ${{ inputs.retention_days || 7 }}
 
-      - name: Publish alpha build summary
+      - name: Publish portable Node build summary
         shell: bash
         run: |
           {
-            echo "## Legion Node alpha"
+            echo "## Portable Legion Node"
             echo
             echo "- Source: \`${SOURCE_SHA}\`"
             echo "- Tag: \`${NODE_VERSION}\`"
             echo "- Target: \`${TARGET_OS}/${TARGET_ARCH}\`"
             echo "- Build tags: none (local integration node, not HIDS Product Node)"
-            echo "- Retention: 7 days"
+            echo "- Production release: \`${PRODUCTION_RELEASE}\`"
+            echo "- Retention: \`${RETENTION_DAYS} days\`"
             echo "- Distribution: Actions artifact only; not published to OSS or a stable channel"
           } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-legion-node-alpha.yml
+++ b/.github/workflows/build-legion-node-alpha.yml
@@ -1,0 +1,186 @@
+name: Build Legion Node Alpha
+
+on:
+  push:
+    tags:
+      - "legion-node-alpha-*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: legion-node-alpha-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  SOURCE_SHA: ${{ github.sha }}
+  NODE_VERSION: ${{ github.ref_name }}
+
+jobs:
+  source-contract:
+    name: Validate tagged source
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out tagged source commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 0
+
+      - name: Validate alpha tag and source
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_EVENT_NAME" == push ]]
+          [[ "$GITHUB_REF" =~ ^refs/tags/legion-node-alpha-[0-9A-Za-z][0-9A-Za-z._-]*$ ]] || {
+            echo "unexpected Legion Node alpha tag: $GITHUB_REF" >&2
+            exit 1
+          }
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
+          [[ -z "$(git status --porcelain --untracked-files=all)" ]]
+
+      - name: Test Legion Node entrypoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          export GOTOOLCHAIN=local
+          go test ./cmd/legion-smoke-node ./common/node ./scannode
+
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }} Legion Node
+    needs: source-contract
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+            runner: macos-15-intel
+            file_fragment: Mach-O 64-bit executable x86_64
+          - goos: darwin
+            goarch: arm64
+            runner: macos-15
+            file_fragment: Mach-O 64-bit executable arm64
+          - goos: linux
+            goarch: amd64
+            runner: ubuntu-22.04
+            file_fragment: ELF 64-bit LSB executable, x86-64
+          - goos: linux
+            goarch: arm64
+            runner: ubuntu-24.04-arm
+            file_fragment: ELF 64-bit LSB executable, ARM aarch64
+    env:
+      TARGET_OS: ${{ matrix.goos }}
+      TARGET_ARCH: ${{ matrix.goarch }}
+      EXPECTED_FILE_FRAGMENT: ${{ matrix.file_fragment }}
+      BINARY_NAME: legion-smoke-node_${{ matrix.goos }}_${{ matrix.goarch }}
+    steps:
+      - name: Check out tagged source commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 0
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build native Legion Node alpha artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          export GOTOOLCHAIN=local
+          mkdir -p dist/legion-node-alpha
+          binary="dist/legion-node-alpha/${BINARY_NAME}"
+          CGO_ENABLED=1 GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" go build \
+            -trimpath \
+            -buildvcs=true \
+            -ldflags '-s -w -buildid=' \
+            -o "$binary" \
+            ./cmd/legion-smoke-node
+
+          file "$binary" | tee dist/legion-node-alpha/FILE.txt
+          grep -Fq "$EXPECTED_FILE_FRAGMENT" dist/legion-node-alpha/FILE.txt
+          go version -m "$binary" >dist/legion-node-alpha/GO_VERSION.txt
+
+          if command -v sha256sum >/dev/null 2>&1; then
+            binary_sha="$(sha256sum "$binary" | awk '{print $1}')"
+          else
+            binary_sha="$(shasum -a 256 "$binary" | awk '{print $1}')"
+          fi
+          if stat -c %s "$binary" >/dev/null 2>&1; then
+            binary_size="$(stat -c %s "$binary")"
+          else
+            binary_size="$(stat -f %z "$binary")"
+          fi
+          printf '%s  %s\n' "$binary_sha" "$BINARY_NAME" \
+            >dist/legion-node-alpha/SHA256SUMS
+
+          jq -n \
+            --arg version "$NODE_VERSION" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg go_version "$(go version)" \
+            --arg target_os "$TARGET_OS" \
+            --arg target_arch "$TARGET_ARCH" \
+            --arg binary_name "$BINARY_NAME" \
+            --arg binary_sha "$binary_sha" \
+            --argjson binary_size "$binary_size" \
+            --arg built_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+              {
+                schema_version: "1",
+                artifact_type: "legion-node-alpha",
+                version: $version,
+                source: {
+                  repository: $repository,
+                  commit: $source_sha,
+                  dirty: false
+                },
+                recipe: {
+                  goos: $target_os,
+                  goarch: $target_arch,
+                  cgo_enabled: true,
+                  build_tags: "",
+                  go_version: $go_version
+                },
+                capabilities: ["ssa.rule_sync.export", "yak.execute"],
+                binary: {
+                  path: $binary_name,
+                  sha256: $binary_sha,
+                  size: $binary_size
+                },
+                distribution: {
+                  channel: "github-actions",
+                  retention_days: 7,
+                  production_release: false
+                },
+                built_at: $built_at
+              }
+            ' >dist/legion-node-alpha/LEGION_NODE_ALPHA_MANIFEST.json
+
+      - name: Upload short-lived Legion Node artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ env.NODE_VERSION }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/legion-node-alpha/*
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Publish alpha build summary
+        shell: bash
+        run: |
+          {
+            echo "## Legion Node alpha"
+            echo
+            echo "- Source: \`${SOURCE_SHA}\`"
+            echo "- Tag: \`${NODE_VERSION}\`"
+            echo "- Target: \`${TARGET_OS}/${TARGET_ARCH}\`"
+            echo "- Build tags: none (local integration node, not HIDS Product Node)"
+            echo "- Retention: 7 days"
+            echo "- Distribution: Actions artifact only; not published to OSS or a stable channel"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -13,6 +13,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build-portable-nodes:
+    name: Build cross-platform portable Node artifacts
+    uses: ./.github/workflows/build-legion-node-alpha.yml
+    with:
+      source_mode: release
+      retention_days: 14
+      production_release: true
+
   build-and-publish:
     name: Build Linux ${{ matrix.goarch }} HIDS node
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/verify-legion-component-release-contracts.yml
+++ b/.github/workflows/verify-legion-component-release-contracts.yml
@@ -10,6 +10,7 @@ on:
       - ".github/scripts/test-legion-component-workflow-contract.sh"
       - ".github/scripts/test-package-legion-ai-session-runtime.sh"
       - ".github/workflows/build-legion-ai-session-runtime.yml"
+      - ".github/workflows/build-legion-ai-session-runtime-alpha.yml"
       - ".github/workflows/build-legion-node-alpha.yml"
       - ".github/workflows/build-legion-product-node.yml"
       - ".github/workflows/verify-legion-component-release-contracts.yml"
@@ -128,7 +129,13 @@ jobs:
           docker run --rm --entrypoint /bin/sh "$image" -ec \
             'test -x /usr/local/bin/legion-session-runtime; ldd /usr/local/bin/legion-session-runtime' \
             >"${RUNNER_TEMP}/runtime-${TARGET_ARCH}.ldd"
-          ! grep -q 'not found' "${RUNNER_TEMP}/runtime-${TARGET_ARCH}.ldd"
+          if grep -q 'not found' "${RUNNER_TEMP}/runtime-${TARGET_ARCH}.ldd"; then
+            echo "Runtime binary has unresolved shared libraries" >&2
+            exit 1
+          fi
+          docker save "$image" | gzip -n -1 \
+            >"${RUNNER_TEMP}/runtime-${TARGET_ARCH}.docker.tar.gz"
+          gzip -t "${RUNNER_TEMP}/runtime-${TARGET_ARCH}.docker.tar.gz"
 
   alpha-node-targets:
     name: Compile alpha node for ${{ matrix.goos }}/${{ matrix.goarch }}

--- a/.github/workflows/verify-legion-component-release-contracts.yml
+++ b/.github/workflows/verify-legion-component-release-contracts.yml
@@ -10,6 +10,7 @@ on:
       - ".github/scripts/test-legion-component-workflow-contract.sh"
       - ".github/scripts/test-package-legion-ai-session-runtime.sh"
       - ".github/workflows/build-legion-ai-session-runtime.yml"
+      - ".github/workflows/build-legion-node-alpha.yml"
       - ".github/workflows/build-legion-product-node.yml"
       - ".github/workflows/verify-legion-component-release-contracts.yml"
       - "docker/session-runtime/**"
@@ -25,7 +26,7 @@ concurrency:
 
 jobs:
   contracts:
-    name: Verify release-only multi-architecture contracts
+    name: Verify release and alpha node contracts
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -128,3 +129,56 @@ jobs:
             'test -x /usr/local/bin/legion-session-runtime; ldd /usr/local/bin/legion-session-runtime' \
             >"${RUNNER_TEMP}/runtime-${TARGET_ARCH}.ldd"
           ! grep -q 'not found' "${RUNNER_TEMP}/runtime-${TARGET_ARCH}.ldd"
+
+  alpha-node-targets:
+    name: Compile alpha node for ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+            runner: macos-15-intel
+            file_fragment: Mach-O 64-bit executable x86_64
+          - goos: darwin
+            goarch: arm64
+            runner: macos-15
+            file_fragment: Mach-O 64-bit executable arm64
+          - goos: linux
+            goarch: amd64
+            runner: ubuntu-22.04
+            file_fragment: ELF 64-bit LSB executable, x86-64
+          - goos: linux
+            goarch: arm64
+            runner: ubuntu-24.04-arm
+            file_fragment: ELF 64-bit LSB executable, ARM aarch64
+    steps:
+      - name: Check out source commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Compile portable Legion Node
+        shell: bash
+        env:
+          TARGET_OS: ${{ matrix.goos }}
+          TARGET_ARCH: ${{ matrix.goarch }}
+          EXPECTED_FILE_FRAGMENT: ${{ matrix.file_fragment }}
+        run: |
+          set -euo pipefail
+          export GOTOOLCHAIN=local
+          binary="${RUNNER_TEMP}/legion-smoke-node-${TARGET_OS}-${TARGET_ARCH}"
+          CGO_ENABLED=1 GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" go build \
+            -trimpath \
+            -buildvcs=true \
+            -ldflags '-s -w -buildid=' \
+            -o "$binary" \
+            ./cmd/legion-smoke-node
+          file "$binary" | grep -Fq "$EXPECTED_FILE_FRAGMENT"
+          go version -m "$binary"

--- a/docs/legion-ai-session-runtime-release.md
+++ b/docs/legion-ai-session-runtime-release.md
@@ -12,11 +12,27 @@ provenance.
 | Event | Behavior | Output trust level |
 |---|---|---|
 | Pull request or ordinary branch push | Does not run or produce a Runtime package | No release artifact |
+| `legion-runtime-alpha-*` tag on any selected commit | Build Linux amd64 and arm64 image archives and provenance packages; retain Actions artifacts for 7 days without OSS credentials or publication | Short-lived integration candidate |
 | SemVer `legion-runtime-v*` tag reachable from `main` | Build amd64 and arm64 variants, then publish immutable image archives, provenance, and release indexes to OSS | Trusted producer release |
 
 The isolated tag prefix intentionally does not match the repository's generic
 `v*` release workflows. For example, an alpha producer release can use
 `legion-runtime-v0.1.0-alpha.1`.
+
+For short-lived testing of a pull request commit, use the separate candidate
+namespace:
+
+```bash
+git tag legion-runtime-alpha-0212 <commit-sha>
+git push origin refs/tags/legion-runtime-alpha-0212
+```
+
+The tagged commit is the complete source identity; the tag does not carry or
+resolve a pull request number. Each candidate tag must be new and immutable.
+The tagged commit must already contain the alpha entry workflow. Candidate
+artifacts include `linux/amd64` and `linux/arm64` Docker image archives plus
+their provenance packages. They are Actions-only and never receive OSS release
+secrets.
 
 ## Published outputs
 

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -49,6 +49,12 @@ ordinary branch pushes do not produce trusted Product Node packages. This
 namespace does not trigger the repository's existing general `v*` release
 workflows.
 
+The same formal tag also calls the portable Node workflow and emits native
+development nodes for macOS Intel, macOS Apple Silicon, Linux amd64, and Linux
+arm64. These four GitHub Actions artifacts use the default non-HIDS build and
+are retained for 14 days. The existing Linux HIDS Product Node artifacts and
+their immutable OSS release indexes remain unchanged for deployment consumers.
+
 ### Short-lived native alpha nodes
 
 For short-lived testing of any tagged commit, including the current head of a

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -37,16 +37,52 @@ go build -tags hids -o ./legion-smoke-node-hids ./cmd/legion-smoke-node
 GOOS=linux GOARCH=amd64 go build -tags hids -o ./legion-smoke-node-hids-linux-amd64 ./cmd/legion-smoke-node
 ```
 
-## CI Product Node Package
+## CI Node Artifacts
+
+### Trusted HIDS Product Node release
 
 `.github/workflows/build-legion-product-node.yml` produces the deployable
 Linux amd64 and arm64 product nodes from the repository's declared Go version.
 The trusted packaging workflow runs only for tags in the isolated
-`legion-node-v*` namespace, including alpha tags. Pull requests and ordinary
-branch pushes do not produce Product Node packages. This namespace does not
-trigger the repository's existing general `v*` release workflows.
+`legion-node-v*` namespace, including alpha tags. The `pull_request` event and
+ordinary branch pushes do not produce trusted Product Node packages. This
+namespace does not trigger the repository's existing general `v*` release
+workflows.
 
-The workflow emits separate `legion-product-node_linux_amd64` and
+### Short-lived native alpha nodes
+
+For short-lived testing of any tagged commit, including the current head of a
+pull request, a maintainer may create a `legion-node-alpha-*` tag such as
+`legion-node-alpha-0212`. The separate
+`.github/workflows/build-legion-node-alpha.yml` workflow builds native
+development nodes for macOS Intel, macOS Apple Silicon, Linux amd64, and Linux
+arm64. The tag does not carry or resolve a pull request number: the tagged
+commit is the complete source identity.
+
+Alpha packages are kept as GitHub Actions artifacts for seven days. They are
+not uploaded to OSS, do not update a stable channel, and are not accepted as
+trusted product-release inputs. They use the default build without the `hids`
+tag, so macOS testers can run them locally while exercising `yak.execute` and
+`ssa.rule_sync.export`. Use a new alpha tag for every candidate; never move or
+reuse an existing tag.
+
+Example:
+
+```bash
+git fetch origin pull/4872/head
+git tag legion-node-alpha-0212 FETCH_HEAD
+git push origin refs/tags/legion-node-alpha-0212
+```
+
+GitHub builds the exact commit referenced by the pushed tag. If the pull
+request receives another commit, create a new tag on that new SHA. The alpha
+workflow must exist in the tagged commit. After this workflow is first merged,
+rebase an older pull request onto the updated `main` before creating its first
+alpha tag.
+
+### Trusted HIDS Product Node outputs
+
+The trusted workflow emits separate `legion-product-node_linux_amd64` and
 `legion-product-node_linux_arm64` Actions artifacts. Each architecture package
 contains its executable, `PRODUCT_NODE_MANIFEST.json`, and `SHA256SUMS`. The
 outer release artifact also contains the package archive and its checksum.


### PR DESCRIPTION
## 改动摘要

- 新增 `legion-node-alpha-*` tag 构建入口，直接以 tag 指向的 commit 作为源码身份，不要求在 tag 中携带 PR 号，也不查询 PR 元数据。
- 构建原生 macOS Intel、macOS Apple Silicon、Linux amd64、Linux arm64 Legion Node，方便前端和节点能力的本地联调。
- 将同一套四平台 workflow 暴露为 `workflow_call`，`legion-node-v*` 正式 tag 直接复用，不复制编译矩阵。
- 候选产物仅作为 GitHub Actions artifact 保留 7 天，不上传 OSS，不进入稳定发布通道。
- 正式 tag 同时保留既有 Linux amd64/arm64 HIDS Product Node 和 OSS 发布契约。
- 新增 `legion-runtime-alpha-*` tag 入口，通过无 secrets 的 `workflow_call` 复用正式 AI Session Runtime 构建和 provenance 打包逻辑。
- Runtime alpha 生成 Linux amd64/arm64 Docker image archive，作为 7 天 Actions artifact，不上传 OSS。

## 使用方式

目标 commit 必须已经包含本 PR 新增的 workflow：

```bash
git tag legion-node-alpha-0212 <commit-sha>
git push origin refs/tags/legion-node-alpha-0212
```

PR 更新 commit 后应创建新 tag，不移动或复用已经推送的 tag。

Runtime 候选使用独立 tag：

```bash
git tag legion-runtime-alpha-0212 <commit-sha>
git push origin refs/tags/legion-runtime-alpha-0212
```

## 主要文件

- `.github/workflows/build-legion-node-alpha.yml`
- `.github/workflows/build-legion-product-node.yml`
- `.github/workflows/build-legion-ai-session-runtime-alpha.yml`
- `.github/workflows/build-legion-ai-session-runtime.yml`
- `.github/workflows/verify-legion-component-release-contracts.yml`
- `.github/scripts/test-legion-component-workflow-contract.sh`
- `docs/legion-linux-hids-readiness.md`

## 验证方式

- `bash -n .github/scripts/test-legion-component-workflow-contract.sh`
- `shellcheck .github/scripts/test-legion-component-workflow-contract.sh`
- `./.github/scripts/test-legion-component-workflow-contract.sh`
- YAML 解析和 actionlint 检查三个受影响 workflow
- 校验 reusable workflow 的 alpha/release 输入、正式 workflow 调用关系和 portable manifest JSON
- 校验 Runtime alpha 调用不继承 OSS secrets，OSS 发布和 attestation 仅在正式 release 模式运行
- CI 对 Linux amd64/arm64 Runtime 镜像执行 `docker save` 并校验 gzip image archive
- `go test ./cmd/legion-smoke-node ./common/node ./scannode`
- 本地真实编译 `CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build ./cmd/legion-smoke-node`，确认产物为 x86-64 ELF 且可读取 Go 构建元数据

当前为 T1 代码完成。四平台 Node 及 Linux amd64/arm64 Runtime image archive 由本 PR 的 GitHub Actions 矩阵继续验证；实际 alpha/正式 tag 推送入口将在本 PR 合入后验证。
