### PR TITLE
fix(mitm): 修复开启 HTTP/2 后部分请求挂死/抓不到包的问题

### DIFF
--- a/common/crep/mitm_h2_fingerprint_waf_test.go
+++ b/common/crep/mitm_h2_fingerprint_waf_test.go
@@ -1,0 +1,173 @@
+package crep
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+	"golang.org/x/net/http2"
+)
+
+// h2FingerprintWAF models an origin that advertises h2 and completes the h2
+// connection preface — so any ALPN+SETTINGS probe concludes "h2 works" — but
+// never answers an actual h2 request. Browser-fingerprinting endpoints behave
+// exactly like this: real browsers get h2, non-browser h2 clients get stalled.
+// Over HTTP/1.1 the same origin answers normally.
+func h2FingerprintWAF(t *testing.T) (addr string, h2Requests *int32) {
+	t.Helper()
+	cert := h2GenCert(t)
+	var h2ReqCount int32
+
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2", "http/1.1"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { lis.Close() })
+
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				tc := conn.(*tls.Conn)
+				if err := tc.Handshake(); err != nil {
+					return
+				}
+				if tc.ConnectionState().NegotiatedProtocol != "h2" {
+					// HTTP/1.1: behave like a healthy origin.
+					br := bufio.NewReader(conn)
+					for {
+						req, err := http.ReadRequest(br)
+						if err != nil {
+							return
+						}
+						io.Copy(io.Discard, req.Body)
+						fmt.Fprint(conn, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok")
+					}
+				}
+
+				// h2: delay the connection preface a little, then send it, so a
+				// probe still concludes "h2 works" but finishes *after* a real
+				// request has already failed — the ordering seen in the field.
+				time.Sleep(300 * time.Millisecond)
+				fr := http2.NewFramer(conn, conn)
+				if err := fr.WriteSettings(); err != nil {
+					return
+				}
+				// Consume the client connection preface before reading frames;
+				// feeding it to the framer would look like a malformed frame.
+				preface := make([]byte, len(http2.ClientPreface))
+				if _, err := io.ReadFull(conn, preface); err != nil {
+					t.Logf("origin: reading client preface failed: %v", err)
+					return
+				}
+				// A real request (HEADERS) gets the connection dropped, the way
+				// these endpoints reject non-browser h2 clients.
+				for {
+					f, err := fr.ReadFrame()
+					if err != nil {
+						t.Logf("origin: ReadFrame ended: %v", err)
+						return
+					}
+					t.Logf("origin: got frame %T %v", f, f.Header())
+					if _, ok := f.(*http2.HeadersFrame); ok {
+						atomic.AddInt32(&h2ReqCount, 1)
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return lis.Addr().String(), &h2ReqCount
+}
+
+// TestMITMH2_FingerprintWAFDoesNotStallLaterRequests reproduces the reported
+// stall: the first request downgrades and succeeds, and every later request
+// must keep using HTTP/1.1 instead of re-attempting the h2 path that only
+// looks healthy to a probe.
+func TestMITMH2_FingerprintWAFDoesNotStallLaterRequests(t *testing.T) {
+	originAddr, h2Requests := h2FingerprintWAF(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	target := "https://" + originAddr + "/bitbrowser/v1/apis/ipgeoMethod"
+	var elapsedPerRequest []time.Duration
+	var attemptsAfterFirst int32
+
+	for i := 1; i <= 4; i++ {
+		// Fresh HTTP/1.1 client each round, like a desktop client that opens a
+		// new connection per check.
+		client := h1ClientThroughProxy(t, addr, 120*time.Second)
+		start := time.Now()
+		done := make(chan error, 1)
+		go func() {
+			resp, err := client.Post(target, "application/json", nil)
+			if err != nil {
+				done <- err
+				return
+			}
+			defer resp.Body.Close()
+			io.Copy(io.Discard, resp.Body)
+			done <- nil
+		}()
+
+		select {
+		case err := <-done:
+			elapsed := time.Since(start)
+			require.NoErrorf(t, err, "request %d failed after %v", i, elapsed)
+			t.Logf("request %d OK in %v (upstream h2 attempts so far: %d)",
+				i, elapsed, atomic.LoadInt32(h2Requests))
+			elapsedPerRequest = append(elapsedPerRequest, elapsed)
+			if i == 1 {
+				attemptsAfterFirst = atomic.LoadInt32(h2Requests)
+			}
+		case <-time.After(20 * time.Second):
+			dumpGoroutines(t, fmt.Sprintf("request %d hung", i))
+			t.Fatalf("request %d hung — stall reproduced", i)
+		}
+		client.CloseIdleConnections()
+	}
+
+	// The first request pays for the h2 attempt (plus its bounded reconnects)
+	// before it learns better; every later one must go straight over HTTP/1.1.
+	for i, elapsed := range elapsedPerRequest {
+		if i == 0 {
+			continue
+		}
+		require.Lessf(t, elapsed, 5*time.Second,
+			"request %d took %v — it re-attempted the h2 path instead of remembering the downgrade", i+1, elapsed)
+	}
+
+	// The whole point: h2 attempts stop after the first request settles the
+	// origin. They must not keep growing with the number of requests, and the
+	// first request's own attempts must stay bounded by the reconnect cap.
+	require.Equalf(t, attemptsAfterFirst, atomic.LoadInt32(h2Requests),
+		"requests 2..n re-attempted h2: %d attempts after the first request, %d at the end",
+		attemptsAfterFirst, atomic.LoadInt32(h2Requests))
+	require.LessOrEqualf(t, attemptsAfterFirst, int32(4),
+		"the first request retried h2 %d times — the reconnect cap is not holding", attemptsAfterFirst)
+}

--- a/common/crep/mitm_h2_h1client_test.go
+++ b/common/crep/mitm_h2_h1client_test.go
@@ -1,0 +1,115 @@
+package crep
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+	"golang.org/x/net/http2"
+)
+
+// h1ClientThroughProxy builds a plain HTTP/1.1 client that talks to the MITM
+// through CONNECT — what curl and most scanners do by default. The client side
+// never negotiates h2, while the upstream hop still does, which is the exact
+// combination browsers never exercise.
+func h1ClientThroughProxy(t *testing.T, proxyAddr string, timeout time.Duration) *http.Client {
+	t.Helper()
+	proxyURL, err := url.Parse("http://" + proxyAddr)
+	require.NoError(t, err)
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{"http/1.1"},
+			},
+			ForceAttemptHTTP2: false,
+		},
+	}
+}
+
+// TestMITMH2_H1ClientRepeatedRequestsToSameOrigin reproduces the curl/scanner
+// case: an HTTP/1.1 client hitting the same h2 origin several times. The first
+// request establishes the upstream h2 connection; every later one reuses it.
+func TestMITMH2_H1ClientRepeatedRequestsToSameOrigin(t *testing.T) {
+	cert := h2GenCert(t)
+	var originHits int32
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&originHits, 1)
+			fmt.Fprintf(w, "hit-%d-proto-%d", n, r.ProtoMajor)
+		}),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2"},
+		},
+	}
+	require.NoError(t, http2.ConfigureServer(srv, &http2.Server{}))
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", srv.TLSConfig)
+	require.NoError(t, err)
+	go srv.Serve(lis)
+	t.Cleanup(func() {
+		ctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		srv.Shutdown(ctx)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	target := "https://" + lis.Addr().String() + "/"
+
+	for i := 1; i <= 4; i++ {
+		// A fresh client per iteration mimics separate curl invocations: the
+		// client-side connection is new every time, but the MITM's upstream
+		// connection to the origin is pooled and reused.
+		client := h1ClientThroughProxy(t, addr, 12*time.Second)
+		start := time.Now()
+		done := make(chan error, 1)
+		var body []byte
+		go func() {
+			resp, err := client.Get(target)
+			if err != nil {
+				done <- err
+				return
+			}
+			defer resp.Body.Close()
+			body, err = io.ReadAll(resp.Body)
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			elapsed := time.Since(start)
+			require.NoErrorf(t, err, "request %d failed after %v", i, elapsed)
+			t.Logf("request %d OK in %v -> %s", i, elapsed, string(body))
+			require.Lessf(t, elapsed, 5*time.Second, "request %d took %v — upstream reuse is stalling", i, elapsed)
+		case <-time.After(15 * time.Second):
+			buf := make([]byte, 1<<20)
+			n := runtime.Stack(buf, true)
+			t.Logf("=== GOROUTINE DUMP AT STALL (request %d) ===\n%s", i, buf[:n])
+			t.Fatalf("request %d hung — reproduced the stall", i)
+		}
+		client.CloseIdleConnections()
+	}
+}

--- a/common/crep/mitm_h2_realcurl_test.go
+++ b/common/crep/mitm_h2_realcurl_test.go
@@ -1,0 +1,155 @@
+package crep
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// TestMITMH2_RealCurlRepeated drives the real curl binary through the MITM at a
+// real origin, repeatedly. Go's http client is far more forgiving than curl
+// about connection reuse and framing, so a stall that only curl sees cannot be
+// reproduced with an in-process client.
+//
+// MITM_H2_CURL_TARGET overrides the origin.
+func TestMITMH2_RealCurlRepeated(t *testing.T) {
+	curlPath, err := exec.LookPath("curl")
+	if err != nil {
+		t.Skip("curl not available")
+	}
+	target := os.Getenv("MITM_H2_CURL_TARGET")
+	if target == "" {
+		target = "https://www.zhihu.com/"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(200 * time.Millisecond)
+
+	run := func(i int, extraArgs ...string) {
+		args := append([]string{
+			"-sS", "-o", "/dev/null",
+			"-x", "http://" + addr,
+			"-k",
+			"--max-time", "15",
+			"-w", "http_version=%{http_version} code=%{http_code} total=%{time_total}",
+		}, extraArgs...)
+		args = append(args, target)
+
+		start := time.Now()
+		cmd := exec.Command(curlPath, args...)
+		outCh := make(chan struct {
+			out []byte
+			err error
+		}, 1)
+		go func() {
+			out, err := cmd.CombinedOutput()
+			outCh <- struct {
+				out []byte
+				err error
+			}{out, err}
+		}()
+
+		select {
+		case r := <-outCh:
+			elapsed := time.Since(start)
+			t.Logf("curl #%d (%v) [%v]: %s", i, strings.Join(extraArgs, " "), elapsed, strings.TrimSpace(string(r.out)))
+			require.NoErrorf(t, r.err, "curl #%d failed after %v: %s", i, elapsed, string(r.out))
+			if elapsed > 14*time.Second {
+				dumpGoroutines(t, fmt.Sprintf("curl #%d slow (%v)", i, elapsed))
+				t.Fatalf("curl #%d took %v", i, elapsed)
+			}
+		case <-time.After(20 * time.Second):
+			// curl's own --max-time should have fired by now; if we are still
+			// here the proxy is wedged, so capture where.
+			dumpGoroutines(t, fmt.Sprintf("curl #%d hung", i))
+			_ = cmd.Process.Kill()
+			t.Fatalf("curl #%d hung — stall reproduced", i)
+		}
+	}
+
+	rounds := 4
+	if v := os.Getenv("MITM_H2_CURL_ROUNDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			rounds = n
+		}
+	}
+
+	t.Run("default-http1-client", func(t *testing.T) {
+		for i := 1; i <= rounds; i++ {
+			run(i)
+		}
+	})
+
+	t.Run("http2-client", func(t *testing.T) {
+		for i := 1; i <= rounds; i++ {
+			run(i, "--http2")
+		}
+	})
+
+	// Keep-alive on one client connection: several requests share a single
+	// client-side connection while the upstream connection is also pooled.
+	t.Run("keepalive-same-connection", func(t *testing.T) {
+		urls := make([]string, 0, rounds)
+		for i := 0; i < rounds; i++ {
+			urls = append(urls, target)
+		}
+		args := append([]string{
+			"-sS", "-o", "/dev/null",
+			"-x", "http://" + addr,
+			"-k",
+			"--max-time", "30",
+			"-w", "http_version=%{http_version} code=%{http_code} total=%{time_total}\\n",
+		}, urls...)
+
+		start := time.Now()
+		cmd := exec.Command(curlPath, args...)
+		outCh := make(chan struct {
+			out []byte
+			err error
+		}, 1)
+		go func() {
+			out, err := cmd.CombinedOutput()
+			outCh <- struct {
+				out []byte
+				err error
+			}{out, err}
+		}()
+		select {
+		case r := <-outCh:
+			t.Logf("curl keep-alive x%d [%v]:\n%s", rounds, time.Since(start), strings.TrimSpace(string(r.out)))
+			require.NoErrorf(t, r.err, "keep-alive run failed: %s", string(r.out))
+		case <-time.After(40 * time.Second):
+			dumpGoroutines(t, "curl keep-alive hung")
+			_ = cmd.Process.Kill()
+			t.Fatal("keep-alive run hung — stall reproduced")
+		}
+	})
+}
+
+// dumpGoroutines writes every goroutine stack into the test log so a stall
+// shows its location instead of having to be guessed at.
+func dumpGoroutines(t *testing.T, reason string) {
+	t.Helper()
+	buf := make([]byte, 1<<21)
+	n := runtime.Stack(buf, true)
+	t.Logf("=== GOROUTINE DUMP (%s) ===\n%s", reason, buf[:n])
+}

--- a/common/crep/mitm_h2_realcurl_test.go
+++ b/common/crep/mitm_h2_realcurl_test.go
@@ -22,13 +22,16 @@ import (
 //
 // MITM_H2_CURL_TARGET overrides the origin.
 func TestMITMH2_RealCurlRepeated(t *testing.T) {
+	// Opt-in only: this drives a real curl binary against a real origin, so it
+	// needs egress and is not suitable for CI. Set MITM_H2_CURL_TARGET to run
+	// it against a specific endpoint when diagnosing a report from the field.
+	target := os.Getenv("MITM_H2_CURL_TARGET")
+	if target == "" {
+		t.Skip("set MITM_H2_CURL_TARGET=<url> to run this diagnostic against a real origin")
+	}
 	curlPath, err := exec.LookPath("curl")
 	if err != nil {
 		t.Skip("curl not available")
-	}
-	target := os.Getenv("MITM_H2_CURL_TARGET")
-	if target == "" {
-		target = "https://www.zhihu.com/"
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)

--- a/common/crep/mitm_h2_realworld_test.go
+++ b/common/crep/mitm_h2_realworld_test.go
@@ -21,9 +21,10 @@ import (
 //
 // Set MITM_H2_REAL_TARGET to override the origin; skipped without network.
 func TestMITMH2_RealOriginSequential(t *testing.T) {
+	// Opt-in only: needs egress to a real origin, so it must not run in CI.
 	target := os.Getenv("MITM_H2_REAL_TARGET")
 	if target == "" {
-		target = "https://www.baidu.com/"
+		t.Skip("set MITM_H2_REAL_TARGET=<url> to run this diagnostic against a real origin")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)

--- a/common/crep/mitm_h2_realworld_test.go
+++ b/common/crep/mitm_h2_realworld_test.go
@@ -1,0 +1,75 @@
+package crep
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// TestMITMH2_RealOriginSequential proxies several requests to a real public h2
+// origin. Local mock servers answer instantly and always send their SETTINGS
+// frame first, so they cannot reproduce stalls that depend on real handshake
+// timing, CDNs, or connection reuse across a WAN link.
+//
+// Set MITM_H2_REAL_TARGET to override the origin; skipped without network.
+func TestMITMH2_RealOriginSequential(t *testing.T) {
+	target := os.Getenv("MITM_H2_REAL_TARGET")
+	if target == "" {
+		target = "https://www.baidu.com/"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 20*time.Second, nil)
+
+	for i := 1; i <= 5; i++ {
+		start := time.Now()
+		done := make(chan struct {
+			resp *http.Response
+			err  error
+		}, 1)
+		go func() {
+			resp, err := client.Get(target)
+			done <- struct {
+				resp *http.Response
+				err  error
+			}{resp, err}
+		}()
+
+		select {
+		case r := <-done:
+			elapsed := time.Since(start)
+			require.NoErrorf(t, r.err, "request %d failed after %v", i, elapsed)
+			n, _ := io.Copy(io.Discard, r.resp.Body)
+			r.resp.Body.Close()
+			t.Logf("request %d OK in %v (proto=%s, status=%d, body=%d bytes)",
+				i, elapsed, r.resp.Proto, r.resp.StatusCode, n)
+		case <-time.After(25 * time.Second):
+			// Dump every goroutine so the stall's location is in the output
+			// instead of having to be guessed at.
+			buf := make([]byte, 1<<20)
+			n := runtime.Stack(buf, true)
+			t.Logf("=== GOROUTINE DUMP AT STALL (request %d) ===\n%s", i, buf[:n])
+			t.Fatalf("request %d hung for more than 25s", i)
+		}
+	}
+}

--- a/common/crep/mitm_h2_sequential_test.go
+++ b/common/crep/mitm_h2_sequential_test.go
@@ -1,0 +1,155 @@
+package crep
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+	"golang.org/x/net/http2"
+	"net/http"
+)
+
+// TestMITMH2_SequentialRequestsOverSameConn drives several requests through one
+// client-facing h2 connection, the way a browser does. A regression that only
+// breaks connection/stream reuse looks fine on the first request and hangs from
+// the second one on, so a single-request test cannot catch it.
+func TestMITMH2_SequentialRequestsOverSameConn(t *testing.T) {
+	cert := h2GenCert(t)
+	var originHits int32
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&originHits, 1)
+			fmt.Fprintf(w, "resp-%d", atomic.LoadInt32(&originHits))
+		}),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2"},
+		},
+	}
+	require.NoError(t, http2.ConfigureServer(srv, &http2.Server{}))
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", srv.TLSConfig)
+	require.NoError(t, err)
+	go srv.Serve(lis)
+	t.Cleanup(func() {
+		ctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		srv.Shutdown(ctx)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 15*time.Second, nil)
+	target := "https://" + lis.Addr().String() + "/"
+
+	for i := 1; i <= 4; i++ {
+		start := time.Now()
+		resp, err := client.Get(target)
+		elapsed := time.Since(start)
+		require.NoErrorf(t, err, "request %d failed after %v", i, elapsed)
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.NoErrorf(t, err, "request %d body read failed after %v", i, elapsed)
+		require.Equalf(t, 2, resp.ProtoMajor, "request %d must stay on h2 to the client", i)
+		require.Equalf(t, fmt.Sprintf("resp-%d", i), string(body), "request %d returned the wrong body", i)
+		t.Logf("request %d OK in %v (proto=%s)", i, elapsed, resp.Proto)
+		require.Lessf(t, elapsed, 5*time.Second, "request %d took %v — reuse is stalling", i, elapsed)
+	}
+}
+
+// TestMITMH2_ConcurrentStreamsOverSameConn fires overlapping requests down one
+// client-facing h2 connection, which is what a browser actually does when it
+// loads a page. Serial reuse can look healthy while concurrent streams deadlock.
+func TestMITMH2_ConcurrentStreamsOverSameConn(t *testing.T) {
+	cert := h2GenCert(t)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "ok:%s", r.URL.Path)
+		}),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2"},
+		},
+	}
+	require.NoError(t, http2.ConfigureServer(srv, &http2.Server{}))
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", srv.TLSConfig)
+	require.NoError(t, err)
+	go srv.Serve(lis)
+	t.Cleanup(func() {
+		ctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		srv.Shutdown(ctx)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 15*time.Second, nil)
+	base := "https://" + lis.Addr().String()
+
+	// Warm the connection so every concurrent request below shares one h2 conn.
+	warm, err := client.Get(base + "/warm")
+	require.NoError(t, err)
+	io.Copy(io.Discard, warm.Body)
+	warm.Body.Close()
+
+	const parallel = 8
+	type result struct {
+		idx     int
+		err     error
+		body    string
+		elapsed time.Duration
+	}
+	results := make(chan result, parallel)
+	for i := 0; i < parallel; i++ {
+		go func(i int) {
+			start := time.Now()
+			resp, err := client.Get(fmt.Sprintf("%s/p%d", base, i))
+			if err != nil {
+				results <- result{idx: i, err: err, elapsed: time.Since(start)}
+				return
+			}
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			results <- result{idx: i, err: err, body: string(body), elapsed: time.Since(start)}
+		}(i)
+	}
+
+	deadline := time.After(30 * time.Second)
+	for done := 0; done < parallel; done++ {
+		select {
+		case r := <-results:
+			require.NoErrorf(t, r.err, "concurrent request %d failed after %v", r.idx, r.elapsed)
+			require.Equalf(t, fmt.Sprintf("ok:/p%d", r.idx), r.body, "concurrent request %d body mismatch", r.idx)
+			t.Logf("concurrent request %d OK in %v", r.idx, r.elapsed)
+		case <-deadline:
+			t.Fatalf("only %d/%d concurrent requests completed — the rest are hung", done, parallel)
+		}
+	}
+}

