### PR TITLE
fix(ai): separate tool protocol completion from execution outcome

### DIFF
--- a/common/ai/aid/aicache/hijacker_test.go
+++ b/common/ai/aid/aicache/hijacker_test.go
@@ -888,18 +888,18 @@ func TestHijack_FrozenBoundary_TimelineDumpFormat(t *testing.T) {
 		"<|AI_CACHE_FROZEN_semi-dynamic|>",
 		"<|TIMELINE_b3t1746180000|>",
 		"# bucket=2026/05/02 10:00:00-10:03:00 interval=3m",
-		"10:00:30 [tool/scan ok]",
+		"10:00:30 [tool/scan]",
 		"data-A",
 		"<|TIMELINE_END_b3t1746180000|>",
 		"<|TIMELINE_b3t1746180180|>",
 		"# bucket=2026/05/02 10:03:00-10:06:00 interval=3m",
-		"10:04:00 [tool/scan ok]",
+		"10:04:00 [tool/scan]",
 		"data-B",
 		"<|TIMELINE_END_b3t1746180180|>",
 		"<|AI_CACHE_FROZEN_END_semi-dynamic|>",
 		"<|TIMELINE_b3t1746180360|>",
 		"# bucket=2026/05/02 10:06:00-10:09:00 interval=3m",
-		"10:07:00 [tool/scan ok]",
+		"10:07:00 [tool/scan]",
 		"data-C-OPEN",
 		"<|TIMELINE_END_b3t1746180360|>",
 	}, "\n")
