### PR TITLE
Improve AI stream and crawler result output

### DIFF
--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -322,7 +322,6 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 	if r.useSpeedPriorityAI {
 		aiCallback = r.config.CallSpeedPriorityAI
 	}
-	var promptRefOnce sync.Once
 	transactionErr := aicommon.CallAITransaction(
 		r.config,
 		prompt,
@@ -432,7 +431,7 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 							return
 						}
 
-						event, emitErr := boundEmitter.EmitStreamEventWithVizSource(
+						_, emitErr := boundEmitter.EmitStreamEventWithVizSource(
 							defaultNodeId,
 							preparedReader,
 							resp.GetTaskIndex(),
@@ -448,16 +447,6 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 							log.Errorf("EmitStreamEvent for field [%s] failed: %v", key, emitErr)
 							done() // Ensure done is called even on error
 							return
-						}
-
-						// Emit prompt as reference material (only once per transaction)
-						if event != nil && prompt != "" {
-							promptRefOnce.Do(func() {
-								streamId := event.GetContentJSONPath(`$.event_writer_id`)
-								if streamId != "" {
-									boundEmitter.EmitTextReferenceMaterial(streamId, prompt)
-								}
-							})
 						}
 					}),
 			)

--- a/common/ai/aid/aireact/reactloops/reactloopstests/prompt_reference_material_test.go
+++ b/common/ai/aid/aireact/reactloops/reactloopstests/prompt_reference_material_test.go
@@ -11,242 +11,69 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
-	"github.com/yaklang/yaklang/common/jsonpath"
 	"github.com/yaklang/yaklang/common/schema"
-	"github.com/yaklang/yaklang/common/utils"
 )
 
