### PR TITLE
fix(release): 修复 Runtime 归档在 containerd 主机无法加载

### DIFF
--- a/.github/scripts/package-legion-ai-session-runtime.sh
+++ b/.github/scripts/package-legion-ai-session-runtime.sh
@@ -65,6 +65,30 @@ runtime_go_version="${RUNTIME_GO_VERSION:-}"
   die "RUNTIME_IMAGE_TAG must be the human-readable build tag"
 [[ -f "$runtime_image_archive" ]] || die "RUNTIME_IMAGE_ARCHIVE must reference the gzip-compressed Docker image archive"
 gzip -t "$runtime_image_archive" || die "RUNTIME_IMAGE_ARCHIVE is not valid gzip data"
+runtime_image_id="${runtime_image_ref##*@}"
+runtime_image_digest="${runtime_image_id#sha256:}"
+if ! runtime_archive_manifest="$(tar -xOzf "$runtime_image_archive" manifest.json 2>/dev/null)"; then
+  die "RUNTIME_IMAGE_ARCHIVE does not contain Docker manifest.json"
+fi
+runtime_archive_config="$({
+  jq -er --arg image_tag "$runtime_image_tag" '
+    select(type == "array" and length == 1) |
+    .[0] |
+    select((.RepoTags | type) == "array" and (.RepoTags | index($image_tag)) != null) |
+    .Config
+  ' <<<"$runtime_archive_manifest"
+} 2>/dev/null)" || die "RUNTIME_IMAGE_ARCHIVE must contain exactly one image tagged as RUNTIME_IMAGE_TAG"
+case "$runtime_archive_config" in
+  "$runtime_image_digest.json"|"blobs/sha256/$runtime_image_digest") ;;
+  *)
+    die "RUNTIME_IMAGE_ARCHIVE config path does not match the immutable image ID"
+    ;;
+esac
+if ! runtime_archive_config_sha="$(tar -xOzf "$runtime_image_archive" "$runtime_archive_config" 2>/dev/null | sha256sum | awk '{print $1}')"; then
+  die "RUNTIME_IMAGE_ARCHIVE does not contain its declared image config"
+fi
+[[ "$runtime_archive_config_sha" == "$runtime_image_digest" ]] || \
+  die "RUNTIME_IMAGE_ARCHIVE config digest does not match the immutable image ID"
 [[ "$runtime_base_image" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || \
   die "RUNTIME_BASE_IMAGE must be pinned by sha256 digest"
 [[ "$runtime_builder_image" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || \

--- a/.github/scripts/test-legion-component-workflow-contract.sh
+++ b/.github/scripts/test-legion-component-workflow-contract.sh
@@ -49,6 +49,17 @@ if ! grep -Fq 'archive_dir="${RUNNER_TEMP}/runtime-archive-${RUNTIME_GOARCH}"' "
   exit 1
 fi
 # shellcheck disable=SC2016 # Match literal GitHub Actions expression syntax.
+if ! grep -Fq 'RUNTIME_IMAGE_TAG: ${{ steps.inspect.outputs.image_tag }}' "$runtime_workflow" ||
+   ! grep -Fq 'docker save "$RUNTIME_IMAGE_TAG"' "$runtime_workflow"; then
+  echo "$runtime_workflow must export a tagged Runtime image for containerd-backed Docker hosts" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match literal workflow shell syntax.
+if grep -Fq 'docker save "$RUNTIME_IMAGE_ID"' "$runtime_workflow"; then
+  echo "$runtime_workflow must not export the Runtime by bare image ID" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016 # Match literal GitHub Actions expression syntax.
 if ! grep -Fq 'RUNTIME_IMAGE_ARCHIVE: ${{ steps.runtime-archive.outputs.path }}' "$runtime_workflow"; then
   echo "$runtime_workflow must pass the runner-temp archive into provenance generation" >&2
   exit 1

--- a/.github/scripts/test-package-legion-ai-session-runtime.sh
+++ b/.github/scripts/test-package-legion-ai-session-runtime.sh
@@ -12,32 +12,66 @@ case "$(uname -m)" in
   aarch64|arm64) target_arch="arm64" ;;
   *) echo "unsupported test host architecture: $(uname -m)" >&2; exit 1 ;;
 esac
-fake_digest="$(printf 'a%.0s' {1..64})"
 base_digest="$(printf 'b%.0s' {1..64})"
 builder_digest="$(printf 'c%.0s' {1..64})"
 runtime_binary="$test_root/legion-session-runtime"
 runtime_ldd="$test_root/runtime.ldd"
 runtime_archive="$test_root/runtime.docker.tar.gz"
+runtime_image_tag="registry.example/legion-ai-session-runtime:fixture"
+runtime_archive_root="$test_root/runtime-archive"
 cp /bin/true "$runtime_binary"
 ldd "$runtime_binary" >"$runtime_ldd"
-printf 'runtime-image\n' | gzip -n >"$runtime_archive"
+mkdir -p "$runtime_archive_root/blobs/sha256"
+printf '{"architecture":"%s","fixture":true}\n' "$target_arch" \
+  >"$runtime_archive_root/runtime-config.json"
+fake_digest="$(sha256sum "$runtime_archive_root/runtime-config.json" | awk '{print $1}')"
+runtime_config_path="blobs/sha256/$fake_digest"
+mv "$runtime_archive_root/runtime-config.json" "$runtime_archive_root/$runtime_config_path"
+
+write_runtime_archive() {
+  local output="$1" tag_mode="$2"
+  case "$tag_mode" in
+    tagged)
+      jq -n --arg config "$runtime_config_path" --arg tag "$runtime_image_tag" \
+        '[{Config:$config,RepoTags:[$tag],Layers:[]}]' \
+        >"$runtime_archive_root/manifest.json"
+      ;;
+    untagged)
+      jq -n --arg config "$runtime_config_path" \
+        '[{Config:$config,RepoTags:null,Layers:[]}]' \
+        >"$runtime_archive_root/manifest.json"
+      ;;
+    *)
+      echo "unsupported Runtime archive fixture mode: $tag_mode" >&2
+      exit 1
+      ;;
+  esac
+  tar -C "$runtime_archive_root" -cf - manifest.json blobs | gzip -n >"$output"
+}
+
+run_packager() {
+  local archive="$1" output_dir="$2"
+  SOURCE_SHA="$source_sha" \
+  RUNTIME_PACKAGE_VERSION="fixture-${source_sha:0:12}" \
+  RUNTIME_DIST_DIR="$output_dir" \
+  RUNTIME_BINARY="$runtime_binary" \
+  RUNTIME_LDD_FILE="$runtime_ldd" \
+  RUNTIME_IMAGE_REF="registry.example/legion-ai-session-runtime@sha256:$fake_digest" \
+  RUNTIME_IMAGE_TAG="$runtime_image_tag" \
+  RUNTIME_IMAGE_ARCHIVE="$archive" \
+  RUNTIME_BASE_IMAGE="debian:bookworm-slim@sha256:$base_digest" \
+  RUNTIME_BUILDER_IMAGE="golang:1.22.12-bookworm@sha256:$builder_digest" \
+  RUNTIME_GOARCH="$target_arch" \
+  RUNTIME_GO_VERSION="go version go1.22.12 linux/$target_arch" \
+  RUNTIME_CI_PROVIDER="fixture" \
+  SESSION_RUNTIME_WORKFLOW_NAME="fixture" \
+  "$packager"
+}
+
+write_runtime_archive "$runtime_archive" tagged
 runtime_archive_sha="$(sha256sum "$runtime_archive" | awk '{print $1}')"
 
