### PR TITLE
fix(webfuzzer): harden Streamable HTTP and SSE replay

### DIFF
--- a/common/mutate/http_pool.go
+++ b/common/mutate/http_pool.go
@@ -1393,12 +1393,11 @@ func _httpPool(i interface{}, opts ...HttpPoolConfigOption) (chan *HttpResult, e
 						}
 
 						if needSSEStream {
-							if httpPoolIsSSERequest(targetRequest) {
-								lowhttpOptions = append(lowhttpOptions, lowhttp.WithNoBodyBuffer(true))
-							}
-							if config.AutoDetectSSE {
-								lowhttpOptions = append(lowhttpOptions, lowhttp.WithAutoDetectSSE(true))
-							}
+							// Accept: text/event-stream only says that the client can consume SSE.
+							// Streamable HTTP endpoints (including MCP) may still return a normal
+							// application/json response, so defer NoBodyBuffer to lowhttp's
+							// response Content-Type detection instead of discarding the body here.
+							lowhttpOptions = append(lowhttpOptions, lowhttp.WithAutoDetectSSE(true))
 							lowhttpOptions = append(lowhttpOptions, lowhttp.WithBodyStreamReaderHandler(func(respHeaderRaw []byte, bodyReader io.ReadCloser) {
 								defer bodyReader.Close()
 

--- a/common/mutate/http_pool.go
+++ b/common/mutate/http_pool.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -40,14 +41,31 @@ const (
 )
 
 func httpPoolIsSSERequest(reqRaw []byte) bool {
-	accept := strings.ToLower(strings.TrimSpace(lowhttp.GetHTTPPacketHeader(reqRaw, "Accept")))
-	return strings.Contains(accept, "text/event-stream")
+	accept := lowhttp.GetHTTPPacketHeader(reqRaw, "Accept")
+	for _, item := range strings.Split(accept, ",") {
+		mediaType, params, err := mime.ParseMediaType(strings.TrimSpace(item))
+		if err != nil || !strings.EqualFold(mediaType, "text/event-stream") {
+			continue
+		}
+		if rawQ, ok := params["q"]; ok {
+			q, err := strconv.ParseFloat(rawQ, 64)
+			if err != nil || q <= 0 {
+				continue
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func httpPoolIsSSEResponseHeader(respHeaderRaw []byte) (isSSE bool, isChunked bool) {
-	headerLower := strings.ToLower(string(respHeaderRaw))
-	isSSE = strings.Contains(headerLower, "content-type:") && strings.Contains(headerLower, "text/event-stream")
-	isChunked = strings.Contains(headerLower, "transfer-encoding:") && strings.Contains(headerLower, "chunked")
+	isSSE = lowhttp.IsSSEContentTypeHeader(respHeaderRaw)
+	for _, coding := range strings.Split(lowhttp.GetHTTPPacketHeader(respHeaderRaw, "Transfer-Encoding"), ",") {
+		if strings.EqualFold(strings.TrimSpace(coding), "chunked") {
+			isChunked = true
+			break
+		}
+	}
 	return
 }
 
@@ -124,17 +142,32 @@ func httpPoolChunkedStreamDecode(ctx context.Context, r io.Reader, onData func([
 			}
 		}
 
-		buf := make([]byte, int(size))
-		_, err = io.ReadFull(br, buf)
-		if err != nil {
-			return err
+		// A peer controls the advertised chunk size. Read it in bounded blocks
+		// instead of allocating the whole chunk at once.
+		for remaining := size; remaining > 0; {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			blockSize := int64(32 * 1024)
+			if remaining < blockSize {
+				blockSize = remaining
+			}
+			buf := make([]byte, int(blockSize))
+			_, err = io.ReadFull(br, buf)
+			if err != nil {
+				return err
+			}
+			onData(buf)
+			remaining -= blockSize
 		}
-		onData(buf)
 
 		crlf := make([]byte, 2)
 		_, err = io.ReadFull(br, crlf)
 		if err != nil {
 			return err
+		}
+		if !bytes.Equal(crlf, []byte("\r\n")) {
+			return fmt.Errorf("invalid chunk terminator %q", crlf)
 		}
 	}
 }
@@ -1427,16 +1460,14 @@ func _httpPool(i interface{}, opts ...HttpPoolConfigOption) (chan *HttpResult, e
 								sseStateMu.Unlock()
 
 								dataCh := make(chan []byte, 64)
-								doneCh := make(chan struct{})
 
 								go func() {
-									defer close(doneCh)
+									defer close(dataCh)
 									onData := func(b []byte) {
 										select {
 										case <-streamCtx.Done():
 											return
 										case dataCh <- b:
-										default:
 										}
 									}
 									var err error
@@ -1446,7 +1477,6 @@ func _httpPool(i interface{}, opts ...HttpPoolConfigOption) (chan *HttpResult, e
 										err = httpPoolRawStreamRead(streamCtx, bodyReader, onData)
 									}
 									_ = err
-									close(dataCh)
 								}()
 
 								window := 250 * time.Millisecond
@@ -1608,13 +1638,11 @@ func _httpPool(i interface{}, opts ...HttpPoolConfigOption) (chan *HttpResult, e
 										flush()
 										emitFinalMarker()
 										return
-									case <-doneCh:
-										flush()
-										emitFinalMarker()
-										return
 									case b, ok := <-dataCh:
 										if !ok {
-											continue
+											flush()
+											emitFinalMarker()
+											return
 										}
 										if len(b) == 0 {
 											continue

--- a/common/mutate/http_pool_sse_test.go
+++ b/common/mutate/http_pool_sse_test.go
@@ -1,0 +1,70 @@
+package mutate
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPPoolIsSSERequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		accept string
+		want   bool
+	}{
+		{name: "exact", accept: "text/event-stream", want: true},
+		{name: "mixed", accept: "application/json, text/event-stream", want: true},
+		{name: "parameters", accept: "text/event-stream; q=0.8", want: true},
+		{name: "explicitly_rejected", accept: "application/json, text/event-stream; q=0"},
+		{name: "json_profile", accept: `application/json; profile="text/event-stream"`},
+		{name: "missing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte("GET / HTTP/1.1\r\nHost: example.test\r\nAccept: " + tt.accept + "\r\n\r\n")
+			require.Equal(t, tt.want, httpPoolIsSSERequest(raw))
+		})
+	}
+}
+
+func TestHTTPPoolIsSSEResponseHeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		headers     string
+		wantSSE     bool
+		wantChunked bool
+	}{
+		{name: "sse_content_length", headers: "Content-Type: text/event-stream; charset=utf-8", wantSSE: true},
+		{name: "sse_chunked", headers: "Content-Type: text/event-stream\r\nTransfer-Encoding: gzip, chunked", wantSSE: true, wantChunked: true},
+		{name: "json_profile", headers: `Content-Type: application/json; profile="text/event-stream"`},
+		{name: "json_hint", headers: "Content-Type: application/json\r\nX-Stream-Hint: text/event-stream"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte("HTTP/1.1 200 OK\r\n" + tt.headers + "\r\n\r\n")
+			gotSSE, gotChunked := httpPoolIsSSEResponseHeader(raw)
+			require.Equal(t, tt.wantSSE, gotSSE)
+			require.Equal(t, tt.wantChunked, gotChunked)
+		})
+	}
+}
+
+func TestHTTPPoolChunkedStreamDecodeLossless(t *testing.T) {
+	largeChunk := strings.Repeat("a", 96*1024+17)
+	smallChunk := "event: done\ndata: ok\n\n"
+	raw := fmt.Sprintf("%x\r\n%s\r\n%x; extension=value\r\n%s\r\n0\r\nTrailer: value\r\n\r\n", len(largeChunk), largeChunk, len(smallChunk), smallChunk)
+
+	var decoded bytes.Buffer
+	err := httpPoolChunkedStreamDecode(context.Background(), strings.NewReader(raw), func(data []byte) {
+		decoded.Write(data)
+	})
+	require.NoError(t, err)
+	require.Equal(t, largeChunk+smallChunk, decoded.String())
+
+	err = httpPoolChunkedStreamDecode(context.Background(), strings.NewReader("1\r\naXX0\r\n\r\n"), func([]byte) {})
+	require.ErrorContains(t, err, "invalid chunk terminator")
+}

--- a/common/utils/lowhttp/config.go
+++ b/common/utils/lowhttp/config.go
@@ -121,6 +121,9 @@ type LowhttpExecConfig struct {
 
 	// BodyStreamReaderHandler is a callback function to handle the body stream reader
 	BodyStreamReaderHandler func(responseHeader []byte, closer io.ReadCloser)
+	// bodyStreamReaderHandled coordinates the transport-specific stream handler
+	// with HTTPWithoutRedirect's fallback. It keeps the callback exactly-once.
+	bodyStreamReaderHandled *utils.AtomicBool
 	// AutoDetectSSE enables SSE auto-detection by response headers (Content-Type: text/event-stream)
 	// to automatically switch into stream/no-body-buffer mode even when request headers don't include
 	// Accept: text/event-stream.

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -341,6 +341,7 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 
 	// 用于检查 BodyStreamReaderHandler 是否被正常调用
 	bodyStreamReaderHandled := utils.NewAtomicBool()
+	option.bodyStreamReaderHandled = bodyStreamReaderHandled
 	var streamBodyReaderCh chan io.ReadCloser
 	var streamHandlerDone chan struct{}
 	defer func() {

--- a/common/utils/lowhttp/http2_client.go
+++ b/common/utils/lowhttp/http2_client.go
@@ -159,6 +159,7 @@ type http2ClientStream struct {
 	bodyStreamWriter    io.WriteCloser
 	bodyStreamOnce      sync.Once
 	bodyStreamCloseOnce sync.Once
+	bodyStreamDone      chan struct{}
 	headersHandled      bool
 	noBodyBuffer        bool
 }
@@ -191,8 +192,7 @@ func (s *http2ClientStream) handleHeadersDone() {
 
 	headerRaw := s.buildResponseHeaderRaw()
 	if s.option != nil && s.option.AutoDetectSSE {
-		headerLower := strings.ToLower(string(headerRaw))
-		if strings.Contains(headerLower, "content-type:") && strings.Contains(headerLower, "text/event-stream") {
+		if IsSSEContentTypeHeader(headerRaw) {
 			s.noBodyBuffer = true
 			if s.req != nil {
 				httpctx.SetNoBodyBuffer(s.req, true)
@@ -244,10 +244,16 @@ func (s *http2ClientStream) startBodyStreamHandler(headerRaw []byte) {
 	reader := s.bodyStreamReader
 	handler := s.option.BodyStreamReaderHandler
 	s.bodyStreamOnce.Do(func() {
+		if s.option.bodyStreamReaderHandled != nil {
+			s.option.bodyStreamReaderHandled.Set()
+		}
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
 					log.Errorf("BodyStreamReaderHandler panic in http2: %v", r)
+				}
+				if s.bodyStreamDone != nil {
+					close(s.bodyStreamDone)
 				}
 			}()
 			handler(headerCopy, reader)
@@ -261,6 +267,25 @@ func (s *http2ClientStream) closeBodyStreamWriter() {
 			_ = s.bodyStreamWriter.Close()
 		}
 	})
+}
+
+func (s *http2ClientStream) waitBodyStreamHandler() {
+	if s.bodyStreamDone == nil || s.option == nil || s.option.bodyStreamReaderHandled == nil || !s.option.bodyStreamReaderHandled.IsSet() {
+		return
+	}
+	select {
+	case <-s.bodyStreamDone:
+		return
+	case <-time.After(2 * time.Second):
+	}
+	if s.bodyStreamReader != nil {
+		_ = s.bodyStreamReader.Close()
+	}
+	select {
+	case <-s.bodyStreamDone:
+	case <-time.After(2 * time.Second):
+		log.Warn("stream handler wait timeout: http2 stream handler")
+	}
 }
 
 type http2ClientConnReadLoop struct {
@@ -474,6 +499,7 @@ func (h2Conn *http2ClientConn) newStream(req *http.Request, packet []byte, optio
 	cs.headersHandled = false
 	cs.bodyStreamOnce = sync.Once{}
 	cs.bodyStreamCloseOnce = sync.Once{}
+	cs.bodyStreamDone = nil
 	cs.bodyStreamReader = nil
 	cs.bodyStreamWriter = nil
 	cs.noBodyBuffer = false
@@ -483,6 +509,7 @@ func (h2Conn *http2ClientConn) newStream(req *http.Request, packet []byte, optio
 			reader, writer := utils.NewBufPipe(nil)
 			cs.bodyStreamReader = reader
 			cs.bodyStreamWriter = writer
+			cs.bodyStreamDone = make(chan struct{})
 		}
 	}
 
@@ -797,6 +824,8 @@ func (cs *http2ClientStream) waitResponse(ctx context.Context, timeout time.Dura
 			err = utils.Wrapf(errH2ConnClosed, "h2 stream-id %v wait response conn closed : %s", cs.ID, flow)
 		}
 	}
+	cs.closeBodyStreamWriter()
+	cs.waitBodyStreamHandler()
 
 	cs.releaseSlot()
 

--- a/common/utils/lowhttp/http2_client.go
+++ b/common/utils/lowhttp/http2_client.go
@@ -247,17 +247,21 @@ func (s *http2ClientStream) startBodyStreamHandler(headerRaw []byte) {
 		if s.option.bodyStreamReaderHandled != nil {
 			s.option.bodyStreamReaderHandled.Set()
 		}
-		go func() {
+		// Capture the completion channel owned by this handler. The stream object
+		// can be returned to sync.Pool and reused if a slow handler outlives the
+		// bounded wait in waitBodyStreamHandler.
+		done := s.bodyStreamDone
+		go func(done chan struct{}) {
 			defer func() {
 				if r := recover(); r != nil {
 					log.Errorf("BodyStreamReaderHandler panic in http2: %v", r)
 				}
-				if s.bodyStreamDone != nil {
-					close(s.bodyStreamDone)
+				if done != nil {
+					close(done)
 				}
 			}()
 			handler(headerCopy, reader)
-		}()
+		}(done)
 	})
 }
 

--- a/common/utils/lowhttp/http2_client_stream_reuse_test.go
+++ b/common/utils/lowhttp/http2_client_stream_reuse_test.go
@@ -1,0 +1,47 @@
+package lowhttp
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTTP2BodyStreamHandlerDoesNotSignalReusedStream(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	releaseOldHandler := make(chan struct{})
+
+	stream := &http2ClientStream{
+		option: &LowhttpExecConfig{
+			BodyStreamReaderHandler: func([]byte, io.ReadCloser) {
+				close(handlerStarted)
+				<-releaseOldHandler
+			},
+		},
+		bodyStreamReader: io.NopCloser(strings.NewReader("")),
+		bodyStreamDone:   make(chan struct{}),
+	}
+
+	oldDone := stream.bodyStreamDone
+	stream.startBodyStreamHandler(nil)
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("old body stream handler did not start")
+	}
+
+	// Simulate newStream resetting this http2ClientStream after sync.Pool reuse.
+	newDone := make(chan struct{})
+	stream.bodyStreamDone = newDone
+	close(releaseOldHandler)
+
+	select {
+	case <-newDone:
+		t.Fatal("old handler closed the reused stream's completion channel")
+	case <-oldDone:
+		// The old handler must only signal the channel that belonged to it.
+	case <-time.After(time.Second):
+		t.Fatal("old handler did not signal completion")
+	}
+}

--- a/common/utils/lowhttp/response_raw_capture.go
+++ b/common/utils/lowhttp/response_raw_capture.go
@@ -2,6 +2,7 @@ package lowhttp
 
 import (
 	"bytes"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -27,6 +28,23 @@ type responseRawCaptureWriter struct {
 	headerBuf     bytes.Buffer
 
 	discardBody bool
+}
+
+// IsSSEContentTypeHeader reports whether headerRaw declares the SSE media type.
+// It deliberately examines only the Content-Type field's primary media type:
+// Streamable HTTP responses may mention text/event-stream in another header or
+// in an application/json parameter without actually being an SSE response.
+func IsSSEContentTypeHeader(headerRaw []byte) bool {
+	contentType := strings.TrimSpace(GetHTTPPacketHeader(headerRaw, "Content-Type"))
+	if contentType == "" {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType, _, _ = strings.Cut(contentType, ";")
+		mediaType = strings.TrimSpace(mediaType)
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
 }
 
 func (w *responseRawCaptureWriter) Write(p []byte) (int, error) {
@@ -72,8 +90,7 @@ func (w *responseRawCaptureWriter) Write(p []byte) (int, error) {
 				w.matchState = 0
 
 				if w.autoDetectSSE {
-					headerLower := strings.ToLower(w.headerBuf.String())
-					if strings.Contains(headerLower, "content-type:") && strings.Contains(headerLower, "text/event-stream") {
+					if IsSSEContentTypeHeader(w.headerBuf.Bytes()) {
 						w.discardBody = true
 						if w.req != nil {
 							httpctx.SetNoBodyBuffer(w.req, true)

--- a/common/utils/lowhttp/response_raw_capture_test.go
+++ b/common/utils/lowhttp/response_raw_capture_test.go
@@ -1,0 +1,146 @@
+package lowhttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+func TestIsSSEContentTypeHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{name: "exact", header: "Content-Type: text/event-stream", want: true},
+		{name: "case_and_parameters", header: "content-type: Text/Event-Stream; charset=utf-8", want: true},
+		{name: "json", header: "Content-Type: application/json"},
+		{name: "json_profile_mentions_sse", header: `Content-Type: application/json; profile="text/event-stream"`},
+		{name: "other_header_mentions_sse", header: "Content-Type: application/json\r\nX-Stream-Hint: text/event-stream"},
+		{name: "lookalike_header", header: "X-Content-Type: text/event-stream"},
+		{name: "missing", header: "Cache-Control: no-cache"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte("HTTP/1.1 200 OK\r\n" + tt.header + "\r\n\r\n")
+			require.Equal(t, tt.want, IsSSEContentTypeHeader(raw))
+		})
+	}
+}
+
+func TestAutoDetectSSE_StreamableHTTPResponseSwitching(t *testing.T) {
+	const (
+		firstJSON = `{"jsonrpc":"2.0","id":1,"result":{"mode":"json-first"}}`
+		sseBody   = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"result\":{\"mode\":\"sse\"}}\n\n"
+		lastJSON  = `{"jsonrpc":"2.0","id":2,"result":{"mode":"json-last"}}`
+	)
+
+	serve := func(w http.ResponseWriter, r *http.Request) {
+		// Echo the peer address so the test can prove that response-mode changes
+		// happen on the same persistent connection, rather than by reconnecting.
+		w.Header().Set("X-Mock-Remote", r.RemoteAddr)
+		switch r.URL.Path {
+		case "/json-first":
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Stream-Hint", "text/event-stream")
+			_, _ = io.WriteString(w, firstJSON)
+		case "/events":
+			w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+			_, _ = io.WriteString(w, sseBody)
+		case "/json-last":
+			w.Header().Set("Content-Type", `application/json; profile="text/event-stream"`)
+			_, _ = io.WriteString(w, lastJSON)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	h1Host, h1Port := utils.DebugMockHTTPHandlerFunc(serve)
+	h2Host, h2Port := utils.DebugMockHTTP2HandlerFuncContext(ctx, serve)
+
+	transports := []struct {
+		name        string
+		host        string
+		port        int
+		httpVersion string
+		https       bool
+		http2       bool
+	}{
+		{name: "http1_pool", host: h1Host, port: h1Port, httpVersion: "HTTP/1.1"},
+		{name: "http2_pool", host: h2Host, port: h2Port, httpVersion: "HTTP/2.0", https: true, http2: true},
+	}
+
+	type streamCapture struct {
+		header []byte
+		body   []byte
+		err    error
+	}
+	for _, transport := range transports {
+		transport := transport
+		t.Run(transport.name, func(t *testing.T) {
+			pool := NewHttpConnPool(ctx, 10, 2)
+			t.Cleanup(pool.Clear)
+
+			replay := func(path string) (*LowhttpResponse, streamCapture) {
+				t.Helper()
+				captureCh := make(chan streamCapture, 2)
+				request := []byte("GET " + path + " " + transport.httpVersion + "\r\nHost: " + utils.HostPort(transport.host, transport.port) + "\r\nAccept: application/json, text/event-stream\r\n\r\n")
+				rsp, err := HTTP(
+					WithPacketBytes(request),
+					WithHttps(transport.https),
+					WithHttp2(transport.http2),
+					WithConnPool(true),
+					ConnPool(pool),
+					WithTimeout(5*time.Second),
+					WithAutoDetectSSE(true),
+					WithBodyStreamReaderHandler(func(header []byte, body io.ReadCloser) {
+						defer body.Close()
+						bodyBytes, readErr := io.ReadAll(body)
+						captureCh <- streamCapture{header: append([]byte(nil), header...), body: bodyBytes, err: readErr}
+					}),
+				)
+				require.NoError(t, err)
+				select {
+				case captured := <-captureCh:
+					require.NoError(t, captured.err)
+					select {
+					case duplicate := <-captureCh:
+						t.Fatalf("stream handler called more than once: duplicate header=%q body=%q err=%v", duplicate.header, duplicate.body, duplicate.err)
+					default:
+					}
+					return rsp, captured
+				case <-time.After(2 * time.Second):
+					t.Fatal("stream handler did not finish")
+					return nil, streamCapture{}
+				}
+			}
+
+			firstRsp, firstCapture := replay("/json-first")
+			require.False(t, IsSSEContentTypeHeader(firstCapture.header))
+			require.Equal(t, firstJSON, string(GetHTTPPacketBody(firstRsp.RawPacket)))
+			require.Equal(t, firstJSON, string(firstCapture.body))
+			remoteAddr := GetHTTPPacketHeader(firstCapture.header, "X-Mock-Remote")
+			require.NotEmpty(t, remoteAddr)
+
+			eventRsp, eventCapture := replay("/events")
+			require.True(t, IsSSEContentTypeHeader(eventCapture.header))
+			require.Empty(t, GetHTTPPacketBody(eventRsp.RawPacket), "SSE body must stay out of the raw response buffer")
+			require.Equal(t, sseBody, string(eventCapture.body))
+			require.Equal(t, remoteAddr, GetHTTPPacketHeader(eventCapture.header, "X-Mock-Remote"), "SSE must use the same persistent connection")
+
+			lastRsp, lastCapture := replay("/json-last")
+			require.False(t, IsSSEContentTypeHeader(lastCapture.header))
+			require.Equal(t, lastJSON, string(GetHTTPPacketBody(lastRsp.RawPacket)))
+			require.Equal(t, lastJSON, string(lastCapture.body))
+			require.Equal(t, remoteAddr, GetHTTPPacketHeader(lastCapture.header, "X-Mock-Remote"), "SSE mode must not leak into the next JSON response")
+		})
+	}
+}

--- a/common/yakgrpc/grpc_fuzzer.go
+++ b/common/yakgrpc/grpc_fuzzer.go
@@ -1778,9 +1778,9 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 							}
 						}
 					}
+					redirectRsp.TaskId = int64(taskID)
 					// yakit.SaveWebFuzzerResponse(s.GetProjectDatabase(), int(task.ID), redirectRes.Uuid, redirectRsp)
 					yakit.SaveWebFuzzerResponseEx(int(task.ID), redirectRes.HiddenIndex, redirectRsp)
-					redirectRsp.TaskId = int64(taskID)
 					err := feedbackResponse(redirectRsp, false, false)
 					if err != nil {
 						log.Errorf("send to client failed: %s", err)
@@ -1792,9 +1792,9 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 					rsp.RequestRaw = redirectPacket[len(redirectPacket)-1].Request
 				}
 			}
+			rsp.TaskId = int64(taskID)
 			// yakit.SaveWebFuzzerResponse(s.GetProjectDatabase(), int(task.ID), result.LowhttpResponse.Uuid, rsp)
 			yakit.SaveWebFuzzerResponseEx(int(task.ID), result.LowhttpResponse.HiddenIndex, rsp)
-			rsp.TaskId = int64(taskID)
 			err := feedbackResponse(rsp, false, skipSendForSSEFinal)
 			if du := time.Now().Sub(feedbackNormalResponseStart); du > time.Second {
 				log.Warnf("feedbackNormalResponse cost too much time, try investigate it, cost: %v", du)

--- a/common/yakgrpc/grpc_fuzzer_sse_test.go
+++ b/common/yakgrpc/grpc_fuzzer_sse_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -296,4 +297,88 @@ func TestGRPCMUSTPASS_HTTPFuzzer_SSE_HTTP2_AutoDetectWithoutAccept(t *testing.T)
 
 	require.GreaterOrEqual(t, gotSSE, 2, "should receive incremental SSE updates over HTTP/2 without Accept header")
 	require.True(t, gotFinal, "should receive a final marker chunk")
+}
+
+func TestGRPCMUSTPASS_HTTPFuzzer_MCPMixedAcceptKeepsJSONBody(t *testing.T) {
+	const responseBody = `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","serverInfo":{"name":"streamable-mcp-server","version":"1.0.0"},"instructions":"mock MCP service"}}`
+	const requestBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"poc","version":"1.0"}}}`
+
+	ctx := utils.TimeoutContextSeconds(15)
+	h1Host, h1Port := utils.DebugMockHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/mcp", r.URL.Path)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "application/json, text/event-stream", r.Header.Get("Accept"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestBody, string(body))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Match the real gateway's HTTP/1.1 response framing: headers are flushed
+		// before the body, so net/http uses Transfer-Encoding: chunked.
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte(responseBody))
+	})
+	h2Host, h2Port := utils.DebugMockHTTP2HandlerFuncContext(ctx, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/mcp", r.URL.Path)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "application/json, text/event-stream", r.Header.Get("Accept"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestBody, string(body))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	})
+
+	tests := []struct {
+		name        string
+		host        string
+		port        int
+		httpVersion string
+		isHTTPS     bool
+		disablePool bool
+	}{
+		{name: "http1_pool", host: h1Host, port: h1Port, httpVersion: "HTTP/1.1"},
+		{name: "http1_no_pool", host: h1Host, port: h1Port, httpVersion: "HTTP/1.1", disablePool: true},
+		{name: "http2_pool", host: h2Host, port: h2Port, httpVersion: "HTTP/2.0", isHTTPS: true},
+		{name: "http2_no_pool", host: h2Host, port: h2Port, httpVersion: "HTTP/2.0", isHTTPS: true, disablePool: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewLocalClient()
+			require.NoError(t, err)
+
+			request := fmt.Sprintf("POST /mcp %s\r\nHost: %s\r\nContent-Type: application/json\r\nAccept: application/json, text/event-stream\r\nContent-Length: %d\r\n\r\n%s", tt.httpVersion, utils.HostPort(tt.host, tt.port), len(requestBody), requestBody)
+			stream, err := client.HTTPFuzzer(ctx, &ypb.FuzzerRequest{
+				Request:                  request,
+				IsHTTPS:                  tt.isHTTPS,
+				DisableUseConnPool:       tt.disablePool,
+				PerRequestTimeoutSeconds: 5,
+				DialTimeoutSeconds:       2,
+				ForceFuzz:                true,
+			})
+			require.NoError(t, err)
+
+			var response *ypb.FuzzerResponse
+			for {
+				got, recvErr := stream.Recv()
+				if recvErr != nil {
+					break
+				}
+				if got != nil && got.StatusCode == http.StatusOK {
+					response = got
+				}
+			}
+
+			require.NotNil(t, response)
+			require.Contains(t, string(response.ResponseRaw), responseBody)
+			require.Equal(t, int64(len(responseBody)), response.BodyLength)
+			require.Empty(t, response.RandomChunkedData, "JSON MCP response must not be emitted as SSE chunks")
+		})
+	}
 }

--- a/common/yakgrpc/grpc_fuzzer_sse_test.go
+++ b/common/yakgrpc/grpc_fuzzer_sse_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -379,6 +380,205 @@ func TestGRPCMUSTPASS_HTTPFuzzer_MCPMixedAcceptKeepsJSONBody(t *testing.T) {
 			require.Contains(t, string(response.ResponseRaw), responseBody)
 			require.Equal(t, int64(len(responseBody)), response.BodyLength)
 			require.Empty(t, response.RandomChunkedData, "JSON MCP response must not be emitted as SSE chunks")
+		})
+	}
+}
+
+func TestGRPCMUSTPASS_HTTPFuzzer_MCPJSONContentTypeFalsePositives(t *testing.T) {
+	const responseBody = `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","serverInfo":{"name":"streamable-mcp-server","version":"1.0.0"}}}`
+	const requestBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"poc","version":"1.0"}}}`
+
+	type responseVariant struct {
+		path        string
+		contentType string
+		streamHint  bool
+	}
+	variants := []responseVariant{
+		{
+			path:        "/mcp-json-profile",
+			contentType: `application/json; profile="text/event-stream"`,
+		},
+		{
+			path:        "/mcp-json-hint",
+			contentType: "application/json",
+			streamHint:  true,
+		},
+	}
+
+	serve := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json, text/event-stream", r.Header.Get("Accept"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestBody, string(body))
+
+		var matched *responseVariant
+		for i := range variants {
+			if variants[i].path == r.URL.Path {
+				matched = &variants[i]
+				break
+			}
+		}
+		require.NotNil(t, matched)
+		w.Header().Set("Content-Type", matched.contentType)
+		if matched.streamHint {
+			// A non-Content-Type header mentioning SSE must not change body ownership.
+			w.Header().Set("X-Stream-Hint", "text/event-stream")
+		}
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			// Exercise HTTP/1.1 chunked framing, matching the real MCP gateway.
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte(responseBody))
+	}
+
+	ctx := utils.TimeoutContextSeconds(20)
+	h1Host, h1Port := utils.DebugMockHTTPHandlerFunc(serve)
+	h2Host, h2Port := utils.DebugMockHTTP2HandlerFuncContext(ctx, serve)
+
+	transports := []struct {
+		name        string
+		host        string
+		port        int
+		httpVersion string
+		isHTTPS     bool
+		disablePool bool
+	}{
+		{name: "http1_pool", host: h1Host, port: h1Port, httpVersion: "HTTP/1.1"},
+		{name: "http1_no_pool", host: h1Host, port: h1Port, httpVersion: "HTTP/1.1", disablePool: true},
+		{name: "http2_pool", host: h2Host, port: h2Port, httpVersion: "HTTP/2.0", isHTTPS: true},
+		{name: "http2_no_pool", host: h2Host, port: h2Port, httpVersion: "HTTP/2.0", isHTTPS: true, disablePool: true},
+	}
+
+	for _, variant := range variants {
+		for _, transport := range transports {
+			variant := variant
+			transport := transport
+			t.Run(strings.TrimPrefix(variant.path, "/")+"/"+transport.name, func(t *testing.T) {
+				client, err := NewLocalClient()
+				require.NoError(t, err)
+
+				request := fmt.Sprintf("POST %s %s\r\nHost: %s\r\nContent-Type: application/json\r\nAccept: application/json, text/event-stream\r\nContent-Length: %d\r\n\r\n%s", variant.path, transport.httpVersion, utils.HostPort(transport.host, transport.port), len(requestBody), requestBody)
+				stream, err := client.HTTPFuzzer(ctx, &ypb.FuzzerRequest{
+					Request:                  request,
+					IsHTTPS:                  transport.isHTTPS,
+					DisableUseConnPool:       transport.disablePool,
+					PerRequestTimeoutSeconds: 5,
+					DialTimeoutSeconds:       2,
+					ForceFuzz:                true,
+				})
+				require.NoError(t, err)
+
+				var completeResponse *ypb.FuzzerResponse
+				var responseChunkCount int
+				for {
+					got, recvErr := stream.Recv()
+					if recvErr != nil {
+						break
+					}
+					if got == nil {
+						continue
+					}
+					responseChunkCount += len(got.RandomChunkedData)
+					if bytes.Contains(got.ResponseRaw, []byte(responseBody)) {
+						completeResponse = got
+					}
+				}
+
+				require.NotNil(t, completeResponse, "JSON response must remain in the normal replay path")
+				require.Equal(t, int64(len(responseBody)), completeResponse.BodyLength)
+				require.Zero(t, responseChunkCount, "JSON response must never be emitted as SSE chunks")
+			})
+		}
+	}
+}
+
+func TestGRPCMUSTPASS_HTTPFuzzer_SSE_BurstReplayIsLossless(t *testing.T) {
+	const eventCount = 1024
+	var expected strings.Builder
+	for i := 0; i < eventCount; i++ {
+		_, _ = fmt.Fprintf(&expected, "data: event-%04d\n\n", i)
+	}
+	expectedBody := expected.String()
+
+	serve := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+		for i := 0; i < eventCount; i++ {
+			_, _ = fmt.Fprintf(w, "data: event-%04d\n\n", i)
+			flusher.Flush()
+		}
+	}
+
+	ctx := utils.TimeoutContextSeconds(30)
+	h1Host, h1Port := utils.DebugMockHTTPHandlerFunc(serve)
+	h2Host, h2Port := utils.DebugMockHTTP2HandlerFuncContext(ctx, serve)
+	tests := []struct {
+		name        string
+		host        string
+		port        int
+		httpVersion string
+		isHTTPS     bool
+		disablePool bool
+	}{
+		{name: "http1_pool", host: h1Host, port: h1Port, httpVersion: "HTTP/1.1"},
+		{name: "http1_no_pool", host: h1Host, port: h1Port, httpVersion: "HTTP/1.1", disablePool: true},
+		{name: "http2_pool", host: h2Host, port: h2Port, httpVersion: "HTTP/2.0", isHTTPS: true},
+		{name: "http2_no_pool", host: h2Host, port: h2Port, httpVersion: "HTTP/2.0", isHTTPS: true, disablePool: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewLocalClient()
+			require.NoError(t, err)
+			request := fmt.Sprintf("GET /events %s\r\nHost: %s\r\nAccept: application/json, text/event-stream\r\n\r\n", tt.httpVersion, utils.HostPort(tt.host, tt.port))
+			stream, err := client.HTTPFuzzer(ctx, &ypb.FuzzerRequest{
+				Request:                  request,
+				IsHTTPS:                  tt.isHTTPS,
+				DisableUseConnPool:       tt.disablePool,
+				PerRequestTimeoutSeconds: 8,
+				DialTimeoutSeconds:       2,
+				ForceFuzz:                true,
+			})
+			require.NoError(t, err)
+
+			var replayed bytes.Buffer
+			var streamID string
+			var finalMarkers int
+			for {
+				got, recvErr := stream.Recv()
+				if recvErr != nil {
+					break
+				}
+				if got == nil || len(got.RandomChunkedData) == 0 {
+					continue
+				}
+				if streamID == "" {
+					streamID = got.UUID
+				} else {
+					require.Equal(t, streamID, got.UUID, "all replay updates must share one stream UUID")
+				}
+				for _, chunk := range got.RandomChunkedData {
+					if chunk == nil {
+						continue
+					}
+					require.NotEqual(t, ypb.ChunkedDataDirection_CHUNKED_DATA_DIRECTION_REQUEST, chunk.Direction)
+					if chunk.IsFinal {
+						finalMarkers++
+						continue
+					}
+					replayed.Write(chunk.Data)
+				}
+			}
+
+			require.NotEmpty(t, streamID)
+			require.Equal(t, 1, finalMarkers, "a stream must terminate exactly once")
+			require.Equal(t, expectedBody, replayed.String(), "SSE replay must not drop or reorder body bytes")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- classify streaming from the actual response `Content-Type`, not merely from request `Accept`
- preserve Streamable HTTP JSON replies and reject SSE false positives in media-type parameters or unrelated headers
- make burst SSE replay lossless with backpressure and channel-drain completion
- keep HTTP/2 body-stream callbacks exactly-once and wait for completion before stream reuse
- decode peer-controlled HTTP/1.1 chunks in bounded blocks and validate chunk terminators
- assign WebFuzzer task IDs before asynchronous persistence

## Root causes

The original empty-body failure came from enabling `NoBodyBuffer` as soon as a request accepted SSE. MCP Streamable HTTP commonly sends `Accept: application/json, text/event-stream`, while `initialize` can return ordinary JSON. The JSON callback then drained the only body copy.

Further protocol-matrix testing exposed three additional bugs: whole-header substring matching could misclassify JSON as SSE; a non-blocking producer and a competing done signal could drop buffered SSE bytes; and HTTP/2 could invoke the real stream callback followed by the generic empty fallback callback.

## Mock coverage

- MCP initialize JSON over HTTP/1.1 and HTTP/2, pool enabled and disabled
- false-positive JSON content types and unrelated SSE hint headers over all four transport modes
- 1024-event burst SSE replay over all four transport modes, exact byte order and one final marker
- persistent JSON -> SSE -> JSON switching on the same HTTP/1.1 or HTTP/2 connection
- exact-once stream callback, strict media-type parsing, chunk extensions, large bounded chunks, trailers, and malformed terminators

## Verification

- `go test -race ./common/yakgrpc -run "^TestGRPCMUSTPASS_HTTPFuzzer_(SSE_|MCP)" -count=3 -timeout 420s`
- `go test -race ./common/utils/lowhttp -run "^(TestIsSSEContentTypeHeader|TestAutoDetectSSE_StreamableHTTPResponseSwitching)$" -count=5 -timeout 180s`
- `go test ./common/mutate -count=1 -timeout 600s`
- `go test ./common/utils/lowhttp -count=1 -timeout 600s`
- manual Yakit verification against the reported Streamable MCP endpoint across HTTP versions and pool modes