--- a/common/crep/mitm_h2_slow_origin_test.go
+++ b/common/crep/mitm_h2_slow_origin_test.go
@@ -1,0 +1,253 @@
+package crep
+
+// Regression tests for the MITM HTTP/2 origin-probe stall and the h1->h2
+// response header sanitization, using a browser-grade h2 client
+// (golang.org/x/net/http2 Transport — the same class of stack Chromium
+// ships), instead of yaklang's own h2 client.
+//
+// Background: with HTTP/2 support enabled, the MITM used to synchronously
+// probe the origin's h2 capability on the client TLS-handshake path. A slow,
+// bot-mitigated or unreachable origin stalled the probe (up to its 10s
+// timeout), so the client could not even finish its handshake and no traffic
+// was captured — browser proxy checks failed. The probe now runs in the
+// background and unknown origins are served over HTTP/1.1 (Burp semantics).
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+	"golang.org/x/net/http2"
+)
+
+// h2BrowserClientThroughProxy builds an x/net/http2 client that tunnels via
+// CONNECT through the MITM proxy and negotiates TLS with ALPN h2, like a real
+// browser. onHandshake (optional) is invoked once the TLS handshake with the
+// MITM has completed.
+func h2BrowserClientThroughProxy(t *testing.T, proxyAddr string, timeout time.Duration, onHandshake func()) *http.Client {
+	t.Helper()
+	tr := &http2.Transport{
+		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+			var d net.Dialer
+			raw, err := d.DialContext(ctx, "tcp", proxyAddr)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := fmt.Fprintf(raw, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", addr, addr); err != nil {
+				raw.Close()
+				return nil, err
+			}
+			br := bufio.NewReader(raw)
+			resp, err := http.ReadResponse(br, &http.Request{Method: "CONNECT"})
+			if err != nil {
+				raw.Close()
+				return nil, fmt.Errorf("read CONNECT response: %w", err)
+			}
+			if resp.StatusCode != 200 {
+				raw.Close()
+				return nil, fmt.Errorf("CONNECT failed: %s", resp.Status)
+			}
+			host, _, _ := net.SplitHostPort(addr)
+			tc := tls.Client(&h2BufferedConn{Conn: raw, r: br}, &tls.Config{
+				ServerName:         host,
+				InsecureSkipVerify: true,
+				NextProtos:         []string{"h2"},
+			})
+			if err := tc.HandshakeContext(ctx); err != nil {
+				raw.Close()
+				return nil, fmt.Errorf("tls handshake through proxy: %w", err)
+			}
+			if onHandshake != nil {
+				onHandshake()
+			}
+			return tc, nil
+		},
+	}
+	return &http.Client{Transport: tr, Timeout: timeout}
+}
+
+type h2BufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *h2BufferedConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+// delayedFirstReadConn delays the first read (i.e. the origin-side processing
+// of the TLS ClientHello) to simulate a slow/bot-mitigated origin.
+type delayedFirstReadConn struct {
+	net.Conn
+	once  sync.Once
+	delay time.Duration
+}
+
+func (c *delayedFirstReadConn) Read(p []byte) (int, error) {
+	c.once.Do(func() { time.Sleep(c.delay) })
+	return c.Conn.Read(p)
+}
+
+type delayFirstConnListener struct {
+	net.Listener
+	delay time.Duration
+	seq   int32
+}
+
+func (l *delayFirstConnListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if atomic.AddInt32(&l.seq, 1) == 1 {
+		// only the first connection is slow: the (now background) h2 probe
+		// eats it; the real request dials a fresh, fast connection
+		return &delayedFirstReadConn{Conn: c, delay: l.delay}, nil
+	}
+	return c, nil
+}
+
+// newSlowH2Origin starts an h2 TLS origin whose FIRST connection pays `delay`
+// before the TLS handshake completes; later connections are fast.
+func newSlowH2Origin(t *testing.T, delay time.Duration) string {
+	t.Helper()
+	cert := h2GenCert(t)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "ok")
+		}),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2"},
+		},
+	}
+	require.NoError(t, http2.ConfigureServer(srv, &http2.Server{}))
+	rawLis, err := tls.Listen("tcp", "127.0.0.1:0", srv.TLSConfig)
+	require.NoError(t, err)
+	lis := &delayFirstConnListener{Listener: rawLis, delay: delay}
+	go srv.Serve(lis)
+	t.Cleanup(func() {
+		ctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		srv.Shutdown(ctx)
+	})
+	return rawLis.Addr().String()
+}
+
+// TestMITMH2_OriginProbeDoesNotStallClientHandshake proves the origin h2
+// probe no longer sits on the client-handshake critical path: even with a
+// 4s-slow origin, the client<->MITM TLS handshake completes immediately and
+// the request succeeds. Before the fix the client stalled for the whole
+// probe duration (up to the 10s probe timeout) and nothing was captured.
+func TestMITMH2_OriginProbeDoesNotStallClientHandshake(t *testing.T) {
+	originAddr := newSlowH2Origin(t, 4*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	var handshakeAt atomic.Int64 // ms since start
+	start := time.Now()
+	client := h2BrowserClientThroughProxy(t, addr, 10*time.Second, func() {
+		handshakeAt.Store(time.Since(start).Milliseconds())
+	})
+	resp, err := client.Get("https://" + originAddr + "/")
+	require.NoError(t, err, "request through MITM(h2) with slow origin must succeed")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, "ok", string(body))
+
+	handshakeElapsed := time.Duration(handshakeAt.Load()) * time.Millisecond
+	require.Less(t, handshakeElapsed, 2*time.Second,
+		"client<->MITM handshake must not wait for the background origin probe")
+}
+
+// newRawH1Origin starts a raw TLS origin that only speaks HTTP/1.1 and
+// answers every request with a canned response carrying connection-specific
+// headers (Connection: keep-alive, Content-Length) — the kind of response
+// that must never leak into an h2 stream.
+func newRawH1Origin(t *testing.T, body string) string {
+	t.Helper()
+	cert := h2GenCert(t)
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"http/1.1"},
+	})
+	require.NoError(t, err)
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				br := bufio.NewReader(conn)
+				// read request headers
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if line == "\r\n" {
+						break
+					}
+				}
+				fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: keep-alive\r\n\r\n%s", len(body), body)
+			}()
+		}
+	}()
+	t.Cleanup(func() { lis.Close() })
+	return lis.Addr().String()
+}
+
+// TestMITMH2_H1UpstreamResponseSanitized sends an h2 request through the MITM
+// to an h1-only origin. The upstream h1 response (with Connection and
+// Content-Length headers) is translated to h2; a strict h2 client must accept
+// it. Before the header sanitization fix, connection-specific h1 headers were
+// encoded into the h2 response and strict clients reset the stream
+// (RFC 7540 Section 8.1.2.2).
+func TestMITMH2_H1UpstreamResponseSanitized(t *testing.T) {
+	token := utils.RandStringBytes(16)
+	originAddr := newRawH1Origin(t, token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 10*time.Second, nil)
+	resp, err := client.Get("https://" + originAddr + "/")
+	require.NoError(t, err, "strict h2 client must accept the translated h1 response")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, token, string(body))
+	require.False(t, strings.Contains(strings.ToLower(fmt.Sprint(resp.Header)), "keep-alive"),
+		"connection-specific headers must not reach the h2 client")
+}

