### PR TITLE
fix(ssa): guard debug setup panics and foreach nil iterable

### DIFF
--- a/common/yak/php/php2ssa/visit_while_n_for.go
+++ b/common/yak/php/php2ssa/visit_while_n_for.go
@@ -181,6 +181,12 @@ func (y *builder) VisitForeachStatement(raw phpparser.IForeachStatementContext) 
 	loop.SetCondition(func() ssa.Value {
 		var lefts []*ssa.Variable
 		var valueLeft *ssa.Variable
+		// A nil iterable (e.g. an expression that failed to compile or an
+		// undefined variable) must terminate the loop instead of panicking in
+		// NewNext. See ssa.NewNext nil guard.
+		if utils.IsNil(value) {
+			return y.EmitConstInst(false)
+		}
 		if i.ArrayDestructuring() != nil {
 			lefts = y.VisitArrayDestructuring(i.ArrayDestructuring())
 		} else if i.Assignable() != nil {

--- a/common/yak/ssa/InstructionEmit.go
+++ b/common/yak/ssa/InstructionEmit.go
@@ -528,6 +528,9 @@ func (f *FunctionBuilder) EmitNextOnly(iter Value, isIn bool) *Next {
 		return nil
 	}
 	n := NewNext(iter, isIn)
+	if n == nil {
+		return nil
+	}
 	f.emit(n)
 	return n
 }
@@ -537,6 +540,9 @@ func (f *FunctionBuilder) EmitNext(iter Value, isIn bool) (key, field, ok Value)
 		return nil, nil, nil
 	}
 	n := f.EmitNextOnly(iter, isIn)
+	if n == nil {
+		return nil, nil, nil
+	}
 	// n iter-type: map[T]U   n-type {key: T, field: U, ok: bool}
 	key = f.ReadMemberCallValue(n, f.EmitConstInstPlaceholder(NextKey.String()))
 	field = f.ReadMemberCallValue(n, f.EmitConstInstPlaceholder(NextField.String()))

--- a/common/yak/ssa/instruction.go
+++ b/common/yak/ssa/instruction.go
@@ -142,6 +142,9 @@ func NewAssert(cond, msgValue Value, msg string) *Assert {
 }
 
 func NewNext(iter Value, isIn bool) *Next {
+	if utils.IsNil(iter) {
+		return nil
+	}
 	n := &Next{
 		anValue: NewValue(),
 		Iter:    iter.GetId(),

--- a/common/yak/ssa/next_nil_test.go
+++ b/common/yak/ssa/next_nil_test.go
@@ -1,0 +1,25 @@
+package ssa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+func TestNewNextNilIterReturnsNil(t *testing.T) {
+	require.Nil(t, NewNext(nil, false))
+}
+
+func TestEmitNextNilIterReturnsNilTriple(t *testing.T) {
+	cfg, err := ssaconfig.New(ssaconfig.ModeSSACompile)
+	require.NoError(t, err)
+	prog := NewProgram(cfg, ProgramCacheMemory, Application, nil, "", 1)
+	builder := prog.GetAndCreateFunctionBuilder("", string(MainFunctionName))
+
+	key, field, ok := builder.EmitNext(nil, false)
+	require.Nil(t, key)
+	require.Nil(t, field)
+	require.Nil(t, ok)
+}

--- a/common/yak/ssaapi/debug_output.go
+++ b/common/yak/ssaapi/debug_output.go
@@ -14,6 +14,10 @@ type DebugOutputCleanup func()
 // noopDebugCleanup is returned when debug is disabled or setup fails non-fatally.
 func noopDebugCleanup() {}
 
+// startDebugOutputImpl is an indirection over StartDebugOutput so tests can
+// simulate a panic during debug setup.
+var startDebugOutputImpl = StartDebugOutput
+
 // SetupDebugDir wires debug/pprof output when debugDir is non-empty.
 // Empty debugDir returns a no-op cleanup so callers can always:
 //
@@ -22,11 +26,17 @@ func noopDebugCleanup() {}
 //
 // Setup failures are logged and treated as non-fatal (no-op cleanup).
 // See StartDebugOutput for redirectSSADB semantics.
-func SetupDebugDir(debugDir string, redirectSSADB bool) DebugOutputCleanup {
+func SetupDebugDir(debugDir string, redirectSSADB bool) (cleanup DebugOutputCleanup) {
 	if debugDir == "" {
 		return noopDebugCleanup
 	}
-	cleanup, err := StartDebugOutput(debugDir, redirectSSADB)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("[debug] setup debug dir %s panicked: %v, continuing without debug", debugDir, r)
+			cleanup = noopDebugCleanup
+		}
+	}()
+	cleanup, err := startDebugOutputImpl(debugDir, redirectSSADB)
 	if err != nil {
 		log.Warnf("[debug] setup debug dir %s failed: %v, continuing without debug", debugDir, err)
 		return noopDebugCleanup

--- a/common/yak/ssaapi/debug_output_test.go
+++ b/common/yak/ssaapi/debug_output_test.go
@@ -32,3 +32,15 @@ func TestSetupDebugDirCreatesLogAndDirs(t *testing.T) {
 	_, err = os.Stat(filepath.Join(target, "cpu-pprof"))
 	require.NoError(t, err)
 }
+
+func TestSetupDebugDirPanicDoesNotEscape(t *testing.T) {
+	orig := startDebugOutputImpl
+	startDebugOutputImpl = func(string, bool) (DebugOutputCleanup, error) {
+		panic("boom: debug setup")
+	}
+	t.Cleanup(func() { startDebugOutputImpl = orig })
+
+	cleanup := SetupDebugDir(t.TempDir(), false)
+	require.NotNil(t, cleanup)
+	require.NotPanics(t, func() { cleanup() })
+}

--- a/common/yak/ssaapi/php_foreach_nil_test.go
+++ b/common/yak/ssaapi/php_foreach_nil_test.go
@@ -1,0 +1,23 @@
+package ssaapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+// TestForeachNilIterableDoesNotPanic guards the panic observed on grav's
+// tests/conformance/run.php: a foreach whose iterable expression compiled to
+// nil used to crash NewNext with nil pointer dereference.
+func TestForeachNilIterableDoesNotPanic(t *testing.T) {
+	src := `<?php
+foreach ($missing as $v) {
+    echo $v;
+}
+`
+	prog, err := Parse(src, WithLanguage(ssaconfig.PHP))
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+}

--- a/common/yak/ssaapi/pprof_collector.go
+++ b/common/yak/ssaapi/pprof_collector.go
@@ -110,6 +110,11 @@ func startPprofHTTPServer(addr string) {
 
 func (c *pprofCollector) collectLoop(ctx context.Context) {
 	defer c.wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("[pprof] collector loop panicked: %v", r)
+		}
+	}()
 
 	select {
 	case <-ctx.Done():
@@ -163,6 +168,11 @@ func (c *pprofCollector) collectSnapshot(tag string, syncCPU bool) {
 		c.wg.Add(1)
 		go func() {
 			defer c.wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf("[pprof] periodic CPU snapshot panicked: %v", r)
+				}
+			}()
 			c.fetchCPU(label, cpuDuration)
 		}()
 	}


### PR DESCRIPTION
## 变更内容

1. **fix(ssaapi): guard debug dir setup and pprof collectors against panics**：debug 目录初始化和 pprof 采集器加 panic 兜底，防止单个任务崩溃拖垮节点进程。
2. **fix(ssa): guard foreach nil iterable from panicking in NewNext**：修复 grav 项目 tests/conformance/run.php 触发的 PHP foreach nil 迭代值崩溃（NewNext 对 nil 调用 GetId 导致 nil pointer dereference）。NewNext/EmitNext 对 nil 返回安全值，PHP foreach 对 nil 迭代表达式直接终止循环；新增 ssa 单测和 PHP 编译回归测试。

说明：GetNativeCall 保持原有 nil + CriticalError 语义不变。
