### PR TITLE
feat(ai): tune prompt weight for batch tool calls

### DIFF
--- a/common/ai/aid/aireact/reactloops/loop_default/parallel_tool_prompt_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/parallel_tool_prompt_test.go
@@ -1,0 +1,52 @@
+package loop_default
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Keep the batch-first rule in the prompt layers closest to model output.
+// Earlier generic guidance is not enough: a later scalar-only example used to
+// outweigh it and made otherwise independent calls run in separate ReAct
+// rounds.
+func TestDefaultPromptTeachesIndependentBatchBeforeScalarFallback(t *testing.T) {
+	const batchField = "tool_require_calls"
+
+	for name, test := range map[string]struct {
+		prompt       string
+		scalarMarker string
+		noGuessRule  string
+	}{
+		"instruction": {
+			prompt:       instruction,
+			scalarMarker: "标量 `tool_require_payload`",
+			noGuessRule:  "严禁猜测",
+		},
+		"output_example": {
+			prompt:       outputExample,
+			scalarMarker: `"tool_require_payload":"..[your-toolname].."`,
+			noGuessRule:  "禁止猜参数",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			batchIndex := strings.Index(test.prompt, batchField)
+			scalarIndex := strings.Index(test.prompt, test.scalarMarker)
+			require.NotEqual(t, -1, batchIndex, "prompt must show the batch action field")
+			require.NotEqual(t, -1, scalarIndex, "prompt must retain a one-call fallback")
+			assert.Less(t, batchIndex, scalarIndex, "batch form must be taught before scalar fallback")
+			assert.Contains(t, test.prompt, test.noGuessRule)
+		})
+	}
+
+	assert.NotContains(t, instruction, "多工具 + 明确依赖图（串行或并行）")
+	assert.NotContains(t, outputExample, "已知多工具且存在明确依赖图")
+	assert.Contains(t, instruction, "后序参数依赖前序真实输出")
+	assert.Contains(t, instruction, "严禁输出 `<@action=...>`")
+	assert.Contains(t, outputExample, "禁止 `<@action=...>`")
+	assert.Contains(t, instruction, "本轮输出 `require_tool` / `directly_call_tool` action 本身就是获得工具执行机会")
+	assert.Contains(t, outputExample, "本轮工具 action 就是执行机会")
+	assert.Contains(t, instruction, "恰好 1 个用标量；2-8 个且独立用批次")
+}

--- a/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
+++ b/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
@@ -68,8 +68,9 @@
 
 - **P1: PLAN**：如果任务目标复杂、范围不清、存在多阶段探索或明显不确定性，优先使用 `request_plan`（先规划并审查，审查通过后再执行）。
 - **P2: SKILL**：如果任务涉及特定领域方法或操作规范，优先加载技能（`loading_skills` / `load_skill_resources`）获取指导后再执行。
-- **P3: TOOL_COMPOSE**：仅当你已经明确知道要调用哪些具体工具，并且这些工具之间存在明确依赖/并行关系时，才使用 `tool_compose`。
-- **禁止误用**：不要把 `tool_compose` 当成"通用规划器"；不要用 `tool_compose` 调用 AI Blueprint（蓝图应使用 `require_ai_blueprint`）。
+- **P3: 并发工具批次**：若本轮已经明确 2-8 个彼此独立、互不干扰的真实调用，必须优先在一个 `directly_call_tool_calls` 或 `tool_require_calls` 数组中一次提交，不要拆成多个 ReAct 轮次。
+- **P4: TOOL_COMPOSE**：仅当后续工具的参数必须依赖前序工具的真实输出时，才使用 `tool_compose`。独立并发调用不属于 `tool_compose` 场景。
+- **禁止误用**：不要把 `tool_compose` 当成"通用规划器"或普通并发器；不要用 `tool_compose` 调用 AI Blueprint（蓝图应使用 `require_ai_blueprint`）。
 {{ if .AllowPlan }}
 如果遇到比较复杂的任务，可申请计划：`{"@action": "request_plan", "plan_request_payload": "..."}`（规划经用户审查通过后再异步执行）。申请任务列表执行的时候，可以从用户最终目标来反推一些提示，辅助系统进行任务规划。
 {{ end }}