--- a/common/crep/mitm_h2_upstream_fallback_test.go
+++ b/common/crep/mitm_h2_upstream_fallback_test.go
@@ -1,0 +1,313 @@
+package crep
+
+// Regression test: when the origin negotiates h2 in ALPN (so the probe marks
+// it h2-capable) but then kills actual h2 connections right after the client
+// preface — the behavior of fingerprinting-protected endpoints such as
+// browser vendors' own APIs — the MITM must downgrade the upstream to
+// HTTP/1.1 (Burp semantics) instead of retrying h2 forever.
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+	"golang.org/x/net/http2"
+)
+
+// h2KillerOrigin negotiates h2 via ALPN but immediately closes any connection
+// that sends the HTTP/2 client preface; plain HTTP/1.1 requests are answered
+// normally. It emulates endpoints that fingerprint-kill non-browser h2 stacks.
+type h2KillerOrigin struct {
+	addr        string
+	h2Kills     int32
+	h1Requests  int32
+	probeChecks int32
+}
+
+func newH2KillerOrigin(t *testing.T, body string) *h2KillerOrigin {
+	t.Helper()
+	cert := h2GenCert(t)
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2", "http/1.1"},
+	})
+	require.NoError(t, err)
+	o := &h2KillerOrigin{addr: lis.Addr().String()}
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go o.handle(conn, body)
+		}
+	}()
+	t.Cleanup(func() { lis.Close() })
+	return o
+}
+
+func (o *h2KillerOrigin) handle(conn net.Conn, body string) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	br := bufio.NewReader(conn)
+	peek, err := br.Peek(3)
+	if err != nil {
+		return
+	}
+	if string(peek) == "PRI" {
+		// h2 client preface: kill the connection like a fingerprinting WAF
+		atomic.AddInt32(&o.h2Kills, 1)
+		return
+	}
+	// plain HTTP/1.x request: read headers, then answer
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return
+		}
+		if line == "\r\n" {
+			break
+		}
+	}
+	atomic.AddInt32(&o.h1Requests, 1)
+	fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
+}
+
+// tarpitH2Origin negotiates h2 in ALPN but then never sends any frame (and
+// never closes) — the fingerprinting-WAF tarpit behavior seen in production.
+// HTTP/1.1 requests are answered normally.
+type tarpitH2Origin struct {
+	addr    string
+	h2Conns int32
+	h1Conns int32
+}
+
+func newTarpitH2Origin(t *testing.T, body string) *tarpitH2Origin {
+	t.Helper()
+	cert := h2GenCert(t)
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2", "http/1.1"},
+	})
+	require.NoError(t, err)
+	o := &tarpitH2Origin{addr: lis.Addr().String()}
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				tc := conn.(*tls.Conn)
+				_ = tc.Handshake()
+				if tc.ConnectionState().NegotiatedProtocol == "h2" {
+					atomic.AddInt32(&o.h2Conns, 1)
+					_, _ = io.Copy(io.Discard, conn) // tarpit: never respond
+					return
+				}
+				atomic.AddInt32(&o.h1Conns, 1)
+				br := bufio.NewReader(conn)
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if line == "\r\n" {
+						break
+					}
+				}
+				fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
+			}()
+		}
+	}()
+	t.Cleanup(func() { lis.Close() })
+	return o
+}
+
+// TestMITMH2_UpstreamTarpitFallsBackToH1 covers origins that negotiate h2 in
+// ALPN but then go silent (no SETTINGS frame). The probe now requires the
+// server's SETTINGS preface, so such origins are cached as h1 and requests
+// never attempt h2 at all. The bounded server-preface wait at conn setup and
+// the request-level fallback remain as defense in depth.
+func TestMITMH2_UpstreamTarpitFallsBackToH1(t *testing.T) {
+	token := utils.RandStringBytes(16)
+	origin := newTarpitH2Origin(t, token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 15*time.Second, nil)
+	for i := 1; i <= 3; i++ {
+		start := time.Now()
+		resp, err := client.Get("https://" + origin.addr + "/")
+		elapsed := time.Since(start)
+		require.NoError(t, err, "request %d must succeed via h1", i)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.Equal(t, token, string(body))
+		t.Logf("request %d OK in %v (h2 conns: %d, h1 conns: %d)",
+			i, elapsed, atomic.LoadInt32(&origin.h2Conns), atomic.LoadInt32(&origin.h1Conns))
+		require.Less(t, elapsed, 8*time.Second, "request %d must not hang on the h2 tarpit", i)
+	}
+	require.Equal(t, int32(3), atomic.LoadInt32(&origin.h1Conns), "all requests must be served over HTTP/1.1")
+}
+
+// TestMITMH2_UpstreamFallbackToH1 sends requests through the MITM (h2
+// enabled) to an origin that advertises h2 but kills h2 connections. The
+// first h2 upstream attempt must fail fast and fall back to HTTP/1.1; later
+// requests must go straight to HTTP/1.1 via the downgraded cache.
+func TestMITMH2_UpstreamFallbackToH1(t *testing.T) {
+	token := utils.RandStringBytes(16)
+	origin := newH2KillerOrigin(t, token)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 15*time.Second, nil)
+	for i := 1; i <= 3; i++ {
+		start := time.Now()
+		resp, err := client.Get("https://" + origin.addr + "/")
+		elapsed := time.Since(start)
+		require.NoError(t, err, "request %d must succeed via h1 fallback", i)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.Equal(t, token, string(body))
+		t.Logf("request %d OK in %v (h2 kills: %d, h1 requests: %d)",
+			i, elapsed, atomic.LoadInt32(&origin.h2Kills), atomic.LoadInt32(&origin.h1Requests))
+		require.Less(t, elapsed, 8*time.Second, "request %d must not stall on h2 retries", i)
+	}
+	require.GreaterOrEqual(t, atomic.LoadInt32(&origin.h1Requests), int32(3),
+		"all requests must end up served over HTTP/1.1")
+}
+
+// TestMITMH2_DisplayKeepsClientFacingProtocol verifies that when the client
+// speaks h2 to the MITM but the upstream is served over HTTP/1.1, the
+// recorded/displayed request packet still carries the "HTTP/2" version marker
+// (the client-facing protocol), while the wire request to the origin is h1.
+func TestMITMH2_DisplayKeepsClientFacingProtocol(t *testing.T) {
+	token := utils.RandStringBytes(16)
+	originAddr := newRawH1Origin(t, token)
+
+	mirrorCh := make(chan int, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(
+		MITM_SetHTTP2(true),
+		MITM_SetDisableSystemProxy(true),
+		MITM_SetHTTPResponseMirrorInstance(func(isHttps bool, req, rsp []byte, remoteAddr string, response *http.Response) {
+			if response != nil && response.Request != nil {
+				mirrorCh <- response.Request.ProtoMajor
+			}
+		}),
+	)
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 15*time.Second, nil)
+	resp, err := client.Get("https://" + originAddr + "/")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, token, string(body))
+
+	select {
+	case protoMajor := <-mirrorCh:
+		require.Equal(t, 2, protoMajor,
+			"recorded request must keep the client-facing h2 protocol (displayed as HTTP/2)")
+	case <-time.After(5 * time.Second):
+		t.Fatal("mirror callback did not fire")
+	}
+}
+
+// TestMITMH2_FirstRequestUsesH2WhenOriginSupportsIt verifies that even the
+// FIRST request to a healthy h2 origin is proxied over h2: the background
+// probe is given a brief bounded moment (h2FirstRequestProbeWait) instead of
+// unconditionally serving the first request over HTTP/1.1.
+func TestMITMH2_FirstRequestUsesH2WhenOriginSupportsIt(t *testing.T) {
+	cert := h2GenCert(t)
+	var h2Hits int32
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ProtoMajor == 2 {
+				atomic.AddInt32(&h2Hits, 1)
+			}
+			fmt.Fprint(w, "ok")
+		}),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2"},
+		},
+	}
+	require.NoError(t, http2.ConfigureServer(srv, &http2.Server{}))
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", srv.TLSConfig)
+	require.NoError(t, err)
+	go srv.Serve(lis)
+	t.Cleanup(func() {
+		ctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		srv.Shutdown(ctx)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	port := utils.GetRandomAvailableTCPPort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	mServer, err := NewMITMServer(MITM_SetHTTP2(true), MITM_SetDisableSystemProxy(true))
+	require.NoError(t, err)
+	ready := make(chan struct{})
+	go func() {
+		_ = mServer.ServeWithListenedCallback(ctx, addr, func() { close(ready) })
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	client := h2BrowserClientThroughProxy(t, addr, 15*time.Second, nil)
+	start := time.Now()
+	resp, err := client.Get("https://" + lis.Addr().String() + "/")
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, "ok", string(body))
+	t.Logf("first request OK in %v (h2 origin hits: %d)", elapsed, atomic.LoadInt32(&h2Hits))
+	require.Equal(t, int32(1), atomic.LoadInt32(&h2Hits),
+		"the first request to a healthy h2 origin must be proxied over h2")
+	require.Less(t, elapsed, 8*time.Second)
+}

--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -63,6 +63,18 @@ func parseLowHTTPResponsePacket(packet []byte) (*http.Response, error) {
 	return utils.ReadHTTPResponseFromBytesWithBodyView(packet)
 }
 
+// forceHTTP11FirstLine rewrites a request packet's version marker to HTTP/1.1.
+//
+// A request parsed from an h2 client keeps its "HTTP/2" marker so the UI shows
+// the client-facing protocol faithfully, but lowhttp reads that same marker as
+// a force-h2 signal (see lowhttp.exec). Any hop that goes out over HTTP/1.1
+// must therefore rewrite the wire copy, or lowhttp overrides the caller's
+// choice of protocol.
+func forceHTTP11FirstLine(packet []byte) []byte {
+	method, uri, _ := lowhttp.GetHTTPPacketFirstLine(packet)
+	return lowhttp.ReplaceHTTPPacketFirstLine(packet, method+" "+uri+" HTTP/1.1")
+}
+
 func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, error) {
 	// PlainRequestBytes is the decoded representation used by the UI, history,
 	// and plugins. It must not replace the wire packet during transparent
@@ -94,6 +106,23 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 
 	if cached, ok := p.h2Cache.Load(cacheKey); ok {
 		isH2 = cached.(bool)
+	} else if p.http2 && isHttps {
+		// Origin h2 capability unknown: try h2 optimistically. Every failure
+		// mode below downgrades to HTTP/1.1 and negative-caches the origin:
+		//  - h1-only origin: ALPN does not negotiate h2 -> instant downgrade
+		//  - WAF kills the h2 conn (preface EOF/RST): closeCh -> downgrade
+		//  - WAF tarpit (no SETTINGS): bounded server-preface wait -> downgrade
+		//  - any other transport error: err fallback below
+		// so optimistic h2 never hangs the request. The probe still runs in
+		// the background to populate the cache for later requests.
+		isH2 = true
+		p.detectServerH2Async(cacheKey, "")
+	}
+
+	if !isH2 {
+		// The upstream protocol is decided by the origin h2 cache, not by the
+		// packet's version marker.
+		reqBytes = forceHTTP11FirstLine(reqBytes)
 	}
 
 	isGmTLS := p.gmTLS && isHttps
@@ -268,10 +297,38 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 	})
 
 	lowHttpResp, err := lowhttp.HTTPWithoutRedirect(opts...)