-// TestReActLoop_PromptReferenceMaterial tests that the prompt is emitted as reference material
-func TestReActLoop_PromptReferenceMaterial(t *testing.T) {
-	callCount := 0
-	var events []*schema.AiOutputEvent
-	var eventsMu sync.Mutex
+func TestReActLoop_StreamFieldsDoNotAutomaticallyBindPromptReferenceMaterial(t *testing.T) {
+	var (
+		eventsMu sync.Mutex
+		events   []*schema.AiOutputEvent
+	)
 
-	testInput := "test input for reference material"
-
-	// Create ReAct instance as invoker
 	reactIns, err := aireact.NewTestReAct(
-		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
+		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {
 			eventsMu.Lock()
 			defer eventsMu.Unlock()
-			events = append(events, e)
+			events = append(events, event)
 		}),
-		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
-			callCount++
-			rsp := i.NewAIResponse()
-
-			// Return finish action with a thought field to trigger stream event
-			rsp.EmitOutputStream(bytes.NewBufferString(`{
-				"@action": "finish",
-				"answer": "Task completed",
-				"human_readable_thought": "This is a test thought"
+		aicommon.WithAICallback(func(config aicommon.AICallerConfigIf, request *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			response := config.NewAIResponse()
+			response.EmitOutputStream(bytes.NewBufferString(`{
+				"@action": "capture_summary",
+				"human_readable_thought": "Brief status",
+				"summary": "Substantive streamed result"
 			}`))
-			rsp.Close()
-			return rsp, nil
+			response.Close()
+			return response, nil
 		}),
 	)
-	require.NoError(t, err, "Failed to create ReAct")
-	require.NotNil(t, reactIns, "ReAct instance should not be nil")
+	require.NoError(t, err)
 
-	// Create loop using ReAct as invoker
-	loop, err := reactloops.NewReActLoop("test-ref-material-loop", reactIns)
-	require.NoError(t, err, "Failed to create loop")
-	require.NotNil(t, loop, "Loop should not be nil")
-
-	// Execute loop
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	err = loop.Execute("test-task", ctx, testInput)
-	require.NoError(t, err, "Execute should not fail")
-
-	// Wait for events to be processed
-	time.Sleep(500 * time.Millisecond)
-
-	require.Greater(t, callCount, 0, "AI should have been called at least once")
-
-	// Find reference material event
-	eventsMu.Lock()
-	defer eventsMu.Unlock()
-
-	var referenceMaterialEvent *schema.AiOutputEvent
-	for _, e := range events {
-		if e.Type == schema.EVENT_TYPE_REFERENCE_MATERIAL {
-			referenceMaterialEvent = e
-			break
-		}
-	}
-
-	require.NotNil(t, referenceMaterialEvent, "Expected to find reference material event, but none found. Total events: %d", len(events))
-
-	// Verify event structure
-	require.NotEmpty(t, referenceMaterialEvent.Content, "Reference material event content should not be empty")
-
-	// Extract and verify payload
-	payload := jsonpath.FindFirst(referenceMaterialEvent.Content, "$.payload")
-	require.NotNil(t, payload, "Reference material payload should exist")
-
-	payloadStr := utils.InterfaceToString(payload)
-	require.NotEmpty(t, payloadStr, "Reference material payload should not be empty")
-
-	// Verify event_uuid exists (this links to the stream event)
-	eventUUID := jsonpath.FindFirst(referenceMaterialEvent.Content, "$.event_uuid")
-	require.NotNil(t, eventUUID, "Reference material event_uuid should exist")
-	require.NotEmpty(t, utils.InterfaceToString(eventUUID), "Reference material event_uuid should not be empty")
-
-	// Verify type field
-	typeField := jsonpath.FindFirst(referenceMaterialEvent.Content, "$.type")
-	require.NotNil(t, typeField, "Reference material type field should exist")
-	require.Equal(t, "text", utils.InterfaceToString(typeField), "Reference material type should be 'text'")
-
-	// Verify payload contains expected content (prompt should include user input)
-	require.Contains(t, payloadStr, testInput, "Reference material payload should contain user input")
-
-	t.Logf("Reference material verified successfully")
-	t.Logf("Event UUID: %s", utils.InterfaceToString(eventUUID))
-	t.Logf("Payload length: %d bytes", len(payloadStr))
-}
-
-// TestReActLoop_PromptReferenceMaterial_OnlyOnce tests that reference material is emitted only once per transaction
-func TestReActLoop_PromptReferenceMaterial_OnlyOnce(t *testing.T) {
-	var events []*schema.AiOutputEvent
-	var eventsMu sync.Mutex
-	var transactionCount int
-
-	// Create ReAct instance as invoker
-	reactIns, err := aireact.NewTestReAct(
-		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
-			eventsMu.Lock()
-			defer eventsMu.Unlock()
-			events = append(events, e)
-		}),
-		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
-			transactionCount++
-			rsp := i.NewAIResponse()
-
-			// Return finish action with multiple thought fields
-			rsp.EmitOutputStream(bytes.NewBufferString(`{
-				"@action": "finish",
-				"answer": "Task completed",
-				"human_readable_thought": "First thought",
-				"reasoning": "Some reasoning",
-				"summary": "Summary content"
-			}`))
-			rsp.Close()
-			return rsp, nil
-		}),
+	loop, err := reactloops.NewReActLoop("no-automatic-prompt-reference", reactIns,
+		reactloops.WithRegisterLoopActionWithStreamField(
+			"capture_summary",
+			"capture summary stream",
+			nil,
+			[]*reactloops.LoopStreamField{{FieldName: "summary", AINodeId: "test-summary"}},
+			nil,
+			func(loop *reactloops.ReActLoop, action *aicommon.Action, operator *reactloops.LoopActionHandlerOperator) {
+				operator.Exit()
+			},
+		),
 	)
-	require.NoError(t, err, "Failed to create ReAct")
-
-	// Create loop using ReAct as invoker
-	loop, err := reactloops.NewReActLoop("test-ref-once-loop", reactIns)
-	require.NoError(t, err, "Failed to create loop")
-
-	// Execute loop
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	err = loop.Execute("test-task", ctx, "test input")
-	require.NoError(t, err, "Execute should not fail")
-
-	// Wait for events to be processed
-	time.Sleep(500 * time.Millisecond)
-
-	// Count reference material events
-	eventsMu.Lock()
-	defer eventsMu.Unlock()
-
-	var referenceMaterialEvents []*schema.AiOutputEvent
-	for _, e := range events {
-		if e.Type == schema.EVENT_TYPE_REFERENCE_MATERIAL {
-			referenceMaterialEvents = append(referenceMaterialEvents, e)
-		}
-	}
-
-	require.Len(t, referenceMaterialEvents, transactionCount, "Expected exactly one reference material event per transaction")
-
-	// Verify every transaction's event has valid content. A normal finish now
-	// has two transactions because the soft TODO checkpoint requires an
-	// explicit confirmation.
-	for _, event := range referenceMaterialEvents {
-		require.NotEmpty(t, event.Content, "Reference material content should not be empty")
-
-		payload := jsonpath.FindFirst(event.Content, "$.payload")
-		require.NotNil(t, payload, "Payload should exist")
-		require.NotEmpty(t, utils.InterfaceToString(payload), "Payload should not be empty")
-	}
-
-	t.Logf("Successfully verified reference material was emitted exactly once")
-}
-
-// TestReActLoop_PromptReferenceMaterial_EventUUIDValid tests that reference material event_uuid is valid
-func TestReActLoop_PromptReferenceMaterial_EventUUIDValid(t *testing.T) {
-	var events []*schema.AiOutputEvent
-	var eventsMu sync.Mutex
-
-	// Create ReAct instance as invoker
-	reactIns, err := aireact.NewTestReAct(
-		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
-			eventsMu.Lock()
-			defer eventsMu.Unlock()
-			events = append(events, e)
-		}),
-		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
-			rsp := i.NewAIResponse()
-
-			rsp.EmitOutputStream(bytes.NewBufferString(`{
-				"@action": "finish",
-				"answer": "Task completed",
-				"human_readable_thought": "Test thought"
-			}`))
-			rsp.Close()
-			return rsp, nil
-		}),
-	)
-	require.NoError(t, err, "Failed to create ReAct")
-
-	loop, err := reactloops.NewReActLoop("test-event-uuid-loop", reactIns)
-	require.NoError(t, err, "Failed to create loop")
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-
-	err = loop.Execute("test-task", ctx, "test input")
-	require.NoError(t, err, "Execute should not fail")
+	require.NoError(t, loop.Execute("test-task", ctx, "sensitive prompt content"))
 
 	time.Sleep(500 * time.Millisecond)
 
 	eventsMu.Lock()
 	defer eventsMu.Unlock()
 
-	// Find reference material event and its linked stream event
-	var refMaterialEvent *schema.AiOutputEvent
-	streamEventIDs := make(map[string]bool)
-
-	for _, e := range events {
-		if e.Type == schema.EVENT_TYPE_REFERENCE_MATERIAL {
-			refMaterialEvent = e
+	streamSources := make(map[string]bool)
+	for _, event := range events {
+		if event == nil {
+			continue
 		}
-		// Collect stream start event IDs
-		if e.Type == schema.EVENT_TYPE_STREAM_START {
-			eventWriterID := jsonpath.FindFirst(e.Content, "$.event_writer_id")
-			if eventWriterID != nil {
-				streamEventIDs[utils.InterfaceToString(eventWriterID)] = true
-			}
+		require.NotEqual(t, schema.EVENT_TYPE_REFERENCE_MATERIAL, event.Type,
+			"stream fields must not automatically expose the decision prompt as reference material")
+		if event.Type == schema.EVENT_TYPE_STREAM_START {
+			streamSources[event.VizSource] = true
 		}
 	}
 
-	require.NotNil(t, refMaterialEvent, "Reference material event should exist")
-
-	// Verify event_uuid in reference material matches a stream event
-	eventUUID := jsonpath.FindFirst(refMaterialEvent.Content, "$.event_uuid")
-	require.NotNil(t, eventUUID, "event_uuid should exist in reference material")
-
-	eventUUIDStr := utils.InterfaceToString(eventUUID)
-	require.NotEmpty(t, eventUUIDStr, "event_uuid should not be empty")
-
-	// The event_uuid should match one of the stream event IDs
-	require.True(t, streamEventIDs[eventUUIDStr], "event_uuid should match a stream event ID. Got: %s, Available: %v", eventUUIDStr, streamEventIDs)
-
-	t.Logf("Reference material event_uuid validated: %s", eventUUIDStr)
+	require.True(t, streamSources["human_readable_thought"])
+	require.True(t, streamSources["summary"])
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/simple_crawler_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/simple_crawler_test.go
@@ -95,11 +95,32 @@ func TestSimpleCrawler_CoverageHint(t *testing.T) {
 	assert.Assert(t, strings.Contains(stdout, "todo"),
 		"hint should mention breaking work into todos")
 
-	// The standard crawl output must still be present (summary + requested URLs).
+	// The crawler output should separate requested and merely discovered URLs,
+	// without the noisy duplicated website tree.
 	assert.Assert(t, strings.Contains(stdout, "=== Crawl Summary ==="),
 		"standard crawl summary should still be present")
 	assert.Assert(t, strings.Contains(stdout, "=== Requested URLs ==="),
 		"requested URLs section should still be present")
+	assert.Assert(t, strings.Contains(stdout, "=== Found URLs ==="),
+		"found URLs section should be present")
+	assert.Assert(t, strings.Contains(stdout, "=== Follow-up Guidance ==="),
+		"follow-up guidance should be present")
+	assert.Assert(t, !strings.Contains(stdout, "Website Forest:"),
+		"website forest should no longer be emitted")
+
+	// Requested URL records carry compact response metadata useful for triage.
+	assert.Assert(t, strings.Contains(stdout, "[200 OK]"),
+		"requested URL should include status code and text; got:\n%s", stdout)
+	assert.Assert(t, strings.Contains(stdout, "type=text/html; charset=utf-8"),
+		"requested URL should include content type; got:\n%s", stdout)
+	assert.Assert(t, strings.Contains(stdout, "bytes="),
+		"requested URL should include response body size; got:\n%s", stdout)
+
+	// Guidance must explain how to crawl selected discoveries more deeply.
+	assert.Assert(t, strings.Contains(stdout, "Found URLs") && strings.Contains(stdout, "`urls`"),
+		"guidance should tell the AI to re-crawl selected Found URLs")
+	assert.Assert(t, strings.Contains(stdout, "`reqs-max`") && strings.Contains(stdout, "`max-depth`"),
+		"guidance should explain request/depth controls")
 }
 
 func TestSimpleCrawler_HidesAndDoesNotRequestURLFragments(t *testing.T) {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
@@ -11,10 +11,10 @@ automatically fall back to HTTP when an HTTPS start URL yields no crawl results.
 
 Output includes:
   1. Crawl summary (requests made, total URLs discovered, pending URLs)
-  2. Website forest: a tree structure showing the full site hierarchy,
-     including URLs discovered in responses but NOT yet requested.
-     This gives a broad view of the site structure even with limited requests.
-  3. Requested URL list with HTTP method and response status.
+  2. Requested URLs with HTTP method, response status, content type, body size,
+     and redirect location when available.
+  3. Found URLs discovered in responses but NOT yet requested.
+  4. Follow-up guidance for selecting Found URLs and tuning crawl limits.
 
 Required Parameters:
   urls            (string)  Start URL(s) for crawling. Multiple URLs can be provided
@@ -23,8 +23,7 @@ Required Parameters:
 Optional Parameters:
   reqs-max        (int)     Maximum number of outbound HTTP requests allowed.
                             Default: 300. The crawler discovers many more URLs than
-                            it requests; all discovered URLs appear in the website
-                            forest output even if not requested.
+                            it requests; unrequested discoveries appear under Found URLs.
   max-retry       (int)     Maximum retry count per request. Default: 1.
   forbid-for-parent-path (string)  Whether to forbid crawling parent paths.
                             Accepted values: "yes"/"no". Default: "no".
@@ -55,9 +54,9 @@ timeoutSecond := cli.Int("timeout", cli.setHelp("设置超时秒数(单次请求
 httpsFallback := cli.Bool("https-fallback", cli.setHelp("HTTPS 失败时是否自动切回 HTTP"), cli.setDefault(true))
 cli.check()
 
-forest = webforest.New(50)
 discoveredUrls = sync.NewLock()
 discoveredUrlSet = {}
+discoveredUrlList = []
 requestedUrlSet = {}
 
 normalizeDisplayUrl = func(rawUrl) {
@@ -102,7 +101,7 @@ opts.Append(crawler.onUrlFound(func(urlStr) {
         return
     }
     discoveredUrlSet[urlStr] = true
-    try { forest.AddNode(urlStr) } catch {}
+    discoveredUrlList.Append(urlStr)
 }))
 
 targetCandidates = [startUrl]
@@ -136,16 +135,23 @@ for currentStartUrl in targetCandidates {
         requestedUrlSet[urlstr] = true
         if !(urlstr in discoveredUrlSet) {
             discoveredUrlSet[urlstr] = true
-            try { forest.AddNode(urlstr) } catch {}
+            discoveredUrlList.Append(urlstr)
         }
         discoveredUrls.Unlock()
 
         req, _ := http.dump(result.Request())
         method := poc.GetHTTPRequestMethod(req)
-        var rspdesc = ""
+        status = "unknown"
+        contentType = ""
+        bodySize = 0
+        redirectLocation = ""
         try {
             rsp, _ := http.dump(result.Response()[0])
-            rspdesc = str.Join(poc.GetHTTPPacketFirstLine(rsp), " ")
+            _, statusCode, statusText = poc.GetHTTPPacketFirstLine(rsp)
+            status = str.TrimSpace(sprintf("%v %v", statusCode, statusText))
+            contentType = str.TrimSpace(poc.GetHTTPPacketHeader(rsp, "Content-Type"))
+            bodySize = len(poc.GetHTTPPacketBody(rsp))
+            redirectLocation = str.TrimSpace(poc.GetHTTPPacketHeader(rsp, "Location"))
         } catch {}
 
         // A URL fragment is browser-only and must never be sent to the server.
@@ -153,10 +159,17 @@ for currentStartUrl in targetCandidates {
         // returns a misleading 404 for one; the crawler now strips fragments at
         // request construction time, so this is only a defensive compatibility
         // guard.
-        if rawUrlstr != urlstr && str.Contains(rspdesc, " 404 ") {
+        if rawUrlstr != urlstr && str.HasPrefix(status, "404") {
             continue
         }
-        requestLines.Append(sprintf("[%v] [%v] %v", method, rspdesc, urlstr))
+        responseInfo = [sprintf("bytes=%v", bodySize)]
+        if contentType != "" {
+            responseInfo.Append("type=" + contentType)
+        }
+        if redirectLocation != "" {
+            responseInfo.Append("location=" + redirectLocation)
+        }
+        requestLines.Append(sprintf("[%v] [%v] [%v] %v", method, status, str.Join(responseInfo, "; "), urlstr))
     }
 
     if currentResults > 0 {
@@ -180,34 +193,17 @@ if usedFallback {
 
 discoveredCount = len(discoveredUrlSet)
 requestedCount = len(requestedUrlSet)
+pendingCount = discoveredCount - requestedCount
 
-output = bufio.NewBuffer()
-
-output.WriteString("=== Crawl Summary ===\n")
-output.WriteString(sprintf("Requests sent:   %v\n", requestedCount))
-output.WriteString(sprintf("URLs discovered: %v (includes URLs found in responses but not yet requested)\n", discoveredCount))
-output.WriteString(sprintf("Pending:         %v\n", discoveredCount - requestedCount))
-
-output.WriteString("\n")
-output.WriteString(forest.Output())
-
-output.WriteString("\n=== Requested URLs ===\n")
-for line in requestLines {
-    output.WriteString(line)
-    output.WriteString("\n")
+foundUrlLines = []
+discoveredUrls.Lock()
+for u in discoveredUrlList {
+    if !(u in requestedUrlSet) {
+        foundUrlLines.Append(u)
+    }
 }
+discoveredUrls.Unlock()
 
-result = string(output.String())
-if len(result) <= 30000 {
-    yakit.Info(result)
-} else {
-    yakit.Info(result[:30000] + "... (truncated)")
-}
-
-// 覆盖度提示: 爬虫发现的往往是多个子站 / 大量路径, 实战里 AI 经常只盯住一个深挖而漏掉其余.
-// 这里不钉死具体清单(避免过拟合到某个形态), 只用"子站数 + pending 数"作为广度信号, 引导 AI
-// 在下一步用 adjust_todo 把待测面拆成多个 todo —— 多 todo 是保证执行深度和覆盖完整度的关键.
-// 关键词: simple_crawler 覆盖度提示, adjust_todo, 多 todo, 执行深度
 distinctSubdomains = {}
 for u, _ in discoveredUrlSet {
     lower = str.ToLower(u)
@@ -223,9 +219,45 @@ for u, _ in discoveredUrlSet {
     }
 }
 subdomainCount = len(distinctSubdomains)
-pendingCount = discoveredCount - requestedCount
+
+output = bufio.NewBuffer()
+
+output.WriteString("=== Crawl Summary ===\n")
+output.WriteString(sprintf("Requests sent:   %v\n", requestedCount))
+output.WriteString(sprintf("URLs discovered: %v (includes URLs found in responses but not yet requested)\n", discoveredCount))
+output.WriteString(sprintf("Pending:         %v\n", pendingCount))
+
+output.WriteString("\n=== Requested URLs ===\n")
+for line in requestLines {
+    output.WriteString(line)
+    output.WriteString("\n")
+}
+
+output.WriteString("\n=== Found URLs ===\n")
+output.WriteString("Discovered but not requested; treat these as follow-up candidates, not verified live endpoints.\n")
+if len(foundUrlLines) == 0 {
+    output.WriteString("(none)\n")
+} else {
+    for line in foundUrlLines {
+        output.WriteString(line)
+        output.WriteString("\n")
+    }
+}
+
+output.WriteString("\n=== Follow-up Guidance ===\n")
+output.WriteString("- Select high-value Found URLs and run `simple_crawler` again with them in `urls`; prioritize dynamic pages, APIs, auth/account, admin, and parameterized endpoints before static assets.\n")
+output.WriteString("- If Pending remains high, increase `reqs-max`, `urls-max`, or `max-depth` gradually to collect more of the discovered surface.\n")
+output.WriteString("- For a focused branch, lower `reqs-max`/`max-depth` or set `forbid-for-parent-path=yes`; this reduces noise and request cost.\n")
+output.WriteString("- Compare status, content type, body size, and redirect location in Requested URLs to prioritize unusual or dynamic responses.\n")
 if subdomainCount > 1 || pendingCount > 0 {
-    yakit.Info("[coverage hint] Crawler discovered %v distinct subdomain(s) and %v unrequested URL(s) (see the website forest + pending count above). A common failure mode is to fixate on ONE subdomain or ONE thread and skip the rest. In your NEXT iteration, use `adjust_todo` to break the remaining surface into MULTIPLE concrete todos (e.g. one per subdomain / per untested endpoint group, plus auth, IDOR, and parameter testing for each) before diving into any single one. More (and finer-grained) todos => better depth and coverage, and they prevent the loop from finishing before the surface is covered.", subdomainCount, pendingCount)
+    output.WriteString(sprintf("- [coverage hint] %v distinct subdomain(s) and %v Found URL(s) remain. In the NEXT iteration, use `adjust_todo` to split work by subdomain and endpoint group before deep-diving into one thread; do not claim full coverage while high-value Found URLs remain unrequested.\n", subdomainCount, pendingCount))
+}
+
+result = string(output.String())
+if len(result) <= 30000 {
+    yakit.Info(result)
+} else {
+    yakit.Info(result[:30000] + "... (truncated)")
 }
 
 try {

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "b4b14d12e9c9cdf09f7d39a17b8f8e9d4b8078383ba4ee02b4342640c4181a4e"
+const ExistedBuildInAIToolEmbedFSHash string = "f33f9e3064309a22a37fd6799ed5d4e366f2785f1f4cc9d3399b2536390024a4"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "410cc6295a00f43655313d6ce258e8adc0f712b020101bf6199bc305f210b2e3"
+const ExistedBuildInAIToolEmbedFSHash string = "b4b14d12e9c9cdf09f7d39a17b8f8e9d4b8078383ba4ee02b4342640c4181a4e"


### PR DESCRIPTION
## Summary

- stop automatically attaching full decision prompts as reference material to streamed fields
- replace the simple crawler website forest with separate Requested URLs and Found URLs sections
- include response status, content type, body size, and redirect metadata for requested URLs
- add follow-up guidance for re-crawling discoveries and tuning crawl limits

## Tests

- `go test ./common/ai/aid/aitool/buildinaitools/yakscripttools/test -run 'TestSimpleCrawler_(CoverageHint|HidesAndDoesNotRequestURLFragments)' -count=1`\n- `go test ./common/ai/aid/aireact/reactloops -count=1`\n- `go test ./common/ai/aid/aireact/reactloops/reactloopstests -count=1`