### PR TITLE
fix(ai): 规范化裸目标漏洞回传地址

### DIFF
--- a/scannode/legion_ai_focus_runtime.go
+++ b/scannode/legion_ai_focus_runtime.go
@@ -422,7 +422,8 @@ func normalizeServerFocusResultTarget(authorizedTarget, candidate string) (strin
 	if err != nil {
 		return "", err
 	}
-	ref, err := url.Parse(strings.TrimSpace(candidate))
+	candidate = strings.TrimSpace(candidate)
+	ref, err := parseServerFocusResultReference(authorized, candidate)
 	if err != nil {
 		return "", err
 	}
@@ -434,6 +435,35 @@ func normalizeServerFocusResultTarget(authorizedTarget, candidate string) (strin
 		return "", fmt.Errorf("focus result target is outside the authorized origin")
 	}
 	return resolved.String(), nil
+}
+
+func parseServerFocusResultReference(authorized *url.URL, candidate string) (*url.URL, error) {
+	if strings.HasPrefix(candidate, "/") {
+		return url.Parse(candidate)
+	}
+	authorityEnd := strings.IndexAny(candidate, "/?#")
+	if authorityEnd < 0 {
+		authorityEnd = len(candidate)
+	}
+	authority := candidate[:authorityEnd]
+	suffix := candidate[authorityEnd:]
+	if strings.Count(authority, ":") > 1 && !strings.HasPrefix(authority, "[") {
+		if net.ParseIP(authority) == nil {
+			return url.Parse(candidate)
+		}
+		authority = "[" + authority + "]"
+	}
+	bare, normalizeErr := normalizeServerFocusURL(authorized.Scheme + "://" + authority + suffix)
+	if normalizeErr == nil && isServerFocusNetworkHost(bare.Hostname(), authorized.Hostname()) {
+		return bare, nil
+	}
+	return url.Parse(candidate)
+}
+
+func isServerFocusNetworkHost(hostname, authorizedHostname string) bool {
+	return net.ParseIP(hostname) != nil ||
+		strings.Contains(hostname, ".") ||
+		strings.EqualFold(hostname, authorizedHostname)
 }
 
 func applyServerFocusHeaders(request *http.Request, raw any) error {

--- a/scannode/legion_ai_result_sink_test.go
+++ b/scannode/legion_ai_result_sink_test.go
@@ -403,6 +403,120 @@ func TestLegionAIFocusResultSinkRejectsOffOriginTargets(t *testing.T) {
 	}); err == nil || !strings.Contains(err.Error(), "outside the authorized origin") {
 		t.Fatalf("expected off-origin risk rejection, got %v", err)
 	}