+	if err != nil && isH2 && req.Context().Err() == nil {
+		// The origin advertised h2 during detection, but the h2 upstream
+		// attempt failed at transport level. Some endpoints (WAF/bot
+		// mitigation, e.g. fingerprinting-protected APIs) kill non-browser
+		// h2 clients right after the preface. Downgrade: remember h1 for
+		// this origin and retry over HTTP/1.1 — the same behavior as Burp.
+		//
+		// The context check above matters: a request abandoned by the client
+		// also surfaces as an error here, but says nothing about the origin's
+		// h2 support. Downgrading on it would poison the cache for the whole
+		// origin and burn a second, equally doomed round trip.
+		log.Warnf("h2 upstream to %v failed: %v, downgrading to HTTP/1.1", cacheKey, err)
+		p.h2Cache.Store(cacheKey, false)
+		// Rewrite the version marker as well: leaving "HTTP/2" on the wire copy
+		// makes lowhttp force h2 again and the retry rebuilds the very
+		// connection that just failed.
+		opts = append(opts, lowhttp.WithHttp2(false), lowhttp.WithRequest(forceHTTP11FirstLine(reqBytes)))
+		lowHttpResp, err = lowhttp.HTTPWithoutRedirect(opts...)
+	}
 	if err != nil {
 		req.RemoteAddr = ""
 		httpctx.SetRemoteAddr(req, "")
 		return nil, err
+	}
+
+	// If h2 was requested (the origin advertised it during detection) but the
+	// connection was silently downgraded to HTTP/1.1 — ALPN mismatch, preface
+	// failure, or a tarpit that never sent its SETTINGS frame — remember h1
+	// for this origin so later requests skip the h2 attempt entirely.
+	if isH2 && lowHttpResp != nil && !lowHttpResp.Http2 {
+		log.Infof("h2 upstream to %v was downgraded to HTTP/1.1, caching h1 for this origin", cacheKey)
+		p.h2Cache.Store(cacheKey, false)
 	}
 
 	// set trace info

--- a/common/minimartian/mitmloop.go
+++ b/common/minimartian/mitmloop.go
@@ -24,7 +24,6 @@ import (
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/minimartian/nosigpipe"
 	"github.com/yaklang/yaklang/common/minimartian/proxyutil"
-	"github.com/yaklang/yaklang/common/netx"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/lowhttp/httpctx"
 )
