### PR TITLE
fix(release): 支持可选的引擎发布签名

### DIFF
--- a/.github/scripts/build-legion-node-engine-import-bundle.sh
+++ b/.github/scripts/build-legion-node-engine-import-bundle.sh
@@ -19,12 +19,15 @@ Required:
   --source-sha SHA
   --artifact-dir DIR
   --output FILE
-  --signing-private-key-file FILE
-  --expected-public-key BASE64
 
 Optional:
   --goos linux
   --goarch amd64|arm64
+  --signing-private-key-file FILE
+  --expected-public-key BASE64
+
+The signing options must be provided together. If neither is provided, the
+bundle is checksum-verified but does not contain release-index.json.sig.
 EOF
 }
 
@@ -51,8 +54,10 @@ done
 case "$target_arch" in amd64|arm64) ;; *) die "unsupported target architecture: $target_arch" ;; esac
 [[ -d "$artifact_dir" ]] || die "artifact directory does not exist"
 [[ -n "$output" ]] || die "--output is required"
-[[ -f "$signing_private_key_file" ]] || die "--signing-private-key-file is required"
-[[ -n "$expected_public_key" ]] || die "--expected-public-key is required"
+if [[ -n "$signing_private_key_file" || -n "$expected_public_key" ]]; then
+  [[ -f "$signing_private_key_file" && -n "$expected_public_key" ]] || \
+    die "--signing-private-key-file and --expected-public-key must be configured together"
+fi
 
 for command in go gzip jq sha256sum stat tar; do
   command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