-SOURCE_SHA="$source_sha" \
-RUNTIME_PACKAGE_VERSION="fixture-${source_sha:0:12}" \
-RUNTIME_DIST_DIR="$test_root/dist" \
-RUNTIME_BINARY="$runtime_binary" \
-RUNTIME_LDD_FILE="$runtime_ldd" \
-RUNTIME_IMAGE_REF="registry.example/legion-ai-session-runtime@sha256:$fake_digest" \
-RUNTIME_IMAGE_TAG="registry.example/legion-ai-session-runtime:fixture" \
-RUNTIME_IMAGE_ARCHIVE="$runtime_archive" \
-RUNTIME_BASE_IMAGE="debian:bookworm-slim@sha256:$base_digest" \
-RUNTIME_BUILDER_IMAGE="golang:1.22.12-bookworm@sha256:$builder_digest" \
-RUNTIME_GOARCH="$target_arch" \
-RUNTIME_GO_VERSION="go version go1.22.12 linux/$target_arch" \
-RUNTIME_CI_PROVIDER="fixture" \
-SESSION_RUNTIME_WORKFLOW_NAME="fixture" \
-"$packager"
+run_packager "$runtime_archive" "$test_root/dist"
 
 package_name="legion-ai-session-runtime_linux_${target_arch}"
 package_dir="$test_root/dist/$package_name"