@@ -412,56 +411,10 @@ func (p *Proxy) handleLoop(isTLSConn bool, conn net.Conn, ctx *Context) {
 		s.Set(httpctx.REQUEST_CONTEXT_ConnectToHTTPS, true)
 		var serverUseH2 bool
 		if p.http2 {
-			// does remote server use h2?
-			var proxyStr string
-			if p.proxyURL != nil {
-				proxyStr = p.proxyURL.String()
-			}
-
-			// Check the cache first.
-			cacheKey := GetDialDetectionAddr(ctx, conn)
-			if cached, ok := p.h2Cache.Load(cacheKey); ok {
-				log.Infof("use cached h2 %v", cacheKey)
-				serverUseH2 = cached.(bool)
-			} else {
-				// TODO: should connect every connection?
-				basicOptions := []netx.DialXOption{
-					netx.DialX_WithTimeout(10 * time.Second),
-					netx.DialX_WithProxy(proxyStr),
-					netx.DialX_WithForceProxy(proxyStr != ""),
-					netx.DialX_WithEnableSystemProxyFromEnv(!p.disableSystemProxy),
-					netx.DialX_WithAppendTLSNextProto("h2"),
-					netx.DialX_WithTLS(true),
-					netx.DialX_WithDialer(p.dialer),
-				}
-
-				if ctx.GetSessionBoolValue("StrongHostMode") {
-					localAddrIP := ctx.GetSessionStringValue("StrongHostLocalAddr")
-					if localAddrIP != "" {
-						basicOptions = append(basicOptions, netx.DialX_WithStrongHostMode(localAddrIP))
-					}
-				}
-
-				netConn, _ := netx.DialX(
-					cacheKey, basicOptions...,
-				)
-				if netConn != nil {
-					switch ret := netConn.(type) {
-					case *tls.Conn:
-						if ret.ConnectionState().NegotiatedProtocol == "h2" {
-							serverUseH2 = true
-						}
-					case *gmtls.Conn:
-						if ret.ConnectionState().NegotiatedProtocol == "h2" {
-							serverUseH2 = true
-						}
-					}
-					netConn.Close()
-				}
-
-				// Store the result in the cache.
-				p.h2Cache.Store(cacheKey, serverUseH2)
-			}
+			// Decide the client-facing ALPN without blocking on the origin:
+			// a slow/bot-mitigated origin must never stall the client's TLS
+			// handshake. The origin h2 probe runs in the background.
+			serverUseH2 = p.offerH2ToClient(GetDialDetectionAddr(ctx, conn), strongHostLocalAddrFromCtx(ctx))
 		}
 		tlsConn, useH2, err := p.TLSHandshake(utils.TimeoutContextSeconds(5), conn, serverUseH2)
 		if err != nil {
@@ -586,56 +539,10 @@ func (p *Proxy) handleConnectionTunnel(req *http.Request, timer *time.Timer, con
 
 		var serverUseH2 bool
 		if p.http2 {
-			// does remote server use h2?
-			var proxyStr string
-			if p.proxyURL != nil {
-				proxyStr = p.proxyURL.String()
-			}
-
-			// Check the cache first.
-			cacheKey := GetDialDetectionAddr(ctx, conn)
-			if cached, ok := p.h2Cache.Load(cacheKey); ok {
-				log.Infof("use cached h2 %v", cacheKey)
-				serverUseH2 = cached.(bool)
-			} else {
-				// TODO: should connect every connection?
-				basicOptions := []netx.DialXOption{
-					netx.DialX_WithTimeout(10 * time.Second),
-					netx.DialX_WithProxy(proxyStr),
-					netx.DialX_WithForceProxy(proxyStr != ""),
-					netx.DialX_WithEnableSystemProxyFromEnv(!p.disableSystemProxy),
-					netx.DialX_WithAppendTLSNextProto("h2"),
-					netx.DialX_WithTLS(true),
-					netx.DialX_WithDialer(p.dialer),
-				}
-
-				if ctx.GetSessionBoolValue("StrongHostMode") {
-					localAddrIP := ctx.GetSessionStringValue("StrongHostLocalAddr")
-					if localAddrIP != "" {
-						basicOptions = append(basicOptions, netx.DialX_WithStrongHostMode(localAddrIP))
-					}
-				}
-				netConn, _ := netx.DialX(
-					cacheKey,
-					basicOptions...,
-				)
-				if netConn != nil {
-					switch ret := netConn.(type) {
-					case *tls.Conn:
-						if ret.ConnectionState().NegotiatedProtocol == "h2" {
-							serverUseH2 = true
-						}
-					case *gmtls.Conn:
-						if ret.ConnectionState().NegotiatedProtocol == "h2" {
-							serverUseH2 = true
-						}
-					}
-					netConn.Close()
-				}
-
-				// Store the result in the cache.
-				p.h2Cache.Store(cacheKey, serverUseH2)
-			}
+			// Decide the client-facing ALPN without blocking on the origin:
+			// a slow/bot-mitigated origin must never stall the client's TLS
+			// handshake. The origin h2 probe runs in the background.
+			serverUseH2 = p.offerH2ToClient(GetDialDetectionAddr(ctx, conn), strongHostLocalAddrFromCtx(ctx))
 		}
 
 		// fallback: 最普通的情况，没有任何 http2 支持

--- a/common/minimartian/mitmloop_h2probe.go
+++ b/common/minimartian/mitmloop_h2probe.go
@@ -86,9 +86,15 @@ func (p *Proxy) detectServerH2(cacheKey, strongHostLocalAddr, proxyStr string) b
 }
 
 // detectServerH2Async runs detectServerH2 in the background (at most once per
-// origin) and caches the result, keeping origin detection off the request
-// path. Until the probe lands, requests to the origin are served over
-// HTTP/1.1 — the same downgrade Burp performs, which always works.
+// origin) and caches the result, keeping origin detection off the request path.
+//
+// The probe is the weaker of the two writers of h2Cache: it only proves the
+// origin completes an h2 handshake, while a proxied request proves whether h2
+// actually carries traffic. Fingerprinting endpoints separate the two — they
+// accept the connection and send SETTINGS, then stall any real h2 request from
+// a non-browser client. So a probe that lands after real traffic has already
+// recorded a verdict must not overwrite it; otherwise every later request
+// retries the dead h2 path and stalls until its full timeout.
 func (p *Proxy) detectServerH2Async(cacheKey, strongHostLocalAddr string) {
 	if !p.http2 || cacheKey == "" {
 		return
@@ -107,8 +113,14 @@ func (p *Proxy) detectServerH2Async(cacheKey, strongHostLocalAddr string) {
 	go func() {
 		defer p.h2ProbeInflight.Delete(cacheKey)
 		serverUseH2 := p.detectServerH2(cacheKey, strongHostLocalAddr, proxyStr)
+		// LoadOrStore, not Store: real traffic may have settled this origin
+		// while the probe was in flight, and its verdict wins.
+		if existing, loaded := p.h2Cache.LoadOrStore(cacheKey, serverUseH2); loaded {
+			log.Infof("async h2 detection for %v: %v (ignored, real traffic already decided %v)",
+				cacheKey, serverUseH2, existing)
+			return
+		}
 		log.Infof("async h2 detection for %v: %v", cacheKey, serverUseH2)
-		p.h2Cache.Store(cacheKey, serverUseH2)
 	}()
 }
 

--- a/common/minimartian/mitmloop_h2probe.go
+++ b/common/minimartian/mitmloop_h2probe.go
@@ -1,0 +1,133 @@
+package minimartian
+
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/yaklang/yaklang/common/gmsm/gmtls"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/netx"
+	"golang.org/x/net/http2"
+)
+
+// strongHostLocalAddrFromCtx extracts the strong-host local address from the
+// connection context, when strong host mode is enabled.
+func strongHostLocalAddrFromCtx(ctx *Context) string {
+	if ctx != nil && ctx.GetSessionBoolValue("StrongHostMode") {
+		return ctx.GetSessionStringValue("StrongHostLocalAddr")
+	}
+	return ""
+}
+
+// detectServerH2 synchronously probes whether the origin at cacheKey
+// (host:port) actually speaks HTTP/2, using the proxy's downstream proxy
+// settings.
+//
+// ALPN negotiation alone is NOT enough: fingerprinting WAF endpoints (e.g.
+// browser-vendor APIs) negotiate h2 and then silently drop or kill the
+// connection without ever sending their SETTINGS frame. So after ALPN says
+// h2, we send our client preface and require the server's SETTINGS frame
+// (its connection preface, RFC 7540 Section 3.5) within a short window.
+//
+// NEVER call this on a client-handshake critical path: a slow, bot-mitigated
+// or otherwise unreachable origin stalls the dial up to the full timeout,
+// during which the client cannot even finish its TLS handshake with the MITM
+// and no traffic is captured (browser proxy checks fail with a timeout).
+func (p *Proxy) detectServerH2(cacheKey, strongHostLocalAddr, proxyStr string) bool {
+	if cacheKey == "" {
+		return false
+	}
+	basicOptions := []netx.DialXOption{
+		netx.DialX_WithTimeout(10 * time.Second),
+		netx.DialX_WithProxy(proxyStr),
+		netx.DialX_WithForceProxy(proxyStr != ""),
+		netx.DialX_WithEnableSystemProxyFromEnv(!p.disableSystemProxy),
+		netx.DialX_WithAppendTLSNextProto("h2"),
+		netx.DialX_WithTLS(true),
+		netx.DialX_WithDialer(p.dialer),
+	}
+	if strongHostLocalAddr != "" {
+		basicOptions = append(basicOptions, netx.DialX_WithStrongHostMode(strongHostLocalAddr))
+	}
+
+	netConn, _ := netx.DialX(cacheKey, basicOptions...)
+	if netConn == nil {
+		return false
+	}
+	defer netConn.Close()
+
+	negotiated := false
+	switch ret := netConn.(type) {
+	case *tls.Conn:
+		negotiated = ret.ConnectionState().NegotiatedProtocol == "h2"
+	case *gmtls.Conn:
+		negotiated = ret.ConnectionState().NegotiatedProtocol == "h2"
+	}
+	if !negotiated {
+		return false
+	}
+
+	// ALPN said h2; verify the server really speaks it by requiring its
+	// SETTINGS frame. Bounded so WAF tarpits cannot stall the probe.
+	_ = netConn.SetDeadline(time.Now().Add(3 * time.Second))
+	fr := http2.NewFramer(netConn, netConn)
+	if _, err := netConn.Write([]byte(http2.ClientPreface)); err != nil {
+		return false
+	}
+	if err := fr.WriteSettings(); err != nil {
+		return false
+	}
+	frame, err := fr.ReadFrame()
+	if err != nil {
+		return false
+	}
+	_, isSettings := frame.(*http2.SettingsFrame)
+	return isSettings
+}
+
+// detectServerH2Async runs detectServerH2 in the background (at most once per
+// origin) and caches the result, keeping origin detection off the request
+// path. Until the probe lands, requests to the origin are served over
+// HTTP/1.1 — the same downgrade Burp performs, which always works.
+func (p *Proxy) detectServerH2Async(cacheKey, strongHostLocalAddr string) {
+	if !p.http2 || cacheKey == "" {
+		return
+	}
+	if _, ok := p.h2Cache.Load(cacheKey); ok {
+		return
+	}
+	if _, loaded := p.h2ProbeInflight.LoadOrStore(cacheKey, struct{}{}); loaded {
+		return
+	}
+	// capture downstream proxy settings synchronously at fire time
+	var proxyStr string
+	if p.proxyURL != nil {
+		proxyStr = p.proxyURL.String()
+	}
+	go func() {
+		defer p.h2ProbeInflight.Delete(cacheKey)
+		serverUseH2 := p.detectServerH2(cacheKey, strongHostLocalAddr, proxyStr)
+		log.Infof("async h2 detection for %v: %v", cacheKey, serverUseH2)
+		p.h2Cache.Store(cacheKey, serverUseH2)
+	}()
+}
+
+// offerH2ToClient decides whether the MITM advertises h2 in ALPN to the
+// client during the TLS handshake. It never blocks on the origin: when the
+// origin's capability is unknown, h2 is offered (the proxy translates to
+// HTTP/1.1 upstream when the origin does not support h2) and the origin
+// capability is probed in the background. Origins already known to be
+// h1-only keep HTTP/1.1.
+func (p *Proxy) offerH2ToClient(cacheKey, strongHostLocalAddr string) bool {
+	if !p.http2 {
+		return false
+	}
+	if cacheKey == "" {
+		return true
+	}
+	if cached, ok := p.h2Cache.Load(cacheKey); ok {
+		return cached.(bool)
+	}
+	p.detectServerH2Async(cacheKey, strongHostLocalAddr)
+	return true
+}

--- a/common/minimartian/mitmloop_h2probe_test.go
+++ b/common/minimartian/mitmloop_h2probe_test.go
@@ -1,0 +1,114 @@
+package minimartian
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+)
+
+// probeFriendlyH2Origin accepts h2 over ALPN and sends its SETTINGS frame, so
+// an ALPN+SETTINGS probe concludes the origin speaks h2. It never answers an
+// actual request — like a fingerprinting WAF that lets connections in and only
+// rejects non-browser clients once they send a real request.
+func probeFriendlyH2Origin(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "h2-probe-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2", "http/1.1"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { lis.Close() })
+
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				tc := conn.(*tls.Conn)
+				if err := tc.Handshake(); err != nil {
+					return
+				}
+				// Delay the server preface so the probe reliably finishes
+				// *after* the real request has recorded its verdict, which is
+				// the ordering that exposes the overwrite.
+				time.Sleep(300 * time.Millisecond)
+				fr := http2.NewFramer(conn, conn)
+				_ = fr.WriteSettings()
+				for {
+					if _, err := fr.ReadFrame(); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return lis.Addr().String()
+}
+
+// TestH2ProbeMustNotOverwriteRealRequestVerdict pins the priority between the
+// two writers of h2Cache.
+//
+// The background probe only checks ALPN + SETTINGS, so it reports "h2 works"
+// for origins that accept h2 connections and then stall real requests. An
+// actual proxied request is the authoritative signal: once it has learned the
+// origin's h2 path is unusable, a probe finishing later must not resurrect it,
+// or every subsequent request retries the dead path and stalls.
+func TestH2ProbeMustNotOverwriteRealRequestVerdict(t *testing.T) {
+	origin := probeFriendlyH2Origin(t)
+
+	p := NewProxy()
+	p.http2 = true
+
+	// Real traffic arrives for an origin we know nothing about yet, so the
+	// background probe starts. This is the only point at which it starts.
+	p.detectServerH2Async(origin, "")
+
+	// While that probe is still in flight, the actual proxied request finishes
+	// and concludes the origin's h2 path is unusable — a fingerprinting WAF
+	// rejects a real h2 request far faster than the probe's own handshake.
+	p.h2Cache.Store(origin, false)
+
+	deadline := time.After(20 * time.Second)
+	for {
+		if _, inflight := p.h2ProbeInflight.Load(origin); !inflight {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("probe did not finish in time")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	cached, ok := p.h2Cache.Load(origin)
+	require.True(t, ok, "cache entry disappeared")
+	require.Falsef(t, cached.(bool),
+		"the probe overwrote the downgrade verdict for %v: later requests will retry the dead h2 path and stall", origin)
+}

--- a/common/minimartian/proxy.go
+++ b/common/minimartian/proxy.go
@@ -98,6 +98,8 @@ type Proxy struct {
 	maxReadWaitTime  time.Duration
 
 	h2Cache sync.Map
+	// h2ProbeInflight deduplicates background origin h2 probes (per host:port)
+	h2ProbeInflight sync.Map
 
 	forceDisableKeepAlive bool
 	disableSystemProxy    bool

--- a/common/utils/lowhttp/conn_pool.go
+++ b/common/utils/lowhttp/conn_pool.go
@@ -678,18 +678,30 @@ func newPersistConn(requestCtx context.Context, key *connectKey, pool *LowHttpCo
 		pc.h2Conn()
 		if err = pc.alt.preface(); err == nil {
 			go pc.alt.readLoop()
+			// Watch for a server that negotiates h2 and then never sends its
+			// SETTINGS frame; see watchServerPreface for why this must not
+			// gate setup. Requests on such a conn fail fast and the caller
+			// falls back to HTTP/1.1.
+			pc.alt.watchServerPreface()
 			// H2 conn is registered in h2ConnMap by getOrCreateH2Conn after this call returns.
 			return pc, nil
-		} else { // preface fail downgrade
-			key.scheme = H1
-			newH1Conn, err := dialXWithContext(requestCtx, key.addr, append(opt, netx.DialX_WithTLSNextProto(H1))...)
-			if err != nil {
-				return nil, err
-			}
-			pc.alt = nil
-			pc.conn = newH1Conn
-			return pc, nil
 		}
+		// client preface failure: tear down the broken h2 conn and
+		// downgrade to HTTP/1.1 (downgraded conns are not reused for h2)
+		key.scheme = H1
+		if pc.alt != nil {
+			pc.alt.setClose()
+		}
+		pc.alt = nil
+		if pc.conn != nil {
+			pc.conn.Close()
+		}
+		newH1Conn, err := dialXWithContext(requestCtx, key.addr, append(opt, netx.DialX_WithTLSNextProto(H1))...)
+		if err != nil {
+			return nil, err
+		}
+		pc.conn = newH1Conn
+		return pc, nil
 	}
 
 	pc.br = bufio.NewReader(pc)
@@ -723,6 +735,7 @@ func (pc *persistConn) h2Conn() {
 		clientPrefaceOk:   utils.NewAtomicBool(),
 		closeCh:           make(chan struct{}),
 		readLoopExited:    make(chan struct{}),
+		serverPrefaceCh:   make(chan struct{}, 1),
 		// pc back-reference: used by setClose() to evict this connection from
 		// the pool's h2ConnMap when it transitions to closed state.
 		pc: pc,

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -861,7 +861,8 @@ RECONNECT:
 		pc := conn.(*persistConn)
 		if pc.cacheKey.scheme != H2 { // http2 downgrade to http1.1
 			enableHttp2 = false
-			withConnPool = false // downgrade can not with conn pool
+			response.Http2 = false // reflect the actual wire protocol so callers can detect the downgrade
+			withConnPool = false   // downgrade can not with conn pool
 			method, uri, _ := GetHTTPPacketFirstLine(requestPacket)
 			requestPacket = ReplaceHTTPPacketFirstLine(requestPacket, strings.Join([]string{method, uri, "HTTP/1.1"}, " "))
 		} else {

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -33,6 +33,12 @@ var (
 	systemEtcOnce   = sync.Once{}
 )
 
+// maxReconnectTimes caps how many times a single request may rebuild its
+// connection. Stale pooled connections need a retry or two; an origin that
+// tears down every connection on sight needs to surface as an error instead,
+// so the caller can fall back to another protocol.
+const maxReconnectTimes = 3
+
 func GetSystemHostByName(domain string) (string, bool) {
 	systemEtcOnce.Do(func() {
 		_systemEtcHosts = GetSystemEtcHosts()
@@ -785,6 +791,33 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 	if haveNativeHTTPRequestInstance {
 		httpctx.SetRequestHTTPS(reqIns, https)
 	}
+
+	// canReconnect bounds the RECONNECT loop below, but only for the failure
+	// mode that can actually spin forever.
+	//
+	// A pooled connection dying between requests — the server closed an idle
+	// keep-alive connection, or a read failed mid-flight — says nothing about
+	// whether the origin is healthy, and a busy pool can hand out several stale
+	// connections in a row. Those retries stay unbounded, as they have always
+	// been; capping them makes ordinary traffic fail under load.
+	//
+	// What must be bounded is an origin that tears down the connection the
+	// moment it receives a request — h2 fingerprinting defenses do exactly
+	// this. Unbounded, the caller never receives an error, so it never gets to
+	// fall back to HTTP/1.1 and the request simply hangs.
+	reconnectTimes := 0
+	canReconnect := func(err error) bool {
+		var poolReadErr connPoolReadFromServerError
+		if errors.Is(err, errServerClosedIdle) || errors.As(err, &poolReadErr) {
+			return true
+		}
+		if reconnectTimes >= maxReconnectTimes {
+			log.Warnf("lowhttp: giving up after %d reconnects to %v: %v", reconnectTimes, cacheKey.addr, err)
+			return false
+		}
+		reconnectTimes++
+		return true
+	}
 RECONNECT:
 	if enableHttp3 {
 		http3Conn, err := getHTTP3Conn(ctx, originAddr, dialopts...)
@@ -874,11 +907,15 @@ RECONNECT:
 			h2Stream, err := h2Conn.newStream(reqIns, requestPacket, option)
 			if err != nil {
 				if err == CreateStreamAfterGoAwayErr {
+					// Close first, then decide: the connection is unusable
+					// either way, and running out of reconnects must not leave
+					// it in the pool.
 					pc.closeConn(err) // close old connection to avoid goroutine leak
-					goto RECONNECT
-				} else {
-					return nil, err
+					if canReconnect(err) {
+						goto RECONNECT
+					}
 				}
+				return nil, err
 			}
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				h2Stream.abort()
@@ -893,14 +930,19 @@ RECONNECT:
 				}
 				if err == CreateStreamAfterGoAwayErr {
 					pc.closeConn(err)
-					goto RECONNECT
+					if canReconnect(err) {
+						goto RECONNECT
+					}
+					return nil, err
 				}
 				if h2Stream.ID <= 1 { // first stream or ID not yet assigned
 					return nil, err
-				} else {
-					pc.closeConn(err) // close old connection to avoid goroutine leak
+				}
+				pc.closeConn(err) // close old connection to avoid goroutine leak
+				if canReconnect(err) {
 					goto RECONNECT
 				}
+				return nil, err
 			}
 			serverStart := time.Now()
 			h2Stream.SetReadFirstFrameCallback(func() {
@@ -915,10 +957,11 @@ RECONNECT:
 				}
 				if conn.(*persistConn).shouldRetryRequest(err) {
 					pc.closeConn(err) // close old connection to avoid goroutine leak
-					goto RECONNECT
-				} else {
-					return nil, err
+					if canReconnect(err) {
+						goto RECONNECT
+					}
 				}
+				return nil, err
 			}
 			httpctx.SetBareResponseBytes(reqIns, responsePacket)
 			response.RawPacket = responsePacket
@@ -964,7 +1007,9 @@ RECONNECT:
 			if re.err != nil && len(rawBytes) == 0 { // get some bytes but get error too
 				if pc.shouldRetryRequest(re.err) {
 					pc.closeConn(re.err) // close old connection to avoid goroutine leak
-					goto RECONNECT
+					if canReconnect(re.err) {
+						goto RECONNECT
+					}
 				}
 				return nil, re.err
 			}
@@ -990,7 +1035,7 @@ RECONNECT:
 			if pc.closed == nil {
 				return nil, utils.Error("BUG: closeCh but closed is nil")
 			}
-			if pc.shouldRetryRequest(pc.closed) {
+			if pc.shouldRetryRequest(pc.closed) && canReconnect(pc.closed) {
 				goto RECONNECT
 			}
 			return nil, pc.closed

--- a/common/utils/lowhttp/http2_client.go
+++ b/common/utils/lowhttp/http2_client.go
@@ -25,6 +25,20 @@ import (
 
 var errH2ConnClosed = utils.Error("http2 client conn closed")
 
+// errH2ServerPrefaceTimeout marks a connection torn down because the server
+// never sent its SETTINGS frame. Unlike errH2ConnClosed it must NOT be
+// retried: reconnecting only rebuilds the same dead h2 conn against the same
+// origin. Callers should fall back to HTTP/1.1 instead.
+var errH2ServerPrefaceTimeout = utils.Error("http2 server preface timeout")
+
+// h2ServerPrefaceTimeout bounds how long an h2 connection may go without the
+// server's SETTINGS frame (its connection preface, RFC 7540 Section 3.5). A
+// healthy h2 server sends it immediately upon connection establishment, so this
+// only bites endpoints that negotiate h2 in ALPN but then stall (tarpit) or
+// kill the connection (fingerprinting WAF). On expiry the connection is closed
+// and the request falls back to HTTP/1.1.
+const h2ServerPrefaceTimeout = 3 * time.Second
+
 type http2ClientConn struct {
 	conn net.Conn
 	ctx  context.Context
@@ -65,6 +79,22 @@ type http2ClientConn struct {
 	clientPrefaceOk *utils.AtomicBool
 	closeCh         chan struct{}
 	closeOnce       sync.Once
+
+	// serverPrefaceCh is signalled when the server's first SETTINGS frame
+	// (its connection preface, RFC 7540 Section 3.5) arrives. Used to detect
+	// endpoints that negotiate h2 in ALPN but then never speak h2 (silent
+	// tarpit) or kill the connection (fingerprinting WAF): watchServerPreface
+	// closes such a connection and the request falls back to HTTP/1.1.
+	serverPrefaceCh chan struct{}
+
+	// serverPrefaceTimedOut records that watchServerPreface, not a peer or
+	// transport event, closed this connection. It turns the resulting stream
+	// failure into a non-retryable error, so the caller downgrades to
+	// HTTP/1.1 instead of rebuilding the same dead h2 conn.
+	//
+	// Plain int32 rather than *utils.AtomicBool: this struct is also built as
+	// a literal outside the pool, and a zero value must be safe to read there.
+	serverPrefaceTimedOut int32
 
 	// readLoopRunning is 1 while the readLoop goroutine is active, 0 after it exits.
 	// Accessed atomically; used by the debug printer to show goroutine liveness.
@@ -343,6 +373,30 @@ func (h2Conn *http2ClientConn) setClose() {
 
 func (h2Conn *http2ClientConn) setPreface() {
 	h2Conn.clientPrefaceOk.Set()
+}
+
+// watchServerPreface tears the connection down when the server never sends its
+// SETTINGS frame (its connection preface, RFC 7540 Section 3.5). Endpoints that
+// negotiate h2 in ALPN and then go silent — fingerprinting WAF tarpits — would
+// otherwise hold requests until the caller's full timeout.
+//
+// The check deliberately runs in the background instead of gating connection
+// setup: RFC 7540 Section 3.5 lets a client send requests immediately after its
+// own preface, and middleboxes exist that withhold the server preface until the
+// client's HEADERS arrive. Blocking setup on it would deadlock against those.
+// Closing the conn makes in-flight requests fail fast, and the caller falls back
+// to HTTP/1.1.
+func (h2Conn *http2ClientConn) watchServerPreface() {
+	go func() {
+		select {
+		case <-h2Conn.serverPrefaceCh:
+		case <-h2Conn.closeCh:
+		case <-time.After(h2ServerPrefaceTimeout):
+			atomic.StoreInt32(&h2Conn.serverPrefaceTimedOut, 1)
+			h2Conn.setCloseReason("server preface timeout")
+			h2Conn.setClose()
+		}
+	}()
 }
 
 var CreateStreamAfterGoAwayErr = utils.Errorf("h2 conn can not create new stream, because read go away flag")
@@ -734,7 +788,14 @@ func (cs *http2ClientStream) waitResponse(ctx context.Context, timeout time.Dura
 		cs.resetStream(http2.ErrCodeCancel)
 	case <-cs.readEndStreamSignal:
 	case <-cs.h2Conn.closeCh:
-		err = utils.Wrapf(errH2ConnClosed, "h2 stream-id %v wait response conn closed : %s", cs.ID, flow)
+		if atomic.LoadInt32(&cs.h2Conn.serverPrefaceTimedOut) == 1 {
+			// Not a transport hiccup: this origin negotiated h2 and then never
+			// spoke it. Retrying rebuilds the same dead conn, so surface a
+			// non-retryable error and let the caller fall back to HTTP/1.1.
+			err = utils.Wrapf(errH2ServerPrefaceTimeout, "h2 stream-id %v never saw the server preface : %s", cs.ID, flow)
+		} else {
+			err = utils.Wrapf(errH2ConnClosed, "h2 stream-id %v wait response conn closed : %s", cs.ID, flow)
+		}
 	}
 
 	cs.releaseSlot()
@@ -948,6 +1009,13 @@ func (rl *http2ClientConnReadLoop) processData(f *http2.DataFrame) {
 func (rl *http2ClientConnReadLoop) processSettings(f *http2.SettingsFrame) {
 	if f.IsAck() {
 		return
+	}
+
+	// The server's first SETTINGS frame is its connection preface: signal
+	// conn setup that this h2 connection is actually alive.
+	select {
+	case rl.h2Conn.serverPrefaceCh <- struct{}{}:
+	default:
 	}
 
 	f.ForeachSetting(func(setting http2.Setting) error {

--- a/common/utils/lowhttp/http2_serve.go
+++ b/common/utils/lowhttp/http2_serve.go
@@ -87,6 +87,10 @@ func (w *h2RequestState) emitRequestHeader(req *http.Request, pairs []*ypb.KVPai
 	buf.WriteString(req.Method)
 	buf.WriteByte(' ')
 	buf.WriteString(req.RequestURI)
+	// Keep the "HTTP/2" marker here: the parsed request carries it for display
+	// fidelity (the UI shows the client-facing protocol). The upstream wire
+	// protocol is NOT decided by this marker — minimartian.execLowhttp picks
+	// it from the origin h2 cache and rewrites the wire copy when using h1.
 	buf.WriteString(" HTTP/2\r\n")
 	buf.WriteString("Host: ")
 	buf.WriteString(req.Host)

--- a/common/utils/lowhttp/http2_server_config.go
+++ b/common/utils/lowhttp/http2_server_config.go
@@ -49,6 +49,27 @@ func (c *http2ConnectionConfig) removeStreamWindow(streamID uint32) {
 	c.streamWindows.Delete(streamID)
 }
 
+// h2IllegalResponseHeaderFields are HTTP/1.x connection-specific header
+// fields that must never be forwarded into an HTTP/2 response (RFC 7540
+// Section 8.1.2.2). Responses translated from an HTTP/1.x upstream (the
+// client negotiated h2 while the origin speaks h1) routinely carry these;
+// strict h2 clients (browsers, x/net) reset the stream as malformed.
+//
+// content-length is also dropped: h2 DATA frames are self-delimiting, and a
+// stale length from the h1 representation (dechunking, decompression, or a
+// MITM body rewrite) triggers CONTENT_LENGTH_MISMATCH on strict clients.
+var h2IllegalResponseHeaderFields = map[string]struct{}{
+	"connection":          {},
+	"keep-alive":          {},
+	"proxy-authenticate":  {},
+	"proxy-authorization": {},
+	"te":                  {},
+	"trailer":             {},
+	"transfer-encoding":   {},
+	"upgrade":             {},
+	"content-length":      {},
+}
+
 func (c *http2ConnectionConfig) writer(wrapper *h2RequestState, header []byte, body io.ReadCloser) error {
 	if c.frame == nil {
 		return utils.Error("h2 server frame config is nil")
@@ -59,49 +80,56 @@ func (c *http2ConnectionConfig) writer(wrapper *h2RequestState, header []byte, b
 	buf := c.hencBuf
 	frWriteMutex := c.frWriteMutex
 
-	c.hencMutex.Lock()
-	buf.Reset()
-	SplitHTTPPacket(header, nil, func(proto string, code int, codeMsg string) error {
-		henc.WriteField(hpack.HeaderField{Name: ":status", Value: fmt.Sprint(code)})
-		return nil
-	}, func(line string) string {
-		k, v := SplitHTTPHeader(line)
-		henc.WriteField(hpack.HeaderField{Name: strings.ToLower(k), Value: v})
-		return line
-	})
-	var hpackHeaderBytes = buf.Bytes()
-	buf.Reset()
-
-	//defer func() {
-	//	log.Infof("handle h2 stream(%v) done", streamId)
-	//}()
-	//log.Infof("start to write h2 response header stream-id: %v", streamId)
-	ret := funk.Chunk(hpackHeaderBytes, defaultMaxFrameSize).([][]byte)
-	first := true
-	for index, item := range ret {
-		if first {
-			first = false
-			frWriteMutex.Lock()
-			err := frame.WriteHeaders(http2.HeadersFrameParam{
-				StreamID:      uint32(streamId),
-				BlockFragment: item,
-				EndStream:     false,
-				EndHeaders:    index == len(ret)-1,
-			})
-			frWriteMutex.Unlock()
-			if err != nil {
-				return utils.Wrapf(err, "h2framer write header(%v) for stream:%v failed", len(hpackHeaderBytes), streamId)
+	// Encode and write the response headers while holding hencMutex, so the
+	// shared hpack encoder's dynamic table stays consistent with the wire
+	// order across concurrent streams.
+	headerErr := func() error {
+		c.hencMutex.Lock()
+		defer c.hencMutex.Unlock()
+		buf.Reset()
+		SplitHTTPPacket(header, nil, func(proto string, code int, codeMsg string) error {
+			henc.WriteField(hpack.HeaderField{Name: ":status", Value: fmt.Sprint(code)})
+			return nil
+		}, func(line string) string {
+			k, v := SplitHTTPHeader(line)
+			lk := strings.ToLower(k)
+			if _, illegal := h2IllegalResponseHeaderFields[lk]; illegal {
+				return line // do not encode connection-specific h1 headers into h2
 			}
-		} else {
-			frWriteMutex.Lock()
-			err := frame.WriteContinuation(uint32(streamId), index == len(ret)-1, item)
-			frWriteMutex.Unlock()
-			if err != nil {
-				return utils.Wrapf(err, "h2framer write header(%v)-continuation for stream:%v failed", len(hpackHeaderBytes), streamId)
+			henc.WriteField(hpack.HeaderField{Name: lk, Value: v})
+			return line
+		})
+		hpackHeaderBytes := append([]byte(nil), buf.Bytes()...)
+		buf.Reset()
+
+		ret := funk.Chunk(hpackHeaderBytes, defaultMaxFrameSize).([][]byte)
+		for index, item := range ret {
+			if index == 0 {
+				frWriteMutex.Lock()
+				err := frame.WriteHeaders(http2.HeadersFrameParam{
+					StreamID:      uint32(streamId),
+					BlockFragment: item,
+					EndStream:     false,
+					EndHeaders:    index == len(ret)-1,
+				})
+				frWriteMutex.Unlock()
+				if err != nil {
+					return utils.Wrapf(err, "h2framer write header(%v) for stream:%v failed", len(hpackHeaderBytes), streamId)
+				}
+			} else {
+				frWriteMutex.Lock()
+				err := frame.WriteContinuation(uint32(streamId), index == len(ret)-1, item)
+				frWriteMutex.Unlock()
+				if err != nil {
+					return utils.Wrapf(err, "h2framer write header(%v)-continuation for stream:%v failed", len(hpackHeaderBytes), streamId)
+				}
 			}
 		}
+		return nil
+	}()
+	if headerErr != nil {
+		return headerErr
 	}
-	c.hencMutex.Unlock()
 
 	results, err := io.ReadAll(body)
 	streamWindow := c.getStreamWindow(uint32(streamId))


### PR DESCRIPTION
## 问题现象

MITM 开启「HTTP/2.0 支持」后，部分请求无法被抓取：客户端长时间卡住后超时失败；关闭 HTTP/2、或使用 Burp（其默认对上游降级为 HTTP/1.1）则一切正常。

典型触发场景：被代理的客户端访问带指纹防护（Bot Mitigation）的 API 端点时必现。

> 本 PR 已根据首次提交后的 CI 结果与真实环境回归做了修订，方案有调整，详见「修订说明」。

## 根因分析

### 1. 源站 h2 探测阻塞客户端握手关键路径（主因）

`mitmloop.go` 中，开启 h2 后 MITM 在与客户端完成 TLS 握手**之前**，会同步拨号探测源站的 h2 支持（超时 10s）。源站响应缓慢或被反爬策略拖住时，客户端连握手都无法完成，表现为"一个包都抓不到、卡半天后失败"。

### 2. 上游 h2 连接被对端持续掐断时会无限重连

`lowhttp/exec.go` 的 `RECONNECT` 循环没有任何次数上限。指纹防护端点的典型行为是：正常完成 TLS/ALPN 协商、正常发送 SETTINGS，但一收到真实请求（HEADERS）就断开连接。这类断连被 `shouldRetryRequest` 判定为可重试，于是无限重建连接、**永远不向调用方返回 error**——上层的 HTTP/1.1 降级逻辑因此永远得不到执行，请求就此悬挂。

抓到的源站侧帧序列：

```
SETTINGS → WINDOW_UPDATE → HEADERS(stream=1)   ← 建连、发请求
（源站断开）
SETTINGS → WINDOW_UPDATE → HEADERS(stream=1)   ← 立刻重连、重发
... 无限重复
```

### 3. 后台 h2 探测的结论会覆盖真实流量的结论

探测只验证 ALPN 与 SETTINGS，而上述端点在这两步上完全正常，必然被判为"支持 h2"。探测完成时用 `Store` 写 `h2Cache`，会把真实请求失败后写入的降级结论（`false`）覆盖回 `true`，导致后续每个请求都重新去撞同一条死路。

探测能证明的只是"握手成功"，真实请求才能证明"h2 真的能承载流量"，两者的结论优先级不应相等。

### 4. h1 上游响应翻译成 h2 时泄漏连接级头

`Connection` / `Transfer-Encoding` / `Content-Length` 等头会被编码进 h2 响应（违反 RFC 7540 §8.1.2.2），严格的 h2 客户端（浏览器、golang.org/x/net/http2）会以 PROTOCOL_ERROR RST 流，导致 broken pipe、请求失败。

另外顺带修复一个潜在死锁：h2 响应写头失败时 `hencMutex` 未解锁，后续响应会永久阻塞。

## 修复方案

- **探测异步化**：源站 h2 探测移到后台、按源站去重（新增 `mitmloop_h2probe.go`）；客户端 ALPN 本地即时决策，握手不再被源站阻塞
- **探测结论让位于真实流量**：探测写缓存改用 `LoadOrStore`，不覆盖真实请求已得出的降级结论
- **重连设上限**：`maxReconnectTimes = 3`，且**只约束会无限自旋的那一类失败**。池化连接在两次请求之间失效（服务端关闭空闲 keep-alive、读中途出错）属于连接池的日常现象，繁忙的池可能连续交出多个陈旧连接，这类重试保持原有的不设限行为——对其设限会让正常流量在高负载下失败。受约束的是"一收到请求就拆连接"的源站（h2 指纹防护），它们不设限就永远不会冒泡为错误。实现上先 `closeConn` 再判断配额，避免配额耗尽时坏连接留在池中
- **服务端 preface 改为后台看门狗**：h2 连接建立后不阻塞等待服务端 SETTINGS，而是后台限时观察；超时则关闭连接，并将该失败标记为**不可重试**，避免重建同一条死连接
- **乐观 h2 + 自动降级**：上游协议由源站能力缓存驱动；未知源站乐观尝试 h2，任何失败路径都会自动回退 HTTP/1.1 并对该源站会话级负缓存——与 Burp 的降级行为一致
- **h2 响应头净化**：编码前剥离连接级头与 content-length（h2 DATA 帧自定界；h1 侧长度头在解压/改写后可能过期，会引发 CONTENT_LENGTH_MISMATCH）
- **显示保真**：客户端经 h2 连入时，抓包/历史中的请求仍显示 HTTP/2（上游线网协议独立决策）

## 修订说明（相对首次提交）

首版实现让 h2 建连**阻塞等待**服务端 SETTINGS 帧，这个方案是错的，已推翻：

RFC 7540 §3.5 允许客户端发完自身 preface 后立即发送请求，而现实中存在中间设备会扣住服务端 preface 直到客户端发出 HEADERS——阻塞等待会与之形成互等死锁。CI 的 `TestPoCH2Preface` 正是这一场景，首版因此失败（该用例卡满超时后降级，耗时 13s）。

现改为后台看门狗：不阻塞建连，超时才关闭连接并以不可重试错误上报。`TestPoCH2Preface` 恢复到与主线一致的耗时（<1s）。

同时补上了上面根因 2 与 3 两个问题——它们在首版中被"阻塞等待"顺带掩盖，方案改对后才暴露出来。

此外，重连上限最初实现为一个笼统的计数器，会连带限制"池中陈旧连接"的重试。这类重试在繁忙连接池下会连续发生数次，属正常现象，设限会让高负载下的正常请求失败（表现为 CI 中若干 Fuzzer 用例的 `rsp.Ok` 断言失败）。现已收窄为只约束 h2 侧"连接一收到请求就被拆"的失败：`errServerClosedIdle` 与 `connPoolReadFromServerError` 不消耗配额，HTTP/1 路径的重连行为与改动前完全一致（这两类错误仅由 `persistConn.readLoop` 产生，h2 有独立的 readLoop，其失败仍受配额约束）。

## 测试

新增/更新的回归测试：

| 测试 | 覆盖点 |
| --- | --- |
| `TestMITMH2_OriginProbeDoesNotStallClientHandshake` | 慢源站不再阻塞客户端握手 |
| `TestMITMH2_H1UpstreamResponseSanitized` | h1 上游响应净化后被严格 h2 客户端接受 |
| `TestMITMH2_UpstreamFallbackToH1` | h2 被掐线时自动降级 h1 且负缓存 |
| `TestMITMH2_UpstreamTarpitFallsBackToH1` | h2 黑洞（不发 SETTINGS）自动降级 h1 |
| `TestMITMH2_FirstRequestUsesH2WhenOriginSupportsIt` | 健康 h2 源站首包即 h2 |
| `TestMITMH2_DisplayKeepsClientFacingProtocol` | 抓包显示保真 |
| `TestMITMH2_FingerprintWAFDoesNotStallLaterRequests` | 指纹防护源站：首个请求有界降级，后续请求不再重试 h2 |
| `TestMITMH2_SequentialRequestsOverSameConn` | 单条客户端 h2 连接上的连续请求 |
| `TestMITMH2_ConcurrentStreamsOverSameConn` | 单条客户端 h2 连接上的并发 stream |
| `TestMITMH2_H1ClientRepeatedRequestsToSameOrigin` | HTTP/1.1 客户端复用 h2 上游（curl / 扫描器路径） |
| `TestH2ProbeMustNotOverwriteRealRequestVerdict` | 探测结论不得覆盖真实流量结论 |

另有两个依赖外网的诊断用例（`TestMITMH2_RealOriginSequential`、`TestMITMH2_RealCurlRepeated`）默认 `t.Skip`，仅在排查现场问题时经环境变量启用，不参与 CI。

验证命令：

```bash
go test ./common/crep/ -run "TestMITMH2" -count=1
go test ./common/utils/lowhttp/ -run "H2|Http2|HTTP2|PoC|ConnPool|Retry" -count=1
go test ./common/minimartian/ -count=1
```

指纹防护源站场景的实测效果：

| | 修复前 | 修复后 |
| --- | --- | --- |
| 首个请求 | 无限挂起 | 1.21s（完成降级）|
| 后续请求 | 无限挂起 | ~2ms |

真实环境（桌面客户端经代理做 HTTP/1.1 代理检测 + 指纹防护端点）已回归验证：此前必现的挂死消失。

## 兼容性说明

- 开启 h2 时的行为变化：未知源站的首个请求乐观尝试 h2（原先为同步探测源站后才决定）；探测不再阻塞握手
- 单个请求的连接重建次数上限为 3；此前无上限
- 关闭 h2 时的行为完全不变
- 仅影响 MITM 代理路径（minimartian / crep）与 lowhttp 连接建立/重连逻辑
