### PR TITLE
fix(ai): replay all visible model thinking

### DIFF
--- a/common/ai/aid/aicommon/timeline_prompt_projection.go
+++ b/common/ai/aid/aicommon/timeline_prompt_projection.go
@@ -92,14 +92,13 @@ func cloneTextTimelineItemForPrompt(item *TimelineItem, textItem *TextTimelineIt
 }
 
 func projectTimelineItemsForPrompt(items []*TimelineItem) []*TimelineItem {
-	return projectTimelineItemsForPromptWithLatestModelReplay(items, 0)
+	return projectTimelineItemsForPromptWithModelReplay(items, false)
 }
 
-func projectTimelineItemsForPromptWithLatestModelReplay(items []*TimelineItem, latestReplayID int64) []*TimelineItem {
+func projectTimelineItemsForPromptWithModelReplay(items []*TimelineItem, includeModelReplay bool) []*TimelineItem {
 	projected := make([]*TimelineItem, 0, len(items))
 	for _, item := range items {
-		allowReplay := latestReplayID > 0 && item != nil && item.GetID() == latestReplayID
-		if promptItem := projectTimelineItemForPromptWithModelReplay(item, allowReplay); promptItem != nil {
+		if promptItem := projectTimelineItemForPromptWithModelReplay(item, includeModelReplay); promptItem != nil {
 			projected = append(projected, promptItem)
 		}
 	}
@@ -114,31 +113,15 @@ func projectTimelineRenderableBlocksForPrompt(blocks TimelineRenderableBlocks) T
 }
 
 // projectTimelineRenderableBlocksForPromptWithLatestModelReplay preserves the
-// existing bucket topology while allowing exactly the newest successful model
-// replay record into the prompt. Older model thinking remains UI-only.
+// existing bucket topology while allowing every successful model replay still
+// present in the visible frozen/open interval blocks into the prompt. Existing
+// compressed heads remain untouched, so reduced or evicted items are not
+// reconstructed here.
 func projectTimelineRenderableBlocksForPromptWithLatestModelReplay(blocks TimelineRenderableBlocks) TimelineRenderableBlocks {
 	return projectTimelineRenderableBlocksForPromptWithModelReplay(blocks, true)
 }
 
-func projectTimelineRenderableBlocksForPromptWithModelReplay(blocks TimelineRenderableBlocks, includeLatestReplay bool) TimelineRenderableBlocks {
-	var latestReplayID int64
-	if includeLatestReplay {
-		for _, block := range blocks {
-			interval, ok := block.(*TimelineIntervalBlock)
-			if !ok || interval == nil {
-				continue
-			}
-			for _, item := range interval.Items {
-				textItem, ok := timelineTextItem(item)
-				if !ok || strings.TrimSpace(textItem.PromptText) == "" || normalizeTimelinePromptCategory(extractTextEntryType(textItem.Text)) != "MODEL_THINKING" {
-					continue
-				}
-				if id := item.GetID(); id > latestReplayID {
-					latestReplayID = id
-				}
-			}
-		}
-	}
+func projectTimelineRenderableBlocksForPromptWithModelReplay(blocks TimelineRenderableBlocks, includeModelReplay bool) TimelineRenderableBlocks {
 	projected := make(TimelineRenderableBlocks, 0, len(blocks))
 	for _, block := range blocks {
 		switch typed := block.(type) {
@@ -147,7 +130,7 @@ func projectTimelineRenderableBlocksForPromptWithModelReplay(blocks TimelineRend
 				continue
 			}
 			copyBlock := *typed
-			copyBlock.Items = projectTimelineItemsForPromptWithLatestModelReplay(typed.Items, latestReplayID)
+			copyBlock.Items = projectTimelineItemsForPromptWithModelReplay(typed.Items, includeModelReplay)
 			projected = append(projected, &copyBlock)
 		default:
 			// Existing compressed heads are historical facts. Rewriting them here

--- a/common/ai/aid/aicommon/timeline_prompt_projection_test.go
+++ b/common/ai/aid/aicommon/timeline_prompt_projection_test.go
@@ -99,7 +99,7 @@ func TestTimelinePromptProjectionKeepsRealAndDropsOnlyRedundantErrorLines(t *tes
 	require.Nil(t, projectTimelineItemForPrompt(onlyRedundant))
 }
 
-func TestTimelinePromptProjectionIncludesOnlyLatestSuccessfulModelReplay(t *testing.T) {
+func TestTimelinePromptProjectionIncludesAllVisibleSuccessfulModelReplays(t *testing.T) {
 	base := time.Date(2026, 8, 13, 9, 0, 0, 0, time.UTC)
 	timeline := NewTimeline(nil, nil)
 	injectTimelineItem(timeline, 1, base, &TextTimelineItem{
@@ -108,12 +108,12 @@ func TestTimelinePromptProjectionIncludesOnlyLatestSuccessfulModelReplay(t *test
 		PromptText: "[model_thinking]:\n<|TIMELINE_MODEL_THINKING_n1|>\n{\"reasoning_content\":\"R1\",\"content\":\"A1\"}\n<|TIMELINE_MODEL_THINKING_END_n1|>",
 	})
 	injectTimelineItem(timeline, 2, base.Add(time.Second), &TextTimelineItem{ID: 2, Text: "[tool_observation]:\nOBSERVATION_ONE"})
-	injectTimelineItem(timeline, 3, base.Add(2*time.Second), &TextTimelineItem{
+	injectTimelineItem(timeline, 3, base.Add(4*time.Minute), &TextTimelineItem{
 		ID:         3,
 		Text:       "[model_thinking]:\nDISPLAY_REASON_TWO",
 		PromptText: "[model_thinking]:\n<|TIMELINE_MODEL_THINKING_n2|>\n{\"reasoning_content\":\"R2\",\"content\":\"A2\"}\n<|TIMELINE_MODEL_THINKING_END_n2|>",
 	})
-	injectTimelineItem(timeline, 4, base.Add(3*time.Second), &TextTimelineItem{ID: 4, Text: "[tool_observation]:\nOBSERVATION_TWO"})
+	injectTimelineItem(timeline, 4, base.Add(4*time.Minute+time.Second), &TextTimelineItem{ID: 4, Text: "[tool_observation]:\nOBSERVATION_TWO"})
 
 	raw := timeline.Dump()
 	require.Contains(t, raw, "DISPLAY_REASON_ONE")
@@ -124,18 +124,20 @@ func TestTimelinePromptProjectionIncludesOnlyLatestSuccessfulModelReplay(t *test
 	prompt := projectTimelineRenderableBlocksForPromptWithLatestModelReplay(blocks).RenderOpenOnly(TimelineDumpDefaultAITagName)
 	require.NotContains(t, prompt, "DISPLAY_REASON_ONE")
 	require.NotContains(t, prompt, "DISPLAY_REASON_TWO")
-	require.NotContains(t, prompt, "TIMELINE_MODEL_THINKING_n1")
+	require.Contains(t, projectTimelineRenderableBlocksForPromptWithLatestModelReplay(blocks).RenderFrozenOnly(TimelineDumpDefaultAITagName), "TIMELINE_MODEL_THINKING_n1")
 	require.Contains(t, prompt, "TIMELINE_MODEL_THINKING_n2")
-	require.Contains(t, prompt, "OBSERVATION_ONE")
 	require.Contains(t, prompt, "OBSERVATION_TWO")
 
 	// Generic prompt helpers continue to exclude every model replay marker;
-	// only the explicit main-ReAct renderer includes the newest one.
+	// only the explicit main-ReAct renderer includes the surviving records.
 	require.NotContains(t, timeline.DumpForPrompt(), "TIMELINE_MODEL_THINKING_n2")
 	generic := RenderTimelineFrozenOpen(timeline)
 	require.NotContains(t, generic.Frozen+generic.Open, "TIMELINE_MODEL_THINKING_n2")
 	mainReAct := RenderTimelineFrozenOpenWithLatestModelReplay(timeline)
+	require.Contains(t, mainReAct.Frozen, "TIMELINE_MODEL_THINKING_n1")
+	require.Contains(t, mainReAct.Frozen, "OBSERVATION_ONE")
 	require.Contains(t, mainReAct.Frozen+mainReAct.Open, "TIMELINE_MODEL_THINKING_n2")
+	require.Contains(t, mainReAct.Open, "TIMELINE_MODEL_THINKING_n2")
 }
 
 func TestTimelineDumpRecentForPromptKeepsNewestCompleteItemsWithinBudget(t *testing.T) {


### PR DESCRIPTION
## Summary

- replay every successful model-thinking record still visible in Timeline frozen/open intervals
- keep reduced or evicted Timeline items absent by leaving compressed heads unchanged
- preserve generic prompt helpers that intentionally exclude model replay

## Validation

- `go test ./common/ai/aid/aicommon -run 'TestTimelinePromptProjectionIncludesAllVisibleSuccessfulModelReplays|TestTimelineDumpRecentForPrompt' -count=1`\n- `go test ./common/ai/aid/aicache -run 'TestExpandReasoningReplayMessagesSupportsAdjacentRecords|TestExpandReasoningReplayMessagesStringOrdering|TestHijackHighStaticProducesStandardReasoningContent' -count=1`\n- full relevant package tests previously passed for `aicommon`, `aicache`, and `reactloops`\n- controlled long-chain `memfit-standard-thinking-free` A/B runs reduced mean completion tokens by 62.4% and mean output duration by 53.2%; replay records accumulated across rounds instead of remaining fixed at one