### PR TITLE
feat(rag): add Collection2DPoints to project collection embeddings to 2D

### DIFF
--- a/common/ai/rag/vectorstore/embedding2d.go
+++ b/common/ai/rag/vectorstore/embedding2d.go
@@ -1,0 +1,94 @@
+package vectorstore
+
+import (
+	"strings"
+
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/ai/embedding"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+// embedding2DContentPreviewLen 限制 ContentPreview 的最大字符数，避免大文档拖垮返回体
+const embedding2DContentPreviewLen = 100
+
+// Embedding2DPoint 表示集合内一个文档向量降维后的二维坐标点，
+// 携带文档标识、类型与内容预览，便于绘图侧做分组着色与悬停标注。
+type Embedding2DPoint struct {
+	// 文档 ID（集合内唯一）
+	DocumentID string `json:"documentID"`
+	// 文档类型（schema.RAGDocumentType）
+	Type string `json:"type"`
+	// PCA 降维后的横坐标
+	X float32 `json:"x"`
+	// PCA 降维后的纵坐标
+	Y float32 `json:"y"`
+	// 文档内容预览（换行折叠为空格并截断），可用作悬停提示
+	ContentPreview string `json:"contentPreview"`
+}
+
+// Collection2DPoints 读取指定集合的全部文档向量，通过 PCA 统一降维为二维点。
+//
+// 只读取数据库中已持久化的向量，不初始化 embedding 客户端（不访问远端/本地
+// embedding 服务），也不加载 HNSW 图，适合 embedding 分布可视化等离线分析场景。
+// 输出顺序与内部文档查询顺序一致，坐标由固定随机种子的 PCA 计算，可复现。
+func Collection2DPoints(db *gorm.DB, collectionName string) ([]*Embedding2DPoint, error) {
+	collection, err := yakit.QueryRAGCollectionByName(db, collectionName)
+	if err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return nil, utils.Errorf("rag collection %s not found", collectionName)
+		}
+		return nil, utils.Wrap(err, "query rag collection")
+	}
+	if collection == nil {
+		return nil, utils.Errorf("rag collection %s not found", collectionName)
+	}
+
+	var docs []schema.VectorStoreDocument
+	if err := db.Where("collection_id = ?", collection.ID).
+		Where("document_id <> ?", DocumentTypeCollectionInfo).
+		Find(&docs).Error; err != nil {
+		return nil, utils.Wrap(err, "query collection documents")
+	}
+
+	vectors := make([][]float32, 0, len(docs))
+	kept := make([]*schema.VectorStoreDocument, 0, len(docs))
+	for i := range docs {
+		if len(docs[i].Embedding) == 0 {
+			continue
+		}
+		vectors = append(vectors, []float32(docs[i].Embedding))
+		kept = append(kept, &docs[i])
+	}
+	if len(vectors) == 0 {
+		return []*Embedding2DPoint{}, nil
+	}
+
+	coords, err := embedding.ReduceTo2D(vectors)
+	if err != nil {
+		return nil, utils.Wrap(err, "reduce embeddings to 2d")
+	}
+
+	points := make([]*Embedding2DPoint, len(kept))
+	for i, doc := range kept {
+		points[i] = &Embedding2DPoint{
+			DocumentID:     doc.DocumentID,
+			Type:           string(doc.DocumentType),
+			X:              coords[i][0],
+			Y:              coords[i][1],
+			ContentPreview: truncateContentPreview(doc.Content),
+		}
+	}
+	return points, nil
+}
+
+// truncateContentPreview 折叠连续空白（含换行）并截断内容预览
+func truncateContentPreview(content string) string {
+	preview := strings.Join(strings.Fields(content), " ")
+	runes := []rune(preview)
+	if len(runes) > embedding2DContentPreviewLen {
+		return string(runes[:embedding2DContentPreviewLen]) + "..."
+	}
+	return preview
+}

