### PR TITLE
feat(scannode): legion plugin store commands

### DIFF
--- a/common/consts/yakit.go
+++ b/common/consts/yakit.go
@@ -207,6 +207,19 @@ func BindProfileDatabase(db *gorm.DB, path string) {
 	schema.SetGormProfileDatabase(db)
 }
 
+// CloseProfileDatabase closes the global profile DB handle and clears the
+// binding so the underlying SQLite file can be replaced on disk. Used by the
+// plugin store import flow to atomically swap the local plugin database.
+func CloseProfileDatabase() {
+	if profileDatabase != nil {
+		if sqlDB := profileDatabase.DB(); sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
+	profileDatabase = nil
+	schema.SetGormProfileDatabase(nil)
+}
+
 func GetGormProfileDatabase() *gorm.DB {
 	if profileDatabase != nil {
 		if debugProfileDatabase {

--- a/scannode/gen/legionpb/legion/plugin/v1/plugin.pb.go
+++ b/scannode/gen/legionpb/legion/plugin/v1/plugin.pb.go
@@ -379,6 +379,651 @@ func (x *PluginSyncFailed) GetObservedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+type ListPluginGroupsCommand struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Metadata      *v1.CommandMetadata    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	TargetNodeId  string                 `protobuf:"bytes,2,opt,name=target_node_id,json=targetNodeId,proto3" json:"target_node_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPluginGroupsCommand) Reset() {
+	*x = ListPluginGroupsCommand{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPluginGroupsCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPluginGroupsCommand) ProtoMessage() {}
+
+func (x *ListPluginGroupsCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPluginGroupsCommand.ProtoReflect.Descriptor instead.
+func (*ListPluginGroupsCommand) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ListPluginGroupsCommand) GetMetadata() *v1.CommandMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ListPluginGroupsCommand) GetTargetNodeId() string {
+	if x != nil {
+		return x.TargetNodeId
+	}
+	return ""
+}
+
+type PluginGroupInfo struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Group           string                 `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
+	Total           int32                  `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty"`
+	CompatibleTotal int32                  `protobuf:"varint,3,opt,name=compatible_total,json=compatibleTotal,proto3" json:"compatible_total,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *PluginGroupInfo) Reset() {
+	*x = PluginGroupInfo{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginGroupInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginGroupInfo) ProtoMessage() {}
+
+func (x *PluginGroupInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginGroupInfo.ProtoReflect.Descriptor instead.
+func (*PluginGroupInfo) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *PluginGroupInfo) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *PluginGroupInfo) GetTotal() int32 {
+	if x != nil {
+		return x.Total
+	}
+	return 0
+}
+
+func (x *PluginGroupInfo) GetCompatibleTotal() int32 {
+	if x != nil {
+		return x.CompatibleTotal
+	}
+	return 0
+}
+
+type PluginGroupScript struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Group         string                 `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
+	ScriptName    string                 `protobuf:"bytes,2,opt,name=script_name,json=scriptName,proto3" json:"script_name,omitempty"`
+	ScriptType    string                 `protobuf:"bytes,3,opt,name=script_type,json=scriptType,proto3" json:"script_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginGroupScript) Reset() {
+	*x = PluginGroupScript{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginGroupScript) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginGroupScript) ProtoMessage() {}
+
+func (x *PluginGroupScript) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginGroupScript.ProtoReflect.Descriptor instead.
+func (*PluginGroupScript) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *PluginGroupScript) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *PluginGroupScript) GetScriptName() string {
+	if x != nil {
+		return x.ScriptName
+	}
+	return ""
+}
+
+func (x *PluginGroupScript) GetScriptType() string {
+	if x != nil {
+		return x.ScriptType
+	}
+	return ""
+}
+
+type ListPluginGroupsResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Groups        []*PluginGroupInfo     `protobuf:"bytes,1,rep,name=groups,proto3" json:"groups,omitempty"`
+	Scripts       []*PluginGroupScript   `protobuf:"bytes,2,rep,name=scripts,proto3" json:"scripts,omitempty"`
+	ErrorCode     string                 `protobuf:"bytes,3,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,4,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPluginGroupsResult) Reset() {
+	*x = ListPluginGroupsResult{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPluginGroupsResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPluginGroupsResult) ProtoMessage() {}
+
+func (x *ListPluginGroupsResult) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPluginGroupsResult.ProtoReflect.Descriptor instead.
+func (*ListPluginGroupsResult) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ListPluginGroupsResult) GetGroups() []*PluginGroupInfo {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
+}
+
+func (x *ListPluginGroupsResult) GetScripts() []*PluginGroupScript {
+	if x != nil {
+		return x.Scripts
+	}
+	return nil
+}
+
+func (x *ListPluginGroupsResult) GetErrorCode() string {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ""
+}
+
+func (x *ListPluginGroupsResult) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+type SyncPluginStoreCommand struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Metadata      *v1.CommandMetadata    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	TargetNodeId  string                 `protobuf:"bytes,2,opt,name=target_node_id,json=targetNodeId,proto3" json:"target_node_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SyncPluginStoreCommand) Reset() {
+	*x = SyncPluginStoreCommand{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SyncPluginStoreCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SyncPluginStoreCommand) ProtoMessage() {}
+
+func (x *SyncPluginStoreCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SyncPluginStoreCommand.ProtoReflect.Descriptor instead.
+func (*SyncPluginStoreCommand) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *SyncPluginStoreCommand) GetMetadata() *v1.CommandMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *SyncPluginStoreCommand) GetTargetNodeId() string {
+	if x != nil {
+		return x.TargetNodeId
+	}
+	return ""
+}
+
+type PluginStoreSyncProgress struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CommandId     string                 `protobuf:"bytes,1,opt,name=command_id,json=commandId,proto3" json:"command_id,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`       // running | succeeded | failed
+	Progress      float64                `protobuf:"fixed64,3,opt,name=progress,proto3" json:"progress,omitempty"` // 0..1
+	Total         int32                  `protobuf:"varint,4,opt,name=total,proto3" json:"total,omitempty"`
+	Completed     int32                  `protobuf:"varint,5,opt,name=completed,proto3" json:"completed,omitempty"`
+	Succeeded     int32                  `protobuf:"varint,6,opt,name=succeeded,proto3" json:"succeeded,omitempty"`
+	Failed        int32                  `protobuf:"varint,7,opt,name=failed,proto3" json:"failed,omitempty"`
+	CurrentPlugin string                 `protobuf:"bytes,8,opt,name=current_plugin,json=currentPlugin,proto3" json:"current_plugin,omitempty"`
+	ErrorCode     string                 `protobuf:"bytes,9,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,10,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginStoreSyncProgress) Reset() {
+	*x = PluginStoreSyncProgress{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginStoreSyncProgress) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginStoreSyncProgress) ProtoMessage() {}
+
+func (x *PluginStoreSyncProgress) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginStoreSyncProgress.ProtoReflect.Descriptor instead.
+func (*PluginStoreSyncProgress) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *PluginStoreSyncProgress) GetCommandId() string {
+	if x != nil {
+		return x.CommandId
+	}
+	return ""
+}
+
+func (x *PluginStoreSyncProgress) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *PluginStoreSyncProgress) GetProgress() float64 {
+	if x != nil {
+		return x.Progress
+	}
+	return 0
+}
+
+func (x *PluginStoreSyncProgress) GetTotal() int32 {
+	if x != nil {
+		return x.Total
+	}
+	return 0
+}
+
+func (x *PluginStoreSyncProgress) GetCompleted() int32 {
+	if x != nil {
+		return x.Completed
+	}
+	return 0
+}
+
+func (x *PluginStoreSyncProgress) GetSucceeded() int32 {
+	if x != nil {
+		return x.Succeeded
+	}
+	return 0
+}
+
+func (x *PluginStoreSyncProgress) GetFailed() int32 {
+	if x != nil {
+		return x.Failed
+	}
+	return 0
+}
+
+func (x *PluginStoreSyncProgress) GetCurrentPlugin() string {
+	if x != nil {
+		return x.CurrentPlugin
+	}
+	return ""
+}
+
+func (x *PluginStoreSyncProgress) GetErrorCode() string {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ""
+}
+
+func (x *PluginStoreSyncProgress) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *PluginStoreSyncProgress) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+type QueryPluginStoreSyncStatusCommand struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Metadata      *v1.CommandMetadata    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	TargetNodeId  string                 `protobuf:"bytes,2,opt,name=target_node_id,json=targetNodeId,proto3" json:"target_node_id,omitempty"`
+	CommandId     string                 `protobuf:"bytes,3,opt,name=command_id,json=commandId,proto3" json:"command_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryPluginStoreSyncStatusCommand) Reset() {
+	*x = QueryPluginStoreSyncStatusCommand{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryPluginStoreSyncStatusCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryPluginStoreSyncStatusCommand) ProtoMessage() {}
+
+func (x *QueryPluginStoreSyncStatusCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryPluginStoreSyncStatusCommand.ProtoReflect.Descriptor instead.
+func (*QueryPluginStoreSyncStatusCommand) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *QueryPluginStoreSyncStatusCommand) GetMetadata() *v1.CommandMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *QueryPluginStoreSyncStatusCommand) GetTargetNodeId() string {
+	if x != nil {
+		return x.TargetNodeId
+	}
+	return ""
+}
+
+func (x *QueryPluginStoreSyncStatusCommand) GetCommandId() string {
+	if x != nil {
+		return x.CommandId
+	}
+	return ""
+}
+
+type ImportPluginStoreCommand struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Metadata     *v1.CommandMetadata    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	TargetNodeId string                 `protobuf:"bytes,2,opt,name=target_node_id,json=targetNodeId,proto3" json:"target_node_id,omitempty"`
+	// Platform-served download URL of the uploaded SQLite plugin database.
+	ArtifactUrl       string `protobuf:"bytes,3,opt,name=artifact_url,json=artifactUrl,proto3" json:"artifact_url,omitempty"`
+	ArtifactSha256    string `protobuf:"bytes,4,opt,name=artifact_sha256,json=artifactSha256,proto3" json:"artifact_sha256,omitempty"`
+	ArtifactSizeBytes int64  `protobuf:"varint,5,opt,name=artifact_size_bytes,json=artifactSizeBytes,proto3" json:"artifact_size_bytes,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ImportPluginStoreCommand) Reset() {
+	*x = ImportPluginStoreCommand{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ImportPluginStoreCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ImportPluginStoreCommand) ProtoMessage() {}
+
+func (x *ImportPluginStoreCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ImportPluginStoreCommand.ProtoReflect.Descriptor instead.
+func (*ImportPluginStoreCommand) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ImportPluginStoreCommand) GetMetadata() *v1.CommandMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ImportPluginStoreCommand) GetTargetNodeId() string {
+	if x != nil {
+		return x.TargetNodeId
+	}
+	return ""
+}
+
+func (x *ImportPluginStoreCommand) GetArtifactUrl() string {
+	if x != nil {
+		return x.ArtifactUrl
+	}
+	return ""
+}
+
+func (x *ImportPluginStoreCommand) GetArtifactSha256() string {
+	if x != nil {
+		return x.ArtifactSha256
+	}
+	return ""
+}
+
+func (x *ImportPluginStoreCommand) GetArtifactSizeBytes() int64 {
+	if x != nil {
+		return x.ArtifactSizeBytes
+	}
+	return 0
+}
+
+type PluginStoreImportResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CommandId     string                 `protobuf:"bytes,1,opt,name=command_id,json=commandId,proto3" json:"command_id,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`                               // running | succeeded | failed
+	PluginCount   int32                  `protobuf:"varint,3,opt,name=plugin_count,json=pluginCount,proto3" json:"plugin_count,omitempty"` // informational count reported by node
+	BackupPath    string                 `protobuf:"bytes,4,opt,name=backup_path,json=backupPath,proto3" json:"backup_path,omitempty"`
+	ErrorCode     string                 `protobuf:"bytes,5,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,6,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginStoreImportResult) Reset() {
+	*x = PluginStoreImportResult{}
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginStoreImportResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginStoreImportResult) ProtoMessage() {}
+
+func (x *PluginStoreImportResult) ProtoReflect() protoreflect.Message {
+	mi := &file_legion_plugin_v1_plugin_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginStoreImportResult.ProtoReflect.Descriptor instead.
+func (*PluginStoreImportResult) Descriptor() ([]byte, []int) {
+	return file_legion_plugin_v1_plugin_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *PluginStoreImportResult) GetCommandId() string {
+	if x != nil {
+		return x.CommandId
+	}
+	return ""
+}
+
+func (x *PluginStoreImportResult) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *PluginStoreImportResult) GetPluginCount() int32 {
+	if x != nil {
+		return x.PluginCount
+	}
+	return 0
+}
+
+func (x *PluginStoreImportResult) GetBackupPath() string {
+	if x != nil {
+		return x.BackupPath
+	}
+	return ""
+}
+
+func (x *PluginStoreImportResult) GetErrorCode() string {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ""
+}
+
+func (x *PluginStoreImportResult) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *PluginStoreImportResult) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
 var File_legion_plugin_v1_plugin_proto protoreflect.FileDescriptor
 
 const file_legion_plugin_v1_plugin_proto_rawDesc = "" +
@@ -416,7 +1061,68 @@ const file_legion_plugin_v1_plugin_proto_rawDesc = "" +
 	"error_code\x18\x03 \x01(\tR\terrorCode\x12#\n" +
 	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\x12;\n" +
 	"\vobserved_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"observedAtBLZJgithub.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1;pluginv1b\x06proto3"
+	"observedAt\"|\n" +
+	"\x17ListPluginGroupsCommand\x12;\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x1f.legion.node.v1.CommandMetadataR\bmetadata\x12$\n" +
+	"\x0etarget_node_id\x18\x02 \x01(\tR\ftargetNodeId\"h\n" +
+	"\x0fPluginGroupInfo\x12\x14\n" +
+	"\x05group\x18\x01 \x01(\tR\x05group\x12\x14\n" +
+	"\x05total\x18\x02 \x01(\x05R\x05total\x12)\n" +
+	"\x10compatible_total\x18\x03 \x01(\x05R\x0fcompatibleTotal\"k\n" +
+	"\x11PluginGroupScript\x12\x14\n" +
+	"\x05group\x18\x01 \x01(\tR\x05group\x12\x1f\n" +
+	"\vscript_name\x18\x02 \x01(\tR\n" +
+	"scriptName\x12\x1f\n" +
+	"\vscript_type\x18\x03 \x01(\tR\n" +
+	"scriptType\"\xd6\x01\n" +
+	"\x16ListPluginGroupsResult\x129\n" +
+	"\x06groups\x18\x01 \x03(\v2!.legion.plugin.v1.PluginGroupInfoR\x06groups\x12=\n" +
+	"\ascripts\x18\x02 \x03(\v2#.legion.plugin.v1.PluginGroupScriptR\ascripts\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\x03 \x01(\tR\terrorCode\x12#\n" +
+	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\"{\n" +
+	"\x16SyncPluginStoreCommand\x12;\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x1f.legion.node.v1.CommandMetadataR\bmetadata\x12$\n" +
+	"\x0etarget_node_id\x18\x02 \x01(\tR\ftargetNodeId\"\xfc\x02\n" +
+	"\x17PluginStoreSyncProgress\x12\x1d\n" +
+	"\n" +
+	"command_id\x18\x01 \x01(\tR\tcommandId\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1a\n" +
+	"\bprogress\x18\x03 \x01(\x01R\bprogress\x12\x14\n" +
+	"\x05total\x18\x04 \x01(\x05R\x05total\x12\x1c\n" +
+	"\tcompleted\x18\x05 \x01(\x05R\tcompleted\x12\x1c\n" +
+	"\tsucceeded\x18\x06 \x01(\x05R\tsucceeded\x12\x16\n" +
+	"\x06failed\x18\a \x01(\x05R\x06failed\x12%\n" +
+	"\x0ecurrent_plugin\x18\b \x01(\tR\rcurrentPlugin\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\t \x01(\tR\terrorCode\x12#\n" +
+	"\rerror_message\x18\n" +
+	" \x01(\tR\ferrorMessage\x129\n" +
+	"\n" +
+	"updated_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xa5\x01\n" +
+	"!QueryPluginStoreSyncStatusCommand\x12;\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x1f.legion.node.v1.CommandMetadataR\bmetadata\x12$\n" +
+	"\x0etarget_node_id\x18\x02 \x01(\tR\ftargetNodeId\x12\x1d\n" +
+	"\n" +
+	"command_id\x18\x03 \x01(\tR\tcommandId\"\xf9\x01\n" +
+	"\x18ImportPluginStoreCommand\x12;\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x1f.legion.node.v1.CommandMetadataR\bmetadata\x12$\n" +
+	"\x0etarget_node_id\x18\x02 \x01(\tR\ftargetNodeId\x12!\n" +
+	"\fartifact_url\x18\x03 \x01(\tR\vartifactUrl\x12'\n" +
+	"\x0fartifact_sha256\x18\x04 \x01(\tR\x0eartifactSha256\x12.\n" +
+	"\x13artifact_size_bytes\x18\x05 \x01(\x03R\x11artifactSizeBytes\"\x93\x02\n" +
+	"\x17PluginStoreImportResult\x12\x1d\n" +
+	"\n" +
+	"command_id\x18\x01 \x01(\tR\tcommandId\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12!\n" +
+	"\fplugin_count\x18\x03 \x01(\x05R\vpluginCount\x12\x1f\n" +
+	"\vbackup_path\x18\x04 \x01(\tR\n" +
+	"backupPath\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\x05 \x01(\tR\terrorCode\x12#\n" +
+	"\rerror_message\x18\x06 \x01(\tR\ferrorMessage\x129\n" +
+	"\n" +
+	"updated_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAtBLZJgithub.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1;pluginv1b\x06proto3"
 
 var (
 	file_legion_plugin_v1_plugin_proto_rawDescOnce sync.Once
@@ -430,32 +1136,49 @@ func file_legion_plugin_v1_plugin_proto_rawDescGZIP() []byte {
 	return file_legion_plugin_v1_plugin_proto_rawDescData
 }
 
-var file_legion_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_legion_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_legion_plugin_v1_plugin_proto_goTypes = []any{
-	(*PluginReleaseRef)(nil),      // 0: legion.plugin.v1.PluginReleaseRef
-	(*PluginArtifactRef)(nil),     // 1: legion.plugin.v1.PluginArtifactRef
-	(*SyncPluginCommand)(nil),     // 2: legion.plugin.v1.SyncPluginCommand
-	(*PluginSyncStatus)(nil),      // 3: legion.plugin.v1.PluginSyncStatus
-	(*PluginSyncFailed)(nil),      // 4: legion.plugin.v1.PluginSyncFailed
-	(*v1.CommandMetadata)(nil),    // 5: legion.node.v1.CommandMetadata
-	(*v1.EventMetadata)(nil),      // 6: legion.node.v1.EventMetadata
-	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*PluginReleaseRef)(nil),                  // 0: legion.plugin.v1.PluginReleaseRef
+	(*PluginArtifactRef)(nil),                 // 1: legion.plugin.v1.PluginArtifactRef
+	(*SyncPluginCommand)(nil),                 // 2: legion.plugin.v1.SyncPluginCommand
+	(*PluginSyncStatus)(nil),                  // 3: legion.plugin.v1.PluginSyncStatus
+	(*PluginSyncFailed)(nil),                  // 4: legion.plugin.v1.PluginSyncFailed
+	(*ListPluginGroupsCommand)(nil),           // 5: legion.plugin.v1.ListPluginGroupsCommand
+	(*PluginGroupInfo)(nil),                   // 6: legion.plugin.v1.PluginGroupInfo
+	(*PluginGroupScript)(nil),                 // 7: legion.plugin.v1.PluginGroupScript
+	(*ListPluginGroupsResult)(nil),            // 8: legion.plugin.v1.ListPluginGroupsResult
+	(*SyncPluginStoreCommand)(nil),            // 9: legion.plugin.v1.SyncPluginStoreCommand
+	(*PluginStoreSyncProgress)(nil),           // 10: legion.plugin.v1.PluginStoreSyncProgress
+	(*QueryPluginStoreSyncStatusCommand)(nil), // 11: legion.plugin.v1.QueryPluginStoreSyncStatusCommand
+	(*ImportPluginStoreCommand)(nil),          // 12: legion.plugin.v1.ImportPluginStoreCommand
+	(*PluginStoreImportResult)(nil),           // 13: legion.plugin.v1.PluginStoreImportResult
+	(*v1.CommandMetadata)(nil),                // 14: legion.node.v1.CommandMetadata
+	(*v1.EventMetadata)(nil),                  // 15: legion.node.v1.EventMetadata
+	(*timestamppb.Timestamp)(nil),             // 16: google.protobuf.Timestamp
 }
 var file_legion_plugin_v1_plugin_proto_depIdxs = []int32{
-	5, // 0: legion.plugin.v1.SyncPluginCommand.metadata:type_name -> legion.node.v1.CommandMetadata
-	0, // 1: legion.plugin.v1.SyncPluginCommand.release:type_name -> legion.plugin.v1.PluginReleaseRef
-	1, // 2: legion.plugin.v1.SyncPluginCommand.artifact:type_name -> legion.plugin.v1.PluginArtifactRef
-	6, // 3: legion.plugin.v1.PluginSyncStatus.metadata:type_name -> legion.node.v1.EventMetadata
-	0, // 4: legion.plugin.v1.PluginSyncStatus.release:type_name -> legion.plugin.v1.PluginReleaseRef
-	7, // 5: legion.plugin.v1.PluginSyncStatus.observed_at:type_name -> google.protobuf.Timestamp
-	6, // 6: legion.plugin.v1.PluginSyncFailed.metadata:type_name -> legion.node.v1.EventMetadata
-	0, // 7: legion.plugin.v1.PluginSyncFailed.release:type_name -> legion.plugin.v1.PluginReleaseRef
-	7, // 8: legion.plugin.v1.PluginSyncFailed.observed_at:type_name -> google.protobuf.Timestamp
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	14, // 0: legion.plugin.v1.SyncPluginCommand.metadata:type_name -> legion.node.v1.CommandMetadata
+	0,  // 1: legion.plugin.v1.SyncPluginCommand.release:type_name -> legion.plugin.v1.PluginReleaseRef
+	1,  // 2: legion.plugin.v1.SyncPluginCommand.artifact:type_name -> legion.plugin.v1.PluginArtifactRef
+	15, // 3: legion.plugin.v1.PluginSyncStatus.metadata:type_name -> legion.node.v1.EventMetadata
+	0,  // 4: legion.plugin.v1.PluginSyncStatus.release:type_name -> legion.plugin.v1.PluginReleaseRef
+	16, // 5: legion.plugin.v1.PluginSyncStatus.observed_at:type_name -> google.protobuf.Timestamp
+	15, // 6: legion.plugin.v1.PluginSyncFailed.metadata:type_name -> legion.node.v1.EventMetadata
+	0,  // 7: legion.plugin.v1.PluginSyncFailed.release:type_name -> legion.plugin.v1.PluginReleaseRef
+	16, // 8: legion.plugin.v1.PluginSyncFailed.observed_at:type_name -> google.protobuf.Timestamp
+	14, // 9: legion.plugin.v1.ListPluginGroupsCommand.metadata:type_name -> legion.node.v1.CommandMetadata
+	6,  // 10: legion.plugin.v1.ListPluginGroupsResult.groups:type_name -> legion.plugin.v1.PluginGroupInfo
+	7,  // 11: legion.plugin.v1.ListPluginGroupsResult.scripts:type_name -> legion.plugin.v1.PluginGroupScript
+	14, // 12: legion.plugin.v1.SyncPluginStoreCommand.metadata:type_name -> legion.node.v1.CommandMetadata
+	16, // 13: legion.plugin.v1.PluginStoreSyncProgress.updated_at:type_name -> google.protobuf.Timestamp
+	14, // 14: legion.plugin.v1.QueryPluginStoreSyncStatusCommand.metadata:type_name -> legion.node.v1.CommandMetadata
+	14, // 15: legion.plugin.v1.ImportPluginStoreCommand.metadata:type_name -> legion.node.v1.CommandMetadata
+	16, // 16: legion.plugin.v1.PluginStoreImportResult.updated_at:type_name -> google.protobuf.Timestamp
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_legion_plugin_v1_plugin_proto_init() }
@@ -469,7 +1192,7 @@ func file_legion_plugin_v1_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_legion_plugin_v1_plugin_proto_rawDesc), len(file_legion_plugin_v1_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/scannode/legion_capability_events.go
+++ b/scannode/legion_capability_events.go
@@ -168,6 +168,34 @@ func (p *capabilityEventPublisher) PublishResponseActionResult(
 	})
 }
 
+// PublishRaw 在核心 NATS（非 JetStream）上发布一条实时结果消息，
+// 供平台同步等待的查询命令（如 plugin.groups.list）按 commandID 派生 subject 接收。
+func (p *capabilityEventPublisher) PublishRaw(ctx context.Context, subject string, raw []byte) error {
+	session, ok := p.node.GetSessionState()
+	if !ok {
+		return ErrNodeSessionNotReady
+	}
+	if err := p.ensureJetStream(session.NATSURL); err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	conn := p.conn
+	p.mu.Unlock()
+	if conn == nil {
+		return fmt.Errorf("capability event nats connection is not ready")
+	}
+	if err := conn.Publish(subject, raw); err != nil {
+		return fmt.Errorf("publish raw realtime result: %w", err)
+	}
+	flushCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	if err := conn.FlushWithContext(flushCtx); err != nil {
+		return fmt.Errorf("flush raw realtime result: %w", err)
+	}
+	return nil
+}
+
 func (p *capabilityEventPublisher) PublishDesiredSpecDryRunResult(
 	ctx context.Context,
 	ref capabilityCommandRef,

--- a/scannode/legion_command_consumer.go
+++ b/scannode/legion_command_consumer.go
@@ -280,6 +280,14 @@ func (b *legionJobBridge) handleMessage(
 		return b.handleHIDSResponseActionExecute(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandSSARuleSyncExport):
 		return b.handleSSARuleSyncExport(ctx, message.Data)
+	case strings.HasSuffix(message.Subject, "."+legionCommandPluginGroupsList):
+		return b.handlePluginGroupsList(ctx, message.Data)
+	case strings.HasSuffix(message.Subject, "."+legionCommandPluginStoreSync):
+		return b.handlePluginStoreSync(ctx, message.Data)
+	case strings.HasSuffix(message.Subject, "."+legionCommandPluginStoreSyncStatusQuery):
+		return b.handlePluginStoreSyncStatusQuery(ctx, message.Data)
+	case strings.HasSuffix(message.Subject, "."+legionCommandPluginStoreImport):
+		return b.handlePluginStoreImport(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandAISessionBind):
 		return b.handleAISessionBind(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandAISessionInput):

--- a/scannode/legion_protocol.go
+++ b/scannode/legion_protocol.go
@@ -15,6 +15,10 @@ const (
 	legionCommandHIDSCurrentStateCollect              = "hids.current_state.collect"
 	legionCommandHIDSFileEvidenceCollect              = "hids.file_evidence.collect"
 	legionCommandSSARuleSyncExport                    = "ssa.rule_sync.export"
+	legionCommandPluginGroupsList                     = "plugin.groups.list"
+	legionCommandPluginStoreSync                      = "plugin.store.sync"
+	legionCommandPluginStoreSyncStatusQuery           = "plugin.store.sync.status"
+	legionCommandPluginStoreImport                    = "plugin.store.import"
 	legionCommandAISessionBind                        = "ai.session.bind"
 	legionCommandAISessionInput                       = "ai.session.input"
 	legionCommandAISessionAppend                      = "ai.session.context.append"
@@ -247,6 +251,10 @@ const (
 
 const legionRealtimeHIDSDesiredSpecDryRunResultPrefix = legionRealtimePrefix + ".hids.desired_spec_dry_run.result"
 
+const legionRealtimePluginGroupsResultPrefix = legionRealtimePrefix + ".plugin.groups.result"
+
+const legionRealtimePluginStoreSyncResultPrefix = legionRealtimePrefix + ".plugin.store.sync.result"
+
 func commandSubjectWildcard(base string) string {
 	return trimSubject(base) + ".>"
 }
@@ -272,6 +280,22 @@ func hidsDesiredSpecDryRunResultSubject(commandID string) string {
 		return legionRealtimeHIDSDesiredSpecDryRunResultPrefix
 	}
 	return legionRealtimeHIDSDesiredSpecDryRunResultPrefix + "." + commandID
+}
+
+func pluginGroupsResultSubject(commandID string) string {
+	commandID = strings.TrimSpace(commandID)
+	if commandID == "" {
+		return legionRealtimePluginGroupsResultPrefix
+	}
+	return legionRealtimePluginGroupsResultPrefix + "." + commandID
+}
+
+func pluginStoreSyncResultSubject(commandID string) string {
+	commandID = strings.TrimSpace(commandID)
+	if commandID == "" {
+		return legionRealtimePluginStoreSyncResultPrefix
+	}
+	return legionRealtimePluginStoreSyncResultPrefix + "." + commandID
 }
 
 func trimSubject(value string) string {

--- a/scannode/plugin_groups_list.go
+++ b/scannode/plugin_groups_list.go
@@ -1,0 +1,151 @@
+package scannode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	pluginv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1"
+)
+
+// 端口扫描管理器 (hook.NewMixPluginCaller) 仅能加载这些类型的插件；
+// mitm/yak/codec 插件对端口扫描流程无效，统计时单列 compatible_total。
+var portScanCompatiblePluginTypes = map[string]struct{}{
+	"port-scan": {},
+	"nuclei":    {},
+	"nasl":      {},
+}
+
+func isPortScanCompatiblePluginType(pluginType string) bool {
+	_, ok := portScanCompatiblePluginTypes[strings.ToLower(strings.TrimSpace(pluginType))]
+	return ok
+}
+
+func (b *legionJobBridge) handlePluginGroupsList(ctx context.Context, raw []byte) error {
+	var command pluginv1.ListPluginGroupsCommand
+	if err := proto.Unmarshal(raw, &command); err != nil {
+		return fmt.Errorf("unmarshal plugin groups list command: %w", err)
+	}
+
+	currentNodeID := b.agent.node.CurrentNodeID()
+	if err := validatePluginGroupsListCommand(currentNodeID, &command); err != nil {
+		return b.publishPluginGroupsResult(ctx, command.GetMetadata().GetCommandId(), pluginGroupsListErrorResult("invalid_plugin_groups_command", err.Error()))
+	}
+
+	result, err := queryLocalPluginGroups()
+	if err != nil {
+		log.Errorf("plugin groups list failed: node_id=%s command_id=%s err=%v",
+			currentNodeID, command.GetMetadata().GetCommandId(), err)
+		result = pluginGroupsListErrorResult("plugin_groups_query_failed", err.Error())
+	}
+	return b.publishPluginGroupsResult(ctx, command.GetMetadata().GetCommandId(), result)
+}
+
+func validatePluginGroupsListCommand(nodeID string, command *pluginv1.ListPluginGroupsCommand) error {
+	switch {
+	case command.GetMetadata() == nil:
+		return fmt.Errorf("plugin groups list metadata is required")
+	case strings.TrimSpace(command.GetMetadata().GetCommandId()) == "":
+		return fmt.Errorf("plugin groups list command_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) == "":
+		return fmt.Errorf("plugin groups list target_node_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) != strings.TrimSpace(nodeID):
+		return fmt.Errorf("plugin groups list target_node_id mismatch: %s", command.GetTargetNodeId())
+	default:
+		return nil
+	}
+}
+
+type pluginGroupMembership struct {
+	Group      string
+	ScriptName string
+	ScriptType string
+}
+
+func queryLocalPluginGroups() (*pluginv1.ListPluginGroupsResult, error) {
+	db := consts.GetGormProfileDatabase()
+	if db == nil {
+		return nil, fmt.Errorf("profile database is not initialized")
+	}
+
+	var rows []pluginGroupMembership
+	if err := db.Table("plugin_groups").
+		Select("plugin_groups.`group` AS `group`, yak_scripts.script_name AS script_name, yak_scripts.type AS script_type").
+		Joins("INNER JOIN yak_scripts ON yak_scripts.script_name = plugin_groups.yak_script_name AND yak_scripts.deleted_at IS NULL").
+		Where("plugin_groups.deleted_at IS NULL").
+		Where("plugin_groups.is_poc_built_in = ?", false).
+		Where("plugin_groups.temporary_id = ?", "").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("query plugin groups: %w", err)
+	}
+
+	members := make(map[string][]pluginGroupMembership, len(rows))
+	for _, row := range rows {
+		group := strings.TrimSpace(row.Group)
+		if group == "" || strings.HasPrefix(group, "mcp-group-") {
+			continue
+		}
+		members[group] = append(members[group], pluginGroupMembership{
+			ScriptName: strings.TrimSpace(row.ScriptName),
+			ScriptType: strings.TrimSpace(row.ScriptType),
+		})
+	}
+
+	result := &pluginv1.ListPluginGroupsResult{}
+	for group, items := range members {
+		compatible := 0
+		scripts := make([]*pluginv1.PluginGroupScript, 0, len(items))
+		for _, item := range items {
+			if item.ScriptName == "" {
+				continue
+			}
+			scripts = append(scripts, &pluginv1.PluginGroupScript{
+				Group:      group,
+				ScriptName: item.ScriptName,
+				ScriptType: item.ScriptType,
+			})
+			if isPortScanCompatiblePluginType(item.ScriptType) {
+				compatible++
+			}
+		}
+		if len(scripts) == 0 {
+			continue
+		}
+		result.Groups = append(result.Groups, &pluginv1.PluginGroupInfo{
+			Group:           group,
+			Total:           int32(len(scripts)),
+			CompatibleTotal: int32(compatible),
+		})
+		result.Scripts = append(result.Scripts, scripts...)
+	}
+	return result, nil
+}
+
+func pluginGroupsListErrorResult(code, message string) *pluginv1.ListPluginGroupsResult {
+	return &pluginv1.ListPluginGroupsResult{
+		ErrorCode:    code,
+		ErrorMessage: message,
+	}
+}
+
+func (b *legionJobBridge) publishPluginGroupsResult(ctx context.Context, commandID string, result *pluginv1.ListPluginGroupsResult) error {
+	raw, err := proto.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("marshal plugin groups result: %w", err)
+	}
+
+	publisher, ok := b.capabilityPublisher.(*capabilityEventPublisher)
+	if !ok || publisher == nil {
+		return fmt.Errorf("capability event publisher is not ready")
+	}
+
+	if err := publisher.PublishRaw(ctx, pluginGroupsResultSubject(commandID), raw); err != nil {
+		return fmt.Errorf("publish plugin groups result: %w", err)
+	}
+	log.Infof("published plugin groups result: command_id=%s groups=%d", commandID, len(result.GetGroups()))
+	return nil
+}

--- a/scannode/plugin_groups_list_test.go
+++ b/scannode/plugin_groups_list_test.go
@@ -1,0 +1,141 @@
+package scannode
+
+import (
+	"testing"
+
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	nodev1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/node/v1"
+	pluginv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1"
+)
+
+func setupPluginGroupsTestDB(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	db, err := consts.CreateProfileDatabase(dir + "/plugin-groups-test.db")
+	if err != nil {
+		t.Fatalf("create profile database: %v", err)
+	}
+	consts.BindProfileDatabase(db, dir+"/plugin-groups-test.db")
+	t.Cleanup(func() {
+		consts.BindProfileDatabase(nil, "")
+	})
+
+	scripts := []*schema.YakScript{
+		{ScriptName: "weblogic-rce", Type: "port-scan"},
+		{ScriptName: "weblogic-weak-pass", Type: "nuclei"},
+		{ScriptName: "weblogic-mitm-only", Type: "mitm"},
+		{ScriptName: "weaver-oa-rce", Type: "port-scan"},
+		{ScriptName: "wordpress-sqli", Type: "nuclei"},
+		{ScriptName: "not-grouped", Type: "port-scan"},
+	}
+	for _, script := range scripts {
+		if err := db.Create(script).Error; err != nil {
+			t.Fatalf("create yak script %s: %v", script.ScriptName, err)
+		}
+	}
+
+	groups := []*schema.PluginGroup{
+		{YakScriptName: "weblogic-rce", Group: "Weblogic"},
+		{YakScriptName: "weblogic-weak-pass", Group: "Weblogic"},
+		{YakScriptName: "weblogic-mitm-only", Group: "Weblogic"},
+		{YakScriptName: "weaver-oa-rce", Group: "泛微OA"},
+		{YakScriptName: "wordpress-sqli", Group: "Wordpress"},
+		{YakScriptName: "weaver-oa-rce", Group: "mcp-group-1783762872931342355"},
+		{YakScriptName: "weblogic-rce", Group: "BuiltInGroup", IsPocBuiltIn: true},
+		{YakScriptName: "weblogic-rce", Group: "TemporaryGroup", TemporaryId: "page-1"},
+	}
+	for _, group := range groups {
+		group.Hash = group.CalcHash()
+		if err := db.Create(group).Error; err != nil {
+			t.Fatalf("create plugin group %s/%s: %v", group.Group, group.YakScriptName, err)
+		}
+	}
+}
+
+func TestQueryLocalPluginGroups(t *testing.T) {
+	setupPluginGroupsTestDB(t)
+
+	result, err := queryLocalPluginGroups()
+	if err != nil {
+		t.Fatalf("queryLocalPluginGroups: %v", err)
+	}
+
+	groupTotals := make(map[string]*pluginv1.PluginGroupInfo)
+	for _, group := range result.GetGroups() {
+		groupTotals[group.GetGroup()] = group
+	}
+
+	if got := groupTotals["Weblogic"]; got == nil {
+		t.Fatalf("Weblogic group missing, got groups: %v", groupTotals)
+	} else {
+		if got.GetTotal() != 3 {
+			t.Fatalf("Weblogic total = %d, want 3", got.GetTotal())
+		}
+		if got.GetCompatibleTotal() != 2 {
+			t.Fatalf("Weblogic compatible_total = %d, want 2 (mitm excluded)", got.GetCompatibleTotal())
+		}
+	}
+
+	if got := groupTotals["泛微OA"]; got == nil {
+		t.Fatalf("泛微OA group missing")
+	} else if got.GetCompatibleTotal() != 1 || got.GetTotal() != 1 {
+		t.Fatalf("泛微OA totals = %d/%d, want 1/1", got.GetCompatibleTotal(), got.GetTotal())
+	}
+
+	for _, excluded := range []string{"mcp-group-1783762872931342355", "BuiltInGroup", "TemporaryGroup"} {
+		if _, ok := groupTotals[excluded]; ok {
+			t.Fatalf("group %s should be excluded", excluded)
+		}
+	}
+
+	scriptsByGroup := make(map[string][]string)
+	for _, script := range result.GetScripts() {
+		scriptsByGroup[script.GetGroup()] = append(scriptsByGroup[script.GetGroup()], script.GetScriptName())
+	}
+	if got := scriptsByGroup["Weblogic"]; len(got) != 3 {
+		t.Fatalf("Weblogic scripts = %v, want 3 entries", got)
+	}
+	if _, ok := scriptsByGroup["not-grouped"]; ok {
+		t.Fatalf("ungrouped script leaked into result")
+	}
+}
+
+func TestValidatePluginGroupsListCommand(t *testing.T) {
+	newCommand := func() *pluginv1.ListPluginGroupsCommand {
+		return &pluginv1.ListPluginGroupsCommand{
+			Metadata:     &nodev1.CommandMetadata{CommandId: "cmd-groups-1"},
+			TargetNodeId: "node-a",
+		}
+	}
+
+	if err := validatePluginGroupsListCommand("node-a", newCommand()); err != nil {
+		t.Fatalf("valid command rejected: %v", err)
+	}
+
+	command := newCommand()
+	command.Metadata = nil
+	if err := validatePluginGroupsListCommand("node-a", command); err == nil {
+		t.Fatal("missing metadata should fail")
+	}
+
+	command = newCommand()
+	command.TargetNodeId = "node-b"
+	if err := validatePluginGroupsListCommand("node-a", command); err == nil {
+		t.Fatal("target node mismatch should fail")
+	}
+}
+
+func TestIsPortScanCompatiblePluginType(t *testing.T) {
+	for _, compatible := range []string{"port-scan", "nuclei", "NASL", " nuclei "} {
+		if !isPortScanCompatiblePluginType(compatible) {
+			t.Fatalf("type %q should be compatible", compatible)
+		}
+	}
+	for _, incompatible := range []string{"mitm", "yak", "codec", "", "portscan"} {
+		if isPortScanCompatiblePluginType(incompatible) {
+			t.Fatalf("type %q should be incompatible", incompatible)
+		}
+	}
+}

--- a/scannode/plugin_store_import.go
+++ b/scannode/plugin_store_import.go
@@ -1,0 +1,274 @@
+package scannode
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/schema"
+	pluginv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1"
+)
+
+const (
+	pluginStoreImportStatusRunning   = "running"
+	pluginStoreImportStatusSucceeded = "succeeded"
+	pluginStoreImportStatusFailed    = "failed"
+
+	pluginStoreImportDownloadTimeout = 5 * time.Minute
+)
+
+var sqliteHeader = []byte("SQLite format 3\x00")
+
+func (b *legionJobBridge) handlePluginStoreImport(ctx context.Context, raw []byte) error {
+	var command pluginv1.ImportPluginStoreCommand
+	if err := proto.Unmarshal(raw, &command); err != nil {
+		return fmt.Errorf("unmarshal plugin store import command: %w", err)
+	}
+
+	commandID := strings.TrimSpace(command.GetMetadata().GetCommandId())
+	currentNodeID := b.agent.node.CurrentNodeID()
+	if err := validatePluginStoreImportCommand(currentNodeID, &command); err != nil {
+		return b.publishPluginStoreSyncProgress(commandID, &pluginv1.PluginStoreSyncProgress{
+			CommandId:    commandID,
+			Status:       pluginStoreImportStatusFailed,
+			ErrorCode:    "invalid_plugin_store_import_command",
+			ErrorMessage: err.Error(),
+			UpdatedAt:    timestamppb.New(time.Now().UTC()),
+		})
+	}
+
+	// 导入同样复用同步状态机，进度通过 plugin.store.sync.result 通道回传。
+	if snapshot := pluginStoreSync.snapshot(); snapshot != nil && snapshot.Status == pluginStoreSyncStatusRunning {
+		return b.publishPluginStoreSyncProgress(commandID, &pluginv1.PluginStoreSyncProgress{
+			CommandId:    commandID,
+			Status:       pluginStoreImportStatusFailed,
+			ErrorCode:    "plugin_store_sync_busy",
+			ErrorMessage: "another plugin store sync or import is already running on this node",
+			UpdatedAt:    timestamppb.New(time.Now().UTC()),
+		})
+	}
+
+	go b.runPluginStoreImport(b.agent.node.GetRootContext(), commandID, &command)
+	return nil
+}
+
+func (b *legionJobBridge) runPluginStoreImport(ctx context.Context, commandID string, command *pluginv1.ImportPluginStoreCommand) {
+	pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreImportStatusRunning
+		p.CurrentPlugin = "downloading plugin database"
+		p.Progress = 0
+	})
+	b.publishPluginStoreSyncProgress(commandID, pluginStoreSync.snapshot())
+
+	progress, err := b.executePluginStoreImport(ctx, commandID, command)
+	if err != nil {
+		log.Errorf("plugin store import failed: command_id=%s err=%v", commandID, err)
+		progress = pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+			p.Status = pluginStoreImportStatusFailed
+			p.ErrorCode = "plugin_store_import_failed"
+			p.ErrorMessage = err.Error()
+		})
+	}
+	b.publishPluginStoreSyncProgress(commandID, progress)
+}
+
+func (b *legionJobBridge) executePluginStoreImport(
+	ctx context.Context,
+	commandID string,
+	command *pluginv1.ImportPluginStoreCommand,
+) (*pluginv1.PluginStoreSyncProgress, error) {
+	// 1. 下载上传的 db 文件到临时路径。用节点自己的 session 认证下载。
+	session, ok := b.agent.node.GetSessionState()
+	if !ok {
+		return nil, fmt.Errorf("node session is not ready")
+	}
+
+	downloadCtx, cancel := context.WithTimeout(ctx, pluginStoreImportDownloadTimeout)
+	defer cancel()
+
+	tempPath, err := downloadPluginStoreDB(downloadCtx, command.GetArtifactUrl(), command.GetArtifactSha256(), session.SessionID, session.SessionToken)
+	if err != nil {
+		return nil, fmt.Errorf("download plugin db: %w", err)
+	}
+	defer os.Remove(tempPath)
+
+	// 2. 校验文件头是 SQLite。
+	header := make([]byte, len(sqliteHeader))
+	file, err := os.Open(tempPath)
+	if err != nil {
+		return nil, fmt.Errorf("open downloaded db: %w", err)
+	}
+	if _, err := file.Read(header); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("read db header: %w", err)
+	}
+	file.Close()
+	if len(header) < len(sqliteHeader) || string(header[:len(sqliteHeader)]) != string(sqliteHeader) {
+		return nil, fmt.Errorf("downloaded file is not a SQLite database")
+	}
+
+	pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+		p.CurrentPlugin = "replacing local plugin database"
+		p.Progress = 0.5
+	})
+	b.publishPluginStoreSyncProgress(commandID, pluginStoreSync.snapshot())
+
+	// 3. 安全替换：备份旧库 → 原子 rename → 重新绑定 profile DB。
+	currentPath := consts.GetCurrentProfileDatabasePath()
+	backupPath := currentPath + ".import-bak"
+
+	// 关闭当前 gorm 连接，避免文件锁冲突。
+	consts.CloseProfileDatabase()
+
+	if _, err := os.Stat(currentPath); err == nil {
+		if err := os.Rename(currentPath, backupPath); err != nil {
+			b.rebindProfileDatabase(currentPath)
+			return nil, fmt.Errorf("backup current db: %w", err)
+		}
+	}
+
+	if err := os.Rename(tempPath, currentPath); err != nil {
+		// 回滚：恢复备份
+		if _, bakErr := os.Stat(backupPath); bakErr == nil {
+			os.Rename(backupPath, currentPath)
+		}
+		b.rebindProfileDatabase(currentPath)
+		return nil, fmt.Errorf("replace db file: %w", err)
+	}
+
+	// 重新打开并绑定新库。
+	if err := b.rebindProfileDatabase(currentPath); err != nil {
+		// 打开失败，尝试回滚备份。
+		if _, bakErr := os.Stat(backupPath); bakErr == nil {
+			os.Rename(currentPath, currentPath+".failed")
+			os.Rename(backupPath, currentPath)
+			consts.CreateProfileDatabase(currentPath) // best-effort
+		}
+		return nil, fmt.Errorf("rebind profile database: %w", err)
+	}
+
+	// 4. 统计新库插件数作为信息性结果。
+	pluginCount := countPluginsInProfileDB()
+
+	final := pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreImportStatusSucceeded
+		p.Progress = 1
+		p.Total = int32(pluginCount)
+		p.Completed = int32(pluginCount)
+		p.Succeeded = int32(pluginCount)
+		p.CurrentPlugin = ""
+	})
+	log.Infof("plugin store import finished: command_id=%s plugins=%d backup=%s", commandID, pluginCount, backupPath)
+	return final, nil
+}
+
+func (b *legionJobBridge) rebindProfileDatabase(path string) error {
+	db, err := consts.CreateProfileDatabase(path)
+	if err != nil {
+		return err
+	}
+	consts.BindProfileDatabase(db, path)
+	return nil
+}
+
+func countPluginsInProfileDB() int {
+	db := consts.GetGormProfileDatabase()
+	if db == nil {
+		return 0
+	}
+	var count int64
+	db.Model(&schema.YakScript{}).Where("deleted_at IS NULL").Count(&count)
+	return int(count)
+}
+
+func downloadPluginStoreDB(ctx context.Context, url, expectedSHA256, sessionID, sessionToken string) (string, error) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return "", fmt.Errorf("artifact url is empty")
+	}
+
+	tempDir := os.TempDir()
+	tempFile, err := os.CreateTemp(tempDir, "plugin-store-import-*.db")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	tempFile.Close()
+
+	if err := os.Remove(tempPath); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("clear temp path: %w", err)
+	}
+
+	// 构造带节点 session 认证的 HTTP 请求下载 db。
+	parsed, err := neturl.Parse(url)
+	if err != nil {
+		return "", fmt.Errorf("parse artifact url: %w", err)
+	}
+	q := parsed.Query()
+	q.Set("node_session_id", sessionID)
+	parsed.RawQuery = q.Encode()
+	authURL := parsed.String()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build download request: %w", err)
+	}
+	if sessionToken != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(sessionToken))
+	}
+	client := &http.Client{Timeout: pluginStoreImportDownloadTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch artifact: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch artifact: unexpected status %d", resp.StatusCode)
+	}
+
+	hasher := sha256.New()
+	out, err := os.Create(tempPath)
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer out.Close()
+	if _, err := io.Copy(io.MultiWriter(out, hasher), resp.Body); err != nil {
+		os.Remove(tempPath)
+		return "", fmt.Errorf("download plugin db: %w", err)
+	}
+	actualSHA := hex.EncodeToString(hasher.Sum(nil))
+	if expectedSHA256 != "" && !strings.EqualFold(actualSHA, strings.TrimSpace(expectedSHA256)) {
+		os.Remove(tempPath)
+		return "", fmt.Errorf("sha256 mismatch: expected %s got %s", expectedSHA256, actualSHA)
+	}
+	return tempPath, nil
+}
+
+func validatePluginStoreImportCommand(nodeID string, command *pluginv1.ImportPluginStoreCommand) error {
+	switch {
+	case command.GetMetadata() == nil:
+		return fmt.Errorf("plugin store import metadata is required")
+	case strings.TrimSpace(command.GetMetadata().GetCommandId()) == "":
+		return fmt.Errorf("plugin store import command_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) == "":
+		return fmt.Errorf("plugin store import target_node_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) != strings.TrimSpace(nodeID):
+		return fmt.Errorf("plugin store import target_node_id mismatch: %s", command.GetTargetNodeId())
+	case strings.TrimSpace(command.GetArtifactUrl()) == "":
+		return fmt.Errorf("plugin store import artifact_url is required")
+	default:
+		return nil
+	}
+}

--- a/scannode/plugin_store_import_test.go
+++ b/scannode/plugin_store_import_test.go
@@ -1,0 +1,65 @@
+package scannode
+
+import (
+	"testing"
+
+	pluginv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1"
+	nodev1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/node/v1"
+)
+
+func TestValidatePluginStoreImportCommand(t *testing.T) {
+	newCommand := func() *pluginv1.ImportPluginStoreCommand {
+		return &pluginv1.ImportPluginStoreCommand{
+			Metadata:     &nodev1.CommandMetadata{CommandId: "cmd-imp-1"},
+			TargetNodeId: "node-a",
+			ArtifactUrl:  "http://api/v1/plugin-store/imports/x/download",
+		}
+	}
+
+	if err := validatePluginStoreImportCommand("node-a", newCommand()); err != nil {
+		t.Fatalf("valid command rejected: %v", err)
+	}
+
+	command := newCommand()
+	command.Metadata = nil
+	if err := validatePluginStoreImportCommand("node-a", command); err == nil {
+		t.Fatal("missing metadata should fail")
+	}
+
+	command = newCommand()
+	command.TargetNodeId = "node-b"
+	if err := validatePluginStoreImportCommand("node-a", command); err == nil {
+		t.Fatal("target mismatch should fail")
+	}
+
+	command = newCommand()
+	command.ArtifactUrl = ""
+	if err := validatePluginStoreImportCommand("node-a", command); err == nil {
+		t.Fatal("missing artifact url should fail")
+	}
+}
+
+func TestPluginStoreImportStateMachine(t *testing.T) {
+	state := &pluginStoreSyncState{}
+
+	// import 复用同步状态机：进度/状态/计数走同一份快照
+	progress := state.update("cmd-imp-1", func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreImportStatusRunning
+		p.Progress = 0.5
+		p.CurrentPlugin = "downloading plugin database"
+	})
+	if progress.Status != pluginStoreImportStatusRunning || progress.Progress != 0.5 {
+		t.Fatalf("unexpected progress: %+v", progress)
+	}
+
+	state.update("cmd-imp-1", func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreImportStatusSucceeded
+		p.Progress = 1
+		p.Total = 100
+		p.Completed = 100
+	})
+	snapshot := state.snapshot()
+	if snapshot.Status != pluginStoreImportStatusSucceeded || snapshot.Total != 100 {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+}

--- a/scannode/plugin_store_sync.go
+++ b/scannode/plugin_store_sync.go
@@ -1,0 +1,305 @@
+package scannode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/yak/yaklib"
+	pluginv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1"
+)
+
+const (
+	pluginStoreSyncStatusRunning   = "running"
+	pluginStoreSyncStatusSucceeded = "succeeded"
+	pluginStoreSyncStatusFailed    = "failed"
+
+	// 进度回传节流：商店全量下载上千个插件，逐条回传会刷爆 NATS。
+	pluginStoreSyncReportInterval = 2 * time.Second
+)
+
+type pluginStoreSyncState struct {
+	mu      sync.Mutex
+	current *pluginv1.PluginStoreSyncProgress
+}
+
+var pluginStoreSync = &pluginStoreSyncState{}
+
+func (s *pluginStoreSyncState) snapshot() *pluginv1.PluginStoreSyncProgress {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return nil
+	}
+	return proto.Clone(s.current).(*pluginv1.PluginStoreSyncProgress)
+}
+
+func (s *pluginStoreSyncState) update(
+	commandID string,
+	mutate func(*pluginv1.PluginStoreSyncProgress),
+) *pluginv1.PluginStoreSyncProgress {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil || s.current.CommandId != commandID {
+		s.current = &pluginv1.PluginStoreSyncProgress{
+			CommandId: commandID,
+			Status:    pluginStoreSyncStatusRunning,
+			UpdatedAt: timestamppb.New(time.Now().UTC()),
+		}
+	}
+	if s.current.CommandId != commandID {
+		s.current = &pluginv1.PluginStoreSyncProgress{
+			CommandId: commandID,
+			Status:    pluginStoreSyncStatusRunning,
+			UpdatedAt: timestamppb.New(time.Now().UTC()),
+		}
+	}
+	mutate(s.current)
+	s.current.UpdatedAt = timestamppb.New(time.Now().UTC())
+	return proto.Clone(s.current).(*pluginv1.PluginStoreSyncProgress)
+}
+
+func (b *legionJobBridge) handlePluginStoreSync(ctx context.Context, raw []byte) error {
+	var command pluginv1.SyncPluginStoreCommand
+	if err := proto.Unmarshal(raw, &command); err != nil {
+		return fmt.Errorf("unmarshal plugin store sync command: %w", err)
+	}
+
+	commandID := strings.TrimSpace(command.GetMetadata().GetCommandId())
+	currentNodeID := b.agent.node.CurrentNodeID()
+	if err := validatePluginStoreSyncCommand(currentNodeID, &command); err != nil {
+		return b.publishPluginStoreSyncProgress(commandID, &pluginv1.PluginStoreSyncProgress{
+			CommandId:    commandID,
+			Status:       pluginStoreSyncStatusFailed,
+			ErrorCode:    "invalid_plugin_store_sync_command",
+			ErrorMessage: err.Error(),
+			UpdatedAt:    timestamppb.New(time.Now().UTC()),
+		})
+	}
+
+	if snapshot := pluginStoreSync.snapshot(); snapshot != nil && snapshot.Status == pluginStoreSyncStatusRunning {
+		return b.publishPluginStoreSyncProgress(commandID, &pluginv1.PluginStoreSyncProgress{
+			CommandId:    commandID,
+			Status:       pluginStoreSyncStatusFailed,
+			ErrorCode:    "plugin_store_sync_busy",
+			ErrorMessage: "another plugin store sync is already running on this node",
+			UpdatedAt:    timestamppb.New(time.Now().UTC()),
+		})
+	}
+
+	// 同步耗时可达分钟级，放到后台执行，不阻塞命令消费循环。
+	go b.runPluginStoreSync(b.agent.node.GetRootContext(), commandID)
+	return nil
+}
+
+func (b *legionJobBridge) runPluginStoreSync(ctx context.Context, commandID string) {
+	progress, err := b.downloadPluginStore(ctx, commandID)
+	if err != nil {
+		log.Errorf("plugin store sync failed: command_id=%s err=%v", commandID, err)
+		progress = b.reportPluginStoreFailure(commandID, "plugin_store_sync_failed", err.Error())
+	}
+	if publishErr := b.publishPluginStoreSyncProgress(commandID, progress); publishErr != nil {
+		log.Errorf("publish plugin store sync final progress: %v", publishErr)
+	}
+}
+
+func (b *legionJobBridge) downloadPluginStore(
+	ctx context.Context,
+	commandID string,
+) (*pluginv1.PluginStoreSyncProgress, error) {
+	b.publishPluginStoreSyncProgress(
+		commandID,
+		pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+			p.Status = pluginStoreSyncStatusRunning
+			p.CurrentPlugin = "connecting to plugin store"
+		}),
+	)
+
+	if err := yaklib.DownloadOnlineAuthProxy(consts.GetOnlineBaseUrl()); err != nil {
+		return nil, fmt.Errorf("connect plugin store: %w", err)
+	}
+
+	client := yaklib.NewOnlineClient(consts.GetOnlineBaseUrl())
+	db := consts.GetGormProfileDatabase()
+	if db == nil {
+		return nil, fmt.Errorf("profile database is not initialized")
+	}
+
+	// 与 Yakit 桌面端「插件商店-下载全部」同一条下载链路
+	// （DownloadOnlinePluginsBatch -> api/plugins/download，数组型过滤字段），
+	// 不使用遗留的 DownloadYakitPluginAllWithToken 旧路径。
+	stream := client.DownloadOnlinePluginsBatch(ctx, "", nil, "", nil, nil, "", 0, "", nil, "", nil, nil, nil, nil)
+	if stream == nil {
+		return nil, fmt.Errorf("download stream error: empty")
+	}
+
+	var (
+		total     int64
+		completed int32
+		succeeded int32
+		failed    int32
+		lastSend  time.Time
+	)
+	for item := range stream.Chan {
+		if item == nil || item.Plugin == nil {
+			continue
+		}
+		if item.Total > 0 {
+			total = item.Total
+		}
+		completed++
+		if err := client.Save(db, item.Plugin); err != nil {
+			failed++
+			log.Errorf("plugin store sync: save [%s] failed: %v", item.Plugin.ScriptName, err)
+		} else {
+			succeeded++
+		}
+
+		now := time.Now()
+		if now.Sub(lastSend) >= pluginStoreSyncReportInterval {
+			lastSend = now
+			b.publishPluginStoreSyncProgress(
+				commandID,
+				pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+					p.Status = pluginStoreSyncStatusRunning
+					p.Total = int32(total)
+					p.Completed = completed
+					p.Succeeded = succeeded
+					p.Failed = failed
+					p.CurrentPlugin = item.Plugin.ScriptName
+					if total > 0 {
+						p.Progress = float64(completed) / float64(total)
+					}
+				}),
+			)
+		}
+	}
+
+	// 商店不可达或返回空目录时下载流以零插件结束；这与“正常但无插件”无法区分，
+	// 但 Yakit 社区商店始终有上千公共插件，零结果一律按连接失败上报。
+	if total == 0 && completed == 0 {
+		return nil, fmt.Errorf("plugin store returned no plugins (store unreachable or empty)")
+	}
+
+	final := pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreSyncStatusSucceeded
+		p.Total = int32(total)
+		p.Completed = completed
+		p.Succeeded = succeeded
+		p.Failed = failed
+		p.CurrentPlugin = ""
+		if total > 0 {
+			p.Progress = float64(completed) / float64(total)
+		} else {
+			p.Progress = 1
+		}
+	})
+	log.Infof(
+		"plugin store sync finished: command_id=%s total=%d succeeded=%d failed=%d",
+		commandID, total, succeeded, failed,
+	)
+	return final, nil
+}
+
+func (b *legionJobBridge) reportPluginStoreFailure(commandID, code, message string) *pluginv1.PluginStoreSyncProgress {
+	return pluginStoreSync.update(commandID, func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreSyncStatusFailed
+		p.ErrorCode = code
+		p.ErrorMessage = message
+	})
+}
+
+func (b *legionJobBridge) handlePluginStoreSyncStatusQuery(ctx context.Context, raw []byte) error {
+	var command pluginv1.QueryPluginStoreSyncStatusCommand
+	if err := proto.Unmarshal(raw, &command); err != nil {
+		return fmt.Errorf("unmarshal plugin store sync status query: %w", err)
+	}
+
+	currentNodeID := b.agent.node.CurrentNodeID()
+	if err := validatePluginStoreSyncStatusQuery(currentNodeID, &command); err != nil {
+		return b.publishPluginStoreSyncProgress(command.GetMetadata().GetCommandId(), &pluginv1.PluginStoreSyncProgress{
+			CommandId:    command.GetMetadata().GetCommandId(),
+			Status:       pluginStoreSyncStatusFailed,
+			ErrorCode:    "invalid_plugin_store_sync_status_query",
+			ErrorMessage: err.Error(),
+			UpdatedAt:    timestamppb.New(time.Now().UTC()),
+		})
+	}
+
+	// 查询任意 commandID 的当前状态：节点只保留最近一次同步的结果，
+	// 非当前 commandID 的查询返回空状态由平台侧判定为已过期。
+	// 空 command_id 表示 latest 查询：返回最近一次同步的快照并发到基础结果 subject，
+	// 快照本体保留真实 command_id，平台侧据此回填 sync_id。
+	// 回复必须发到平台订阅的 subject（按被查询的 syncID 派生），而不是查询命令自身的 id。
+	snapshot := pluginStoreSync.snapshot()
+	if snapshot == nil {
+		snapshot = &pluginv1.PluginStoreSyncProgress{
+			CommandId: command.GetCommandId(),
+			Status:    "",
+			UpdatedAt: timestamppb.New(time.Now().UTC()),
+		}
+	}
+	return b.publishPluginStoreSyncProgress(command.GetCommandId(), snapshot)
+}
+
+func (b *legionJobBridge) publishPluginStoreSyncProgress(
+	commandID string,
+	progress *pluginv1.PluginStoreSyncProgress,
+) error {
+	raw, err := proto.Marshal(progress)
+	if err != nil {
+		return fmt.Errorf("marshal plugin store sync progress: %w", err)
+	}
+
+	publisher, ok := b.capabilityPublisher.(*capabilityEventPublisher)
+	if !ok || publisher == nil {
+		return fmt.Errorf("capability event publisher is not ready")
+	}
+
+	publishCtx, cancel := context.WithTimeout(b.agent.node.GetRootContext(), 5*time.Second)
+	defer cancel()
+	if err := publisher.PublishRaw(publishCtx, pluginStoreSyncResultSubject(commandID), raw); err != nil {
+		return fmt.Errorf("publish plugin store sync progress: %w", err)
+	}
+	return nil
+}
+
+func validatePluginStoreSyncCommand(nodeID string, command *pluginv1.SyncPluginStoreCommand) error {
+	switch {
+	case command.GetMetadata() == nil:
+		return fmt.Errorf("plugin store sync metadata is required")
+	case strings.TrimSpace(command.GetMetadata().GetCommandId()) == "":
+		return fmt.Errorf("plugin store sync command_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) == "":
+		return fmt.Errorf("plugin store sync target_node_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) != strings.TrimSpace(nodeID):
+		return fmt.Errorf("plugin store sync target_node_id mismatch: %s", command.GetTargetNodeId())
+	default:
+		return nil
+	}
+}
+
+func validatePluginStoreSyncStatusQuery(
+	nodeID string,
+	command *pluginv1.QueryPluginStoreSyncStatusCommand,
+) error {
+	switch {
+	case command.GetMetadata() == nil:
+		return fmt.Errorf("plugin store sync status metadata is required")
+	case strings.TrimSpace(command.GetMetadata().GetCommandId()) == "":
+		return fmt.Errorf("plugin store sync status command_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) == "":
+		return fmt.Errorf("plugin store sync status target_node_id is required")
+	case strings.TrimSpace(command.GetTargetNodeId()) != strings.TrimSpace(nodeID):
+		return fmt.Errorf("plugin store sync status target_node_id mismatch: %s", command.GetTargetNodeId())
+	default:
+		return nil
+	}
+}

--- a/scannode/plugin_store_sync_test.go
+++ b/scannode/plugin_store_sync_test.go
@@ -1,0 +1,97 @@
+package scannode
+
+import (
+	"testing"
+
+	nodev1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/node/v1"
+	pluginv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/plugin/v1"
+)
+
+func TestPluginStoreSyncStateUpdate(t *testing.T) {
+	state := &pluginStoreSyncState{}
+
+	progress := state.update("cmd-1", func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreSyncStatusRunning
+		p.Total = 100
+		p.Completed = 10
+	})
+	if progress.CommandId != "cmd-1" || progress.Status != pluginStoreSyncStatusRunning {
+		t.Fatalf("unexpected progress: %+v", progress)
+	}
+	if progress.Total != 100 || progress.Completed != 10 {
+		t.Fatalf("unexpected counters: %+v", progress)
+	}
+	if progress.UpdatedAt == nil || progress.UpdatedAt.AsTime().IsZero() {
+		t.Fatal("updated_at must be set")
+	}
+
+	// 同一命令连续 update 累加字段
+	state.update("cmd-1", func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Completed = 50
+		p.Status = pluginStoreSyncStatusSucceeded
+	})
+	snapshot := state.snapshot()
+	if snapshot.Completed != 50 || snapshot.Status != pluginStoreSyncStatusSucceeded {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+
+	// 新命令应重置状态
+	progress = state.update("cmd-2", func(p *pluginv1.PluginStoreSyncProgress) {
+		p.Status = pluginStoreSyncStatusRunning
+	})
+	if progress.CommandId != "cmd-2" || progress.Completed != 0 {
+		t.Fatalf("new command must reset state: %+v", progress)
+	}
+}
+
+func TestPluginStoreSyncStateEmptySnapshot(t *testing.T) {
+	state := &pluginStoreSyncState{}
+	if snapshot := state.snapshot(); snapshot != nil {
+		t.Fatalf("empty state snapshot = %+v, want nil", snapshot)
+	}
+}
+
+func TestValidatePluginStoreSyncCommand(t *testing.T) {
+	newCommand := func() *pluginv1.SyncPluginStoreCommand {
+		return &pluginv1.SyncPluginStoreCommand{
+			Metadata:     &nodev1.CommandMetadata{CommandId: "cmd-sync-1"},
+			TargetNodeId: "node-a",
+		}
+	}
+
+	if err := validatePluginStoreSyncCommand("node-a", newCommand()); err != nil {
+		t.Fatalf("valid command rejected: %v", err)
+	}
+
+	command := newCommand()
+	command.Metadata = nil
+	if err := validatePluginStoreSyncCommand("node-a", command); err == nil {
+		t.Fatal("missing metadata should fail")
+	}
+
+	command = newCommand()
+	command.TargetNodeId = "node-b"
+	if err := validatePluginStoreSyncCommand("node-a", command); err == nil {
+		t.Fatal("target node mismatch should fail")
+	}
+}
+
+func TestValidatePluginStoreSyncStatusQuery(t *testing.T) {
+	newCommand := func() *pluginv1.QueryPluginStoreSyncStatusCommand {
+		return &pluginv1.QueryPluginStoreSyncStatusCommand{
+			Metadata:     &nodev1.CommandMetadata{CommandId: "cmd-query-1"},
+			TargetNodeId: "node-a",
+			CommandId:    "cmd-sync-1",
+		}
+	}
+
+	if err := validatePluginStoreSyncStatusQuery("node-a", newCommand()); err != nil {
+		t.Fatalf("valid query rejected: %v", err)
+	}
+
+	command := newCommand()
+	command.TargetNodeId = ""
+	if err := validatePluginStoreSyncStatusQuery("node-a", command); err == nil {
+		t.Fatal("missing target node should fail")
+	}
+}

--- a/scannode/proto/legion/plugin/v1/plugin.proto
+++ b/scannode/proto/legion/plugin/v1/plugin.proto
@@ -43,3 +43,71 @@ message PluginSyncFailed {
   string error_message = 4;
   google.protobuf.Timestamp observed_at = 5;
 }
+
+message ListPluginGroupsCommand {
+  legion.node.v1.CommandMetadata metadata = 1;
+  string target_node_id = 2;
+}
+
+message PluginGroupInfo {
+  string group = 1;
+  int32 total = 2;
+  int32 compatible_total = 3;
+}
+
+message PluginGroupScript {
+  string group = 1;
+  string script_name = 2;
+  string script_type = 3;
+}
+
+message ListPluginGroupsResult {
+  repeated PluginGroupInfo groups = 1;
+  repeated PluginGroupScript scripts = 2;
+  string error_code = 3;
+  string error_message = 4;
+}
+
+message SyncPluginStoreCommand {
+  legion.node.v1.CommandMetadata metadata = 1;
+  string target_node_id = 2;
+}
+
+message PluginStoreSyncProgress {
+  string command_id = 1;
+  string status = 2; // running | succeeded | failed
+  double progress = 3; // 0..1
+  int32 total = 4;
+  int32 completed = 5;
+  int32 succeeded = 6;
+  int32 failed = 7;
+  string current_plugin = 8;
+  string error_code = 9;
+  string error_message = 10;
+  google.protobuf.Timestamp updated_at = 11;
+}
+
+message QueryPluginStoreSyncStatusCommand {
+  legion.node.v1.CommandMetadata metadata = 1;
+  string target_node_id = 2;
+  string command_id = 3;
+}
+
+message ImportPluginStoreCommand {
+  legion.node.v1.CommandMetadata metadata = 1;
+  string target_node_id = 2;
+  // Platform-served download URL of the uploaded SQLite plugin database.
+  string artifact_url = 3;
+  string artifact_sha256 = 4;
+  int64 artifact_size_bytes = 5;
+}
+
+message PluginStoreImportResult {
+  string command_id = 1;
+  string status = 2; // running | succeeded | failed
+  int32 plugin_count = 3; // informational count reported by node
+  string backup_path = 4;
+  string error_code = 5;
+  string error_message = 6;
+  google.protobuf.Timestamp updated_at = 7;
+}


### PR DESCRIPTION
Legion northbound plugin lifecycle commands on the scan node:
- plugin.groups.list: enumerate local yakit plugin groups and member scripts from the profile database (port-scan compatible counts, builtin/temporary groups excluded)
- plugin.store.sync: re-download plugins from the Yakit community store via the same DownloadOnlinePluginsBatch path the Yakit UI uses; throttled progress snapshots over the realtime subject with a shared in-memory state machine (busy-rejection between syncs)
- plugin.store.import: download a platform-imported SQLite plugin db (node-session authenticated, sha256 + header verified) and atomically replace the local profile database with automatic .import-bak backup and rollback
- consts: CloseProfileDatabase to release the profile handle for the atomic swap