@@ -206,12 +211,14 @@ jq -n \
     }
   ' >"$bundle_dir/release-index.json"
 (cd "$bundle_dir" && sha256sum release-index.json >release-index.json.sha256)
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-go run "$repo_root/.github/scripts/sign-legion-node-release-index.go" \
-  --private-key-file "$signing_private_key_file" \
-  --expected-public-key "$expected_public_key" \
-  --input "$bundle_dir/release-index.json" \
-  --output "$bundle_dir/release-index.json.sig"
+if [[ -n "$signing_private_key_file" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  go run "$repo_root/.github/scripts/sign-legion-node-release-index.go" \
+    --private-key-file "$signing_private_key_file" \
+    --expected-public-key "$expected_public_key" \
+    --input "$bundle_dir/release-index.json" \
+    --output "$bundle_dir/release-index.json.sig"
+fi
 cp "$producer_binary" "$bundle_dir/yaklang-node"
 cp "$runtime_manifest" "$bundle_dir/runtime-manifest.json"
 cp "$runtime_archive" "$bundle_dir/ai-session-runtime.docker.tar.gz"
@@ -219,6 +226,16 @@ cp "$runtime_archive" "$bundle_dir/ai-session-runtime.docker.tar.gz"
 mkdir -p "$(dirname "$output")"
 [[ ! -e "$output" ]] || die "output already exists: $output"
 source_epoch="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../.." show -s --format=%ct "$source_sha")"
+archive_files=(
+  ai-session-runtime.docker.tar.gz
+  manifest.json
+  release-index.json
+  release-index.json.sha256
+)
+if [[ -n "$signing_private_key_file" ]]; then
+  archive_files+=(release-index.json.sig)
+fi
+archive_files+=(runtime-manifest.json yaklang-node)
 tar \
   --sort=name \
   --mtime="@$source_epoch" \
@@ -226,8 +243,7 @@ tar \
   --group=0 \
   --numeric-owner \
   -C "$bundle_dir" \
-  -cf - ai-session-runtime.docker.tar.gz manifest.json release-index.json \
-  release-index.json.sha256 release-index.json.sig runtime-manifest.json yaklang-node | gzip -n -1 >"$output"
+  -cf - "${archive_files[@]}" | gzip -n -1 >"$output"
 (cd "$(dirname "$output")" && sha256sum "$(basename "$output")" >"$(basename "$output").sha256")
 
 printf '[legion-node-engine-bundle] created %s\n' "$output"

--- a/.github/scripts/test-build-legion-node-engine-import-bundle.sh
+++ b/.github/scripts/test-build-legion-node-engine-import-bundle.sh
@@ -121,6 +121,44 @@ cmp "$artifact_dir/legion-smoke-node" "$extract_dir/yaklang-node"
 cmp "$artifact_dir/SESSION_RUNTIME_MANIFEST.json" "$extract_dir/runtime-manifest.json"
 cmp "$artifact_dir/legion-ai-session-runtime_linux_amd64.docker.tar.gz" "$extract_dir/ai-session-runtime.docker.tar.gz"
 
+unsigned_output="$test_root/yaklang-node-engine_legion-node-v1.2.3_linux_amd64-unsigned.tar.gz"
+"$builder" \
+  --version legion-node-v1.2.3 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$artifact_dir" \
+  --output "$unsigned_output"
+gzip -t "$unsigned_output"
+(cd "$test_root" && sha256sum -c "$(basename "$unsigned_output").sha256" >/dev/null)
+unsigned_extract_dir="$test_root/unsigned-extracted"
+mkdir -p "$unsigned_extract_dir"
+tar -xzf "$unsigned_output" -C "$unsigned_extract_dir"
+[[ "$(find "$unsigned_extract_dir" -maxdepth 1 -type f | wc -l)" == 6 ]]
+[[ ! -e "$unsigned_extract_dir/release-index.json.sig" ]]
+(cd "$unsigned_extract_dir" && sha256sum -c release-index.json.sha256 >/dev/null)
+cmp "$artifact_dir/legion-smoke-node" "$unsigned_extract_dir/yaklang-node"
+cmp "$artifact_dir/SESSION_RUNTIME_MANIFEST.json" "$unsigned_extract_dir/runtime-manifest.json"
+cmp "$artifact_dir/legion-ai-session-runtime_linux_amd64.docker.tar.gz" "$unsigned_extract_dir/ai-session-runtime.docker.tar.gz"
+
+if "$builder" \
+  --version legion-node-v1.2.3 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$artifact_dir" \
+  --signing-private-key-file "$signing_key" \
+  --output "$test_root/private-key-only.tar.gz"; then
+  echo 'incomplete signing configuration unexpectedly accepted' >&2
+  exit 1
+fi
+
+if "$builder" \
+  --version legion-node-v1.2.3 \
+  --source-sha "$source_sha" \
+  --artifact-dir "$artifact_dir" \
+  --expected-public-key "$signing_public_key" \
+  --output "$test_root/public-key-only.tar.gz"; then
+  echo 'incomplete signing configuration unexpectedly accepted' >&2
+  exit 1
+fi
+
 tampered_runtime="$test_root/tampered-runtime"
 cp -a "$artifact_dir" "$tampered_runtime"
 printf 'tampered\n' >>"$tampered_runtime/legion-ai-session-runtime_linux_amd64.docker.tar.gz"

--- a/.github/scripts/test-legion-component-workflow-contract.sh
+++ b/.github/scripts/test-legion-component-workflow-contract.sh
@@ -129,6 +129,11 @@ grep -Fq 'environment: production-release' "$product_workflow"
 grep -Fq 'LEGION_NODE_RELEASE_SIGNING_PRIVATE_KEY_B64' "$product_workflow"
 grep -Fq 'LEGION_NODE_RELEASE_SIGNING_PUBLIC_KEY_B64' "$product_workflow"
 grep -Fq 'release-index.json.sig' "$repo_root/.github/scripts/build-legion-node-engine-import-bundle.sh"
+grep -Fq 'both Yaklang Node release signing values or neither' "$product_workflow"
+if grep -Fq 'must configure the Yaklang Node release signing key pair' "$product_workflow"; then
+  echo 'Yaklang Node signing is unexpectedly mandatory' >&2
+  exit 1
+fi
 # shellcheck disable=SC2016 # Match literal workflow environment syntax.
 grep -Fq 'yaklang-node-engine_${NODE_PACKAGE_VERSION}_${NODE_GOOS}_${NODE_GOARCH}.tar.gz' "$product_workflow"
 

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -191,14 +191,21 @@ jobs:
           RELEASE_SIGNING_PUBLIC_KEY: ${{ vars.LEGION_NODE_RELEASE_SIGNING_PUBLIC_KEY_B64 }}
         run: |
           set -euo pipefail
-          [[ -n "$RELEASE_SIGNING_PRIVATE_KEY" && -n "$RELEASE_SIGNING_PUBLIC_KEY" ]] || {
-            echo "production-release must configure the Yaklang Node release signing key pair" >&2
-            exit 1
-          }
-          signing_key="${RUNNER_TEMP}/legion-node-release-signing-key.b64"
-          umask 077
-          printf '%s\n' "$RELEASE_SIGNING_PRIVATE_KEY" >"$signing_key"
-          trap 'rm -f "$signing_key"' EXIT
+          signing_args=()
+          if [[ -n "$RELEASE_SIGNING_PRIVATE_KEY" || -n "$RELEASE_SIGNING_PUBLIC_KEY" ]]; then
+            [[ -n "$RELEASE_SIGNING_PRIVATE_KEY" && -n "$RELEASE_SIGNING_PUBLIC_KEY" ]] || {
+              echo "production-release must configure both Yaklang Node release signing values or neither" >&2
+              exit 1
+            }
+            signing_key="${RUNNER_TEMP}/legion-node-release-signing-key.b64"
+            umask 077
+            printf '%s\n' "$RELEASE_SIGNING_PRIVATE_KEY" >"$signing_key"
+            trap 'rm -f "$signing_key"' EXIT
+            signing_args=(
+              --signing-private-key-file "$signing_key"
+              --expected-public-key "$RELEASE_SIGNING_PUBLIC_KEY"
+            )
+          fi
           engine_bundle="dist/artifact/yaklang-node-engine_${NODE_PACKAGE_VERSION}_${NODE_GOOS}_${NODE_GOARCH}.tar.gz"
           ./.github/scripts/build-legion-node-engine-import-bundle.sh \
             --version "$NODE_PACKAGE_VERSION" \
@@ -206,8 +213,7 @@ jobs:
             --artifact-dir dist/artifact \
             --goos "$NODE_GOOS" \
             --goarch "$NODE_GOARCH" \
-            --signing-private-key-file "$signing_key" \
-            --expected-public-key "$RELEASE_SIGNING_PUBLIC_KEY" \
+            "${signing_args[@]}" \
             --output "$engine_bundle"
           gzip -t "$engine_bundle"
           (cd dist/artifact && sha256sum -c "$(basename "$engine_bundle").sha256")


### PR DESCRIPTION
## 改动摘要

- Yaklang Node + AI Runtime 统一安装包的 Ed25519 签名改为可选能力。
- `production-release` 未配置签名密钥时，仍生成包含完整 SHA-256 校验的六文件安装包。
- 私钥和批准公钥同时配置时，继续生成 `release-index.json.sig` 并校验密钥匹配。
- 只配置其中一项时立即失败，避免生成信任策略不明确的产物。
- 保留 Node/Runtime 摘要、复合 release ID、来源提交、平台与能力清单等既有校验。

## 主要文件

- `.github/scripts/build-legion-node-engine-import-bundle.sh`
- `.github/scripts/test-build-legion-node-engine-import-bundle.sh`
- `.github/scripts/test-legion-component-workflow-contract.sh`
- `.github/workflows/build-legion-product-node.yml`

## 验证方式

- `./.github/scripts/test-build-legion-node-engine-import-bundle.sh`
  - 签名单包生成并验签通过；
  - 无签名单包生成成功，恰好六个文件且无 `.sig`；
  - 半配置密钥、错误密钥、非法版本、篡改 Runtime 均被拒绝。
- `./.github/scripts/test-legion-component-workflow-contract.sh`
- `bash -n` 与 ShellCheck（本次涉及脚本）
- 跨仓 T2：Legion 无公钥时 preview/import 为 `200/201`；篡改索引为 `400`；配置公钥后无签名包为 `400` 且 catalog 不变。

## 配套改动

- Legion Draft PR：VillanCh/legion#320
- Legion 未配置公钥时使用 checksum-only 模式；配置公钥后仍严格验签。