--- a/common/ai/rag/vectorstore/embedding2d_test.go
+++ b/common/ai/rag/vectorstore/embedding2d_test.go
@@ -1,0 +1,128 @@
+package vectorstore
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// newDistinctMockEmbedder 返回对每个文本生成确定性且互不相同向量的 mock embedder，
+// 避免依赖词典式 mock 的具体词表内容。
+func newDistinctMockEmbedder() EmbeddingClient {
+	return NewMockEmbedder(func(text string) ([]float32, error) {
+		vec := make([]float32, 1024)
+		h := fnv.New64a()
+		_, _ = h.Write([]byte(text))
+		seed := h.Sum64()
+		for i := range vec {
+			// 简单确定性伪随机，保证不同文本产生不同向量
+			seed = seed*6364136223846793005 + 1442695040888963407
+			vec[i] = float32(int64(seed>>33)%1000) / 1000.0
+		}
+		return vec, nil
+	})
+}
+
+func TestMUSTPASS_Collection2DPoints(t *testing.T) {
+	testDB, err := createTempTestDatabase()
+	require.NoError(t, err)
+	t.Cleanup(func() { testDB.Close() })
+
+	collectionName := utils.RandStringBytes(10)
+	store, err := GetCollection(testDB, collectionName, WithEmbeddingClient(newDistinctMockEmbedder()))
+	require.NoError(t, err)
+
+	documentIDs := make(map[string]struct{})
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("document-%d", i)
+		content := fmt.Sprintf("unique document content %d about yak security topic %d", i, i)
+		require.NoError(t, store.AddWithOptions(id, content))
+		documentIDs[id] = struct{}{}
+	}
+
+	points, err := Collection2DPoints(testDB, collectionName)
+	require.NoError(t, err)
+	require.Len(t, points, len(documentIDs), "every document should have one 2d point")
+
+	seen := make(map[string]struct{})
+	distinctCoords := map[[2]float32]struct{}{}
+	for _, p := range points {
+		_, ok := documentIDs[p.DocumentID]
+		assert.True(t, ok, "point should reference an added document, got %s", p.DocumentID)
+		seen[p.DocumentID] = struct{}{}
+		assert.NotEqual(t, string(DocumentTypeCollectionInfo), p.DocumentID, "collection info document must be excluded")
+		assert.False(t, math.IsNaN(float64(p.X)) || math.IsInf(float64(p.X), 0), "x should be finite")
+		assert.False(t, math.IsNaN(float64(p.Y)) || math.IsInf(float64(p.Y), 0), "y should be finite")
+		assert.NotContains(t, p.ContentPreview, "\n", "content preview should collapse newlines")
+		assert.LessOrEqual(t, len([]rune(p.ContentPreview)), embedding2DContentPreviewLen+3, "content preview should be truncated")
+		distinctCoords[[2]float32{p.X, p.Y}] = struct{}{}
+	}
+	assert.Len(t, seen, len(documentIDs), "all document ids should be covered")
+	assert.Greater(t, len(distinctCoords), 1, "distinct documents should not collapse to a single point")
+
+	// PCA 使用固定随机种子，同一集合重复计算结果应一致
+	again, err := Collection2DPoints(testDB, collectionName)
+	require.NoError(t, err)
+	require.Len(t, again, len(points))
+	for i := range points {
+		assert.Equal(t, points[i].DocumentID, again[i].DocumentID)
+		assert.Equal(t, points[i].X, again[i].X, "x should be deterministic")
+		assert.Equal(t, points[i].Y, again[i].Y, "y should be deterministic")
+	}
+}
+
+func TestMUSTPASS_Collection2DPointsSkipsDocumentsWithoutEmbedding(t *testing.T) {
+	testDB, err := createTempTestDatabase()
+	require.NoError(t, err)
+	t.Cleanup(func() { testDB.Close() })
+
+	collectionName := utils.RandStringBytes(10)
+	store, err := GetCollection(testDB, collectionName, WithEmbeddingClient(NewDefaultMockEmbedding()))
+	require.NoError(t, err)
+	require.NoError(t, store.AddWithOptions("with-embedding", "document with embedding"))
+
+	// 直接插入一条没有向量的文档行，模拟历史脏数据
+	require.NoError(t, testDB.Create(&schema.VectorStoreDocument{
+		DocumentID:     "without-embedding",
+		CollectionID:   store.collection.ID,
+		CollectionUUID: store.collection.UUID,
+		Content:        "legacy document without embedding",
+	}).Error)
+
+	points, err := Collection2DPoints(testDB, collectionName)
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.Equal(t, "with-embedding", points[0].DocumentID)
+	assert.NotEmpty(t, points[0].ContentPreview)
+}
+
+func TestMUSTPASS_Collection2DPointsEmptyCollection(t *testing.T) {
+	testDB, err := createTempTestDatabase()
+	require.NoError(t, err)
+	t.Cleanup(func() { testDB.Close() })
+
+	collectionName := utils.RandStringBytes(10)
+	_, err = GetCollection(testDB, collectionName, WithEmbeddingClient(NewDefaultMockEmbedding()))
+	require.NoError(t, err)
+
+	// 新建集合只包含 collection info 文档（会被排除），应返回空切片而不是报错
+	points, err := Collection2DPoints(testDB, collectionName)
+	require.NoError(t, err)
+	assert.Empty(t, points)
+}
+
+func TestMUSTPASS_Collection2DPointsCollectionNotFound(t *testing.T) {
+	testDB, err := createTempTestDatabase()
+	require.NoError(t, err)
+	t.Cleanup(func() { testDB.Close() })
+
+	_, err = Collection2DPoints(testDB, "no-such-collection")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no-such-collection")
+}

