### PR TITLE
fix(ci): 修复 Runtime 来源证明误判脏工作区

### DIFF
--- a/.github/scripts/test-legion-component-workflow-contract.sh
+++ b/.github/scripts/test-legion-component-workflow-contract.sh
@@ -36,6 +36,33 @@ grep -Fq 'uses: ./.github/workflows/build-legion-ai-session-runtime-common.yml' 
 grep -Fq 'Source validation mode: alpha or unified' "$runtime_workflow"
 grep -Fq 'refs/tags/legion-node-v' "$runtime_workflow"
 grep -Fq '.docker.tar.gz' "$runtime_workflow"
+# The Runtime packager verifies a clean Git checkout before generating
+# provenance. Keep the image archive outside the checkout until that gate has
+# passed, then copy it into the Actions handoff directory.
+if ! grep -Fq 'id: runtime-archive' "$runtime_workflow"; then
+  echo "$runtime_workflow must expose the runner-temp Runtime archive path" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match literal workflow shell syntax.
+if ! grep -Fq 'archive_dir="${RUNNER_TEMP}/runtime-archive-${RUNTIME_GOARCH}"' "$runtime_workflow"; then
+  echo "$runtime_workflow must stage the Runtime archive outside the checkout" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match literal GitHub Actions expression syntax.
+if ! grep -Fq 'RUNTIME_IMAGE_ARCHIVE: ${{ steps.runtime-archive.outputs.path }}' "$runtime_workflow"; then
+  echo "$runtime_workflow must pass the runner-temp archive into provenance generation" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match literal workflow shell syntax.
+if ! grep -Fq 'cp "$RUNTIME_IMAGE_ARCHIVE" dist/artifact/' "$runtime_workflow"; then
+  echo "$runtime_workflow must stage the verified Runtime archive for handoff" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Reject the literal checkout-local archive path.
+if grep -Fq '>"dist/artifact/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"' "$runtime_workflow"; then
+  echo "$runtime_workflow must not dirty the checkout before Runtime provenance is generated" >&2
+  exit 1
+fi
 grep -Fq 'contents: read' "$runtime_alpha_workflow"
 if grep -Eq 'secrets: inherit|OSS_KEY_(ID|SECRET)|upload-oss' "$runtime_alpha_workflow"; then
   echo "$runtime_alpha_workflow must not receive Runtime release secrets or publish to OSS" >&2

--- a/.github/workflows/build-legion-ai-session-runtime-common.yml
+++ b/.github/workflows/build-legion-ai-session-runtime-common.yml
@@ -190,15 +190,19 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Stage Runtime image archive
+        id: runtime-archive
         shell: bash
         env:
           RUNTIME_IMAGE_ID: ${{ steps.inspect.outputs.image_id }}
         run: |
           set -euo pipefail
-          mkdir -p dist/artifact
+          archive_dir="${RUNNER_TEMP}/runtime-archive-${RUNTIME_GOARCH}"
+          archive_path="${archive_dir}/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
+          mkdir -p "$archive_dir"
           docker save "$RUNTIME_IMAGE_ID" | gzip -n -1 \
-            >"dist/artifact/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
-          gzip -t "dist/artifact/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
+            >"$archive_path"
+          gzip -t "$archive_path"
+          echo "path=$archive_path" >>"$GITHUB_OUTPUT"
 
       - name: Generate Runtime provenance package
         env:
@@ -207,7 +211,7 @@ jobs:
           RUNTIME_LDD_FILE: ${{ steps.inspect.outputs.inspect_dir }}/runtime.ldd
           RUNTIME_IMAGE_REF: ${{ steps.inspect.outputs.image_ref }}
           RUNTIME_IMAGE_TAG: ${{ steps.inspect.outputs.image_tag }}
-          RUNTIME_IMAGE_ARCHIVE: dist/artifact/${{ env.RUNTIME_PACKAGE_NAME }}.docker.tar.gz
+          RUNTIME_IMAGE_ARCHIVE: ${{ steps.runtime-archive.outputs.path }}
           RUNTIME_BASE_IMAGE: ${{ steps.bases.outputs.runtime_ref }}
           RUNTIME_BUILDER_IMAGE: ${{ steps.bases.outputs.builder_ref }}
           RUNTIME_GO_VERSION: ${{ steps.bases.outputs.go_version }}
@@ -215,6 +219,8 @@ jobs:
 
       - name: Verify and stage architecture-specific artifact contract
         shell: bash
+        env:
+          RUNTIME_IMAGE_ARCHIVE: ${{ steps.runtime-archive.outputs.path }}
         run: |
           set -euo pipefail
           package_dir="dist/${RUNTIME_PACKAGE_NAME}"
@@ -251,6 +257,7 @@ jobs:
           cp "$package_dir/SHA256SUMS" "dist/artifact/SHA256SUMS${ARTIFACT_SUFFIX}"
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz" dist/artifact/
           cp "dist/${RUNTIME_PACKAGE_NAME}.tar.gz.sha256" dist/artifact/
+          cp "$RUNTIME_IMAGE_ARCHIVE" dist/artifact/
 
       - name: Verify staged Runtime image archive
         shell: bash


### PR DESCRIPTION
## 问题

`legion-node-v0.2.0` 发布运行在 Linux amd64/arm64 的 `Generate Runtime provenance package` 步骤失败：

```text
CI checkout must be clean before provenance is generated
```

Runtime 编译、镜像构建和归档均已成功。失败原因是工作流先把 Docker 归档写入仓库内的 `dist/artifact`，随后来源证明脚本通过 `git status --untracked-files=all` 校验源码检出，因而把 CI 自己生成的文件误判为源码污染。

失败运行：https://github.com/yaklang/yaklang/actions/runs/31676428789

## 修改

- 在 `$RUNNER_TEMP/runtime-archive-$RUNTIME_GOARCH` 生成 Runtime Docker 归档。
- 通过 step output 将临时归档的绝对路径传给来源证明脚本。
- 来源证明及清洁检出校验通过后，再将归档复制到 `dist/artifact` 供统一安装包和 Actions artifact 使用。
- 增加工作流契约测试，禁止来源证明前重新向检出目录写入 Runtime 归档。

安全门禁没有被放宽，正式发布仍要求来源证明生成前源码检出完全干净。

## 影响

- 不改变 `legion-node-v*` 单 Tag 发布方式。
- 不改变统一 Node + AI Runtime 安装包格式、摘要或签名契约。
- 不修改或复用失败的 `legion-node-v0.2.0` Tag。
- 合入后应使用新的 SemVer Tag 重新发布。

## 验证

- 旧工作流在新增契约断言下失败，修复后通过。
- 干净检出、`CI=true` 下 `test-package-legion-ai-session-runtime.sh` 通过。
- `test-legion-component-workflow-contract.sh` 通过。
- 相关 ShellCheck 通过。
- 工作流 YAML 解析通过。
