### PR TITLE
fix(pagination): handle nil paging in query paths

### DIFF
--- a/common/ai/aid/aicommon/config_utils_types.go
+++ b/common/ai/aid/aicommon/config_utils_types.go
@@ -69,7 +69,9 @@ func WithForgeQueryFilter(filter *ypb.AIForgeFilter) ForgeQueryOption {
 
 func WithForgeQueryPaging(paging *ypb.Paging) ForgeQueryOption {
 	return func(config *ForgeQueryConfig) {
-		config.Paging = paging
+		if paging != nil {
+			config.Paging = paging
+		}
 	}
 }
 
@@ -84,6 +86,9 @@ func WithForgeFilter_Keyword(keyword string) ForgeQueryOption {
 func WithForgeFilter_Limit(limit int) ForgeQueryOption {
 	return func(config *ForgeQueryConfig) {
 		if limit > 0 {
+			if config.Paging == nil {
+				config.Paging = &ypb.Paging{Page: 1, Limit: 50}
+			}
 			config.Paging.Limit = int64(limit)
 		}
 	}

--- a/common/ai/aid/aicommon/config_utils_types_test.go
+++ b/common/ai/aid/aicommon/config_utils_types_test.go
@@ -1,0 +1,29 @@
+package aicommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForgeQueryOptionsAcceptNilPaging(t *testing.T) {
+	config := NewForgeQueryConfig(
+		WithForgeQueryPaging(nil),
+		WithForgeFilter_Limit(5),
+	)
+
+	require.NotNil(t, config.Paging)
+	require.Equal(t, int64(1), config.Paging.GetPage())
+	require.Equal(t, int64(5), config.Paging.GetLimit())
+}
+
+func TestForgeFilterLimitRepairsNilPaging(t *testing.T) {
+	clearPaging := func(config *ForgeQueryConfig) {
+		config.Paging = nil
+	}
+	config := NewForgeQueryConfig(clearPaging, WithForgeFilter_Limit(5))
+
+	require.NotNil(t, config.Paging)
+	require.Equal(t, int64(1), config.Paging.GetPage())
+	require.Equal(t, int64(5), config.Paging.GetLimit())
+}

--- a/common/chaosmaker/rule/model.go
+++ b/common/chaosmaker/rule/model.go
@@ -78,6 +78,13 @@ func (*Storage) TableName() string {
 }
 
 func QueryRule(db *gorm.DB, req *ypb.QueryChaosMakerRuleRequest) (*bizhelper.Paginator, []*Storage, error) {
+	if req == nil {
+		req = &ypb.QueryChaosMakerRuleRequest{}
+	}
+	if req.Pagination == nil {
+		req.Pagination = &ypb.Paging{Page: 1, Limit: 10}
+	}
+
 	db = db.Model(&Storage{})
 
 	params := req.GetPagination()

--- a/common/mcp/legacy_tools_test.go
+++ b/common/mcp/legacy_tools_test.go
@@ -1735,6 +1735,18 @@ func legacyFingerprintToolCases() map[string][]legacyToolCase {
 	return map[string][]legacyToolCase{
 		"query_fingerprint": {
 			{
+				name:    "empty_args_use_default_paging",
+				args:    map[string]any{},
+				timeout: 5 * time.Second,
+				validate: func(t *testing.T, text string, result *rawmcp.CallToolResult) {
+					require.NotNil(t, result)
+					var response ypb.QueryFingerprintResponse
+					decodeToolResultJSON(t, text, &response)
+					require.Equal(t, int64(1), response.GetPagination().GetPage())
+					require.Equal(t, int64(10), response.GetPagination().GetLimit())
+				},
+			},
+			{
 				name:    "minimal_pagination_should_not_panic",
 				args:    pagingArgs(),
 				timeout: 5 * time.Second,

--- a/common/utils/bizhelper/dbutil.go
+++ b/common/utils/bizhelper/dbutil.go
@@ -1304,6 +1304,9 @@ func GetTableCurrentId(db *gorm.DB, tableName string) (int64, error) {
 }
 
 func YakitPagingQuery(db *gorm.DB, p *ypb.Paging, data any) (*Paginator, *gorm.DB) {
+	if p == nil {
+		p = &ypb.Paging{}
+	}
 	db = QueryOrder(db, p.OrderBy, p.Order)          // set order by
 	if p.GetBeforeId() <= 0 && p.GetAfterId() <= 0 { // if not set after_id and before_id, use page and limit
 		return NewPagination(&Param{

--- a/common/utils/bizhelper/paging_test.go
+++ b/common/utils/bizhelper/paging_test.go
@@ -85,3 +85,24 @@ func TestNewPaginationRecordsCountAndDataQueryDurations(t *testing.T) {
 	require.Zero(t, paginator.TotalRecord)
 	require.Len(t, items, 1)
 }
+
+func TestYakitPagingQueryAcceptsNilPaging(t *testing.T) {
+	db, err := createTempTestDatabase()
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AutoMigrate(&paginationTestItem{}).Error)
+	require.NoError(t, db.Create(&paginationTestItem{Name: "alpha"}).Error)
+
+	var items []paginationTestItem
+	paginator, queryDB := YakitPagingQuery(
+		db.Model(&paginationTestItem{}),
+		nil,
+		&items,
+	)
+
+	require.NoError(t, queryDB.Error)
+	require.Equal(t, 1, paginator.Page)
+	require.Equal(t, 10, paginator.Limit)
+	require.Len(t, items, 1)
+}

--- a/common/yak/yaklib/yakit_online.go
+++ b/common/yak/yaklib/yakit_online.go
@@ -879,7 +879,27 @@ func (s *OnlineClient) SaveYakScriptToOnline(ctx context.Context,
 	return nil
 }
 
+func normalizeQueryOnlinePluginsRequest(req *ypb.QueryOnlinePluginsRequest) *ypb.QueryOnlinePluginsRequest {
+	if req == nil {
+		req = &ypb.QueryOnlinePluginsRequest{}
+	}
+	if req.Pagination == nil {
+		req.Pagination = &ypb.Paging{
+			Page:    1,
+			Limit:   20,
+			OrderBy: "updated_at",
+			Order:   "desc",
+		}
+	}
+	if req.Data == nil {
+		req.Data = &ypb.DownloadOnlinePluginsRequest{}
+	}
+	return req
+}
+
 func (s *OnlineClient) QueryPlugins(req *ypb.QueryOnlinePluginsRequest) ([]*OnlinePlugin, *OnlinePaging, error) {
+	req = normalizeQueryOnlinePluginsRequest(req)
+
 	raw, err := json.Marshal(DownloadOnlinePluginRequest{
 		Keywords:      req.Data.Keywords,
 		PluginType:    req.Data.PluginType,

--- a/common/yak/yaklib/yakit_online_pagination_test.go
+++ b/common/yak/yaklib/yakit_online_pagination_test.go
@@ -1,0 +1,18 @@
+package yaklib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeQueryOnlinePluginsRequestAcceptsNil(t *testing.T) {
+	req := normalizeQueryOnlinePluginsRequest(nil)
+
+	require.NotNil(t, req)
+	require.NotNil(t, req.GetData())
+	require.Equal(t, int64(1), req.GetPagination().GetPage())
+	require.Equal(t, int64(20), req.GetPagination().GetLimit())
+	require.Equal(t, "updated_at", req.GetPagination().GetOrderBy())
+	require.Equal(t, "desc", req.GetPagination().GetOrder())
+}

--- a/common/yakgrpc/grpc_nil_pagination_test.go
+++ b/common/yakgrpc/grpc_nil_pagination_test.go
@@ -1,0 +1,54 @@
+package yakgrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func TestQueryRPCsAcceptNilPagination(t *testing.T) {
+	client, server, err := NewLocalClientAndServerWithTempDatabase(t)
+	require.NoError(t, err)
+	require.NoError(t, server.GetProfileDatabase().AutoMigrate(&schema.AIAgentRuntime{}).Error)
+
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		query func() (*ypb.Paging, error)
+	}{
+		{
+			name: "chaos maker rules",
+			query: func() (*ypb.Paging, error) {
+				response, err := client.QueryChaosMakerRule(ctx, &ypb.QueryChaosMakerRuleRequest{})
+				return response.GetPagination(), err
+			},
+		},
+		{
+			name: "HTTP fuzzer history",
+			query: func() (*ypb.Paging, error) {
+				response, err := client.QueryHistoryHTTPFuzzerTaskEx(ctx, &ypb.QueryHistoryHTTPFuzzerTaskExParams{})
+				return response.GetPagination(), err
+			},
+		},
+		{
+			name: "AI tasks",
+			query: func() (*ypb.Paging, error) {
+				response, err := client.QueryAITask(ctx, &ypb.AITaskQueryRequest{})
+				return response.GetPagination(), err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pagination, err := test.query()
+			require.NoError(t, err)
+			require.NotNil(t, pagination)
+			require.Equal(t, int64(1), pagination.GetPage())
+			require.Equal(t, int64(10), pagination.GetLimit())
+		})
+	}
+}

--- a/common/yakgrpc/yakit/ai_infra.go
+++ b/common/yakgrpc/yakit/ai_infra.go
@@ -161,6 +161,10 @@ func FilterAgentRuntime(db *gorm.DB, filter *ypb.AITaskFilter) *gorm.DB {
 }
 
 func QueryAgentRuntime(db *gorm.DB, filter *ypb.AITaskFilter, paging *ypb.Paging) (*bizhelper.Paginator, []schema.AIAgentRuntime, error) {
+	if paging == nil {
+		paging = &ypb.Paging{}
+	}
+
 	db = FilterAgentRuntime(db, filter)
 	db = bizhelper.OrderByPaging(db, paging)
 	var aiTasks []schema.AIAgentRuntime

--- a/common/yakgrpc/yakit/fuzzer_task.go
+++ b/common/yakgrpc/yakit/fuzzer_task.go
@@ -32,6 +32,13 @@ func QueryFirst50WebFuzzerTask(db *gorm.DB) []*ypb.HistoryHTTPFuzzerTask {
 }
 
 func QueryFuzzerHistoryTasks(db *gorm.DB, req *ypb.QueryHistoryHTTPFuzzerTaskExParams) (*bizhelper.Paginator, []*schema.WebFuzzerTask, error) {
+	if req == nil {
+		req = &ypb.QueryHistoryHTTPFuzzerTaskExParams{}
+	}
+	if req.Pagination == nil {
+		req.Pagination = &ypb.Paging{Page: 1, Limit: 10}
+	}
+
 	db = db.Model(&schema.WebFuzzerTask{})
 	oldDB := db
 

--- a/common/yakgrpc/yakit/nil_pagination_test.go
+++ b/common/yakgrpc/yakit/nil_pagination_test.go
@@ -1,0 +1,21 @@
+package yakit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+func TestQueryPayloadAcceptsNilPaging(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.Payload{}).Error)
+
+	pagination, payloads, err := QueryPayload(db, "", "", "", nil)
+	require.NoError(t, err)
+	require.Empty(t, payloads)
+	require.Equal(t, 1, pagination.Page)
+	require.Equal(t, 30, pagination.Limit)
+}

--- a/common/yakgrpc/yakit/payload.go
+++ b/common/yakgrpc/yakit/payload.go
@@ -474,6 +474,10 @@ func QueryPayloadWithoutPaging(db *gorm.DB, folder, group, keyword string) ([]*s
 }
 
 func QueryPayload(db *gorm.DB, folder, group, keyword string, paging *Paging) (*bizhelper.Paginator, []*schema.Payload, error) {
+	if paging == nil {
+		paging = NewPaging()
+	}
+
 	db = db.Model(&schema.Payload{})
 	db = bizhelper.QueryOrder(db, paging.OrderBy, paging.Order)
 	db = bizhelper.ExactQueryString(db, "`folder`", folder)


### PR DESCRIPTION
Prevent empty MCP and gRPC query requests from dereferencing nil pagination values. Normalize paging defaults across shared query helpers and latent internal callers, and add regression coverage for query_fingerprint and related query endpoints.