--- a/common/yak/rag_export.go
+++ b/common/yak/rag_export.go
@@ -130,6 +130,9 @@ var RagExports = map[string]interface{}{
 	"LocalEmbedding":  _localEmbedding,
 	"OnlineEmbedding": _onlineEmbedding,
 
+	// Collection2DPoints - 集合向量二维化（PCA），供绘图侧使用
+	"Collection2DPoints": _collection2DPoints,
+
 	// DBQuery - 数据库直接查询接口（快速，不使用语义搜索）
 	// 用于去重检查、快速验证等场景
 	"DBQueryKnowledge":             _dbQueryKnowledge,             // 查询知识库条目

--- a/common/yak/rag_visualization.go
+++ b/common/yak/rag_visualization.go
@@ -1,0 +1,35 @@
+package yak
+
+import (
+	"github.com/yaklang/yaklang/common/ai/rag/vectorstore"
+)
+
+// _collection2DPoints 获取指定集合所有文档向量的二维投影（PCA 降维）
+//
+// 输入集合名称，读取该集合已持久化的全部向量，统一降维为二维点后返回。
+// 只读取数据库中已存储的向量，不会调用远端/本地 embedding 服务。
+//
+// 参数:
+//   - collectionName: 集合名称
+//   - opts: 可选查询选项（如 rag.dbQueryDB 指定数据库连接）
+//
+// 返回值:
+//   - 二维点列表，每个点包含 documentID / type / x / y / contentPreview 字段
+//   - 错误信息（集合不存在时返回错误）
+//
+// Example:
+// ```
+//
+//	points = rag.Collection2DPoints("my-collection")~
+//	for _, p in points {
+//	    println(p.documentID, p.x, p.y, p.contentPreview)
+//	}
+//
+//	// 指定数据库连接
+//	points = rag.Collection2DPoints("my-collection", rag.dbQueryDB(db))~
+//
+// ```
+func _collection2DPoints(collectionName string, opts ...DBQueryOption) ([]*vectorstore.Embedding2DPoint, error) {
+	config := NewDBQueryConfig(opts...)
+	return vectorstore.Collection2DPoints(config.db, collectionName)
+}


### PR DESCRIPTION
## 背景

使用 AIBalance 远端 embedding 服务时，缺少直观观察集合内向量分布的手段。本 PR 在 yak 库层新增一个只读接口：输入集合名，输出该集合全部向量的二维投影（PCA），绘图交给调用方。

## 接口

```yak
points = rag.Collection2DPoints("my-collection")~
for p in points {
    println(p.documentID, p.x, p.y, p.contentPreview)
}

// 指定数据库连接
points = rag.Collection2DPoints("my-collection", rag.dbQueryDB(db))~
```

每个点为 `Embedding2DPoint{ documentID, type, x, y, contentPreview }`，其中 contentPreview 折叠换行并截断到 100 字符，方便绘图侧做悬停标注/分组着色。

## 实现说明

- 核心 `vectorstore.Collection2DPoints(db, name)` 直接查询 `rag_vector_document_v1` 中已持久化的向量：
  - 不初始化 embedding 客户端（不访问远端/本地 embedding 服务）
  - 不加载 HNSW 图，零副作用，适合离线分析
  - 自动跳过无向量的历史脏数据，排除 collection info 文档
- 降维复用现有 `embedding.ReduceTo2D`（幂迭代 PCA，固定随机种子），输出可复现
- 集合不存在时返回明确错误

## 测试

- [x] `TestMUSTPASS_Collection2DPoints`：点数/覆盖、坐标有限性、确定性、preview 截断
- [x] `TestMUSTPASS_Collection2DPointsSkipsDocumentsWithoutEmbedding`
- [x] `TestMUSTPASS_Collection2DPointsEmptyCollection`
- [x] `TestMUSTPASS_Collection2DPointsCollectionNotFound`
- [x] yak 脚本端到端验证（构建 yak 二进制后跑通新增接口及错误路径）