### PR TITLE
修复 Runtime 镜像导入后的本地身份解析

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -7,6 +7,14 @@ on:
         description: "PR number, branch (e.g. owner:branch for fork), or commit SHA"
         required: false
         default: ""
+      test_scope:
+        description: "Test scope (PR events are detected automatically)"
+        required: true
+        type: choice
+        options:
+          - full
+          - scannode
+        default: full
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -30,6 +38,7 @@ jobs:
       fork_repo: ${{ steps.target.outputs.fork_repo }}
       is_same_repo: ${{ steps.target.outputs.is_same_repo }}
       is_pull_request: ${{ steps.target.outputs.is_pull_request }}
+      test_scope: ${{ steps.scope.outputs.test_scope }}
     steps:
       - name: Determine target revision
         id: target
@@ -151,6 +160,51 @@ jobs:
         if: steps.target.outputs.is_pull_request != 'true' || steps.target.outputs.is_same_repo == 'false'
         run: echo "SHOULD_RUN=true" >> $GITHUB_ENV
 
+      - name: Detect test scope
+        id: scope
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_SCOPE: ${{ inputs.test_scope }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          TEST_SCOPE="full"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TEST_SCOPE="${REQUESTED_SCOPE:-full}"
+          elif [ -n "$PR_NUMBER" ]; then
+            PAGE=1
+            FILE_COUNT=0
+            SCANNODE_ONLY="true"
+
+            while [ "$PAGE" -le 30 ]; do
+              RESPONSE=$(curl -fsSL \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/files?per_page=100&page=$PAGE")
+              PAGE_COUNT=$(echo "$RESPONSE" | jq 'length')
+
+              if ! echo "$RESPONSE" | jq -e 'all(.[]; (.filename | startswith("scannode/")))' >/dev/null; then
+                SCANNODE_ONLY="false"
+              fi
+
+              FILE_COUNT=$((FILE_COUNT + PAGE_COUNT))
+              if [ "$PAGE_COUNT" -lt 100 ]; then
+                break
+              fi
+              PAGE=$((PAGE + 1))
+            done
+
+            # GitHub caps this endpoint at 3,000 files. Fall back to the full
+            # suite when the complete PR scope cannot be proven.
+            if [ "$FILE_COUNT" -gt 0 ] && [ "$FILE_COUNT" -lt 3000 ] && [ "$SCANNODE_ONLY" = "true" ]; then
+              TEST_SCOPE="scannode"
+            fi
+          fi
+
+          echo "test_scope=$TEST_SCOPE" >> "$GITHUB_OUTPUT"
+          echo "Selected test scope: $TEST_SCOPE"
+
       - name: Finalize outputs
         id: finalize
         run: echo "should_run_tests=$SHOULD_RUN" >> $GITHUB_OUTPUT
@@ -159,7 +213,7 @@ jobs:
 
   prepare-yak:
     needs: check-wip
-    if: needs.check-wip.outputs.should_run_tests == 'true'
+    if: needs.check-wip.outputs.should_run_tests == 'true' && needs.check-wip.outputs.test_scope == 'full'
     runs-on: ubuntu-22.04
     outputs:
       yak_artifact_id: ${{ steps.upload_yak.outputs.artifact-id }}
@@ -222,6 +276,41 @@ jobs:
           path: ${{ runner.temp }}/essential-tests-yak-cache.tar.gz
           retention-days: 1
           compression-level: 0
+
+  scannode-focused:
+    name: Test ScanNode Focused
+    needs: check-wip
+    if: needs.check-wip.outputs.should_run_tests == 'true' && needs.check-wip.outputs.test_scope == 'scannode'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.check-wip.outputs.fork_repo || github.repository }}
+          ref: ${{ needs.check-wip.outputs.target_ref || github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+          cache: false
+
+      - name: Configure Go build directories
+        run: |
+          mkdir -p "$RUNNER_TEMP/go-build-cache" "$RUNNER_TEMP/go-mod-cache"
+          echo "GOCACHE=$RUNNER_TEMP/go-build-cache" >> "$GITHUB_ENV"
+          echo "GOMODCACHE=$RUNNER_TEMP/go-mod-cache" >> "$GITHUB_ENV"
+
+      - name: Test ScanNode packages
+        run: go test -count=1 -timeout 10m ./scannode/...
+
+      - name: Test Legion Node entrypoint
+        run: go test -count=1 -timeout 10m ./cmd/legion-smoke-node
+
+      - name: Vet ScanNode and Legion Node
+        run: go vet ./scannode/... ./cmd/legion-smoke-node
 
   slim-gate:
     needs: [check-wip, prepare-yak]
@@ -1011,3 +1100,47 @@ jobs:
         uses: ./.github/actions/post-check
         with:
           cache-key-prefix: 'essential-tests'
+
+  essential-tests-gate:
+    name: Essential Tests Gate
+    needs:
+      - check-wip
+      - scannode-focused
+      - slim-gate
+      - test-local
+      - test-prepared-yakgrpc
+      - test-prepared-coreplugin
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Verify selected test scope
+        env:
+          SHOULD_RUN_TESTS: ${{ needs.check-wip.outputs.should_run_tests }}
+          TEST_SCOPE: ${{ needs.check-wip.outputs.test_scope }}
+          SCANNODE_RESULT: ${{ needs.scannode-focused.result }}
+          SLIM_RESULT: ${{ needs.slim-gate.result }}
+          LOCAL_RESULT: ${{ needs.test-local.result }}
+          YAKGRPC_RESULT: ${{ needs.test-prepared-yakgrpc.result }}
+          COREPLUGIN_RESULT: ${{ needs.test-prepared-coreplugin.result }}
+        run: |
+          if [ "$SHOULD_RUN_TESTS" != "true" ]; then
+            echo "Tests were intentionally disabled by the pre-check."
+            exit 0
+          fi
+
+          if [ "$TEST_SCOPE" = "scannode" ]; then
+            if [ "$SCANNODE_RESULT" != "success" ]; then
+              echo "ScanNode focused tests did not pass: $SCANNODE_RESULT" >&2
+              exit 1
+            fi
+            echo "ScanNode focused test scope passed."
+            exit 0
+          fi
+
+          for result in "$SLIM_RESULT" "$LOCAL_RESULT" "$YAKGRPC_RESULT" "$COREPLUGIN_RESULT"; do
+            if [ "$result" != "success" ]; then
+              echo "Full test scope did not pass: $result" >&2
+              exit 1
+            fi
+          done
+          echo "Full test scope passed."

--- a/docs/legion-ai-session-runtime-release.md
+++ b/docs/legion-ai-session-runtime-release.md
@@ -51,6 +51,16 @@ Runtime manifest. This makes `docker load` register an addressable image on
 both the classic Docker image store and containerd-backed Docker engines;
 archives with `RepoTags=null` are rejected before publication.
 
+The Runtime Host does not require the image ID reported by the target Docker
+engine after `docker load` to equal the producer's config digest. Some
+containerd-backed Docker versions assign a different target-local descriptor
+while importing the same verified archive. Before loading, the host still
+requires exactly one fixed non-pullable tag and proves that the referenced
+config blob hashes to the producer image ID. It then persists the exact release,
+archive, tag, and target-local image ID mapping and re-resolves that mapping
+before starting a session container. A missing, retagged, or mismatched local
+image is never adopted without re-validating and re-loading the pinned archive.
+
 The unified bundle builder rejects a Node and Runtime pair when their version,
 source commit, operating system, architecture, workflow identity, capability
 set, manifest digest, or image-archive digest differs. The Runtime archive is

--- a/scannode/runtime_host.go
+++ b/scannode/runtime_host.go
@@ -68,6 +68,7 @@ type runtimeHostExecutor struct {
 	nodeIDProvider      func() string
 	sessionProvider     func() (node.SessionState, bool)
 	operations          map[string]runtimeHostOperationRecord
+	images              map[string]runtimeHostImageRecord
 	mu                  sync.Mutex
 }
 
@@ -404,7 +405,7 @@ func (e *runtimeHostExecutor) execute(ctx context.Context, command *nodev1.AIRun
 }
 
 func (e *runtimeHostExecutor) ensureImage(ctx context.Context, release *nodev1.AIRuntimeRelease) (string, error) {
-	if imageID, exists, err := e.docker.ResolveImageID(ctx, release.ImageId); err != nil || exists {
+	if imageID, exists, err := e.resolveRuntimeImage(ctx, release); err != nil || exists {
 		return imageID, err
 	}
 	archive, cleanup, err := e.downloadRuntimeArchive(ctx, release)
@@ -412,15 +413,25 @@ func (e *runtimeHostExecutor) ensureImage(ctx context.Context, release *nodev1.A
 		return "", err
 	}
 	defer cleanup()
-	if err := e.docker.LoadImage(ctx, archive); err != nil {
-		return "", fmt.Errorf("load verified Runtime image: %w", err)
-	}
-	imageID, exists, err := e.docker.ResolveImageID(ctx, release.ImageId)
+	imageTag, err := inspectRuntimeImageArchive(archive, release)
 	if err != nil {
 		return "", err
 	}
-	if !exists || imageID != release.ImageId {
-		return "", fmt.Errorf("loaded Runtime image does not match the pinned identity")
+	if _, err := archive.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	if err := e.docker.LoadImage(ctx, archive); err != nil {
+		return "", fmt.Errorf("load verified Runtime image: %w", err)
+	}
+	imageID, exists, err := e.docker.ResolveImageID(ctx, imageTag)
+	if err != nil {
+		return "", err
+	}
+	if !exists || !runtimeHostImageIDPattern.MatchString(strings.ToLower(strings.TrimSpace(imageID))) {
+		return "", fmt.Errorf("loaded Runtime image has no target-local identity")
+	}
+	if err := e.recordRuntimeImage(release, imageTag, imageID); err != nil {
+		return "", fmt.Errorf("persist target-local Runtime image identity: %w", err)
 	}
 	return imageID, nil
 }
@@ -482,11 +493,11 @@ func (e *runtimeHostExecutor) start(ctx context.Context, command *nodev1.AIRunti
 			return "", false, fmt.Errorf("runtime container ownership does not match the active generation")
 		}
 	}
-	imageID, exists, err := e.docker.ResolveImageID(ctx, command.Release.ImageId)
+	imageID, exists, err := e.resolveRuntimeImage(ctx, command.Release)
 	if err != nil {
 		return "", false, err
 	}
-	if !exists || imageID != command.Release.ImageId {
+	if !exists {
 		return "", false, fmt.Errorf("pinned Runtime image is not ready")
 	}
 	if existing, found, err := e.docker.FindContainer(ctx, command.CleanupKey); err != nil {

--- a/scannode/runtime_host_image.go
+++ b/scannode/runtime_host_image.go
@@ -1,0 +1,200 @@
+package scannode
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	nodev1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/node/v1"
+)
+
+const (
+	runtimeHostArchiveManifestLimit = 1 << 20
+	runtimeHostArchiveConfigLimit   = 4 << 20
+)
+
+var runtimeHostImageIDPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+var runtimeHostImageTagPattern = regexp.MustCompile(`^local\.invalid/yaklang/legion-ai-session-runtime:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
+
+type runtimeHostImageRecord struct {
+	ReleaseID       string    `json:"release_id"`
+	EngineDigest    string    `json:"engine_digest"`
+	ProducerImageID string    `json:"producer_image_id"`
+	ArchiveSHA256   string    `json:"archive_sha256"`
+	ArchiveSize     int64     `json:"archive_size"`
+	ImageTag        string    `json:"image_tag"`
+	LocalImageID    string    `json:"local_image_id"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+type runtimeHostArchiveManifestEntry struct {
+	Config   string   `json:"Config"`
+	RepoTags []string `json:"RepoTags"`
+}
+
+func (e *runtimeHostExecutor) resolveRuntimeImage(ctx context.Context, release *nodev1.AIRuntimeRelease) (string, bool, error) {
+	producerImageID := strings.ToLower(strings.TrimSpace(release.GetImageId()))
+	imageID, exists, err := e.docker.ResolveImageID(ctx, producerImageID)
+	if err != nil {
+		return "", false, err
+	}
+	if exists {
+		imageID = strings.ToLower(strings.TrimSpace(imageID))
+		if !runtimeHostImageIDPattern.MatchString(imageID) {
+			return "", false, fmt.Errorf("Runtime image has an invalid target-local identity")
+		}
+		return imageID, true, nil
+	}
+
+	record, ok := e.images[release.GetReleaseId()]
+	if !ok || !runtimeHostImageRecordMatchesRelease(record, release) {
+		return "", false, nil
+	}
+	imageID, exists, err = e.docker.ResolveImageID(ctx, record.ImageTag)
+	if err != nil || !exists {
+		return "", exists, err
+	}
+	imageID = strings.ToLower(strings.TrimSpace(imageID))
+	if imageID != record.LocalImageID {
+		// Treat a changed or retagged local descriptor as not ready. ENSURE_IMAGE
+		// will re-validate and re-load the exact pinned archive before replacing
+		// the durable mapping; START never adopts the changed image directly.
+		return "", false, nil
+	}
+	return imageID, true, nil
+}
+
+func runtimeHostImageRecordMatchesRelease(record runtimeHostImageRecord, release *nodev1.AIRuntimeRelease) bool {
+	return record.ReleaseID == release.GetReleaseId() &&
+		strings.EqualFold(record.EngineDigest, release.GetEngineDigest()) &&
+		strings.EqualFold(record.ProducerImageID, release.GetImageId()) &&
+		strings.EqualFold(record.ArchiveSHA256, release.GetArchiveSha256()) &&
+		record.ArchiveSize == release.GetArchiveSize() &&
+		runtimeHostImageTagPattern.MatchString(record.ImageTag) &&
+		runtimeHostImageIDPattern.MatchString(record.LocalImageID)
+}
+
+func (e *runtimeHostExecutor) recordRuntimeImage(release *nodev1.AIRuntimeRelease, imageTag, localImageID string) error {
+	record := runtimeHostImageRecord{
+		ReleaseID:       release.GetReleaseId(),
+		EngineDigest:    strings.ToLower(release.GetEngineDigest()),
+		ProducerImageID: strings.ToLower(release.GetImageId()),
+		ArchiveSHA256:   strings.ToLower(release.GetArchiveSha256()),
+		ArchiveSize:     release.GetArchiveSize(),
+		ImageTag:        imageTag,
+		LocalImageID:    strings.ToLower(strings.TrimSpace(localImageID)),
+		UpdatedAt:       time.Now().UTC(),
+	}
+	previous, existed := e.images[record.ReleaseID]
+	e.images[record.ReleaseID] = record
+	if err := e.saveOperationJournal(); err != nil {
+		if existed {
+			e.images[record.ReleaseID] = previous
+		} else {
+			delete(e.images, record.ReleaseID)
+		}
+		return err
+	}
+	return nil
+}
+
+func inspectRuntimeImageArchive(archive io.ReadSeeker, release *nodev1.AIRuntimeRelease) (string, error) {
+	producerImageID := strings.ToLower(strings.TrimSpace(release.GetImageId()))
+	if !runtimeHostImageIDPattern.MatchString(producerImageID) {
+		return "", fmt.Errorf("Runtime archive producer image identity is invalid")
+	}
+	producerDigest := strings.TrimPrefix(producerImageID, "sha256:")
+	manifestJSON, configDigests, err := inspectRuntimeArchiveEntries(archive, producerDigest)
+	if err != nil {
+		return "", fmt.Errorf("inspect Runtime archive: %w", err)
+	}
+	manifest := make([]runtimeHostArchiveManifestEntry, 0, 1)
+	if err := json.Unmarshal(manifestJSON, &manifest); err != nil {
+		return "", fmt.Errorf("decode Runtime archive manifest: %w", err)
+	}
+	if len(manifest) != 1 || len(manifest[0].RepoTags) != 1 {
+		return "", fmt.Errorf("Runtime archive must contain exactly one tagged image")
+	}
+	imageTag := strings.TrimSpace(manifest[0].RepoTags[0])
+	if !runtimeHostImageTagPattern.MatchString(imageTag) {
+		return "", fmt.Errorf("Runtime archive image tag is not the fixed local release tag")
+	}
+	configPath := strings.TrimSpace(manifest[0].Config)
+	if configPath != producerDigest+".json" && configPath != "blobs/sha256/"+producerDigest {
+		return "", fmt.Errorf("Runtime archive config path does not match the producer image identity")
+	}
+	if configDigests[configPath] != producerDigest {
+		return "", fmt.Errorf("Runtime archive image config does not match the producer image identity")
+	}
+	return imageTag, nil
+}
+
+func inspectRuntimeArchiveEntries(archive io.ReadSeeker, producerDigest string) ([]byte, map[string]string, error) {
+	if _, err := archive.Seek(0, io.SeekStart); err != nil {
+		return nil, nil, err
+	}
+	gzipReader, err := gzip.NewReader(archive)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer gzipReader.Close()
+	tarReader := tar.NewReader(gzipReader)
+	var manifestJSON []byte
+	configDigests := make(map[string]string, 2)
+	legacyConfigPath := producerDigest + ".json"
+	contentStoreConfigPath := "blobs/sha256/" + producerDigest
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		name := header.Name
+		if name != "manifest.json" && name != legacyConfigPath && name != contentStoreConfigPath {
+			continue
+		}
+		if name == "manifest.json" && manifestJSON != nil {
+			return nil, nil, fmt.Errorf("archive contains duplicate manifest.json")
+		}
+		if _, duplicate := configDigests[name]; duplicate {
+			return nil, nil, fmt.Errorf("archive contains duplicate %s", name)
+		}
+		if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
+			return nil, nil, fmt.Errorf("archive entry %s is not a regular file", name)
+		}
+		sizeLimit := int64(runtimeHostArchiveConfigLimit)
+		if name == "manifest.json" {
+			sizeLimit = runtimeHostArchiveManifestLimit
+		}
+		if header.Size < 0 || header.Size > sizeLimit {
+			return nil, nil, fmt.Errorf("archive entry %s exceeds the size limit", name)
+		}
+		data, err := io.ReadAll(io.LimitReader(tarReader, sizeLimit+1))
+		if err != nil {
+			return nil, nil, err
+		}
+		if int64(len(data)) != header.Size {
+			return nil, nil, fmt.Errorf("archive entry %s is truncated", name)
+		}
+		if name == "manifest.json" {
+			manifestJSON = data
+			continue
+		}
+		digest := sha256.Sum256(data)
+		configDigests[name] = hex.EncodeToString(digest[:])
+	}
+	if manifestJSON == nil {
+		return nil, nil, fmt.Errorf("archive does not contain manifest.json")
+	}
+	return manifestJSON, configDigests, nil
+}

--- a/scannode/runtime_host_journal.go
+++ b/scannode/runtime_host_journal.go
@@ -26,6 +26,7 @@ type runtimeHostOperationRecord struct {
 type runtimeHostOperationJournal struct {
 	Version    int                                   `json:"version"`
 	Operations map[string]runtimeHostOperationRecord `json:"operations"`
+	Images     map[string]runtimeHostImageRecord     `json:"images,omitempty"`
 }
 
 func (e *runtimeHostExecutor) journalPath() string {
@@ -37,6 +38,7 @@ func (e *runtimeHostExecutor) loadOperationJournal() error {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		e.operations = make(map[string]runtimeHostOperationRecord)
+		e.images = make(map[string]runtimeHostImageRecord)
 		return nil
 	}
 	if err != nil {
@@ -52,7 +54,11 @@ func (e *runtimeHostExecutor) loadOperationJournal() error {
 	if journal.Operations == nil {
 		journal.Operations = make(map[string]runtimeHostOperationRecord)
 	}
+	if journal.Images == nil {
+		journal.Images = make(map[string]runtimeHostImageRecord)
+	}
 	e.operations = journal.Operations
+	e.images = journal.Images
 	return nil
 }
 
@@ -62,7 +68,7 @@ func (e *runtimeHostExecutor) saveOperationJournal() error {
 		return err
 	}
 	payload, err := json.MarshalIndent(runtimeHostOperationJournal{
-		Version: runtimeHostJournalVersion, Operations: e.operations,
+		Version: runtimeHostJournalVersion, Operations: e.operations, Images: e.images,
 	}, "", "  ")
 	if err != nil {
 		return err

--- a/scannode/runtime_host_test.go
+++ b/scannode/runtime_host_test.go
@@ -1,11 +1,17 @@
 package scannode
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -21,8 +27,17 @@ type runtimeHostDockerStub struct {
 	pingErr    error
 	images     map[string]string
 	containers map[string]runtimeHostContainer
+	loadImages map[string]string
+	loadErr    error
+	loads      int
 	creates    int
 	stops      int
+}
+
+type runtimeHostRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function runtimeHostRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
 }
 
 func (d *runtimeHostDockerStub) Ping(context.Context) error { return d.pingErr }
@@ -30,7 +45,19 @@ func (d *runtimeHostDockerStub) ResolveImageID(_ context.Context, selector strin
 	image, ok := d.images[selector]
 	return image, ok, nil
 }
-func (d *runtimeHostDockerStub) LoadImage(context.Context, io.Reader) error { return nil }
+func (d *runtimeHostDockerStub) LoadImage(context.Context, io.Reader) error {
+	d.loads++
+	if d.loadErr != nil {
+		return d.loadErr
+	}
+	if d.images == nil {
+		d.images = make(map[string]string)
+	}
+	for selector, imageID := range d.loadImages {
+		d.images[selector] = imageID
+	}
+	return nil
+}
 func (d *runtimeHostDockerStub) FindContainer(_ context.Context, cleanupKey string) (runtimeHostContainer, bool, error) {
 	container, ok := d.containers[cleanupKey]
 	return container, ok, nil
@@ -65,12 +92,20 @@ func (d *runtimeHostDockerStub) StopAndRemove(_ context.Context, containerID str
 func (d *runtimeHostDockerStub) Close() error { return nil }
 
 func newRuntimeHostTestExecutor(t *testing.T, docker *runtimeHostDockerStub, baseDir string) *runtimeHostExecutor {
+	return newRuntimeHostTestExecutorAt(t, docker, baseDir, "http://platform.invalid")
+}
+
+func newRuntimeHostTestExecutorAt(t *testing.T, docker *runtimeHostDockerStub, baseDir, platformAPIBaseURL string) *runtimeHostExecutor {
+	return newRuntimeHostTestExecutorWithClient(t, docker, baseDir, platformAPIBaseURL, nil)
+}
+
+func newRuntimeHostTestExecutorWithClient(t *testing.T, docker *runtimeHostDockerStub, baseDir, platformAPIBaseURL string, httpClient *http.Client) *runtimeHostExecutor {
 	t.Helper()
 	executor, err := newRuntimeHostExecutor(RuntimeHostConfig{
-		Enabled: true, BaseDir: baseDir, PlatformAPIBaseURL: "http://platform.invalid",
+		Enabled: true, BaseDir: baseDir, PlatformAPIBaseURL: platformAPIBaseURL,
 		EnrollmentToken: "enrollment-ticket", AgentInstallationID: "host-installation-1",
 		EngineReleaseID: "sha256-" + strings.Repeat("d", 64), EngineDigest: strings.Repeat("a", 64),
-		Network: "bridge", docker: docker, NodeIDProvider: func() string { return "node-1" },
+		Network: "bridge", HTTPClient: httpClient, docker: docker, NodeIDProvider: func() string { return "node-1" },
 		SessionProvider: func() (node.SessionState, bool) {
 			return node.SessionState{NodeID: "node-1", SessionID: "node-session-1"}, true
 		},
@@ -79,6 +114,51 @@ func newRuntimeHostTestExecutor(t *testing.T, docker *runtimeHostDockerStub, bas
 		t.Fatalf("newRuntimeHostExecutor() error = %v", err)
 	}
 	return executor
+}
+
+func runtimeHostTestImageArchive(t *testing.T, tags []string, imageCount int) ([]byte, string) {
+	t.Helper()
+	config := []byte(`{"architecture":"amd64","config":{"Labels":{"org.opencontainers.image.revision":"fixture"}}}`)
+	digest := sha256.Sum256(config)
+	producerImageID := "sha256:" + hex.EncodeToString(digest[:])
+	configPath := "blobs/sha256/" + strings.TrimPrefix(producerImageID, "sha256:")
+	type manifestEntry struct {
+		Config   string   `json:"Config"`
+		RepoTags []string `json:"RepoTags"`
+		Layers   []string `json:"Layers"`
+	}
+	manifest := make([]manifestEntry, imageCount)
+	for index := range manifest {
+		manifest[index] = manifestEntry{Config: configPath, RepoTags: tags, Layers: []string{}}
+	}
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, file := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "manifest.json", data: manifestJSON},
+		{name: configPath, data: config},
+	} {
+		if err := tarWriter.WriteHeader(&tar.Header{Name: file.name, Mode: 0o600, Size: int64(len(file.data))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tarWriter.Write(file.data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes(), producerImageID
 }
 
 func runtimeHostTestCommand(t *testing.T) *nodev1.AIRuntimeCommand {
@@ -269,5 +349,109 @@ func TestResilienceRuntimeHostReplayRestartAndStopDoNotDuplicateContainer(t *tes
 	replayedStart := afterStopRestart.execute(context.Background(), command, session)
 	if replayedStart.Success || docker.creates != 1 {
 		t.Fatalf("stopped generation was recreated: result=%+v creates=%d", replayedStart, docker.creates)
+	}
+}
+
+func TestRuntimeHostEnsureImageAcceptsAndPersistsTargetLocalIdentity(t *testing.T) {
+	tag := "local.invalid/yaklang/legion-ai-session-runtime:legion-node-v0.3.3-amd64"
+	archive, producerImageID := runtimeHostTestImageArchive(t, []string{tag}, 1)
+	archiveDigest := sha256.Sum256(archive)
+	httpClient := &http.Client{Transport: runtimeHostRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/v1/node-engine-control/runtime" ||
+			request.Header.Get("Authorization") != "Enrollment enrollment-ticket" {
+			return &http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(strings.NewReader("unexpected request"))}, nil
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(archive))}, nil
+	})}
+
+	localImageID := "sha256:" + strings.Repeat("e", 64)
+	docker := &runtimeHostDockerStub{
+		images: make(map[string]string), containers: make(map[string]runtimeHostContainer),
+		loadImages: map[string]string{tag: localImageID},
+	}
+	baseDir := t.TempDir()
+	executor := newRuntimeHostTestExecutorWithClient(t, docker, baseDir, "http://platform.invalid", httpClient)
+	command := runtimeHostTestCommand(t)
+	command.Release.ImageId = producerImageID
+	command.Release.ArchiveSha256 = hex.EncodeToString(archiveDigest[:])
+	command.Release.ArchiveSize = int64(len(archive))
+
+	resolved, err := executor.ensureImage(context.Background(), command.Release)
+	if err != nil || resolved != localImageID || docker.loads != 1 {
+		t.Fatalf("ensureImage() = %q, %v; loads=%d", resolved, err, docker.loads)
+	}
+
+	restarted := newRuntimeHostTestExecutorWithClient(t, docker, baseDir, "http://platform.invalid", httpClient)
+	result := restarted.execute(context.Background(), command, node.SessionState{
+		NodeID: "node-1", SessionID: "node-session-1",
+	})
+	if !result.Success || result.ContainerId == "" || docker.creates != 1 {
+		t.Fatalf("start after restart = %+v; creates=%d", result, docker.creates)
+	}
+	container := docker.containers[command.CleanupKey]
+	if container.ImageID != localImageID {
+		t.Fatalf("container image = %q, want target-local %q", container.ImageID, localImageID)
+	}
+}
+
+func TestRuntimeHostEnsureImageKeepsProducerIdentityWhenLocallyAddressable(t *testing.T) {
+	command := runtimeHostTestCommand(t)
+	docker := &runtimeHostDockerStub{
+		images:     map[string]string{command.Release.ImageId: command.Release.ImageId},
+		containers: make(map[string]runtimeHostContainer),
+	}
+	executor := newRuntimeHostTestExecutor(t, docker, t.TempDir())
+	resolved, err := executor.ensureImage(context.Background(), command.Release)
+	if err != nil || resolved != command.Release.ImageId || docker.loads != 0 {
+		t.Fatalf("ensureImage() = %q, %v; loads=%d", resolved, err, docker.loads)
+	}
+}
+
+func TestRuntimeHostArchiveIdentityValidationRejectsUnsafeArchives(t *testing.T) {
+	validTag := "local.invalid/yaklang/legion-ai-session-runtime:legion-node-v0.3.3-amd64"
+	tests := []struct {
+		name       string
+		tags       []string
+		imageCount int
+		wrongImage bool
+	}{
+		{name: "multiple images", tags: []string{validTag}, imageCount: 2},
+		{name: "multiple tags", tags: []string{validTag, validTag + "-other"}, imageCount: 1},
+		{name: "pullable tag", tags: []string{"registry.example/runtime:latest"}, imageCount: 1},
+		{name: "wrong config digest", tags: []string{validTag}, imageCount: 1, wrongImage: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archive, producerImageID := runtimeHostTestImageArchive(t, test.tags, test.imageCount)
+			if test.wrongImage {
+				producerImageID = "sha256:" + strings.Repeat("f", 64)
+			}
+			release := &nodev1.AIRuntimeRelease{ImageId: producerImageID}
+			if _, err := inspectRuntimeImageArchive(bytes.NewReader(archive), release); err == nil {
+				t.Fatal("inspectRuntimeImageArchive() accepted an unsafe archive")
+			}
+		})
+	}
+}
+
+func TestRuntimeHostStartDoesNotAdoptRetaggedLocalImage(t *testing.T) {
+	command := runtimeHostTestCommand(t)
+	tag := "local.invalid/yaklang/legion-ai-session-runtime:legion-node-v0.3.3-amd64"
+	expectedLocalImageID := "sha256:" + strings.Repeat("e", 64)
+	docker := &runtimeHostDockerStub{
+		images:     map[string]string{tag: "sha256:" + strings.Repeat("f", 64)},
+		containers: make(map[string]runtimeHostContainer),
+	}
+	executor := newRuntimeHostTestExecutor(t, docker, t.TempDir())
+	executor.images[command.Release.ReleaseId] = runtimeHostImageRecord{
+		ReleaseID: command.Release.ReleaseId, EngineDigest: command.Release.EngineDigest,
+		ProducerImageID: command.Release.ImageId, ArchiveSHA256: command.Release.ArchiveSha256,
+		ArchiveSize: command.Release.ArchiveSize, ImageTag: tag, LocalImageID: expectedLocalImageID,
+	}
+	result := executor.execute(context.Background(), command, node.SessionState{
+		NodeID: "node-1", SessionID: "node-session-1",
+	})
+	if result.Success || docker.creates != 0 || !strings.Contains(result.ErrorMessage, "not ready") {
+		t.Fatalf("retagged start result = %+v; creates=%d", result, docker.creates)
 	}
 }


### PR DESCRIPTION
## 背景

在 Docker 29/containerd-backed Docker 上，可信 Runtime 归档导入后，Docker 返回的目标机本地镜像 ID 可能不同于生产构建阶段记录的配置摘要。原逻辑要求两者完全相等，导致镜像已经正确导入但 Runtime Host 仍返回 runtime_release_mismatch，AI 会话节点不可用。

## 修改

- 将稳定的生产镜像身份与目标机本地镜像身份分离。
- 导入前校验归档仅包含一个固定的不可拉取标签，并校验配置 blob 摘要等于锁定的生产镜像 ID。
- 导入后记录发布 ID、引擎摘要、归档摘要、固定标签和目标机本地镜像 ID 的持久化映射。
- START 前重新解析并验证本地映射；标签被替换或镜像缺失时拒绝直接采用，必须重新执行 ENSURE_IMAGE。
- 归档 manifest 与配置 blob 使用单次 gzip/tar 扫描完成验证。
- 保持旧 Docker 环境中生产 ID 可直接定位镜像的兼容路径。

## CI 优化

- PR 的全部改动都位于 `scannode/**` 时，只运行 ScanNode、Legion Node 入口和对应 `go vet`。
- 存在 `common/**`、依赖、workflow 或其他目录改动时，继续运行原 Essential Tests 全量矩阵。
- 文件范围为空、超过 GitHub 3000 文件上限或无法完整判断时，安全回退到全量测试。
- 新增稳定的 `Essential Tests Gate`，统一校验 focused 或 full 路径的结果。
- `workflow_dispatch` 默认运行全量，也可显式选择 `scannode` 验证 focused 路径。

## 安全边界

该修改只取消本机镜像 ID 与生产配置摘要必须相等这一不稳定条件，不取消发布 ID、归档 SHA256、生产镜像配置摘要、固定标签、命令鉴权和节点发布绑定校验。

CI 分流只对纯 `scannode/**` 改动生效；任何无法证明范围完整的情况都不会跳过全量矩阵。

## 验证

- `go test ./scannode -run 'RuntimeHost|ResilienceRuntimeHost' -count=1`
- `go test ./cmd/legion-smoke-node -count=1`
- focused GitHub Actions：`go test ./scannode/...`、Legion Node 入口测试、`go vet` 和聚合 Gate 全部通过。
- 当前 PR 同时修改文档和 workflow，自动 PR run 按预期保留全量 Essential Tests；独立 `workflow_dispatch` 已验证 focused 路径不会启动全量矩阵。
