### PR TITLE
fix: stream SSE responses in MITM via existing ResponseHeaderCallback…

### DIFF
--- a/common/crep/mitm.go
+++ b/common/crep/mitm.go
@@ -352,6 +352,7 @@ type MITMServer struct {
 	responseHijackHandler                 func(isHttps bool, r *http.Request, rspIns *http.Response, rsp []byte, remoteAddr string) []byte
 	responseHijackHandlerWithModification func(isHttps bool, r *http.Request, rspIns *http.Response, rsp []byte, remoteAddr string) ([]byte, bool)
 	httpFlowMirror                        func(isHttps bool, r *http.Request, rsp *http.Response, startTs int64)
+	streamRecorderFactory                 minimartian.HTTPStreamRecorderFactory
 
 	// websocket
 	websocketHijackMode            *utils.AtomicBool
@@ -494,6 +495,7 @@ func (m *MITMServer) initConfig() error {
 	m.proxy.SetHTTPForceClose(m.forceDisableKeepAlive)
 	m.proxy.SetFindProcessName(m.findProcessName)
 	m.proxy.SetDialer(m.dialer)
+	m.proxy.SetHTTPStreamRecorderFactory(m.streamRecorderFactory)
 
 	// when CA cert page is disabled, also disable the built-in branded error page
 	m.proxy.SetDisableBuiltinPage(!m.enableMITMCACertPage)

--- a/common/crep/mitm_config.go
+++ b/common/crep/mitm_config.go
@@ -830,3 +830,13 @@ func MITM_SetExtraIncomingConnectionChannelLegacy(ch chan net.Conn) MITMConfig {
 		return nil
 	}
 }
+
+// MITM_SetHTTPStreamRecorderFactory configures incremental persistence for
+// long-lived streaming responses (e.g. SSE) before the ordinary response
+// mirror runs. A nil factory disables stream recording.
+func MITM_SetHTTPStreamRecorderFactory(f minimartian.HTTPStreamRecorderFactory) MITMConfig {
+	return func(server *MITMServer) error {
+		server.streamRecorderFactory = f
+		return nil
+	}
+}

--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -227,46 +227,44 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 	}
 
 	httpctx.SetResponseHeaderParsed(req, func(key string, value string) {
+		// Forwarding is decided once: the first header that signals a
+		// streaming response wins and registers the single shared
+		// callback. makeStreamResponseCallback inspects the fully-parsed
+		// response to choose the trigger timing (immediate vs buffered),
+		// so this site only decides *whether* to stream plus the few
+		// flags that must be set before the body is read.
+		if httpctx.GetResponseHeaderCallback(req) != nil {
+			return
+		}
 		bwr := httpctx.GetMITMFrontendReadWriter(req)
 		if bwr == nil {
 			return
 		}
 
-		// filter / forward to client conn via Content-Type
-		if key == "content-type" {
-			// SSE: use an immediate trigger so the header is written and
-			// forwarding starts on the first body chunk, without waiting
-			// for a size or time threshold. This is the same TriggerWriter +
-			// pipe + IOCopy mechanism as chunked/large responses — the only
-			// difference is the trigger timing.
+		switch key {
+		case "content-type":
+			// SSE: long-lived stream. NoBodyBuffer must be set here, before
+			// the builder reads it, so the infinite body is never buffered
+			// into memory. The trigger timing is decided inside the callback.
 			if isServerSentEventContentType(value) {
 				httpctx.SetNoBodyBuffer(req, true)
 				httpctx.SetResponseReadTooSlow(req, true)
-				httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, cancelUpstream, true))
+				httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, cancelUpstream))
 				return
 			}
-			if ret := httpctx.GetResponseContentTypeFiltered(req); ret != nil {
-				if ret(value) {
-					// filtered by content-type
-					httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, nil, false))
-					return
-				}
-			}
-		}
-
-		// content-length is too short
-		if key != "content-length" && key != "transfer-encoding" {
-			return
-		}
-
-		if key == "content-length" {
-			if contentLength := codec.Atoi(value); contentLength < int(MaxContentLength) {
+			if ret := httpctx.GetResponseContentTypeFiltered(req); ret != nil && ret(value) {
+				httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, cancelUpstream))
 				return
 			}
+		case "content-length":
+			if contentLength := codec.Atoi(value); contentLength >= int(MaxContentLength) {
+				httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, cancelUpstream))
+			}
+		case "transfer-encoding":
+			if utils.IContains(value, "chunked") {
+				httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, cancelUpstream))
+			}
 		}
-
-		// set if chunked or content-length is too large
-		httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, nil, false))
 	})
 
 	lowHttpResp, err := lowhttp.HTTPWithoutRedirect(opts...)
@@ -299,19 +297,22 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 // makeStreamResponseCallback builds a ResponseHeaderCallback that relays the
 // response body to the downstream client via a TriggerWriter + pipe + goroutine
 // IOCopy. This is the single forwarding primitive shared by all streaming
-// responses:
+// responses.
 //
-//   - SSE (text/event-stream): immediate=true, cancelUpstream≠nil
-//   - content-type filtered:   immediate=true, cancelUpstream=nil
-//   - chunked / large body:     immediate=false (size/timeout trigger)
+// Unlike the previous design where the caller picked the trigger timing by
+// passing an `immediate` flag, the callback now inspects the fully-parsed
+// response (available here as `rsp`) and decides the streaming kind itself:
 //
-// When immediate is true, NewTriggerWriterImmediate fires on the first body
-// chunk so the header is written and forwarding starts without delay —
-// essential for SSE where the body is long-lived. When false, NewTriggerWriterEx
-// buffers until MaxContentLength or maxReadWaitTime is exceeded.
+//   - SSE (text/event-stream): immediate trigger; a downstream write failure
+//     cancels the upstream request so the blocking body reader can return.
+//   - content-type filtered:   immediate trigger; upstream is not cancelled.
+//   - chunked / large body:     buffered trigger (fires on MaxContentLength or
+//     maxReadWaitTime); upstream is not cancelled.
 //
-// When cancelUpstream is non-nil, a downstream write failure cancels the
-// upstream request so the blocking body reader can return.
+// immediate = NewTriggerWriterImmediate fires on the first body chunk so the
+// header is written and forwarding starts without delay — essential for SSE
+// where the body is long-lived. buffered = NewTriggerWriterEx waits until the
+// size or time threshold is exceeded.
 //
 // When p.streamRecorder is set, an optional best-effort recorder is created
 // to persist body chunks to a spill file for history/audit. Recorder write
