### PR TITLE
fix(workflows): enhance license initialization and error handling

### DIFF
--- a/.github/workflows/exp-cross-build.yml
+++ b/.github/workflows/exp-cross-build.yml
@@ -6,6 +6,7 @@ name: Cross-Build-Yak
 # ------------------------------------------------------------------------------------------------
 # 标准版本              gzip_embed             yak_                   yak_linux_amd64 / yak_windows_arm64.exe
 # yak-slim（并行构建）  gzip_embed,irify_exclude  yak-slim_             yak-slim_linux_amd64
+# slim 必须 ee=true：与完整引擎嵌入同一套 license 证书，否则企业版无法跨引擎切换
 #
 # Windows ARM64: windows-11-arm 原生 runner + llvm-mingw (CC=aarch64-w64-mingw32-clang)
 # 标准 MinGW 无法处理 runtime/cgo 的 ARM64 汇编；参考 agentsview/nginx-ui/llvm-mingw
@@ -371,7 +372,14 @@ jobs:
           gzip-embed -cache --source ./common/aiforge/buildinforge --gz ./common/aiforge/buildinforge.tar.gz --root-path --no-embed
 
       - name: Initialize License Machine
-        run: go run common/xlic/cmd/initializer.go --ak ${{ secrets.OSS_KEY_ID }} --sk ${{ secrets.OSS_KEY_SECRET }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          go run common/xlic/cmd/initializer.go --ak "${{ secrets.OSS_KEY_ID }}" --sk "${{ secrets.OSS_KEY_SECRET }}"
+          if [ ! -s common/xlic/certs/pub.gzip ] || [ ! -s common/xlic/certs/pri.gzip ]; then
+            echo "::error::License certs missing after initializer; refusing to embed random license keys"
+            exit 1
+          fi
 
       - name: Build for Windows
         if: contains(matrix.os, 'windows')
@@ -588,7 +596,10 @@ jobs:
     with:
       os: ${{ matrix.os }}
       build_type: yakslim
-      ee: false
+      # Slim is a Yakit engine drop-in. It must embed the same official license
+      # certs as the full engine; otherwise GetLicense/CheckLicense use a random
+      # 2048-bit key and enterprise licenses cannot be shared across engines.
+      ee: true
       sign: ${{ matrix.os == 'windows' || matrix.os == 'windows-arm64' }}
     secrets: inherit
 

--- a/.github/workflows/reuse-build.yml
+++ b/.github/workflows/reuse-build.yml
@@ -308,8 +308,17 @@ jobs:
           gzip-embed -cache --source ./common/aiforge/buildinforge --gz ./common/aiforge/buildinforge.tar.gz --root-path --no-embed
 
       - name: Initialize License Machine
-        if: inputs.ee
-        run: go run common/xlic/cmd/initializer.go --ak ${{ secrets.OSS_KEY_ID }} --sk ${{ secrets.OSS_KEY_SECRET }}
+        # yak-slim is a Yakit engine drop-in and must share the official license
+        # certs with the full engine, even when the caller forgets ee=true.
+        if: ${{ inputs.ee || inputs.build_type == 'yakslim' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          go run common/xlic/cmd/initializer.go --ak "${{ secrets.OSS_KEY_ID }}" --sk "${{ secrets.OSS_KEY_SECRET }}"
+          if [ ! -s common/xlic/certs/pub.gzip ] || [ ! -s common/xlic/certs/pri.gzip ]; then
+            echo "::error::License certs missing after initializer; refusing to embed random license keys"
+            exit 1
+          fi
 
       - name: Build for Windows
         if: contains(inputs.os, 'windows')

--- a/common/xlic/license.go
+++ b/common/xlic/license.go
@@ -27,7 +27,7 @@ func initMachine() {
 
 		raw, err := certs.ReadFile("certs/pub.gzip")
 		if err != nil {
-			log.Debugf("read enc.gzip error: %v", err)
+			log.Debugf("read pub.gzip error: %v", err)
 		}
 		if len(raw) > 0 {
 			if raw, _ := utils.GzipDeCompress(raw); len(raw) > 0 {
@@ -47,6 +47,10 @@ func initMachine() {
 		}
 
 		if len(encBytes) <= 0 || len(decBytes) <= 0 {
+			// Local/CE builds have no official certs (initializer.go is CI-only).
+			// A random 2048-bit key makes GetLicense/CheckLicense incompatible
+			// with the official engine — never ship this path in release binaries.
+			log.Warn("xlic: official license certs not embedded; generating ephemeral RSA keys. Enterprise licenses will not work across engines. Run common/xlic/cmd/initializer.go before building a release.")
 			decBytes, encBytes, _ = tlsutils.GeneratePrivateAndPublicKeyPEM()
 		}
 


### PR DESCRIPTION
- Updated the license initialization step in both `exp-cross-build.yml` and `reuse-build.yml` to ensure proper error handling for missing license certificates.
- Modified the `ee` flag handling to enforce the requirement for official license certs in yak-slim builds.
- Improved logging in `license.go` to clarify the implications of missing official certs during the build process.