@@ -80,15 +81,24 @@
 
 ## 3. action 使用技巧准则
 
+所有 R1 action 都必须直接输出一个使用 Schema 原始英文键名的 JSON object。严禁输出 `<@action=...>` / `<@action_end>` 标签、`标识符：` 等中文字段说明、YAML 或自然语言包装；这些格式无法被 action 解析器执行，会浪费整轮模型调用。
+
+R1 本轮输出 `require_tool` / `directly_call_tool` action 本身就是获得工具执行机会的方式。缺少完成任务所需的一手证据时，必须现在选择合适的工具 action；禁止回答“没有工具执行机会”“需要重发任务”或在尚未尝试工具时直接拒绝。
+
 ### 3.1 工具使用流程
 
-如果你想要使用工具，请严格遵循以下流程：
+使用工具前，先枚举本轮已经确定且现在就能执行的真实调用，再按下列规则选择唯一一种 action 形态：
 
-1. **申请工具：** 使用以下格式提交工具申请，确保清晰指定你需要的工具名称。申请内容为：
-   {"@action": "require_tool", "tool_require_payload": "..[your-toolname]..", "human_readable_thought": "..."}
-   请确保 `tool_require_payload` 中填写的工具名称准确无误，并在 `human_readable_thought` 中简要说明调用该工具的目的和预期结果。
-2. **查看参数：** 在工具申请通过后，系统会返回该工具所需的参数列表。请仔细阅读每个参数的说明，确保理解其用途和格式要求。根据任务需求填写参数，确保输入信息完整且正确。
-3. **执行工具：** 提交参数后，系统将执行工具并返回结果。请关注工具的输出内容，并在后续步骤中根据结果决定下一步行动。
+**选择门（按顺序只判断一次）：** 先问“现在是否确实需要工具”；需要时枚举真实调用数量，再判断调用之间是否有数据依赖或写入冲突。恰好 1 个用标量；2-8 个且独立用批次；有依赖则只执行当前已就绪的一层。不要因为存在批次能力而增加不必要的调用，也不要把已经明确的独立调用留到下一轮。
+
+1. **2-8 个独立调用必须批量提交：**
+   - 动态段已经展示各工具的 `CACHE_TOOL_CALL` / `<|TOOL_SCHEMA_...|>`，且你能严格按真实 Schema 给出全部参数时，使用一个 `directly_call_tool` action 的 `directly_call_tool_calls` 数组。
+   - 参数 Schema 没有展示、参数仍不确定或需要运行时生成时，使用一个 `require_tool` action 的 `tool_require_calls` 数组；每项只填写准确的 `tool_name`、`identifier` 和 `reason`，严禁猜测或填写 `params`。运行时会分别生成参数并有界并发执行。
+2. **单次调用：** 只有本轮恰好一个调用，或调用之间存在先后依赖/写入冲突时，才使用标量 `tool_require_payload` / `directly_call_tool_name`；有依赖的后续调用应等待前序结果后再提交。
+3. **不要为凑数发明调用：** 一次批量 action 中只放当前任务确实需要、彼此独立的调用。批次会等待全部 child 结束，再把整组结果送入下一轮。
+
+批量申请格式示例（参数由运行时分别生成）：
+`{"@action":"require_tool","identifier":"parallel_inspection","human_readable_thought":"并发收集独立证据","tool_require_calls":[{"tool_name":"grep","identifier":"find_handlers","reason":"定位处理函数"},{"tool_name":"read_file","identifier":"read_config","reason":"读取独立配置"}]}`
 
 **工具选择原则：**
 
@@ -97,7 +107,7 @@
   2. **能批量发现就不逐个手发**：需要快速摸清站点多 URL/参数/表单/接口时，优先用轻量爬取类工具，而非手工逐个发请求。
   3. **一次调用拿到足够信息就停**：若一次请求已返回足以决策的内容，不要为了"再多看看"重复调用同类工具取相同信息；需要更多细节时再针对性发起下一步。
 - **搜索优先**：如果你不确定如何完成任务或是否需要特定工具，请果断使用 `tools_search` 寻找合适的工具或解决方案。搜索可以帮助你快速定位可用资源，避免浪费时间在无效尝试上。