@@ -78,5 +112,20 @@ jq -e \
     (.recipe.dockerfile_sha256 | test("^[0-9a-f]{64}$")) and
     (.recipe.dockerignore_sha256 | test("^[0-9a-f]{64}$"))
   ' "$manifest" >/dev/null
+
+untagged_archive="$test_root/runtime-untagged.docker.tar.gz"
+write_runtime_archive "$untagged_archive" untagged
+if run_packager "$untagged_archive" "$test_root/untagged-dist" >/dev/null 2>&1; then
+  echo 'Runtime packager accepted an archive without an importable image tag' >&2
+  exit 1
+fi
+
+mismatched_archive="$test_root/runtime-config-mismatch.docker.tar.gz"
+printf '{"tampered":true}\n' >"$runtime_archive_root/$runtime_config_path"
+write_runtime_archive "$mismatched_archive" tagged
+if run_packager "$mismatched_archive" "$test_root/mismatched-dist" >/dev/null 2>&1; then
+  echo 'Runtime packager accepted a config blob that did not match the immutable image ID' >&2
+  exit 1
+fi
 
 printf '[legion-ai-session-runtime-test] PASS\n'

--- a/.github/workflows/build-legion-ai-session-runtime-common.yml
+++ b/.github/workflows/build-legion-ai-session-runtime-common.yml
@@ -193,13 +193,13 @@ jobs:
         id: runtime-archive
         shell: bash
         env:
-          RUNTIME_IMAGE_ID: ${{ steps.inspect.outputs.image_id }}
+          RUNTIME_IMAGE_TAG: ${{ steps.inspect.outputs.image_tag }}
         run: |
           set -euo pipefail
           archive_dir="${RUNNER_TEMP}/runtime-archive-${RUNTIME_GOARCH}"
           archive_path="${archive_dir}/${RUNTIME_PACKAGE_NAME}.docker.tar.gz"
           mkdir -p "$archive_dir"
-          docker save "$RUNTIME_IMAGE_ID" | gzip -n -1 \
+          docker save "$RUNTIME_IMAGE_TAG" | gzip -n -1 \
             >"$archive_path"
           gzip -t "$archive_path"
           echo "path=$archive_path" >>"$GITHUB_OUTPUT"

--- a/docs/legion-ai-session-runtime-release.md
+++ b/docs/legion-ai-session-runtime-release.md
@@ -44,6 +44,13 @@ workflow, target platform, Dockerfile, immutable base images, embedded binary
 digest, image archive digest and size, immutable image ID, and the
 `ai.session.runtime` plus `yak.execute` capabilities.
 
+The Docker archive is exported through the verified build tag rather than a
+bare image ID. Its `manifest.json` must retain that non-pullable tag, and the
+referenced config blob must hash to the immutable image ID recorded by the
+Runtime manifest. This makes `docker load` register an addressable image on
+both the classic Docker image store and containerd-backed Docker engines;
+archives with `RepoTags=null` are rejected before publication.
+
 The unified bundle builder rejects a Node and Runtime pair when their version,
 source commit, operating system, architecture, workflow identity, capability
 set, manifest digest, or image-archive digest differs. The Runtime archive is


### PR DESCRIPTION
## 改动摘要

- Runtime 镜像归档改为通过已验证的构建标签导出，避免 Docker manifest 中出现 RepoTags=null。
- Runtime 打包器校验归档只包含一个目标镜像、保留构建标签，并校验 config blob SHA 与锁定 image ID 完全一致。
- 增加无标签归档和 config digest 不匹配的回归测试，并同步统一 Yaklang Release 文档。

## 改动文件

- `.github/workflows/build-legion-ai-session-runtime-common.yml`
- `.github/scripts/package-legion-ai-session-runtime.sh`
- `.github/scripts/test-package-legion-ai-session-runtime.sh`
- `.github/scripts/test-legion-component-workflow-contract.sh`
- `docs/legion-ai-session-runtime-release.md`

## 验证方式

- `bash .github/scripts/test-package-legion-ai-session-runtime.sh`
- `bash .github/scripts/test-legion-component-workflow-contract.sh`
- `shellcheck` 覆盖本次修改的三个脚本
- `actionlint .github/workflows/build-legion-ai-session-runtime-common.yml`
- `git diff --check`

以上聚焦 T1 均通过；真实 containerd Runtime 加载验证正在独立收集。