### PR TITLE
feat(loop_http_fuzztest): add decrypt_data action for offline data de…

### DIFF
--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_decrypt_data.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_decrypt_data.go
@@ -1,0 +1,487 @@
+package loop_http_fuzztest
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/tlsutils"
+	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
+)
+
+const (
+	loopHTTPFuzzDecryptContentField      = "decrypt_data_content"
+	loopHTTPFuzzDecryptResultKey         = "decrypt_data_result"
+	loopHTTPFuzzDecryptResultHexKey      = "decrypt_data_result_hex"
+	loopHTTPFuzzDecryptResultBase64Key   = "decrypt_data_result_base64"
+	loopHTTPFuzzDecryptErrorKey          = "decrypt_data_error"
+	loopHTTPFuzzDecryptSummaryKey        = "decrypt_data_summary"
+	loopHTTPFuzzDecryptAITagNode         = "decrypt-data-content"
+	loopHTTPFuzzDecryptResultMarkdownKey = "decrypt_data_result_markdown"
+)
+
+// loopHTTPFuzzDecryptSpec 描述一次离线数据解密请求的完整参数。
+type loopHTTPFuzzDecryptSpec struct {
+	Algorithm      string // aes-cbc / aes-ecb / aes-cfb / aes-ofb / aes-ctr / aes-gcm / des-cbc / des-ecb / 3des-cbc / 3des-ecb / rc4 / sm4-cbc / sm4-ecb / rsa
+	Key            []byte
+	KeyEncoding    string // utf8 / hex / base64
+	IV             []byte
+	IVEncoding     string
+	Data           []byte
+	DataEncoding   string // utf8 / hex / base64
+	Padding        string // pkcs7 / zero / none
+	OutputEncoding string // utf8 / hex / base64
+}
+
+var decryptDataAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption {
+	return reactloops.WithRegisterLoopActionWithStreamField(
+		"decrypt_data",
+		"使用给定的密钥和算法对加密数据进行离线解密，适用于用户提供密文 + 密钥并要求解密的场景（如数据包中的加密参数、Cookie、Body 字段等）。解密过程不发送任何请求，只做本地计算。",
+		[]aitool.ToolOption{
+			aitool.WithStringParam("algorithm", aitool.WithParam_Description("解密算法：aes-cbc / aes-ecb / aes-cfb / aes-ofb / aes-ctr / aes-gcm / des-cbc / des-ecb / 3des-cbc / 3des-ecb / rc4 / sm4-cbc / sm4-ecb / rsa"), aitool.WithParam_Required(true)),
+			aitool.WithStringParam("key", aitool.WithParam_Description("解密密钥。默认按 UTF-8 字符串解释；也可以通过 key_encoding 指定 hex/base64 编码。RSA 场景下这里是 PEM 私钥全文。"), aitool.WithParam_Required(true)),
+			aitool.WithStringParam("key_encoding", aitool.WithParam_Description("密钥编码：utf8 / hex / base64，默认 utf8。")),
+			aitool.WithStringParam("iv", aitool.WithParam_Description("IV/Nonce。仅 CBC/CFB/OFB/CTR/GCM 模式需要；ECB/RC4/RSA 不需要。")),
+			aitool.WithStringParam("iv_encoding", aitool.WithParam_Description("IV 编码：utf8 / hex / base64，默认 utf8。")),
+			aitool.WithStringParam("data", aitool.WithParam_Description("待解密的密文。支持通过 DECRYPT_DATA AITAG 传递大段密文；data 与 AITAG 至少提供一个。"), aitool.WithParam_Required(true)),
+			aitool.WithStringParam("data_encoding", aitool.WithParam_Description("密文编码：base64 / hex / utf8，默认 base64。数据包中最常见的密文是 base64。")),
+			aitool.WithStringParam("padding", aitool.WithParam_Description("填充模式：pkcs7 / zero / none，默认 pkcs7。流模式（OFB/CTR/CFB）和 GCM/RC4/RSA 无需填充，可忽略。")),
+			aitool.WithStringParam("output_encoding", aitool.WithParam_Description("输出编码：utf8 / hex / base64，默认 utf8。若明文不是合法 UTF-8，会自动回退为 hex 输出。")),
+		},
+		[]*reactloops.LoopStreamField{
+			{FieldName: "reason", AINodeId: "thought"},
+		},
+		func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
+			spec, err := parseLoopHTTPFuzzDecryptSpec(action, loop)
+			if err != nil {
+				return err
+			}
+			// 预校验：算法+密钥长度是否合法，避免进入 handler 后才失败。
+			if err := validateLoopHTTPFuzzDecryptSpec(spec); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(loop *reactloops.ReActLoop, action *aicommon.Action, operator *reactloops.LoopActionHandlerOperator) {
+			spec, err := parseLoopHTTPFuzzDecryptSpec(action, loop)
+			if err != nil {
+				operator.Fail(err)
+				return
+			}
+
+			paramSummary := buildLoopHTTPFuzzDecryptParamSummary(spec)
+			log.Infof("decrypt_data action: %s", paramSummary)
+
+			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeSetRequest, fmt.Sprintf("解密数据: %s", spec.Algorithm))
+			reactloops.EmitStatus(loop, "解密中 / Decrypting...")
+
+			plainBytes, err := decryptLoopHTTPFuzzData(spec)
+			if err != nil {
+				loop.Set(loopHTTPFuzzDecryptErrorKey, err.Error())
+				feedback := fmt.Sprintf("解密失败：%v\n\n请检查 algorithm / key / iv / padding / 编码参数是否匹配实际加密方式。", err)
+				record := recordLoopHTTPFuzzMetaAction(loop, "decrypt_data", paramSummary, utils.ShrinkTextBlock(feedback, 240))
+				r.AddToTimeline("decrypt_data", fmt.Sprintf("Decrypt failed: %s\n%s", spec.Algorithm, err.Error()))
+				persistLoopHTTPFuzzSessionContext(loop, "decrypt_data_failed")
+				reactloops.EmitStatus(loop, "解密失败 / Decrypt Failed")
+				operator.Feedback(buildLoopHTTPFuzzActionFeedback(record) + "\n\n" + feedback)
+				return
+			}
+
+			outputText := encodeLoopHTTPFuzzDecryptOutput(plainBytes, spec.OutputEncoding)
+			loop.Set(loopHTTPFuzzDecryptResultKey, outputText)
+			loop.Set(loopHTTPFuzzDecryptResultHexKey, codec.EncodeToHex(plainBytes))
+			loop.Set(loopHTTPFuzzDecryptResultBase64Key, codec.EncodeBase64(plainBytes))
+			loop.Set(loopHTTPFuzzDecryptErrorKey, "")
+
+			resultMarkdown := buildLoopHTTPFuzzDecryptResultMarkdown(spec, plainBytes, outputText)
+			loop.Set(loopHTTPFuzzDecryptResultMarkdownKey, resultMarkdown)
+			loop.Set(loopHTTPFuzzDecryptSummaryKey, buildLoopHTTPFuzzDecryptParamSummary(spec))
+
+			// 交付结果：markdown 流 + 文件 artifact + result
+			invoker := loop.GetInvoker()
+			if emitter := loop.GetEmitter(); emitter != nil {
+				taskID := ""
+				if task := loop.GetCurrentTask(); task != nil {
+					taskID = task.GetId()
+				}
+				if _, err := emitter.EmitTextMarkdownStreamEvent("re-act-loop-answer-payload", strings.NewReader(resultMarkdown), taskID, func() {}); err != nil {
+					log.Warnf("decrypt_data: failed to emit markdown stream: %v", err)
+				}
+			}
+			invoker.EmitFileArtifactWithExt("decrypt_data", ".md", resultMarkdown)
+			invoker.EmitResultAfterStream(resultMarkdown)
+
+			record := recordLoopHTTPFuzzMetaAction(loop, "decrypt_data", paramSummary, utils.ShrinkTextBlock(resultMarkdown, 240))
+			r.AddToTimeline("decrypt_data", fmt.Sprintf("Decrypted %s, output: %s", spec.Algorithm, utils.ShrinkTextBlock(outputText, 200)))
+			persistLoopHTTPFuzzSessionContext(loop, "decrypt_data")
+			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeSetRequest, "解密完成 / Decrypt Complete", utils.ShrinkTextBlock(outputText, 1200))
+			operator.Feedback(buildLoopHTTPFuzzActionFeedback(record) + "\n\n" + resultMarkdown)
+		},
+	)
+}
+
+// parseLoopHTTPFuzzDecryptSpec 从 action 中解析解密参数，兼容 data 参数与 DECRYPT_DATA AITAG 两种来源。
+func parseLoopHTTPFuzzDecryptSpec(action *aicommon.Action, loop *reactloops.ReActLoop) (*loopHTTPFuzzDecryptSpec, error) {
+	if action == nil {
+		return nil, fmt.Errorf("decrypt_data action is nil")
+	}
+
+	algorithm := strings.ToLower(strings.TrimSpace(action.GetString("algorithm")))
+	if algorithm == "" {
+		return nil, fmt.Errorf("algorithm is required")
+	}
+	keyRaw := action.GetString("key")
+	keyEncoding := strings.ToLower(strings.TrimSpace(action.GetString("key_encoding")))
+	if keyEncoding == "" {
+		keyEncoding = "utf8"
+	}
+	ivRaw := action.GetString("iv")
+	ivEncoding := strings.ToLower(strings.TrimSpace(action.GetString("iv_encoding")))
+	if ivEncoding == "" {
+		ivEncoding = "utf8"
+	}
+	dataRaw := strings.TrimSpace(action.GetString("data"))
+	if dataRaw == "" {
+		dataRaw = strings.TrimSpace(action.GetString(loopHTTPFuzzDecryptContentField))
+	}
+	if dataRaw == "" && loop != nil {
+		dataRaw = strings.TrimSpace(loop.Get(loopHTTPFuzzDecryptContentField))
+	}
+	if dataRaw == "" {
+		return nil, fmt.Errorf("data is required: provide 'data' param or DECRYPT_DATA AITAG content")
+	}
+	dataEncoding := strings.ToLower(strings.TrimSpace(action.GetString("data_encoding")))
+	if dataEncoding == "" {
+		dataEncoding = "base64"
+	}
+	padding := strings.ToLower(strings.TrimSpace(action.GetString("padding")))
+	if padding == "" {
+		padding = "pkcs7"
+	}
+	outputEncoding := strings.ToLower(strings.TrimSpace(action.GetString("output_encoding")))
+	if outputEncoding == "" {
+		outputEncoding = "utf8"
+	}
+
+	key, err := decodeLoopHTTPFuzzByteString(keyRaw, keyEncoding)
+	if err != nil {
+		return nil, fmt.Errorf("invalid key: %w", err)
+	}
+	iv, err := decodeLoopHTTPFuzzByteString(ivRaw, ivEncoding)
+	if err != nil {
+		return nil, fmt.Errorf("invalid iv: %w", err)
+	}
+	data, err := decodeLoopHTTPFuzzByteString(dataRaw, dataEncoding)
+	if err != nil {
+		return nil, fmt.Errorf("invalid data: %w", err)
+	}
+
+	return &loopHTTPFuzzDecryptSpec{
+		Algorithm:      algorithm,
+		Key:            key,
+		KeyEncoding:    keyEncoding,
+		IV:             iv,
+		IVEncoding:     ivEncoding,
+		Data:           data,
+		DataEncoding:   dataEncoding,
+		Padding:        padding,
+		OutputEncoding: outputEncoding,
+	}, nil
+}
+
+// validateLoopHTTPFuzzDecryptSpec 校验算法枚举、编码枚举和 RSA 密钥格式。
+func validateLoopHTTPFuzzDecryptSpec(spec *loopHTTPFuzzDecryptSpec) error {
+	if spec == nil {
+		return fmt.Errorf("decrypt spec is nil")
+	}
+	validAlgorithms := map[string]struct{}{
+		"aes-cbc": {}, "aes-ecb": {}, "aes-cfb": {}, "aes-ofb": {}, "aes-ctr": {}, "aes-gcm": {},
+		"des-cbc": {}, "des-ecb": {},
+		"3des-cbc": {}, "3des-ecb": {},
+		"rc4":     {},
+		"sm4-cbc": {}, "sm4-ecb": {},
+		"rsa": {},
+	}
+	if _, ok := validAlgorithms[spec.Algorithm]; !ok {
+		return fmt.Errorf("algorithm must be one of: aes-cbc, aes-ecb, aes-cfb, aes-ofb, aes-ctr, aes-gcm, des-cbc, des-ecb, 3des-cbc, 3des-ecb, rc4, sm4-cbc, sm4-ecb, rsa")
+	}
+	if err := validateLoopHTTPFuzzByteEncoding("key_encoding", spec.KeyEncoding); err != nil {
+		return err
+	}
+	if err := validateLoopHTTPFuzzByteEncoding("iv_encoding", spec.IVEncoding); err != nil {
+		return err
+	}
+	if err := validateLoopHTTPFuzzByteEncoding("data_encoding", spec.DataEncoding); err != nil {
+		return err
+	}
+	if spec.Padding != "pkcs7" && spec.Padding != "zero" && spec.Padding != "none" {
+		return fmt.Errorf("padding must be one of: pkcs7, zero, none")
+	}
+	if spec.OutputEncoding != "utf8" && spec.OutputEncoding != "hex" && spec.OutputEncoding != "base64" {
+		return fmt.Errorf("output_encoding must be one of: utf8, hex, base64")
+	}
+	if spec.Algorithm == "rsa" && len(spec.Key) == 0 {
+		return fmt.Errorf("rsa requires a PEM private key in 'key'")
+	}
+	return nil
+}
+
+// decodeLoopHTTPFuzzByteString 按编码把字符串还原为字节。
+func decodeLoopHTTPFuzzByteString(raw, encoding string) ([]byte, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "hex":
+		return codec.DecodeHex(raw)
+	case "base64":
+		return codec.DecodeBase64(raw)
+	case "utf8", "utf-8", "":
+		return []byte(raw), nil
+	default:
+		return nil, fmt.Errorf("unsupported encoding: %s", encoding)
+	}
+}
+
+func validateLoopHTTPFuzzByteEncoding(name, encoding string) error {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "utf8", "utf-8", "hex", "base64":
+		return nil
+	default:
+		return fmt.Errorf("%s must be one of: utf8, hex, base64", name)
+	}
+}
+
+// decryptLoopHTTPFuzzData 根据算法把 spec 中的密文解密为明文，并处理填充。
+func decryptLoopHTTPFuzzData(spec *loopHTTPFuzzDecryptSpec) ([]byte, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("decrypt spec is nil")
+	}
+	if len(spec.Data) == 0 {
+		return nil, fmt.Errorf("data is empty")
+	}
+	if len(spec.Key) == 0 {
+		return nil, fmt.Errorf("key is empty")
+	}
+
+	switch spec.Algorithm {
+	case "aes-cbc", "aes-ecb", "aes-cfb", "aes-ofb", "aes-ctr", "aes-gcm":
+		return decryptLoopHTTPFuzzAES(spec)
+	case "des-cbc", "des-ecb":
+		return decryptLoopHTTPFuzzDES(spec)
+	case "3des-cbc", "3des-ecb":
+		return decryptLoopHTTPFuzzTripleDES(spec)
+	case "rc4":
+		return codec.RC4Decrypt(spec.Key, spec.Data)
+	case "sm4-cbc", "sm4-ecb":
+		return decryptLoopHTTPFuzzSM4(spec)
+	case "rsa":
+		return tlsutils.RSADecryptWithPKCS1v15Block(string(spec.Key), spec.Data)
+	default:
+		return nil, fmt.Errorf("unsupported algorithm: %s", spec.Algorithm)
+	}
+}
+
+// decryptLoopHTTPFuzzAES 处理 AES 全模式解密：块模式支持 pkcs7/zero 填充，流模式无需填充。
+func decryptLoopHTTPFuzzAES(spec *loopHTTPFuzzDecryptSpec) ([]byte, error) {
+	switch spec.Algorithm {
+	case "aes-cbc":
+		switch spec.Padding {
+		case "zero":
+			return codec.AESDecryptCBCWithZeroPadding(spec.Key, spec.Data, spec.IV)
+		case "none":
+			return codec.AESDec(spec.Key, spec.Data, spec.IV, codec.CBC)
+		default: // pkcs7
+			return codec.AESDecryptCBCWithPKCSPadding(spec.Key, spec.Data, spec.IV)
+		}
+	case "aes-ecb":
+		switch spec.Padding {
+		case "zero":
+			return codec.AESDecryptECBWithZeroPadding(spec.Key, spec.Data, spec.IV)
+		case "none":
+			return codec.AESDec(spec.Key, spec.Data, nil, codec.ECB)
+		default: // pkcs7
+			return codec.AESDecryptECBWithPKCSPadding(spec.Key, spec.Data, spec.IV)
+		}
+	case "aes-cfb":
+		switch spec.Padding {
+		case "zero":
+			return codec.AESDecryptCFBWithZeroPadding(spec.Key, spec.Data, spec.IV)
+		case "none":
+			return codec.AESDec(spec.Key, spec.Data, spec.IV, codec.CFB)
+		default: // pkcs7
+			return codec.AESDecryptCFBWithPKCSPadding(spec.Key, spec.Data, spec.IV)
+		}
+	case "aes-ofb":
+		return codec.AESDec(spec.Key, spec.Data, spec.IV, codec.OFB)
+	case "aes-ctr":
+		return codec.AESDec(spec.Key, spec.Data, spec.IV, codec.CTR)
+	case "aes-gcm":
+		return codec.AESGCMDecrypt(spec.Key, spec.Data, spec.IV)
+	default:
+		return nil, fmt.Errorf("unsupported AES mode: %s", spec.Algorithm)
+	}
+}
+
+// decryptLoopHTTPFuzzDES 处理 DES CBC/ECB 解密，按 padding 去填充。
+func decryptLoopHTTPFuzzDES(spec *loopHTTPFuzzDecryptSpec) ([]byte, error) {
+	var raw []byte
+	var err error
+	if spec.Algorithm == "des-ecb" {
+		raw, err = codec.DESDec(spec.Key, spec.Data, nil, codec.ECB)
+	} else {
+		raw, err = codec.DESDec(spec.Key, spec.Data, spec.IV, codec.CBC)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return unpadLoopHTTPFuzzBlock(raw, 8, spec.Padding)
+}
+
+// decryptLoopHTTPFuzzTripleDES 处理 3DES CBC/ECB 解密，按 padding 去填充。
+func decryptLoopHTTPFuzzTripleDES(spec *loopHTTPFuzzDecryptSpec) ([]byte, error) {
+	var raw []byte
+	var err error
+	if spec.Algorithm == "3des-ecb" {
+		raw, err = codec.TripleDesDec(spec.Key, spec.Data, nil, codec.ECB)
+	} else {
+		raw, err = codec.TripleDesDec(spec.Key, spec.Data, spec.IV, codec.CBC)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return unpadLoopHTTPFuzzBlock(raw, 8, spec.Padding)
+}
+
+// decryptLoopHTTPFuzzSM4 处理 SM4 CBC/ECB 解密，按 padding 去填充。
+func decryptLoopHTTPFuzzSM4(spec *loopHTTPFuzzDecryptSpec) ([]byte, error) {
+	var raw []byte
+	var err error
+	if spec.Algorithm == "sm4-ecb" {
+		raw, err = codec.SM4Dec(spec.Key, spec.Data, nil, codec.ECB)
+	} else {
+		raw, err = codec.SM4Dec(spec.Key, spec.Data, spec.IV, codec.CBC)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return unpadLoopHTTPFuzzBlock(raw, 16, spec.Padding)
+}
+
+// unpadLoopHTTPFuzzBlock 按指定块大小和 padding 模式去填充。
+func unpadLoopHTTPFuzzBlock(raw []byte, blockSize int, padding string) ([]byte, error) {
+	switch strings.ToLower(strings.TrimSpace(padding)) {
+	case "pkcs7":
+		if blockSize == 8 {
+			return codec.PKCS7UnPaddingFor8ByteBlock(raw), nil
+		}
+		return codec.PKCS7UnPadding(raw), nil
+	case "zero":
+		return codec.ZeroUnPadding(raw), nil
+	default: // none
+		return raw, nil
+	}
+}
+
+// encodeLoopHTTPFuzzDecryptOutput 按输出编码渲染明文；utf8 输出但内容非法时自动回退 hex。
+func encodeLoopHTTPFuzzDecryptOutput(plain []byte, outputEncoding string) string {
+	switch strings.ToLower(strings.TrimSpace(outputEncoding)) {
+	case "hex":
+		return codec.EncodeToHex(plain)
+	case "base64":
+		return codec.EncodeBase64(plain)
+	default: // utf8
+		if utf8.Valid(plain) {
+			return string(plain)
+		}
+		return "(非 UTF-8 二进制，以下为 hex 表示)\n" + codec.EncodeToHex(plain)
+	}
+}
+
+// buildLoopHTTPFuzzDecryptResultMarkdown 构造用户可读的解密结果 markdown。
+func buildLoopHTTPFuzzDecryptResultMarkdown(spec *loopHTTPFuzzDecryptSpec, plain []byte, outputText string) string {
+	var out strings.Builder
+	out.WriteString("## 解密结果\n\n")
+	out.WriteString(fmt.Sprintf("- 算法：`%s`\n", spec.Algorithm))
+	out.WriteString(fmt.Sprintf("- 填充：`%s`\n", spec.Padding))
+	out.WriteString(fmt.Sprintf("- 密钥编码：`%s`；IV 编码：`%s`；密文编码：`%s`\n", spec.KeyEncoding, spec.IVEncoding, spec.DataEncoding))
+	out.WriteString(fmt.Sprintf("- 明文长度：%d 字节\n", len(plain)))
+	if len(spec.IV) > 0 {
+		out.WriteString(fmt.Sprintf("- IV：`%s`\n", codec.EncodeToHex(spec.IV)))
+	}
+	out.WriteString("\n### 明文\n\n```text\n")
+	out.WriteString(outputText)
+	out.WriteString("\n```\n")
+	return out.String()
+}
+
+// looksLikeLoopHTTPFuzzNonFuzzDataTask 判断用户输入是否属于不需要 HTTP 请求的离线数据处理任务
+// （解密/加密/编码/变换等）。用于 bootstrap 失败时决定是否继续循环而不是直接退出。
+func looksLikeLoopHTTPFuzzNonFuzzDataTask(userInput string) bool {
+	lower := strings.ToLower(strings.TrimSpace(userInput))
+	if lower == "" {
+		return false
+	}
+	// 如果输入里明显包含 URL 或 HTTP 报文特征，说明用户是想测 HTTP 目标，
+	// 不应视为离线数据处理任务。
+	if urlPattern.MatchString(userInput) {
+		return false
+	}
+	if strings.Contains(lower, "http/1.1") || strings.Contains(lower, "http/1.0") || strings.Contains(lower, "get ") || strings.Contains(lower, "post ") {
+		return false
+	}
+	signals := []string{
+		"解密", "加密", "解密数据", "加密数据", "密文", "明文",
+		"decrypt", "encrypt", "cipher", "ciphertext", "plaintext", "crypto",
+		"密钥", "解码", "编码", "decode", "encode", "transform", "转换", "哈希", "hash", "摘要", "sign", "签名", "jwt",
+	}
+	for _, signal := range signals {
+		if strings.Contains(lower, signal) {
+			return true
+		}
+	}
+	// 短 token（key/iv/aes/des/rc4/sm4/rsa/gcm/cbc/ecb）使用词边界匹配，避免把
+	// hockey/monkey/keyboard 等普通词误判为离线数据处理任务。
+	shortTokens := []string{"key", "iv", "aes", "des", "rc4", "sm4", "rsa", "gcm", "cbc", "ecb"}
+	for _, token := range shortTokens {
+		if regexpWordBoundaryMatch(lower, token) {
+			return true
+		}
+	}
+	return false
+}
+
+// regexpWordBoundaryMatch 用词边界正则匹配 token，避免子串误伤。
+func regexpWordBoundaryMatch(text, token string) bool {
+	matched, _ := regexp.MatchString(`(^|[^a-z0-9])`+regexp.QuoteMeta(token)+`($|[^a-z0-9])`, text)
+	return matched
+}
+
+// buildLoopHTTPFuzzDecryptParamSummary 生成动作记录用的参数摘要。
+func buildLoopHTTPFuzzDecryptParamSummary(spec *loopHTTPFuzzDecryptSpec) string {
+	if spec == nil {
+		return ""
+	}
+	parts := []string{
+		fmt.Sprintf("algorithm=%s", spec.Algorithm),
+		fmt.Sprintf("padding=%s", spec.Padding),
+		fmt.Sprintf("data_encoding=%s", spec.DataEncoding),
+		fmt.Sprintf("key_encoding=%s", spec.KeyEncoding),
+		fmt.Sprintf("iv_encoding=%s", spec.IVEncoding),
+		fmt.Sprintf("output_encoding=%s", spec.OutputEncoding),
+		fmt.Sprintf("key_len=%d", len(spec.Key)),
+		fmt.Sprintf("data_len=%d", len(spec.Data)),
+	}
+	if len(spec.IV) > 0 {
+		parts = append(parts, fmt.Sprintf("iv_len=%d", len(spec.IV)))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_decrypt_data_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_decrypt_data_test.go
@@ -1,0 +1,378 @@
+package loop_http_fuzztest
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
+)
+
+func newHTTPFuzztestLoopForDecryptTest(t *testing.T) *reactloops.ReActLoop {
+	t.Helper()
+	invoker := mock.NewMockInvoker(context.Background())
+	loop, err := reactloops.CreateLoopByName(
+		LoopHTTPFuzztestName,
+		invoker,
+		reactloops.WithAllowRAG(false),
+		reactloops.WithAllowAIForge(false),
+		reactloops.WithAllowPlanAndExec(false),
+		reactloops.WithAllowUserInteract(false),
+		reactloops.WithInitTask(func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
+			operator.Continue()
+		}),
+	)
+	if err != nil {
+		t.Fatalf("create http_fuzztest loop: %v", err)
+	}
+	return loop
+}
+
+func executeDecryptDataAction(t *testing.T, loop *reactloops.ReActLoop, params map[string]any) *reactloops.LoopActionHandlerOperator {
+	t.Helper()
+	handler, err := loop.GetActionHandler("decrypt_data")
+	if err != nil {
+		t.Fatalf("get decrypt_data action: %v", err)
+	}
+
+	actionMap := map[string]any{
+		"@action": "decrypt_data",
+	}
+	for key, value := range params {
+		actionMap[key] = value
+	}
+	rawAction, err := json.Marshal(actionMap)
+	if err != nil {
+		t.Fatalf("marshal action: %v", err)
+	}
+	action, err := aicommon.ExtractAction(string(rawAction), "decrypt_data")
+	if err != nil {
+		t.Fatalf("extract action: %v", err)
+	}
+	if err := handler.ActionVerifier(loop, action); err != nil {
+		t.Fatalf("verify action: %v", err)
+	}
+
+	task := aicommon.NewStatefulTaskBase("decrypt-data-test", "decrypt data", context.Background(), loop.GetEmitter())
+	operator := reactloops.NewActionHandlerOperator(task)
+	handler.ActionHandler(loop, action, operator)
+	return operator
+}
+
+func TestDecryptDataAction_AESCBCBase64PKCS7(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	key := []byte("1234567890123456")
+	iv := []byte("abcdefghijklmnop")
+	ciphertext, err := codec.AESEncryptCBCWithPKCSPadding(key, []byte("hello yaklang"), iv)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	executeDecryptDataAction(t, loop, map[string]any{
+		"algorithm":       "aes-cbc",
+		"key":             string(key),
+		"iv":              string(iv),
+		"data":            codec.EncodeBase64(ciphertext),
+		"data_encoding":   "base64",
+		"padding":         "pkcs7",
+		"output_encoding": "utf8",
+		"reason":          "测试 AES-CBC 解密。",
+	})
+
+	if got := loop.Get(loopHTTPFuzzDecryptResultKey); got != "hello yaklang" {
+		t.Fatalf("expected decrypted 'hello yaklang', got %q", got)
+	}
+	if errStr := loop.Get(loopHTTPFuzzDecryptErrorKey); errStr != "" {
+		t.Fatalf("expected no decrypt error, got %q", errStr)
+	}
+	// hex 与 base64 结果也应正确落库
+	if loop.Get(loopHTTPFuzzDecryptResultHexKey) != codec.EncodeToHex([]byte("hello yaklang")) {
+		t.Fatalf("unexpected hex result: %s", loop.Get(loopHTTPFuzzDecryptResultHexKey))
+	}
+	if loop.Get(loopHTTPFuzzDecryptResultBase64Key) != codec.EncodeBase64([]byte("hello yaklang")) {
+		t.Fatalf("unexpected base64 result: %s", loop.Get(loopHTTPFuzzDecryptResultBase64Key))
+	}
+}
+
+func TestDecryptDataAction_AESECBHexKeyHexData(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	key := []byte("0123456789abcdef")
+	ciphertext, err := codec.AESEncryptECBWithPKCSPadding(key, []byte("ecb-mode-test"), nil)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	executeDecryptDataAction(t, loop, map[string]any{
+		"algorithm":       "aes-ecb",
+		"key":             codec.EncodeToHex(key),
+		"key_encoding":    "hex",
+		"data":            codec.EncodeToHex(ciphertext),
+		"data_encoding":   "hex",
+		"padding":         "pkcs7",
+		"output_encoding": "utf8",
+		"reason":          "测试 AES-ECB 解密。",
+	})
+
+	if got := loop.Get(loopHTTPFuzzDecryptResultKey); got != "ecb-mode-test" {
+		t.Fatalf("expected decrypted 'ecb-mode-test', got %q", got)
+	}
+}
+
+func TestDecryptDataAction_DESECBZeroPadding(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	key := []byte("12345678")
+	// 构造 DES-ECB 零填充密文：data 长度自动补 0 到 8 字节倍数
+	raw := []byte("des-data")
+	if len(raw)%8 != 0 {
+		raw = codec.ZeroPadding(raw, 8)
+	}
+	ciphertext, err := codec.DESEnc(key, raw, nil, codec.ECB)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	executeDecryptDataAction(t, loop, map[string]any{
+		"algorithm":       "des-ecb",
+		"key":             string(key),
+		"data":            codec.EncodeToHex(ciphertext),
+		"data_encoding":   "hex",
+		"padding":         "zero",
+		"output_encoding": "utf8",
+		"reason":          "测试 DES-ECB 零填充解密。",
+	})
+
+	if got := loop.Get(loopHTTPFuzzDecryptResultKey); got != "des-data" {
+		t.Fatalf("expected decrypted 'des-data', got %q", got)
+	}
+}
+
+func TestDecryptDataAction_InvalidAlgorithmRejected(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	handler, err := loop.GetActionHandler("decrypt_data")
+	if err != nil {
+		t.Fatalf("get decrypt_data action: %v", err)
+	}
+	action, err := aicommon.ExtractAction(`{"@action":"decrypt_data","algorithm":"unknown-x","key":"k","data":"ZGF0YQ==","reason":"r"}`, "decrypt_data")
+	if err != nil {
+		t.Fatalf("extract action: %v", err)
+	}
+	if err := handler.ActionVerifier(loop, action); err == nil {
+		t.Fatal("expected verifier to reject unknown algorithm")
+	}
+}
+
+func TestDecryptDataAction_MissingDataRejected(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	handler, err := loop.GetActionHandler("decrypt_data")
+	if err != nil {
+		t.Fatalf("get decrypt_data action: %v", err)
+	}
+	action, err := aicommon.ExtractAction(`{"@action":"decrypt_data","algorithm":"aes-cbc","key":"k","reason":"r"}`, "decrypt_data")
+	if err != nil {
+		t.Fatalf("extract action: %v", err)
+	}
+	if err := handler.ActionVerifier(loop, action); err == nil {
+		t.Fatal("expected verifier to reject missing data")
+	}
+}
+
+func TestDecryptDataAction_NonUTF8OutputFallsBackToHex(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	key := []byte("1234567890123456")
+	iv := []byte("abcdefghijklmnop")
+	// 二进制明文：包含非 UTF-8 字节（0xff 0xfe 等），不是合法 UTF-8
+	bin := []byte{0xff, 0xfe, 0xfd, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d}
+	ciphertext, err := codec.AESEncryptCBCWithPKCSPadding(key, bin, iv)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	executeDecryptDataAction(t, loop, map[string]any{
+		"algorithm":       "aes-cbc",
+		"key":             string(key),
+		"iv":              string(iv),
+		"data":            codec.EncodeBase64(ciphertext),
+		"data_encoding":   "base64",
+		"padding":         "pkcs7",
+		"output_encoding": "utf8",
+		"reason":          "测试非 UTF-8 明文输出回退。",
+	})
+
+	result := loop.Get(loopHTTPFuzzDecryptResultKey)
+	if !strings.Contains(result, "hex") {
+		t.Fatalf("expected non-utf8 output to fall back to hex, got %q", result)
+	}
+	if !strings.Contains(result, codec.EncodeToHex(bin)) {
+		t.Fatalf("expected hex representation of plaintext in output, got %q", result)
+	}
+}
+
+func TestDecryptDataAction_DecryptFailureSetsError(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	// 用错误长度的 key 触发失败
+	executeDecryptDataAction(t, loop, map[string]any{
+		"algorithm":     "aes-cbc",
+		"key":           "short",
+		"iv":            "abcdefghijklmnop",
+		"data":          "AAAA",
+		"data_encoding": "base64",
+		"padding":       "pkcs7",
+		"reason":        "测试错误 key 长度导致解密失败。",
+	})
+
+	if errStr := loop.Get(loopHTTPFuzzDecryptErrorKey); errStr == "" {
+		t.Fatal("expected decrypt error to be recorded")
+	}
+	if got := loop.Get(loopHTTPFuzzDecryptResultKey); got != "" {
+		t.Fatalf("expected no decrypt result on failure, got %q", got)
+	}
+}
+
+func TestDecryptDataAction_SM4CBC(t *testing.T) {
+	loop := newHTTPFuzztestLoopForDecryptTest(t)
+	key := []byte("0123456789abcdef")
+	iv := []byte("abcdefghijklmnop")
+	ciphertext, err := codec.SM4EncryptCBCWithPKCSPadding(key, []byte("sm4-cbc-test"), iv)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	executeDecryptDataAction(t, loop, map[string]any{
+		"algorithm":       "sm4-cbc",
+		"key":             string(key),
+		"iv":              string(iv),
+		"data":            codec.EncodeBase64(ciphertext),
+		"data_encoding":   "base64",
+		"padding":         "pkcs7",
+		"output_encoding": "utf8",
+		"reason":          "测试 SM4-CBC 解密。",
+	})
+
+	if got := loop.Get(loopHTTPFuzzDecryptResultKey); got != "sm4-cbc-test" {
+		t.Fatalf("expected decrypted 'sm4-cbc-test', got %q", got)
+	}
+}
+
+func TestLooksLikeLoopHTTPFuzzNonFuzzDataTask(t *testing.T) {
+	cases := map[string]bool{
+		"帮我解密这段数据，key 是 abc123":                     true,
+		"decrypt this AES-CBC ciphertext with key":  true,
+		"把这段密文用 RSA 私钥解出来":                          true,
+		"请帮我解析这个 JWT":                               true,
+		"帮我 fuzz 一下这个 URL: http://example.com?id=1": false,
+		"GET /login HTTP/1.1\nHost: example.com":    false,
+		"今天天气怎么样":                                   false,
+		"帮我看看这个 hockey 比赛的比分":                       false,
+		"monkey 和 donkey 有什么区别":                     false,
+	}
+	for input, want := range cases {
+		if got := looksLikeLoopHTTPFuzzNonFuzzDataTask(input); got != want {
+			t.Fatalf("looksLikeLoopHTTPFuzzNonFuzzDataTask(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+type decryptActionTestInvoker struct {
+	*mock.MockInvoker
+	artifactDir    string
+	events         []*schema.AiOutputEvent
+	resultPayloads []string
+	mu             sync.Mutex
+}
+
+func newDecryptActionTestInvoker(t *testing.T) *decryptActionTestInvoker {
+	t.Helper()
+	invoker := &decryptActionTestInvoker{
+		MockInvoker: mock.NewMockInvoker(context.Background()),
+		artifactDir: t.TempDir(),
+	}
+	if cfg, ok := invoker.GetConfig().(*mock.MockedAIConfig); ok {
+		cfg.Emitter = aicommon.NewEmitter("http-fuzztest-decrypt-test", func(e *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+			invoker.mu.Lock()
+			defer invoker.mu.Unlock()
+			invoker.events = append(invoker.events, e)
+			return e, nil
+		})
+	}
+	return invoker
+}
+
+func (i *decryptActionTestInvoker) EmitResultAfterStream(result any) {
+	i.mu.Lock()
+	i.resultPayloads = append(i.resultPayloads, strings.TrimSpace(utils.InterfaceToString(result)))
+	i.mu.Unlock()
+	if cfg, ok := i.GetConfig().(*mock.MockedAIConfig); ok && cfg.Emitter != nil {
+		_, _ = cfg.Emitter.EmitResultAfterStream("result", result, false)
+	}
+}
+
+func (i *decryptActionTestInvoker) EmitFileArtifactWithExt(name, ext string, data any) string {
+	return i.artifactDir
+}
+
+func TestDecryptDataAction_EmitsMarkdownResult(t *testing.T) {
+	invoker := newDecryptActionTestInvoker(t)
+	loop, err := reactloops.CreateLoopByName(
+		LoopHTTPFuzztestName,
+		invoker,
+		reactloops.WithAllowRAG(false),
+		reactloops.WithAllowAIForge(false),
+		reactloops.WithAllowPlanAndExec(false),
+		reactloops.WithAllowUserInteract(false),
+		reactloops.WithInitTask(func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
+			operator.Continue()
+		}),
+	)
+	if err != nil {
+		t.Fatalf("create loop: %v", err)
+	}
+
+	key := []byte("1234567890123456")
+	iv := []byte("abcdefghijklmnop")
+	ciphertext, err := codec.AESEncryptCBCWithPKCSPadding(key, []byte("visible-markdown-result"), iv)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	executeDecryptDataAction(t, loop, map[string]any{
+		"algorithm":       "aes-cbc",
+		"key":             string(key),
+		"iv":              string(iv),
+		"data":            codec.EncodeBase64(ciphertext),
+		"data_encoding":   "base64",
+		"padding":         "pkcs7",
+		"output_encoding": "utf8",
+		"reason":          "验证解密结果以 markdown 交付。",
+	})
+
+	if emitter := loop.GetEmitter(); emitter != nil {
+		emitter.WaitForStream()
+	}
+
+	if len(invoker.resultPayloads) != 1 {
+		t.Fatalf("expected one result payload, got %d", len(invoker.resultPayloads))
+	}
+	if !strings.Contains(invoker.resultPayloads[0], "## 解密结果") {
+		t.Fatalf("expected markdown result header, got: %s", invoker.resultPayloads[0])
+	}
+	if !strings.Contains(invoker.resultPayloads[0], "visible-markdown-result") {
+		t.Fatalf("expected decrypted plaintext in result, got: %s", invoker.resultPayloads[0])
+	}
+	var sawMarkdownStream bool
+	for _, event := range invoker.events {
+		if event.NodeId == "re-act-loop-answer-payload" && event.IsStream {
+			sawMarkdownStream = true
+			break
+		}
+	}
+	if !sawMarkdownStream {
+		t.Fatal("expected decrypt_data to emit markdown stream")
+	}
+}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
@@ -42,6 +42,7 @@ func init() {
 				reactloops.WithAllowToolCall(true),
 				reactloops.WithAITagFieldWithAINodeId("GEN_PACKET", generatedPacketContentField, "http_flow", aicommon.TypeCodeHTTPRequest),
 				reactloops.WithAITagFieldWithAINodeId("GEN_MODIFIED_PACKET", modifiedPacketContentField, "http_flow", aicommon.TypeCodeHTTPRequest),
+				reactloops.WithAITagFieldWithAINodeId("DECRYPT_DATA", loopHTTPFuzzDecryptContentField, loopHTTPFuzzDecryptAITagNode, aicommon.TypeTextPlain),
 				reactloops.WithOverrideLoopAction(loopActionDirectlyAnswerHTTPFuzztest),
 				reactloops.WithInitTask(buildInitTask(r)),
 				BuildOnPostIterationHook(r),
@@ -107,6 +108,7 @@ func init() {
 				fuzzUploadAction(r),
 				fuzzCookieAction(r),
 				generateAndSendPacketAction(r),
+				decryptDataAction(r),
 				generateRiskAction(r),
 			}
 			preset = append(preset, opts...)
@@ -116,7 +118,7 @@ func init() {
 		reactloops.WithLoopDescriptionZh("HTTP 安全模糊测试模式：对 HTTP 请求进行变异、发送和响应差异分析，用于发现潜在安全问题。"),
 		reactloops.WithVerboseName("HTTP Fuzz Test"),
 		reactloops.WithVerboseNameZh("HTTP 安全模糊测试"),
-		reactloops.WithLoopUsagePrompt("Use when user wants to fuzz HTTP requests and analyze security-relevant response differences. First use 'set_http_request' to set the target request, then use 'patch_http_request' for fine-grained single-step packet edits, auth/header/body format transforms, or repair, fuzz actions (fuzz_method, fuzz_path, fuzz_header, fuzz_get_params, fuzz_body, fuzz_upload, fuzz_cookie), 'modify_http_request' when the current packet must be revised with visible merge details via a full raw packet, 'generate_and_send_packet' when a complete raw packet must be constructed and sent, 'generate_risk' when validated or defensible vulnerability evidence should be saved as a Yakit risk, or 'directly_answer' for short testing-process Q&A."),
+		reactloops.WithLoopUsagePrompt("Use when user wants to fuzz HTTP requests and analyze security-relevant response differences, or process encrypted data offline. First use 'set_http_request' to set the target request, then use 'patch_http_request' for fine-grained single-step packet edits, auth/header/body format transforms, or repair, fuzz actions (fuzz_method, fuzz_path, fuzz_header, fuzz_get_params, fuzz_body, fuzz_upload, fuzz_cookie), 'modify_http_request' when the current packet must be revised with visible merge details via a full raw packet, 'generate_and_send_packet' when a complete raw packet must be constructed and sent, 'decrypt_data' when the user provides ciphertext + key and asks to decrypt (offline, no request sent), 'generate_risk' when validated or defensible vulnerability evidence should be saved as a Yakit risk, or 'directly_answer' for short testing-process Q&A."),
 		reactloops.WithLoopOutputExample(`
 * When user requests to fuzz HTTP request:
   {"@action": "http_fuzztest", "human_readable_thought": "I need to fuzz HTTP request parameters to find vulnerabilities"}
@@ -156,8 +158,12 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 				if restoreLoopHTTPFuzzSessionContext(loop, r) {
 					reactloops.EmitStatus(loop, "已恢复会话上下文 / Restored Session Context")
 					invoker.AddToTimeline("http_fuzztest_restore", "Restored HTTP fuzz session context from persistent session history")
+				} else if looksLikeLoopHTTPFuzzNonFuzzDataTask(task.GetUserInput()) {
+					loop.Set("non_fuzz_data_task", "true")
+					reactloops.EmitStatus(loop, "Non-Fuzz Data Processing Task Detected")
+					invoker.AddToTimeline("http_fuzztest_non_fuzz", "No HTTP packet found; user input looks like an offline data-processing task (decrypt/encode/transform). Proceeding without a request.")
 				} else {
-					reactloops.EmitStatus(loop, "未找到有效 HTTP 数据包 / No Valid HTTP Packet Found")
+					reactloops.EmitStatus(loop, "No Valid HTTP Packet Found")
 					operator.Done()
 					return
 				}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/output_example.txt
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/output_example.txt
@@ -270,3 +270,33 @@ Content-Type: application/json
   ]
 }
 ```
+
+### 示例 17：解密数据包中的加密参数（用户给了 key）
+```json
+{
+  "@action": "decrypt_data",
+  "algorithm": "aes-cbc",
+  "key": "1234567890123456",
+  "iv": "abcdefghijklmnop",
+  "data": "eGVsbG8geWFrIGVuY3J5cHRlZCBkYXRh",
+  "data_encoding": "base64",
+  "padding": "pkcs7",
+  "reason": "用户提供的数据包中 id 参数是加密值，并提供了 AES-CBC 密钥和 IV，需要先离线解密得到明文，再决定后续测试方向。"
+}
+```
+
+### 示例 18：大段密文通过 DECRYPT_DATA AITAG 传入
+```json
+{
+  "@action": "decrypt_data",
+  "algorithm": "aes-ecb",
+  "key": "0123456789abcdef",
+  "data_encoding": "base64",
+  "padding": "pkcs7",
+  "reason": "响应体中的 token 字段是 AES-ECB 加密值，密文较长，通过 AITAG 传入完整密文。"
+}
+```
+
+<|DECRYPT_DATA_CURRENT_NONCE|>
+G9y3fHdKDyDk8sYh5ZgH2JkLmNqPvBsWxCzEfGhIjKlMnOpQrStUvWxYzAbCdEfGh
+<|DECRYPT_DATA_END_CURRENT_NONCE|>

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/persistent_instruction.txt
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/prompts/persistent_instruction.txt
@@ -32,7 +32,8 @@
 9. modify_http_request：当需要修改当前有效 HTTP 数据包，并把 merge 结果明确展示给用户时使用。修改后应保留前一个版本、当前版本、修改原因和审核结果。
 10. generate_and_send_packet：当需要 AI 直接生成完整原始 HTTP 数据包并立即发送测试时使用。必须通过 AITAG 输出完整原始包。
 11. generate_risk：当已有明确漏洞证据，或有可辩护的潜在风险需要落库时，生成一条或多条 Yakit Risk。单条可直接写顶层字段；多条必须使用 risks 数组。每条 risk 都要写清 target、title、risk_type、severity、description、details、payload 等核心字段。
-12. directly_answer：仅用于回答测试过程中的简短问题，例如当前发现、下一步计划、为什么怀疑某漏洞、为什么需要人工审核。不要把它用于替代 fuzz、改包、整包生成或 risk 落库。
+12. decrypt_data：当用户提供密文 + 密钥并要求解密时使用（典型场景：数据包里的加密参数、Cookie、Body 字段，用户给了 key）。这是一个离线非 fuzz 动作，不发送任何请求，只做本地解密计算。需明确 algorithm、key、data；iv/padding/data_encoding 按实际情况补充。
+13. directly_answer：仅用于回答测试过程中的简短问题，例如当前发现、下一步计划、为什么怀疑某漏洞、为什么需要人工审核。不要把它用于替代 fuzz、改包、整包生成、risk 落库或数据解密。
 
 ### 漏洞分析优先级
 
@@ -116,6 +117,17 @@
 5. `location=body.format` 仅与 `operation=transform` 搭配，可用于 JSON/XML/Form 的格式切换。
 6. `location=auth.basic` 用于改账号密码并自动重编 Base64；`location=auth.bearer.jwt` 用于在无签名校验假设下修改 JWT payload。
 7. 如果只是补一个字段，不要为了这点改动重新生成整包。
+
+### decrypt_data 的使用规则
+
+1. 当用户给出密文 + 密钥要求解密时，优先使用 decrypt_data，而不是 modify_http_request / generate_and_send_packet。解密是离线计算，不发送请求。
+2. 常用算法：aes-cbc、aes-ecb、aes-cfb、aes-ofb、aes-ctr、aes-gcm、des-cbc、des-ecb、3des-cbc、3des-ecb、rc4、sm4-cbc、sm4-ecb、rsa。不确定算法时先分析密文特征（长度、前缀、base64 结构、IV 是否存在），必要时先用 auto_decode / decode 工具排除纯编码。
+3. 数据包中常见的密文是 base64，默认 data_encoding=base64；如果是 hex 则显式指定。密钥默认 utf8，也可以是 hex/base64。
+4. CBC/CFB/OFB/CTR/GCM 模式通常需要 IV（GCM 里叫 nonce）；ECB/RC4/RSA 不需要。
+5. 块模式默认 padding=pkcs7；如果是零填充或不需要填充，显式指定 padding=zero / padding=none。
+6. 如果大段密文需要传入，使用 DECRYPT_DATA AITAG 块输出密文，data 参数可省略。
+7. 解密成功后，明文会写入 loop 状态（decrypt_data_result / decrypt_data_result_hex / decrypt_data_result_base64），后续如需把明文写回数据包再测，可继续用 patch_http_request 或直接基于明文做分析。
+8. 解密失败时，先检查 key 长度（AES-128/192/256 分别要求 16/24/32 字节，DES 8 字节，3DES 24 字节，SM4 16 字节）、IV 长度、padding 和编码是否正确，再调整参数重试。
 
 ### generate_risk 的使用规则
 


### PR DESCRIPTION
…cryption

The loop_http_fuzztest loop previously had no way to handle non-fuzz utility tasks like decrypting encrypted data found in HTTP packets. Users who provided ciphertext + key and asked to decrypt were blocked by two issues:

1. No decrypt action existed — all 13 actions were fuzz-focused (send request, analyze response, save risk). The built-in AI tools only handle encodings (base64/hex/url), not keyed crypto.
2. buildInitTask exited early (operator.Done) when no HTTP packet was found, so pure decrypt requests never reached the AI.

This commit adds:

- action_decrypt_data.go: new 'decrypt_data' action supporting AES (CBC/ECB/CFB/OFB/CTR/GCM), DES, 3DES, RC4, SM4, and RSA decryption with configurable encoding (utf8/hex/base64) for key, IV, and data, padding modes (pkcs7/zero/none), and automatic hex fallback for non-UTF-8 plaintext. Large ciphertext can be passed via DECRYPT_DATA AITAG. Results are delivered via markdown stream + file artifact + loop state keys for downstream use.

- init.go changes: register DECRYPT_DATA AITAG field and the new action; update loop usage prompt; modify buildInitTask to continue (instead of exiting) when no HTTP packet is found but the user input looks like an offline data-processing task (decrypt/encrypt/encode/transform keywords with word-boundary matching to avoid false positives).

- prompts/persistent_instruction.txt: add decrypt_data to the action list and a dedicated usage rules section.

- prompts/output_example.txt: add two few-shot examples (inline data param and AITAG for large ciphertext).

- action_decrypt_data_test.go: 10 tests covering AES-CBC/ECB, DES-ECB, SM4-CBC, hex/base64 encodings, zero padding, invalid algorithm rejection, missing data rejection, non-UTF-8 output fallback, decrypt failure error recording, markdown result emission, and intent detection with false-positive guards.