+	for _, candidate := range []string{
+		"ftp://focus.example.test/api",
+		"mailto:security@focus.example.test",
+	} {
+		if _, err := rawSink.SubmitRisk(context.Background(), &schema.Risk{
+			Title:    "Unsupported target",
+			RiskType: "test",
+			Url:      candidate,
+		}); err == nil {
+			t.Fatalf("expected non-HTTP(S) target rejection for %q", candidate)
+		}
+	}
+}
+
+func TestLegionAIFocusResultSinkNormalizesBareAuthorizedRiskTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		authorized string
+		candidate  string
+		want       string
+	}{
+		{
+			name:       "ipv4",
+			authorized: "http://192.0.2.88/",
+			candidate:  "192.0.2.88",
+			want:       "http://192.0.2.88/",
+		},
+		{
+			name:       "ipv4 with port",
+			authorized: "http://192.0.2.88:8080/",
+			candidate:  "192.0.2.88:8080",
+			want:       "http://192.0.2.88:8080/",
+		},
+		{
+			name:       "bracketed ipv6 with port",
+			authorized: "http://[2001:db8::1]:8443/",
+			candidate:  "[2001:db8::1]:8443",
+			want:       "http://[2001:db8::1]:8443/",
+		},
+		{
+			name:       "unbracketed ipv6",
+			authorized: "http://[2001:db8::1]/",
+			candidate:  "2001:db8::1",
+			want:       "http://[2001:db8::1]/",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			resultContext := validAIFocusResultContext()
+			resultContext.TargetUrl = test.authorized
+			publisher := &recordingAIFocusRiskPublisher{}
+			sink, err := newLegionAIFocusResultSink(publisher, "bind-1", resultContext)
+			if err != nil {
+				t.Fatalf("new result sink: %v", err)
+			}
+			if _, err := sink.SubmitRisk(context.Background(), &schema.Risk{
+				Title:    "SQL injection",
+				RiskType: "sql_injection",
+				Url:      test.candidate,
+			}); err != nil {
+				t.Fatalf("submit bare authorized target: %v", err)
+			}
+			if len(publisher.risks) != 1 || publisher.risks[0].target != test.want {
+				t.Fatalf("unexpected published target: %#v", publisher.risks)
+			}
+		})
+	}
+}
+
+func TestLegionAIFocusResultSinkNormalizesBareDomainAndPortRiskTarget(t *testing.T) {
+	t.Parallel()
+
+	resultContext := validAIFocusResultContext()
+	resultContext.TargetUrl = "http://app.example.test:8080/"
+	publisher := &recordingAIFocusRiskPublisher{}
+	sink, err := newLegionAIFocusResultSink(publisher, "bind-1", resultContext)
+	if err != nil {
+		t.Fatalf("new result sink: %v", err)
+	}
+	if _, err := sink.SubmitRisk(context.Background(), &schema.Risk{
+		Title:    "SQL injection",
+		RiskType: "sql_injection",
+		Url:      "app.example.test:8080/audit?q=1",
+	}); err != nil {
+		t.Fatalf("submit bare authorized target: %v", err)
+	}
+	if len(publisher.risks) != 1 || publisher.risks[0].target != "http://app.example.test:8080/audit?q=1" {
+		t.Fatalf("unexpected published target: %#v", publisher.risks)
+	}
+}
+
+func TestLegionAIFocusResultSinkRejectsBareOffOriginTarget(t *testing.T) {
+	t.Parallel()
+
+	resultContext := validAIFocusResultContext()
+	resultContext.TargetUrl = "http://192.0.2.88/"
+	sink, err := newLegionAIFocusResultSink(
+		&recordingAIFocusRiskPublisher{},
+		"bind-1",
+		resultContext,
+	)
+	if err != nil {
+		t.Fatalf("new result sink: %v", err)
+	}
+	if _, err := sink.SubmitRisk(context.Background(), &schema.Risk{
+		Title:    "Outside risk",
+		RiskType: "test",
+		Url:      "192.0.2.89",
+	}); err == nil || !strings.Contains(err.Error(), "outside the authorized origin") {
+		t.Fatalf("expected bare off-origin risk rejection, got %v", err)
+	}
 }
 
 func TestValidateLegionAIFocusResultContextRejectsIncompleteIdentity(t *testing.T) {


### PR DESCRIPTION
## 问题

Legion 会话授权裸 IP 或域名后，`cybersecurity-risk` 可能把同一个裸目标写入 Risk URL。节点原先按相对路径解析，导致平台收到类似 `/目标地址` 的重复路径；IP 带端口和 IPv6 还可能直接解析失败。

## 修复

- 在 result sink 中识别裸 IP、域名、端口和 IPv6，并按已授权 scheme 规范为绝对 URL。
- 规范化后继续执行严格的 scheme、host 和有效端口同源校验。
- 异源裸目标以及 `ftp:`、`mailto:` 等非 HTTP(S) 目标继续拒绝。

## 验证

- `go test ./scannode -run TestLegionAIFocusResultSink -count=1`
- `go test ./scannode -run TestLegionAIFocusResultSink\|TestLegionServerFocusRuntime -count=1`
- `git diff --check`
- 只读安全审查无 P0-P2。

配套平台授权修复：VillanCh/legion#319。