### PR TITLE
fix(ssadb): silently dedup duplicate ir_codes/ir_offsets before creating unique index

### DIFF
--- a/common/yak/ssa/ssadb/database.go
+++ b/common/yak/ssa/ssadb/database.go
@@ -1,12 +1,12 @@
 package ssadb
 
 import (
-	"strings"
 	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/ssa/reportstore"
+	"strings"
 )
 
 var SSAProjectTables = []any{
@@ -130,9 +130,46 @@ func patchIrCodeIndex(db *gorm.DB) {
 	ensureUniqueIrOffsetsIndex(db)
 }
 
+// deleteDuplicateIrCodes removes every row except the oldest (MIN id) per
+// (program_name, code_id) using a single window query, and returns the number
+// of removed rows. The oldest row is exactly what normal single-read paths
+// return, so existing databases keep behaving identically after the cleanup.
+func deleteDuplicateIrCodes(db *gorm.DB) (int64, error) {
+	res := db.Exec(`DELETE FROM ` + TableIrCodes + ` WHERE id IN (
+		SELECT id FROM (
+			SELECT id, ROW_NUMBER() OVER (PARTITION BY program_name, code_id ORDER BY id) AS rn
+			FROM ` + TableIrCodes + `
+		) WHERE rn > 1
+	)`)
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
+}
+
+// deleteDuplicateIrOffsets removes every row except the oldest (MIN id) per
+// composite key using a single window query, and returns the number of
+// removed rows.
+func deleteDuplicateIrOffsets(db *gorm.DB) (int64, error) {
+	res := db.Exec(`DELETE FROM ` + TableIrOffsets + ` WHERE id IN (
+		SELECT id FROM (
+			SELECT id, ROW_NUMBER() OVER (
+				PARTITION BY program_name, value_id, file_hash, start_offset, end_offset, COALESCE(variable_name, '')
+				ORDER BY id
+			) AS rn
+			FROM ` + TableIrOffsets + `
+		) WHERE rn > 1
+	)`)
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
+}
+
 // ensureUniqueIrCodesProgramCodeIndex creates a UNIQUE INDEX on
-// (program_name, code_id) for the ir_codes table. If duplicate rows
-// already exist, it logs them and fails — it does NOT silently dedup.
+// (program_name, code_id) for the ir_codes table. If duplicate rows already
+// exist, the extras are removed (keeping MIN(id)) before the index is
+// created, so legacy databases upgrade cleanly.
 func ensureUniqueIrCodesProgramCodeIndex(db *gorm.DB) {
 	if !db.HasTable(TableIrCodes) {
 		return
@@ -147,42 +184,17 @@ func ensureUniqueIrCodesProgramCodeIndex(db *gorm.DB) {
 		return // already created
 	}
 
-	// Check for existing duplicates BEFORE creating the unique index.
-	// If duplicates exist, we cannot create the unique index without
-	// resolving them first. We log the duplicates and return without
-	// creating the index (the caller will see duplicate INSERTs fail
-	// later, which is the desired behavior for new data).
-	type dupRow struct {
-		ProgramName string
-		CodeID      int64
-		DupCount    int64
-	}
-	var dups []dupRow
-	rows, err := db.Raw(
-		`SELECT program_name, code_id, COUNT(*) as dup_count
-		 FROM ir_codes
-		 GROUP BY program_name, code_id
-		 HAVING COUNT(*) > 1
-		 LIMIT 10`,
-	).Rows()
-	if err == nil {
-		for rows.Next() {
-			var d dupRow
-			rows.Scan(&d.ProgramName, &d.CodeID, &d.DupCount)
-			dups = append(dups, d)
-		}
-		rows.Close()
-	}
-
-	if len(dups) > 0 {
-		// Log duplicates and do NOT create the index — existing data
-		// has violations that must be resolved manually.
-		for _, d := range dups {
-			log.Errorf("[unique-constraint] DUPLICATE ir_codes: program_name=%s code_id=%d count=%d — cannot create UNIQUE INDEX, resolve duplicates first",
-				d.ProgramName, d.CodeID, d.DupCount)
-		}
-		log.Errorf("[unique-constraint] %d duplicate (program_name, code_id) groups found in ir_codes — UNIQUE INDEX ux_ir_codes_program_code NOT created", len(dups))
+	// Legacy async-persist runs can leave duplicate rows. Remove every row
+	// except the oldest (MIN id) per (program_name, code_id) in one window
+	// query, so the unique index can be created. This runs only once: after
+	// the index exists the function returns at the top.
+	removed, err := deleteDuplicateIrCodes(db)
+	if err != nil {
+		log.Warnf("[unique-constraint] failed to remove duplicate ir_codes rows: %v", err)
 		return
+	}
+	if removed > 0 {
+		log.Infof("[unique-constraint] removed %d duplicate ir_codes rows (kept MIN(id) per (program_name, code_id))", removed)
 	}
 
 	// No duplicates — safe to create the UNIQUE INDEX
@@ -199,7 +211,8 @@ func ensureUniqueIrCodesProgramCodeIndex(db *gorm.DB) {
 // for the ir_offsets table. This prevents duplicate offset INSERTs.
 //
 // If an older non-COALESCE index with the same name exists, it is dropped and
-// recreated with COALESCE. If duplicate rows exist, it logs and returns.
+// recreated with COALESCE. If duplicate rows exist, the extras are removed
+// (keeping MIN(id)) before the index is created.
 func ensureUniqueIrOffsetsIndex(db *gorm.DB) {
 	if !db.HasTable(TableIrOffsets) {
 		return
@@ -242,21 +255,16 @@ func ensureUniqueIrOffsetsIndex(db *gorm.DB) {
 		}
 	}
 
-	// Check for existing duplicates BEFORE creating the unique index
-	var dupCount int64
-	db.Raw(
-		`SELECT COALESCE(SUM(c - 1), 0) FROM (
-			SELECT program_name, value_id, file_hash, start_offset, end_offset, COALESCE(variable_name, ''), COUNT(*) as c
-			FROM ir_offsets
-			GROUP BY program_name, value_id, file_hash, start_offset, end_offset, COALESCE(variable_name, '')
-			HAVING COUNT(*) > 1
-		) as d`,
-	).Row().Scan(&dupCount)
-
-	if dupCount > 0 {
-		log.Errorf("[unique-constraint] %d duplicate ir_offsets rows found — UNIQUE INDEX %s NOT created, resolve duplicates first",
-			dupCount, indexName)
+	// Legacy async-persist runs can leave duplicate rows. Remove every row
+	// except the oldest (MIN id) per composite key in one window query, so
+	// the unique index can be created.
+	removed, err := deleteDuplicateIrOffsets(db)
+	if err != nil {
+		log.Warnf("[unique-constraint] failed to remove duplicate ir_offsets rows: %v", err)
 		return
+	}
+	if removed > 0 {
+		log.Infof("[unique-constraint] removed %d duplicate ir_offsets rows (kept MIN(id) per composite key)", removed)
 	}
 
 	query := `CREATE UNIQUE INDEX IF NOT EXISTS "ux_ir_offsets_program_value_file_range" ON "` + TableIrOffsets + `" ("program_name", "value_id", "file_hash", "start_offset", "end_offset", COALESCE("variable_name", ''));`

--- a/common/yak/ssa/ssadb/unique_index_repair_test.go
+++ b/common/yak/ssa/ssadb/unique_index_repair_test.go
@@ -1,0 +1,151 @@
+package ssadb
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+	_ "github.com/yaklang/gorm/dialects/sqlite"
+)
+
+func openRepairTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open("sqlite3", filepath.Join(t.TempDir(), "repair.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&IrCode{}, &IrOffset{}).Error)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func uniqueIndexExists(t *testing.T, db *gorm.DB, table, index string) bool {
+	t.Helper()
+	var exists int64
+	require.NoError(t, db.Raw(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name=? AND name=?`,
+		table, index,
+	).Row().Scan(&exists))
+	return exists > 0
+}
+
+// TestUniqueIndexPatch_RepairsExactDuplicateIrCodes proves that the patch
+// auto-repairs legacy exact-duplicate ir_codes rows (same content, only
+// id/timestamps differ) by keeping MIN(id) — the row normal single-read paths
+// return — and then creates the unique index.
+func TestUniqueIndexPatch_RepairsExactDuplicateIrCodes(t *testing.T) {
+	db := openRepairTestDB(t)
+	prog := "repair-prog"
+
+	// Three exact copies of code_id=10 and two exact copies of code_id=20,
+	// plus one unique row. Content is identical; only id/timestamps differ.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, db.Create(&IrCode{
+			ProgramName: prog, CodeID: 10, Opcode: 12, Name: "UploadFile",
+		}).Error)
+	}
+	for i := 0; i < 2; i++ {
+		require.NoError(t, db.Create(&IrCode{
+			ProgramName: prog, CodeID: 20, Opcode: 5, Name: "Const",
+		}).Error)
+	}
+	require.NoError(t, db.Create(&IrCode{
+		ProgramName: prog, CodeID: 30, Opcode: 1, Name: "Unique",
+	}).Error)
+
+	patchIrCodeIndex(db)
+
+	var count int64
+	require.NoError(t, db.Model(&IrCode{}).Where("program_name = ?", prog).Count(&count).Error)
+	require.Equal(t, int64(3), count, "duplicates must be removed, one row per code_id")
+
+	// The kept row must be the first inserted (MIN id), matching normal reads.
+	var kept IrCode
+	require.NoError(t, db.Where("program_name = ? AND code_id = ?", prog, 10).First(&kept).Error)
+	require.Equal(t, "UploadFile", kept.Name)
+	require.Equal(t, int64(12), kept.Opcode)
+
+	require.True(t, uniqueIndexExists(t, db, "ir_codes", "ux_ir_codes_program_code"),
+		"unique index must be created after exact-duplicate repair")
+}
+
+// TestUniqueIndexPatch_RepairsExactDuplicateIrOffsets proves the same
+// auto-repair for ir_offsets, whose composite key already covers every content
+// column.
+func TestUniqueIndexPatch_RepairsExactDuplicateIrOffsets(t *testing.T) {
+	db := openRepairTestDB(t)
+	prog := "repair-offset-prog"
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, db.Create(&IrOffset{
+			ProgramName: prog, ValueID: 1260, FileHash: "h",
+			StartOffset: 3701, EndOffset: 3761, VariableName: "ternary_expression",
+		}).Error)
+	}
+
+	patchIrCodeIndex(db)
+
+	var count int64
+	require.NoError(t, db.Model(&IrOffset{}).Where("program_name = ?", prog).Count(&count).Error)
+	require.Equal(t, int64(1), count, "duplicate offsets must be removed, one row per composite key")
+
+	require.True(t, uniqueIndexExists(t, db, "ir_offsets", "ux_ir_offsets_program_value_file_range"),
+		"unique index must be created after exact-duplicate repair")
+}
+
+// TestUniqueIndexPatch_RepairsConflictingIrCodeDuplicates proves that rows
+// sharing (program_name, code_id) are deduplicated even when their content
+// differs: the extra row is removed, MIN(id) is kept, and the unique index
+// is created.
+func TestUniqueIndexPatch_RepairsConflictingIrCodeDuplicates(t *testing.T) {
+	db := openRepairTestDB(t)
+	prog := "conflict-prog"
+
+	require.NoError(t, db.Create(&IrCode{
+		ProgramName: prog, CodeID: 10, Opcode: 12, Name: "A",
+	}).Error)
+	require.NoError(t, db.Create(&IrCode{
+		ProgramName: prog, CodeID: 10, Opcode: 99, Name: "B",
+	}).Error)
+
+	patchIrCodeIndex(db)
+
+	var count int64
+	require.NoError(t, db.Model(&IrCode{}).Where("program_name = ?", prog).Count(&count).Error)
+	require.Equal(t, int64(1), count, "conflicting duplicates must be deduplicated to one row")
+
+	var kept IrCode
+	require.NoError(t, db.Where("program_name = ? AND code_id = ?", prog, 10).First(&kept).Error)
+	require.Equal(t, "A", kept.Name, "MIN(id) row must be kept")
+	require.True(t, uniqueIndexExists(t, db, "ir_codes", "ux_ir_codes_program_code"),
+		"unique index must be created after dedup")
+}
+
+// TestUniqueIndexPatch_RepairsMixedDuplicateGroup proves that a key group
+// containing exact copies plus a conflicting row (A, A, B) is deduplicated to
+// the MIN(id) row and the unique index is created.
+func TestUniqueIndexPatch_RepairsMixedDuplicateGroup(t *testing.T) {
+	db := openRepairTestDB(t)
+	prog := "mixed-prog"
+
+	require.NoError(t, db.Create(&IrCode{
+		ProgramName: prog, CodeID: 10, Opcode: 12, Name: "A",
+	}).Error)
+	require.NoError(t, db.Create(&IrCode{
+		ProgramName: prog, CodeID: 10, Opcode: 12, Name: "A",
+	}).Error)
+	require.NoError(t, db.Create(&IrCode{
+		ProgramName: prog, CodeID: 10, Opcode: 99, Name: "B",
+	}).Error)
+
+	patchIrCodeIndex(db)
+
+	var count int64
+	require.NoError(t, db.Model(&IrCode{}).Where("program_name = ?", prog).Count(&count).Error)
+	require.Equal(t, int64(1), count, "mixed duplicate group must be deduplicated to one row")
+
+	var kept IrCode
+	require.NoError(t, db.Where("program_name = ? AND code_id = ?", prog, 10).First(&kept).Error)
+	require.Equal(t, "A", kept.Name, "MIN(id) row must be kept")
+	require.True(t, uniqueIndexExists(t, db, "ir_codes", "ux_ir_codes_program_code"),
+		"unique index must be created after dedup")
+}


### PR DESCRIPTION
## 背景

旧版异步持久化管线可能在 `ir_codes` / `ir_offsets` 中留下重复行。此前 `patchIrCodeIndex` 在创建唯一索引前发现重复时会拒绝建索引并打印 ERROR，导致启动时日志报错（例如 `DUPLICATE ir_codes`、`duplicate ir_offsets rows found`），且唯一索引一直无法建立。

## 修改

- 在 `ensureUniqueIrCodesProgramCodeIndex` / `ensureUniqueIrOffsetsIndex` 中，用一条窗口函数 SQL 直接删除每组除最小 `id` 之外的多余行（`ROW_NUMBER() OVER (PARTITION BY ... ORDER BY id)`，`rn > 1` 即多余行），保留的 `MIN(id)` 正是正常单条读取路径实际返回的那一行。
- 删除后照常创建唯一索引 `ux_ir_codes_program_code` 和 `ux_ir_offsets_program_value_file_range`。
- 无全表 `id NOT IN (...)` 扫描、无重复组预查询循环、无二次查询；不再打印 ERROR。
- 该删除仅在索引缺失且存在重复时执行一次，索引建立后后续启动直接返回。

## 测试

- 新增回归测试覆盖：`ir_codes` 精确重复、`ir_offsets` 精确重复、同 key 不同内容、A/A/B 混合组，均验证保留 `MIN(id)` 且唯一索引成功创建。
- `go test ./common/yak/ssa/ssadb` 通过。
- `go build ./common/yak/cmd/yak.go` 通过。
- 使用真实旧库副本验证：重复行被清理、唯一索引建立、`PRAGMA integrity_check` 为 ok。