### PR TITLE
fix(scannode): 明确 AI Chat 单轮生命周期与 Runtime 复用

### DIFF
--- a/.github/scripts/build-legion-product-node.sh
+++ b/.github/scripts/build-legion-product-node.sh
@@ -133,7 +133,7 @@ jq -n \
       module_go_version: $module_go_version,
       go_version: $go_version
     },
-    capabilities: ["ai.session.bind_epoch.v1", "hids", "ssa.rule_sync.export", "yak.execute"],
+    capabilities: ["ai.session.bind_epoch.v1", "ai.session.turn_lifecycle.v1", "hids", "ssa.rule_sync.export", "yak.execute"],
     binary: {
       path: $binary_name,
       sha256: $binary_sha,

--- a/.github/scripts/package-legion-ai-session-runtime.sh
+++ b/.github/scripts/package-legion-ai-session-runtime.sh
@@ -151,7 +151,7 @@ jq -n \
       module_go_version: $module_go_version,
       go_version: $runtime_go_version
     },
-    capabilities: ["ai.session.bind_epoch.v1", "ai.session.runtime", "yak.execute"],
+    capabilities: ["ai.session.bind_epoch.v1", "ai.session.runtime", "ai.session.turn_lifecycle.v1", "yak.execute"],
     binary: {
       path: "/usr/local/bin/legion-session-runtime",
       sha256: $binary_sha,

--- a/.github/scripts/test-package-legion-ai-session-runtime.sh
+++ b/.github/scripts/test-package-legion-ai-session-runtime.sh
@@ -62,6 +62,7 @@ jq -e \
     .recipe.link_mode == "dynamic-container" and
     .recipe.module_go_version == "1.22.12" and
     (.capabilities | index("ai.session.bind_epoch.v1")) != null and
+    (.capabilities | index("ai.session.turn_lifecycle.v1")) != null and
     (.capabilities | index("ai.session.runtime")) != null and
     (.capabilities | index("yak.execute")) != null and
     .image.ref == $image_ref and

--- a/.github/workflows/build-legion-ai-session-runtime-common.yml
+++ b/.github/workflows/build-legion-ai-session-runtime-common.yml
@@ -237,6 +237,8 @@ jobs:
               .recipe.goarch == $goarch and
               .recipe.cgo_enabled == true and
               .recipe.link_mode == "dynamic-container" and
+              (.capabilities | index("ai.session.bind_epoch.v1")) != null and
+              (.capabilities | index("ai.session.turn_lifecycle.v1")) != null and
               (.capabilities | index("ai.session.runtime")) != null and
               (.capabilities | index("yak.execute")) != null and
               .image.ref == $image_ref and

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -113,7 +113,8 @@ jobs:
               .recipe.build_tags == "hids" and
               .ci.workflow == "Build Trusted Legion Product Node" and
               (.capabilities | index("hids") != null) and
-              (.capabilities | index("ai.session.bind_epoch.v1") != null)
+              (.capabilities | index("ai.session.bind_epoch.v1") != null) and
+              (.capabilities | index("ai.session.turn_lifecycle.v1") != null)
             ' PRODUCT_NODE_MANIFEST.json >/dev/null
 
       - name: Stage architecture-specific artifact contract

--- a/common/ai/aid/aireact/queue_emit_test.go
+++ b/common/ai/aid/aireact/queue_emit_test.go
@@ -92,3 +92,17 @@ func TestEmitDequeueReActTask_IncludesUserInputUUID(t *testing.T) {
 	payload := parsePayload(t, events[0].Content)
 	require.Equal(t, "ui-uuid-dequeue-456", payload["react_task_user_input_uuid"])
 }
+
+func TestGetQueueInfoIncludesUserInputUUID(t *testing.T) {
+	queue := NewTaskQueue("test")
+	task := aicommon.NewStatefulTaskBase("task-queue-info", "follow up", nil, nil, true)
+	task.SetUserInputUUID("ui-uuid-queue-info-789")
+	require.NoError(t, queue.Append(task))
+
+	react := &ReAct{taskQueue: queue}
+	info := react.GetQueueInfo()
+	tasks, ok := info["tasks"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, tasks, 1)
+	require.Equal(t, "ui-uuid-queue-info-789", tasks[0]["user_input_uuid"])
+}

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -581,11 +581,12 @@ func (r *ReAct) GetQueueInfo() map[string]interface{} {
 
 	for _, task := range queueingTasks {
 		taskInfo := map[string]interface{}{
-			"id":         task.GetId(),
-			"user_input": task.GetUserInput(),
-			"status":     task.GetStatus(),
-			"created_at": task.GetCreatedAt(),
-			"focus_mode": task.GetFocusMode(),
+			"id":              task.GetId(),
+			"user_input":      task.GetUserInput(),
+			"user_input_uuid": task.GetUserInputUUID(),
+			"status":          task.GetStatus(),
+			"created_at":      task.GetCreatedAt(),
+			"focus_mode":      task.GetFocusMode(),
 		}
 
 		taskInfos = append(taskInfos, taskInfo)

--- a/docs/legion-linux-hids-readiness.md
+++ b/docs/legion-linux-hids-readiness.md
@@ -13,9 +13,9 @@ This document describes how to build, validate, and operate the current Legion H
 
 | Build mode | Host OS | Advertised capability keys | HIDS apply behavior |
 | --- | --- | --- | --- |
-| default build | any | `yak.execute`, `ssa.rule_sync.export`, `ai.session.bind_epoch.v1` | `ErrHIDSCapabilityNotCompiled` |
-| `-tags hids` | non-Linux | `yak.execute`, `hids`, `ssa.rule_sync.export`, `ai.session.bind_epoch.v1` | `ErrHIDSCapabilityUnsupportedPlatform` |
-| `-tags hids` | Linux | `yak.execute`, `hids`, `ssa.rule_sync.export`, `ai.session.bind_epoch.v1` | HIDS runtime starts if at least one collector comes up |
+| default build | any | `yak.execute`, `ssa.rule_sync.export`, `ai.session.bind_epoch.v1`, `ai.session.turn_lifecycle.v1` | `ErrHIDSCapabilityNotCompiled` |
+| `-tags hids` | non-Linux | `yak.execute`, `hids`, `ssa.rule_sync.export`, `ai.session.bind_epoch.v1`, `ai.session.turn_lifecycle.v1` | `ErrHIDSCapabilityUnsupportedPlatform` |
+| `-tags hids` | Linux | `yak.execute`, `hids`, `ssa.rule_sync.export`, `ai.session.bind_epoch.v1`, `ai.session.turn_lifecycle.v1` | HIDS runtime starts if at least one collector comes up |
 
 Operational implication: a build that advertises `hids` must still be scheduled to Linux hosts only. Building with `-tags hids` on macOS or Windows advertises the capability key, but the runtime cannot start there.
 

--- a/scannode/capability_keys.go
+++ b/scannode/capability_keys.go
@@ -5,6 +5,7 @@ import "strings"
 const (
 	capabilityKeySSARuleSyncExport = "ssa.rule_sync.export"
 	capabilityKeyAIBindEpochV1     = "ai.session.bind_epoch.v1"
+	capabilityKeyAITurnLifecycleV1 = "ai.session.turn_lifecycle.v1"
 )
 
 func normalizeScanNodeCapabilityKeys(input []string) []string {

--- a/scannode/capability_keys_hids.go
+++ b/scannode/capability_keys_hids.go
@@ -3,5 +3,11 @@
 package scannode
 
 func compiledScanNodeCapabilityKeys() []string {
-	return []string{"yak.execute", "hids", capabilityKeySSARuleSyncExport, capabilityKeyAIBindEpochV1}
+	return []string{
+		"yak.execute",
+		"hids",
+		capabilityKeySSARuleSyncExport,
+		capabilityKeyAIBindEpochV1,
+		capabilityKeyAITurnLifecycleV1,
+	}
 }

--- a/scannode/capability_keys_hids_test.go
+++ b/scannode/capability_keys_hids_test.go
@@ -11,7 +11,13 @@ func TestNormalizeScanNodeCapabilityKeysAddsHIDSCapabilityWhenCompiled(t *testin
 	t.Parallel()
 
 	got := normalizeScanNodeCapabilityKeys(nil)
-	want := []string{"yak.execute", "hids", capabilityKeySSARuleSyncExport, capabilityKeyAIBindEpochV1}
+	want := []string{
+		"yak.execute",
+		"hids",
+		capabilityKeySSARuleSyncExport,
+		capabilityKeyAIBindEpochV1,
+		capabilityKeyAITurnLifecycleV1,
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}
@@ -27,7 +33,14 @@ func TestNormalizeScanNodeCapabilityKeysDeduplicatesCompiledHIDSCapability(t *te
 		"yak.execute",
 		"extra.capability",
 	})
-	want := []string{"yak.execute", "hids", capabilityKeySSARuleSyncExport, capabilityKeyAIBindEpochV1, "extra.capability"}
+	want := []string{
+		"yak.execute",
+		"hids",
+		capabilityKeySSARuleSyncExport,
+		capabilityKeyAIBindEpochV1,
+		capabilityKeyAITurnLifecycleV1,
+		"extra.capability",
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}

--- a/scannode/capability_keys_nohids.go
+++ b/scannode/capability_keys_nohids.go
@@ -3,5 +3,10 @@
 package scannode
 
 func compiledScanNodeCapabilityKeys() []string {
-	return []string{"yak.execute", capabilityKeySSARuleSyncExport, capabilityKeyAIBindEpochV1}
+	return []string{
+		"yak.execute",
+		capabilityKeySSARuleSyncExport,
+		capabilityKeyAIBindEpochV1,
+		capabilityKeyAITurnLifecycleV1,
+	}
 }

--- a/scannode/capability_keys_nohids_test.go
+++ b/scannode/capability_keys_nohids_test.go
@@ -11,7 +11,12 @@ func TestNormalizeScanNodeCapabilityKeysDefaultsToNonHIDSBuildSurface(t *testing
 	t.Parallel()
 
 	got := normalizeScanNodeCapabilityKeys(nil)
-	want := []string{"yak.execute", capabilityKeySSARuleSyncExport, capabilityKeyAIBindEpochV1}
+	want := []string{
+		"yak.execute",
+		capabilityKeySSARuleSyncExport,
+		capabilityKeyAIBindEpochV1,
+		capabilityKeyAITurnLifecycleV1,
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}
@@ -27,7 +32,13 @@ func TestNormalizeScanNodeCapabilityKeysKeepsExplicitExtrasWithoutDuplicates(t *
 		" ",
 		"extra.capability",
 	})
-	want := []string{"yak.execute", capabilityKeySSARuleSyncExport, capabilityKeyAIBindEpochV1, "extra.capability"}
+	want := []string{
+		"yak.execute",
+		capabilityKeySSARuleSyncExport,
+		capabilityKeyAIBindEpochV1,
+		capabilityKeyAITurnLifecycleV1,
+		"extra.capability",
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}

--- a/scannode/legion_ai_bridge.go
+++ b/scannode/legion_ai_bridge.go
@@ -58,6 +58,8 @@ func normalizeAISessionRuntimeMode(rawMode string) (string, bool) {
 
 const aiSessionRuntimeEventInput = "ai.session.input"
 const aiSessionRuntimeEventContextUpdated = "ai.session.context_updated"
+const aiSessionRuntimeEventTurnCompleted = "ai.session.turn.completed"
+const aiSessionRuntimeEventTurnFailed = "ai.session.turn.failed"
 
 var errAISessionInputInFlight = errors.New("ai session input command is already in flight")
 
@@ -97,6 +99,14 @@ type aiSessionRuntimeRefEmitter interface {
 type aiSessionRuntimeTurnCompleter interface {
 	DoneTurn(string, []byte)
 	FailTurn(string, string, string, []byte)
+}
+
+// aiSessionRuntimeTurnReporter closes a logical turn without closing the
+// reusable multi-turn Session runtime. Session terminal completion continues
+// to use aiSessionRuntimeTurnCompleter for single_run execution only.
+type aiSessionRuntimeTurnReporter interface {
+	TurnCompleted(string, []byte)
+	TurnFailed(string, string, string, []byte)
 }
 
 type aiSessionBinding struct {
@@ -533,6 +543,16 @@ func (m *aiSessionRuntimeManager) AcceptInput(
 	}
 
 	session.mu.Lock()
+	if ref.BindEpoch != session.ref.BindEpoch {
+		currentEpoch := session.ref.BindEpoch
+		session.mu.Unlock()
+		return acceptedAISessionInput{ref: ref}, fmt.Errorf(
+			"ai session bind epoch mismatch: command=%d runtime=%d session=%s",
+			ref.BindEpoch,
+			currentEpoch,
+			ref.SessionID,
+		)
+	}
 	if processed, ok := session.processedInputCommands[ref.CommandID]; ok {
 		ref.RunID = session.ref.RunID
 		ref.BindEpoch = session.ref.BindEpoch
@@ -641,6 +661,16 @@ func (m *aiSessionRuntimeManager) AcceptContextUpdate(
 	reason := strings.TrimSpace(command.GetReason())
 
 	session.mu.Lock()
+	if ref.BindEpoch != session.ref.BindEpoch {
+		currentEpoch := session.ref.BindEpoch
+		session.mu.Unlock()
+		return acceptedAISessionContextUpdate{ref: ref}, fmt.Errorf(
+			"ai session bind epoch mismatch: command=%d runtime=%d session=%s",
+			ref.BindEpoch,
+			currentEpoch,
+			ref.SessionID,
+		)
+	}
 	if session.terminalCommandID != "" || session.terminalPublishFailed {
 		terminalCommandID := session.terminalCommandID
 		session.mu.Unlock()
@@ -708,6 +738,16 @@ func (m *aiSessionRuntimeManager) Cancel(
 		return cancelledAISessionRuntime{ref: ref, reason: reason}, fmt.Errorf("ai session owner mismatch: %s", session.ref.OwnerUserID)
 	}
 	session.mu.Lock()
+	if ref.BindEpoch != session.ref.BindEpoch {
+		currentEpoch := session.ref.BindEpoch
+		session.mu.Unlock()
+		return cancelledAISessionRuntime{ref: ref, reason: reason}, fmt.Errorf(
+			"ai session bind epoch mismatch: command=%d runtime=%d session=%s",
+			ref.BindEpoch,
+			currentEpoch,
+			ref.SessionID,
+		)
+	}
 	ref.RunID = session.ref.RunID
 	ref.BindEpoch = session.ref.BindEpoch
 	handle := session.handle
@@ -768,6 +808,16 @@ func (m *aiSessionRuntimeManager) Close(
 		return closedAISessionRuntime{ref: ref, reason: reason}, fmt.Errorf("ai session owner mismatch: %s", session.ref.OwnerUserID)
 	}
 	session.mu.Lock()
+	if ref.BindEpoch != session.ref.BindEpoch {
+		currentEpoch := session.ref.BindEpoch
+		session.mu.Unlock()
+		return closedAISessionRuntime{ref: ref, reason: reason}, fmt.Errorf(
+			"ai session bind epoch mismatch: command=%d runtime=%d session=%s",
+			ref.BindEpoch,
+			currentEpoch,
+			ref.SessionID,
+		)
+	}
 	ref.RunID = session.ref.RunID
 	ref.BindEpoch = session.ref.BindEpoch
 	handle := session.handle
@@ -1398,6 +1448,7 @@ func aiSessionRefFromInputCommand(command *aiv1.PushAISessionInputCommand) aiSes
 		CommandID:   command.GetMetadata().GetCommandId(),
 		SessionID:   command.GetSession().GetSessionId(),
 		RunID:       command.GetSession().GetRunId(),
+		BindEpoch:   command.GetSession().GetBindEpoch(),
 		OwnerUserID: strings.TrimSpace(command.GetOwnerUserId()),
 	}
 }
@@ -1407,6 +1458,7 @@ func aiSessionRefFromContextCommand(command *aiv1.AppendAISessionContextCommand)
 		CommandID:   command.GetMetadata().GetCommandId(),
 		SessionID:   command.GetSession().GetSessionId(),
 		RunID:       command.GetSession().GetRunId(),
+		BindEpoch:   command.GetSession().GetBindEpoch(),
 		OwnerUserID: strings.TrimSpace(command.GetOwnerUserId()),
 	}
 }
@@ -1416,6 +1468,7 @@ func aiSessionRefFromCancelCommand(command *aiv1.CancelAISessionCommand) aiSessi
 		CommandID:   command.GetMetadata().GetCommandId(),
 		SessionID:   command.GetSession().GetSessionId(),
 		RunID:       command.GetSession().GetRunId(),
+		BindEpoch:   command.GetSession().GetBindEpoch(),
 		OwnerUserID: strings.TrimSpace(command.GetOwnerUserId()),
 	}
 }
@@ -1425,6 +1478,7 @@ func aiSessionRefFromCloseCommand(command *aiv1.CloseAISessionCommand) aiSession
 		CommandID:   command.GetMetadata().GetCommandId(),
 		SessionID:   command.GetSession().GetSessionId(),
 		RunID:       command.GetSession().GetRunId(),
+		BindEpoch:   command.GetSession().GetBindEpoch(),
 		OwnerUserID: strings.TrimSpace(command.GetOwnerUserId()),
 	}
 }
@@ -1490,7 +1544,7 @@ func (e *managedAISessionRuntimeEmitter) emitForRef(
 	} else {
 		ref, seq = e.runtime.nextEventRefAndSeqFor(*frozenRef)
 	}
-	rootTerminal := isYakAIRootPlanExecutionCompleted(payloadJSON)
+	rootTerminal := e.runtime.singleRunExecution() && isYakAIRootPlanExecutionCompleted(payloadJSON)
 	claimed := false
 	if rootTerminal {
 		ref, claimed = e.runtime.claimRootPlanTerminal(ref.CommandID)
@@ -1608,6 +1662,65 @@ func (e *managedAISessionRuntimeEmitter) FailTurn(
 	}
 }
 
+func (e *managedAISessionRuntimeEmitter) TurnCompleted(turnID string, resultJSON []byte) {
+	e.publishTurnState(
+		turnID,
+		aiSessionRuntimeEventTurnCompleted,
+		mustJSON(map[string]any{
+			"turn_id":     strings.TrimSpace(turnID),
+			"status":      "completed",
+			"finished_at": time.Now().UTC().Format(time.RFC3339Nano),
+			"result":      json.RawMessage(cloneBytes(resultJSON)),
+		}),
+	)
+}
+
+func (e *managedAISessionRuntimeEmitter) TurnFailed(
+	turnID string,
+	code string,
+	message string,
+	detailJSON []byte,
+) {
+	e.publishTurnState(
+		turnID,
+		aiSessionRuntimeEventTurnFailed,
+		mustJSON(map[string]any{
+			"turn_id":     strings.TrimSpace(turnID),
+			"status":      "failed",
+			"finished_at": time.Now().UTC().Format(time.RFC3339Nano),
+			"error": map[string]any{
+				"code":    strings.TrimSpace(code),
+				"message": strings.TrimSpace(message),
+				"detail":  json.RawMessage(cloneBytes(detailJSON)),
+			},
+		}),
+	)
+}
+
+func (e *managedAISessionRuntimeEmitter) publishTurnState(
+	turnID string,
+	eventType string,
+	payloadJSON []byte,
+) {
+	if e == nil || e.runtime == nil || e.publisher == nil {
+		return
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" || !e.runtime.beginEmission() {
+		return
+	}
+	ref := e.runtime.currentRef()
+	ref.CommandID = turnID
+	ref, seq := e.runtime.nextEventRefAndSeqFor(ref)
+	err := retryAISessionTurnPublish(e.ctx, func(ctx context.Context) error {
+		return e.publisher.PublishEvent(ctx, ref, seq, eventType, payloadJSON)
+	})
+	e.runtime.endEmission()
+	if err != nil {
+		logAISessionRuntimePublishError("turn", ref.SessionID, err)
+	}
+}
+
 func (e *managedAISessionRuntimeEmitter) Failed(code string, message string, detailJSON []byte) {
 	if e == nil || e.runtime == nil || e.publisher == nil {
 		return
@@ -1670,6 +1783,48 @@ func retryAISessionTerminalPublish(
 	delay := initialDelay
 	for {
 		err = publish(ctx)
+		if err == nil {
+			return nil
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return errors.Join(err, ctx.Err())
+		case <-timer.C:
+		}
+		if delay < maxDelay {
+			delay *= 2
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+		}
+	}
+}
+
+// Turn completion is the durable boundary that makes a reusable Session
+// accept the next free input. Unlike a Session terminal command, it must not
+// be abandoned after a local timeout: doing so leaves the platform with an
+// active Turn while the runtime silently advances. Retry until the runtime is
+// explicitly cancelled or retired; the handle keeps the Turn active while
+// this call is blocked.
+func retryAISessionTurnPublish(
+	ctx context.Context,
+	publish func(context.Context) error,
+) error {
+	const initialDelay = 100 * time.Millisecond
+	const maxDelay = 5 * time.Second
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	delay := initialDelay
+	for {
+		err := publish(ctx)
 		if err == nil {
 			return nil
 		}
@@ -1782,6 +1937,15 @@ func (r *aiSessionRuntime) claimAutomaticTerminal(turnID string) (aiSessionComma
 	r.terminalKind = "auto"
 	r.terminalReason = "single run completed"
 	return ref, true
+}
+
+func (r *aiSessionRuntime) singleRunExecution() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return strings.EqualFold(strings.TrimSpace(r.executionMode), "single_run")
 }
 
 func (r *aiSessionRuntime) claimTerminalFailure(turnID string) (aiSessionCommandRef, bool) {

--- a/scannode/legion_ai_bridge_test.go
+++ b/scannode/legion_ai_bridge_test.go
@@ -184,7 +184,7 @@ func TestAISessionRuntimeManagerFailedRebindKeepsPreviousRuntime(t *testing.T) {
 	recorder.assertInput(t, 0, "hello")
 }
 
-func TestAISessionRuntimeManagerCarriesInputIdempotencyAcrossRebind(t *testing.T) {
+func TestAISessionRuntimeManagerFencesProcessedInputReplayAcrossRebind(t *testing.T) {
 	recorder := &recordingAISessionRuntimeDriver{}
 	manager := newAISessionRuntimeManager(recorder)
 	first := validAISessionBindCommand()
@@ -213,17 +213,40 @@ func TestAISessionRuntimeManagerCarriesInputIdempotencyAcrossRebind(t *testing.T
 	// The old handle can finish after the swap. Completion must update the
 	// Session-wide command ledger inherited by the new generation.
 	manager.CompleteInput(accepted, true)
-	replayed, err := manager.AcceptInput(input)
-	if err != nil {
-		t.Fatalf("replayed input: %v", err)
-	}
-	if !replayed.duplicate {
-		t.Fatal("replayed pre-rebind command was admitted to the new runtime")
+	if _, err := manager.AcceptInput(input); err == nil {
+		t.Fatal("processed pre-rebind command bypassed the new bind epoch fence")
 	}
 	recorder.mu.Lock()
 	defer recorder.mu.Unlock()
 	if len(recorder.inputs) != 1 {
 		t.Fatalf("input executed %d times, want once", len(recorder.inputs))
+	}
+}
+
+func TestAISessionRuntimeManagerRejectsMissingEpochOnModernRuntime(t *testing.T) {
+	manager := newAISessionRuntimeManager(&recordingAISessionRuntimeDriver{})
+	if _, err := manager.Bind(context.Background(), validAISessionBindCommand(), nil, aiSessionRuntimeBindOptions{}); err != nil {
+		t.Fatalf("bind runtime: %v", err)
+	}
+	input := validAISessionInputCommand()
+	input.Session.BindEpoch = 0
+	if _, err := manager.AcceptInput(input); err == nil {
+		t.Fatal("modern runtime accepted an input without bind epoch")
+	}
+	contextCommand := validAISessionContextCommand()
+	contextCommand.Session.BindEpoch = 0
+	if _, err := manager.AcceptContextUpdate(contextCommand); err == nil {
+		t.Fatal("modern runtime accepted context without bind epoch")
+	}
+	cancelCommand := validAISessionCancelCommand()
+	cancelCommand.Session.BindEpoch = 0
+	if _, err := manager.Cancel(cancelCommand); err == nil {
+		t.Fatal("modern runtime accepted cancel without bind epoch")
+	}
+	closeCommand := validAISessionCloseCommand()
+	closeCommand.Session.BindEpoch = 0
+	if _, err := manager.Close(closeCommand); err == nil {
+		t.Fatal("modern runtime accepted close without bind epoch")
 	}
 }
 
@@ -406,7 +429,15 @@ func TestAISessionRuntimeRebindDrainDoesNotBlockOtherSessions(t *testing.T) {
 func TestAISessionRootTerminalEventFencesLaterRebind(t *testing.T) {
 	bridge, fakeJS, driver := newTestAISessionBridge(t)
 	first := validAISessionBindCommand()
-	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, first)); err != nil {
+	first.ResultContext = validAIFocusResultContext()
+	first.ResultContext.ExecutionMode = "single_run"
+	first.Session.RunId = first.ResultContext.FocusRunId
+	if _, err := bridge.aiRuntime.Bind(
+		context.Background(),
+		first,
+		bridge.ensureAIPublisher(),
+		aiSessionRuntimeBindOptions{},
+	); err != nil {
 		t.Fatalf("first bind: %v", err)
 	}
 	driver.mu.Lock()
@@ -435,6 +466,9 @@ func TestAISessionRootTerminalCompletesFocusResult(t *testing.T) {
 	bridge, _, driver := newTestAISessionBridge(t)
 	sink := &recordingLifecycleAIFocusResultSink{}
 	command := validAISessionBindCommand()
+	command.ResultContext = validAIFocusResultContext()
+	command.ResultContext.ExecutionMode = "single_run"
+	command.Session.RunId = command.ResultContext.FocusRunId
 	if _, err := bridge.aiRuntime.Bind(
 		context.Background(),
 		command,
@@ -462,6 +496,9 @@ func TestAISessionRootTerminalPublishTimeoutAllowsHigherEpochRebind(t *testing.T
 	defer func() { aiSessionTerminalPublishTimeout = oldTimeout }()
 
 	command := validAISessionBindCommand()
+	command.ResultContext = validAIFocusResultContext()
+	command.ResultContext.ExecutionMode = "single_run"
+	command.Session.RunId = command.ResultContext.FocusRunId
 	if _, err := bridge.aiRuntime.Bind(
 		context.Background(),
 		command,
@@ -496,6 +533,9 @@ func TestAISessionRootTerminalPublicationNAKsRecoveryBindUntilClaimSettles(t *te
 	defer func() { aiSessionTerminalPublishTimeout = oldTimeout }()
 
 	command := validAISessionBindCommand()
+	command.ResultContext = validAIFocusResultContext()
+	command.ResultContext.ExecutionMode = "single_run"
+	command.Session.RunId = command.ResultContext.FocusRunId
 	if _, err := bridge.aiRuntime.Bind(
 		context.Background(),
 		command,
@@ -1395,20 +1435,55 @@ func TestRuntimeEmitterConversationResultKeepsRuntimeAfterTurn(t *testing.T) {
 	driver.mu.Lock()
 	emitter := driver.emitters[0]
 	driver.mu.Unlock()
-	completer, ok := emitter.(aiSessionRuntimeTurnCompleter)
+	reporter, ok := emitter.(aiSessionRuntimeTurnReporter)
 	if !ok {
-		t.Fatal("managed runtime emitter does not support turn completion")
+		t.Fatal("managed runtime emitter does not support conversation turn completion")
 	}
-	completer.DoneTurn("cmd-input-1", []byte(`{"status":"done"}`))
+	reporter.TurnCompleted("cmd-input-1", []byte(`{"status":"done"}`))
 
 	assertPublishedSubjectCount(t, fakeJS, "legion.event.job.succeeded", 0)
 	assertPublishedSubjectCount(t, fakeJS, "legion.event.ai.session.done", 0)
+	msg := waitForPublishedMessage(t, fakeJS, 0)
+	var event aiv1.AISessionEvent
+	if err := proto.Unmarshal(msg.Data, &event); err != nil {
+		t.Fatalf("unmarshal conversation turn completion: %v", err)
+	}
+	if event.GetEventType() != aiSessionRuntimeEventTurnCompleted || event.GetSession().GetBindEpoch() != 1 {
+		t.Fatalf("turn completion event = %#v", &event)
+	}
 	if !hasAISessionRuntime(bridge.aiRuntime, "ai-session-1") {
 		t.Fatal("multi-turn conversation runtime was removed after one turn")
 	}
 }
 
-func TestRuntimeEmitterConversationFailureCompletesTerminalRuntime(t *testing.T) {
+func TestRuntimeEmitterConversationTurnPublicationOutlivesTerminalTimeout(t *testing.T) {
+	bridge, fakeJS, driver := newTestAISessionBridge(t)
+	command := validAISessionBindCommand()
+	command.ResultContext = validAIFocusResultContext()
+	command.ResultContext.FocusMode = legionAIConversationAuditResultMode
+	command.ResultContext.FocusReleaseId = ""
+	command.ResultContext.ExecutionMode = legionAIConversationExecutionMode
+	command.Session.RunId = command.ResultContext.FocusRunId
+	bridge.publisher.js = fakeJS
+	bridge.publisher.natsURL = "nats://node-ai.test"
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, command)); err != nil {
+		t.Fatalf("handle conversation bind: %v", err)
+	}
+	resetPublishedMessages(fakeJS)
+	previousTimeout := aiSessionTerminalPublishTimeout
+	aiSessionTerminalPublishTimeout = time.Millisecond
+	defer func() { aiSessionTerminalPublishTimeout = previousTimeout }()
+	fakeJS.failNextPublishes(3)
+
+	driver.mu.Lock()
+	reporter := driver.emitters[0].(aiSessionRuntimeTurnReporter)
+	driver.mu.Unlock()
+	reporter.TurnCompleted("cmd-input-1", []byte(`{"status":"done"}`))
+
+	assertPublishedSubjectCount(t, fakeJS, "legion.event.ai.session.event", 1)
+}
+
+func TestRuntimeEmitterConversationFailureKeepsRuntime(t *testing.T) {
 	bridge, fakeJS, driver := newTestAISessionBridge(t)
 	command := validAISessionBindCommand()
 	command.ResultContext = validAIFocusResultContext()
@@ -1429,21 +1504,52 @@ func TestRuntimeEmitterConversationFailureCompletesTerminalRuntime(t *testing.T)
 	driver.mu.Lock()
 	emitter := driver.emitters[0]
 	driver.mu.Unlock()
-	completer, ok := emitter.(aiSessionRuntimeTurnCompleter)
+	reporter, ok := emitter.(aiSessionRuntimeTurnReporter)
 	if !ok {
-		t.Fatal("managed runtime emitter does not support turn failure")
+		t.Fatal("managed runtime emitter does not support conversation turn failure")
 	}
-	completer.FailTurn(
+	reporter.TurnFailed(
 		"cmd-input-1",
 		"yak_ai_forge_failed",
 		"forge failed",
 		[]byte(`{"runtime":"stateless_yak_ai_engine"}`),
 	)
 
-	assertPublishedSubjectCount(t, fakeJS, "legion.event.ai.session.failed", 1)
-	if hasAISessionRuntime(bridge.aiRuntime, "ai-session-1") {
-		t.Fatal("failed conversation runtime was not removed after terminal publication")
+	assertPublishedSubjectCount(t, fakeJS, "legion.event.ai.session.failed", 0)
+	msg := waitForPublishedMessage(t, fakeJS, 0)
+	var event aiv1.AISessionEvent
+	if err := proto.Unmarshal(msg.Data, &event); err != nil {
+		t.Fatalf("unmarshal conversation turn failure: %v", err)
 	}
+	if event.GetEventType() != aiSessionRuntimeEventTurnFailed {
+		t.Fatalf("turn failure event type = %q", event.GetEventType())
+	}
+	if !hasAISessionRuntime(bridge.aiRuntime, "ai-session-1") {
+		t.Fatal("failed conversation turn removed reusable runtime")
+	}
+}
+
+func TestAISessionConversationRootPlanMarkerDoesNotTerminalizeRuntime(t *testing.T) {
+	bridge, fakeJS, driver := newTestAISessionBridge(t)
+	command := validAISessionBindCommand()
+	command.ResultContext = validAIFocusResultContext()
+	command.ResultContext.ExecutionMode = legionAIConversationExecutionMode
+	command.ResultContext.FocusMode = legionAIConversationAuditResultMode
+	command.ResultContext.FocusReleaseId = ""
+	command.Session.RunId = command.ResultContext.FocusRunId
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, command)); err != nil {
+		t.Fatalf("bind conversation runtime: %v", err)
+	}
+	driver.mu.Lock()
+	emitter := driver.emitters[0]
+	driver.mu.Unlock()
+	resetPublishedMessages(fakeJS)
+	emitter.Emit("ai.session.event", []byte(`{"type":"end_plan_and_execution","task_index":"","content_json":{}}`))
+	if !hasAISessionRuntime(bridge.aiRuntime, command.GetSession().GetSessionId()) {
+		t.Fatal("multi-turn root plan marker terminalized reusable runtime")
+	}
+	assertPublishedSubjectCount(t, fakeJS, "legion.event.ai.session.event", 1)
+	assertPublishedSubjectCount(t, fakeJS, "legion.event.ai.session.done", 0)
 }
 
 func TestRuntimeManagerRejectsNewCommandsAfterTerminalFailureClaim(t *testing.T) {
@@ -1720,10 +1826,78 @@ func validAISessionInputCommand() *aiv1.PushAISessionInputCommand {
 		Session: &aiv1.AISessionRef{
 			SessionId: "ai-session-1",
 			RunId:     "run-1",
+			BindEpoch: 1,
 		},
 		OwnerUserId: "user-1",
 		InputType:   "message",
 		InputJson:   []byte(`{"content":"hello"}`),
+	}
+}
+
+func TestRuntimeManagerRejectsDelayedInputFromOldBindEpoch(t *testing.T) {
+	bridge, fakeJS, driver := newTestAISessionBridge(t)
+	first := validAISessionBindCommand()
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, first)); err != nil {
+		t.Fatalf("bind epoch one: %v", err)
+	}
+	rebind := validAISessionBindCommand()
+	rebind.Metadata.CommandId = "cmd-bind-2"
+	rebind.BindEpoch = 2
+	rebind.Session.BindEpoch = 2
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, rebind)); err != nil {
+		t.Fatalf("bind epoch two: %v", err)
+	}
+
+	delayed := validAISessionInputCommand()
+	delayed.Metadata.CommandId = "cmd-input-delayed"
+	delayed.TurnId = delayed.Metadata.CommandId
+	delayed.Session.BindEpoch = 1
+	resetPublishedMessages(fakeJS)
+	if err := bridge.handleAISessionInput(context.Background(), mustMarshalProto(t, delayed)); err != nil {
+		t.Fatalf("publish delayed old-epoch input failure: %v", err)
+	}
+	assertPublishedSubjectCount(t, fakeJS, "legion.event.ai.session.failed", 1)
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if got := len(driver.inputs); got != 0 {
+		t.Fatalf("old-epoch input reached current runtime: inputs=%d", got)
+	}
+}
+
+func TestRuntimeManagerRejectsDelayedControlCommandsFromOldBindEpoch(t *testing.T) {
+	bridge, _, _ := newTestAISessionBridge(t)
+	first := validAISessionBindCommand()
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, first)); err != nil {
+		t.Fatalf("bind epoch one: %v", err)
+	}
+	rebind := validAISessionBindCommand()
+	rebind.Metadata.CommandId = "cmd-bind-control-2"
+	rebind.BindEpoch = 2
+	rebind.Session.BindEpoch = 2
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, rebind)); err != nil {
+		t.Fatalf("bind epoch two: %v", err)
+	}
+
+	contextCommand := validAISessionContextCommand()
+	contextCommand.Metadata.CommandId = "cmd-context-delayed"
+	contextCommand.Session.BindEpoch = 1
+	if _, err := bridge.aiRuntime.AcceptContextUpdate(contextCommand); err == nil {
+		t.Fatal("old-epoch context command was accepted")
+	}
+	cancelCommand := validAISessionCancelCommand()
+	cancelCommand.Metadata.CommandId = "cmd-cancel-delayed"
+	cancelCommand.Session.BindEpoch = 1
+	if _, err := bridge.aiRuntime.Cancel(cancelCommand); err == nil {
+		t.Fatal("old-epoch cancel command was accepted")
+	}
+	closeCommand := validAISessionCloseCommand()
+	closeCommand.Metadata.CommandId = "cmd-close-delayed"
+	closeCommand.Session.BindEpoch = 1
+	if _, err := bridge.aiRuntime.Close(closeCommand); err == nil {
+		t.Fatal("old-epoch close command was accepted")
+	}
+	if !hasAISessionRuntime(bridge.aiRuntime, first.GetSession().GetSessionId()) {
+		t.Fatal("old-epoch control command retired the current runtime")
 	}
 }
 
@@ -1735,6 +1909,7 @@ func validAISessionCancelCommand() *aiv1.CancelAISessionCommand {
 		Session: &aiv1.AISessionRef{
 			SessionId: "ai-session-1",
 			RunId:     "run-1",
+			BindEpoch: 1,
 		},
 		OwnerUserId: "user-1",
 		Reason:      "user requested",
@@ -1749,6 +1924,7 @@ func validAISessionContextCommand() *aiv1.AppendAISessionContextCommand {
 		Session: &aiv1.AISessionRef{
 			SessionId: "ai-session-1",
 			RunId:     "run-1",
+			BindEpoch: 1,
 		},
 		OwnerUserId: "user-1",
 		Attachments: []*aiv1.AISessionAttachmentRef{
@@ -1770,6 +1946,7 @@ func validAISessionCloseCommand() *aiv1.CloseAISessionCommand {
 		Session: &aiv1.AISessionRef{
 			SessionId: "ai-session-1",
 			RunId:     "run-1",
+			BindEpoch: 1,
 		},
 		OwnerUserId: "user-1",
 		Reason:      "platform done",

--- a/scannode/legion_ai_runtime_stateless.go
+++ b/scannode/legion_ai_runtime_stateless.go
@@ -466,20 +466,24 @@ func (h *statelessAIEngineRuntimeHandle) runTurn(
 
 	h.mu.Lock()
 	closed := h.closed
-	singleRunTerminal := ctx.Err() == nil && !closed &&
-		strings.EqualFold(strings.TrimSpace(h.binding.ExecutionMode), "single_run")
-	terminalFailure := err != nil && ctx.Err() == nil && !closed
+	singleRun := strings.EqualFold(strings.TrimSpace(h.binding.ExecutionMode), "single_run")
+	singleRunTerminal := ctx.Err() == nil && !closed && singleRun
+	turnFailure := err != nil && ctx.Err() == nil && !closed
 	autoComplete := err == nil && singleRunTerminal
-	if singleRunTerminal || terminalFailure {
+	if singleRunTerminal || (turnFailure && singleRun) {
 		h.closed = true
-	}
-	if h.activeTurn == turn {
-		h.activeTurn = nil
 	}
 	h.mu.Unlock()
 	turn.close()
+	defer func() {
+		h.mu.Lock()
+		if h.activeTurn == turn {
+			h.activeTurn = nil
+		}
+		h.mu.Unlock()
+	}()
 
-	if terminalFailure {
+	if turnFailure {
 		code := yakAISendFailureCode(err)
 		if turn.directForge {
 			code = "yak_ai_forge_failed"
@@ -487,11 +491,35 @@ func (h *statelessAIEngineRuntimeHandle) runTurn(
 		detailJSON := mustJSON(map[string]string{
 			"runtime": "stateless_yak_ai_engine",
 		})
+		if singleRun {
+			if completer, ok := h.emitter.(aiSessionRuntimeTurnCompleter); ok {
+				completer.FailTurn(turn.turnID, code, err.Error(), detailJSON)
+				return
+			}
+			h.emitter.Failed(code, err.Error(), detailJSON)
+			return
+		}
+		if reporter, ok := h.emitter.(aiSessionRuntimeTurnReporter); ok {
+			reporter.TurnFailed(turn.turnID, code, err.Error(), detailJSON)
+			return
+		}
 		if completer, ok := h.emitter.(aiSessionRuntimeTurnCompleter); ok {
 			completer.FailTurn(turn.turnID, code, err.Error(), detailJSON)
 			return
 		}
 		h.emitter.Failed(code, err.Error(), detailJSON)
+		return
+	}
+	if err == nil && !singleRunTerminal && ctx.Err() == nil && !closed {
+		resultJSON := mustJSON(map[string]string{
+			"execution_mode": "multi_turn",
+			"turn_id":        turn.turnID,
+		})
+		if reporter, ok := h.emitter.(aiSessionRuntimeTurnReporter); ok {
+			reporter.TurnCompleted(turn.turnID, resultJSON)
+			return
+		}
+		h.emitter.Emit(aiSessionRuntimeEventTurnCompleted, resultJSON)
 		return
 	}
 	if autoComplete {

--- a/scannode/legion_ai_runtime_stateless_test.go
+++ b/scannode/legion_ai_runtime_stateless_test.go
@@ -109,6 +109,41 @@ func (e *blockingTurnFailureEmitter) FailTurn(string, string, string, []byte) {
 	e.once.Do(func() { close(e.started) })
 	<-e.release
 }
+func (*blockingTurnFailureEmitter) TurnCompleted(string, []byte) {}
+func (e *blockingTurnFailureEmitter) TurnFailed(string, string, string, []byte) {
+	e.once.Do(func() { close(e.started) })
+	<-e.release
+}
+
+type conversationTurnResult struct {
+	turnID  string
+	code    string
+	message string
+	payload []byte
+}
+
+type recordingConversationTurnEmitter struct {
+	completed chan conversationTurnResult
+	failed    chan conversationTurnResult
+}
+
+func (recordingConversationTurnEmitter) Emit(string, []byte)           {}
+func (recordingConversationTurnEmitter) Done([]byte)                   {}
+func (recordingConversationTurnEmitter) Failed(string, string, []byte) {}
+func (recordingConversationTurnEmitter) DoneTurn(string, []byte)       {}
+func (recordingConversationTurnEmitter) FailTurn(string, string, string, []byte) {
+}
+func (e recordingConversationTurnEmitter) TurnCompleted(turnID string, payload []byte) {
+	e.completed <- conversationTurnResult{turnID: turnID, payload: append([]byte(nil), payload...)}
+}
+func (e recordingConversationTurnEmitter) TurnFailed(turnID, code, message string, payload []byte) {
+	e.failed <- conversationTurnResult{
+		turnID:  turnID,
+		code:    code,
+		message: message,
+		payload: append([]byte(nil), payload...),
+	}
+}
 
 func (recordingSingleRunEmitter) Emit(string, []byte) {}
 func (recordingSingleRunEmitter) Done([]byte)         {}
@@ -210,11 +245,10 @@ func TestStatelessDriverBindReturnsHandleWithoutEngineField(t *testing.T) {
 	}
 }
 
-func TestStatelessDriverRejectsNewInputWhileTerminalFailurePublicationIsBlocked(t *testing.T) {
+func TestStatelessDriverKeepsConversationRuntimeAfterTurnFailure(t *testing.T) {
 	engine := newFakeStatelessTurnEngine()
 	engine.sendErr = errors.New("provider failed")
 	emitter := newBlockingTurnFailureEmitter()
-	t.Cleanup(func() { close(emitter.release) })
 	handle := &statelessAIEngineRuntimeHandle{
 		binding: aiSessionBinding{
 			ExecutionMode: "conversation",
@@ -249,8 +283,73 @@ func TestStatelessDriverRejectsNewInputWhileTerminalFailurePublicationIsBlocked(
 		InputType:   "message",
 		PayloadJSON: []byte(`{"content":"second"}`),
 	})
-	if err == nil || !strings.Contains(err.Error(), "runtime is closed") {
-		t.Fatalf("new input during terminal publication error = %v, want closed runtime", err)
+	if err == nil || !strings.Contains(err.Error(), "turn already active") {
+		t.Fatalf("new input during turn-failure publication error = %v, want active turn", err)
+	}
+	close(emitter.release)
+	select {
+	case <-engine.closed:
+	case <-time.After(time.Second):
+		t.Fatal("failed per-turn engine was not closed")
+	}
+	if handle.closed {
+		t.Fatal("conversation runtime was closed by a per-turn failure")
+	}
+}
+
+func TestStatelessConversationPublishesTurnCompletionAndRemainsReusable(t *testing.T) {
+	firstEngine := newFakeStatelessTurnEngine()
+	secondEngine := newFakeStatelessTurnEngine()
+	engines := make(chan statelessTurnEngine, 2)
+	engines <- firstEngine
+	engines <- secondEngine
+	emitter := recordingConversationTurnEmitter{
+		completed: make(chan conversationTurnResult, 2),
+		failed:    make(chan conversationTurnResult, 1),
+	}
+	handle := &statelessAIEngineRuntimeHandle{
+		binding: aiSessionBinding{ExecutionMode: "conversation"},
+		emitter: emitter,
+		newEngine: func(...aiengine.AIEngineConfigOption) (statelessTurnEngine, error) {
+			return <-engines, nil
+		},
+	}
+
+	if err := handle.SendInput(context.Background(), aiSessionInput{
+		Ref: aiSessionCommandRef{CommandID: "turn-one"}, InputType: "message",
+		PayloadJSON: []byte(`{"content":"first"}`),
+	}); err != nil {
+		t.Fatalf("send first turn: %v", err)
+	}
+	<-firstEngine.started
+	close(firstEngine.release)
+	select {
+	case result := <-emitter.completed:
+		if result.turnID != "turn-one" {
+			t.Fatalf("completed turn id = %q, want turn-one", result.turnID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first turn completion was not published")
+	}
+
+	if err := handle.SendInput(context.Background(), aiSessionInput{
+		Ref: aiSessionCommandRef{CommandID: "turn-two"}, InputType: "message",
+		PayloadJSON: []byte(`{"content":"second"}`),
+	}); err != nil {
+		t.Fatalf("send second turn: %v", err)
+	}
+	<-secondEngine.started
+	close(secondEngine.release)
+	select {
+	case result := <-emitter.completed:
+		if result.turnID != "turn-two" {
+			t.Fatalf("completed turn id = %q, want turn-two", result.turnID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second turn completion was not published")
+	}
+	if handle.closed {
+		t.Fatal("conversation runtime was closed after successful turns")
 	}
 }
 

--- a/scannode/legion_ai_runtime_yak.go
+++ b/scannode/legion_ai_runtime_yak.go
@@ -232,21 +232,63 @@ func (h *yakAIEngineRuntimeHandle) sendMessage(queued yakAIQueuedMessage) {
 	}()
 
 	if ok, runtime, binding, config := h.claimDirectForge(); ok {
-		h.executeForgeDirectly(queued.turnID, queued.content, runtime, binding, config)
+		err := h.executeForgeDirectly(queued.content, runtime, binding, config)
+		h.finishMessageTurn(queued.turnID, err, "yak_ai_forge_failed", map[string]string{
+			"runtime":    "yak_ai_engine",
+			"forge_name": strings.TrimSpace(runtime.ForgeName),
+		})
 		return
 	}
 
-	if err := h.engine.SendMsg(queued.content, queued.options...); err != nil {
-		if h.engine.Context().Err() != nil {
-			// 上下文已取消（关闭/关停），不报失败事件。
+	err := h.engine.SendMsg(queued.content, queued.options...)
+	h.finishMessageTurn(queued.turnID, err, yakAISendFailureCode(err), map[string]string{
+		"runtime": "yak_ai_engine",
+	})
+}
+
+func (h *yakAIEngineRuntimeHandle) finishMessageTurn(
+	turnID string,
+	err error,
+	code string,
+	detail map[string]string,
+) {
+	if h.engine.Context().Err() != nil {
+		// 上下文已取消（关闭/关停），不报轮次结果。
+		return
+	}
+	singleRun := strings.EqualFold(strings.TrimSpace(h.binding.ExecutionMode), "single_run")
+	if err != nil {
+		detailJSON := mustJSON(detail)
+		if singleRun {
+			h.closeForTerminalFailure()
+			h.failTurn(turnID, code, err.Error(), detailJSON)
 			return
 		}
-		h.closeForTerminalFailure()
-		// 任务异常终止时上报失败事件，使绑定任务能即时收敛。
-		h.failTurn(queued.turnID, yakAISendFailureCode(err), err.Error(), mustJSON(map[string]string{
-			"runtime": "yak_ai_engine",
-		}))
+		if reporter, ok := h.emitter.(aiSessionRuntimeTurnReporter); ok {
+			reporter.TurnFailed(turnID, code, err.Error(), detailJSON)
+			return
+		}
+		h.emitter.Emit(aiSessionRuntimeEventTurnFailed, detailJSON)
+		return
 	}
+	resultJSON := mustJSON(map[string]string{
+		"execution_mode": map[bool]string{true: "single_run", false: "multi_turn"}[singleRun],
+		"turn_id":        turnID,
+	})
+	if singleRun {
+		h.closeForTerminalFailure()
+		if completer, ok := h.emitter.(aiSessionRuntimeTurnCompleter); ok {
+			completer.DoneTurn(turnID, resultJSON)
+			return
+		}
+		h.emitter.Done(resultJSON)
+		return
+	}
+	if reporter, ok := h.emitter.(aiSessionRuntimeTurnReporter); ok {
+		reporter.TurnCompleted(turnID, resultJSON)
+		return
+	}
+	h.emitter.Emit(aiSessionRuntimeEventTurnCompleted, resultJSON)
 }
 
 func (h *yakAIEngineRuntimeHandle) activeTurnID() string {
@@ -385,12 +427,11 @@ func (h *yakAIEngineRuntimeHandle) sendControlInput(event *ypb.AIInputEvent, kin
 }
 
 func (h *yakAIEngineRuntimeHandle) executeForgeDirectly(
-	turnID string,
 	content string,
 	runtime yakRuntimeOptions,
 	binding aiSessionBinding,
 	config *aiengine.AIEngineConfig,
-) {
+) error {
 	err := runYakAIForgeDirect(
 		h.engine.Context(),
 		config,
@@ -406,13 +447,7 @@ func (h *yakAIEngineRuntimeHandle) executeForgeDirectly(
 	h.mu.Lock()
 	h.forgeRunning = false
 	h.mu.Unlock()
-	if err != nil && h.engine.Context().Err() == nil {
-		h.closeForTerminalFailure()
-		h.failTurn(turnID, "yak_ai_forge_failed", err.Error(), mustJSON(map[string]string{
-			"runtime":    "yak_ai_engine",
-			"forge_name": strings.TrimSpace(runtime.ForgeName),
-		}))
-	}
+	return err
 }
 
 func runYakAIForgeDirect(
@@ -1647,10 +1682,20 @@ func buildYakAIInterventionEvent(input aiSessionInput) (*ypb.AIInputEvent, error
 	if content == "" {
 		return nil, fmt.Errorf("ai session intervention content is required")
 	}
-	return &ypb.AIInputEvent{
+	event := &ypb.AIInputEvent{
 		IsFreeInput: true,
 		FreeInput:   content,
-	}, nil
+	}
+	if interventionID := strings.TrimSpace(input.Ref.CommandID); interventionID != "" {
+		event.AttachedResourceInfo = []*ypb.AttachedResourceInfo{
+			{
+				Type:  aicommon.USER_FREE_INPUT_UUID,
+				Key:   aicommon.USER_FREE_INPUT_UUID,
+				Value: interventionID,
+			},
+		}
+	}
+	return event, nil
 }
 
 func interactiveIDFromPayload(payload map[string]any) string {

--- a/scannode/legion_ai_runtime_yak_test.go
+++ b/scannode/legion_ai_runtime_yak_test.go
@@ -20,11 +20,10 @@ import (
 
 func boolPointer(value bool) *bool { return &value }
 
-func TestStatefulDriverRejectsNewInputWhileTerminalFailurePublicationIsBlocked(t *testing.T) {
+func TestStatefulDriverKeepsConversationRuntimeAfterTurnFailure(t *testing.T) {
 	engine := newFakeStatelessTurnEngine()
 	engine.sendErr = errors.New("provider failed")
 	emitter := newBlockingTurnFailureEmitter()
-	t.Cleanup(func() { close(emitter.release) })
 	handle := &yakAIEngineRuntimeHandle{
 		engine:       engine,
 		emitter:      emitter,
@@ -44,13 +43,23 @@ func TestStatefulDriverRejectsNewInputWhileTerminalFailurePublicationIsBlocked(t
 		t.Fatal("terminal failure publication did not start")
 	}
 
-	err := handle.SendInput(context.Background(), aiSessionInput{
-		Ref:         aiSessionCommandRef{CommandID: "turn-too-late"},
-		InputType:   "message",
-		PayloadJSON: []byte(`{"content":"second"}`),
-	})
-	if err == nil || !strings.Contains(err.Error(), "yak ai engine is closed") {
-		t.Fatalf("new input during terminal publication error = %v, want closed runtime", err)
+	close(emitter.release)
+	deadline := time.After(time.Second)
+	for {
+		handle.mu.Lock()
+		active := handle.currentTurn
+		handle.mu.Unlock()
+		if active == "" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("stateful failed turn did not finish")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if handle.closed {
+		t.Fatal("stateful conversation runtime was closed by a per-turn failure")
 	}
 }
 
@@ -696,6 +705,7 @@ func TestBuildYakAIInterventionEventCarriesEndpointID(t *testing.T) {
 
 	payload := []byte(`{"id":"interactive-1","suggestion":"continue","review_type":"tool_use_review_require"}`)
 	event, err := buildYakAIInterventionEvent(aiSessionInput{
+		Ref:         aiSessionCommandRef{CommandID: "intervention-command-1"},
 		InputType:   "user_intervention",
 		PayloadJSON: payload,
 	})
@@ -752,6 +762,11 @@ func TestBuildYakAIInterventionEventMapsFreeInputWithoutEndpointID(t *testing.T)
 	}
 	if event.GetIsInteractiveMessage() {
 		t.Fatal("free input must not be marked interactive")
+	}
+	resources := event.GetAttachedResourceInfo()
+	if len(resources) != 1 || resources[0].GetType() != aicommon.USER_FREE_INPUT_UUID ||
+		resources[0].GetValue() != "intervention-command-1" {
+		t.Fatalf("free intervention queue identity = %#v", resources)
 	}
 }
 

--- a/scannode/legion_ai_runtime_yak_test.go
+++ b/scannode/legion_ai_runtime_yak_test.go
@@ -705,7 +705,6 @@ func TestBuildYakAIInterventionEventCarriesEndpointID(t *testing.T) {
 
 	payload := []byte(`{"id":"interactive-1","suggestion":"continue","review_type":"tool_use_review_require"}`)
 	event, err := buildYakAIInterventionEvent(aiSessionInput{
-		Ref:         aiSessionCommandRef{CommandID: "intervention-command-1"},
 		InputType:   "user_intervention",
 		PayloadJSON: payload,
 	})
@@ -748,6 +747,7 @@ func TestBuildYakAIInterventionEventMapsFreeInputWithoutEndpointID(t *testing.T)
 	t.Parallel()
 
 	event, err := buildYakAIInterventionEvent(aiSessionInput{
+		Ref:         aiSessionCommandRef{CommandID: "intervention-command-1"},
 		InputType:   "user_intervention",
 		PayloadJSON: []byte(`{"content":"check the authorization path too"}`),
 	})


### PR DESCRIPTION
## 改动摘要

本 PR 为 Legion AI Chat 增加明确的单轮 Turn 生命周期，使可复用的 Session Runtime 能在一轮回答结束后继续处理下一轮输入，同时避免旧绑定、迟到命令和根计划完成事件误终结当前会话。

- 新增 `ai.session.turn_lifecycle.v1` 能力声明，并写入 Product Node、AI Session Runtime 构建及发布清单。
- `multi_turn` 模式显式发布 `ai.session.turn.completed` / `ai.session.turn.failed`，只结束当前 Turn，不销毁可复用 Runtime。
- `single_run` 保留原有 Session 终态与 Runtime 回收语义；根 `end_plan_and_execution` 仅在该模式下终结 Session。
- Input、Context、Cancel、Close 全部消费并校验 `bind_epoch`，拒绝旧 Runtime generation 的迟到命令。
- `queue_info` 补充稳定的 `user_input_uuid`，让前端区分用户追加输入与引擎首问任务。
- Stateful 与 Stateless Runtime 均补齐 Turn 完成、失败、复用和并发 fencing 测试。

## 根因

此前 Yaklang 仅有 Session 级 `done/failed`，缺少可复用会话中的 Turn 级完成边界。Legion 无法可靠判断“一轮回复已结束但容器仍驻留”，只能从通用事件或空闲时间推断；同时节点没有完整消费命令携带的 `bind_epoch`，旧 generation 的迟到命令可能进入新 Runtime。

本次把 `command_id` 作为稳定 Turn 因果标识，并区分 Turn 终态与 Session 终态。该合同与 Legion [PR #304](https://github.com/VillanCh/legion/pull/304) 配套使用。

## 主要改动

- `scannode/legion_ai_bridge.go`：Turn 事件发布、bind epoch fencing、multi-turn 根终态隔离。
- `scannode/legion_ai_runtime_stateless.go`、`legion_ai_runtime_yak.go`：Turn 成功/失败收敛与 Runtime 复用。
- `common/ai/aid/aireact/re-act.go`：队列快照携带 `user_input_uuid`。
- `scannode/capability_keys*` 与构建/打包脚本：发布 `ai.session.turn_lifecycle.v1` 能力。
- 对应 Bridge、Runtime、ReAct、能力声明和包清单测试。

## 验证

当前提交 `cb715e9af` 已 rebase 到最新 `origin/main`，本地仅运行改动范围测试：

```text
go test ./scannode -run '<Turn lifecycle / bind epoch / capability tests>' -count=1
go test ./common/ai/aid/aireact -run '^TestGetQueueInfoIncludesUserInputUUID$' -count=1
go test -tags hids ./scannode -run '^TestNormalizeScanNodeCapabilityKeys...' -count=1
.github/scripts/test-package-legion-ai-session-runtime.sh
```

以上均通过。仓库全量、race 与跨平台构建交由 GitHub CI。

此前 rebase 前的 patch-equivalent 提交已与 Legion 完成真实双轮对话联调：同一 Session 两轮均收敛到 Turn completed，Runtime 保持可复用。rebase 后未重复执行端到端联调。

## 发布顺序

应先发布并部署包含 `ai.session.turn_lifecycle.v1` 的 Yaklang AI Session Runtime，再上线依赖该能力的 Legion PR #304。Legion 对不兼容旧 Runtime 采取 fail-closed，避免输入静默排队。