-- **`tool_compose` 使用门槛**：至少需要满足"多工具 + 明确依赖图（串行或并行）"这两个条件；如果只是单工具调用或依赖关系不明确，优先 `require_tool` 或 `request_plan`。
+- **`tool_compose` 使用门槛**：至少需要满足"多工具 + 后序参数依赖前序真实输出"；彼此独立的多个调用必须使用 `directly_call_tool_calls` / `tool_require_calls` 并发批次，单工具调用优先使用对应标量 action。
 
 **bash 使用规范：**
 

--- a/common/ai/aid/aireact/reactloops/loop_default/prompts/output_example.txt
+++ b/common/ai/aid/aireact/reactloops/loop_default/prompts/output_example.txt
@@ -10,8 +10,15 @@
 # markdown in mass
 <|FINAL_ANSWER_END_CURRENT_NONCE|>
 
-*. 如果你想要使用工具：
-    * `{"@action": "require_tool", "tool_require_payload": "..[your-toolname]..", "human_readable_thought": "先读取配置"}`
+*. 所有 action 必须直接输出使用 Schema 原始英文键名的 JSON object；禁止 `<@action=...>` 标签、中文字段说明、YAML 或 JSON 外包装。
+*. 缺少任务所需的一手证据时，本轮工具 action 就是执行机会；立即选择工具，禁止回答“没有工具执行机会”或要求重发任务。
+
+*. 如果你想要使用工具，先枚举本轮可立即执行的真实调用：
+    * 选择门：1 个真实调用用标量；2-8 个独立真实调用用批次；存在数据依赖或写入冲突时只执行当前已就绪的一层。不要凑调用，也不要把已明确的独立调用留到下一轮。
+    * 有 2-8 个彼此独立的调用时，优先一次批量申请，运行时会分别生成参数并并发执行：
+      `{"@action":"require_tool","identifier":"parallel_inspection","human_readable_thought":"并发收集独立证据","tool_require_calls":[{"tool_name":"grep","identifier":"find_handlers","reason":"定位处理函数"},{"tool_name":"read_file","identifier":"read_config","reason":"读取独立配置"}]}`
+    * 若动态段已经展示真实工具参数 Schema 且全部参数明确，可改用一个 `directly_call_tool_calls` 批次直接执行；没有 Schema 时禁止猜参数。
+    * 只有本轮恰好一个调用或调用之间存在依赖/冲突时，才使用标量：`{"@action":"require_tool","tool_require_payload":"..[your-toolname]..","human_readable_thought":"先读取配置"}`
 
 *. `todo_delta` 使用案例（维护 TODO 工作集，与正常动作同轮携带）：
     * 任务一开始就需要拆成多个入口时，第一条动作同时建立初始 TODO 并指定 current：
@@ -38,7 +45,7 @@
 同时你必须遵循动作选择优先级：
 1. 复杂/不确定任务，或需要新建/修订 Plan：优先 `request_plan`
 2. 需要领域指导：优先加载技能（`loading_skills` / `load_skill_resources`）