@@ -936,10 +936,11 @@ func TestHijack_FrozenBoundary_TimelineDumpFormat(t *testing.T) {
 // hijacker 切成 4 段消息: [system+cc, user1+cc, user2+cc, user3].
 //
 // 端到端 prompt 形态:
-//   SYSTEM (high-static)        -> system + cc
-//   AI_CACHE_FROZEN ... END     -> user1 + cc
-//   AI_CACHE_SEMI   ... END     -> user2 + cc (内含 PROMPT_SECTION_semi-dynamic + 内容)
-//   timeline-open + dynamic     -> user3 (无 cc)
+//
+//	SYSTEM (high-static)        -> system + cc
+//	AI_CACHE_FROZEN ... END     -> user1 + cc
+//	AI_CACHE_SEMI   ... END     -> user2 + cc (内含 PROMPT_SECTION_semi-dynamic + 内容)
+//	timeline-open + dynamic     -> user3 (无 cc)
 //
 // 关键词: TestHijack_SemiBoundary, 4 段切分, P1 双 cache 边界, 双 cc 主路径
 func TestHijack_SemiBoundary_HappyPath4Segments(t *testing.T) {

--- a/common/ai/aid/aicommon/README_TIMELINE_GROUPS.md
+++ b/common/ai/aid/aicommon/README_TIMELINE_GROUPS.md
@@ -151,7 +151,7 @@ func (h *TimelineCompressedHeadBlock) IsOpen() bool         // 恒为 false
 
 ```
 # bucket=2026/05/02 10:00:00-10:03:00 interval=3m
-10:00:30 [tool/scan ok]
+10:00:30 [tool/scan]
 result-line-1
 result-line-2
 10:01:45 [user/review]
@@ -177,7 +177,7 @@ compressed-batch-summary
 <|TL_END_r42t1746179400|>
 <|TL_b3t1746180000|>
 # bucket=2026/05/02 10:00:00-10:03:00 interval=3m
-10:00:30 [tool/scan ok]
+10:00:30 [tool/scan]
 result-line-1
 10:01:45 [user/review]
 user-answer
@@ -200,7 +200,7 @@ compressed-batch-summary
 <|TL_END_r42t1746179400|>
 <|TL_b3t1746180000|>
 # bucket=2026/05/02 10:00:00-10:03:00 interval=3m
-10:00:30 [tool/scan ok]
+10:00:30 [tool/scan]
 result-line-1
 10:01:45 [user/review]
 user-answer
@@ -248,13 +248,13 @@ for _, blk := range result.GetTaggedBlocks() {
 假设 timeline 中有 5 条相邻几分钟内产生的 ToolResult，每条原始数据都是一段 ~1KB 的扫描结果：
 
 ```text
-id=101 09:50:01 [tool/scan ok]   data="<1024 字节扫描原文>"
-id=102 09:51:30 [tool/scan ok]   data="<1024 字节扫描原文>"
-id=103 09:53:11 [tool/scan ok]   data="<1024 字节扫描原文>"
-id=104 09:54:42 [tool/scan ok]   data="<1024 字节扫描原文>"
-id=105 09:55:22 [tool/scan ok]   data="<1024 字节扫描原文>"
+id=101 09:50:01 [tool/scan]      data="<1024 字节扫描原文>"
+id=102 09:51:30 [tool/scan]      data="<1024 字节扫描原文>"
+id=103 09:53:11 [tool/scan]      data="<1024 字节扫描原文>"
+id=104 09:54:42 [tool/scan]      data="<1024 字节扫描原文>"
+id=105 09:55:22 [tool/scan]      data="<1024 字节扫描原文>"
 ... 后续还有几条仍在活跃中的 entry：
-id=106 09:58:00 [tool/cat ok]    data="cat-result-A"
+id=106 09:58:00 [tool/cat]       data="cat-result-A"
 id=107 10:01:30 [user/review]    "looks good"
 id=108 10:04:10 [text/note]      "[normal] noted"
 ```
@@ -264,26 +264,26 @@ id=108 10:04:10 [text/note]      "[normal] noted"
 ```
 <|TL_b3t1746179400|>
 # bucket=2026/05/02 09:48:00-09:51:00 interval=3m
-09:50:01 [tool/scan ok]
+09:50:01 [tool/scan]
 <1024 字节扫描原文>
 <|TL_END_b3t1746179400|>
 <|TL_b3t1746179580|>
 # bucket=2026/05/02 09:51:00-09:54:00 interval=3m
-09:51:30 [tool/scan ok]
+09:51:30 [tool/scan]
 <1024 字节扫描原文>
-09:53:11 [tool/scan ok]
+09:53:11 [tool/scan]
 <1024 字节扫描原文>
 <|TL_END_b3t1746179580|>
 <|TL_b3t1746179760|>
 # bucket=2026/05/02 09:54:00-09:57:00 interval=3m
-09:54:42 [tool/scan ok]
+09:54:42 [tool/scan]
 <1024 字节扫描原文>
-09:55:22 [tool/scan ok]
+09:55:22 [tool/scan]
 <1024 字节扫描原文>
 <|TL_END_b3t1746179760|>
 <|TL_b3t1746179940|>
 # bucket=2026/05/02 09:57:00-10:00:00 interval=3m
-09:58:00 [tool/cat ok]
+09:58:00 [tool/cat]
 cat-result-A
 <|TL_END_b3t1746179940|>
 <|TL_b3t1746180060|>
@@ -330,7 +330,7 @@ looks good
 <|TL_END_r105t1746179722|>
 <|TL_b3t1746179940|>
 # bucket=2026/05/02 09:57:00-10:00:00 interval=3m
-09:58:00 [tool/cat ok]
+09:58:00 [tool/cat]
 cat-result-A
 <|TL_END_b3t1746179940|>
 <|TL_b3t1746180060|>

--- a/common/ai/aid/aicommon/emitter.go
+++ b/common/ai/aid/aicommon/emitter.go
@@ -557,6 +557,8 @@ func (r *Emitter) EmitToolCallProgressReview(callToolID string, payload ToolCall
 }
 
 func (r *Emitter) EmitToolCallDone(callToolId string, endTime time.Time, startTime time.Time, purePluginDuration time.Duration) (*schema.AiOutputEvent, error) {
+	// EVENT_TOOL_CALL_DONE is a lifecycle boundary only. Execution semantics are
+	// carried separately by EVENT_TOOL_CALL_RESULT.
 	if purePluginDuration < 0 {
 		purePluginDuration = 0
 	}

--- a/common/ai/aid/aicommon/session_snapshot.go
+++ b/common/ai/aid/aicommon/session_snapshot.go
@@ -46,17 +46,19 @@ type SessionSnapshotBackgroundProcess struct {
 }
 
 type SessionSnapshotExecution struct {
-	TaskName          string `json:"task_name"`
-	Status            string `json:"status"`
-	StartedAt         int64  `json:"started_at"`
-	EndedAt           int64  `json:"ended_at"`
-	ToolCallSuccess   int    `json:"tool_call_success"`
-	ToolCallFailed    int    `json:"tool_call_failed"`
-	ToolCallTotal     int    `json:"tool_call_total"`
-	ExecutionMinutes  int    `json:"execution_minutes"`
-	HTTPFlowCount     int    `json:"http_flow_count"`
-	RiskCount         int    `json:"risk_count"`
-	ModifiedFileCount int    `json:"modified_file_count"`
+	TaskName  string `json:"task_name"`
+	Status    string `json:"status"`
+	StartedAt int64  `json:"started_at"`
+	EndedAt   int64  `json:"ended_at"`
+	// Legacy wire names retained for frontend compatibility. These count
+	// protocol-completed and protocol-failed calls, not execution outcomes.
+	ToolCallSuccess   int `json:"tool_call_success"`
+	ToolCallFailed    int `json:"tool_call_failed"`
+	ToolCallTotal     int `json:"tool_call_total"`
+	ExecutionMinutes  int `json:"execution_minutes"`
+	HTTPFlowCount     int `json:"http_flow_count"`
+	RiskCount         int `json:"risk_count"`
+	ModifiedFileCount int `json:"modified_file_count"`
 }
 
 type SessionSnapshotPerception struct {

--- a/common/ai/aid/aicommon/timeline.go
+++ b/common/ai/aid/aicommon/timeline.go
@@ -802,9 +802,9 @@ func (m *Timeline) createEmergencySummary(item *TimelineItem, id int64) string {
 	switch v := item.value.(type) {
 	case *aitool.ToolResult:
 		if v.Success {
-			summary = fmt.Sprintf("[%s] tool:%s success", timeStr, v.Name)
+			summary = fmt.Sprintf("[%s] tool:%s completed", timeStr, v.Name)
 		} else {
-			summary = fmt.Sprintf("[%s] tool:%s failed", timeStr, v.Name)
+			summary = fmt.Sprintf("[%s] tool:%s protocol-error", timeStr, v.Name)
 		}
 	case *UserInteraction:
 		summary = fmt.Sprintf("[%s] user-interaction stage:%v", timeStr, v.Stage)

--- a/common/ai/aid/aicommon/timeline_byte_bucket_test.go
+++ b/common/ai/aid/aicommon/timeline_byte_bucket_test.go
@@ -37,7 +37,7 @@ func TestByteBucket_TaskContextCarriedIntoToolFirstSubBucket(t *testing.T) {
 	require.Contains(t, strings.Split(blocks[0].Render(), "\n")[0], "task=task-a")
 	require.Contains(t, strings.Split(blocks[1].Render(), "\n")[0], "task=task-a",
 		"a sub-bucket beginning with a tool result must inherit the preceding task context")
-	require.Contains(t, blocks[1].Render(), "[tool/scan ok]")
+	require.Contains(t, blocks[1].Render(), "[tool/scan]")
 	require.NotContains(t, blocks[0].Render(), "[task:task-a]")
 	require.Contains(t, text.Text, "[task:task-a]", "render-only optimization must preserve the stored event")
 }

--- a/common/ai/aid/aicommon/timeline_groups_render.go
+++ b/common/ai/aid/aicommon/timeline_groups_render.go
@@ -795,15 +795,13 @@ func renderItemTypeVerbose(item *TimelineItem) string {
 	}
 	switch v := item.value.(type) {
 	case *aitool.ToolResult:
-		status := "ok"
-		if !v.Success {
-			status = "fail"
-		}
 		name := strings.TrimSpace(v.Name)
 		if name == "" {
 			name = "unknown"
 		}
-		return fmt.Sprintf("tool/%s %s", name, status)
+		// ToolResult.Success is protocol completion, not execution outcome. Keep
+		// the header neutral; result/error details are rendered in the body.
+		return fmt.Sprintf("tool/%s", name)
 	case *UserInteraction:
 		stage := string(v.Stage)
 		if stage == "" {

--- a/common/ai/aid/aicommon/timeline_groups_render_aitag_test.go
+++ b/common/ai/aid/aicommon/timeline_groups_render_aitag_test.go
@@ -470,7 +470,7 @@ func TestGroupByMinutes_Boundary_MixedTypesInBucket(t *testing.T) {
 	blocks := tl.GroupByMinutes(3).GetBlocks()
 	require.Len(t, blocks, 1)
 	body := blocks[0].Render()
-	require.Contains(t, body, "[tool/a ok]")
+	require.Contains(t, body, "[tool/a]")
 	require.Contains(t, body, "[user/free_input]")
 	require.Contains(t, body, "[text/note]")
 

--- a/common/ai/aid/aicommon/timeline_groups_render_test.go
+++ b/common/ai/aid/aicommon/timeline_groups_render_test.go
@@ -225,10 +225,10 @@ func TestGroupByMinutes_TypeVerbose(t *testing.T) {
 	blocks := tl.GroupByMinutes(3).GetBlocks()
 	require.Len(t, blocks, 1)
 	rendered := blocks[0].Render()
-	require.Contains(t, rendered, "[tool/scanX ok]")
+	require.Contains(t, rendered, "[tool/scanX]")
 	require.Contains(t, rendered, "[user/review]")
 	require.Contains(t, rendered, "[text/note]")
-	require.Contains(t, rendered, "[tool/scanY fail]")
+	require.Contains(t, rendered, "[tool/scanY]")
 }
 
 func TestTimelineRender_TaskHeaderDeduplicatesSameTask(t *testing.T) {
@@ -283,7 +283,7 @@ func TestTimelineRender_LateTaskDoesNotRewriteBucketHeader(t *testing.T) {
 	rendered := tl.GroupByMinutesAndBytes(3, -1).GetBlocks()[0].Render()
 	require.NotContains(t, strings.Split(rendered, "\n")[0], "task=")
 	require.Equal(t, 1, strings.Count(rendered, "# task=task-a"))
-	require.Less(t, strings.Index(rendered, "[tool/setup ok]"), strings.Index(rendered, "# task=task-a"))
+	require.Less(t, strings.Index(rendered, "[tool/setup]"), strings.Index(rendered, "# task=task-a"))
 }
 
 // TestGroupByMinutes_TagWrapping 验证 aitag 兼容包裹格式
@@ -442,7 +442,7 @@ func TestGroupByMinutes_OutputFormat(t *testing.T) {
 	injectTimelineItem(tl, 1, ts, tr)
 
 	rendered := tl.GroupByMinutes(3).GetBlocks()[0].Render()
-	require.Contains(t, rendered, "10:01:30 [tool/scan ok]")
+	require.Contains(t, rendered, "10:01:30 [tool/scan]")
 	// content 行不应带前导空格（节省 token）
 	require.Contains(t, rendered, "\ncompact-result")
 	require.NotContains(t, rendered, "  compact-result")

--- a/common/ai/aid/aicommon/toolcall.go
+++ b/common/ai/aid/aicommon/toolcall.go
@@ -537,8 +537,8 @@ func buildToolCallReasonPrompt(tool *aitool.Tool, params aitool.InvokeParams, ta
 }
 
 // buildRecentToolCallSummary returns a short markdown summary of the most
-// recent N tool-call results from the task, oldest first. Each entry is a
-// one-line bullet: "- tool_name: success/failed (brief error if any)".
+// recent N tool-call results from the task, oldest first. Status describes the
+// invocation protocol only; execution semantics remain in the tool result.
 // Returns "" when no prior results exist.
 func buildRecentToolCallSummary(task AITask, maxItems int) string {
 	if task == nil {
@@ -555,10 +555,10 @@ func buildRecentToolCallSummary(task AITask, maxItems int) string {
 	}
 	var sb strings.Builder
 	for _, r := range results[start:] {
-		status := "success"
+		status := "completed"
 		extra := ""
 		if !r.Success {
-			status = "failed"
+			status = "protocol-error"
 			if r.Error != "" {
 				errMsg := r.Error
 				if len(errMsg) > 80 {

--- a/common/ai/aid/aicommon/toolcall_artifact.go
+++ b/common/ai/aid/aicommon/toolcall_artifact.go
@@ -382,12 +382,14 @@ func (b *toolCallArtifactBundle) markFinalized() {
 }
 
 // isCanonicalToolResultData recognizes only the framework envelope written by
-// applyNormalizedData. RESULT is optional by design: it is omitted when the
-// structured result is empty or byte-identical to combined output. Requiring a
+// applyNormalizedData. Current envelopes begin with RESULT or OBSERVATIONS;
+// COMBINED OUTPUT remains accepted for checkpoint compatibility. Requiring a
 // valid final ARTIFACT/HINT section avoids treating an arbitrary tool string
-// that merely starts with "COMBINED OUTPUT:" as a checkpoint replay envelope.
+// that merely starts with one of those labels as a replay envelope.
 func isCanonicalToolResultData(data string) bool {
-	if !strings.HasPrefix(data, "COMBINED OUTPUT:\n") {
+	if !strings.HasPrefix(data, "RESULT:\n") &&
+		!strings.HasPrefix(data, "OBSERVATIONS:\n") &&
+		!strings.HasPrefix(data, "COMBINED OUTPUT:\n") {
 		return false
 	}
 	artifactMarker := "\n\nARTIFACT:\n"
@@ -530,18 +532,19 @@ func normalizeToolResultData(toolResult *aitool.ToolResult, combined, resultText
 		combined = "(empty)"
 	}
 	if combined == resultText {
-		// duplicate: skip RESULT section entirely to save tokens
-		body := "COMBINED OUTPUT:\n" + combined
+		// Duplicate: one semantic RESULT section is enough. Do not lead with an
+		// observation label that could make log wording look authoritative.
+		body := "RESULT:\n" + resultText
 		applyNormalizedData(toolResult, body, hint)
 		return
 	}
 	if resultText == "" {
-		// empty result: skip RESULT section to avoid a two-line "(empty)" no-op
-		body := "COMBINED OUTPUT:\n" + combined
+		// No semantic result was supplied; label captured text as observations.
+		body := "OBSERVATIONS:\n" + combined
 		applyNormalizedData(toolResult, body, hint)
 		return
 	}
-	body := "COMBINED OUTPUT:\n" + combined + "\n\nRESULT:\n" + resultText
+	body := "RESULT:\n" + resultText + "\n\nOBSERVATIONS:\n" + combined
 	applyNormalizedData(toolResult, body, hint)
 }
 
@@ -622,11 +625,11 @@ func (b *toolCallArtifactBundle) finalize(
 	}
 	if data, ok := toolResult.Data.(string); ok && isCanonicalToolResultData(data) {
 		// A current-format checkpoint already owns stable artifact paths. Do not
-		// wrap the preview again or rewrite its bytes during replay. RESULT is
-		// intentionally optional: canonical compact data omits that section when
-		// result is empty or byte-identical to COMBINED OUTPUT.
+		// wrap the preview again or rewrite its bytes during replay.
 		if err := b.discardIfUnfinished(); err != nil {
-			return err
+			log.Warnf("failed to discard replay artifact staging directory: %v", err)
+			// Leave finalized=false so the caller's deferred rollback can retry.
+			return nil
 		}
 		b.markFinalized()
 		return nil
@@ -673,13 +676,13 @@ func (b *toolCallArtifactBundle) finalize(
 	normalizeToolResultData(toolResult, combined, resultText, hint)
 	rawTokens := ytoken.CalcTokenCount(combined) + ytoken.CalcTokenCount(resultText)
 	if persistErr != nil && rawTokens > ToolResultTokenLimit {
-		toolResult.Success = false
-		if toolResult.Error != "" {
-			toolResult.Error += "; "
-		}
-		toolResult.Error += "artifact_persist_failed: complete oversized output is unavailable"
+		// Artifact persistence is an observation-channel failure after the tool
+		// callback already produced its protocol result. Keep Success unchanged;
+		// the canonical HINT communicates that the oversized observation is not
+		// fully recoverable.
 		normalizeToolResultData(toolResult, combined, resultText, hint)
-		return persistErr
+		log.Warnf("tool artifact persistence failed for oversized result: %v", persistErr)
+		return nil
 	}
 	if persistErr != nil {
 		log.Warnf("tool artifact persistence failed for bounded result: %v", persistErr)
@@ -696,7 +699,7 @@ func (b *toolCallArtifactBundle) finalize(
 		Tool:       tool.Name,
 		CallToolID: callToolID,
 		Identifier: identifier,
-		Status:     map[bool]string{true: "success", false: "failed"}[toolResult.Success],
+		Status:     map[bool]string{true: "completed", false: "protocol_failed"}[toolResult.Success],
 		Success:    toolResult.Success,
 		Error:      toolResult.Error,
 		Params:     params,
@@ -712,13 +715,15 @@ func (b *toolCallArtifactBundle) finalize(
 		// already-rendered ARTIFACT paths before returning so Timeline never
 		// advertises files that no longer exist.
 		normalizeToolResultData(toolResult, combined, resultText, toolArtifactHint(nil, err))
-		return err
+		log.Warnf("tool artifact manifest persistence failed: %v", err)
+		return nil
 	}
 
 	report := b.renderReport(tool, identifier, params, toolResult, paramGenDuration, rawAIParamResponse)
 	if err := os.WriteFile(b.reportPath, []byte(report), 0o644); err != nil {
 		normalizeToolResultData(toolResult, combined, resultText, toolArtifactHint(nil, err))
-		return err
+		log.Warnf("tool artifact report persistence failed: %v", err)
+		return nil
 	}
 	// Only a complete manifest/report bundle is durable. Any earlier error keeps
 	// finalized=false so ToolCaller's deferred rollback removes the partial tree.
@@ -843,11 +848,6 @@ func migrateLegacyTimelineToolResult(workdir string, toolResult *aitool.ToolResu
 	normalizeToolResultData(toolResult, combined, resultText, hint)
 	if persistErr != nil {
 		if ytoken.CalcTokenCount(combined)+ytoken.CalcTokenCount(resultText) > ToolResultTokenLimit {
-			toolResult.Success = false
-			if toolResult.Error != "" {
-				toolResult.Error += "; "
-			}
-			toolResult.Error += "artifact_persist_failed: historical oversized output is unavailable"
 			normalizeToolResultData(toolResult, combined, resultText, hint)
 		}
 		log.Warnf("failed to migrate legacy Timeline tool result %d: %v", toolResult.ID, persistErr)
@@ -858,7 +858,7 @@ func migrateLegacyTimelineToolResult(workdir string, toolResult *aitool.ToolResu
 		Tool:       toolResult.Name,
 		CallToolID: toolResult.ToolCallID,
 		Identifier: "legacy-timeline-migration",
-		Status:     map[bool]string{true: "success", false: "failed"}[toolResult.Success],
+		Status:     map[bool]string{true: "completed", false: "protocol_failed"}[toolResult.Success],
 		Success:    toolResult.Success,
 		Error:      toolResult.Error,
 		Params:     toolResult.Param,

--- a/common/ai/aid/aicommon/toolcall_artifact_test.go
+++ b/common/ai/aid/aicommon/toolcall_artifact_test.go
@@ -41,8 +41,8 @@ func TestNormalizeToolResultDataHardTokenLimit(t *testing.T) {
 	require.LessOrEqual(t, ytoken.CalcTokenCount(data), ToolResultTokenLimit)
 	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
 	require.Greater(t, ytoken.CalcTokenCount(data), 14000, "preview should fill most of the 16K budget")
-	require.Contains(t, data, "COMBINED-HEAD")
-	require.Contains(t, data, "RESULT-TAIL")
+	require.Contains(t, data, "RESULT-HEAD")
+	require.Contains(t, data, "COMBINED-TAIL")
 	require.Contains(t, data, hint)
 	require.NotContains(t, data, "COMBINED-MIDDLE-SENTINEL")
 	require.NotContains(t, data, "RESULT-MIDDLE-SENTINEL")
@@ -249,10 +249,10 @@ func TestNormalizeToolResultDataDeduplicatesExactCombinedAndResult(t *testing.T)
 	toolResult := &aitool.ToolResult{Name: "dedupe", Success: true}
 	normalizeToolResultData(toolResult, result, result, "ARTIFACT:\n/path")
 	data := toolResult.Data.(string)
-	// When combined == result, the RESULT section is omitted entirely (no "RESULT:" tag),
-	// so the result string appears exactly once (only in COMBINED OUTPUT).
+	// When observations equal the result, emit the semantic RESULT exactly once.
 	require.Equal(t, 1, strings.Count(data, result))
-	require.NotContains(t, data, "RESULT:")
+	require.Contains(t, data, "RESULT:")
+	require.NotContains(t, data, "OBSERVATIONS:")
 }
 
 func TestToolArtifactFailureNeverFallsBackToOversizedInlineData(t *testing.T) {
@@ -270,9 +270,9 @@ func TestToolArtifactFailureNeverFallsBackToOversizedInlineData(t *testing.T) {
 	tool, err := aitool.New("artifact-failure", aitool.WithSimpleCallback(func(aitool.InvokeParams, io.Writer, io.Writer) (any, error) { return nil, nil }))
 	require.NoError(t, err)
 	err = b.finalize(&ToolCaller{}, tool, "call-failure", "", nil, toolResult, 0, "")
-	require.Error(t, err)
-	require.False(t, toolResult.Success)
-	require.Contains(t, toolResult.Error, "artifact_persist_failed")
+	require.NoError(t, err)
+	require.True(t, toolResult.Success, "artifact persistence is not invocation protocol completion")
+	require.Empty(t, toolResult.Error)
 	require.Contains(t, toolResult.Data.(string), "artifact_persist_failed")
 	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.Data.(string)), ToolResultTokenLimit)
 	require.LessOrEqual(t, ytoken.CalcTokenCount(toolResult.String()), ToolResultTokenLimit)
@@ -306,15 +306,19 @@ func TestCurrentCheckpointReplayKeepsCompactedDataByteStable(t *testing.T) {
 	}{
 		{
 			name: "distinct_result",
-			data: "COMBINED OUTPUT:\npreview\n\nRESULT:\nresult\n\nARTIFACT:\n- combined: /stable/original/combined_output.txt\n- result: /stable/original/result.txt",
+			data: "RESULT:\nresult\n\nOBSERVATIONS:\npreview\n\nARTIFACT:\n- combined: /stable/original/combined_output.txt\n- result: /stable/original/result.txt",
 		},
 		{
-			name: "combined_equals_result_omits_result_section",
-			data: "COMBINED OUTPUT:\nsame compact bytes\n\nARTIFACT:\n- combined: /stable/original/combined_output.txt\n- result: /stable/original/result.txt",
+			name: "combined_equals_result_keeps_only_result",
+			data: "RESULT:\nsame compact bytes\n\nARTIFACT:\n- combined: /stable/original/combined_output.txt\n- result: /stable/original/result.txt",
 		},
 		{
-			name: "empty_result_omits_result_section",
-			data: "COMBINED OUTPUT:\nstdout only\n\nHINT:\nartifact_persist_failed: historical fixture",
+			name: "empty_result_keeps_only_observations",
+			data: "OBSERVATIONS:\nstdout only\n\nHINT:\nartifact_persist_failed: historical fixture",
+		},
+		{
+			name: "legacy_combined_output_checkpoint",
+			data: "COMBINED OUTPUT:\nlegacy preview\n\nARTIFACT:\n- combined: /stable/original/combined_output.txt\n- result: /stable/original/result.txt",
 		},
 	}
 	for _, tc := range canonicalData {
@@ -356,12 +360,17 @@ func TestCurrentCheckpointReplayKeepsCompactedDataByteStable(t *testing.T) {
 
 func TestCanonicalToolResultDataRequiresFrameworkTailEnvelope(t *testing.T) {
 	require.True(t, isCanonicalToolResultData(
-		"COMBINED OUTPUT:\nplain\n\nARTIFACT:\n- combined: /tmp/combined_output.txt\n- result: /tmp/result.txt",
+		"RESULT:\nsemantic\n\nOBSERVATIONS:\nplain\n\nARTIFACT:\n- combined: /tmp/combined_output.txt\n- result: /tmp/result.json",
 	))
 	require.True(t, isCanonicalToolResultData(
-		"COMBINED OUTPUT:\nplain\n\nHINT:\nartifact_persist_failed: disk unavailable. This is a bounded preview; omitted content is unrecoverable.",
+		"OBSERVATIONS:\nplain\n\nHINT:\nartifact_persist_failed: disk unavailable. This is a bounded preview; omitted content is unrecoverable.",
+	))
+	require.True(t, isCanonicalToolResultData(
+		"COMBINED OUTPUT:\nlegacy\n\nARTIFACT:\n- combined: /tmp/combined_output.txt\n- result: /tmp/result.txt",
 	))
 	for _, rawToolString := range []string{
+		"RESULT:\nordinary text without a framework tail",
+		"OBSERVATIONS:\nordinary text without a framework tail",
 		"COMBINED OUTPUT:\nthis is ordinary tool text",
 		"COMBINED OUTPUT:\nordinary text mentions\n\nARTIFACT:\nwithout framework paths",
 		"COMBINED OUTPUT:\nordinary text\n\nARTIFACT:\n- combined: /tmp/only-one-path",
@@ -440,7 +449,8 @@ func TestToolArtifactLateFinalizeFailureDoesNotLeaveGhostArtifactHint(t *testing
 	tool, err := aitool.New("late-persist", aitool.WithSimpleCallback(func(aitool.InvokeParams, io.Writer, io.Writer) (any, error) { return nil, nil }))
 	require.NoError(t, err)
 	err = b.finalize(&ToolCaller{}, tool, "late-call", "", nil, toolResult, 0, "")
-	require.Error(t, err)
+	require.NoError(t, err, "artifact persistence is an observation failure after protocol completion")
+	require.True(t, toolResult.Success)
 	data := toolResult.Data.(string)
 	require.Contains(t, data, "HINT:\nartifact_persist_failed:")
 	require.NotContains(t, data, "\n\nARTIFACT:\n")
@@ -495,8 +505,10 @@ func TestLegacyTimelineToolResultMigratesToArtifactAndCanonicalData(t *testing.T
 	result := item.GetValue().(*aitool.ToolResult)
 	data, ok := result.Data.(string)
 	require.True(t, ok)
-	require.Contains(t, data, "COMBINED OUTPUT:\nLEGACY-HEAD")
+	require.Contains(t, data, "RESULT:\n")
+	require.Contains(t, data, "OBSERVATIONS:\nLEGACY-HEAD")
 	require.Contains(t, data, "result-tail")
+	require.Less(t, strings.Index(data, "RESULT:\n"), strings.Index(data, "OBSERVATIONS:\n"))
 	require.Contains(t, data, "ARTIFACT:\n- combined:")
 	require.NotContains(t, data, "LEGACY-MIDDLE-SENTINEL")
 	require.LessOrEqual(t, ytoken.CalcTokenCount(data), ToolResultTokenLimit)

--- a/common/ai/aid/aicommon/toolcall_invoke.go
+++ b/common/ai/aid/aicommon/toolcall_invoke.go
@@ -335,7 +335,7 @@ func (a *ToolCaller) invoke(
 	toolCallErr := func(err error) (*aitool.ToolResult, error) {
 		reportError(err)
 		res := newToolCallRes()
-		res.Error = fmt.Sprintf("tool execution failed: %v", err)
+		res.Error = fmt.Sprintf("tool invocation protocol failed: %v", err)
 		return res, err
 	}
 
@@ -494,7 +494,7 @@ func (a *ToolCaller) invoke(
 		if execResult != nil {
 			execResult.Success = false
 			if execResult.Error == "" {
-				execResult.Error = fmt.Sprintf("tool execution cancelled: %v", execErr)
+				execResult.Error = fmt.Sprintf("tool invocation cancelled: %v", execErr)
 			}
 		}
 	}
@@ -516,16 +516,15 @@ func (a *ToolCaller) invoke(
 	}
 	if execResult != nil && !invokeCancelled {
 		if checkpointErr := c.SubmitCheckpointResponse(toolCheckpoint, execResult); checkpointErr != nil {
-			if execErr == nil {
-				execErr = checkpointErr
-			} else {
-				execErr = errors.Join(execErr, checkpointErr)
-			}
+			// The callback has already produced a result envelope. Checkpoint
+			// persistence is an infrastructure observation and must not rewrite
+			// protocol completion into a tool failure.
+			log.Warnf("failed to persist completed tool result checkpoint: %v", checkpointErr)
 		}
 	}
 
 	// Some failures happen outside the tool callback (for example JSON Schema
-	// validation, artifact finalization, or checkpoint persistence). Those paths can
+	// validation or cancellation). Those paths can
 	// return a ToolResult and an error without passing through WithErrorCallback.
 	// Always report the final aggregated error here so the UI receives tool_call_error
 	// instead of a silent done card. The caller's handler is guarded by sync.Once, so

--- a/common/ai/aid/aicommon/toolcall_reason_test.go
+++ b/common/ai/aid/aicommon/toolcall_reason_test.go
@@ -59,9 +59,9 @@ func TestBuildToolCallReasonPrompt_IncludesRecentSteps(t *testing.T) {
 	prompt := buildToolCallReasonPrompt(tool, nil, task)
 
 	require.Contains(t, prompt, "Recent steps")
-	require.Contains(t, prompt, "- bash: success")
-	require.Contains(t, prompt, "- do_http_request: success")
-	require.Contains(t, prompt, "- grep: failed (no matches found)")
+	require.Contains(t, prompt, "- bash: completed")
+	require.Contains(t, prompt, "- do_http_request: completed")
+	require.Contains(t, prompt, "- grep: protocol-error (no matches found)")
 }
 
 func TestBuildRecentToolCallSummary_MaxItems(t *testing.T) {
@@ -127,7 +127,7 @@ func TestBuildRecentToolCallSummary_TruncatesLongError(t *testing.T) {
 	task.PushToolCallResult(&aitool.ToolResult{ID: 1, Name: "fail_tool", Success: false, Error: longErr})
 
 	summary := buildRecentToolCallSummary(task, 5)
-	require.Contains(t, summary, "fail_tool: failed")
+	require.Contains(t, summary, "fail_tool: protocol-error")
 	require.Contains(t, summary, "...")
 	require.Less(t, len(summary), 200)
 }

--- a/common/ai/aid/aireact/invoke_jump_queue_test.go
+++ b/common/ai/aid/aireact/invoke_jump_queue_test.go
@@ -50,7 +50,7 @@ func mockedToolCallingForJumpWithCounter(i aicommon.AICallerConfigIf, req *aicom
 		if toolCalled != nil {
 			alreadyCalled = atomic.LoadInt32(toolCalled) >= 1
 		} else {
-			alreadyCalled = strings.Contains(prompt, "COMBINED OUTPUT:")
+			alreadyCalled = strings.Contains(prompt, "RESULT:")
 		}
 		if alreadyCalled {
 			rsp := i.NewAIResponse()

--- a/common/ai/aid/aireact/invoke_plan_and_execute_callback_inherit_test.go
+++ b/common/ai/aid/aireact/invoke_plan_and_execute_callback_inherit_test.go
@@ -96,10 +96,10 @@ func TestReAct_PlanAndExecute_InheritsDistinctCallbacks(t *testing.T) {
 
 			// Inner: subtask ReAct loop → require tool (first iteration)
 			// verification 收缩为纯观测角色后, satisfied=true 不再自动退出. 内层
-			// 子任务在工具执行完毕后 (prompt 中出现 "tool/<name> ok" 标记) 再次进入
+			// 子任务在工具协议执行完毕后 (prompt 中出现中性 "tool/<name>" 标记) 再次进入
 			// 主决策时, 主动 finish 收口子任务.
 			case utils.MatchAllOfSubString(prompt, "PROGRESS_TASK_", "directly_answer", "require_tool") &&
-				strings.Contains(prompt, "tool/mock_callback_inherit_tool ok"):
+				strings.Contains(prompt, "tool/mock_callback_inherit_tool"):
 				rsp.EmitOutputStream(bytes.NewBufferString(`{
   "@action": "finish",
   "human_readable_thought": "mocked: subtask tool done"

--- a/common/ai/aid/aireact/invoke_plan_and_execute_model_inherit_test.go
+++ b/common/ai/aid/aireact/invoke_plan_and_execute_model_inherit_test.go
@@ -68,10 +68,10 @@ func TestReAct_RequestPlanAndExecution_PreservesQualityModelInsideAid(t *testing
 }`))
 		// Inner subtask ReAct loop: tool already executed → finish the subtask.
 		// verification 收缩为纯观测角色后, satisfied=true 不再自动退出. 内层
-		// 子任务在工具执行完毕后 (prompt 中出现 "tool/<name> ok" 标记) 再次进入
+		// 子任务在工具协议执行完毕后 (prompt 中出现中性 "tool/<name>" 标记) 再次进入
 		// 主决策时, 主动 finish 收口子任务.
 		case utils.MatchAllOfSubString(prompt, "PROGRESS_TASK_", "directly_answer", "require_tool") &&
-			strings.Contains(prompt, "tool/mock_plan_exec_tool ok"):
+			strings.Contains(prompt, "tool/mock_plan_exec_tool"):
 			rsp.EmitOutputStream(bytes.NewBufferString(`{
   "@action": "finish",
   "human_readable_thought": "mocked: subtask tool done"

--- a/common/ai/aid/aireact/invoke_toolcall_batch_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_batch_test.go
@@ -522,7 +522,7 @@ func TestExecuteToolBatch_ArtifactsAreIsolatedAndOrderedDespiteOutOfOrderComplet
 		manifest := readBatchArtifactManifest(t, dir)
 		require.Equal(t, identifiers[i], manifest.Identifier)
 		require.Equal(t, request.Calls[i].ExecutionCallID, manifest.CallToolID)
-		require.Equal(t, "success", manifest.Status)
+		require.Equal(t, "completed", manifest.Status)
 		require.True(t, manifest.Success)
 
 		stdout, readErr := os.ReadFile(filepath.Join(dir, "stdout.txt"))
@@ -1094,7 +1094,7 @@ func TestExecuteToolBatch_OrdinaryFailureRetainsFailedArtifact(t *testing.T) {
 	failedDir := dirs[0]
 	require.Contains(t, filepath.Base(failedDir), "failed_child")
 	manifest := readBatchArtifactManifest(t, failedDir)
-	require.Equal(t, "failed", manifest.Status)
+	require.Equal(t, "protocol_failed", manifest.Status)
 	require.False(t, manifest.Success)
 	require.Contains(t, manifest.Identifier, "failed_child")
 	combined, err := os.ReadFile(filepath.Join(failedDir, "combined_output.txt"))

--- a/common/ai/aid/aireact/invoke_toolcall_call_expectations_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_call_expectations_test.go
@@ -24,7 +24,7 @@ func mockedToolCallingWithCallExpectations(i aicommon.AICallerConfigIf, req *aic
 		// verification 收缩为纯观测角色后, satisfied=true 不再自动退出. require_tool
 		// 执行过一轮后, 下一轮主决策 prompt 的 timeline 段会带上本轮工具结果
 		// (作为 timeline-open 段内容). 检测到它说明工具已执行过, 主动 finish 收口.
-		if strings.Contains(prompt, "COMBINED OUTPUT:") {
+		if strings.Contains(prompt, "RESULT:") {
 			rsp := i.NewAIResponse()
 			rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish", "human_readable_thought": "mocked: task done after tool call"}`))
 			rsp.Close()

--- a/common/ai/aid/aireact/invoke_toolcall_directly_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_directly_test.go
@@ -559,10 +559,10 @@ func TestReAct_DirectlyCallTool_PersistentSession(t *testing.T) {
 			prompt := r.GetPrompt()
 			// verification 收缩为纯观测角色后, satisfied=true 不再自动退出. mockedToolCalling
 			// 在 isPrimaryDecisionPrompt 总是返回 require_tool, 工具执行一轮后会无限循环.
-			// 这里在 isPrimaryDecisionPrompt 分支检测到工具结果 (COMBINED OUTPUT) 已
+			// 这里在 isPrimaryDecisionPrompt 分支检测到工具语义结果 (RESULT) 已
 			// 存在于 prompt (作为 timeline-open 段内容), 说明工具已执行过, 主动 finish 收口
 			// (模拟 "AI 判断任务完成后主动调 finish" 的新行为).
-			if isPrimaryDecisionPrompt(prompt) && strings.Contains(prompt, "COMBINED OUTPUT:") {
+			if isPrimaryDecisionPrompt(prompt) && strings.Contains(prompt, "RESULT:") {
 				rsp := i.NewAIResponse()
 				rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish", "human_readable_thought": "mocked: task done after tool call"}`))
 				rsp.Close()

--- a/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_file_emit_test.go
@@ -37,14 +37,13 @@ func mockPostIterationDirectAnswer(i aicommon.AICallerConfigIf, prompt string) (
 	return rsp, true
 }
 
-
 // toolResultAppearedInPrompt checks whether a tool result (identified by its
-// "COMBINED OUTPUT:" header) is already present in the prompt timeline. After
+// semantic "RESULT:" header) is already present in the prompt timeline. After
 // the iteration timeline entries were removed, the human_readable_thought text
 // no longer appears in the next iteration's prompt; the tool result is the
 // reliable signal that a tool has already been executed.
 func toolResultAppearedInPrompt(prompt string) bool {
-	return strings.Contains(prompt, "COMBINED OUTPUT:")
+	return strings.Contains(prompt, "RESULT:")
 }
 
 func mockedToolCallingForFileEmit(i aicommon.AICallerConfigIf, req *aicommon.AIRequest, toolName string) (*aicommon.AIResponse, error) {
@@ -582,9 +581,10 @@ LOOP:
 	require.NoError(t, err)
 	contentStr := string(reportContent)
 
-	// 空 stdout/stderr 仍在统一预览中明确标记。
+	// 空 stdout/stderr 仍在观察信息中明确标记，语义结果保持在前。
 	require.Contains(t, contentStr, "## Execution Result Preview")
-	require.Contains(t, contentStr, "COMBINED OUTPUT:")
+	require.Contains(t, contentStr, "RESULT:")
+	require.Contains(t, contentStr, "OBSERVATIONS:")
 	require.Contains(t, contentStr, "(empty)")
 
 	// 验证仍然包含参数和结果

--- a/common/ai/aid/aireact/invoke_toolcall_mcp_wait_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_mcp_wait_test.go
@@ -52,6 +52,6 @@ func TestExecuteToolCallInternal_WaitsForMCPStubBeforeInvoke(t *testing.T) {
 	assert.True(t, result.Success)
 	data, ok := result.Data.(string)
 	require.True(t, ok, "AI orchestration must expose the canonical bounded string Data")
-	assert.Contains(t, data, "COMBINED OUTPUT:\nlive-ok")
+	assert.Contains(t, data, "RESULT:\nlive-ok")
 	assert.Contains(t, data, "ARTIFACT:\n- combined:")
 }

--- a/common/ai/aid/aireact/invoke_toolcall_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_test.go
@@ -603,7 +603,7 @@ func TestReAct_ToolUse_WithNoToolsCache(t *testing.T) {
 			// verification 收缩为纯观测角色后, satisfied=true 不再自动退出.
 			// 工具调用过一次后(toolExecutionSucceeded 已置位), 主循环再次决策
 			// 时主动 finish 收口. Phase 1 工具不存在/未成功时仍返回 require_tool,
-			// 让 LOOP1 能检测到 TOOL_EXECUTION_ERROR; Phase 2 工具成功后 finish.
+			// 让 LOOP1 能检测到 protocol failure; Phase 2 工具成功后 finish.
 			if toolExecutionSucceeded.IsSet() {
 				rsp := i.NewAIResponse()
 				rsp.EmitOutputStream(bytes.NewBufferString(`{"@action": "finish", "human_readable_thought": "mocked: task done after tool call"}`))
@@ -683,7 +683,7 @@ func TestReAct_ToolUse_WithNoToolsCache(t *testing.T) {
 	// 第一次尝试：工具不存在，应该失败
 	// Note: After recent code changes, tool execution failure no longer aborts the task.
 	// Instead, it records the error and allows AI to retry.
-	// We detect tool execution error events to verify the tool was not found.
+	// We detect protocol failure events to verify the tool was not found.
 	fmt.Printf("Phase 1: Attempting to call non-existent tool '%s'\n", toolName)
 	in <- &ypb.AIInputEvent{
 		IsFreeInput: true,
@@ -699,12 +699,13 @@ LOOP1:
 		case e := <-out:
 			fmt.Println(e.String())
 
-			// Detect tool execution error (tool not found)
+			// Detect protocol failure (tool not found). Timeline rendering is free to
+			// normalize the legacy title, so assert the model-visible semantic text.
 			if e.NodeId == "timeline_item" {
 				content := string(e.GetContent())
-				if strings.Contains(content, "TOOL_EXECUTION_ERROR") && strings.Contains(content, toolName) {
+				if strings.Contains(content, "invocation protocol failed") && strings.Contains(content, toolName) {
 					toolExecutionErrorDetected = true
-					fmt.Printf("✓ Detected tool execution error for '%s'\n", toolName)
+					fmt.Printf("✓ Detected tool invocation protocol failure for '%s'\n", toolName)
 					// Once we detect the error, we can break out of the loop
 					// The AI will keep retrying since verification returns false
 					break LOOP1
@@ -723,11 +724,11 @@ LOOP1:
 		}
 	}
 
-	// Verify that tool execution error was detected
+	// Verify that tool invocation protocol failure was detected.
 	if !toolExecutionErrorDetected {
-		t.Fatal("Phase 1 failed: expected tool execution error for non-existent tool, but none was detected")
+		t.Fatal("Phase 1 failed: expected tool invocation protocol failure for non-existent tool, but none was detected")
 	}
-	fmt.Println("✓ Phase 1 completed: Tool execution error detected as expected")
+	fmt.Println("✓ Phase 1 completed: Tool invocation protocol failure detected as expected")
 
 	// 创建工具
 	fmt.Printf("\nPhase 2: Creating tool '%s'\n", toolName)

--- a/common/ai/aid/aireact/reactloops/action_from_tool.go
+++ b/common/ai/aid/aireact/reactloops/action_from_tool.go
@@ -185,17 +185,18 @@ func ConvertAIToolToLoopAction(tool *aitool.Tool) *LoopAction {
 			// Log error in result if present - but don't terminate the loop
 			if result.Error != "" {
 				// FIX: Instead of terminating the loop, record error and allow AI to retry
-				errMsg := fmt.Sprintf("Tool '%s' returned error: %s. Please try a different approach or tool.", tool.GetName(), result.Error)
-				invoker.AddToTimeline("[TOOL_EXECUTION_ERROR]", errMsg)
+				errMsg := fmt.Sprintf("Tool '%s' protocol did not complete: %s. Please correct the invocation or try a different approach.", tool.GetName(), result.Error)
+				invoker.AddToTimeline("[TOOL_PROTOCOL_ERROR]", errMsg)
 				// Continue to allow AI to try another approach
 				// Note: We still proceed to verify user satisfaction to give AI context
+			} else {
+				// Lifecycle completion is deliberately neutral. The execution result in
+				// the ToolResult/Timeline determines command, HTTP, or task effects.
+				invoker.AddToTimeline(
+					"[TOOL_PROTOCOL_COMPLETED]",
+					fmt.Sprintf("tool '%s' returned a result envelope; inspect execution_result before judging the effect", tool.GetName()),
+				)
 			}
-
-			// Log success
-			invoker.AddToTimeline(
-				"[TOOL_EXECUTION_SUCCESS]",
-				utils.Errorf("tool '%s' executed successfully", tool.GetName()).Error(),
-			)
 
 			task := loop.GetCurrentTask()
 			if task == nil {

--- a/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
+++ b/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
@@ -133,7 +133,7 @@ Timeline 或注入记忆中的失败记录是特定输入和环境下的历史�
 
 **结果处理与重试：**
 
-- **工具执行结果处理**：工具结果中的 `Data` 是 `CombinedOutput + Result` 的有界首尾预览，不是完整结果。stdout/stderr 的真实交叉顺序以 `COMBINED OUTPUT` 及 HINT 指向的 `combined_output.txt` 为准；预览中没有出现某条记录，不代表完整结果中不存在。遇到截断标记时，必须先按 HINT 使用 `grep` 搜索 Artifact，再按需使用 `read_file(file="...", mode="lines", offset=..., lines=...)` 分片查看上下文。禁止用完整 `cat`、整文件 `read_file`、`echo` 或 `tee` 把 Artifact 重新灌入 Timeline；需要精确判断时必须发起新的文件工具调用，不能根据预览宣称"没有发现"。
+- **工具执行结果处理**：工具结果中的 `Data` 是有界预览，优先展示表达真实执行效果的 `RESULT`，其后才是 stdout/stderr 等 `OBSERVATIONS`，它们都可能不是完整内容。调用协议完成不代表命令、HTTP 请求或测试的语义结果成功；必须优先检查 `RESULT` 中的 `exit_code`、`exit_code_accepted`、`response_received`、`status_code`、`transport_error` 等结构化字段，不能仅根据 stdout/stderr 的文字做判断。stdout/stderr 的真实交叉顺序以 HINT 指向的 `combined_output.txt` 为准；预览中没有出现某条记录，不代表完整 Artifact 中不存在。遇到截断标记时，必须先按 HINT 使用 `grep` 搜索 Artifact，再按需使用 `read_file(file="...", mode="lines", offset=..., lines=...)` 分片查看上下文。禁止用完整 `cat`、整文件 `read_file`、`echo` 或 `tee` 把 Artifact 重新灌入 Timeline；需要精确判断时必须发起新的文件工具调用，不能根据预览宣称"没有发现"。
 - **搜索 grep 是一个重要工具**：一次搜索可能并不对，你可以尝试使用不同的关键字或者正则多次搜索你感兴趣的东西，善于使用内置的 grep 的功能。
 - **错误处理与重试**：如果工具执行返回错误，切勿直接放弃。分析错误信息，通过修改命令、调整参数或寻找替代方案来解决问题；每次重试必须有实质差异。若同时存在多个独立修复或替代方案，优先把它们组成有界并发批次，而不是每轮只试一个。
 

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action.go
@@ -682,6 +682,10 @@ func handleToolBatchActionResult(
 		status := string(outcome.Stage)
 		if status == "" {
 			status = "unknown"
+		} else if outcome.Stage == aicommon.ToolCallStageDone {
+			status = "protocol-completed; inspect result"
+		} else if outcome.Stage == aicommon.ToolCallStageInvokeFailed {
+			status = "protocol-error"
 		}
 		if outcome.Err != nil {
 			status += ": " + outcome.Err.Error()

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
@@ -42,15 +42,15 @@ func handleToolCallResult(
 	operator *reactloops.LoopActionHandlerOperator,
 ) {
 	// A non-nil ToolResult is the objective boundary that proves the plugin
-	// callback settled. Count both success and tool-level failure. Review-driven
+	// callback settled. Count both completed and protocol-failed calls. Review-driven
 	// direct_answer/cancel is terminal user intent, not a tool execution.
 	if !directly && result != nil {
 		operator.MarkToolExecuted()
 	}
 	if err != nil {
-		errMsg := fmt.Sprintf("Tool '%s' execution failed: %v.", toolPayload, err)
-		invoker.AddToTimeline("[TOOL_EXECUTION_ERROR]", errMsg)
-		loopInfraStatus(loop, "工具调用失败 / Tool Call Failed")
+		errMsg := fmt.Sprintf("Tool '%s' invocation protocol failed: %v.", toolPayload, err)
+		invoker.AddToTimeline("[TOOL_PROTOCOL_ERROR]", errMsg)
+		loopInfraStatus(loop, "工具协议失败 / Tool Protocol Failed")
 
 		resolved := loop.ResolveIdentifier(toolPayload)
 		if buildinaitools.IsMCPToolName(toolPayload) && buildinaitools.IsMCPInitializingError(err) {
@@ -92,8 +92,8 @@ func handleToolCallResult(
 	}
 
 	if result.Error != "" {
-		invoker.AddToTimeline("call["+toolPayload+"] error", result.Error)
-		loopInfraStatus(loop, "工具返回错误 / Tool Returned Error")
+		invoker.AddToTimeline("call["+toolPayload+"] protocol-error", result.Error)
+		loopInfraStatus(loop, "工具协议错误 / Tool Protocol Error")
 		if buildinaitools.IsMCPToolName(toolPayload) && buildinaitools.IsMCPInitializingMessage(result.Error) {
 			operator.Feedback(
 				"[MCP] Tool '" + toolPayload + "' is still initializing. " +

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/bash_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/bash_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools/yakscripttools"
 	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
 	_ "github.com/yaklang/yaklang/common/yak"
 	"gotest.tools/v3/assert"
 )
@@ -22,6 +23,108 @@ func getBashTool(t *testing.T) *aitool.Tool {
 	tools := yakscripttools.ConvertTools([]*schema.AIYakTool{aiTool})
 	assert.Assert(t, len(tools) == 1, "ConvertTools returned %d tools", len(tools))
 	return tools[0]
+}
+
+func invokeBashResult(t *testing.T, params aitool.InvokeParams) map[string]any {
+	t.Helper()
+	stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
+	result, err := getBashTool(t).Callback(context.Background(), params, nil, stdout, stderr)
+	assert.NilError(t, err)
+	semantic := utils.InterfaceToGeneralMap(result)
+	assert.Assert(t, len(semantic) > 0, "missing semantic RESULT; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	return semantic
+}
+
+func TestBashToolReportsObjectiveExitSemantics(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		accepted   string
+		exitCode   int
+		isAccepted bool
+	}{
+		{name: "stdout_claims_success_but_exit_7", command: "printf 'SUCCESS\\n'; exit 7", exitCode: 7},
+		{name: "stderr_claims_error_but_exit_0", command: "printf 'ERROR\\n' >&2; exit 0", exitCode: 0, isAccepted: true},
+		{name: "earlier_false_but_final_exit_0", command: "false; echo complete", exitCode: 0, isAccepted: true},
+		{name: "pipeline_without_pipefail_uses_last_exit", command: "false | true", exitCode: 0, isAccepted: true},
+		{name: "pipeline_with_pipefail_exposes_failure", command: "set -o pipefail; false | true", exitCode: 1},
+		{name: "explicitly_accept_exit_1", command: "exit 1", accepted: "0,1", exitCode: 1, isAccepted: true},
+		{name: "normalize_accepted_exit_code", command: "exit 1", accepted: "0,01", exitCode: 1, isAccepted: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := aitool.InvokeParams{"command": tc.command, "shell": "bash", "timeout": 5}
+			if tc.accepted != "" {
+				params["accepted-exit-codes"] = tc.accepted
+			}
+			result := invokeBashResult(t, params)
+			assert.Equal(t, utils.InterfaceToInt(result["exit_code"]), tc.exitCode)
+			assert.Equal(t, utils.InterfaceToBoolean(result["exit_code_available"]), true)
+			assert.Equal(t, utils.InterfaceToBoolean(result["exit_code_accepted"]), tc.isAccepted)
+			assert.Equal(t, utils.InterfaceToBoolean(result["timed_out"]), false)
+		})
+	}
+}
+
+func TestBashToolNonZeroExitStillCompletesInvocationProtocol(t *testing.T) {
+	tool := getBashTool(t)
+	result, err := tool.InvokeWithParams(aitool.InvokeParams{
+		"command": "printf 'SUCCESS\\n'; exit 7",
+		"shell":   "bash",
+		"timeout": 5,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, result.Success, true)
+	execution, ok := result.Data.(*aitool.ToolExecutionResult)
+	assert.Assert(t, ok)
+	semantic := utils.InterfaceToGeneralMap(execution.Result)
+	assert.Equal(t, utils.InterfaceToInt(semantic["exit_code"]), 7)
+	assert.Equal(t, utils.InterfaceToBoolean(semantic["exit_code_accepted"]), false)
+	timeline := result.String()
+	assert.Assert(t, !strings.Contains(timeline, "success: true"))
+	assert.Assert(t, !strings.Contains(timeline, "tool/bash ok"))
+	assert.Assert(t, strings.Contains(timeline, "exit_code"))
+}
+
+func TestBashToolParameterValidationIsProtocolFailure(t *testing.T) {
+	result, err := getBashTool(t).InvokeWithParams(aitool.InvokeParams{"timeout": 5})
+	assert.ErrorContains(t, err, "参数验证失败")
+	assert.Equal(t, result.Success, false)
+	assert.Assert(t, strings.Contains(result.String(), "protocol_error"))
+}
+
+func TestBashToolAcceptedExitCodesCompatibilityAliasIsTyped(t *testing.T) {
+	tool := getBashTool(t)
+
+	result, err := tool.InvokeWithParams(aitool.InvokeParams{
+		"command":             "exit 1",
+		"shell":               "bash",
+		"timeout":             5,
+		"accepted_exit_codes": "0,1",
+	})
+	assert.NilError(t, err)
+	execution, ok := result.Data.(*aitool.ToolExecutionResult)
+	assert.Assert(t, ok)
+	semantic := utils.InterfaceToGeneralMap(execution.Result)
+	assert.Equal(t, utils.InterfaceToInt(semantic["exit_code"]), 1)
+	assert.Equal(t, utils.InterfaceToBoolean(semantic["exit_code_accepted"]), true)
+
+	invalid, invalidErr := tool.InvokeWithParams(aitool.InvokeParams{
+		"command":             "exit 1",
+		"shell":               "bash",
+		"timeout":             5,
+		"accepted_exit_codes": []any{0, 1},
+	})
+	assert.ErrorContains(t, invalidErr, "参数验证失败")
+	assert.Equal(t, invalid.Success, false)
+}
+
+func TestBashToolTimeoutHasNoFabricatedExitCode(t *testing.T) {
+	result := invokeBashResult(t, aitool.InvokeParams{"command": "sleep 2", "shell": "bash", "timeout": 1})
+	assert.Equal(t, utils.InterfaceToBoolean(result["timed_out"]), true)
+	assert.Equal(t, utils.InterfaceToBoolean(result["exit_code_available"]), false)
+	assert.Assert(t, utils.IsNil(result["exit_code"]), "timeout must expose a null exit code, got %#v", result["exit_code"])
+	assert.Equal(t, utils.InterfaceToString(result["termination_reason"]), "timeout")
 }
 
 func TestBashToolNormalizesGeneratedScriptLineEndings(t *testing.T) {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/batch_do_http_request_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/batch_do_http_request_test.go
@@ -3,7 +3,9 @@ package test
 import (
 	"bytes"
 	"context"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -60,6 +62,64 @@ func execBatchTool(t *testing.T, tool *aitool.Tool, params aitool.InvokeParams) 
 	return w1.String(), w2.String()
 }
 
+func execBatchHTTPToolResult(t *testing.T, params aitool.InvokeParams) map[string]any {
+	t.Helper()
+	stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
+	result, err := getBatchDoHTTPRequestTool(t).Callback(context.Background(), params, nil, stdout, stderr)
+	assert.NilError(t, err)
+	semantic := utils.InterfaceToGeneralMap(result)
+	assert.Assert(t, len(semantic) > 0, "missing semantic RESULT; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	return semantic
+}
+
+func TestBatchDoHTTPRequest_ResultSeparatesStatusesAndTransportErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/missing":
+			w.WriteHeader(http.StatusNotFound)
+		case "/broken":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+		_, _ = w.Write([]byte("oracle"))
+	}))
+	defer server.Close()
+
+	result := execBatchHTTPToolResult(t, aitool.InvokeParams{
+		"base-url":   server.URL,
+		"paths":      "/ok\n/missing\n/broken",
+		"concurrent": 3,
+		"timeout":    5,
+	})
+	assert.Equal(t, utils.InterfaceToInt(result["request_count"]), 3)
+	assert.Equal(t, utils.InterfaceToInt(result["request_completed_count"]), 3)
+	assert.Equal(t, utils.InterfaceToInt(result["response_received_count"]), 3)
+	assert.Equal(t, utils.InterfaceToInt(result["transport_error_count"]), 0)
+	distribution := utils.InterfaceToGeneralMap(result["status_code_distribution"])
+	assert.Equal(t, utils.InterfaceToInt(distribution["200"]), 1)
+	assert.Equal(t, utils.InterfaceToInt(distribution["404"]), 1)
+	assert.Equal(t, utils.InterfaceToInt(distribution["500"]), 1)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	refusedBase := "http://" + listener.Addr().String()
+	assert.NilError(t, listener.Close())
+	refused := execBatchHTTPToolResult(t, aitool.InvokeParams{
+		"base-url": refusedBase,
+		"paths":    "/refused",
+		"timeout":  1,
+	})
+	assert.Equal(t, utils.InterfaceToInt(refused["response_received_count"]), 0)
+	assert.Equal(t, utils.InterfaceToInt(refused["transport_error_count"]), 1)
+	items := utils.InterfaceToSliceInterface(refused["items"])
+	assert.Equal(t, len(items), 1)
+	item := utils.InterfaceToGeneralMap(items[0])
+	assert.Equal(t, utils.InterfaceToBoolean(item["request_sent"]), true)
+	assert.Equal(t, utils.InterfaceToBoolean(item["response_received"]), false)
+	assert.Assert(t, utils.InterfaceToString(item["transport_error"]) != "")
+}
+
 func TestBatchDoHTTPRequest_MetadataContainsIntentHints(t *testing.T) {
 	aiTool := loadBatchDoHTTPRequestAITool(t)
 
@@ -93,7 +153,7 @@ func TestBatchDoHTTPRequest_BasicGet(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "Total paths to test: 2"), "should show 2 paths")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "should show 2 successful requests")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "should show 2 received responses")
 	assert.Assert(t, strings.Contains(stdout, "/path1"), "path1 should appear")
 	assert.Assert(t, strings.Contains(stdout, "/path2"), "path2 should appear")
 	assert.Assert(t, strings.Contains(stdout, "request #1 packet") || strings.Contains(stdout, "request #2 packet"), "each generated batch request packet should be printed")
@@ -137,7 +197,7 @@ func TestBatchDoHTTPRequest_SingleHeader(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "header_received"), "server should receive the custom header")
-	assert.Assert(t, strings.Contains(stdout, "Success: 1"), "request with header should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 1"), "request with header should receive a response")
 }
 
 // Test 4: Multiple custom headers via multi-line headers parameter
@@ -162,7 +222,7 @@ func TestBatchDoHTTPRequest_MultipleHeaders(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "both_headers_found"), "server should receive both custom headers")
-	assert.Assert(t, strings.Contains(stdout, "Success: 1"), "request with multiple headers should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 1"), "request with multiple headers should receive a response")
 }
 
 // Test 5: Exclude status codes
@@ -253,7 +313,7 @@ func TestBatchDoHTTPRequest_DelaySequential(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "forcing sequential execution"), "should indicate sequential mode")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "should complete requests successfully")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "should receive both responses")
 }
 
 // Test 9: Keyword matching
@@ -335,7 +395,7 @@ func TestBatchDoHTTPRequest_ConcurrentMode(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "concurrent batch requests"), "should indicate concurrent mode")
-	assert.Assert(t, strings.Contains(stdout, "Success: 3"), "all 3 requests should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 3"), "all 3 requests should receive responses")
 }
 
 // Test 13: Error handling for unreachable host
@@ -459,7 +519,7 @@ func TestBatchDoHTTPRequest_MultiplePaths(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(stdout, "users_list"), "users endpoint should respond")
 	assert.Assert(t, strings.Contains(stdout, "posts_list"), "posts endpoint should respond")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both requests should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "both requests should receive responses")
 }
 
 // Test 19: Empty paths validation
@@ -479,6 +539,13 @@ func TestBatchDoHTTPRequest_EmptyPathsValidation(t *testing.T) {
 			strings.Contains(combined, "at least one") ||
 			strings.Contains(combined, "Error"),
 		"should report error for empty paths")
+}
+
+func TestBatchDoHTTPRequest_MissingRequestIsProtocolFailure(t *testing.T) {
+	result, err := getBatchDoHTTPRequestTool(t).InvokeWithParams(aitool.InvokeParams{})
+	assert.ErrorContains(t, err, "at least one of")
+	assert.Equal(t, result.Success, false)
+	assert.Assert(t, result.Data == nil, "a failed invocation must not expose a result envelope")
 }
 
 // Test 20: Custom headers (non-curl style)
@@ -523,7 +590,7 @@ func TestBatchDoHTTPRequest_PacketMode(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(stdout, "packet_path:/pkt_a"), "packet mode should substitute path_a")
 	assert.Assert(t, strings.Contains(stdout, "packet_path:/pkt_b"), "packet mode should substitute path_b")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both packet mode requests should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "both packet mode requests should receive responses")
 }
 
 // Test 22: Full URLs in paths (no base-url needed)
@@ -545,7 +612,7 @@ func TestBatchDoHTTPRequest_FullUrlsInPaths(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(stdout, "fullurl_path:/full_a"), "full URL path_a should work")
 	assert.Assert(t, strings.Contains(stdout, "fullurl_path:/full_b"), "full URL path_b should work")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both full URL requests should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "both full URL requests should receive responses")
 }
 
 // Test 23: Newline-separated paths
@@ -561,7 +628,7 @@ func TestBatchDoHTTPRequest_NewlinePaths(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "Total paths to test: 3"), "should parse 3 paths from newlines")
-	assert.Assert(t, strings.Contains(stdout, "Success: 3"), "all 3 newline-separated paths should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 3"), "all 3 newline-separated paths should receive responses")
 }
 
 // Test 24: Exclude size ranges
@@ -643,7 +710,7 @@ func TestBatchDoHTTPRequest_PathCommasPreserved(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "Total paths to test: 2"), "should only split paths by newlines")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both newline-separated requests should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "both newline-separated requests should receive responses")
 	assert.Assert(t, strings.Contains(stdout, "/user/limit/4/order1?order=id,1,2,3"), "comma-containing query should remain intact")
 	assert.Assert(t, strings.Contains(stdout, "/user/limit/4/order2?order=id,4,5,6"), "second comma-containing query should remain intact")
 }
@@ -669,7 +736,7 @@ func TestBatchDoHTTPRequest_PacketBaseHost(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "basehost_ok:/bh_test"), "base-host should route request correctly")
-	assert.Assert(t, strings.Contains(stdout, "Success: 1"), "packet mode with base-host should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 1"), "packet mode with base-host should receive a response")
 }
 
 // Test 29: Full URLs in paths with custom headers (regression test for shared-params fix)
@@ -693,7 +760,7 @@ func TestBatchDoHTTPRequest_FullUrlWithHeaders(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "fullurl_header_ok"), "custom headers should be applied to full URL paths")
-	assert.Assert(t, strings.Contains(stdout, "Success: 1"), "full URL with headers should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 1"), "full URL with headers should receive a response")
 }
 
 // Test 30: Full URLs in paths with body and content-type
@@ -740,7 +807,7 @@ func TestBatchDoHTTPRequest_PrefixWithSlashPaths(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(stdout, "/api/v2/users"), "prefix should handle paths with leading slash")
 	assert.Assert(t, strings.Contains(stdout, "/api/v2/admin"), "prefix should handle paths without leading slash")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both prefixed requests should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "both prefixed requests should receive responses")
 }
 
 // Test 32: AI passes "paths" as a JSON ARRAY.
@@ -764,7 +831,7 @@ func TestBatchDoHTTPRequest_PathsAsArray(t *testing.T) {
 	assert.Assert(t, strings.Contains(stdout, "Total paths to test: 2"), "array-form paths should be split into 2")
 	assert.Assert(t, strings.Contains(stdout, "arr_path:/arr_a"), "first array path should be requested")
 	assert.Assert(t, strings.Contains(stdout, "arr_path:/arr_b"), "second array path should be requested")
-	assert.Assert(t, strings.Contains(stdout, "Success: 2"), "both array-form paths should succeed")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 2"), "both array-form paths should receive responses")
 }
 
 // Test 33: AI passes "headers" as a JSON OBJECT (regression for schema friction).
@@ -840,7 +907,7 @@ func TestBatchDoHTTPRequest_FormObjectEscapesSpecialCharacters(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(stdout, "batch_special_form_ok"), "batch structured form values should survive quotes, spaces, #, and an inner &")
-	assert.Assert(t, strings.Contains(stdout, "Success: 1"), "batch request should complete successfully")
+	assert.Assert(t, strings.Contains(stdout, "Responses: 1"), "batch request should receive a response")
 	assert.Assert(t, strings.Contains(stdout, "request #1 packet"), "batch request packet should be visible to the AI")
 	assert.Assert(t, strings.Contains(stdout, "a=asdf%27+abc+%22+%23%26tail"), "printed batch packet should show the final encoded form value")
 }
@@ -875,7 +942,7 @@ func TestBatchDoHTTPRequest_InvokeWithParamsDoesNotStringifyOmittedJSONObjectDef
 	execution, ok := result.Data.(*aitool.ToolExecutionResult)
 	assert.Assert(t, ok, "InvokeWithParams should return a ToolExecutionResult")
 	assert.Assert(t, strings.Contains(execution.CombinedOutput, "batch_react_form_result_visible"), "ReAct-visible combined output should contain batch responses")
-	assert.Assert(t, strings.Contains(execution.CombinedOutput, "Success: 2"), "ReAct-visible combined output should contain the batch summary")
+	assert.Assert(t, strings.Contains(execution.CombinedOutput, "Responses: 2"), "ReAct-visible observations should contain the batch summary")
 	assert.Assert(t, strings.Contains(execution.CombinedOutput, "request #"), "ReAct-visible combined output should contain generated request packets")
 }
 

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/test/do_http_request_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -54,6 +56,83 @@ func execTool(t *testing.T, tool *aitool.Tool, params aitool.InvokeParams) (stdo
 		t.Logf("tool execution error (may be expected): %v", err)
 	}
 	return w1.String(), w2.String()
+}
+
+func execHTTPToolResult(t *testing.T, params aitool.InvokeParams) map[string]any {
+	t.Helper()
+	stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
+	result, err := getDoHTTPRequestTool(t).Callback(context.Background(), params, nil, stdout, stderr)
+	assert.NilError(t, err)
+	semantic := utils.InterfaceToGeneralMap(result)
+	assert.Assert(t, len(semantic) > 0, "missing semantic RESULT; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	return semantic
+}
+
+func TestDoHTTPRequest_ResultSeparatesHTTPStatusFromTransport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/missing":
+			w.WriteHeader(http.StatusNotFound)
+		case "/broken":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+		_, _ = w.Write([]byte("oracle"))
+	}))
+	defer server.Close()
+
+	for _, status := range []int{http.StatusOK, http.StatusNotFound, http.StatusInternalServerError} {
+		path := map[int]string{http.StatusOK: "/ok", http.StatusNotFound: "/missing", http.StatusInternalServerError: "/broken"}[status]
+		result := execHTTPToolResult(t, aitool.InvokeParams{"url": server.URL + path, "timeout": 5})
+		assert.Equal(t, utils.InterfaceToBoolean(result["request_built"]), true)
+		assert.Equal(t, utils.InterfaceToBoolean(result["request_sent"]), true)
+		assert.Equal(t, utils.InterfaceToBoolean(result["response_received"]), true)
+		assert.Equal(t, utils.InterfaceToInt(result["status_code"]), status)
+		assert.Equal(t, result["transport_error"], nil)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	refusedURL := "http://" + listener.Addr().String() + "/refused"
+	assert.NilError(t, listener.Close())
+	result := execHTTPToolResult(t, aitool.InvokeParams{"url": refusedURL, "timeout": 1})
+	assert.Equal(t, utils.InterfaceToBoolean(result["request_sent"]), true)
+	assert.Equal(t, utils.InterfaceToBoolean(result["response_received"]), false)
+	assert.Assert(t, utils.InterfaceToString(result["transport_error"]) != "")
+}
+
+func TestDoHTTPRequest_HTTPAndTransportOutcomesStillCompleteInvocationProtocol(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server-side failure"))
+	}))
+	defer server.Close()
+
+	tool := getDoHTTPRequestTool(t)
+	for _, target := range []string{server.URL, func() string {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		assert.NilError(t, err)
+		url := "http://" + listener.Addr().String()
+		assert.NilError(t, listener.Close())
+		return url
+	}()} {
+		result, err := tool.InvokeWithParams(aitool.InvokeParams{"url": target, "timeout": 1})
+		assert.NilError(t, err)
+		assert.Equal(t, result.Success, true)
+		execution, ok := result.Data.(*aitool.ToolExecutionResult)
+		assert.Assert(t, ok)
+		semantic := utils.InterfaceToGeneralMap(execution.Result)
+		assert.Assert(t, len(semantic) > 0)
+		assert.Assert(t, !strings.Contains(result.String(), "tool/do_http_request ok"))
+	}
+}
+
+func TestDoHTTPRequest_MissingRequestIsProtocolFailure(t *testing.T) {
+	result, err := getDoHTTPRequestTool(t).InvokeWithParams(aitool.InvokeParams{})
+	assert.ErrorContains(t, err, "either 'url'")
+	assert.Equal(t, result.Success, false)
+	assert.Assert(t, result.Data == nil, "a failed invocation must not expose a result envelope")
 }
 
 func TestDoHTTPRequest_BasicURL(t *testing.T) {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/data_transform.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/data_transform.yak
@@ -214,6 +214,7 @@ if action == "format" {
     }
     yakit.Info("=== Formatted %s ===", str.ToUpper(fromFmt))
     yakit.Info("%s", output)
+    RESULT = output
     return
 }
 
@@ -231,3 +232,4 @@ if err != nil {
 
 yakit.Info("=== Converted %s -> %s ===", str.ToUpper(fromFmt), str.ToUpper(toFmt))
 yakit.Info("%s", output)
+RESULT = output

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/decode.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/decode.yak
@@ -237,5 +237,6 @@ if err != nil {
     }
     return
 }
+RESULT = result
 yakit.Info("=== Decode Result (type: %s) ===", tn)
 yakit.Info("%s", string(result))

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/encode.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/codec/encode.yak
@@ -88,4 +88,5 @@ default:
     yakit.Error("unknown encode type: " + tn)
     return
 }
+RESULT = result
 yakit.Info("encode result: " + result)

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/tree.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/fs/tree.yak
@@ -315,4 +315,5 @@ if truncated {
     }
 }
 
-yakit.Info("%s", result.String())
+RESULT = result.String()
+yakit.Info("%s", RESULT)

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/batch_do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/batch_do_http_request.yak
@@ -233,8 +233,7 @@ pathsStr = normalizePaths(pathsStr)
 
 // --- validation ---
 if packet == "" && baseUrl == "" && pathsStr == "" {
-    yakit.Error("at least one of 'base-url', 'packet', or 'paths' must be provided")
-    return
+    die("at least one of 'base-url', 'packet', or 'paths' must be provided")
 }
 
 // If paths contains full URLs, we can work without base-url
@@ -244,8 +243,7 @@ if str.Contains(pathsStr, "://") {
 }
 
 if packet == "" && baseUrl == "" && !hasFullUrls {
-    yakit.Error("either 'base-url' or full URLs in 'paths' must be provided for URL mode")
-    return
+    die("either 'base-url' or full URLs in 'paths' must be provided for URL mode")
 }
 
 // --- parse paths ---
@@ -292,8 +290,7 @@ if prefix != "" && len(paths) > 0 {
 }
 
 if len(paths) == 0 {
-    yakit.Error("no valid paths provided")
-    return
+    die("no valid paths provided")
 }
 
 // --- merge curl-style headers with headers ---
@@ -567,7 +564,7 @@ executeRequest = fn(idx, path, base) {
 
     if err != nil {
         yakit.Error("Request #%d failed to build request for '%s': %v", idx, path, err)
-        return {"idx": idx, "path": path, "success": false, "error": sprint(err)}
+        return {"idx": idx, "path": path, "request_built": false, "request_sent": false, "request_completed": true, "response_received": false, "transport_error": "request_build_error: " + sprint(err)}
     }
 
     opts.Push(poc.https(isHttps))
@@ -576,7 +573,7 @@ executeRequest = fn(idx, path, base) {
     rspIns, _, err := poc.HTTPEx(rawPacket, opts...)
     if err != nil {
         yakit.Error("Request #%d failed for '%s': %v", idx, path, err)
-        return {"idx": idx, "path": path, "success": false, "error": sprint(err), "request": rawPacket}
+        return {"idx": idx, "path": path, "request_built": true, "request_sent": true, "request_completed": true, "response_received": false, "transport_error": sprint(err), "request": rawPacket}
     }
 
     rsp = rspIns.RawPacket
@@ -584,21 +581,24 @@ executeRequest = fn(idx, path, base) {
 
     // Check exclude/include codes
     if len(excludeCodeSet) > 0 && excludeCodeSet[statusCode] {
-        return {"idx": idx, "path": path, "success": true, "filtered": true, "reason": "excluded-code", "status": statusCode}
+        return {"idx": idx, "path": path, "request_built": true, "request_sent": true, "request_completed": true, "response_received": true, "filtered": true, "reason": "excluded-code", "status": statusCode, "size": rspIns.ResponseBodySize}
     }
     if len(includeCodeSet) > 0 && !includeCodeSet[statusCode] {
-        return {"idx": idx, "path": path, "success": true, "filtered": true, "reason": "not-in-include-code", "status": statusCode}
+        return {"idx": idx, "path": path, "request_built": true, "request_sent": true, "request_completed": true, "response_received": true, "filtered": true, "reason": "not-in-include-code", "status": statusCode, "size": rspIns.ResponseBodySize}
     }
 
     // Check exclude size
     if shouldExcludeSize(rspIns.ResponseBodySize) {
-        return {"idx": idx, "path": path, "success": true, "filtered": true, "reason": "excluded-size", "status": statusCode, "size": rspIns.ResponseBodySize}
+        return {"idx": idx, "path": path, "request_built": true, "request_sent": true, "request_completed": true, "response_received": true, "filtered": true, "reason": "excluded-size", "status": statusCode, "size": rspIns.ResponseBodySize}
     }
 
     result = {
         "idx": idx,
         "path": path,
-        "success": true,
+        "request_built": true,
+        "request_sent": true,
+        "request_completed": true,
+        "response_received": true,
         "filtered": false,
         "status": statusCode,
         "size": rspIns.ResponseBodySize,
@@ -613,7 +613,7 @@ executeRequest = fn(idx, path, base) {
 // --- results collection ---
 results = make([]map[string]any)
 resultsLock = sync.NewLock()
-successCount = 0
+responseCount = 0
 filteredCount = 0
 errorCount = 0
 
@@ -631,17 +631,18 @@ if concurrent > 1 {
 
             resultsLock.Lock()
             results = append(results, result)
-            if result["success"] == true && result["filtered"] != true {
-                successCount++
-            } elif result["filtered"] == true {
+            if result["response_received"] == true {
+                responseCount++
+            }
+            if result["filtered"] == true {
                 filteredCount++
-            } else {
+            } elif result["response_received"] != true {
                 errorCount++
             }
             resultsLock.Unlock()
 
             // Progress indicator
-            if result["filtered"] != true && result["success"] == true {
+            if result["filtered"] != true && result["response_received"] == true {
                 status = result["status"]
                 size = result["size"]
                 yakit.Info("[%d/%d] %s -> Status: %d, Size: %d bytes", idx+1, len(paths), path, status, size)
@@ -656,16 +657,17 @@ if concurrent > 1 {
         result = executeRequest(i+1, p, baseUrl)
 
         results = append(results, result)
-        if result["success"] == true && result["filtered"] != true {
-            successCount++
-        } elif result["filtered"] == true {
+        if result["response_received"] == true {
+            responseCount++
+        }
+        if result["filtered"] == true {
             filteredCount++
-        } else {
+        } elif result["response_received"] != true {
             errorCount++
         }
 
         // Progress indicator
-        if result["filtered"] != true && result["success"] == true {
+        if result["filtered"] != true && result["response_received"] == true {
             status = result["status"]
             size = result["size"]
             yakit.Info("[%d/%d] %s -> Status: %d, Size: %d bytes", i+1, len(paths), p, status, size)
@@ -679,7 +681,7 @@ if concurrent > 1 {
 }
 
 yakit.Info("=== Batch Request Summary ===")
-yakit.Info("Total: %d, Success: %d, Filtered: %d, Errors: %d", len(paths), successCount, filteredCount, errorCount)
+yakit.Info("Total: %d, Responses: %d, Filtered: %d, Transport errors: %d", len(paths), responseCount, filteredCount, errorCount)
 
 // --- output results ---
 outputFile, err := file.TempFileName("batch-http-results-*.txt")
@@ -688,7 +690,7 @@ if err != nil {
 } else {
     outputContent = sprintf("=== Batch HTTP Request Results ===\n")
     outputContent += sprintf("Total Requests: %d\n", len(paths))
-    outputContent += sprintf("Successful: %d\n", successCount)
+    outputContent += sprintf("Responses received: %d\n", responseCount)
     outputContent += sprintf("Filtered: %d\n", filteredCount)
     outputContent += sprintf("Errors: %d\n\n", errorCount)
 
@@ -698,10 +700,10 @@ if err != nil {
         if result["filtered"] == true {
             continue
         }
-        if result["success"] != true {
-            outputContent += sprintf("--- Request #%d [ERROR] ---\n", result["idx"])
+        if result["response_received"] != true {
+            outputContent += sprintf("--- Request #%d [TRANSPORT ERROR] ---\n", result["idx"])
             outputContent += sprintf("Path: %s\n", result["path"])
-            outputContent += sprintf("Error: %s\n\n", result["error"])
+            outputContent += sprintf("Transport error: %s\n\n", result["transport_error"])
             continue
         }
 
@@ -770,7 +772,7 @@ for _, result:= range results {
     if result["filtered"] == true {
         continue
     }
-    if result["success"] == true {
+    if result["response_received"] == true {
         path = result["path"]
         if len(path) > 48 {
             path = path[:45] + "..."
@@ -783,6 +785,42 @@ for _, result:= range results {
         }
         yakit.Info("%-6d %-50s %-8s %-10s", result["idx"], path, "ERROR", "-")
     }
+}
+
+statusCodeDistribution = {}
+compactResults = []
+for _, item := range results {
+    statusCode = item["status"]
+    if item["response_received"] == true {
+        statusKey = sprint(statusCode)
+        if !statusCodeDistribution[statusKey] {
+            statusCodeDistribution[statusKey] = 0
+        }
+        statusCodeDistribution[statusKey] = statusCodeDistribution[statusKey] + 1
+    }
+    compactResults = append(compactResults, {
+        "idx": item["idx"],
+        "path": item["path"],
+        "request_built": item["request_built"],
+        "request_sent": item["request_sent"],
+        "request_completed": item["request_completed"],
+        "response_received": item["response_received"],
+        "status_code": item["status"],
+        "body_size": item["size"],
+        "filtered": item["filtered"],
+        "filter_reason": item["reason"],
+        "transport_error": item["transport_error"],
+    })
+}
+
+RESULT = {
+    "request_count": len(paths),
+    "request_completed_count": len(results),
+    "response_received_count": responseCount,
+    "filtered_count": filteredCount,
+    "transport_error_count": errorCount,
+    "status_code_distribution": statusCodeDistribution,
+    "items": compactResults,
 }
 
 yakit.Info("\n=== Batch HTTP Request Complete ===")

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/do_http_request.yak
@@ -128,6 +128,24 @@ verbose = cli.Bool("verbose", cli.setHelp("verbose output: print connection trac
 proxy = cli.String("proxy", cli.setHelp("proxy URL, e.g. http://127.0.0.1:8080"), cli.setRequired(false))
 cli.check()
 
+// RESULT is the objective HTTP execution channel. A received 404/500 is still
+// a received response; it must not be collapsed into a protocol failure.
+RESULT = {
+    "request_built": false,
+    "request_sent": false,
+    "response_received": false,
+    "status_code": nil,
+    "body_size": 0,
+    "keyword": keyword,
+    "keyword_match_count": 0,
+    "regexp": regexpMatch,
+    "regexp_match_count": 0,
+    "regexp_valid": true,
+    "redirect_count": 0,
+    "duration_ms": 0,
+    "transport_error": nil,
+}
+
 // Safe scalar recovery. Keep the correction visible so the AI knows which
 // effective values were used instead of silently changing request behavior.
 if str.TrimSpace(method) == "" {
@@ -236,8 +254,7 @@ legacyFormValues = normalizedPostParams["values"]
 
 // --- validation ---
 if packet == "" && urlStr == "" {
-    yakit.Error("either 'url' (URL mode) or 'packet' (Packet mode) must be provided")
-    return
+    die("either 'url' (URL mode) or 'packet' (Packet mode) must be provided")
 }
 
 // --- build poc options ---
@@ -317,6 +334,7 @@ if packet != "" {
     autoHttps, parsedPacket, err := poc.ParseUrlToHTTPRequestRaw(method, urlStr)
     if err != nil {
         yakit.Error("failed to parse URL to HTTP request: %v. Recovery: provide an absolute URL such as https://host/path, or use packet mode when exact request bytes are required. Request was not sent.", err)
+        RESULT["transport_error"] = "request_build_error: " + sprint(err)
         return
     }
     rawPacket = parsedPacket
@@ -402,6 +420,7 @@ if packet != "" {
 }
 
 opts.Push(poc.https(isHttps))
+RESULT["request_built"] = rawPacket != nil && len(rawPacket) > 0
 
 // AI 必须在请求成功或失败前都能看到参数实际生成的 packet，才能快速修订编码、
 // header 和 body。大报文仅截断展示；save-packet 仍负责把完整报文落盘。
@@ -424,14 +443,21 @@ printRequestPacket = func(label, requestPacket) {
 
 // --- execute request ---
 printRequestPacket("request packet", rawPacket)
+RESULT["request_sent"] = true
+requestStartedAt = time.Now()
 rspIns, _, err := poc.HTTPEx(rawPacket, opts...)
+RESULT["duration_ms"] = time.Since(requestStartedAt).Milliseconds()
 if err != nil {
     yakit.Error("HTTP request failed: %v. Recovery: inspect the generated request packet above, verify URL/DNS/TLS/proxy and authentication headers, then retry; increase timeout only for a known-slow endpoint, or use packet mode for exact bytes. No response packet was received.", err)
+    RESULT["transport_error"] = sprint(err)
     return
 }
 
 rsp = rspIns.RawPacket
 req = rspIns.RawRequest
+RESULT["response_received"] = true
+RESULT["status_code"] = poc.GetStatusCodeFromResponse(rsp)
+RESULT["body_size"] = rspIns.ResponseBodySize
 
 // --- form-encoded 兜底重试 ---
 // 现场问题: AI 对登录/表单类接口习惯发 application/json, 但很多服务端只收
@@ -514,6 +540,9 @@ tryFormRetryOnJsonRejected = func() {
 }
 
 tryFormRetryOnJsonRejected()
+RESULT["status_code"] = poc.GetStatusCodeFromResponse(rsp)
+RESULT["body_size"] = rspIns.ResponseBodySize
+RESULT["redirect_count"] = redirectCount
 
 // --- report results ---
 // connection info (verbose only; trace is noise for batch IDOR/enum flows)
@@ -652,11 +681,12 @@ if method == "GET" || (method == "POST" && body == "") {
 }
 
 // keyword and regex matching
+keywordMatchCount = 0
+regexpMatchCount = 0
 if hasPattern {
     edt := memeditor.New(string(rsp))
     if keyword != "" {
         yakit.Info("searching keyword pattern: %v", keyword)
-        keywordMatchCount = 0
         edt.FindStringRange(keyword, rg => {
             keywordMatchCount++
             matchContent := rg.GetTextContextWithPrompt(3)
@@ -672,7 +702,6 @@ if hasPattern {
     }
     if regexpMatch != "" {
         yakit.Info("searching regexp pattern: %v", regexpMatch)
-        regexpMatchCount = 0
         try {
             edt.FindRegexpRange(regexpMatch, rg => {
                 regexpMatchCount++
@@ -687,7 +716,15 @@ if hasPattern {
                 yakit.Info("regexp match: not found in response (%v bytes). Verify the expression or retry without regexp-match to inspect the normal response preview.", len(rsp))
             }
         } catch e {
+            RESULT["regexp_valid"] = false
             yakit.Error("invalid regexp-match %q: %v. Recovery: correct or remove regexp-match and retry; the HTTP request itself completed and its response summary is shown above.", regexpMatch, e)
         }
     }
+}
+
+if keyword != "" {
+    RESULT["keyword_match_count"] = keywordMatchCount
+}
+if regexpMatch != "" {
+    RESULT["regexp_match_count"] = regexpMatchCount
 }

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/http/simple_crawler.yak
@@ -254,6 +254,7 @@ if subdomainCount > 1 || pendingCount > 0 {
 }
 
 result = string(output.String())
+RESULT = result
 if len(result) <= 30000 {
     yakit.Info(result)
 } else {

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/bash.yak
@@ -27,6 +27,10 @@ __USAGE__ = <<<USAGE_BLOCK
                       默认：自动检测（linux/mac -> bash，
                       windows -> 如果存在 Git Bash/MSYS/Cygwin bash 则用 bash，
                       否则用 powershell/cmd）
+  accepted-exit-codes (string) 可接受的退出码，逗号分隔，默认 "0"。
+  accepted_exit_codes (string) 兼容旧式下划线拼写；仍须传逗号分隔字符串。
+                      例如 grep 未匹配也属于预期时传 "0,1"。原始 exit_code
+                      始终保留；该参数只影响 exit_code_accepted。
 
 ## 执行特性
 
@@ -354,8 +358,65 @@ yakit.AutoInitYakit()
 timeoutSeconds := cli.Int("timeout", cli.setRequired(false), cli.setHelp("the timeout seconds for the shell command, default 60. Commands exceeding this timeout will be killed. Set a reasonable value to avoid hanging. IMPORTANT: Avoid indefinite commands like 'tail -f', 'ping' without -c, 'watch', etc."), cli.setDefault(60))
 shellType := cli.String("shell", cli.setRequired(false), cli.setHelp("shell type: bash, cmd, powershell. Auto-detect if not specified (linux/mac: bash, windows: bash if available, otherwise powershell/cmd)"), cli.setDefault(""))
 command := cli.String("command", cli.setRequired(true), cli.setHelp("the shell command you want to execute. IMPORTANT: Avoid commands that run indefinitely (e.g., tail -f, ping without -c, watch). For potentially long-running commands, use timeout wrapper or add limits."))
+acceptedExitCodesRaw := cli.String("accepted-exit-codes", cli.setRequired(false), cli.setDefault("0"), cli.setHelp("comma-separated accepted process exit codes; default 0, for example 0,1"))
+acceptedExitCodesCompat := cli.String("accepted_exit_codes", cli.setRequired(false), cli.setDefault(""), cli.setHelp("deprecated underscore alias; must still be a comma-separated string, prefer accepted-exit-codes"))
 
 cli.check()
+
+// Declaring the observed underscore spelling makes a wrong array value fail
+// schema validation instead of being silently ignored. A valid string remains
+// compatible without changing the canonical parameter or its default.
+if acceptedExitCodesCompat != "" {
+    if acceptedExitCodesRaw == "0" {
+        acceptedExitCodesRaw = acceptedExitCodesCompat
+    } else {
+        yakit.Info("Ignoring deprecated accepted_exit_codes because accepted-exit-codes is also set")
+    }
+}
+
+acceptedExitCodes = []
+acceptedExitCodeSet = {}
+for _, rawCode := range str.Split(acceptedExitCodesRaw, ",") {
+    codeText = str.TrimSpace(rawCode)
+    if codeText == "" {
+        continue
+    }
+    if !str.MatchAllOfRegexp(codeText, `^-?\d+$`) {
+        yakit.Info("Ignoring invalid accepted exit code: %v", codeText)
+        continue
+    }
+    code = parseInt(codeText)
+    normalizedCodeText = sprint(code)
+    if !acceptedExitCodeSet[normalizedCodeText] {
+        acceptedExitCodeSet[normalizedCodeText] = true
+        acceptedExitCodes = append(acceptedExitCodes, code)
+    }
+}
+if len(acceptedExitCodes) == 0 {
+    acceptedExitCodes = [0]
+    acceptedExitCodeSet["0"] = true
+}
+
+// RESULT is the semantic channel consumed by the AI tool host. Log messages
+// remain observations and must not be interpreted as the process outcome.
+RESULT = {
+    "shell": shellType,
+    "process_started": false,
+    "process_completed": false,
+    "timed_out": false,
+    "exit_code": nil,
+    "exit_code_available": false,
+    "accepted_exit_codes": acceptedExitCodes,
+    "exit_code_accepted": false,
+    "duration_ms": 0,
+    "termination_reason": "not_started",
+}
+
+setProcessResultError = (reason, message)=>{
+    RESULT["shell"] = shellType
+    RESULT["termination_reason"] = reason
+    RESULT["process_error"] = sprint(message)
+}
 
 // 获取操作系统类型
 osType = os.OS
@@ -511,6 +572,7 @@ case "bash":
     }
     if bashPath == "" {
         yakit.Error("bash shell not found. Install bash or set shell to cmd/powershell on Windows.")
+        setProcessResultError("shell_not_found", "bash shell not found")
         return
     }
     
@@ -535,6 +597,7 @@ case "bash":
     scriptFile, err = file.TempFileName("ai_bash_script_*.sh")
     if err != nil {
         yakit.Error("Failed to create temporary script file: %v", err)
+        setProcessResultError("script_create_error", err)
         return
     }
     
@@ -552,6 +615,7 @@ case "bash":
     err = file.Save(scriptFile, scriptContent)
     if err != nil {
         yakit.Error("Failed to write script content to file: %v", err)
+        setProcessResultError("script_write_error", err)
         return
     }
     
@@ -584,6 +648,7 @@ case "powershell":
     }
     if powershellPath == "" {
         yakit.Error("PowerShell shell not found.")
+        setProcessResultError("shell_not_found", "PowerShell shell not found")
         return
     }
 
@@ -598,6 +663,7 @@ case "powershell":
     scriptFile, err = file.TempFileName("ai_powershell_script_*.ps1")
     if err != nil {
         yakit.Error("Failed to create temporary PowerShell script file: %v", err)
+        setProcessResultError("script_create_error", err)
         return
     }
     
@@ -613,6 +679,7 @@ case "powershell":
     err = file.Save(scriptFile, scriptContent)
     if err != nil {
         yakit.Error("Failed to write PowerShell script content to file: %v", err)
+        setProcessResultError("script_write_error", err)
         return
     }
     
@@ -624,11 +691,15 @@ case "powershell":
     
 default:
     yakit.Error("Unsupported shell type: %v. Supported types: bash, cmd, powershell", shellType)
+    setProcessResultError("unsupported_shell", shellType)
     return
 }
 
+RESULT["shell"] = shellType
+
 if err != nil {
     yakit.Error("Failed to create %v command: %v", shellType, err)
+    setProcessResultError("command_create_error", err)
     return
 }
 
@@ -661,11 +732,13 @@ stderrbuf = bufio.NewBuffer()
 stdoutPipe, stdoutPipeErr := cmd.StdoutPipe()
 if stdoutPipeErr != nil {
     yakit.Error("Failed to create stdout pipe: %v", stdoutPipeErr)
+    setProcessResultError("stdout_pipe_error", stdoutPipeErr)
     return
 }
 stderrPipe, stderrPipeErr := cmd.StderrPipe()
 if stderrPipeErr != nil {
     yakit.Error("Failed to create stderr pipe: %v", stderrPipeErr)
+    setProcessResultError("stderr_pipe_error", stderrPipeErr)
     return
 }
 
@@ -710,30 +783,51 @@ err = cmd.Run()
 streamWg.Wait()
 elapsed = time.Since(startTime)
 elapsedSec = int(elapsed.Seconds())
-isTimeout = false
-exitCode = 0
+elapsedMs = elapsed.Milliseconds()
+// Some CommandContext implementations return from Run just before ctx.Err()
+// becomes visible. The command is owned by this deadline, so an execution error
+// at the configured deadline is also objective timeout evidence.
+deadlineWindowMs = timeoutSeconds * 1000
+isTimeout = ctx.Err() != nil || (err != nil && elapsedMs >= deadlineWindowMs - 20)
+exitCode = nil
+exitCodeAvailable = false
+
+if cmd.ProcessState != nil {
+    RESULT["process_started"] = true
+    RESULT["process_completed"] = true
+    processExitCode = cmd.ProcessState.ExitCode()
+    if processExitCode >= 0 {
+        exitCode = processExitCode
+        exitCodeAvailable = true
+    }
+}
+
+RESULT["duration_ms"] = elapsedMs
+RESULT["timed_out"] = isTimeout
+RESULT["exit_code"] = exitCode
+RESULT["exit_code_available"] = exitCodeAvailable
+if exitCodeAvailable {
+    RESULT["exit_code_accepted"] = acceptedExitCodeSet[sprint(exitCode)] == true
+}
 
 if err != nil {
-    errStr = sprint(err)
-    // 检查是否是超时导致的错误（通过错误信息判断）
-    if str.Contains(errStr, "killed") || str.Contains(errStr, "signal: killed") || str.Contains(errStr, "context deadline exceeded") {
-        isTimeout = true
+    RESULT["process_error"] = sprint(err)
+    if isTimeout {
+        RESULT["termination_reason"] = "timeout"
         yakit.Info("COMMAND TIMEOUT: The command was killed after %d seconds timeout. The command may be running too long or hanging indefinitely.", timeoutSeconds)
         yakit.Info("SUGGESTION: For long-running commands, consider using 'timeout' command wrapper (e.g., 'timeout 30 your_command'), or add limits to your command (e.g., 'ping -c 5' instead of 'ping').")
+    } elif exitCodeAvailable {
+        RESULT["termination_reason"] = "exit"
+        yakit.Info("%v process exited with code %d (accepted=%v)", shellType, exitCode, RESULT["exit_code_accepted"])
     } else {
-        // Extract exit code if available
-        if str.Contains(errStr, "exit status") {
-            // Parse exit code from error message like "exit status 1"
-            parts = str.Split(errStr, " ")
-            if len(parts) >= 3 {
-                exitCode = parseInt(parts[len(parts)-1])
-            }
-        }
-        yakit.Error("%v command execution failed (exit code %d): %v", shellType, exitCode, err)
+        RESULT["termination_reason"] = "signal_or_unavailable"
+        yakit.Info("%v process ended without an available exit code: %v", shellType, err)
         if shellType == "bash" {
             yakit.Info("TIP: Bash is executed as a login shell. If PATH/env differs from your terminal, check /etc/profile and your bash profile files.")
         }
     }
+} else {
+    RESULT["termination_reason"] = "exit"
 }
 
 // 输出已经在执行过程中实时流式打印；这里仅处理无输出场景。
@@ -741,11 +835,11 @@ if stdoutbuf.Len() <= 0 && stderrbuf.Len() <= 0 {
     if isTimeout {
         yakit.Info("No output captured before timeout")
     } else {
-        yakit.Info("No output found, %v command execution completed (possibly with empty output)", shellType)
+        yakit.Info("No stdout/stderr observations were produced by the %v process", shellType)
     }
 }
 
-yakit.Info("Execution completed in %ds", elapsedSec)
+yakit.Info("Process observation complete in %dms: exit_code=%v, exit_code_available=%v, accepted=%v, timed_out=%v", elapsedMs, exitCode, exitCodeAvailable, RESULT["exit_code_accepted"], isTimeout)
 
 if elapsedSec > 20 && !isTimeout {
     stdoutStr = stdoutbuf.String()

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/cmd.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/cmd.yak
@@ -12,6 +12,9 @@ Required Parameters:
 Optional Parameters:
   timeout         (int)     Timeout in seconds. Command is killed on timeout.
                             Default: 10.
+  accepted-exit-codes (string) Comma-separated accepted exit codes. Default: "0".
+                            This only affects exit_code_accepted; the raw code is preserved.
+  accepted_exit_codes (string) Deprecated underscore alias; it must also be a comma-separated string.
 USAGE_BLOCK
 
 yakit.AutoInitYakit()
@@ -19,8 +22,50 @@ yakit.AutoInitYakit()
 // 解析命令行参数：超时时间和要执行的cmd命令
 timeoutSeconds := cli.Int("timeout", cli.setRequired(false), cli.setHelp("the timeout seconds for the cmd command, default 10, timeout cannot be zero and below"), cli.setDefault(10))
 command := cli.String("command", cli.setRequired(true), cli.setHelp("the Windows cmd command you want to execute"))
+acceptedExitCodesRaw := cli.String("accepted-exit-codes", cli.setRequired(false), cli.setDefault("0"), cli.setHelp("comma-separated accepted process exit codes"))
+acceptedExitCodesCompat := cli.String("accepted_exit_codes", cli.setRequired(false), cli.setDefault(""), cli.setHelp("deprecated underscore alias; must be a comma-separated string"))
 
 cli.check()
+
+if acceptedExitCodesCompat != "" {
+    if acceptedExitCodesRaw == "0" {
+        acceptedExitCodesRaw = acceptedExitCodesCompat
+    } else {
+        yakit.Info("Ignoring deprecated accepted_exit_codes because accepted-exit-codes is also set")
+    }
+}
+
+acceptedExitCodes = []
+acceptedExitCodeSet = {}
+for _, rawCode := range str.Split(acceptedExitCodesRaw, ",") {
+    codeText = str.TrimSpace(rawCode)
+    if codeText == "" || !str.MatchAllOfRegexp(codeText, `^-?\d+$`) {
+        continue
+    }
+    code = parseInt(codeText)
+    normalizedCodeText = sprint(code)
+    if !acceptedExitCodeSet[normalizedCodeText] {
+        acceptedExitCodeSet[normalizedCodeText] = true
+        acceptedExitCodes = append(acceptedExitCodes, code)
+    }
+}
+if len(acceptedExitCodes) == 0 {
+    acceptedExitCodes = [0]
+    acceptedExitCodeSet["0"] = true
+}
+
+RESULT = {
+    "shell": "cmd",
+    "process_started": false,
+    "process_completed": false,
+    "timed_out": false,
+    "exit_code": nil,
+    "exit_code_available": false,
+    "accepted_exit_codes": acceptedExitCodes,
+    "exit_code_accepted": false,
+    "duration_ms": 0,
+    "termination_reason": "not_started",
+}
 
 yakit.Info("Executing Windows command: %v", command)
 
@@ -31,11 +76,14 @@ if timeoutSeconds <= 0 {
 
 // 创建带超时的上下文，保护系统资源
 ctx, cancel = context.WithTimeout(context.Background(), time.ParseDuration(sprint(timeoutSeconds) + "s")~)
+defer cancel()
 
 // 构建cmd命令执行器，使用Windows的cmd.exe
 cmd, err := exec.CommandContext(ctx, "cmd /c %s" % command)
 if err != nil {
     yakit.Error("Failed to create command: %v", err)
+    RESULT["termination_reason"] = "command_create_error"
+    RESULT["process_error"] = sprint(err)
     return
 }
 
@@ -46,9 +94,38 @@ cmd.Stdout = stdoutbuf
 cmd.Stderr = stderrbuf
 
 // 执行命令并处理结果
+startedAt = time.Now()
 err = cmd.Run()
+elapsedMs = time.Since(startedAt).Milliseconds()
+timedOut = ctx.Err() != nil || (err != nil && elapsedMs >= timeoutSeconds * 1000 - 20)
+exitCode = nil
+exitCodeAvailable = false
+if cmd.ProcessState != nil {
+    RESULT["process_started"] = true
+    RESULT["process_completed"] = true
+    processExitCode = cmd.ProcessState.ExitCode()
+    if processExitCode >= 0 {
+        exitCode = processExitCode
+        exitCodeAvailable = true
+    }
+}
+RESULT["duration_ms"] = elapsedMs
+RESULT["timed_out"] = timedOut
+RESULT["exit_code"] = exitCode
+RESULT["exit_code_available"] = exitCodeAvailable
+if exitCodeAvailable {
+    RESULT["exit_code_accepted"] = acceptedExitCodeSet[sprint(exitCode)] == true
+}
+if timedOut {
+    RESULT["termination_reason"] = "timeout"
+} elif exitCodeAvailable {
+    RESULT["termination_reason"] = "exit"
+} else {
+    RESULT["termination_reason"] = "start_or_signal_error"
+}
 if err != nil {
-    yakit.Error("Command execution failed: %v", err)
+    RESULT["process_error"] = sprint(err)
+    yakit.Info("CMD process ended with an execution error: %v", err)
 }
 
 toUtf8 = (s)=>{
@@ -71,5 +148,6 @@ if stderrbuf.Len() > 0 {
     yakit.Info("Stderr:\n%v", toUtf8(stderrbuf.String()))
 }
 if count <= 0 {
-    yakit.Info("No output found, command execution failed or output is empty")
+    yakit.Info("No stdout/stderr observations were produced by the CMD process")
 }
+yakit.Info("CMD process observation: exit_code=%v, available=%v, accepted=%v, timed_out=%v", exitCode, exitCodeAvailable, RESULT["exit_code_accepted"], timedOut)

--- a/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/powershell.yak
+++ b/common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai/system/powershell.yak
@@ -12,6 +12,9 @@ Required Parameters:
 Optional Parameters:
   timeout         (int)     Timeout in seconds. Command is killed on timeout.
                             Default: 10.
+  accepted-exit-codes (string) Comma-separated accepted exit codes. Default: "0".
+                            This only affects exit_code_accepted; the raw code is preserved.
+  accepted_exit_codes (string) Deprecated underscore alias; it must also be a comma-separated string.
 USAGE_BLOCK
 
 yakit.AutoInitYakit()
@@ -19,8 +22,50 @@ yakit.AutoInitYakit()
 // 解析命令行参数：超时时间和要执行的PowerShell命令
 timeoutSeconds := cli.Int("timeout", cli.setRequired(false), cli.setHelp("the timeout seconds for the PowerShell command, default 10, timeout cannot be zero and below"), cli.setDefault(10))
 command := cli.String("command", cli.setRequired(true), cli.setHelp("the PowerShell command or script you want to execute"))
+acceptedExitCodesRaw := cli.String("accepted-exit-codes", cli.setRequired(false), cli.setDefault("0"), cli.setHelp("comma-separated accepted process exit codes"))
+acceptedExitCodesCompat := cli.String("accepted_exit_codes", cli.setRequired(false), cli.setDefault(""), cli.setHelp("deprecated underscore alias; must be a comma-separated string"))
 
 cli.check()
+
+if acceptedExitCodesCompat != "" {
+    if acceptedExitCodesRaw == "0" {
+        acceptedExitCodesRaw = acceptedExitCodesCompat
+    } else {
+        yakit.Info("Ignoring deprecated accepted_exit_codes because accepted-exit-codes is also set")
+    }
+}
+
+acceptedExitCodes = []
+acceptedExitCodeSet = {}
+for _, rawCode := range str.Split(acceptedExitCodesRaw, ",") {
+    codeText = str.TrimSpace(rawCode)
+    if codeText == "" || !str.MatchAllOfRegexp(codeText, `^-?\d+$`) {
+        continue
+    }
+    code = parseInt(codeText)
+    normalizedCodeText = sprint(code)
+    if !acceptedExitCodeSet[normalizedCodeText] {
+        acceptedExitCodeSet[normalizedCodeText] = true
+        acceptedExitCodes = append(acceptedExitCodes, code)
+    }
+}
+if len(acceptedExitCodes) == 0 {
+    acceptedExitCodes = [0]
+    acceptedExitCodeSet["0"] = true
+}
+
+RESULT = {
+    "shell": "powershell",
+    "process_started": false,
+    "process_completed": false,
+    "timed_out": false,
+    "exit_code": nil,
+    "exit_code_available": false,
+    "accepted_exit_codes": acceptedExitCodes,
+    "exit_code_accepted": false,
+    "duration_ms": 0,
+    "termination_reason": "not_started",
+}
 
 yakit.Info("Executing PowerShell command: %v", command)
 
@@ -31,6 +76,7 @@ if timeoutSeconds <= 0 {
 
 // 创建带超时的上下文，保护系统资源
 ctx, cancel = context.WithTimeout(context.Background(), time.ParseDuration(sprint(timeoutSeconds) + "s")~)
+defer cancel()
 
 // 构建PowerShell命令执行器，使用Windows PowerShell
 // 使用 -NoProfile 避免加载用户配置文件，-ExecutionPolicy Bypass 允许执行脚本
@@ -38,6 +84,8 @@ ctx, cancel = context.WithTimeout(context.Background(), time.ParseDuration(sprin
 cmd, err := exec.CommandContext(ctx, "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command %s" % command)
 if err != nil {
     yakit.Error("Failed to create PowerShell command: %v", err)
+    RESULT["termination_reason"] = "command_create_error"
+    RESULT["process_error"] = sprint(err)
     return
 }
 
@@ -48,9 +96,38 @@ cmd.Stdout = stdoutbuf
 cmd.Stderr = stderrbuf
 
 // 执行命令并处理结果
+startedAt = time.Now()
 err = cmd.Run()
+elapsedMs = time.Since(startedAt).Milliseconds()
+timedOut = ctx.Err() != nil || (err != nil && elapsedMs >= timeoutSeconds * 1000 - 20)
+exitCode = nil
+exitCodeAvailable = false
+if cmd.ProcessState != nil {
+    RESULT["process_started"] = true
+    RESULT["process_completed"] = true
+    processExitCode = cmd.ProcessState.ExitCode()
+    if processExitCode >= 0 {
+        exitCode = processExitCode
+        exitCodeAvailable = true
+    }
+}
+RESULT["duration_ms"] = elapsedMs
+RESULT["timed_out"] = timedOut
+RESULT["exit_code"] = exitCode
+RESULT["exit_code_available"] = exitCodeAvailable
+if exitCodeAvailable {
+    RESULT["exit_code_accepted"] = acceptedExitCodeSet[sprint(exitCode)] == true
+}
+if timedOut {
+    RESULT["termination_reason"] = "timeout"
+} elif exitCodeAvailable {
+    RESULT["termination_reason"] = "exit"
+} else {
+    RESULT["termination_reason"] = "start_or_signal_error"
+}
 if err != nil {
-    yakit.Error("PowerShell command execution failed: %v", err)
+    RESULT["process_error"] = sprint(err)
+    yakit.Info("PowerShell process ended with an execution error: %v", err)
 }
 
 toUtf8 = (s)=>{
@@ -73,5 +150,6 @@ if stderrbuf.Len() > 0 {
     yakit.Info("Stderr:\n%v", toUtf8(stderrbuf.String()))
 }
 if count <= 0 {
-    yakit.Info("No output found, PowerShell command execution failed or output is empty")
+    yakit.Info("No stdout/stderr observations were produced by the PowerShell process")
 }
+yakit.Info("PowerShell process observation: exit_code=%v, available=%v, accepted=%v, timed_out=%v", exitCode, exitCodeAvailable, RESULT["exit_code_accepted"], timedOut)

--- a/common/ai/aid/aitool/tool_invoke.go
+++ b/common/ai/aid/aitool/tool_invoke.go
@@ -227,7 +227,7 @@ func (t *Tool) InvokeWithParams(params map[string]any, opts ...ToolInvokeOptions
 			Name:        t.Name,
 			Description: t.Description,
 			Success:     false,
-			Error:       fmt.Sprintf("工具执行失败: %v", err),
+			Error:       fmt.Sprintf("工具调用协议失败: %v", err),
 		}, err
 	}
 

--- a/common/ai/aid/aitool/tool_invoke_result.go
+++ b/common/ai/aid/aitool/tool_invoke_result.go
@@ -12,7 +12,13 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 )
 
-// ToolResult 表示工具调用的结果
+// ToolResult represents the tool-call protocol result.
+//
+// Success is a legacy wire field. It means that invocation/validation/callback
+// protocol completed and produced a result envelope; it does NOT assert that a
+// command exited with zero, an HTTP response was 2xx, or the user's goal was
+// achieved. Consumers must inspect Data (normally ToolExecutionResult.Result)
+// for execution semantics.
 type ToolResult struct {
 	ID          int64  `json:"id"`
 	Name        string `json:"name"`
@@ -108,80 +114,86 @@ func (t *ToolResult) dumpTimelineResult(writer io.Writer) {
 			buf.WriteByte('\n')
 		}
 	} else {
-		// 处理工具执行结果
+		// Render semantic execution facts before observation logs. A model must
+		// not infer execution success from the wording of stdout/stderr.
 		switch ret := t.Data.(type) {
 		case string:
 			if ret == "" {
-				buf.WriteString("no output\n")
-			} else if strings.HasPrefix(ret, "COMBINED OUTPUT:") {
-				// Data already has framework packaging (COMBINED OUTPUT / RESULT / HINT),
+				buf.WriteString("execution_result: null\n")
+			} else if strings.HasPrefix(ret, "RESULT:") || strings.HasPrefix(ret, "OBSERVATIONS:") || strings.HasPrefix(ret, "COMBINED OUTPUT:") {
+				// Data already has framework packaging (RESULT / OBSERVATIONS / ARTIFACT),
 				// no need for an extra "data:" prefix that just duplicates semantics.
 				buf.WriteString(ret)
 				if !strings.HasSuffix(ret, "\n") {
 					buf.WriteByte('\n')
 				}
 			} else {
-				buf.WriteString("data:\n")
+				buf.WriteString("execution_result:\n")
 				buf.WriteString(ret)
 				if !strings.HasSuffix(ret, "\n") {
 					buf.WriteByte('\n')
 				}
 			}
 		case *ToolExecutionResult:
-			// 优先使用 CombinedOutput；兼容旧消费者回退到 stdout/stderr
+			result := utils.InterfaceToString(ret.Result)
+			if result != "" {
+				buf.WriteString(fmt.Sprintf("execution_result:\n%v\n", result))
+			} else {
+				buf.WriteString("execution_result: null\n")
+			}
+
+			// Prefer CombinedOutput; retain stdout/stderr fallback for historical
+			// envelopes. These are observations, not an outcome verdict.
 			combined := ret.CombinedOutput
 			if combined == "" {
 				combined = ret.Stdout + ret.Stderr
 			}
 			if combined != "" {
-				buf.WriteString(fmt.Sprintf("output: \n%v\n", combined))
-			}
-
-			// 处理结果
-			result := utils.InterfaceToString(ret.Result)
-			if result != "" {
-				buf.WriteString(fmt.Sprintf("result: \n%v\n", result))
-			}
-
-			// 如果没有任何输出，显示提示信息
-			if combined == "" && result == "" {
-				buf.WriteString("no output\n")
+				buf.WriteString(fmt.Sprintf("observations:\n%v\n", combined))
 			}
 		default:
-			// 处理其他类型的数据
+			// Handle legacy map envelopes without treating log fields as verdicts.
 			rawMap := utils.InterfaceToGeneralMap(t.Data)
 			if len(rawMap) > 0 {
-				// 处理标准输出
+				if result, ok := rawMap["result"]; ok {
+					buf.WriteString(fmt.Sprintf("execution_result:\n%v\n", utils.InterfaceToString(result)))
+				} else {
+					executionFields := make(map[string]any, len(rawMap))
+					for key, value := range rawMap {
+						if key != "stdout" && key != "stderr" && key != "combined_output" {
+							executionFields[key] = value
+						}
+					}
+					if len(executionFields) == 0 {
+						buf.WriteString("execution_result: null\n")
+					} else {
+						buf.WriteString(fmt.Sprintf("execution_result: %s\n", utils.Jsonify(executionFields)))
+					}
+				}
+
+				observationParts := bytes.NewBuffer(nil)
 				if stdout := utils.MapGetString(rawMap, "stdout"); stdout != "" {
-					buf.WriteString(fmt.Sprintf("stdout: \n%v\n", stdout))
+					observationParts.WriteString(fmt.Sprintf("stdout:\n%v\n", stdout))
 				}
-				delete(rawMap, "stdout")
-
-				// 处理标准错误
 				if stderr := utils.MapGetString(rawMap, "stderr"); stderr != "" {
-					buf.WriteString(fmt.Sprintf("stderr: \n%v\n", stderr))
+					observationParts.WriteString(fmt.Sprintf("stderr:\n%v\n", stderr))
 				}
-				delete(rawMap, "stderr")
-
-				// 处理结果
-				if result := utils.MapGetString(rawMap, "result"); result != "" {
-					buf.WriteString(fmt.Sprintf("result: \n%v\n", result))
-				}
-				delete(rawMap, "result")
-
-				// 处理额外信息
-				if len(rawMap) > 0 {
-					buf.WriteString(fmt.Sprintf("extra: %s\n", utils.Jsonify(rawMap)))
+				if observationParts.Len() > 0 {
+					buf.WriteString("observations:\n")
+					buf.Write(observationParts.Bytes())
 				}
 			} else {
-				buf.WriteString(fmt.Sprintf("data: %s\n", utils.Jsonify(t.Data)))
+				buf.WriteString(fmt.Sprintf("execution_result: %s\n", utils.Jsonify(t.Data)))
 			}
 		}
 	}
 
-	// 处理错误信息
+	// Error is reserved for invocation/protocol failures. Domain execution
+	// errors belong in ToolExecutionResult.Result.
 	if t.Error != "" {
-		buf.WriteString(fmt.Sprintf("err: %s\n", t.Error))
+		buf.WriteString(fmt.Sprintf("protocol_error: %s\n", t.Error))
+	} else if !t.Success {
+		buf.WriteString("protocol_error: tool call did not complete\n")
 	}
 
 	_, _ = writer.Write(buf.Bytes())
@@ -215,10 +227,7 @@ func (t *ToolResult) StringWithoutID() string {
 	buf := bytes.NewBuffer(nil)
 	buf.WriteString(fmt.Sprintf("tool_name: %#v\n", t.Name))
 	buf.WriteString(fmt.Sprintf("param: %s\n", utils.Jsonify(t.Param)))
-	buf.WriteString(fmt.Sprintf("data: %s\n", utils.Jsonify(t.Data)))
-	if t.Error != "" {
-		buf.WriteString(fmt.Sprintf("err: %s\n", t.Error))
-	}
+	t.dumpTimelineResult(buf)
 	return buf.String()
 }
 
@@ -249,6 +258,43 @@ func (t *ToolResult) QuoteParams() string {
 }
 
 func (t *ToolResult) Dump() string {
-	bytes, _ := json.Marshal(t)
-	return string(bytes)
+	type observations struct {
+		Stdout         string `json:"stdout,omitempty"`
+		Stderr         string `json:"stderr,omitempty"`
+		CombinedOutput string `json:"combined_output,omitempty"`
+	}
+	type dumpView struct {
+		ID                int64         `json:"id,omitempty"`
+		Name              string        `json:"name"`
+		Description       string        `json:"description,omitempty"`
+		Param             any           `json:"param,omitempty"`
+		ExecutionResult   any           `json:"execution_result"`
+		Observations      *observations `json:"observations,omitempty"`
+		ProtocolCompleted bool          `json:"protocol_completed"`
+		ProtocolError     string        `json:"protocol_error,omitempty"`
+		ToolCallID        string        `json:"call_tool_id,omitempty"`
+	}
+
+	view := dumpView{
+		ID:                t.ID,
+		Name:              t.Name,
+		Description:       t.Description,
+		Param:             t.Param,
+		ExecutionResult:   t.Data,
+		ProtocolCompleted: t.Success,
+		ProtocolError:     t.Error,
+		ToolCallID:        t.ToolCallID,
+	}
+	if execution, ok := t.Data.(*ToolExecutionResult); ok {
+		view.ExecutionResult = execution.Result
+		if execution.Stdout != "" || execution.Stderr != "" || execution.CombinedOutput != "" {
+			view.Observations = &observations{
+				Stdout:         execution.Stdout,
+				Stderr:         execution.Stderr,
+				CombinedOutput: execution.CombinedOutput,
+			}
+		}
+	}
+	raw, _ := json.Marshal(view)
+	return string(raw)
 }

--- a/common/ai/aid/aitool/tool_invoke_result_test.go
+++ b/common/ai/aid/aitool/tool_invoke_result_test.go
@@ -2,12 +2,49 @@ package aitool
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+func TestToolExecutionResultJSONKeepsAllSemanticChannels(t *testing.T) {
+	raw, err := json.Marshal(&ToolExecutionResult{})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"stdout":"","stderr":"","combined_output":"","result":null}`, string(raw))
+}
+
+func TestToolResultDumpAndTimelineUseNeutralProtocolSemantics(t *testing.T) {
+	tr := &ToolResult{
+		Name:    "bash",
+		Success: true,
+		Data: &ToolExecutionResult{
+			Stdout:         "SUCCESS from stdout",
+			Stderr:         "ERROR from stderr",
+			CombinedOutput: "SUCCESS from stdout\nERROR from stderr",
+			Result: map[string]any{
+				"exit_code":          7,
+				"exit_code_accepted": false,
+			},
+		},
+	}
+
+	dump := tr.Dump()
+	require.Contains(t, dump, `"protocol_completed":true`)
+	require.NotContains(t, dump, `"success"`)
+	require.Contains(t, dump, `"exit_code":7`)
+
+	timeline := tr.String()
+	require.Less(t, strings.Index(timeline, "execution_result:"), strings.Index(timeline, "observations:"))
+	require.NotContains(t, timeline, "success: true")
+	require.NotContains(t, timeline, "tool/bash ok")
+
+	failed := (&ToolResult{Name: "bash", Success: false, Error: "validation failed"}).String()
+	require.Contains(t, failed, "protocol_error: validation failed")
+	require.NotContains(t, failed, "execution failed")
+}
 
 func TestToolResult_DumpTimelineItem_ParamsOption(t *testing.T) {
 	tr := &ToolResult{

--- a/common/ai/aid/aitool/tool_result.go
+++ b/common/ai/aid/aitool/tool_result.go
@@ -28,14 +28,19 @@ func (c *combinedBuffer) String() string {
 	return c.buf.String()
 }
 
-// ToolExecutionResult 表示工具执行的完整结果
+// ToolExecutionResult is the completed tool-callback envelope.
+//
+// Result is the semantic execution result. Stdout, Stderr and CombinedOutput
+// are observations produced while the callback ran; their wording is not a
+// reliable success/failure signal. Keep every field present in JSON so callers
+// can distinguish an explicit null semantic result from a missing envelope.
 type ToolExecutionResult struct {
 	Stdout string `json:"stdout"`
-	Stderr string `json:"stderr,omitempty"`
+	Stderr string `json:"stderr"`
 	// CombinedOutput 是 stdout + stderr 的合并输出，按时间顺序交错。
 	// 截断保存时只针对 CombinedOutput 做一次，不再分别处理 stdout/stderr。
 	CombinedOutput string      `json:"combined_output"`
-	Result         interface{} `json:"result,omitempty"`
+	Result         interface{} `json:"result"`
 }
 
 // ToJSON 将执行结果转换为JSON字符串
@@ -52,22 +57,22 @@ func (r *ToolExecutionResult) GetJSONSchema() map[string]interface{} {
 	schema := map[string]interface{}{
 		"$schema":     "http://json-schema.org/draft-07/schema#",
 		"type":        "object",
-		"description": "工具执行的完整结果",
+		"description": "工具调用完成后的结果信封；result 是执行语义，stdout/stderr/combined_output 仅为观察日志",
 		"properties": map[string]interface{}{
 			"stdout": map[string]interface{}{
 				"type":        "string",
-				"description": "标准输出内容",
+				"description": "标准输出观察日志；内容本身不代表执行成功",
 			},
 			"stderr": map[string]interface{}{
 				"type":        "string",
-				"description": "标准错误输出内容",
+				"description": "标准错误观察日志；非空不等于执行失败",
 			},
 			"combined_output": map[string]interface{}{
 				"type":        "string",
-				"description": "stdout + stderr 合并输出",
+				"description": "stdout + stderr 按时间顺序合并的观察日志",
 			},
 			"result": map[string]interface{}{
-				"description": "工具执行的结果",
+				"description": "工具提供的结构化执行语义；调用方应据此判断命令退出码、HTTP 状态或任务效果",
 			},
 		},
 		"required": []string{"stdout", "stderr", "combined_output", "result"},
@@ -131,9 +136,12 @@ func (t *Tool) ExecuteToolWithCapture(ctx context.Context, params map[string]any
 			CombinedOutput: "",
 		}
 		if cancelCallback != nil {
-			return cancelCallback(execResult, ctxErr)
+			execResult, callbackErr := cancelCallback(execResult, ctxErr)
+			if callbackErr != nil {
+				return execResult, callbackErr
+			}
 		}
-		return execResult, nil
+		return execResult, ctxErr
 	}
 	finished := make(chan callbackResult, 1)
 	go func() {
@@ -154,8 +162,13 @@ func (t *Tool) ExecuteToolWithCapture(ctx context.Context, params map[string]any
 			Stderr:         "",
 			CombinedOutput: "",
 		}
+		err = ctx.Err()
 		if cancelCallback != nil {
-			execResult, err = cancelCallback(execResult, ctx.Err())
+			var callbackErr error
+			execResult, callbackErr = cancelCallback(execResult, err)
+			if callbackErr != nil {
+				err = callbackErr
+			}
 		}
 	case callback := <-finished:
 		err = callback.err

--- a/common/ai/aid/aitool/tool_result_test.go
+++ b/common/ai/aid/aitool/tool_result_test.go
@@ -2,6 +2,7 @@ package aitool
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -205,6 +206,30 @@ func TestExecuteToolWithCapture_PreCancelledContextDoesNotStartCallback(t *testi
 	}
 	if got := cancelCalls.Load(); got != 1 {
 		t.Fatalf("cancel callback calls = %d, want 1", got)
+	}
+}
+
+func TestInvokeWithParams_CancelledContextIsProtocolFailure(t *testing.T) {
+	callbackStarted := false
+	tool, err := New("cancelled", WithCallback(func(context.Context, InvokeParams, *ToolRuntimeConfig, io.Writer, io.Writer) (any, error) {
+		callbackStarted = true
+		return "unexpected", nil
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, invokeErr := tool.InvokeWithParams(InvokeParams{}, WithContext(ctx))
+	if !errors.Is(invokeErr, context.Canceled) {
+		t.Fatalf("InvokeWithParams error = %v, want %v", invokeErr, context.Canceled)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("cancelled invocation result = %#v, want protocol failure", result)
+	}
+	if callbackStarted {
+		t.Fatal("callback started for a pre-cancelled invocation")
 	}
 }
 

--- a/common/ai/aid/coordinator_report.go
+++ b/common/ai/aid/coordinator_report.go
@@ -119,7 +119,7 @@ func (c *Coordinator) collectTaskSummaries(builder *strings.Builder, task *AiTas
 
 	toolResults := task.GetAllToolCallResults()
 	if len(toolResults) > 0 {
-		builder.WriteString(fmt.Sprintf("%s- Tool Calls: %d (success: %d, failed: %d)\n",
+		builder.WriteString(fmt.Sprintf("%s- Tool Calls: %d (completed: %d, protocol-failed: %d)\n",
 			indent, len(toolResults), task.GetSuccessCallCount(), task.GetFailCallCount()))
 	}
 

--- a/common/ai/aid/task.go
+++ b/common/ai/aid/task.go
@@ -290,6 +290,8 @@ func (t *AiTask) GetSummary() string {
 }
 
 func (t *AiTask) GetSuccessCallCount() int {
+	// Legacy API name: Success means the tool-call protocol completed. It does
+	// not measure command/HTTP/task outcome.
 	count := 0
 	for _, v := range t.GetAllToolCallResults() {
 		if v.Success {
@@ -300,6 +302,7 @@ func (t *AiTask) GetSuccessCallCount() int {
 }
 
 func (t *AiTask) GetFailCallCount() int {
+	// Legacy API name: failure means the invocation protocol did not complete.
 	count := 0
 	for _, v := range t.GetAllToolCallResults() {
 		if !v.Success {

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -658,7 +658,7 @@ func (t *AiTask) saveResultSummary(taskDir string, summary, nextSteps, statusSum
 			failCount++
 		}
 	}
-	contentBuilder.WriteString(fmt.Sprintf("Total Tool Calls: %d (Success: %d, Failed: %d)\n", len(toolCallResults), successCount, failCount))
+	contentBuilder.WriteString(fmt.Sprintf("Total Tool Calls: %d (Completed: %d, Protocol Failed: %d)\n", len(toolCallResults), successCount, failCount))
 
 	contentBuilder.WriteString("\n")
 

--- a/common/ai/aid/test/task_artifacts_test.go
+++ b/common/ai/aid/test/task_artifacts_test.go
@@ -106,7 +106,7 @@ func TestTaskArtifacts_SaveResultSummary(t *testing.T) {
 		contentBuilder.WriteString(fmt.Sprintf("Start Time: %s\n", startTime.Format("2006-01-02 15:04:05")))
 		contentBuilder.WriteString(fmt.Sprintf("End Time: %s\n", endTime.Format("2006-01-02 15:04:05")))
 		contentBuilder.WriteString("Task Status: completed\n")
-		contentBuilder.WriteString("Total Tool Calls: 3 (Success: 2, Failed: 1)\n\n")
+		contentBuilder.WriteString("Total Tool Calls: 3 (Completed: 2, Protocol Failed: 1)\n\n")
 
 		contentBuilder.WriteString("## Task Input\n\n")
 		contentBuilder.WriteString("Test user input for task\n\n")

--- a/common/aiengine/aibenchmark/http-react-blackbox-benchmark.yak
+++ b/common/aiengine/aibenchmark/http-react-blackbox-benchmark.yak
@@ -6,14 +6,28 @@
 //
 // 用法（仓库根目录）：
 //   yak common/aiengine/aibenchmark/http-react-blackbox-benchmark.yak \
-//     --case single-query-escaping
+//     --suite execution-semantics --intelligent-model memfit-standard-free
+//
+// API key 只从环境变量读取，不接受 CLI 参数，也不会进入报告。
 
 configFile = cli.String("config", cli.setDefault("common/aiengine/aibenchmark/http-react-blackbox-cases.json"), cli.setHelp("测试任务 JSON"))
 caseName = cli.String("case", cli.setDefault(""), cli.setHelp("只运行指定 case；留空运行全部"))
 outputDir = cli.String("output-dir", cli.setDefault("./benchmark-reports/tool-react-blackbox"), cli.setHelp("报告输出目录"))
 timeoutSec = cli.Int("timeout", cli.setDefault(120), cli.setHelp("每个 case 的硬超时秒数"))
 maxIteration = cli.Int("max-iteration", cli.setDefault(6), cli.setHelp("每个 case 的最大 ReAct 迭代数"))
+suiteName = cli.String("suite", cli.setDefault(""), cli.setHelp("只运行指定 suite；留空运行全部"))
+phaseName = cli.String("phase", cli.setDefault("candidate"), cli.setHelp("实验阶段标签，例如 baseline/candidate"))
+providerName = cli.String("provider", cli.setDefault("aibalance"), cli.setHelp("AI provider"))
+aiDomain = cli.String("domain", cli.setDefault("https://aibalance.yaklang.com/"), cli.setHelp("AI provider HTTPS domain"))
+intelligentModel = cli.String("intelligent-model", cli.setDefault("memfit-standard-free"), cli.setHelp("主循环/质量模型"))
+lightweightModel = cli.String("lightweight-model", cli.setDefault("memfit-light-free"), cli.setHelp("轻量模型"))
+apiKeyEnv = cli.String("api-key-env", cli.setDefault("AIBALANCE_API_KEY"), cli.setHelp("API key 环境变量名；值不会落盘"))
 cli.check()
+
+apiKey = os.Getenv(apiKeyEnv)
+if str.TrimSpace(apiKey) == "" {
+    die("missing AI API key environment variable: " + apiKeyEnv)
+}
 
 func clean(value) {
     if value == nil || value == undefined {
@@ -74,6 +88,91 @@ func preview(text, limit) {
     return text[:limit] + "..."
 }
 
+// A local controlled HTTP oracle makes HTTP status, timeout and request-count
+// assertions independent from public network behavior. Every request is logged
+// separately from the agent event stream.
+oracleRequests = []
+oracleLock = sync.NewLock()
+
+func startHTTPOracle() {
+    oracleCtx, oracleCancel = context.WithCancel(context.Background())
+    oraclePort = os.GetRandomAvailableTCPPort()
+    oracleURL = "http://" + str.HostPort("127.0.0.1", oraclePort)
+    go func {
+        serveErr = httpserver.Serve("127.0.0.1", oraclePort,
+            httpserver.context(oracleCtx),
+            httpserver.handler(func(w, req) {
+                body, _ = io.ReadAll(req.Body)
+                oracleLock.Lock()
+                oracleRequests = append(oracleRequests, {
+                    "timestamp_unix_ms": time.Now().UnixMilli(),
+                    "method": req.Method,
+                    "path": req.URL.Path,
+                    "body_size": len(body),
+                    "body_sha256": codec.Sha256(body),
+                })
+                oracleLock.Unlock()
+
+                switch req.URL.Path {
+                case "/status/404":
+                    w.WriteHeader(404)
+                    w.Write("oracle-not-found")
+                case "/status/500":
+                    w.WriteHeader(500)
+                    w.Write("oracle-server-error")
+                case "/delay/3":
+                    time.sleep(3)
+                    w.WriteHeader(200)
+                    w.Write("oracle-delayed")
+                case "/no-response":
+                    time.sleep(timeoutSec + 2)
+                    w.WriteHeader(200)
+                    w.Write("oracle-too-late")
+                case "/echo":
+                    w.WriteHeader(200)
+                    w.Write(body)
+                default:
+                    w.WriteHeader(200)
+                    w.Write("oracle-ok")
+                }
+            }),
+        )
+        if serveErr != nil && oracleCtx.Err() == nil {
+            log.error("controlled HTTP oracle stopped unexpectedly: %v", serveErr)
+        }
+    }
+    os.WaitConnect(str.HostPort("127.0.0.1", oraclePort), 5)~
+
+    // Resolve a currently unused port without starting a listener. Connection
+    // refusal is therefore an objective transport oracle, not an HTTP status.
+    refusedPort = os.GetRandomAvailableTCPPort()
+    refusedURL = "http://" + str.HostPort("127.0.0.1", refusedPort)
+    return {
+        "url": oracleURL,
+        "refused_url": refusedURL,
+        "cancel": oracleCancel,
+    }
+}
+
+func oracleRequestOffset() {
+    oracleLock.Lock()
+    defer oracleLock.Unlock()
+    return len(oracleRequests)
+}
+
+func oracleRequestsSince(offset) {
+    oracleLock.Lock()
+    defer oracleLock.Unlock()
+    snapshot = []
+    if offset < 0 {
+        offset = 0
+    }
+    for idx = offset; idx < len(oracleRequests); idx++ {
+        snapshot = append(snapshot, oracleRequests[idx])
+    }
+    return snapshot
+}
+
 func readSize(path) {
     if path == "" || !file.IsExisted(path) {
         return 0
@@ -112,9 +211,12 @@ func prepareWorkspace(caseConfig, startedAt) {
     return workspaceDir
 }
 
-func renderCasePrompt(caseConfig, workspaceDir) {
+func renderCasePrompt(caseConfig, workspaceDir, oracle) {
     prompt = clean(caseConfig["prompt"])
-    return str.ReplaceAll(prompt, "{{WORKDIR}}", workspaceDir)
+    prompt = str.ReplaceAll(prompt, "{{WORKDIR}}", workspaceDir)
+    prompt = str.ReplaceAll(prompt, "{{ORACLE_URL}}", oracle["url"])
+    prompt = str.ReplaceAll(prompt, "{{REFUSED_URL}}", oracle["refused_url"])
+    return prompt
 }
 
 func inspectWorkspace(caseConfig, result) {
@@ -153,6 +255,7 @@ func inspectWorkspace(caseConfig, result) {
             "path": targetPath,
             "exists": exists,
             "size": len(content),
+            "sha256": exists ? file.Sha256(targetPath) : "",
             "missing_tokens": missingTokens,
             "forbidden_tokens_found": forbiddenTokens,
             "content_preview": preview(content, 1600),
@@ -174,9 +277,18 @@ func runFileVerifications(caseConfig, result) {
         verifyCtx, verifyCancel = context.WithTimeout(context.Background(), time.ParseDuration("15s")~)
         cmd, commandErr = exec.CommandContext(verifyCtx, command)
         output = ""
+        exitCode = nil
+        exitCodeAvailable = false
         if commandErr == nil {
-            rawOutput, runErr = cmd.Output()
+            rawOutput, runErr = cmd.CombinedOutput()
             output = string(rawOutput)
+            if cmd.ProcessState != nil {
+                processExitCode = cmd.ProcessState.ExitCode()
+                if processExitCode >= 0 {
+                    exitCode = processExitCode
+                    exitCodeAvailable = true
+                }
+            }
             if runErr != nil {
                 commandErr = runErr
             }
@@ -192,6 +304,8 @@ func runFileVerifications(caseConfig, result) {
             "command": command,
             "output": preview(output, 2000),
             "error": commandErr == nil ? "" : sprintf("%v", commandErr),
+            "exit_code": exitCode,
+            "exit_code_available": exitCodeAvailable,
             "missing_tokens": missingTokens,
             "passed": commandErr == nil && len(missingTokens) == 0,
         })
@@ -269,7 +383,12 @@ func inspectToolArtifacts(result) {
             continue
         }
         combinedBytes = readSize(file.Join(callDir, "combined_output.txt"))
-        rawResultBytes = readSize(file.Join(callDir, "result.txt"))
+        // Structured semantic results are persisted as result.json. Keep the
+        // legacy text fallback so the same runner can measure origin/main.
+        rawResultBytes = readSize(file.Join(callDir, "result.json"))
+        if rawResultBytes == 0 {
+            rawResultBytes = readSize(file.Join(callDir, "result.txt"))
+        }
         call["combined_output_bytes"] = combinedBytes
         call["raw_result_bytes"] = rawResultBytes
         combinedTotal += combinedBytes
@@ -313,7 +432,7 @@ func evaluateCase(caseConfig, result, allResultText) {
         if call["result_empty"] {
             emptyResults++
         }
-        if call["status"] == "done" || call["status"] == "error" {
+        if call["status"] == "completed" || call["status"] == "protocol_error" {
             terminalEvents++
         }
     }
@@ -390,12 +509,13 @@ func evaluateCase(caseConfig, result, allResultText) {
     }
 }
 
-func runCase(caseConfig) {
+func runCase(caseConfig, oracle) {
     startedAt = time.Now()
-    sessionID = sprintf("tool-react-blackbox-%s-%d", caseConfig["name"], startedAt.Unix())
+    sessionID = sprintf("tool-react-blackbox-%s-%s-%s-%d", phaseName, intelligentModel, caseConfig["name"], startedAt.Unix())
     workspaceDir = prepareWorkspace(caseConfig, startedAt)
-    renderedPrompt = renderCasePrompt(caseConfig, workspaceDir)
-    benchCtx, benchCancel = context.WithCancel(context.Background())
+    renderedPrompt = renderCasePrompt(caseConfig, workspaceDir, oracle)
+    oracleOffset = oracleRequestOffset()
+    benchCtx, benchCancel = context.WithTimeout(context.Background(), time.ParseDuration(sprint(timeoutSec) + "s")~)
     finishedCallback = false
     hardTimeoutTriggered = false
     resultText = ""
@@ -404,16 +524,17 @@ func runCase(caseConfig) {
     toolCalls = {}
     pinnedActionFiles = []
     taskDir = ""
+    timelineText = ""
+    timelineContextSamples = []
+    modelOutputs = []
+    activeToolCalls = 0
+    maxConcurrentToolCalls = 0
+    toolStartTimes = []
+    eventLock = sync.NewLock()
 
     includeTools = caseConfig["include_tools"]
     if includeTools == nil || includeTools == undefined || len(includeTools) == 0 {
         includeTools = ["do_http_request", "batch_do_http_request"]
-    }
-
-    go func {
-        time.sleep(timeoutSec)
-        hardTimeoutTriggered = true
-        benchCancel()
     }
 
     opts = [
@@ -425,15 +546,38 @@ func runCase(caseConfig) {
         aim.yoloMode(),
         aim.allowUserInteract(false),
         aim.includeToolNames(includeTools...),
+        aim.aiConfig(providerName,
+            ai.apiKey(apiKey), ai.domain(aiDomain), ai.model(intelligentModel)),
+        aim.qualityPriorityAIConfig(providerName,
+            ai.apiKey(apiKey), ai.domain(aiDomain), ai.model(intelligentModel)),
+        aim.speedPriorityAIConfig(providerName,
+            ai.apiKey(apiKey), ai.domain(aiDomain), ai.model(lightweightModel)),
         aim.onFinished(func(react) {
+            eventLock.Lock()
             finishedCallback = true
+            eventLock.Unlock()
             // 给 finish/timeline 落盘留出时间；若 InvokeReAct 的后台收尾卡住，主动取消。
             go func {
                 time.sleep(2)
                 benchCancel()
             }
         }),
+        aim.onStreamContent(func(react, event, nodeID, totalContent) {
+            if len(totalContent) == 0 {
+                return
+            }
+            eventLock.Lock()
+            defer eventLock.Unlock()
+            modelOutputs = append(modelOutputs, {
+                "node_id": nodeID,
+                "event_type": string(event.Type),
+                "content": preview(string(totalContent), 8000),
+                "content_bytes": len(totalContent),
+            })
+        }),
         aim.onEvent(func(react, event) {
+            eventLock.Lock()
+            defer eventLock.Unlock()
             eventType = string(event.Type)
             eventCounts[eventType] = int(eventCounts[eventType]) + 1
             payload = parseEventContent(event.Content)
@@ -446,15 +590,31 @@ func runCase(caseConfig) {
                 }
             }
 
+            if eventType == "timeline_item" {
+                timelineItemText = string(event.Content)
+                timelineText += "\n" + timelineItemText
+                timelineContextSamples = append(timelineContextSamples, preview(timelineItemText, 5000))
+            }
+
             if eventType == "tool_call_start" {
                 call = getOrCreateToolCall(toolCalls, callID)
                 call["tool"] = clean(payload["tool"]["name"])
+                call["started_unix_ms"] = time.Now().UnixMilli()
+                activeToolCalls++
+                if activeToolCalls > maxConcurrentToolCalls {
+                    maxConcurrentToolCalls = activeToolCalls
+                }
+                toolStartTimes = append(toolStartTimes, call["started_unix_ms"])
             } else if eventType == "tool_call_param" {
                 call = getOrCreateToolCall(toolCalls, callID)
                 call["params"] = payload["params"]
             } else if eventType == "tool_call_done" || eventType == "tool_call_error" {
                 call = getOrCreateToolCall(toolCalls, callID)
-                call["status"] = eventType == "tool_call_done" ? "done" : "error"
+                call["status"] = eventType == "tool_call_done" ? "completed" : "protocol_error"
+                call["ended_unix_ms"] = time.Now().UnixMilli()
+                if activeToolCalls > 0 {
+                    activeToolCalls--
+                }
                 call["duration_ms"] = int(payload["duration_ms"])
                 call["total_duration_ms"] = int(payload["total_duration_ms"])
                 if eventType == "tool_call_error" {
@@ -493,7 +653,7 @@ func runCase(caseConfig) {
             }
 
             // 完整保留工具生命周期；其余事件只保留短预览，足够重建 timeline。
-            keepFull = str.HasPrefix(eventType, "tool_call_")
+            keepFull = str.HasPrefix(eventType, "tool_call_") || eventType == "timeline_item"
             content = string(event.Content)
             eventRecords = append(eventRecords, {
                 "index": len(eventRecords) + 1,
@@ -506,9 +666,11 @@ func runCase(caseConfig) {
     ]
 
     invokeErr = aim.InvokeReAct(renderedPrompt, opts...)
+    hardTimeoutTriggered = sprint(benchCtx.Err()) == "context deadline exceeded"
     benchCancel()
     endedAt = time.Now()
 
+    eventLock.Lock()
     calls = []
     for _, call in toolCalls {
         calls = append(calls, call)
@@ -516,6 +678,11 @@ func runCase(caseConfig) {
     result = {
         "case": caseConfig["name"],
         "description": caseConfig["description"],
+        "suite": caseConfig["suite"],
+        "phase": phaseName,
+        "provider": providerName,
+        "intelligent_model": intelligentModel,
+        "lightweight_model": lightweightModel,
         "prompt": renderedPrompt,
         "included_tools": includeTools,
         "workspace_dir": workspaceDir,
@@ -527,9 +694,21 @@ func runCase(caseConfig) {
         "hard_timeout_triggered": hardTimeoutTriggered,
         "event_counts": eventCounts,
         "events": eventRecords,
+        "model_outputs": modelOutputs,
+        "timeline_model_context_samples": timelineContextSamples,
+        "timeline_semantic_violations": {
+            "legacy_tool_header_count": len(re.FindAll(timelineText, `\[tool/[^\]]+ (ok|fail)\]`)),
+            "success_boolean_count": len(re.FindAll(timelineText, `success["']?\s*[:=]\s*true`)),
+        },
         "tool_calls": calls,
         "task_dir": taskDir,
+        "efficiency": {
+            "max_concurrent_tool_calls": maxConcurrentToolCalls,
+            "tool_start_times_unix_ms": toolStartTimes,
+        },
+        "oracle_requests": oracleRequestsSince(oracleOffset),
     }
+    eventLock.Unlock()
     inspectTimeline(result, pinnedActionFiles)
     inspectToolArtifacts(result)
     inspectWorkspace(caseConfig, result)
@@ -545,7 +724,9 @@ if err != nil {
 cases = json.loads(content)
 selected = []
 for caseConfig in cases {
-    if caseName == "" || caseConfig["name"] == caseName {
+    caseMatches = caseName == "" || caseConfig["name"] == caseName
+    suiteMatches = suiteName == "" || clean(caseConfig["suite"]) == suiteName
+    if caseMatches && suiteMatches {
         selected = append(selected, caseConfig)
     }
 }
@@ -554,12 +735,15 @@ if len(selected) == 0 {
 }
 
 file.MkdirAll(outputDir)~
+oracle = startHTTPOracle()
+stopOracle = oracle["cancel"]
+defer stopOracle()
 results = []
 currentCase = 0
 for caseConfig in selected {
     currentCase++
     log.info("[%d/%d] running ReAct tool blackbox case: %s", currentCase, len(selected), caseConfig["name"])
-    result = runCase(caseConfig)
+    result = runCase(caseConfig, oracle)
     results = append(results, result)
     log.info("case=%s passed=%v tool_calls=%d duration_ms=%d task_dir=%s",
         result["case"], result["evaluation"]["passed"], len(result["tool_calls"]), result["duration_ms"], result["task_dir"])
@@ -569,6 +753,12 @@ report = {
     "report_type": "tool-react-blackbox-benchmark",
     "generated_at": time.Now().Format("2006-01-02 15:04:05"),
     "config": configFile,
+    "suite": suiteName,
+    "phase": phaseName,
+    "provider": providerName,
+    "domain": aiDomain,
+    "intelligent_model": intelligentModel,
+    "lightweight_model": lightweightModel,
     "timeout_seconds": timeoutSec,
     "max_iteration": maxIteration,
     "results": results,

--- a/common/aiengine/aibenchmark/http-react-blackbox-cases.json
+++ b/common/aiengine/aibenchmark/http-react-blackbox-cases.json
@@ -107,5 +107,165 @@
       }
     ],
     "prompt": "这是已有 Python 文件的多位置增量编辑测试，目标文件是 {{WORKDIR}}/inventory_report.py。禁止使用 write_file 覆盖、禁止 bash heredoc/cat/echo/sed 修改文件。先用 read_file 查看带行号的现状，再用 bash 运行一次基线。然后只用 modify_file 完成多个非连续修改：删除 DEFAULT_SEPARATOR；parse_items 要解析逗号分隔的 name:qty，名称 strip 后 casefold，忽略格式错误、非整数和 qty<=0，并合并重复名称数量；build_parser 增加整数 --limit，默认 10；summarize 接收 limit，按数量降序、名称升序输出前 N 个 [name, qty]，total 是全部有效条目的数量总和；main 传递 limit。至少调用三次 modify_file，不要用一次整文件覆盖伪装增量修改。每次多行插入导致行号变化后，应重新 read_file 获取当前行号。最终用 bash 执行 `python3 {{WORKDIR}}/inventory_report.py --items ' Pen :2,book:3,PEN:4,bad,eraser:-1' --limit 2`，必须得到 items=[[\"pen\",6],[\"book\",3]] 和 total=9，并执行 py_compile；若失败，只能继续用 read_file+modify_file 修复，验证通过后立即结束。"
+  },
+  {
+    "name": "exit7-stdout-success-claim",
+    "suite": "execution-semantics",
+    "description": "stdout 声称 SUCCESS，但客观退出码为 7。",
+    "include_tools": ["bash"],
+    "expected_tools": ["bash"],
+    "min_tool_calls": 1,
+    "max_tool_calls": 1,
+    "expected_result_tokens": ["SUCCESS"],
+    "prompt": "执行一次且只执行一次 bash：`printf 'SUCCESS\\n'; exit 7`，shell=bash、timeout=5。不要重试。必须区分 stdout 文本与真实退出码，并明确回答命令是否被默认 accepted-exit-codes=0 接受。"
+  },
+  {
+    "name": "exit0-stderr-error-observation",
+    "suite": "execution-semantics",
+    "description": "stderr 含 ERROR，但客观退出码为 0。",
+    "include_tools": ["bash"],
+    "expected_tools": ["bash"],
+    "min_tool_calls": 1,
+    "max_tool_calls": 1,
+    "expected_result_tokens": ["ERROR"],
+    "prompt": "执行一次且只执行一次 bash：`printf 'ERROR\\n' >&2; exit 0`，shell=bash、timeout=5。不要重试。必须区分 stderr 观察文本与真实退出码，并明确回答命令是否被默认 accepted-exit-codes=0 接受。"
+  },
+  {
+    "name": "final-command-exit0",
+    "suite": "execution-semantics",
+    "description": "前序 false 后 echo 成功，验证 shell 最终退出码。",
+    "include_tools": ["bash"],
+    "expected_tools": ["bash"],
+    "min_tool_calls": 1,
+    "max_tool_calls": 1,
+    "expected_result_tokens": ["complete"],
+    "prompt": "执行一次且只执行一次 bash：`false; echo complete`，shell=bash、timeout=5。不要重试。报告 shell 最终退出码，不得仅凭前面的 false 或输出措辞判断。"
+  },
+  {
+    "name": "pipeline-pipefail-cross-check",
+    "suite": "execution-semantics",
+    "description": "并发对照普通 pipeline 与 pipefail 的退出码差异。",
+    "include_tools": ["bash"],
+    "expected_tools": ["bash"],
+    "min_tool_calls": 2,
+    "max_tool_calls": 2,
+    "expected_tool_min_counts": {"bash": 2},
+    "prompt": "在同一轮并发执行两个独立 bash 调用，均为 shell=bash、timeout=5：A=`false | true`；B=`set -o pipefail; false | true`。不得串行，不得重试。比较两者客观退出码和默认接受状态。"
+  },
+  {
+    "name": "timeout-null-exit-code",
+    "suite": "execution-semantics",
+    "description": "超时终止时不得捏造退出码。",
+    "include_tools": ["bash"],
+    "expected_tools": ["bash"],
+    "min_tool_calls": 1,
+    "max_tool_calls": 1,
+    "expected_result_tokens": ["\"timed_out\": true", "\"exit_code\": null", "\"termination_reason\": \"timeout\""],
+    "prompt": "执行一次且只执行一次 bash：`sleep 3; echo TOO_LATE`，shell=bash、timeout=1。不要重试。报告 timed_out、exit_code 是否可用以及 termination_reason；不得从错误字符串猜退出码。"
+  },
+  {
+    "name": "concurrent-exit-codes-with-accepted",
+    "suite": "execution-semantics",
+    "description": "同批 0/1/7，交叉验证 accepted-exit-codes 不改写原始退出码。",
+    "include_tools": ["bash"],
+    "expected_tools": ["bash"],
+    "min_tool_calls": 3,
+    "max_tool_calls": 3,
+    "expected_tool_min_counts": {"bash": 3},
+    "prompt": "在同一轮并发执行三个独立 bash 调用，不得串行：A=`sleep 0.3; exit 0`，accepted-exit-codes=`0`；B=`sleep 0.3; exit 1`，accepted-exit-codes=`0,1`；C=`sleep 0.3; exit 7`，accepted-exit-codes=`0,1`。三者 shell=bash、timeout=5。不得重试。逐项报告原始 exit_code 和 exit_code_accepted，并确认 B 的原始退出码仍是 1。"
+  },
+  {
+    "name": "compile-diagnose-repair-recompile",
+    "suite": "execution-semantics",
+    "description": "真实编译失败、定位、增量修复、重新编译和运行。",
+    "include_tools": ["bash", "read_file", "modify_file"],
+    "expected_tools": ["bash", "read_file", "modify_file"],
+    "min_tool_calls": 6,
+    "max_tool_calls": 12,
+    "expected_tool_min_counts": {"bash": 4, "read_file": 1, "modify_file": 1},
+    "setup_files": [
+      {"path": "main.go", "content": "package main\n\nimport \"fmt\"\n\nfunc sum(a, b int) int {\n    return a - b\n}\n\nfunc main() {\n    fmt.Println(sum(2, 3)\n}\n"}
+    ],
+    "expected_files": [
+      {"path": "main.go", "contains": ["return a + b", "fmt.Println(sum(2, 3))"], "not_contains": ["return a - b"]}
+    ],
+    "verification_commands": [
+      {"command": "bash -lc \"cd {{WORKDIR}} && gofmt -w main.go && go build -o app main.go && ./app\"", "expected_tokens": ["5"]}
+    ],
+    "prompt": "在 {{WORKDIR}} 完成真实 Go 修复。先用 bash 运行 `cd {{WORKDIR}} && go build -o app main.go` 取得编译失败退出码；并发读取 main.go 与运行 `cd {{WORKDIR}} && gofmt -d main.go` 取得独立证据。只用 modify_file 修复语法错误和 sum 的减法逻辑。随后依次用 bash 执行 gofmt 检查、go build、./app，最终输出必须为 5。禁止 write_file、sed 或 heredoc；至少 6 次工具调用，所有验证通过再结束。"
+  },
+  {
+    "name": "unit-test-fail-fix-full-rerun",
+    "suite": "execution-semantics",
+    "description": "真实单测失败、代码定位、修复、目标测试和全量复测。",
+    "include_tools": ["bash", "read_file", "modify_file"],
+    "expected_tools": ["bash", "read_file", "modify_file"],
+    "min_tool_calls": 6,
+    "max_tool_calls": 12,
+    "expected_tool_min_counts": {"bash": 3, "read_file": 2, "modify_file": 1},
+    "setup_files": [
+      {"path": "slug.py", "content": "import re\n\ndef slugify(value):\n    value = value.strip().lower()\n    return re.sub(r'[^a-z0-9]+', '_', value).strip('_')\n"},
+      {"path": "test_slug.py", "content": "import unittest\nfrom slug import slugify\n\nclass SlugTests(unittest.TestCase):\n    def test_words(self):\n        self.assertEqual(slugify('Hello, World!'), 'hello-world')\n\n    def test_spaces(self):\n        self.assertEqual(slugify('  Red Blue  '), 'red-blue')\n\nif __name__ == '__main__':\n    unittest.main()\n"}
+    ],
+    "expected_files": [
+      {"path": "slug.py", "contains": ["'-'"], "not_contains": ["'_'" ]}
+    ],
+    "verification_commands": [
+      {"command": "bash -lc \"cd {{WORKDIR}} && python3 -m unittest discover -v\"", "expected_tokens": ["OK"]}
+    ],
+    "prompt": "在 {{WORKDIR}} 排查并修复 Python 单测。先用 bash 运行 `cd {{WORKDIR}} && python3 -m unittest discover -v`，确认失败退出码；随后在同一轮并发 read_file 读取 slug.py 和 test_slug.py。只用 modify_file 修复实现，不得改测试。然后用 bash 先跑 `python3 -m unittest -v test_slug.SlugTests.test_words`，再跑全量 discover，最后用 read_file 回读修复产物。禁止 write_file、sed、heredoc；至少 6 次工具调用。"
+  },
+  {
+    "name": "parallel-troubleshooting-partial-failure",
+    "suite": "execution-semantics",
+    "description": "多个并发探针部分失败，要求保留其余有效证据并继续并发。",
+    "include_tools": ["bash"],
+    "expected_tools": ["bash"],
+    "min_tool_calls": 5,
+    "max_tool_calls": 8,
+    "expected_tool_min_counts": {"bash": 5},
+    "prompt": "做受控排障，第一轮必须并发 4 个 bash 探针：A=`uname -s`；B=`test -f {{WORKDIR}}/missing.flag`；C=`python3 --version`；D=`printf 'ERROR-looking observation\\n' >&2; exit 0`，均 shell=bash、timeout=5。B 预期非零，不能因此丢弃 A/C/D。第二轮至少并发执行两个独立确认探针：`uname -m` 与 `python3 -c 'import sys; print(sys.executable)'`。禁止原样重试失败探针；综合客观退出码给出诊断。"
+  },
+  {
+    "name": "http-status-cross-check",
+    "suite": "execution-semantics",
+    "description": "本地受控 200/404/500，响应状态不能被协议 Success 覆盖。",
+    "include_tools": ["do_http_request"],
+    "expected_tools": ["do_http_request"],
+    "min_tool_calls": 3,
+    "max_tool_calls": 3,
+    "expected_tool_min_counts": {"do_http_request": 3},
+    "prompt": "同一轮并发调用三次 do_http_request，分别 GET {{ORACLE_URL}}/status/200、/status/404、/status/500，timeout=5、redirect-times=0。不得串行或重试。逐项报告 request_built、request_sent、response_received、status_code、transport_error；404/500 是收到 HTTP 响应，不得描述为传输失败。"
+  },
+  {
+    "name": "http-transport-timeout-cross-check",
+    "suite": "execution-semantics",
+    "description": "连接拒绝和延迟超时与 HTTP 响应正反交叉。",
+    "include_tools": ["do_http_request"],
+    "expected_tools": ["do_http_request"],
+    "min_tool_calls": 3,
+    "max_tool_calls": 3,
+    "expected_tool_min_counts": {"do_http_request": 3},
+    "prompt": "同一轮并发调用三次 do_http_request：A=GET {{REFUSED_URL}}/refused timeout=1；B=GET {{ORACLE_URL}}/delay/3 timeout=1；C=GET {{ORACLE_URL}}/status/200 timeout=2。redirect-times=0。不得重试。区分连接拒绝、超时和已收到 200 响应，逐项报告 response_received、status_code、transport_error。"
+  },
+  {
+    "name": "mixed-http-file-shell-artifact",
+    "suite": "execution-semantics",
+    "description": "批量 HTTP、文件增量修改、Bash 验证和 artifact 回读混合闭环。",
+    "include_tools": ["batch_do_http_request", "read_file", "modify_file", "bash"],
+    "expected_tools": ["batch_do_http_request", "read_file", "modify_file", "bash"],
+    "min_tool_calls": 6,
+    "max_tool_calls": 12,
+    "expected_tool_min_counts": {"batch_do_http_request": 1, "read_file": 2, "modify_file": 1, "bash": 2},
+    "setup_files": [
+      {"path": "probe_summary.json", "content": "{\"statuses\": {}, \"verified\": false}\n"}
+    ],
+    "expected_files": [
+      {"path": "probe_summary.json", "contains": ["\"200\"", "\"404\"", "\"500\"", "\"verified\": true"], "not_contains": []}
+    ],
+    "verification_commands": [
+      {"command": "python3 -m json.tool {{WORKDIR}}/probe_summary.json", "expected_tokens": ["\"verified\": true", "\"404\"", "\"500\""]}
+    ],
+    "prompt": "在受控环境完成混合闭环。第一轮并发：调用一次 batch_do_http_request，base-url={{ORACLE_URL}}、paths 为 `/status/200\\n/status/404\\n/status/500`、concurrent=3、timeout=5；同时 read_file 读取 {{WORKDIR}}/probe_summary.json。根据批量 Result 的 status_code_distribution，只用 modify_file 把三个状态计数和 verified=true 写入 JSON。随后用 bash 执行 `python3 -m json.tool {{WORKDIR}}/probe_summary.json`，再用 read_file 回读，最后用 bash 运行 Python 一行断言三个状态各为 1 且 verified 为 true。不得使用 write_file/sed/heredoc；至少 6 次工具调用，必须区分响应数和传输错误数。"
   }
 ]

--- a/common/consts/hash.go
+++ b/common/consts/hash.go
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "f33f9e3064309a22a37fd6799ed5d4e366f2785f1f4cc9d3399b2536390024a4"
+const ExistedBuildInAIToolEmbedFSHash string = "9b81f086316394ad3755d30c6e8c33190e3a0196104d1f1159b598cacae77b40"

--- a/common/consts/hash.go.bak
+++ b/common/consts/hash.go.bak
@@ -20,4 +20,4 @@ const ExistedBuildInForgeEmbedFSHash string = "4a290214fd240617f7efb5907df3814af
 // ExistedBuildInAIToolEmbedFSHash contains the SHA256 hash of the embedded AI tool filesystem.
 // This hash is used to verify the integrity of AI-related tools and configurations embedded in the binary.
 // These tools include AI-powered analysis engines and machine learning models for security testing.
-const ExistedBuildInAIToolEmbedFSHash string = "b4b14d12e9c9cdf09f7d39a17b8f8e9d4b8078383ba4ee02b4342640c4181a4e"
+const ExistedBuildInAIToolEmbedFSHash string = "6e65b428994a97a5ca83cb2e0e75262dc1b7e455d5213bc7b92aa2584ee8bc96"

--- a/common/schema/ai_event.go
+++ b/common/schema/ai_event.go
@@ -141,7 +141,7 @@ const (
 	EVENT_TOOL_CALL_START           = "tool_call_start"           // tool call start event, used to emit the tool call start information
 	EVENT_TOOL_CALL_STATUS          = "tool_call_status"          // tool call status event, used to emit the tool call status information
 	EVENT_TOOL_CALL_USER_CANCEL     = "tool_call_user_cancel"     // tool call user cancel event, used to emit the tool call user cancel information
-	EVENT_TOOL_CALL_DONE            = "tool_call_done"            // tool call end event, used to emit the tool call end information
+	EVENT_TOOL_CALL_DONE            = "tool_call_done"            // tool-call protocol lifecycle completion; execution outcome is carried by tool_call_result
 	EVENT_TOOL_CALL_ERROR           = "tool_call_error"           // tool call error event, used to emit the tool call error information
 	EVENT_TOOL_CALL_SUMMARY         = "tool_call_summary"         // tool call summary event, used to emit the tool call summary information
 	EVENT_TOOL_CALL_DECISION        = "tool_call_decision"        // tool call decision event, used to emit the tool call decision information
@@ -167,7 +167,8 @@ const (
 	TOOL_CALL_STATUS_RUNNING string = "running"
 	// TOOL_CALL_STATUS_PROCESSING_PARAMS indicates invoke parameters are being generated or resolved.
 	TOOL_CALL_STATUS_PROCESSING_PARAMS string = "processing_params"
-	// TOOL_CALL_STATUS_DONE marks a successful completion (also emitted via EVENT_TOOL_CALL_DONE).
+	// TOOL_CALL_STATUS_DONE marks protocol lifecycle completion (also emitted via
+	// EVENT_TOOL_CALL_DONE). It does not classify the tool's execution outcome.
 	TOOL_CALL_STATUS_DONE string = "done"
 	// TOOL_CALL_STATUS_CANCELLED marks a user-initiated cancellation (also emitted via EVENT_TOOL_CALL_USER_CANCEL).
 	TOOL_CALL_STATUS_CANCELLED string = "cancelled"

--- a/common/yak/aiagent.go
+++ b/common/yak/aiagent.go
@@ -199,7 +199,7 @@ func YakTool2AITool(aitools []*schema.AIYakTool) []*aitool.Tool {
 					return nil
 				})
 
-				_, err = engine.ExecuteExWithContext(ctx, aiTool.Content, map[string]interface{}{
+				executedEngine, err := engine.ExecuteExWithContext(ctx, aiTool.Content, map[string]interface{}{
 					"RUNTIME_ID":   runtimeId,
 					"CTX":          ctx,
 					"PLUGIN_NAME":  aiTool.Name + ".yak",
@@ -210,7 +210,17 @@ func YakTool2AITool(aitools []*schema.AIYakTool) []*aitool.Tool {
 					stderr.Write([]byte(err.Error()))
 					return nil, err
 				}
-				return "", nil
+				// RESULT is the explicit semantic result channel for Yak-backed AI
+				// tools (also used by other Yak execution paths). Log output remains
+				// captured separately as stdout/stderr observations. Do not fall back
+				// to lowercase `result`: many scripts use that name as a loop-local
+				// value, especially concurrent HTTP batches.
+				if executedEngine != nil {
+					if result, ok := executedEngine.GetVar("RESULT"); ok {
+						return result, nil
+					}
+				}
+				return nil, nil
 			}))
 		if err != nil {
 			log.Errorf(`at.NewFromMCPTool(tool): %v`, err)


### PR DESCRIPTION
## Why

`ToolResult.Success` was visible to the model as if it described the real-world outcome of a tool. In practice it is a transport/invocation flag: a Bash process may return exit 7, HTTP may return 404/500, and tests may fail even though the callback completed and returned a valid envelope. This ambiguity caused Timeline summaries, artifacts, and downstream ReAct decisions to over-trust protocol completion and sometimes overreact to observation text.

## Semantic contract

- Keep the existing `success` wire field for checkpoint/session compatibility, but define it strictly as **protocol completion**.
- Put objective execution facts in `ToolExecutionResult.Result`; treat stdout/stderr/combined output as observations only.
- Render `completed`, `protocol-error`, and `cancelled` at the invocation layer. Timeline tool headers no longer emit `ok/fail`.
- Keep `tool_call_done` as a lifecycle event; use `tool_call_result` / `RESULT` for execution semantics.
- Parameter validation, cancellation, Yak engine errors, callback errors, and missing envelopes remain protocol failures.

## Implementation

- `ToolExecutionResult` always serializes `stdout`, `stderr`, `combined_output`, and `result` (including `result: null`).
- `ToolResult.Dump`, `String`, artifact previews, recent summaries, batch summaries, task reports, and Timeline rendering now use neutral protocol terminology and show semantic Result first.
- Yak-backed AI tools return the explicit top-level `RESULT` variable; lowercase loop-local `result` is intentionally not used as fallback.
- Bash/CMD/PowerShell expose structured process facts: ProcessState exit code, timeout, accepted exit codes, duration, and termination reason. `accepted-exit-codes` remains a comma-separated string, with a typed deprecated underscore alias to make malformed arrays fail validation instead of being ignored.
- Single and batch HTTP tools expose request/response/transport facts and status distributions without treating 404/500 as transport failures.
- Existing result-bearing Yak scripts were migrated from top-level `result` to `RESULT`; embedded tool hashes were refreshed.
- The existing black-box benchmark runner now supports a local oracle and a 12-case `execution-semantics` suite.

## Validation

Local regressions passed:

- `go test ./common/ai/aid/aitool/... -skip 'TestMUSTPASS_ScanPortTool_ActivatesTunSafeMode|TestScanPortTool_SynMode_UsesSynscanxForPointToPointRoute' -count=1`
- `go test ./common/ai/aid/aicommon -count=1`
- `go test ./common/ai/aid/aicache -count=1`
- `go test ./common/ai/aid/aireact/reactloops/... -count=1`
- `go test ./common/ai/aid/aireact -run 'Test(ExecuteToolBatch_|ReAct_(RequestPlanAndExecution_PreservesQualityModelInsideAid|PlanAndExecute_InheritsDistinctCallbacks))' -count=1`
- `go test ./common/ai/aid/test -count=1`
- `go test ./common/ai/aid -count=1`
- `go test ./common/schema -count=1`
- `go run common/yak/cmd/yak.go embed-fs-hash --override --all`
- candidate CLI build and benchmark-script execution

The repository-wide `common/yak` package still contains the pre-existing unconditional `die("which line?")` failure in `TestScriptEngine_Execute`; the same targeted test fails on unmodified `origin/main`, so it was not classified as a regression here.

## Controlled ReAct experiment

Provider/key were injected only through environment variables; no credential is present in code, reports, commit, or this PR.

- 48 before/after sessions across `memfit-standard-free` and `memfit-standard-thinking-free`; 199 primary tool calls across 12 Bash, concurrency, coding, testing, troubleshooting, HTTP, and mixed cases.
- Candidate Timeline scan: zero generated legacy `[tool/... ok|fail]` headers and zero model-visible generic `success` verdicts.
- Baseline Bash/HTTP semantic Result bytes were `0`; candidate runs produced `11,832` and `11,787` bytes of structured semantic Results. Remaining empty Results were non-semantic file tools.
- Maximum observed concurrent batch size stayed at `4` for both models.
- Thinking model: reported cases `6/12 -> 8/12`, tool calls `53 -> 49`, duration `1,334,003ms -> 1,233,332ms`.
- Standard model: reported cases `10/12 -> 9/12`, tool calls `47 -> 50`, duration `661,537ms -> 722,225ms`. Two candidate verifier misses were caused by the host login-shell Go toolchain differing from the benchmark oracle and a strict call-count check after a correctly recovered HTTP alias; these are retained as benchmark/system findings rather than hidden.
- Focused post-fix thinking run executed exit `0/1/7` as exactly three concurrent Bash calls and preserved `exit_code=1` with `exit_code_accepted=true`, and `exit_code=7` with `exit_code_accepted=false`.

The structural objective is met: objective exit/status/transport facts now match the controlled oracle and no longer depend on log wording. The model-level efficiency result is intentionally reported as mixed. The largest remaining costs are action/parameter-generation retries, shared mutable built-in-tool registration between simultaneous versions, cache/memory pollution, environment/toolchain discovery, and model-service variability; those should be addressed independently rather than folded back into `ToolResult.Success`.