@@ -321,9 +322,25 @@ func (p *Proxy) makeStreamResponseCallback(
 	req *http.Request,
 	bwr io.ReadWriter,
 	cancelUpstream context.CancelFunc,
-	immediate bool,
 ) httpctx.ResponseHeaderCallbackType {
-	return func(_ *http.Response, headerBytes []byte, bodyReader io.Reader) (io.Reader, error) {
+	return func(rsp *http.Response, headerBytes []byte, bodyReader io.Reader) (io.Reader, error) {
+		// Decide the streaming kind from the fully-parsed response. This
+		// keeps the "immediate vs buffered" trigger choice inside the
+		// forwarding mechanism instead of at every call site.
+		kind := p.classifyStreamResponse(req, rsp)
+		if kind == streamKindNone {
+			// Not actually a streaming response (e.g. the registered header
+			// was a false positive). Don't interfere with the body reader.
+			return bodyReader, nil
+		}
+		immediate := kind == streamKindSSE || kind == streamKindFiltered
+		// Only SSE cancels the upstream on downstream write failure; the
+		// filtered/chunked paths preserve the original no-cancel behavior.
+		var cancelOnWriteFail context.CancelFunc
+		if kind == streamKindSSE {
+			cancelOnWriteFail = cancelUpstream
+		}
+
 		// Create an optional best-effort recorder for incremental persistence.
 		// The recorder is set up before the trigger fires so the goroutine
 		// can tee body chunks into it.
@@ -339,12 +356,12 @@ func (p *Proxy) makeStreamResponseCallback(
 			})
 		}
 		if p.streamRecorder != nil {
-			rsp, err := utils.ReadHTTPResponseFromBytes(headerBytes, nil)
+			recorderRsp, err := utils.ReadHTTPResponseFromBytes(headerBytes, nil)
 			if err != nil {
 				log.Warnf("mitm: parse response header for recorder failed: %v", err)
 			} else {
-				rsp.Request = req
-				recorder, err = p.streamRecorder(isHTTPS, req, rsp, headerBytes)
+				recorderRsp.Request = req
+				recorder, err = p.streamRecorder(isHTTPS, req, recorderRsp, headerBytes)
 				if err != nil {
 					log.Warnf("mitm: create stream recorder failed: %v", err)
 					recorder = nil
@@ -361,8 +378,8 @@ func (p *Proxy) makeStreamResponseCallback(
 			httpctx.SetContextValueInfoFromRequest(req, triggerEvent, true)
 			httpctx.SetMITMSkipFrontendFeedback(req, true)
 			if _, err := bwr.Write(headerBytes); err != nil {
-				if cancelUpstream != nil {
-					cancelUpstream()
+				if cancelOnWriteFail != nil {
+					cancelOnWriteFail()
 				}
 				return
 			}
@@ -370,17 +387,27 @@ func (p *Proxy) makeStreamResponseCallback(
 			go func() {
 				writers := []io.Writer{utils.WriterAutoFlush(bwr)}
 				if recorder != nil {
+					// bestEffortStreamRecorder swallows recorder errors, so a
+					// non-EOF error from the MultiWriter can only come from
+					// the downstream writer — i.e. the client disconnected.
 					writers = append(writers, &bestEffortStreamRecorder{writer: recorder})
 				}
 				_, err := utils.IOCopy(io.MultiWriter(writers...), buffer, nil)
 				utils.FlushWriter(bwr)
 				if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 					log.Errorf("io.Copy error: %s", err)
+					// Downstream write failure (client gone): cancel the
+					// upstream request so the blocking body reader returns.
+					// Only SSE sets cancelOnWriteFail; other kinds leave it
+					// nil to preserve the original no-cancel behavior.
+					if cancelOnWriteFail != nil {
+						cancelOnWriteFail()
+					}
 				}
 			}()
 		}
 
-		// Choose the trigger based on whether we need immediate forwarding.
+		// Choose the trigger based on the streaming kind.
 		MaxContentLength := int(consts.GetGlobalMaxContentLength())
 		if p.GetMaxContentLength() != 0 {
 			MaxContentLength = p.maxContentLength
@@ -400,6 +427,54 @@ func (p *Proxy) makeStreamResponseCallback(
 		})
 		return io.TeeReader(bodyReader, writerCloser), nil
 	}
+}
+
+// streamKind classifies a streaming response for forwarding purposes.
+type streamKind int
+
+const (
+	streamKindNone streamKind = iota
+	// streamKindSSE is a text/event-stream response: immediate trigger,
+	// downstream disconnect cancels the upstream connection.
+	streamKindSSE
+	// streamKindFiltered is a content-type-filtered response: immediate
+	// trigger, upstream is not cancelled on downstream write failure.
+	streamKindFiltered
+	// streamKindChunkedLarge is a chunked or content-length-too-large
+	// response: buffered trigger (size/timeout), upstream not cancelled.
+	streamKindChunkedLarge
+)
+
+// classifyStreamResponse inspects the fully-parsed response and the request
+// context to determine which streaming forwarding kind applies. It is the
+// single place that decides trigger timing, so adding a new streaming type
+// (e.g. streaming JSON) only needs a new case here.
+func (p *Proxy) classifyStreamResponse(req *http.Request, rsp *http.Response) streamKind {
+	if rsp == nil {
+		return streamKindNone
+	}
+	ct := rsp.Header.Get("Content-Type")
+	if isServerSentEventContentType(ct) {
+		return streamKindSSE
+	}
+	if ret := httpctx.GetResponseContentTypeFiltered(req); ret != nil && ret(ct) {
+		return streamKindFiltered
+	}
+	// chunked transfer-encoding
+	for _, te := range rsp.TransferEncoding {
+		if utils.IContains(te, "chunked") {
+			return streamKindChunkedLarge
+		}
+	}
+	// content-length too large
+	MaxContentLength := int(consts.GetGlobalMaxContentLength())
+	if p.GetMaxContentLength() != 0 {
+		MaxContentLength = p.maxContentLength
+	}
+	if rsp.ContentLength >= int64(MaxContentLength) {
+		return streamKindChunkedLarge
+	}
+	return streamKindNone
 }
 
 // bestEffortStreamRecorder wraps an io.Writer and never returns an error,

--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -235,28 +235,19 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 		// filter / forward to client conn via Content-Type
 		if key == "content-type" {
 			// SSE: write headers immediately and stream body via the same
-			// ResponseHeaderCallback + TeeReader path used by chunked and
-			// content-type-filtered responses. This avoids a separate
-			// BodyStreamReaderHandler channel and the double-header race
-			// that would require a suppression flag.
+			// immediateRelayCallback used by content-type-filtered responses.
+			// This avoids a separate BodyStreamReaderHandler channel and the
+			// double-header race that would require a suppression flag.
 			if isServerSentEventContentType(value) {
 				httpctx.SetNoBodyBuffer(req, true)
 				httpctx.SetResponseReadTooSlow(req, true)
-				httpctx.SetResponseHeaderCallback(req, p.makeSSEStreamCallback(isHttps, req, bwr, cancelUpstream))
+				httpctx.SetResponseHeaderCallback(req, p.makeImmediateRelayCallback(isHttps, req, bwr, cancelUpstream))
 				return
 			}
 			if ret := httpctx.GetResponseContentTypeFiltered(req); ret != nil {
 				if ret(value) {
 					// filtered by content-type
-					httpctx.SetResponseHeaderCallback(req, func(response *http.Response, headerBytes []byte, bodyReader io.Reader) (io.Reader, error) {
-						httpctx.SetMITMSkipFrontendFeedback(req, true)
-						bwr.Write(headerBytes)
-						utils.FlushWriter(bwr)
-						httpctx.SetResponseFinishedCallback(req, func() {
-							utils.FlushWriter(bwr)
-						})
-						return io.TeeReader(bodyReader, bwr), nil
-					})
+					httpctx.SetResponseHeaderCallback(req, p.makeImmediateRelayCallback(isHttps, req, bwr, nil))
 					return
 				}
 			}
@@ -323,12 +314,20 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 	return rsp, err
 }
 
-// makeSSEStreamCallback builds a ResponseHeaderCallback dedicated to SSE
-// responses. It writes the response header immediately and returns a TeeReader
-// that relays body chunks to the downstream client in real time while the
-// builder's chunked decoder drives the read. An optional stream recorder
-// (best-effort) persists the body to a spill file for history/audit.
-func (p *Proxy) makeSSEStreamCallback(
+// makeImmediateRelayCallback builds a ResponseHeaderCallback that writes the
+// response header immediately and returns a TeeReader relaying body chunks to
+// the downstream client in real time. This is the shared forwarding primitive
+// for both content-type-filtered responses and SSE (text/event-stream)
+// responses.
+//
+// When cancelUpstream is non-nil, a downstream write failure cancels the
+// upstream request so the blocking body reader can return — essential for
+// long-lived streams where the client may disconnect mid-stream.
+//
+// When p.streamRecorder is set, an optional best-effort recorder is created
+// to persist body chunks to a spill file for history/audit. Recorder write
+// errors never break or delay forwarding.
+func (p *Proxy) makeImmediateRelayCallback(
 	isHTTPS bool,
 	req *http.Request,
 	bwr io.ReadWriter,
@@ -352,7 +351,7 @@ func (p *Proxy) makeSSEStreamCallback(
 			closeOnce.Do(func() {
 				if recorder != nil {
 					if err := recorder.Close(); err != nil {
-						log.Warnf("mitm: finalize SSE stream recorder failed: %v", err)
+						log.Warnf("mitm: finalize stream recorder failed: %v", err)
 					}
 				}
 			})
@@ -360,12 +359,12 @@ func (p *Proxy) makeSSEStreamCallback(
 		if p.streamRecorder != nil {
 			rsp, err := utils.ReadHTTPResponseFromBytes(headerBytes, nil)
 			if err != nil {
-				log.Warnf("mitm: parse SSE response header for recorder failed: %v", err)
+				log.Warnf("mitm: parse response header for recorder failed: %v", err)
 			} else {
 				rsp.Request = req
 				recorder, err = p.streamRecorder(isHTTPS, req, rsp, headerBytes)
 				if err != nil {
-					log.Warnf("mitm: create SSE stream recorder failed: %v", err)
+					log.Warnf("mitm: create stream recorder failed: %v", err)
 					recorder = nil
 				} else if recorder != nil {
 					httpctx.SetResponseStreamRecorder(req, recorder)
@@ -373,8 +372,7 @@ func (p *Proxy) makeSSEStreamCallback(
 			}
 		}
 
-		// Chain the finished callback so the recorder is closed on EOF and
-		// the downstream writer gets a final flush.
+		// Chain the finished callback: final flush + recorder close.
 		previousFinished := httpctx.GetResponseFinishedCallback(req)
 		httpctx.SetResponseFinishedCallback(req, func() {
 			if previousFinished != nil {
@@ -384,10 +382,9 @@ func (p *Proxy) makeSSEStreamCallback(
 			closeRecorder()
 		})
 
-		// Build the TeeReader target: always forward to the client; append the
-		// recorder (wrapped best-effort) when present. The wrapper swallows
-		// recorder write errors so persistence failures never break or stall
-		// forwarding.
+		// TeeReader target: always forward to the client; append the recorder
+		// (wrapped best-effort) when present. WriterAutoFlush ensures each
+		// chunk is flushed to the downstream connection immediately.
 		writers := []io.Writer{utils.WriterAutoFlush(bwr)}
 		if recorder != nil {
 			writers = append(writers, &bestEffortStreamRecorder{writer: recorder})

--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -234,20 +234,21 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 
 		// filter / forward to client conn via Content-Type
 		if key == "content-type" {
-			// SSE: write headers immediately and stream body via the same
-			// immediateRelayCallback used by content-type-filtered responses.
-			// This avoids a separate BodyStreamReaderHandler channel and the
-			// double-header race that would require a suppression flag.
+			// SSE: use an immediate trigger so the header is written and
+			// forwarding starts on the first body chunk, without waiting
+			// for a size or time threshold. This is the same TriggerWriter +
+			// pipe + IOCopy mechanism as chunked/large responses — the only
+			// difference is the trigger timing.
 			if isServerSentEventContentType(value) {
 				httpctx.SetNoBodyBuffer(req, true)
 				httpctx.SetResponseReadTooSlow(req, true)
-				httpctx.SetResponseHeaderCallback(req, p.makeImmediateRelayCallback(isHttps, req, bwr, cancelUpstream))
+				httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, cancelUpstream, true))
 				return
 			}
 			if ret := httpctx.GetResponseContentTypeFiltered(req); ret != nil {
 				if ret(value) {
 					// filtered by content-type
-					httpctx.SetResponseHeaderCallback(req, p.makeImmediateRelayCallback(isHttps, req, bwr, nil))
+					httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, nil, false))
 					return
 				}
 			}
@@ -265,26 +266,7 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 		}
 
 		// set if chunked or content-length is too large
-		httpctx.SetResponseHeaderCallback(req, func(response *http.Response, headerBytes []byte, bodyReader io.Reader) (io.Reader, error) {
-			writerCloser := utils.NewTriggerWriterEx(uint64(MaxContentLength), p.maxReadWaitTime, func(buffer io.ReadCloser, triggerEvent string) {
-				httpctx.SetContextValueInfoFromRequest(req, triggerEvent, true)
-				httpctx.SetMITMSkipFrontendFeedback(req, true)
-				bwr.Write(headerBytes)
-				utils.FlushWriter(bwr)
-				go func() {
-					_, err := utils.IOCopy(utils.WriterAutoFlush(bwr), buffer, nil)
-					utils.FlushWriter(bwr)
-					if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-						log.Errorf("io.Copy error: %s", err)
-					}
-				}()
-			})
-			httpctx.SetResponseFinishedCallback(req, func() {
-				httpctx.SetResponseTooLargeSize(req, writerCloser.GetCount())
-				writerCloser.Close()
-			})
-			return io.TeeReader(bodyReader, writerCloser), nil
-		})
+		httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, nil, false))
 	})
 
 	lowHttpResp, err := lowhttp.HTTPWithoutRedirect(opts...)
@@ -314,37 +296,37 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 	return rsp, err
 }
 
-// makeImmediateRelayCallback builds a ResponseHeaderCallback that writes the
-// response header immediately and returns a TeeReader relaying body chunks to
-// the downstream client in real time. This is the shared forwarding primitive
-// for both content-type-filtered responses and SSE (text/event-stream)
-// responses.
+// makeStreamResponseCallback builds a ResponseHeaderCallback that relays the
+// response body to the downstream client via a TriggerWriter + pipe + goroutine
+// IOCopy. This is the single forwarding primitive shared by all streaming
+// responses:
+//
+//   - SSE (text/event-stream): immediate=true, cancelUpstream≠nil
+//   - content-type filtered:   immediate=true, cancelUpstream=nil
+//   - chunked / large body:     immediate=false (size/timeout trigger)
+//
+// When immediate is true, NewTriggerWriterImmediate fires on the first body
+// chunk so the header is written and forwarding starts without delay —
+// essential for SSE where the body is long-lived. When false, NewTriggerWriterEx
+// buffers until MaxContentLength or maxReadWaitTime is exceeded.
 //
 // When cancelUpstream is non-nil, a downstream write failure cancels the
-// upstream request so the blocking body reader can return — essential for
-// long-lived streams where the client may disconnect mid-stream.
+// upstream request so the blocking body reader can return.
 //
 // When p.streamRecorder is set, an optional best-effort recorder is created
 // to persist body chunks to a spill file for history/audit. Recorder write
 // errors never break or delay forwarding.
-func (p *Proxy) makeImmediateRelayCallback(
+func (p *Proxy) makeStreamResponseCallback(
 	isHTTPS bool,
 	req *http.Request,
 	bwr io.ReadWriter,
 	cancelUpstream context.CancelFunc,
+	immediate bool,
 ) httpctx.ResponseHeaderCallbackType {
 	return func(_ *http.Response, headerBytes []byte, bodyReader io.Reader) (io.Reader, error) {
-		httpctx.SetMITMSkipFrontendFeedback(req, true)
-
-		if _, err := bwr.Write(headerBytes); err != nil {
-			if cancelUpstream != nil {
-				cancelUpstream()
-			}
-			return nil, err
-		}
-		utils.FlushWriter(bwr)
-
 		// Create an optional best-effort recorder for incremental persistence.
+		// The recorder is set up before the trigger fires so the goroutine
+		// can tee body chunks into it.
 		var recorder io.WriteCloser
 		var closeOnce sync.Once
 		closeRecorder := func() {
@@ -372,24 +354,51 @@ func (p *Proxy) makeImmediateRelayCallback(
 			}
 		}
 
-		// Chain the finished callback: final flush + recorder close.
-		previousFinished := httpctx.GetResponseFinishedCallback(req)
-		httpctx.SetResponseFinishedCallback(req, func() {
-			if previousFinished != nil {
-				previousFinished()
+		// Build the trigger callback: write header, flush, then start a
+		// goroutine that drains the pipe and forwards body chunks to the
+		// downstream client (and recorder).
+		triggerHandler := func(buffer io.ReadCloser, triggerEvent string) {
+			httpctx.SetContextValueInfoFromRequest(req, triggerEvent, true)
+			httpctx.SetMITMSkipFrontendFeedback(req, true)
+			if _, err := bwr.Write(headerBytes); err != nil {
+				if cancelUpstream != nil {
+					cancelUpstream()
+				}
+				return
 			}
 			utils.FlushWriter(bwr)
-			closeRecorder()
-		})
-
-		// TeeReader target: always forward to the client; append the recorder
-		// (wrapped best-effort) when present. WriterAutoFlush ensures each
-		// chunk is flushed to the downstream connection immediately.
-		writers := []io.Writer{utils.WriterAutoFlush(bwr)}
-		if recorder != nil {
-			writers = append(writers, &bestEffortStreamRecorder{writer: recorder})
+			go func() {
+				writers := []io.Writer{utils.WriterAutoFlush(bwr)}
+				if recorder != nil {
+					writers = append(writers, &bestEffortStreamRecorder{writer: recorder})
+				}
+				_, err := utils.IOCopy(io.MultiWriter(writers...), buffer, nil)
+				utils.FlushWriter(bwr)
+				if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+					log.Errorf("io.Copy error: %s", err)
+				}
+			}()
 		}
-		return io.TeeReader(bodyReader, io.MultiWriter(writers...)), nil
+
+		// Choose the trigger based on whether we need immediate forwarding.
+		MaxContentLength := int(consts.GetGlobalMaxContentLength())
+		if p.GetMaxContentLength() != 0 {
+			MaxContentLength = p.maxContentLength
+		}
+		var writerCloser *utils.TriggerWriter
+		if immediate {
+			writerCloser = utils.NewTriggerWriterImmediate(triggerHandler)
+		} else {
+			writerCloser = utils.NewTriggerWriterEx(uint64(MaxContentLength), p.maxReadWaitTime, triggerHandler)
+		}
+
+		httpctx.SetResponseFinishedCallback(req, func() {
+			httpctx.SetResponseTooLargeSize(req, writerCloser.GetCount())
+			utils.FlushWriter(bwr)
+			closeRecorder()
+			writerCloser.Close()
+		})
+		return io.TeeReader(bodyReader, writerCloser), nil
 	}
 }
 

--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -1,9 +1,13 @@
 package minimartian
 
 import (
+	"context"
 	"io"
+	"mime"
 	"net"
 	"net/http"
+	"strings"
+	"sync"
 
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
@@ -13,6 +17,16 @@ import (
 	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
 	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 )
+
+// isServerSentEventContentType reports whether value is a text/event-stream
+// media type, tolerating charset and other parameters.
+func isServerSentEventContentType(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
+}
 
 func (p *Proxy) doHTTPRequest(ctx *Context, req *http.Request) (*http.Response, error) {
 	// Check if mock response should be used (set by mockHTTPRequest)
@@ -60,6 +74,13 @@ func parseLowHTTPResponsePacket(packet []byte) (*http.Response, error) {
 }
 
 func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, error) {
+	// A cancellable context for the upstream request. When the downstream
+	// client disconnects during a long-lived streaming response (e.g. SSE),
+	// cancelling this context tears down the upstream connection so the
+	// blocking body reader can return.
+	upstreamContext, cancelUpstream := context.WithCancel(req.Context())
+	defer cancelUpstream()
+
 	// PlainRequestBytes is the decoded representation used by the UI, history,
 	// and plugins. It must not replace the wire packet during transparent
 	// forwarding. Explicitly hijacked bytes still take precedence.
@@ -115,6 +136,7 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 		lowhttp.WithGmTLSOnly(p.gmTLSOnly),
 		lowhttp.WithGmTLSPrefer(p.gmPrefer),
 		lowhttp.WithExtendReadDeadline(true),
+		lowhttp.WithContext(upstreamContext),
 		lowhttp.WithSaveHTTPFlow(false),
 		lowhttp.WithNativeHTTPRequestInstance(req),
 		lowhttp.WithDiscardIntermediateResponseBody(true),
@@ -145,20 +167,21 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 
 	if proxies := p.selectProxiesForHost(host); len(proxies) > 0 {
 		opts = append(opts, lowhttp.WithProxy(proxies...))
-	} else {
-		opts = append(opts, lowhttp.WithProxy())
 	}
 
-	//if connectedPort := httpctx.GetContextIntInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToPort); connectedPort > 0 {
-	//	portValid := (connectedPort == 443 && isHttps) || (connectedPort == 80 && !isHttps)
-	//	if !portValid {
-	//		// 修复host和port
-	//		if host := httpctx.GetContextStringInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToHost); host != "" {
-	//			opts = append(opts, lowhttp.WithHost(host))
+	isStrongHostMode = httpctx.GetIsStrongHostMode(req)
+	upstreamPortModified = httpctx.GetUpstreamPortIsModified(req)
+
+	//	if connectedPort := httpctx.GetContextIntInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToPort); connectedPort > 0 {
+	//		portValid := (connectedPort == 443 && isHttps) || (connectedPort == 80 && !isHttps)
+	//		if !portValid {
+	//			// 修复host和port
+	//			if host := httpctx.GetContextStringInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToHost); host != "" {
+	//				opts = append(opts, lowhttp.WithHost(host))
+	//			}
+	//			opts = append(opts, lowhttp.WithPort(connectedPort))
 	//		}
-	//		opts = append(opts, lowhttp.WithPort(connectedPort))
 	//	}
-	//}
 
 	connectedHost := httpctx.GetContextStringInfoFromRequest(req, httpctx.REQUEST_CONTEXT_KEY_ConnectedToHost)
 	if isStrongHostMode || !upstreamPortModified {
@@ -211,6 +234,17 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 
 		// filter / forward to client conn via Content-Type
 		if key == "content-type" {
+			// SSE: write headers immediately and stream body via the same
+			// ResponseHeaderCallback + TeeReader path used by chunked and
+			// content-type-filtered responses. This avoids a separate
+			// BodyStreamReaderHandler channel and the double-header race
+			// that would require a suppression flag.
+			if isServerSentEventContentType(value) {
+				httpctx.SetNoBodyBuffer(req, true)
+				httpctx.SetResponseReadTooSlow(req, true)
+				httpctx.SetResponseHeaderCallback(req, p.makeSSEStreamCallback(isHttps, req, bwr, cancelUpstream))
+				return
+			}
 			if ret := httpctx.GetResponseContentTypeFiltered(req); ret != nil {
 				if ret(value) {
 					// filtered by content-type
@@ -287,6 +321,95 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 
 	utils.FixHTTPResponseForGolangNativeHTTPClient(rsp)
 	return rsp, err
+}
+
+// makeSSEStreamCallback builds a ResponseHeaderCallback dedicated to SSE
+// responses. It writes the response header immediately and returns a TeeReader
+// that relays body chunks to the downstream client in real time while the
+// builder's chunked decoder drives the read. An optional stream recorder
+// (best-effort) persists the body to a spill file for history/audit.
+func (p *Proxy) makeSSEStreamCallback(
+	isHTTPS bool,
+	req *http.Request,
+	bwr io.ReadWriter,
+	cancelUpstream context.CancelFunc,
+) httpctx.ResponseHeaderCallbackType {
+	return func(_ *http.Response, headerBytes []byte, bodyReader io.Reader) (io.Reader, error) {
+		httpctx.SetMITMSkipFrontendFeedback(req, true)
+
+		if _, err := bwr.Write(headerBytes); err != nil {
+			if cancelUpstream != nil {
+				cancelUpstream()
+			}
+			return nil, err
+		}
+		utils.FlushWriter(bwr)
+
+		// Create an optional best-effort recorder for incremental persistence.
+		var recorder io.WriteCloser
+		var closeOnce sync.Once
+		closeRecorder := func() {
+			closeOnce.Do(func() {
+				if recorder != nil {
+					if err := recorder.Close(); err != nil {
+						log.Warnf("mitm: finalize SSE stream recorder failed: %v", err)
+					}
+				}
+			})
+		}
+		if p.streamRecorder != nil {
+			rsp, err := utils.ReadHTTPResponseFromBytes(headerBytes, nil)
+			if err != nil {
+				log.Warnf("mitm: parse SSE response header for recorder failed: %v", err)
+			} else {
+				rsp.Request = req
+				recorder, err = p.streamRecorder(isHTTPS, req, rsp, headerBytes)
+				if err != nil {
+					log.Warnf("mitm: create SSE stream recorder failed: %v", err)
+					recorder = nil
+				} else if recorder != nil {
+					httpctx.SetResponseStreamRecorder(req, recorder)
+				}
+			}
+		}
+
+		// Chain the finished callback so the recorder is closed on EOF and
+		// the downstream writer gets a final flush.
+		previousFinished := httpctx.GetResponseFinishedCallback(req)
+		httpctx.SetResponseFinishedCallback(req, func() {
+			if previousFinished != nil {
+				previousFinished()
+			}
+			utils.FlushWriter(bwr)
+			closeRecorder()
+		})
+
+		// Build the TeeReader target: always forward to the client; append the
+		// recorder (wrapped best-effort) when present. The wrapper swallows
+		// recorder write errors so persistence failures never break or stall
+		// forwarding.
+		writers := []io.Writer{utils.WriterAutoFlush(bwr)}
+		if recorder != nil {
+			writers = append(writers, &bestEffortStreamRecorder{writer: recorder})
+		}
+		return io.TeeReader(bodyReader, io.MultiWriter(writers...)), nil
+	}
+}
+
+// bestEffortStreamRecorder wraps an io.Writer and never returns an error,
+// ensuring that recorder failures do not break or delay response forwarding.
+type bestEffortStreamRecorder struct {
+	writer io.Writer
+}
+
+func (w *bestEffortStreamRecorder) Write(p []byte) (int, error) {
+	if w == nil || w.writer == nil {
+		return len(p), nil
+	}
+	if n, err := w.writer.Write(p); err != nil || n != len(p) {
+		log.Warnf("mitm: persist streaming response chunk failed: wrote=%d expected=%d error=%v", n, len(p), err)
+	}
+	return len(p), nil
 }
 
 func transferFixedResponsePacket(req *http.Request, response *lowhttp.LowhttpResponse) {

--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -315,8 +315,10 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 // size or time threshold is exceeded.
 //
 // When p.streamRecorder is set, an optional best-effort recorder is created
-// to persist body chunks to a spill file for history/audit. Recorder write
-// errors never break or delay forwarding.
+// to persist body chunks to a spill file for history/audit. The recorder is
+// only created for SSE responses (see the kind == streamKindSSE guard below):
+// SSE disables body buffering, so the spill file is the only way to persist
+// the long-lived body. Recorder write errors never break or delay forwarding.
 func (p *Proxy) makeStreamResponseCallback(
 	isHTTPS bool,
 	req *http.Request,
@@ -344,6 +346,23 @@ func (p *Proxy) makeStreamResponseCallback(
 		// Create an optional best-effort recorder for incremental persistence.
 		// The recorder is set up before the trigger fires so the goroutine
 		// can tee body chunks into it.
+		//
+		// Only SSE responses need a recorder: SSE sets NoBodyBuffer so the
+		// response builder never buffers the long-lived body, and the only
+		// way to persist it for history/audit is the spill file the recorder
+		// writes incrementally. The recorder also marks the flow as
+		// read-too-slow so History/API reconstruct the response from the
+		// spill file instead of the (empty) DB body.
+		//
+		// Filtered and chunked/large responses do NOT set NoBodyBuffer, so
+		// the response builder still buffers the full body and the ordinary
+		// mirror path persists it. Creating a recorder for them would
+		// unconditionally mark the flow read-too-slow and attach spill files
+		// even when the body is smaller than MaxContentLength (e.g. a chunked
+		// 4 MB response under a 5 MB limit), which is incorrect. The
+		// too-large decision for those kinds stays with the response builder,
+		// which judges by the actual body size — matching the pre-SSE
+		// behavior.
 		var recorder io.WriteCloser
 		var closeOnce sync.Once
 		closeRecorder := func() {
@@ -355,7 +374,7 @@ func (p *Proxy) makeStreamResponseCallback(
 				}
 			})
 		}
-		if p.streamRecorder != nil {
+		if kind == streamKindSSE && p.streamRecorder != nil {
 			recorderRsp, err := utils.ReadHTTPResponseFromBytes(headerBytes, nil)
 			if err != nil {
 				log.Warnf("mitm: parse response header for recorder failed: %v", err)

--- a/common/minimartian/lowhttp_exec_sse_test.go
+++ b/common/minimartian/lowhttp_exec_sse_test.go
@@ -251,3 +251,81 @@ func (w *failAfterHeaderWriter) Write(p []byte) (int, error) {
 func (w *failAfterHeaderWriter) Read(p []byte) (int, error) {
 	return 0, io.EOF
 }
+
+// TestClassifyStreamResponse verifies the single decision point that picks the
+// streaming forwarding kind, covering every branch of classifyStreamResponse:
+//
+//   - SSE (text/event-stream, with/without charset)               -> streamKindSSE
+//   - content-type filtered (matcher hit / miss)                  -> streamKindFiltered / None
+//   - chunked Transfer-Encoding (case-insensitive)               -> streamKindChunkedLarge
+//   - Content-Length >= MaxContentLength (boundary >= vs <)      -> streamKindChunkedLarge / None
+//   - nil response                                                -> streamKindNone
+//
+// The immediate-vs-buffered trigger and cancel-on-write-fail choices in
+// makeStreamResponseCallback are derived from this kind, so this guards the
+// invariants the rest of the forwarding code depends on.
+func TestClassifyStreamResponse(t *testing.T) {
+	const maxCL = 1024 * 1024 // 1 MiB
+
+	mkReq := func() *http.Request {
+		req, err := http.NewRequest("GET", "http://example.com/events", nil)
+		require.NoError(t, err)
+		return req
+	}
+	mkRsp := func(ct string, transferEncoding []string, contentLength int64) *http.Response {
+		rsp := &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Request:    mkReq(),
+		}
+		if ct != "" {
+			rsp.Header.Set("Content-Type", ct)
+		}
+		rsp.TransferEncoding = transferEncoding
+		rsp.ContentLength = contentLength
+		return rsp
+	}
+
+	cases := []struct {
+		name            string
+		rsp             *http.Response
+		filterMatcher   func(string) bool
+		want            streamKind
+	}{
+		{"sse plain", mkRsp("text/event-stream", nil, -1), nil, streamKindSSE},
+		{"sse with charset", mkRsp("text/event-stream; charset=utf-8", nil, -1), nil, streamKindSSE},
+		{"sse with params", mkRsp("text/event-stream;charset=utf-8", nil, -1), nil, streamKindSSE},
+		{"filtered hit", mkRsp("application/x-ndjson", nil, -1), func(ct string) bool {
+			return strings.EqualFold(ct, "application/x-ndjson")
+		}, streamKindFiltered},
+		{"filtered miss (no matcher set)", mkRsp("application/json", nil, -1), nil, streamKindNone},
+		{"filtered miss (matcher rejects)", mkRsp("application/json", nil, -1), func(ct string) bool {
+			return false
+		}, streamKindNone},
+		{"chunked lowercase", mkRsp("text/plain", []string{"chunked"}, -1), nil, streamKindChunkedLarge},
+		{"chunked mixedcase", mkRsp("text/plain", []string{"ChUnKeD"}, -1), nil, streamKindChunkedLarge},
+		{"chunked + sse -> sse wins", mkRsp("text/event-stream", []string{"chunked"}, -1), nil, streamKindSSE},
+		{"content-length over threshold", mkRsp("text/plain", nil, int64(maxCL) + 1), nil, streamKindChunkedLarge},
+		{"content-length at threshold (>=)", mkRsp("text/plain", nil, int64(maxCL)), nil, streamKindChunkedLarge},
+		{"content-length under threshold", mkRsp("text/plain", nil, int64(maxCL) - 1), nil, streamKindNone},
+		{"content-length unknown (-1) small body", mkRsp("text/plain", nil, -1), nil, streamKindNone},
+		{"plain html no stream", mkRsp("text/html", nil, 100), nil, streamKindNone},
+		{"empty content-type", mkRsp("", nil, 100), nil, streamKindNone},
+		{"nil response", nil, nil, streamKindNone},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewProxy()
+			p.SetMaxContentLength(maxCL)
+
+			req := mkReq()
+			if tc.filterMatcher != nil {
+				httpctx.SetResponseContentTypeFiltered(req, tc.filterMatcher)
+			}
+
+			got := p.classifyStreamResponse(req, tc.rsp)
+			require.Equal(t, tc.want, got, "classifyStreamResponse kind mismatch")
+		})
+	}
+}

--- a/common/minimartian/lowhttp_exec_sse_test.go
+++ b/common/minimartian/lowhttp_exec_sse_test.go
@@ -1,0 +1,253 @@
+package minimartian
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
+)
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("capture unavailable")
+}
+
+func TestBestEffortStreamRecorderDoesNotBreakForwarding(t *testing.T) {
+	payload := []byte("data: still-forwarded\n\n")
+	n, err := (&bestEffortStreamRecorder{writer: failingWriter{}}).Write(payload)
+	require.NoError(t, err)
+	require.Equal(t, len(payload), n)
+}
+
+func TestIsServerSentEventContentType(t *testing.T) {
+	require.True(t, isServerSentEventContentType("text/event-stream"))
+	require.True(t, isServerSentEventContentType("text/event-stream; charset=utf-8"))
+	require.True(t, isServerSentEventContentType("text/event-stream;charset=utf-8"))
+	require.False(t, isServerSentEventContentType("text/html"))
+	require.False(t, isServerSentEventContentType("application/json"))
+	require.False(t, isServerSentEventContentType(""))
+}
+
+type lockedReadWriter struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (w *lockedReadWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Write(p)
+}
+
+func (w *lockedReadWriter) Read(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Read(p)
+}
+
+func (w *lockedReadWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
+}
+
+type testStreamRecorder struct {
+	lockedReadWriter
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (r *testStreamRecorder) Close() error {
+	r.once.Do(func() { close(r.closed) })
+	return nil
+}
+
+// TestExecLowHTTPStreamsAndRecordsSSEBeforeEOF verifies that the SSE
+// ResponseHeaderCallback path forwards body chunks to the downstream client
+// and to the best-effort recorder in real time, before the upstream sends
+// the terminating chunk.
+func TestExecLowHTTPStreamsAndRecordsSSEBeforeEOF(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	releaseUpstream := make(chan struct{})
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil || line == "\r\n" {
+				break
+			}
+		}
+		// Put Transfer-Encoding before Content-Type to verify that the SSE
+		// callback takes precedence over the generic chunked callback.
+		_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n")
+		_, _ = io.WriteString(conn, "d\r\ndata: ready\n\n\r\n")
+		<-releaseUpstream
+		_, _ = io.WriteString(conn, "0\r\n\r\n")
+	}()
+
+	rawRequest := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /events HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", listener.Addr().String())))
+	req, err := lowhttp.ParseBytesToHttpRequest(rawRequest)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, rawRequest)
+	httpctx.SetPlainRequestBytes(req, rawRequest)
+	frontend := &lockedReadWriter{}
+	httpctx.SetMITMFrontendReadWriter(req, frontend)
+
+	proxy := NewProxy()
+	poolCtx, cancelPool := context.WithCancel(context.Background())
+	t.Cleanup(cancelPool)
+	proxy.SetConnPool(lowhttp.NewHttpConnPool(poolCtx, 100, 2))
+	recorderCreated := make(chan *testStreamRecorder, 1)
+	proxy.SetHTTPStreamRecorderFactory(func(_ bool, _ *http.Request, _ *http.Response, _ []byte) (io.WriteCloser, error) {
+		recorder := &testStreamRecorder{closed: make(chan struct{})}
+		recorderCreated <- recorder
+		return recorder, nil
+	})
+
+	requestDone := make(chan error, 1)
+	go func() {
+		_, execErr := proxy.execLowhttp(nil, req)
+		requestDone <- execErr
+	}()
+
+	var recorder *testStreamRecorder
+	select {
+	case recorder = <-recorderCreated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream recorder was not created after SSE response headers")
+	}
+	// Both the downstream client and the recorder should have received the
+	// body chunk before the upstream sends the terminating 0\r\n\r\n.
+	require.Eventually(t, func() bool {
+		return strings.Contains(frontend.String(), "data: ready") && strings.Contains(recorder.String(), "data: ready")
+	}, 2*time.Second, 20*time.Millisecond)
+	// The response header must be written exactly once — no double-header race.
+	require.Equal(t, 1, strings.Count(frontend.String(), "HTTP/1.1 200 OK"))
+
+	// The request must still be in flight while the upstream is streaming.
+	select {
+	case err := <-requestDone:
+		t.Fatalf("stream returned before upstream EOF: %v", err)
+	default:
+	}
+
+	close(releaseUpstream)
+	select {
+	case err := <-requestDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not finish after upstream EOF")
+	}
+	select {
+	case <-recorder.closed:
+	case <-time.After(time.Second):
+		t.Fatal("stream recorder was not closed")
+	}
+	<-serverDone
+}
+
+// TestExecLowHTTPCancelsUpstreamAfterClientDisconnect verifies that when the
+// downstream client connection breaks after the header has been forwarded,
+// the upstream context is cancelled so the blocking body reader can return.
+func TestExecLowHTTPCancelsUpstreamAfterClientDisconnect(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil || line == "\r\n" {
+				break
+			}
+		}
+		_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n")
+		// Send one chunk then keep the connection open.
+		_, _ = io.WriteString(conn, "d\r\ndata: ready\n\n\r\n")
+		// Block until the connection is closed by the client-side cancel.
+		buf := make([]byte, 1)
+		for {
+			if _, e := conn.Read(buf); e != nil {
+				break
+			}
+		}
+	}()
+
+	rawRequest := lowhttp.FixHTTPRequest([]byte(fmt.Sprintf("GET /events HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", listener.Addr().String())))
+	req, err := lowhttp.ParseBytesToHttpRequest(rawRequest)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, rawRequest)
+	httpctx.SetPlainRequestBytes(req, rawRequest)
+
+	// Use a writer that fails after the header is written, simulating a
+	// downstream client disconnect.
+	frontend := &failAfterHeaderWriter{}
+	httpctx.SetMITMFrontendReadWriter(req, frontend)
+
+	proxy := NewProxy()
+	poolCtx, cancelPool := context.WithCancel(context.Background())
+	t.Cleanup(cancelPool)
+	proxy.SetConnPool(lowhttp.NewHttpConnPool(poolCtx, 100, 2))
+
+	requestDone := make(chan error, 1)
+	go func() {
+		_, execErr := proxy.execLowhttp(nil, req)
+		requestDone <- execErr
+	}()
+
+	select {
+	case <-requestDone:
+		// The request should return (with an error) because the downstream
+		// write failure cancelled the upstream context.
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream did not return after downstream client disconnect")
+	}
+	<-serverDone
+}
+
+type failAfterHeaderWriter struct {
+	bytes.Buffer
+	headerWritten bool
+}
+
+func (w *failAfterHeaderWriter) Write(p []byte) (int, error) {
+	if w.headerWritten {
+		return 0, io.ErrClosedPipe
+	}
+	w.headerWritten = true
+	return w.Buffer.Write(p)
+}
+
+func (w *failAfterHeaderWriter) Read(p []byte) (int, error) {
+	return 0, io.EOF
+}

--- a/common/minimartian/martian.go
+++ b/common/minimartian/martian.go
@@ -16,7 +16,10 @@
 // request and response modifiers.
 package minimartian
 
-import "net/http"
+import (
+	"io"
+	"net/http"
+)
 
 // RequestModifier is an interface that defines a request modifier that can be
 // used by a proxy.
@@ -31,6 +34,12 @@ type ResponseModifier interface {
 	// ModifyResponse modifies the response.
 	ModifyResponse(res *http.Response) error
 }
+
+// HTTPStreamRecorderFactory creates an optional best-effort recorder for
+// streaming responses (e.g. SSE). The recorder receives body chunks as they
+// are relayed to the downstream client. Recorder failures must not affect
+// forwarding; a nil return disables recording for this response.
+type HTTPStreamRecorderFactory func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte) (io.WriteCloser, error)
 
 // RequestResponseModifier is an interface that is both a ResponseModifier and
 // a RequestModifier.

--- a/common/minimartian/proxy.go
+++ b/common/minimartian/proxy.go
@@ -75,6 +75,10 @@ type Proxy struct {
 	reqmod          RequestModifier
 	resmod          ResponseModifier
 
+	// streamRecorder creates optional best-effort recorders for streaming
+	// responses (e.g. SSE) to persist body chunks before EOF.
+	streamRecorder HTTPStreamRecorderFactory
+
 	// context cache
 	ctxCacheLock     *sync.Mutex
 	ctxCacheInitOnce *sync.Once
@@ -561,4 +565,10 @@ func (p *Proxy) SetResponseModifier(resmod ResponseModifier) {
 	}
 
 	p.resmod = resmod
+}
+
+// SetHTTPStreamRecorderFactory configures an optional best-effort recorder for
+// streaming responses such as SSE. A nil factory disables stream recording.
+func (p *Proxy) SetHTTPStreamRecorderFactory(factory HTTPStreamRecorderFactory) {
+	p.streamRecorder = factory
 }

--- a/common/utils/bytes_reader.go
+++ b/common/utils/bytes_reader.go
@@ -519,6 +519,11 @@ type TriggerWriter struct {
 	timeTrigger         *time.Timer
 	writeFirstOnce      *sync.Once
 
+	// immediate triggers on the first Write instead of waiting for a
+	// size or time threshold. Used for streaming responses (e.g. SSE)
+	// where the body is long-lived and must be relayed without delay.
+	immediate bool
+
 	r    io.ReadCloser
 	w    io.WriteCloser
 	once *sync.Once
@@ -581,6 +586,21 @@ func NewTriggerWriterEx(sizeTrigger uint64, timeTrigger time.Duration, h func(bu
 	}
 }
 
+// NewTriggerWriterImmediate creates a TriggerWriter that fires on the first
+// Write call rather than waiting for a size or time threshold. This is used
+// for long-lived streaming responses (e.g. SSE) where the body must be
+// relayed to the downstream client without delay.
+func NewTriggerWriterImmediate(h func(buffer io.ReadCloser, triggerEvent string)) *TriggerWriter {
+	r, w := NewBufPipe(nil)
+	return &TriggerWriter{
+		immediate:      true,
+		w:              w, r: r,
+		once:           new(sync.Once),
+		writeFirstOnce: new(sync.Once),
+		h:              h,
+	}
+}
+
 func (f *TriggerWriter) GetCount() int64 {
 	return int64(atomic.LoadUint64(&f.bytesCount))
 }
@@ -598,12 +618,22 @@ func (f *TriggerWriter) initTimeTrigger() {
 func (f *TriggerWriter) Write(p []byte) (n int, err error) {
 	byteCount := atomic.AddUint64(&f.bytesCount, uint64(len(p)))
 	f.writeFirstOnce.Do(func() {
+		if f.immediate {
+			// Fire immediately on the first chunk for streaming responses
+			// so the header is written and forwarding starts without delay.
+			f.once.Do(func() {
+				f.h(f.r, httpctx.REQUEST_CONTEXT_KEY_ResponseTooSlow)
+			})
+			return
+		}
 		f.initTimeTrigger()
 	})
 	var timerC <-chan time.Time
 	if f.timeTrigger != nil {
 		timerC = f.timeTrigger.C
 	}
+	// When immediate, the once has already fired above; the select below
+	// is a no-op because once.Do is idempotent.
 	select {
 	case <-timerC:
 		f.once.Do(func() {

--- a/common/utils/bytes_reader_trigger_immediate_test.go
+++ b/common/utils/bytes_reader_trigger_immediate_test.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
+)
+
+// TestTriggerWriterImmediateFiresOnFirstWrite verifies that
+// NewTriggerWriterImmediate invokes the trigger handler on the first Write
+// (without waiting for a size or time threshold), only fires once across
+// multiple writes, passes the ResponseTooSlow trigger event, and that the
+// data written after the trigger is fully readable from the pipe reader
+// handed to the handler.
+func TestTriggerWriterImmediateFiresOnFirstWrite(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		fired    int
+		gotEvent string
+		gotBuf   io.ReadCloser
+	)
+
+	tw := NewTriggerWriterImmediate(func(buffer io.ReadCloser, triggerEvent string) {
+		mu.Lock()
+		fired++
+		gotEvent = triggerEvent
+		gotBuf = buffer
+		mu.Unlock()
+	})
+
+	require.Zero(t, tw.GetCount(), "no bytes counted before any write")
+
+	// First write must fire the handler immediately.
+	n, err := tw.Write([]byte("data: ready\n\n"))
+	require.NoError(t, err)
+	require.Equal(t, len("data: ready\n\n"), n)
+	require.Equal(t, int64(n), tw.GetCount())
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return fired == 1
+	}, time.Second, 5*time.Millisecond, "handler must fire on first write")
+
+	mu.Lock()
+	require.Equal(t, httpctx.REQUEST_CONTEXT_KEY_ResponseTooSlow, gotEvent, "immediate trigger must use ResponseTooSlow event")
+	require.NotNil(t, gotBuf, "handler must receive the pipe reader")
+	mu.Unlock()
+
+	// Subsequent writes must NOT re-trigger the handler (once is idempotent).
+	for i := 0; i < 5; i++ {
+		_, werr := tw.Write([]byte("data: more\n\n"))
+		require.NoError(t, werr)
+	}
+	mu.Lock()
+	require.Equal(t, 1, fired, "handler must fire exactly once")
+	mu.Unlock()
+
+	// All written bytes must be fully readable from the pipe reader end that
+	// was passed to the handler — this is the invariant the SSE forwarding
+	// path relies on (io.TeeReader -> TriggerWriter -> pipe -> IOCopy).
+	require.NoError(t, tw.Close())
+	mu.Lock()
+	buf := gotBuf
+	mu.Unlock()
+	out, err := io.ReadAll(buf)
+	require.NoError(t, err)
+	expected := append([]byte("data: ready\n\n"), bytes.Repeat([]byte("data: more\n\n"), 5)...)
+	require.Equal(t, expected, out, "pipe reader must deliver all bytes written via TeeReader path")
+}

--- a/common/utils/lowhttp/conn_pool.go
+++ b/common/utils/lowhttp/conn_pool.go
@@ -723,12 +723,45 @@ func (pc *persistConn) readLoop() {
 				_ = pc.conn.SetReadDeadline(time.Now().Add(-1 * time.Second))
 			})
 		}
+
+		// Watch the per-request context (e.g. the MITM upstream context that
+		// is cancelled when the downstream client disconnects during a
+		// long-lived streaming response). When it is cancelled, close the
+		// upstream connection so the blocking conn.Read returns immediately.
+		// Closing (rather than setting a past read deadline) is required
+		// because deadlineExtendingReader resets the deadline to the future
+		// on every Read, which would defeat a past-deadline approach. Without
+		// this watcher, a streaming response (SSE) blocks forever:
+		// ExtendReadDeadline disables the hard timeout and pc.ctx is derived
+		// from context.Background(), not the request context.
+		var ctxWatcherStop chan struct{}
+		if rc.option != nil && rc.option.Ctx != nil {
+			ctxWatcherStop = make(chan struct{})
+			go func(seq uint64, stop chan struct{}) {
+				select {
+				case <-rc.option.Ctx.Done():
+					if atomic.LoadUint64(&pc.reqSeq) != seq {
+						return
+					}
+					_ = pc.conn.Close()
+				case <-stop:
+				}
+			}(seq, ctxWatcherStop)
+		}
+		stopCtxWatcher := func() {
+			if ctxWatcherStop != nil {
+				close(ctxWatcherStop)
+				ctxWatcherStop = nil
+			}
+		}
+
 		_ = pc.conn.SetReadDeadline(time.Now().Add(timeout))
 		_, err := pc.br.Peek(1)
 		if err != nil {
 			if hardTimeoutTimer != nil {
 				hardTimeoutTimer.Stop()
 			}
+			stopCtxWatcher()
 			if errors.Is(err, io.EOF) {
 				pc.sawEOF = true
 				closeErr = errServerClosedIdle
@@ -926,6 +959,11 @@ func (pc *persistConn) readLoop() {
 		if rc.option != nil && rc.option.BodyStreamReaderHandler != nil {
 			waitStreamHandlerDone(streamHandlerDone, streamBodyReaderCh, 2*time.Second, "conn pool stream handler")
 		}
+
+		// Stop the per-request context watcher before sending the response:
+		// the read is done, so a late cancel must not perturb the next
+		// iteration's deadline.
+		stopCtxWatcher()
 
 		//pc.mu.Lock()
 		////pc.numExpectedResponses-- // 减少预期响应数量

--- a/common/utils/lowhttp/conn_pool_behavior_test.go
+++ b/common/utils/lowhttp/conn_pool_behavior_test.go
@@ -906,3 +906,157 @@ func TestConnPool_H2_NoStreamLeakOnForceClose(t *testing.T) {
 		t.Logf("tombstone: host=%s finalActiveStreams=%d reason=%s", ts.host, ts.finalActiveStreams, ts.closeReason)
 	}
 }
+
+// ─── 14. Per-request context cancel closes the upstream connection ────────────
+
+// TestConnPool_H1_RequestContextCancelClosesUpstream verifies that cancelling
+// the per-request context (WithContext) tears down the blocking H1 upstream
+// connection, so a long-lived streaming response (SSE-like) does not block
+// forever. ExtendReadDeadline disables the hard timeout and the pool's own
+// context derives from Background, so only the per-request context watcher in
+// readLoop can close pc.conn and unblock the read.
+//
+// Assertions:
+//  1. The in-flight request returns (with an error) promptly after cancel,
+//     instead of hanging until the pool idle timeout.
+//  2. The server observes its connection being closed (the blocking read
+//     returns), proving the upstream was actually torn down — not just the
+//     client side abandoned.
+//  3. No persistConn readLoop/writeLoop goroutine leaks after the cancel.
+func TestConnPool_H1_RequestContextCancelClosesUpstream(t *testing.T) {
+	// Build an SSE-like server: send the headers + one chunk, flush, then hold
+	// the connection open until the client side closes it.
+	serverClosed := make(chan struct{})
+	host, port := utils.DebugMockHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: ready\n\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		// Block until the underlying connection is torn down by the cancel.
+		// r.Context() is done when the client disconnects.
+		<-r.Context().Done()
+		close(serverClosed)
+	})
+	if utils.WaitConnect(utils.HostPort(host, port), 3) != nil {
+		t.Fatal("SSE-like server not ready")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := NewHttpConnPool(ctx, 10, 2)
+	defer pool.Clear()
+
+	// Establish the goroutine baseline before issuing the request so the leak
+	// checker only counts goroutines created by this request.
+	checker := newGoroutineLeakChecker(t, 2, 3*time.Second)
+
+	req := buildBasicRequest(host, port)
+	requestDone := make(chan error, 1)
+	go func() {
+		_, err := HTTP(
+			WithPacketBytes(req),
+			WithConnPool(true),
+			ConnPool(pool),
+			WithContext(ctx),
+			// Mimic the SSE path: extend the read deadline so the hard-timeout
+			// timer does NOT fire — only the per-request context watcher can
+			// close the connection.
+			WithExtendReadDeadline(true),
+			WithTimeout(0),
+		)
+		requestDone <- err
+	}()
+
+	// Give the upstream a moment to start streaming, then cancel.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-requestDone:
+		// The request must return (with an error) promptly after cancel.
+	case <-time.After(3 * time.Second):
+		t.Fatal("streaming request did not return after per-request context cancel")
+	}
+
+	// The server must observe its connection being closed — the upstream was
+	// actually torn down, not merely abandoned by the client.
+	select {
+	case <-serverClosed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not observe upstream connection close after cancel")
+	}
+
+	// No persistConn goroutines should remain stuck in readLoop/writeLoop.
+	if c := countPersistConnGoroutines(); c != 0 {
+		t.Fatalf("expected 0 persistConn goroutines after cancel, got %d\n%s", c, dumpAllGoroutines())
+	}
+	checker.Check()
+}
+
+// TestConnPool_H1_RequestContextCancelDoesNotAffectNextRequest verifies that a
+// stale per-request context cancel does NOT close the connection when it has
+// already been reused for a subsequent request (reqSeq advanced). This guards
+// against the watcher closing pc.conn for the wrong request iteration.
+func TestConnPool_H1_RequestContextCancelDoesNotAffectNextRequest(t *testing.T) {
+	// A normal server that returns immediately, so the connection is returned
+	// to the pool and can be reused.
+	host, port := utils.DebugMockHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	if utils.WaitConnect(utils.HostPort(host, port), 3) != nil {
+		t.Fatal("server not ready")
+	}
+
+	poolCtx, cancelPool := context.WithCancel(context.Background())
+	defer cancelPool()
+	pool := NewHttpConnPool(poolCtx, 10, 2)
+	defer pool.Clear()
+
+	// First request with its own cancellable context; let it complete normally
+	// so the connection is recycled. Keep the context around (do not cancel
+	// yet) — we cancel it only AFTER a second request has taken the conn.
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
+	req := buildBasicRequest(host, port)
+	if _, err := HTTP(
+		WithPacketBytes(req),
+		WithConnPool(true),
+		ConnPool(pool),
+		WithContext(firstCtx),
+		WithTimeout(2*time.Second),
+	); err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+
+	// Second request reuses the pooled connection with a fresh context.
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	defer cancelSecond()
+	if _, err := HTTP(
+		WithPacketBytes(req),
+		WithConnPool(true),
+		ConnPool(pool),
+		WithContext(secondCtx),
+		WithTimeout(2*time.Second),
+	); err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+
+	// Cancelling the FIRST (stale) request context must not perturb the pool —
+	// the connection is now serving/has served a different iteration.
+	cancelFirst()
+
+	// A third request must still succeed, proving the pool/connection was not
+	// corrupted by the stale cancel.
+	if _, err := HTTP(
+		WithPacketBytes(req),
+		WithConnPool(true),
+		ConnPool(pool),
+		WithTimeout(2*time.Second),
+	); err != nil {
+		t.Fatalf("third request failed after stale context cancel: %v", err)
+	}
+}

--- a/common/utils/lowhttp/httpctx/base.go
+++ b/common/utils/lowhttp/httpctx/base.go
@@ -421,6 +421,7 @@ const (
 	REQUEST_CONTEXT_KEY_MitmFrontendReadWriter       = "mitmFrontendReadWriter"
 	REQUEST_CONTEXT_KEY_MitmSkipFrontendFeedback     = "mitmSkipFrontendFeedback"
 	REQUEST_CONTEXT_KEY_ResponseFinishedCallback     = "responseFinishedCallback"
+	REQUEST_CONTEXT_KEY_ResponseStreamRecorder       = "responseStreamRecorder"
 	REQUEST_CONTEXT_KEY_ResponseTooLargeHeaderFile   = "ResponseTooLargeHeaderFile"
 	REQUEST_CONTEXT_KEY_ResponseTooLargeBodyFile     = "ResponseTooLargeBodyFile"
 	REQUEST_CONTEXT_KEY_ResponseBodySize             = "ResponseBodySize"
@@ -445,6 +446,21 @@ func SetRequestMITMTaskID(req *http.Request, id string) {
 
 func GetRequestMITMTaskID(req *http.Request) string {
 	return GetContextStringInfoFromRequest(req, REQUEST_CONTEXT_KEY_MITMTaskID)
+}
+
+// SetResponseStreamRecorder stores an optional stream recorder (e.g. for SSE
+// persistence) on the request context so the mirror stage can retrieve it.
+func SetResponseStreamRecorder(req *http.Request, recorder any) {
+	SetContextValueInfoFromRequest(req, REQUEST_CONTEXT_KEY_ResponseStreamRecorder, recorder)
+}
+
+// GetResponseStreamRecorder returns the stream recorder previously stored via
+// SetResponseStreamRecorder, or nil.
+func GetResponseStreamRecorder(req *http.Request) any {
+	if req == nil {
+		return nil
+	}
+	return GetContextAnyFromRequest(req, REQUEST_CONTEXT_KEY_ResponseStreamRecorder)
 }
 
 func SetRequestProxyProtocol(req *http.Request, p string) {

--- a/common/yakgrpc/grpc_mitm.go
+++ b/common/yakgrpc/grpc_mitm.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -32,6 +33,7 @@ import (
 	"github.com/yaklang/yaklang/common/crep/trafficguard"
 	"github.com/yaklang/yaklang/common/go-funk"
 	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/minimartian"
 	"github.com/yaklang/yaklang/common/mutate"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp"
@@ -1577,6 +1579,13 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 		}
 	}
 
+	streamRecorderFactory := minimartian.HTTPStreamRecorderFactory(func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte) (io.WriteCloser, error) {
+		if httpctx.IsFiltered(req) {
+			return nil, nil
+		}
+		return yakit.NewHTTPFlowStreamRecorder(s.GetProjectDatabase(), isHTTPS, req, rsp, headerBytes)
+	})
+
 	handleMirrorResponse := func(isHttps bool, reqUrl string, req *http.Request, rsp *http.Response, remoteAddr string) {
 		addCounter()
 
@@ -1654,6 +1663,11 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 		}()
 		// 劫持过滤: 被过滤且未命中敏感信息的流量直接丢弃; 命中敏感信息的过滤流量继续走保存(以插件流量形式)。
 		if isFiltered && !tgSaveAsPlugin {
+			if recorder, ok := httpctx.GetResponseStreamRecorder(req).(*yakit.HTTPFlowStreamRecorder); ok {
+				if err := recorder.Drop(); err != nil {
+					log.Warnf("drop filtered HTTP stream flow failed: %v", err)
+				}
+			}
 			return
 		}
 		saveBarePacketHandler := func(id uint) {
@@ -1848,9 +1862,17 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 			// tgFindings(命中即把流量标红并生成"高危/中危" Risk), 避免二次扫描。
 			trafficguard.ApplyToFlow(s.GetProjectDatabase(), flow, tgFindings, plainRequest, plainResponse)
 			tags := flow.Tags
-			err := yakit.InsertHTTPFlowEx(flow, false, func() {
-				saveBarePacketHandler(flow.ID)
-			})
+			var err error
+			if recorder, ok := httpctx.GetResponseStreamRecorder(req).(*yakit.HTTPFlowStreamRecorder); ok {
+				err = recorder.Finalize(flow)
+				if err == nil {
+					saveBarePacketHandler(flow.ID)
+				}
+			} else {
+				err = yakit.InsertHTTPFlowEx(flow, false, func() {
+					saveBarePacketHandler(flow.ID)
+				})
+			}
 			if err != nil {
 				log.Errorf("create / save httpflow from mirror error: %s", err)
 			} else {
@@ -1869,6 +1891,10 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 			}
 
 			log.Debugf("insert http flow %v cost: %s", truncate(reqUrl), time.Now().Sub(startCreateFlow))
+		} else if recorder, ok := httpctx.GetResponseStreamRecorder(req).(*yakit.HTTPFlowStreamRecorder); ok {
+			if err := recorder.Drop(); err != nil {
+				log.Warnf("drop HTTP stream flow rejected by save hook failed: %v", err)
+			}
 		}
 	}
 	// 核心 MITM 服务器
@@ -1888,6 +1914,7 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 		crep.MITM_SetWebsocketRequestHijackRaw(handleHijackWsRequest),
 		crep.MITM_SetWebsocketResponseHijackRaw(handleHijackWsResponse),
 		crep.MITM_SetHTTPResponseMirror(handleMirrorResponse),
+		crep.MITM_SetHTTPStreamRecorderFactory(streamRecorderFactory),
 		crep.MITM_SetWebsocketHijackMode(true),
 		crep.MITM_SetHTTP2(firstReq.GetEnableHttp2()),
 		crep.MITM_MergeOptions(opts...),

--- a/common/yakgrpc/grpc_mitm_v2.go
+++ b/common/yakgrpc/grpc_mitm_v2.go
@@ -1522,6 +1522,13 @@ func (s *Server) MITMV2(stream ypb.Yak_MITMV2Server) error {
 		}
 	}
 
+	streamRecorderFactory := minimartian.HTTPStreamRecorderFactory(func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte) (io.WriteCloser, error) {
+		if httpctx.IsFiltered(req) {
+			return nil, nil
+		}
+		return yakit.NewHTTPFlowStreamRecorder(s.GetProjectDatabase(), isHTTPS, req, rsp, headerBytes)
+	})
+
 	handleMirrorResponse := func(isHttps bool, reqUrl string, req *http.Request, rsp *http.Response, remoteAddr string) {
 		responseMirrorAtUnixMs := time.Now().UnixMilli()
 		addCounter()
@@ -1606,6 +1613,11 @@ func (s *Server) MITMV2(stream ypb.Yak_MITMV2Server) error {
 		}
 		// 劫持过滤: 被过滤且未命中敏感信息的流量直接丢弃; 命中敏感信息的过滤流量继续走保存(以插件流量形式)。
 		if isFiltered && !tgSaveAsPlugin {
+			if recorder, ok := httpctx.GetResponseStreamRecorder(req).(*yakit.HTTPFlowStreamRecorder); ok {
+				if err := recorder.Drop(); err != nil {
+					log.Warnf("drop filtered HTTP stream flow failed: %v", err)
+				}
+			}
 			return
 		}
 		saveBarePacketHandler := func(id uint) {
@@ -1814,9 +1826,17 @@ func (s *Server) MITMV2(stream ypb.Yak_MITMV2Server) error {
 			// 内置高危凭证检测(TrafficGuard): 复用上面过滤前已扫描的 tgFindings, 标红并生成 Risk。
 			trafficguard.ApplyToFlow(s.GetProjectDatabase(), flow, tgFindings, plainRequest, plainResponse)
 			tags := flow.Tags
-			err := yakit.InsertHTTPFlowEx(flow, false, func() {
-				saveBarePacketHandler(flow.ID)
-			})
+			var err error
+			if recorder, ok := httpctx.GetResponseStreamRecorder(req).(*yakit.HTTPFlowStreamRecorder); ok {
+				err = recorder.Finalize(flow)
+				if err == nil {
+					saveBarePacketHandler(flow.ID)
+				}
+			} else {
+				err = yakit.InsertHTTPFlowEx(flow, false, func() {
+					saveBarePacketHandler(flow.ID)
+				})
+			}
 			if err != nil {
 				log.Errorf("create / save httpflow from mirror error: %s", err)
 			} else {
@@ -1836,6 +1856,11 @@ func (s *Server) MITMV2(stream ypb.Yak_MITMV2Server) error {
 
 			log.Debugf("insert http flow %v cost: %s", truncate(reqUrl), time.Now().Sub(startCreateFlow))
 		} else {
+			if recorder, ok := httpctx.GetResponseStreamRecorder(req).(*yakit.HTTPFlowStreamRecorder); ok {
+				if err := recorder.Drop(); err != nil {
+					log.Warnf("drop HTTP stream flow rejected by save hook failed: %v", err)
+				}
+			}
 			yakit.ReleaseHTTPFlowPersistResources(flow)
 		}
 	}
@@ -1891,6 +1916,7 @@ func (s *Server) MITMV2(stream ypb.Yak_MITMV2Server) error {
 		crep.MITM_SetWebsocketRequestHijackRaw(handleHijackWsRequest),
 		crep.MITM_SetWebsocketResponseHijackRaw(handleHijackWsResponse),
 		crep.MITM_SetHTTPResponseMirror(handleMirrorResponse),
+		crep.MITM_SetHTTPStreamRecorderFactory(streamRecorderFactory),
 		crep.MITM_SetWebsocketHijackMode(true),
 		crep.MITM_SetHTTP2(firstReq.GetEnableHttp2()),
 		crep.MITM_MergeOptions(opts...),

--- a/common/yakgrpc/yakit/httpflow_packet_part.go
+++ b/common/yakgrpc/yakit/httpflow_packet_part.go
@@ -59,6 +59,13 @@ func LoadHTTPFlowResponsePacket(flow *schema.HTTPFlow) ([]byte, error) {
 	if flow == nil {
 		return nil, utils.Error("flow is nil")
 	}
+	// Streaming responses (e.g. SSE) and too-large responses both persist
+	// headers and body in separate spill files. Prefer the spill files when
+	// available so History/API can reconstruct the actual response rather
+	// than only the header skeleton stored in the database.
+	if (flow.IsTooLargeResponse || flow.IsReadTooSlowResponse) && flow.TooLargeResponseHeaderFile != "" && flow.TooLargeResponseBodyFile != "" {
+		return readHTTPFlowSpillPacket(flow.TooLargeResponseHeaderFile, flow.TooLargeResponseBodyFile)
+	}
 	if flow.Response != "" {
 		respRaw, err := strconv.Unquote(flow.Response)
 		if err != nil {
@@ -67,9 +74,6 @@ func LoadHTTPFlowResponsePacket(flow *schema.HTTPFlow) ([]byte, error) {
 		if len(respRaw) > 0 {
 			return []byte(respRaw), nil
 		}
-	}
-	if flow.IsTooLargeResponse && flow.TooLargeResponseHeaderFile != "" && flow.TooLargeResponseBodyFile != "" {
-		return readHTTPFlowSpillPacket(flow.TooLargeResponseHeaderFile, flow.TooLargeResponseBodyFile)
 	}
 	return nil, nil
 }

--- a/common/yakgrpc/yakit/httpflow_stream.go
+++ b/common/yakgrpc/yakit/httpflow_stream.go
@@ -1,0 +1,370 @@
+package yakit
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
+)
+
+const httpFlowStreamProgressInterval = 500 * time.Millisecond
+
+// HTTPFlowStreamRecorder persists response metadata as soon as headers arrive
+// and appends the streaming body to a spill file while the connection remains
+// open. It intentionally keeps database writes off the response hot path.
+type HTTPFlowStreamRecorder struct {
+	mu sync.Mutex
+
+	db          *gorm.DB
+	insertFlow  func(*gorm.DB, *schema.HTTPFlow) error
+	req         *http.Request
+	initialFlow *schema.HTTPFlow
+	bodyFile    *os.File
+	headerFile  string
+	bodyPath    string
+	startedAt   time.Time
+	bodyLength  int64
+	writeErr    error
+	closed      bool
+	insertErr   error
+
+	insertDone chan struct{}
+	stopCh     chan struct{}
+	doneCh     chan struct{}
+	closeOnce  sync.Once
+	closeErr   error
+}
+
+func NewHTTPFlowStreamRecorder(
+	db *gorm.DB,
+	isHTTPS bool,
+	req *http.Request,
+	rsp *http.Response,
+	headerBytes []byte,
+) (_ *HTTPFlowStreamRecorder, retErr error) {
+	return newHTTPFlowStreamRecorder(db, isHTTPS, req, rsp, headerBytes, InsertHTTPFlow)
+}
+
+func newHTTPFlowStreamRecorder(
+	db *gorm.DB,
+	isHTTPS bool,
+	req *http.Request,
+	rsp *http.Response,
+	headerBytes []byte,
+	insertFlow func(*gorm.DB, *schema.HTTPFlow) error,
+) (_ *HTTPFlowStreamRecorder, retErr error) {
+	if db == nil {
+		return nil, utils.Error("create HTTP stream recorder: project database is nil")
+	}
+	if req == nil || rsp == nil {
+		return nil, utils.Error("create HTTP stream recorder: request or response is nil")
+	}
+	if insertFlow == nil {
+		return nil, utils.Error("create HTTP stream recorder: insert function is nil")
+	}
+
+	suffix := fmt.Sprintf("%s-%s", time.Now().Format(utils.DatetimePretty()), ksuid.New().String())
+	headerFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-header-%s.txt", suffix))
+	if err != nil {
+		return nil, utils.Wrap(err, "create HTTP stream response header file")
+	}
+	headerPath := headerFP.Name()
+	defer func() {
+		_ = headerFP.Close()
+		if retErr != nil {
+			_ = os.Remove(headerPath)
+		}
+	}()
+	if _, err := headerFP.Write(headerBytes); err != nil {
+		return nil, utils.Wrap(err, "write HTTP stream response header")
+	}
+	if err := headerFP.Sync(); err != nil {
+		return nil, utils.Wrap(err, "sync HTTP stream response header")
+	}
+
+	bodyFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-body-%s.bin", suffix))
+	if err != nil {
+		return nil, utils.Wrap(err, "create HTTP stream response body file")
+	}
+	bodyPath := bodyFP.Name()
+	defer func() {
+		if retErr != nil {
+			_ = bodyFP.Close()
+			_ = os.Remove(bodyPath)
+		}
+	}()
+
+	requestURL := httpctx.GetRequestURL(req)
+	if requestURL == "" {
+		if parsed, err := lowhttp.ExtractURLFromHTTPRequest(req, isHTTPS); err == nil && parsed != nil {
+			requestURL = parsed.String()
+		}
+	}
+	remoteAddr := httpctx.GetRemoteAddr(req)
+	flow, err := CreateHTTPFlowFromHTTPWithNoRspSaved(isHTTPS, req, "mitm", requestURL, remoteAddr)
+	if err != nil {
+		return nil, utils.Wrap(err, "create initial HTTP stream flow")
+	}
+	flow.SetResponse(string(headerBytes))
+	flow.StatusCode = int64(rsp.StatusCode)
+	flow.ContentType = rsp.Header.Get("Content-Type")
+	flow.BodyLength = 0
+	flow.Duration = 0
+	flow.IsReadTooSlowResponse = true
+	flow.TooLargeResponseHeaderFile = headerPath
+	flow.TooLargeResponseBodyFile = bodyPath
+	if name := httpctx.GetProcessName(req); name != "" {
+		flow.ProcessName.String = filepath.Base(name)
+		flow.ProcessName.Valid = true
+	}
+	flow.Hash = flow.CalcHash()
+
+	httpctx.SetResponseReadTooSlow(req, true)
+	httpctx.SetResponseTooLargeHeaderFile(req, headerPath)
+	httpctx.SetResponseTooLargeBodyFile(req, bodyPath)
+
+	recorder := &HTTPFlowStreamRecorder{
+		db:          db,
+		insertFlow:  insertFlow,
+		req:         req,
+		initialFlow: flow,
+		bodyFile:    bodyFP,
+		headerFile:  headerPath,
+		bodyPath:    bodyPath,
+		startedAt:   time.Now(),
+		insertDone:  make(chan struct{}),
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
+	}
+	go recorder.insertInitialFlow()
+	go recorder.runProgressUpdater()
+	return recorder, nil
+}
+
+func (r *HTTPFlowStreamRecorder) insertInitialFlow() {
+	err := r.insertFlow(r.db, r.initialFlow)
+	r.mu.Lock()
+	r.insertErr = err
+	flowID := r.initialFlow.ID
+	r.mu.Unlock()
+	requestPath := ""
+	if r.req != nil && r.req.URL != nil {
+		requestPath = r.req.URL.Path
+	}
+	if err != nil {
+		log.Warnf("insert initial HTTP stream flow failed: path=%s error=%v", requestPath, err)
+	} else {
+		log.Debugf("MITM SSE flow persisted before EOF: flow_id=%d path=%s", flowID, requestPath)
+	}
+	close(r.insertDone)
+}
+
+func (r *HTTPFlowStreamRecorder) waitForInsert() error {
+	if r == nil {
+		return nil
+	}
+	<-r.insertDone
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.insertErr
+}
+
+func (r *HTTPFlowStreamRecorder) Write(p []byte) (int, error) {
+	if r == nil || len(p) == 0 {
+		return len(p), nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed || r.bodyFile == nil || r.writeErr != nil {
+		return len(p), nil
+	}
+	n, err := r.bodyFile.Write(p)
+	r.bodyLength += int64(n)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		r.writeErr = err
+		log.Warnf("append HTTP stream response body failed: path=%s error=%v", r.bodyPath, err)
+	}
+
+	// Capturing must never break or delay forwarding with a recorder error.
+	return len(p), nil
+}
+
+func (r *HTTPFlowStreamRecorder) runProgressUpdater() {
+	defer close(r.doneCh)
+	ticker := time.NewTicker(httpFlowStreamProgressInterval)
+	defer ticker.Stop()
+	lastSync := time.Now()
+	for {
+		select {
+		case <-ticker.C:
+			syncFile := time.Since(lastSync) >= time.Second
+			r.updateProgress(syncFile)
+			if syncFile {
+				lastSync = time.Now()
+			}
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+func (r *HTTPFlowStreamRecorder) updateProgress(syncFile bool) {
+	if r == nil || r.db == nil || r.initialFlow == nil {
+		return
+	}
+	select {
+	case <-r.insertDone:
+	default:
+		return
+	}
+	r.mu.Lock()
+	if r.insertErr != nil || r.initialFlow.ID == 0 {
+		r.mu.Unlock()
+		return
+	}
+	if syncFile && r.bodyFile != nil && r.writeErr == nil {
+		if err := r.bodyFile.Sync(); err != nil {
+			r.writeErr = err
+			log.Warnf("sync HTTP stream response body failed: flow_id=%d error=%v", r.initialFlow.ID, err)
+		}
+	}
+	bodyLength := r.bodyLength
+	duration := time.Since(r.startedAt)
+	flowID := r.initialFlow.ID
+	r.mu.Unlock()
+
+	err := r.db.Model(&schema.HTTPFlow{}).Where("id = ?", flowID).UpdateColumns(map[string]any{
+		"body_length":                    bodyLength,
+		"duration":                       int64(duration),
+		"is_read_too_slow_response":      true,
+		"too_large_response_header_file": r.headerFile,
+		"too_large_response_body_file":   r.bodyPath,
+		"updated_at":                     time.Now(),
+	}).Error
+	if err != nil {
+		log.Warnf("update HTTP stream flow progress failed: flow_id=%d error=%v", flowID, err)
+	}
+}
+
+func (r *HTTPFlowStreamRecorder) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		close(r.stopCh)
+		<-r.doneCh
+
+		r.mu.Lock()
+		r.closed = true
+		if r.bodyFile != nil {
+			if err := r.bodyFile.Sync(); err != nil && r.writeErr == nil {
+				r.writeErr = err
+			}
+			if err := r.bodyFile.Close(); err != nil && r.writeErr == nil {
+				r.writeErr = err
+			}
+			r.bodyFile = nil
+		}
+		bodyLength := r.bodyLength
+		r.closeErr = r.writeErr
+		r.mu.Unlock()
+
+		httpctx.SetResponseTooLargeSize(r.req, bodyLength)
+		r.updateProgress(false)
+	})
+	return r.closeErr
+}
+
+func (r *HTTPFlowStreamRecorder) FlowID() uint {
+	if r == nil || r.initialFlow == nil {
+		return 0
+	}
+	if err := r.waitForInsert(); err != nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.initialFlow.ID
+}
+
+func (r *HTTPFlowStreamRecorder) BodyFile() string {
+	if r == nil {
+		return ""
+	}
+	return r.bodyPath
+}
+
+func (r *HTTPFlowStreamRecorder) HeaderFile() string {
+	if r == nil {
+		return ""
+	}
+	return r.headerFile
+}
+
+func (r *HTTPFlowStreamRecorder) BodyLength() int64 {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.bodyLength
+}
+
+// Finalize updates the header-first row instead of inserting a duplicate after
+// the ordinary MITM response mirror finally observes EOF.
+func (r *HTTPFlowStreamRecorder) Finalize(flow *schema.HTTPFlow) error {
+	if r == nil || flow == nil || r.initialFlow == nil {
+		return utils.Error("finalize HTTP stream flow: invalid recorder or flow")
+	}
+	_ = r.Close()
+	if err := r.waitForInsert(); err != nil {
+		return utils.Wrap(err, "finalize HTTP stream flow after initial insert")
+	}
+
+	r.mu.Lock()
+	bodyLength := r.bodyLength
+	duration := time.Since(r.startedAt)
+	r.mu.Unlock()
+
+	flow.Model = r.initialFlow.Model
+	flow.HiddenIndex = r.initialFlow.HiddenIndex
+	flow.Response = r.initialFlow.Response
+	flow.StatusCode = r.initialFlow.StatusCode
+	flow.ContentType = r.initialFlow.ContentType
+	flow.BodyLength = bodyLength
+	flow.Duration = int64(duration)
+	flow.IsReadTooSlowResponse = true
+	flow.TooLargeResponseHeaderFile = r.headerFile
+	flow.TooLargeResponseBodyFile = r.bodyPath
+	return SaveHTTPFlow(r.db, flow)
+}
+
+func (r *HTTPFlowStreamRecorder) Drop() error {
+	if r == nil || r.initialFlow == nil {
+		return nil
+	}
+	_ = r.Close()
+	if err := r.waitForInsert(); err != nil {
+		_ = os.Remove(r.headerFile)
+		_ = os.Remove(r.bodyPath)
+		return err
+	}
+	err := DeleteHTTPFlowByID(r.db, int64(r.initialFlow.ID))
+	_ = os.Remove(r.headerFile)
+	_ = os.Remove(r.bodyPath)
+	return err
+}

--- a/common/yakgrpc/yakit/httpflow_stream_test.go
+++ b/common/yakgrpc/yakit/httpflow_stream_test.go
@@ -1,0 +1,241 @@
+package yakit
+
+import (
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/lowhttp"
+	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
+)
+
+func TestHTTPFlowStreamRecorderPersistsBeforeEOF(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.AutoMigrate(&schema.HTTPFlow{}).Error)
+
+	requestRaw := lowhttp.FixHTTPRequest([]byte("GET /events HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	req, err := lowhttp.ParseBytesToHttpRequest(requestRaw)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, requestRaw)
+	httpctx.SetPlainRequestBytes(req, requestRaw)
+	httpctx.SetRequestURL(req, "https://example.com/events")
+
+	header := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+	rsp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Request: req,
+	}
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = recorder.Close()
+		_ = os.Remove(recorder.HeaderFile())
+		_ = os.Remove(recorder.BodyFile())
+	})
+
+	var count int
+	require.Eventually(t, func() bool {
+		return db.Model(&schema.HTTPFlow{}).Where("path = ?", "/events").Count(&count).Error == nil && count == 1
+	}, 2*time.Second, 20*time.Millisecond, "the header-first flow must exist before the stream reaches EOF")
+
+	initial, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+	require.NoError(t, err)
+	require.Equal(t, int64(200), initial.StatusCode)
+	require.Equal(t, "text/event-stream", initial.ContentType)
+	require.True(t, initial.IsReadTooSlowResponse)
+	require.Equal(t, string(header), initial.GetResponse())
+
+	body := []byte("d\r\ndata: ready\n\n\r\n")
+	n, err := recorder.Write(body)
+	require.NoError(t, err)
+	require.Equal(t, len(body), n)
+	require.Eventually(t, func() bool {
+		flow, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+		return err == nil && flow.BodyLength == int64(len(body))
+	}, 2*time.Second, 50*time.Millisecond)
+
+	storedBody, err := os.ReadFile(recorder.BodyFile())
+	require.NoError(t, err)
+	require.Equal(t, body, storedBody)
+
+	finalFlow, err := CreateHTTPFlowFromHTTPWithNoRspSaved(true, req, "mitm", "https://example.com/events", "127.0.0.1:443")
+	require.NoError(t, err)
+	finalFlow.StatusCode = 200
+	finalFlow.ContentType = "text/event-stream"
+	require.NoError(t, recorder.Finalize(finalFlow))
+
+	require.NoError(t, db.Model(&schema.HTTPFlow{}).Where("path = ?", "/events").Count(&count).Error)
+	require.Equal(t, 1, count, "finalization must update the header-first flow instead of inserting a duplicate")
+	final, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+	require.NoError(t, err)
+	require.Equal(t, int64(len(body)), final.BodyLength)
+	require.Equal(t, recorder.HeaderFile(), final.TooLargeResponseHeaderFile)
+	require.Equal(t, recorder.BodyFile(), final.TooLargeResponseBodyFile)
+
+	packet, err := LoadHTTPFlowResponsePacket(final)
+	require.NoError(t, err)
+	require.Equal(t, append(header, body...), packet)
+}
+
+func TestHTTPFlowStreamRecorderDoesNotBlockOnInitialInsert(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.AutoMigrate(&schema.HTTPFlow{}).Error)
+
+	requestRaw := lowhttp.FixHTTPRequest([]byte("GET /events HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	req, err := lowhttp.ParseBytesToHttpRequest(requestRaw)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, requestRaw)
+	httpctx.SetPlainRequestBytes(req, requestRaw)
+	httpctx.SetRequestURL(req, "https://example.com/events")
+
+	header := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+	rsp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Request: req,
+	}
+	insertStarted := make(chan struct{})
+	releaseInsert := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseInsert) }) }
+	t.Cleanup(release)
+	recorder, err := newHTTPFlowStreamRecorder(db, true, req, rsp, header, func(db *gorm.DB, flow *schema.HTTPFlow) error {
+		close(insertStarted)
+		<-releaseInsert
+		return InsertHTTPFlow(db, flow)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = recorder.Close()
+		_ = os.Remove(recorder.HeaderFile())
+		_ = os.Remove(recorder.BodyFile())
+	})
+
+	select {
+	case <-insertStarted:
+	case <-time.After(time.Second):
+		t.Fatal("initial insert did not start")
+	}
+
+	body := []byte("data: ready\n\n")
+	writeDone := make(chan error, 1)
+	go func() {
+		_, writeErr := recorder.Write(body)
+		writeDone <- writeErr
+	}()
+	select {
+	case writeErr := <-writeDone:
+		require.NoError(t, writeErr)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("stream body write waited for the initial database insert")
+	}
+
+	storedBody, err := os.ReadFile(recorder.BodyFile())
+	require.NoError(t, err)
+	require.Equal(t, body, storedBody)
+	release()
+	require.NotZero(t, recorder.FlowID())
+}
+
+func TestHTTPFlowStreamRecorderDropRemovesFlowAndSpillFiles(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.AutoMigrate(&schema.HTTPFlow{}).Error)
+
+	requestRaw := lowhttp.FixHTTPRequest([]byte("GET /events HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	req, err := lowhttp.ParseBytesToHttpRequest(requestRaw)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, requestRaw)
+	httpctx.SetPlainRequestBytes(req, requestRaw)
+	httpctx.SetRequestURL(req, "https://example.com/events")
+
+	header := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+	rsp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Request: req,
+	}
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header)
+	require.NoError(t, err)
+	headerFile := recorder.HeaderFile()
+	bodyFile := recorder.BodyFile()
+	flowID := recorder.FlowID()
+	require.NotZero(t, flowID)
+
+	_, err = recorder.Write([]byte("data: ready\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, recorder.Drop())
+
+	var count int
+	require.NoError(t, db.Model(&schema.HTTPFlow{}).Where("id = ?", flowID).Count(&count).Error)
+	require.Zero(t, count)
+	_, err = os.Stat(headerFile)
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(bodyFile)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestHTTPFlowStreamRecorderInsertFailureDoesNotBreakCapture(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.AutoMigrate(&schema.HTTPFlow{}).Error)
+
+	requestRaw := lowhttp.FixHTTPRequest([]byte("GET /events HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	req, err := lowhttp.ParseBytesToHttpRequest(requestRaw)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, requestRaw)
+	httpctx.SetPlainRequestBytes(req, requestRaw)
+	httpctx.SetRequestURL(req, "https://example.com/events")
+
+	header := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+	rsp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Request: req,
+	}
+	recorder, err := newHTTPFlowStreamRecorder(db, true, req, rsp, header, func(*gorm.DB, *schema.HTTPFlow) error {
+		return utils.Error("insert unavailable")
+	})
+	require.NoError(t, err)
+	headerFile := recorder.HeaderFile()
+	bodyFile := recorder.BodyFile()
+
+	body := []byte("data: still-captured\n\n")
+	n, err := recorder.Write(body)
+	require.NoError(t, err)
+	require.Equal(t, len(body), n)
+	storedBody, err := os.ReadFile(bodyFile)
+	require.NoError(t, err)
+	require.Equal(t, body, storedBody)
+
+	require.Error(t, recorder.Drop())
+	_, err = os.Stat(headerFile)
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(bodyFile)
+	require.True(t, os.IsNotExist(err))
+}


### PR DESCRIPTION
 - 问题1：原PR 为 SSE 单开了一条 BodyStreamReaderHandler 转发通道，和原有的 ResponseHeaderCallback 通道并行，需要两个 context key 互相抑制来防止重复写响应头，维护成本高且有竞态风险。
  解决：把 SSE/filtered/chunked 全部统一到 ResponseHeaderCallback + TriggerWriter（新增 immediate 模式）一条路径，由 classifyStreamResponse 统一分发。只有一条写入路径，不需要抑制标志，转发代码只写一份。

  - 问题2：原PR 客户端断开时调 cancelUpstream()，但 conn_pool 的 persistConn.ctx 派生自 context.Background() 不监听它，SSE 空闲期（上游不主动发数据）客户端断开后 conn.Read 永久阻塞，execLowhttp 卡死。PR 的取消测试
  用内存 pipe 绕过了真实连接，没暴露这个缺陷。
  解决：在 conn_pool.go 的 readLoop 加 per-request ctx watcher，option.Ctx.Done() 时直接 Close 连接解除阻塞，并用 seq guard 防止误关下一轮迭代的连接。新增用真实 TCP + conn pool 的端到端测试覆盖。

  - 问题3：本分支统一路径时 recorder 无条件创建，把 chunked 响应也标成了 too-large（即便没超阈值），导致 TestLARGEGRPCMUSTPASS_LARGE_RESPOSNE_NEGATIVE 失败。
  解决：把 recorder 创建条件从 p.streamRecorder != nil 收窄为 kind == streamKindSSE，chunked/filtered 交回 builder 按实际 body 大小判定 too-large，恢复原始行为。