-3. 仅在“已知多工具且存在明确依赖图”时使用 `tool_compose`
+3. 仅在后序参数依赖前序真实输出时使用 `tool_compose`；独立多调用使用 `tool_require_calls` / `directly_call_tool_calls` 批次
 4. AI Blueprint 必须使用 `require_ai_blueprint`，禁止通过 `tool_compose` 代替
 
 反例（禁止）：

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action.go
@@ -35,7 +35,7 @@ const directlyCallToolScalarOutputExampleJSON = `{
   "identifier": "read_project_config",
   "human_readable_thought": "读取单个项目配置",
   "directly_call_tool_name": "read_file",
-  "directly_call_tool_params": {"path": "/workspace/go.mod"},
+  "directly_call_tool_params": {"file": "/workspace/go.mod"},
   "directly_call_identifier": "read_go_mod",
   "directly_call_expectations": "~1s",
   "directly_call_reason": "读取模块定义"
@@ -48,14 +48,14 @@ const directlyCallToolBatchOutputExampleJSON = `{
   "directly_call_tool_calls": [
     {
       "tool_name": "read_file",
-      "params": {"path": "/workspace/go.mod"},
+      "params": {"file": "/workspace/go.mod"},
       "identifier": "read_go_mod",
       "expectations": "~1s",
       "reason": "读取模块定义"
     },
     {
       "tool_name": "read_file",
-      "params": {"path": "/workspace/README.md"},
+      "params": {"file": "/workspace/README.md"},
       "identifier": "read_readme",
       "expectations": "~1s",
       "reason": "读取项目说明"

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action_test.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools/yakscripttools"
 	"github.com/yaklang/yaklang/common/schema"
 )
 
@@ -22,7 +24,10 @@ func newToolBatchTestManager(t *testing.T) (*buildinaitools.AiToolManager, *aito
 	t.Helper()
 	readFile := mustNewTool(
 		"read_file",
-		aitool.WithStringParam("path", aitool.WithParam_Required(true)),
+		// Keep this fixture aligned with the production read_file Yak tool. A
+		// stale "path" fixture previously let prompt examples pass CI while the
+		// real tool rejected them and forced an extra reasoning-model retry.
+		aitool.WithStringParam("file", aitool.WithParam_Required(true)),
 		aitool.WithSimpleCallback(func(params aitool.InvokeParams, stdout io.Writer, stderr io.Writer) (any, error) {
 			return "content", nil
 		}),
@@ -102,8 +107,8 @@ func TestDirectToolScalarParamsSchema_AcceptsObjectAndLegacyJSONString(t *testin
 		params any
 		valid  bool
 	}{
-		{name: "preferred object", params: map[string]any{"path": "/workspace/go.mod"}, valid: true},
-		{name: "legacy JSON string", params: `{"path":"/workspace/go.mod"}`, valid: true},
+		{name: "preferred object", params: map[string]any{"file": "/workspace/go.mod"}, valid: true},
+		{name: "legacy JSON string", params: `{"file":"/workspace/go.mod"}`, valid: true},
 		{name: "array remains invalid", params: []any{"/workspace/go.mod"}, valid: false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -153,9 +158,9 @@ func TestToolCallPromptExamples_ParseAndVerifyExactBytes(t *testing.T) {
 		require.Len(t, request.Calls, 2)
 		assert.Equal(t, aicommon.ToolCallModeDirect, request.Calls[0].Mode)
 		assert.Equal(t, "read_file", request.Calls[0].ToolName)
-		assert.Equal(t, "/workspace/go.mod", request.Calls[0].Params.GetString("path"))
+		assert.Equal(t, "/workspace/go.mod", request.Calls[0].Params.GetString("file"))
 		assert.Equal(t, "read_go_mod", request.Calls[0].Identifier)
-		assert.Equal(t, "/workspace/README.md", request.Calls[1].Params.GetString("path"))
+		assert.Equal(t, "/workspace/README.md", request.Calls[1].Params.GetString("file"))
 		assert.Contains(t, loopAction_directlyCallTool.OutputExamples, directlyCallToolBatchOutputExampleJSON)
 	})
 
@@ -191,6 +196,38 @@ func TestToolCallPromptExamples_ParseAndVerifyExactBytes(t *testing.T) {
 		assert.Equal(t, "read_file", request.Calls[1].ToolName)
 		assert.Contains(t, loopAction_toolRequireAndCall.OutputExamples, requireToolBatchOutputExampleJSON)
 	})
+}
+
+// Cross-check the prompt fixture against the embedded production read_file
+// definition, rather than only against the test double. This catches a future
+// CLI parameter rename before a highly weighted few-shot teaches every model
+// an invalid direct-call payload.
+func TestToolCallPromptExamples_MatchProductionReadFileParameter(t *testing.T) {
+	source, err := yakscripttools.GetEmbedFS().ReadFile("yakscriptforai/fs/read_file.yak")
+	require.NoError(t, err)
+
+	pathParamPattern := regexp.MustCompile(`cli\.String\("([^"]+)",\s*cli\.setRequired\(true\),\s*cli\.setHelp\("target file absolute path`)
+	match := pathParamPattern.FindSubmatch(source)
+	require.Len(t, match, 2, "production read_file must expose a required absolute-path parameter")
+	pathParamName := string(match[1])
+
+	var scalar map[string]any
+	require.NoError(t, json.Unmarshal([]byte(directlyCallToolScalarOutputExampleJSON), &scalar))
+	scalarParams, ok := scalar["directly_call_tool_params"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, scalarParams, pathParamName)
+
+	var batch map[string]any
+	require.NoError(t, json.Unmarshal([]byte(directlyCallToolBatchOutputExampleJSON), &batch))
+	calls, ok := batch[directlyCallToolBatchField].([]any)
+	require.True(t, ok)
+	for index, rawCall := range calls {
+		call, ok := rawCall.(map[string]any)
+		require.True(t, ok, "call %d must be an object", index)
+		params, ok := call["params"].(map[string]any)
+		require.True(t, ok, "call %d params must be an object", index)
+		assert.Contains(t, params, pathParamName, "call %d must match production read_file", index)
+	}
 }
 
 func TestToolCallActionDescriptionsUseChineseBatchFirstPolicy(t *testing.T) {
@@ -317,12 +354,12 @@ func TestDirectToolBatchVerifier_RejectsAmbiguousOrInvalidBatchBeforeHandler(t *
 	}{
 		{
 			name:       "not_an_array",
-			payload:    `{"@action":"directly_call_tool","directly_call_tool_calls":{"tool_name":"read_file","params":{"path":"/a"}}}`,
+			payload:    `{"@action":"directly_call_tool","directly_call_tool_calls":{"tool_name":"read_file","params":{"file":"/a"}}}`,
 			errContain: "array of objects",
 		},
 		{
 			name:       "one_item",
-			payload:    `{"@action":"directly_call_tool","directly_call_tool_calls":[{"tool_name":"read_file","params":{"path":"/a"}}]}`,
+			payload:    `{"@action":"directly_call_tool","directly_call_tool_calls":[{"tool_name":"read_file","params":{"file":"/a"}}]}`,
 			errContain: "at least 2",
 		},
 		{
@@ -330,7 +367,7 @@ func TestDirectToolBatchVerifier_RejectsAmbiguousOrInvalidBatchBeforeHandler(t *
 			payload: `{
 				"@action":"directly_call_tool",
 				"directly_call_tool_calls":[
-					{"tool_name":"read_file","params":{"path":"/valid"}},
+					{"tool_name":"read_file","params":{"file":"/valid"}},
 					{"tool_name":"read_file","params":{}}
 				]
 			}`,
@@ -341,8 +378,8 @@ func TestDirectToolBatchVerifier_RejectsAmbiguousOrInvalidBatchBeforeHandler(t *
 			payload: `{
 				"@action":"directly_call_tool",
 				"directly_call_tool_calls":[
-					{"tool_name":"read_file","params":{"path":"/a"},"identifier":"same"},
-					{"tool_name":"read_file","params":{"path":"/b"},"identifier":"same"}
+					{"tool_name":"read_file","params":{"file":"/a"},"identifier":"same"},
+					{"tool_name":"read_file","params":{"file":"/b"},"identifier":"same"}
 				]
 			}`,
 			errContain: "duplicates",
@@ -352,8 +389,8 @@ func TestDirectToolBatchVerifier_RejectsAmbiguousOrInvalidBatchBeforeHandler(t *
 			payload: `{
 				"@action":"directly_call_tool",
 				"directly_call_tool_calls":[
-					{"tool_name":"read_file","params":{"path":"/a"}},
-					{"tool_name":"read_file","params":{"path":"/b"}}
+					{"tool_name":"read_file","params":{"file":"/a"}},
+					{"tool_name":"read_file","params":{"file":"/b"}}
 				],
 				"tool_require_calls":[
 					{"tool_name":"grep"},
@@ -368,7 +405,7 @@ func TestDirectToolBatchVerifier_RejectsAmbiguousOrInvalidBatchBeforeHandler(t *
 				"@action":"directly_call_tool",
 				"directly_call_tool_calls":[
 					{"tool_name":"read_file","params":[]},
-					{"tool_name":"read_file","params":{"path":"/b"}}
+					{"tool_name":"read_file","params":{"file":"/b"}}
 				]
 			}`,
 			errContain: "params must be a non-null JSON object",
@@ -411,8 +448,8 @@ func TestRequireToolBatchVerifier_RejectsParamsAndMixedForms(t *testing.T) {
 					{"tool_name":"read_file"}
 				],
 				"directly_call_tool_calls":[
-					{"tool_name":"read_file","params":{"path":"/a"}},
-					{"tool_name":"read_file","params":{"path":"/b"}}
+					{"tool_name":"read_file","params":{"file":"/a"}},
+					{"tool_name":"read_file","params":{"file":"/b"}}
 				]
 			}`,
 			errContain: "cannot be combined with directly_call_tool fields",
@@ -441,7 +478,7 @@ func TestToolScalarVerifier_PreservesLegacyPriorityWhenMalformedActionAlsoContai
 		{
 			name:       "direct",
 			actionType: schema.AI_REACT_LOOP_ACTION_DIRECTLY_CALL_TOOL,
-			payload:    `{"@action":"directly_call_tool","directly_call_tool_name":"read_file","directly_call_tool_params":{"path":"/scalar"},"directly_call_tool_calls":[{"tool_name":"read_file","params":{"path":"/a"}},{"tool_name":"read_file","params":{"path":"/b"}}]}`,
+			payload:    `{"@action":"directly_call_tool","directly_call_tool_name":"read_file","directly_call_tool_params":{"file":"/scalar"},"directly_call_tool_calls":[{"tool_name":"read_file","params":{"file":"/a"}},{"tool_name":"read_file","params":{"file":"/b"}}]}`,
 			verify:     loopAction_directlyCallTool.ActionVerifier,
 			stateKey:   "directly_call_tool_name",
 			wantValue:  "read_file",
@@ -471,7 +508,7 @@ func TestToolBatchVerifier_RejectsTruncatedAction(t *testing.T) {
 	loop, _ := newToolBatchTestLoop(t)
 	action, err := aicommon.ExtractActionFromStream(
 		context.Background(),
-		strings.NewReader(`{"@action":"directly_call_tool","directly_call_tool_calls":[{"tool_name":"read_file","params":{"path":"/a"}},{"tool_name":`),
+		strings.NewReader(`{"@action":"directly_call_tool","directly_call_tool_calls":[{"tool_name":"read_file","params":{"file":"/a"}},{"tool_name":`),
 		schema.AI_REACT_LOOP_ACTION_DIRECTLY_CALL_TOOL,
 	)
 	require.NoError(t, err)
@@ -496,7 +533,7 @@ func (r *eofGateReader) Read(p []byte) (int, error) {
 }
 
 func TestToolBatchVerifier_WaitsForCompleteResponseEOF(t *testing.T) {
-	payload := `{"@action":"directly_call_tool","directly_call_tool_calls":[{"tool_name":"read_file","params":{"path":"/a"}},{"tool_name":"read_file","params":{"path":"/b"}}]}`
+	payload := `{"@action":"directly_call_tool","directly_call_tool_calls":[{"tool_name":"read_file","params":{"file":"/a"}},{"tool_name":"read_file","params":{"file":"/b"}}]}`
 	source := &eofGateReader{
 		reader:  strings.NewReader(payload),
 		waiting: make(chan struct{}),
@@ -534,7 +571,7 @@ func TestToolScalarVerifier_ReturnsBeforeCompleteResponseEOF(t *testing.T) {
 		{
 			name:       "direct",
 			actionType: schema.AI_REACT_LOOP_ACTION_DIRECTLY_CALL_TOOL,
-			payload:    `{"@action":"directly_call_tool","directly_call_tool_name":"read_file","directly_call_tool_params":{"path":"/a"}}`,
+			payload:    `{"@action":"directly_call_tool","directly_call_tool_name":"read_file","directly_call_tool_params":{"file":"/a"}}`,
 			verify:     loopAction_directlyCallTool.ActionVerifier,
 			stateKey:   "directly_call_tool_name",
 			want:       "read_file",
@@ -686,7 +723,7 @@ func (i *executingToolBatchTestInvoker) ExecuteToolBatch(
 			case "grep":
 				params = aitool.InvokeParams{"path": "/workspace", "pattern": "auth"}
 			case "read_file":
-				params = aitool.InvokeParams{"path": "/workspace/project.json"}
+				params = aitool.InvokeParams{"file": "/workspace/project.json"}
 			}
 		}
 		tool, lookupErr := i.manager.GetToolByName(call.ToolName)
@@ -829,7 +866,7 @@ func TestToolBatchActionHandler_CachesOnlySuccessfulChildren(t *testing.T) {
 	loop := reactloops.NewMinimalReActLoop(cfg, invoker)
 	loop.SetCurrentTask(task)
 	request := &aicommon.ToolBatchRequest{Calls: []aicommon.ToolBatchCall{
-		{Index: 0, Mode: aicommon.ToolCallModeDirect, ToolName: readFile.Name, Params: aitool.InvokeParams{"path": "/workspace/go.mod"}},
+		{Index: 0, Mode: aicommon.ToolCallModeDirect, ToolName: readFile.Name, Params: aitool.InvokeParams{"file": "/workspace/go.mod"}},
 		{Index: 1, Mode: aicommon.ToolCallModeDirect, ToolName: grep.Name, Params: aitool.InvokeParams{"pattern": "auth"}},
 	}}
 
@@ -991,7 +1028,7 @@ func TestToolScalarPromptExamples_ExecuteActualToolCallbacks(t *testing.T) {
 			actionType:    schema.AI_REACT_LOOP_ACTION_DIRECTLY_CALL_TOOL,
 			action:        loopAction_directlyCallTool,
 			expectedTool:  "read_file",
-			expectedParam: "path",
+			expectedParam: "file",
 			expectedValue: "/workspace/go.mod",
 		},
 		{


### PR DESCRIPTION
## 目的

提高 ReAct 主决策中批量工具调用的提示优先级，让模型在单调用、独立批量调用和有依赖调用之间做明确选择，同时保持现有运行时行为不变。

## 改动

- 在靠近模型输出的 instruction 与 output example 中加入一次性选择门：
  - 1 个真实调用使用标量 action
  - 2-8 个独立调用使用 `tool_require_calls` / `directly_call_tool_calls`
  - 有数据依赖或写冲突时只执行当前已就绪的一层
- 将 `tool_compose` 收窄为后序参数依赖前序真实输出的 DAG 场景，避免与普通并发批次冲突。
- 提高批次 few-shot 的位置和明确度，同时禁止为了凑批次发明调用、猜测未展示的参数 Schema。
- 修正高权重 direct-call few-shot：生产 `read_file` 参数名是 `file`，原示例错误使用 `path`，会导致模型生成无效参数并额外重试一轮。
- 增加提示顺序、矛盾规则和生产工具 Schema 交叉检查，防止回归。

## `memfit-standard-thinking-free` 实测

| 场景 | 首次主决策 | 观察 |
|---|---|---|
| 4 个彼此独立的文件读取 | 单个 `directly_call_tool`，包含 4 个 children | 四项参数均使用真实 `file` 字段，无 action/参数纠错轮，children 同秒完成 |
| 单文件读取 | 标量 `require_tool` | 没有为追求批次发明额外调用 |
| 第二个路径必须由第一个文件内容决定 | 标量 `directly_call_tool` | 没有猜测下游参数或错误并发 |

一次有效样本中，4 文件任务的首个主决策耗时 7.98s；单文件为 4.12s；依赖任务为 3.92s。这些数据证明选择边界和无效参数重试得到改善，但样本量不足以声称统计显著的整体墙钟加速，模型本身延迟波动仍然较大。

## 验证

- `go test ./common/ai/aid/aireact/reactloops/loopinfra -count=1`
- `go test ./common/ai/aid/aireact/reactloops/loop_default -count=1`
- `go test ./common/ai/aid/aireact -run 'TestToolCallExamplesAreInAssembledMainLoopSchema|TestLegacyBasePromptUsesTheSameBatchFirstSelectionPolicy' -count=1`
- `GITHUB_ACTIONS=true go test ./common/ai/aid/aireact -run '^TestReAct_ToolUse_MultiCalls$' -count=1 -timeout 30s`

完整本地 `go test ./common/ai/aid/aireact/... -count=1` 的所有子包通过，但顶层既有 `TestReAct_ToolUse_MultiCalls` 使用本地 5 秒固定终态门槛并失败；同一失败在未修改的 `origin/main` 上连续 3/3 复现。该测试在代码自带的 GitHub Actions 10 秒门槛下 6.807s 通过。
