### PR TITLE
fix(ai): 修复队列停止与同步控制闭环

### DIFF
--- a/cmd/legion-smoke-node/main.go
+++ b/cmd/legion-smoke-node/main.go
@@ -59,6 +59,7 @@ func runDistYak(args []string) error {
 func runNode(args []string) error {
 	flags := flag.NewFlagSet("legion-smoke-node", flag.ContinueOnError)
 	apiURL := flags.String("api-url", "http://127.0.0.1:8080", "Legion platform HTTP API base URL")
+	runtimeAPIURL := flags.String("runtime-api-url", strings.TrimSpace(os.Getenv("LEGION_RUNTIME_API_URL")), "Container-facing Legion platform HTTP API base URL for Runtime Host commands")
 	enrollmentToken := flags.String("enrollment-token", "", "Legion node enrollment token")
 	nodeID := flags.String("id", "", "Legacy node ID fallback; canonical node_id is assigned by platform")
 	displayName := flags.String("name", "smoke-node", "Display name reported to Legion")
@@ -173,7 +174,7 @@ func runNode(args []string) error {
 	scanNodeOptions := []scannode.ScanNodeOption{}
 	if *runtimeHost && strings.TrimSpace(*kind) != "ai_session" {
 		scanNodeOptions = append(scanNodeOptions, scannode.WithRuntimeHost(scannode.RuntimeHostConfig{
-			Enabled: true, PlatformAPIBaseURL: *apiURL, EnrollmentToken: *enrollmentToken,
+			Enabled: true, PlatformAPIBaseURL: *apiURL, RuntimePlatformAPIBaseURL: *runtimeAPIURL, EnrollmentToken: *enrollmentToken,
 			AgentInstallationID: *agentInstallationID, Network: *runtimeNetwork,
 			EngineReleaseID: *engineReleaseID, EngineDigest: *engineDigest,
 		}))

--- a/common/ai/aid/aireact/invoke_cancel_task_test.go
+++ b/common/ai/aid/aireact/invoke_cancel_task_test.go
@@ -48,6 +48,47 @@ func mockedToolCallingForCancel(i aicommon.AICallerConfigIf, req *aicommon.AIReq
 	return nil, utils.Errorf("unexpected prompt: %s", prompt)
 }
 
+func TestReAct_CancelCurrentTaskTargetsQueueRootDuringNestedLoop(t *testing.T) {
+	emitter := aicommon.NewDummyEmitter()
+	rootTask := aicommon.NewStatefulTaskBase(
+		"queue-root",
+		"root task",
+		context.Background(),
+		emitter,
+	)
+	rootTask.SetStatus(aicommon.AITaskState_Processing)
+	nestedTask := aicommon.NewStatefulTaskBase(
+		"queue-root_intent",
+		"intent task",
+		rootTask.GetContext(),
+		emitter,
+		true,
+	)
+	nestedTask.SetStatus(aicommon.AITaskState_Processing)
+
+	react := &ReAct{
+		Emitter:      emitter,
+		currentTask:  nestedTask,
+		RuntimeTasks: []aicommon.AIStatefulTask{rootTask},
+	}
+
+	err := react.HandleSyncTypeReactCancelCurrentTaskEvent(&ypb.AIInputEvent{SyncID: "stop-root"})
+	if err != nil {
+		t.Fatalf("cancel current task: %v", err)
+	}
+	if got := rootTask.GetStatus(); got != aicommon.AITaskState_Skipped {
+		t.Fatalf("root task status = %s, want %s", got, aicommon.AITaskState_Skipped)
+	}
+	if got := nestedTask.GetStatus(); got != aicommon.AITaskState_Processing {
+		t.Fatalf("nested task status = %s, want unchanged %s", got, aicommon.AITaskState_Processing)
+	}
+	select {
+	case <-rootTask.GetContext().Done():
+	default:
+		t.Fatal("root task context was not cancelled")
+	}
+}
+
 // TestReAct_CancelCurrentTask_StatusChanges 测试取消当前任务对状态的影响
 func TestReAct_CancelCurrentTask_StatusChanges(t *testing.T) {
 	flag := ksuid.New().String()

--- a/common/ai/aid/aireact/invoke_cancel_task_test.go
+++ b/common/ai/aid/aireact/invoke_cancel_task_test.go
@@ -65,11 +65,18 @@ func TestReAct_CancelCurrentTaskTargetsQueueRootDuringNestedLoop(t *testing.T) {
 		true,
 	)
 	nestedTask.SetStatus(aicommon.AITaskState_Processing)
+	processingSubAgent := aicommon.NewSubTaskBaseWithOptions(
+		rootTask,
+		"queue-root_sub-agent",
+		"sub agent task",
+		aicommon.WithStatefulTaskBaseSubAgent(),
+	)
+	processingSubAgent.SetStatus(aicommon.AITaskState_Processing)
 
 	react := &ReAct{
 		Emitter:      emitter,
 		currentTask:  nestedTask,
-		RuntimeTasks: []aicommon.AIStatefulTask{rootTask},
+		RuntimeTasks: []aicommon.AIStatefulTask{rootTask, processingSubAgent},
 	}
 
 	err := react.HandleSyncTypeReactCancelCurrentTaskEvent(&ypb.AIInputEvent{SyncID: "stop-root"})
@@ -81,6 +88,9 @@ func TestReAct_CancelCurrentTaskTargetsQueueRootDuringNestedLoop(t *testing.T) {
 	}
 	if got := nestedTask.GetStatus(); got != aicommon.AITaskState_Processing {
 		t.Fatalf("nested task status = %s, want unchanged %s", got, aicommon.AITaskState_Processing)
+	}
+	if got := processingSubAgent.GetStatus(); got != aicommon.AITaskState_Processing {
+		t.Fatalf("sub-agent task status = %s, want unchanged %s", got, aicommon.AITaskState_Processing)
 	}
 	select {
 	case <-rootTask.GetContext().Done():

--- a/common/ai/aid/aireact/invoke_directly_answer.go
+++ b/common/ai/aid/aireact/invoke_directly_answer.go
@@ -154,6 +154,7 @@ func (r *ReAct) DirectlyAnswer(ctx context.Context, query string, tools []*aitoo
 			return nil
 		},
 		aicommon.WithAIRequest_CallerLabel("directly-answer"),
+		aicommon.WithAIRequest_Context(ctx),
 	)
 	if finalResult != "" {
 		return finalResult, nil

--- a/common/ai/aid/aireact/invoke_directly_answer_retry_test.go
+++ b/common/ai/aid/aireact/invoke_directly_answer_retry_test.go
@@ -3,14 +3,75 @@ package aireact
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/utils"
 )
+
+func TestReAct_DirectlyAnswerBindsProviderRequestToCallerContext(t *testing.T) {
+	requestStarted := make(chan context.Context, 1)
+	release := make(chan struct{})
+	defer close(release)
+
+	ins, err := NewTestReAct(
+		aicommon.WithAITransactionAutoRetry(1),
+		aicommon.WithAICallback(func(_ aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			requestCtx := req.GetContext()
+			requestStarted <- requestCtx
+			if requestCtx == nil {
+				<-release
+				return nil, utils.Error("provider request context is nil")
+			}
+			select {
+			case <-requestCtx.Done():
+				return nil, requestCtx.Err()
+			case <-release:
+				return nil, utils.Error("test released provider request")
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	callerCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, directErr := ins.DirectlyAnswer(callerCtx, "cancel this provider request", nil)
+		done <- directErr
+	}()
+
+	var requestCtx context.Context
+	select {
+	case requestCtx = <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider request did not start")
+	}
+	if requestCtx == nil {
+		t.Fatal("provider request did not inherit the directly-answer caller context")
+	}
+
+	cancel()
+	select {
+	case <-requestCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("provider request context was not cancelled")
+	}
+	select {
+	case directErr := <-done:
+		if !errors.Is(directErr, context.Canceled) {
+			t.Fatalf("DirectlyAnswer error = %v, want context canceled", directErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("DirectlyAnswer did not return after caller cancellation")
+	}
+}
 
 func TestReAct_DirectlyAnswer_RetryIncludesLastErrorAndAITAGHint(t *testing.T) {
 	var prompts []string

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -82,14 +82,16 @@ func (r *ReAct) updateRuntimeTasks() {
 // getProcessingRuntimeTask returns the queue-owned root task. ReAct sub-loops
 // temporarily publish their own task through SetCurrentTask, so GetCurrentTask
 // may point at an intent or other nested task while a user presses Stop. The
-// runtime task list is the stable owner of the queued root task.
+// runtime task list is the stable owner of the queued root task. It also holds
+// sub-agent tasks, which must be ignored because cancelling a child does not
+// cancel the queue-owned root context.
 func (r *ReAct) getProcessingRuntimeTask() aicommon.AIStatefulTask {
 	r.UpdateRuntimeTaskMutex.Lock()
 	defer r.UpdateRuntimeTaskMutex.Unlock()
 
 	for index := len(r.RuntimeTasks) - 1; index >= 0; index-- {
 		task := r.RuntimeTasks[index]
-		if task != nil && task.GetStatus() == aicommon.AITaskState_Processing {
+		if task != nil && !task.IsSubAgent() && task.GetStatus() == aicommon.AITaskState_Processing {
 			return task
 		}
 	}

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -79,6 +79,23 @@ func (r *ReAct) updateRuntimeTasks() {
 	r.RuntimeTasks = newRuntimeTasks
 }
 
+// getProcessingRuntimeTask returns the queue-owned root task. ReAct sub-loops
+// temporarily publish their own task through SetCurrentTask, so GetCurrentTask
+// may point at an intent or other nested task while a user presses Stop. The
+// runtime task list is the stable owner of the queued root task.
+func (r *ReAct) getProcessingRuntimeTask() aicommon.AIStatefulTask {
+	r.UpdateRuntimeTaskMutex.Lock()
+	defer r.UpdateRuntimeTaskMutex.Unlock()
+
+	for index := len(r.RuntimeTasks) - 1; index >= 0; index-- {
+		task := r.RuntimeTasks[index]
+		if task != nil && task.GetStatus() == aicommon.AITaskState_Processing {
+			return task
+		}
+	}
+	return nil
+}
+
 // processReActFromQueue 处理队列中的下一个任务
 func (r *ReAct) processReActFromQueue() {
 	if r.taskQueue.IsEmpty() {

--- a/common/ai/aid/aireact/re-act_sync_request.go
+++ b/common/ai/aid/aireact/re-act_sync_request.go
@@ -334,7 +334,11 @@ func (r *ReAct) CancelTask(task aicommon.AIStatefulTask, event *ypb.AIInputEvent
 
 func (r *ReAct) HandleSyncTypeReactCancelCurrentTaskEvent(event *ypb.AIInputEvent) error {
 	// 中断当前正在执行的任务
-	currentTask := r.GetCurrentTask()
+	currentTask := r.getProcessingRuntimeTask()
+	if currentTask == nil {
+		// Pure-invoker callers and legacy tests may not populate RuntimeTasks.
+		currentTask = r.GetCurrentTask()
+	}
 	if currentTask == nil {
 		r.EmitError("no current task to cancel")
 		return nil

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -329,6 +329,16 @@ func (r *ReActLoop) Execute(taskId string, ctx context.Context, userInput string
 func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, nonce string) (*aicommon.Action, *LoopAction, error) {
 	var action *aicommon.Action
 	var actionNames = r.GetAllActionNames()
+	// Bind the provider request to the immutable task that owns this
+	// transaction. ReAct.currentTask may temporarily point at a nested loop,
+	// while Stop cancels the queue-owned task context. If the request only uses
+	// the session config context, the runtime can emit a successful cancellation
+	// receipt yet continue streaming model output until the provider finishes.
+	activeTask := r.GetCurrentTask()
+	activeTaskCtx := r.config.GetContext()
+	if activeTask != nil && !utils.IsNil(activeTask.GetContext()) {
+		activeTaskCtx = activeTask.GetContext()
+	}
 
 	getNextActionType := func(a *aicommon.Action) string { //legacy support
 		return inferActionTypeFromPayload(a, r.Get("tag_final_answer"))
@@ -336,9 +346,9 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 
 	ctxCanceled := utils.NewBool(false)
 	currentCtxCanceled := func() bool {
-		if r.GetCurrentTask() != nil {
+		if !utils.IsNil(activeTaskCtx) {
 			select {
-			case <-r.GetCurrentTask().GetContext().Done():
+			case <-activeTaskCtx.Done():
 				ctxCanceled.SetTo(true)
 				return true
 			default:
@@ -495,7 +505,7 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 			r.loadingStatus("解析 AI 响应中 / Parsing AI Response...")
 			extractStart := time.Now()
 			action, actionErr = aicommon.ExtractActionFromStream(
-				r.GetCurrentTask().GetContext(),
+				activeTaskCtx,
 				stream,
 				"object",
 				options...,
@@ -553,6 +563,7 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 			return nil
 		},
 		aicommon.WithAIRequest_CallerLabel(fmt.Sprintf("react-loop:%s", r.loopName)),
+		aicommon.WithAIRequest_Context(activeTaskCtx),
 	)
 	if transactionErr != nil {
 		r.loadingStatus(fmt.Sprintf("AI 事务失败 / AI Transaction Failed: %v", transactionErr))
@@ -594,7 +605,7 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 	waitDone := make(chan struct{})
 	go func() {
 		defer close(waitDone)
-		action.WaitStream(r.GetCurrentTask().GetContext())
+		action.WaitStream(activeTaskCtx)
 	}()
 
 	select {

--- a/common/ai/aid/aireact/reactloops/task_request_context_test.go
+++ b/common/ai/aid/aireact/reactloops/task_request_context_test.go
@@ -1,0 +1,101 @@
+package reactloops
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+type taskRequestContextConfig struct {
+	*mock.MockedAIConfig
+	requestStarted chan context.Context
+	release        <-chan struct{}
+}
+
+func (c *taskRequestContextConfig) waitForRequest(req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+	requestCtx := req.GetContext()
+	c.requestStarted <- requestCtx
+	if requestCtx == nil {
+		<-c.release
+		return nil, utils.Error("provider request context is nil")
+	}
+	select {
+	case <-requestCtx.Done():
+		return nil, requestCtx.Err()
+	case <-c.release:
+		return nil, utils.Error("test released provider request")
+	}
+}
+
+func (c *taskRequestContextConfig) CallAI(req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+	return c.waitForRequest(req)
+}
+
+func (c *taskRequestContextConfig) CallSpeedPriorityAI(req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+	return c.waitForRequest(req)
+}
+
+func (c *taskRequestContextConfig) CallQualityPriorityAI(req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+	return c.waitForRequest(req)
+}
+
+func TestReActLoopTransactionBindsProviderRequestToActiveTask(t *testing.T) {
+	requestStarted := make(chan context.Context, 1)
+	release := make(chan struct{})
+	defer close(release)
+
+	baseConfig, ok := mock.NewMockedAIConfig(context.Background()).(*mock.MockedAIConfig)
+	if !ok {
+		t.Fatal("mock config has unexpected type")
+	}
+	baseConfig.SetConfig("AiTransactionAutoRetry", 1)
+	config := &taskRequestContextConfig{
+		MockedAIConfig: baseConfig,
+		requestStarted: requestStarted,
+		release:        release,
+	}
+	invoker := mock.NewMockInvoker(context.Background())
+	invoker.SetConfig(config)
+	loop := NewMinimalReActLoop(config, invoker)
+
+	taskCtx, cancelTask := context.WithCancel(context.Background())
+	task := aicommon.NewStatefulTaskBase("queue-root", "cancel the active provider request", taskCtx, config.GetEmitter())
+	loop.SetCurrentTask(task)
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, transactionErr := loop.callAITransaction(&sync.WaitGroup{}, "prompt", "nonce")
+		done <- transactionErr
+	}()
+
+	var requestCtx context.Context
+	select {
+	case requestCtx = <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider request did not start")
+	}
+	if requestCtx == nil {
+		t.Fatal("provider request did not inherit the active task context")
+	}
+
+	cancelTask()
+	select {
+	case <-requestCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("provider request context was not cancelled with the active task")
+	}
+	select {
+	case transactionErr := <-done:
+		if !errors.Is(transactionErr, context.Canceled) {
+			t.Fatalf("transaction error = %v, want context canceled", transactionErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("transaction did not stop after active task cancellation")
+	}
+}

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -204,17 +204,16 @@ func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 		return utils.Error("taskID cannot be empty")
 	}
 
-	// 检查任务是否已经完成
-	e.tasksMutex.RLock()
+	// 终态检查与 endpoint 注册必须在同一个临界区内完成。
+	// 否则任务在两步之间进入终态时，状态处理器看不到
+	// 尚未注册的 endpoint，后续等待将永久错过释放信号。
+	e.tasksMutex.Lock()
 	status, exists := e.activeTasks[taskID]
 	if exists && isTerminalAITaskState(status) {
-		e.tasksMutex.RUnlock()
+		e.tasksMutex.Unlock()
 		return waitTaskFinishByTaskNameResult(status)
 	}
-	e.tasksMutex.RUnlock()
 
-	// 创建该任务的 endpoint
-	e.tasksMutex.Lock()
 	taskEndpoint, exists := e.taskEndpoints[taskID]
 	if !exists {
 		epm := aicommon.NewEndpointManagerContext(e.ctx)
@@ -271,22 +270,33 @@ func isTerminalAITaskState(status aicommon.AITaskState) bool {
 // WaitTaskFinish 等待所有任务完成
 // 通过监听任务状态变化来判断所有任务是否完成
 func (e *AIEngine) WaitTaskFinish() error {
-	// 检查是否还有活跃任务
-	if !e.hasActiveTasks() {
-		return nil
-	}
+	for {
+		e.tasksMutex.RLock()
+		if !hasActiveTasksLocked(e.activeTasks) {
+			e.tasksMutex.RUnlock()
+			return nil
+		}
+		endpoint := e.allTasksEndpoint
+		e.tasksMutex.RUnlock()
 
-	// 等待所有任务完成
-	e.allTasksEndpoint.WaitContext(e.ctx)
-	return e.ctx.Err()
+		// 等待当前任务代际完成。唤醒后重新检查，以覆盖
+		// 终态信号与同时到达的后续任务之间的竞态。
+		endpoint.WaitContext(e.ctx)
+		if err := e.ctx.Err(); err != nil {
+			return err
+		}
+	}
 }
 
 // hasActiveTasks 检查是否还有活跃的任务（未完成或未中止的任务）
 func (e *AIEngine) hasActiveTasks() bool {
 	e.tasksMutex.RLock()
 	defer e.tasksMutex.RUnlock()
+	return hasActiveTasksLocked(e.activeTasks)
+}
 
-	for _, status := range e.activeTasks {
+func hasActiveTasksLocked(tasks map[string]aicommon.AITaskState) bool {
+	for _, status := range tasks {
 		if !isTerminalAITaskState(status) {
 			return true
 		}
@@ -301,7 +311,7 @@ func (e *AIEngine) GetActiveTaskCount() int {
 
 	count := 0
 	for _, status := range e.activeTasks {
-		if status != aicommon.AITaskState_Completed && status != aicommon.AITaskState_Aborted {
+		if !isTerminalAITaskState(status) {
 			count++
 		}
 	}
@@ -409,8 +419,14 @@ func (e *AIEngine) processOutputEvent(event *schema.AiOutputEvent) {
 			taskID := utils.InterfaceToString(taskInfo["react_task_id"])
 			taskStatus := aicommon.AITaskState(utils.InterfaceToString(taskInfo["react_task_status"]))
 
-			// 记录新任务
+			// 记录新任务。上一代任务全部结束时 allTasksEndpoint
+			// 已经释放；新一代的首个任务必须换用新 endpoint，
+			// 否则多轮 runtime 中 WaitTaskFinish 会被旧信号立即唤醒。
 			e.tasksMutex.Lock()
+			if !hasActiveTasksLocked(e.activeTasks) {
+				epm := aicommon.NewEndpointManagerContext(e.ctx)
+				e.allTasksEndpoint = epm.CreateEndpoint()
+			}
 			e.activeTasks[taskID] = taskStatus
 
 			// 通知任务已创建（如果有等待的 endpoint）

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -198,7 +198,7 @@ func (e *AIEngine) SendMsg(input string, options ...AIEngineConfigOption) error 
 var ErrAITaskAborted = utils.Error("ai task aborted")
 
 // WaitTaskFinishByTaskName 等待指定任务完成
-// 传入任务ID，等待该任务状态变为 Completed 或 Aborted
+// 传入任务ID，等待该任务进入 Completed、Aborted 或 Skipped 终态。
 func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 	if taskID == "" {
 		return utils.Error("taskID cannot be empty")
@@ -207,7 +207,7 @@ func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 	// 检查任务是否已经完成
 	e.tasksMutex.RLock()
 	status, exists := e.activeTasks[taskID]
-	if exists && (status == aicommon.AITaskState_Completed || status == aicommon.AITaskState_Aborted) {
+	if exists && isTerminalAITaskState(status) {
 		e.tasksMutex.RUnlock()
 		return waitTaskFinishByTaskNameResult(status)
 	}
@@ -244,16 +244,27 @@ func (e *AIEngine) WaitTaskFinishByTaskName(taskID string) error {
 	return waitTaskFinishByTaskNameResult(finalStatus)
 }
 
-// waitTaskFinishByTaskNameResult 将终态映射为返回值：Completed -> nil，
-// Aborted -> ErrAITaskAborted，非终态（防御性，正常不应发生）-> error。
+// waitTaskFinishByTaskNameResult 将终态映射为返回值：Completed/Skipped ->
+// nil，Aborted -> ErrAITaskAborted，非终态（防御性，正常不应发生）-> error。
+// Skipped 是用户主动停止当前任务的正常终态；把它视为完成，才能让上层
+// SendMsg 返回并发布 turn terminal event，而不是永远阻塞当前 turn 和后续队列。
 func waitTaskFinishByTaskNameResult(status aicommon.AITaskState) error {
 	switch status {
-	case aicommon.AITaskState_Completed:
+	case aicommon.AITaskState_Completed, aicommon.AITaskState_Skipped:
 		return nil
 	case aicommon.AITaskState_Aborted:
 		return ErrAITaskAborted
 	default:
 		return utils.Errorf("ai task ended in non-terminal state: %s", status)
+	}
+}
+
+func isTerminalAITaskState(status aicommon.AITaskState) bool {
+	switch status {
+	case aicommon.AITaskState_Completed, aicommon.AITaskState_Aborted, aicommon.AITaskState_Skipped:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -276,7 +287,7 @@ func (e *AIEngine) hasActiveTasks() bool {
 	defer e.tasksMutex.RUnlock()
 
 	for _, status := range e.activeTasks {
-		if status != aicommon.AITaskState_Completed && status != aicommon.AITaskState_Aborted {
+		if !isTerminalAITaskState(status) {
 			return true
 		}
 	}
@@ -428,8 +439,9 @@ func (e *AIEngine) processOutputEvent(event *schema.AiOutputEvent) {
 			e.activeTasks[taskID] = nowStatus
 			e.tasksMutex.Unlock()
 
-			// 检查任务是否完成或中止
-			if nowStatus == aicommon.AITaskState_Completed || nowStatus == aicommon.AITaskState_Aborted {
+			// 检查任务是否进入任一终态。Skipped 是 Stop 当前任务的正常终态，
+			// 也必须释放 SendMsg 的等待者和全局完成信号。
+			if isTerminalAITaskState(nowStatus) {
 				// 通知该任务的等待者
 				e.tasksMutex.Lock()
 				if taskEndpoint, exists := e.taskEndpoints[taskID]; exists {

--- a/common/aiengine/aiengine_terminate_test.go
+++ b/common/aiengine/aiengine_terminate_test.go
@@ -141,6 +141,101 @@ func TestProcessOutputEventSkippedReleasesWaiter(t *testing.T) {
 	}
 }
 
+func TestWaitTaskFinishDrainsQueuedTaskAfterCurrentTaskIsSkipped(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	e.activeTasks["task-current"] = aicommon.AITaskState_Processing
+	e.activeTasks["task-queued"] = aicommon.AITaskState_Queueing
+
+	done := make(chan error, 1)
+	go func() { done <- e.WaitTaskFinish() }()
+	time.Sleep(20 * time.Millisecond)
+
+	e.processOutputEvent(&schema.AiOutputEvent{
+		Type:   schema.EVENT_TYPE_STRUCTURED,
+		NodeId: "react_task_status_changed",
+		Content: []byte(`{
+			"react_task_id":"task-current",
+			"react_task_now_status":"skipped",
+			"react_task_old_status":"processing"
+		}`),
+	})
+	select {
+	case err := <-done:
+		t.Fatalf("queue drain returned while queued task was still active: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	e.processOutputEvent(&schema.AiOutputEvent{
+		Type:   schema.EVENT_TYPE_STRUCTURED,
+		NodeId: "react_task_status_changed",
+		Content: []byte(`{
+			"react_task_id":"task-queued",
+			"react_task_now_status":"completed",
+			"react_task_old_status":"processing"
+		}`),
+	})
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("queue drain returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("queue drain did not return after every task became terminal")
+	}
+}
+
+func TestWaitTaskFinishUsesFreshEndpointForNextTaskGeneration(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	complete := func(taskID string) {
+		t.Helper()
+		e.processOutputEvent(&schema.AiOutputEvent{
+			Type:   schema.EVENT_TYPE_STRUCTURED,
+			NodeId: "react_task_status_changed",
+			Content: []byte(`{
+				"react_task_id":"` + taskID + `",
+				"react_task_now_status":"completed",
+				"react_task_old_status":"processing"
+			}`),
+		})
+	}
+	create := func(taskID string) {
+		t.Helper()
+		e.processOutputEvent(&schema.AiOutputEvent{
+			Type:   schema.EVENT_TYPE_STRUCTURED,
+			NodeId: "react_task_created",
+			Content: []byte(`{
+				"react_task_id":"` + taskID + `",
+				"react_task_status":"processing"
+			}`),
+		})
+	}
+	waitAndAssertBlocked := func(taskID string) chan error {
+		t.Helper()
+		done := make(chan error, 1)
+		go func() { done <- e.WaitTaskFinish() }()
+		select {
+		case err := <-done:
+			t.Fatalf("task generation %s reused a released endpoint: %v", taskID, err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		return done
+	}
+
+	create("task-generation-1")
+	done1 := waitAndAssertBlocked("task-generation-1")
+	complete("task-generation-1")
+	if err := <-done1; err != nil {
+		t.Fatalf("first task generation: %v", err)
+	}
+
+	create("task-generation-2")
+	done2 := waitAndAssertBlocked("task-generation-2")
+	complete("task-generation-2")
+	if err := <-done2; err != nil {
+		t.Fatalf("second task generation: %v", err)
+	}
+}
+
 // TestWaitTaskFinishByTaskNameAbortedReleasesEndpoint verifies that when the
 // endpoint is created and the task is then flipped to Aborted (which calls
 // Release()), WaitTaskFinishByTaskName unblocks and returns ErrAITaskAborted.

--- a/common/aiengine/aiengine_terminate_test.go
+++ b/common/aiengine/aiengine_terminate_test.go
@@ -17,11 +17,13 @@ func newEngineForTerminalTest(t *testing.T) *AIEngine {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
+	epm := aicommon.NewEndpointManagerContext(ctx)
 	return &AIEngine{
-		ctx:           ctx,
-		cancel:        cancel,
-		activeTasks:   make(map[string]aicommon.AITaskState),
-		taskEndpoints: make(map[string]*aicommon.Endpoint),
+		ctx:              ctx,
+		cancel:           cancel,
+		activeTasks:      make(map[string]aicommon.AITaskState),
+		allTasksEndpoint: epm.CreateEndpoint(),
+		taskEndpoints:    make(map[string]*aicommon.Endpoint),
 	}
 }
 
@@ -68,18 +70,27 @@ func TestProcessOutputEventAcceptsMixedTaskMetadata(t *testing.T) {
 func TestWaitTaskFinishByTaskNameFastPath(t *testing.T) {
 	e := newEngineForTerminalTest(t)
 	e.activeTasks["task-aborted"] = aicommon.AITaskState_Aborted
+	e.activeTasks["task-skipped"] = aicommon.AITaskState_Skipped
 
 	cases := []struct {
 		name    string
 		taskID  string
 		wantErr error // nil means expect a non-nil error (guards), only checked when set
+		wantNil bool
 	}{
-		{"aborted returns ErrAITaskAborted", "task-aborted", ErrAITaskAborted},
-		{"empty taskID errors", "", nil},
+		{"aborted returns ErrAITaskAborted", "task-aborted", ErrAITaskAborted, false},
+		{"skipped returns successfully", "task-skipped", nil, true},
+		{"empty taskID errors", "", nil, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := e.WaitTaskFinishByTaskName(tc.taskID)
+			if tc.wantNil {
+				if err != nil {
+					t.Fatalf("expected nil, got %v", err)
+				}
+				return
+			}
 			if tc.wantErr != nil {
 				if !errors.Is(err, tc.wantErr) {
 					t.Fatalf("expected %v, got %v", tc.wantErr, err)
@@ -90,6 +101,43 @@ func TestWaitTaskFinishByTaskNameFastPath(t *testing.T) {
 				t.Fatal("expected error, got nil")
 			}
 		})
+	}
+}
+
+// TestProcessOutputEventSkippedReleasesWaiter covers the real Stop path:
+// ReAct emits a skipped status change, AIEngine releases SendMsg, and skipped
+// no longer counts as active work that can hold the next queued turn hostage.
+func TestProcessOutputEventSkippedReleasesWaiter(t *testing.T) {
+	e := newEngineForTerminalTest(t)
+	taskID := "task-user-stopped"
+	e.activeTasks[taskID] = aicommon.AITaskState_Processing
+
+	epm := aicommon.NewEndpointManagerContext(e.ctx)
+	e.taskEndpoints[taskID] = epm.CreateEndpoint()
+	errCh := make(chan error, 1)
+	go func() { errCh <- e.WaitTaskFinishByTaskName(taskID) }()
+	time.Sleep(20 * time.Millisecond)
+
+	e.processOutputEvent(&schema.AiOutputEvent{
+		Type:   schema.EVENT_TYPE_STRUCTURED,
+		NodeId: "react_task_status_changed",
+		Content: []byte(`{
+			"react_task_id":"task-user-stopped",
+			"react_task_now_status":"skipped",
+			"react_task_old_status":"processing"
+		}`),
+	})
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("skipped Stop task returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("skipped Stop task did not release SendMsg waiter")
+	}
+	if e.hasActiveTasks() {
+		t.Fatal("skipped Stop task still counted as active")
 	}
 }
 

--- a/scannode/legion_ai_runtime_stateless.go
+++ b/scannode/legion_ai_runtime_stateless.go
@@ -60,6 +60,7 @@ func (statelessAIEngineRuntimeDriver) Bind(
 
 type statelessTurnEngine interface {
 	SendMsg(string, ...aiengine.AIEngineConfigOption) error
+	WaitTaskFinish() error
 	SendInputEvent(*ypb.AIInputEvent) error
 	Config() *aiengine.AIEngineConfig
 	Context() context.Context

--- a/scannode/legion_ai_runtime_stateless.go
+++ b/scannode/legion_ai_runtime_stateless.go
@@ -473,6 +473,12 @@ func (h *statelessAIEngineRuntimeHandle) runTurn(
 		)
 	} else {
 		err = turn.engine.SendMsg(userInput, options...)
+		if err == nil {
+			// SendMsg 只等待根任务。活跃 turn 期间接收的
+			// user_intervention 可能已进入同一 ReAct 队列；必须等它们
+			// 排空后才能 close stateless engine 并发布 turn.completed。
+			err = turn.engine.WaitTaskFinish()
+		}
 	}
 
 	h.mu.Lock()

--- a/scannode/legion_ai_runtime_stateless.go
+++ b/scannode/legion_ai_runtime_stateless.go
@@ -344,7 +344,11 @@ func (h *statelessAIEngineRuntimeHandle) sendInterventionInput(input aiSessionIn
 			turn.turnID,
 		)
 	}
-	if err := turn.engine.SendInputEvent(event); err != nil {
+	if turn.directForge && turn.forgeInput != nil {
+		if !turn.forgeInput.SafeFeedWithResult(event) {
+			return true, fmt.Errorf("stateless sendinput: direct forge intervention channel is closed")
+		}
+	} else if err := turn.engine.SendInputEvent(event); err != nil {
 		return true, fmt.Errorf("stateless sendinput: send user intervention: %w", err)
 	}
 	if h.closed || h.activeTurn != turn || turn.engine.Context().Err() != nil {
@@ -383,12 +387,17 @@ func (h *statelessAIEngineRuntimeHandle) sendSyncInput(input aiSessionInput) err
 		return fmt.Errorf("stateless sendinput: no active turn for sync event")
 	}
 	defer h.mu.Unlock()
-	if err := turn.engine.SendInputEvent(&ypb.AIInputEvent{
+	event := &ypb.AIInputEvent{
 		IsSyncMessage: true,
 		SyncType:      syncEvent.SyncType,
 		SyncJsonInput: syncEvent.SyncJSONInput,
 		SyncID:        syncEvent.SyncID,
-	}); err != nil {
+	}
+	if turn.directForge && turn.forgeInput != nil {
+		if !turn.forgeInput.SafeFeedWithResult(event) {
+			return fmt.Errorf("stateless sendinput: direct forge sync channel is closed")
+		}
+	} else if err := turn.engine.SendInputEvent(event); err != nil {
 		return fmt.Errorf("stateless sendinput: send sync event: %w", err)
 	}
 	if h.closed || h.activeTurn != turn || turn.engine.Context().Err() != nil {

--- a/scannode/legion_ai_runtime_stateless.go
+++ b/scannode/legion_ai_runtime_stateless.go
@@ -387,6 +387,7 @@ func (h *statelessAIEngineRuntimeHandle) sendSyncInput(input aiSessionInput) err
 		IsSyncMessage: true,
 		SyncType:      syncEvent.SyncType,
 		SyncJsonInput: syncEvent.SyncJSONInput,
+		SyncID:        syncEvent.SyncID,
 	}); err != nil {
 		return fmt.Errorf("stateless sendinput: send sync event: %w", err)
 	}

--- a/scannode/legion_ai_runtime_stateless_test.go
+++ b/scannode/legion_ai_runtime_stateless_test.go
@@ -174,7 +174,11 @@ type fakeStatelessTurnEngine struct {
 	eventRelease chan struct{}
 	sendErr      error
 	eventErr     error
+	drainStarted chan struct{}
+	drainRelease chan struct{}
+	drainErr     error
 	startOnce    sync.Once
+	drainOnce    sync.Once
 	closeOnce    sync.Once
 }
 
@@ -200,6 +204,20 @@ func (f *fakeStatelessTurnEngine) SendMsg(string, ...aiengine.AIEngineConfigOpti
 	case <-f.closed:
 	}
 	return f.sendErr
+}
+
+func (f *fakeStatelessTurnEngine) WaitTaskFinish() error {
+	if f.drainStarted == nil {
+		return f.drainErr
+	}
+	f.drainOnce.Do(func() { close(f.drainStarted) })
+	if f.drainRelease != nil {
+		select {
+		case <-f.drainRelease:
+		case <-f.closed:
+		}
+	}
+	return f.drainErr
 }
 
 func (f *fakeStatelessTurnEngine) SendInputEvent(event *ypb.AIInputEvent) error {

--- a/scannode/legion_ai_runtime_stateless_test.go
+++ b/scannode/legion_ai_runtime_stateless_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact"
 	"github.com/yaklang/yaklang/common/aiengine"
+	"github.com/yaklang/yaklang/common/utils/chanx"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 	aiv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/ai/v1"
 )
@@ -1009,6 +1010,84 @@ func TestStatelessActiveTurnPreservesSyncID(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("active turn did not receive sync input")
+	}
+}
+
+func TestStatelessDirectForgeRoutesQueuedInterventionToForgeInput(t *testing.T) {
+	engine := newFakeStatelessTurnEngine()
+	forgeInput := chanx.NewUnlimitedChan[*ypb.AIInputEvent](context.Background(), 2)
+	t.Cleanup(forgeInput.CloseForce)
+	handle := &statelessAIEngineRuntimeHandle{
+		activeTurn: &statelessAITurn{
+			engine:      engine,
+			turnID:      "turn-direct-forge-intervention",
+			directForge: true,
+			forgeInput:  forgeInput,
+		},
+	}
+
+	err := handle.SendInput(context.Background(), aiSessionInput{
+		Ref:         aiSessionCommandRef{CommandID: "queued-follow-up-1"},
+		InputType:   "user_intervention",
+		PayloadJSON: []byte(`{"content":"run after the current task stops"}`),
+	})
+	if err != nil {
+		t.Fatalf("send queued intervention: %v", err)
+	}
+
+	select {
+	case event := <-forgeInput.OutputChannel():
+		if !event.GetIsFreeInput() || event.GetFreeInput() != "run after the current task stops" {
+			t.Fatalf("unexpected Forge intervention: %#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("direct Forge did not receive the queued intervention")
+	}
+	select {
+	case event := <-engine.events:
+		t.Fatalf("queued intervention reached unused turn engine input: %#v", event)
+	default:
+	}
+}
+
+func TestStatelessDirectForgeRoutesSyncControlToForgeInput(t *testing.T) {
+	engine := newFakeStatelessTurnEngine()
+	forgeInput := chanx.NewUnlimitedChan[*ypb.AIInputEvent](context.Background(), 2)
+	t.Cleanup(forgeInput.CloseForce)
+	handle := &statelessAIEngineRuntimeHandle{
+		activeTurn: &statelessAITurn{
+			engine:      engine,
+			turnID:      "turn-direct-forge-sync",
+			directForge: true,
+			forgeInput:  forgeInput,
+		},
+	}
+
+	err := handle.SendInput(context.Background(), aiSessionInput{
+		InputType: "sync_event",
+		PayloadJSON: []byte(
+			`{"sync_type":"react_cancel_current_task","sync_id":"sync-stop-1","sync_json_input":{}}`,
+		),
+	})
+	if err != nil {
+		t.Fatalf("send sync control: %v", err)
+	}
+
+	select {
+	case event := <-forgeInput.OutputChannel():
+		if event.GetSyncType() != "react_cancel_current_task" {
+			t.Fatalf("sync type = %q", event.GetSyncType())
+		}
+		if event.GetSyncID() != "sync-stop-1" {
+			t.Fatalf("sync id = %q, want sync-stop-1", event.GetSyncID())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("direct Forge did not receive the sync control")
+	}
+	select {
+	case event := <-engine.events:
+		t.Fatalf("sync control reached unused turn engine input: %#v", event)
+	default:
 	}
 }
 

--- a/scannode/legion_ai_runtime_stateless_test.go
+++ b/scannode/legion_ai_runtime_stateless_test.go
@@ -238,6 +238,56 @@ func (f *fakeStatelessTurnEngine) Close() {
 	f.closeOnce.Do(func() { close(f.closed) })
 }
 
+func TestStatelessTurnWaitsForReActQueueDrainBeforeCompleting(t *testing.T) {
+	engine := newFakeStatelessTurnEngine()
+	engine.drainStarted = make(chan struct{})
+	engine.drainRelease = make(chan struct{})
+	emitter := recordingConversationTurnEmitter{
+		completed: make(chan conversationTurnResult, 1),
+		failed:    make(chan conversationTurnResult, 1),
+	}
+	turn := &statelessAITurn{engine: engine, turnID: "turn-with-queued-follow-up"}
+	handle := &statelessAIEngineRuntimeHandle{
+		emitter:    emitter,
+		activeTurn: turn,
+	}
+
+	go handle.runTurn(context.Background(), turn, "first")
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("root task did not start")
+	}
+	close(engine.release)
+	select {
+	case <-engine.drainStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stateless runtime did not wait for the ReAct queue to drain")
+	}
+	select {
+	case completed := <-emitter.completed:
+		t.Fatalf("turn completed before queued follow-up drained: %#v", completed)
+	case <-engine.closed:
+		t.Fatal("stateless engine closed before queued follow-up drained")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(engine.drainRelease)
+	select {
+	case completed := <-emitter.completed:
+		if completed.turnID != "turn-with-queued-follow-up" {
+			t.Fatalf("completed turn = %q", completed.turnID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("turn did not complete after queued follow-up drained")
+	}
+	select {
+	case <-engine.closed:
+	case <-time.After(time.Second):
+		t.Fatal("stateless engine did not close after queue drain")
+	}
+}
+
 func TestStatelessDriverBindReturnsHandleWithoutEngineField(t *testing.T) {
 	driver := newStatelessAIEngineRuntimeDriver()
 	binding := aiSessionBinding{

--- a/scannode/legion_ai_runtime_stateless_test.go
+++ b/scannode/legion_ai_runtime_stateless_test.go
@@ -980,6 +980,38 @@ func TestStatelessControlInputsAreLinearizedWithTurnClose(t *testing.T) {
 	}
 }
 
+func TestStatelessActiveTurnPreservesSyncID(t *testing.T) {
+	engine := newFakeStatelessTurnEngine()
+	handle := &statelessAIEngineRuntimeHandle{
+		activeTurn: &statelessAITurn{
+			engine: engine,
+			turnID: "turn-sync-id",
+		},
+	}
+
+	err := handle.SendInput(context.Background(), aiSessionInput{
+		InputType: "sync_event",
+		PayloadJSON: []byte(
+			`{"sync_type":"skip_subtask_in_plan","sync_id":"sync-skip-1","sync_json_input":{"skip_current_task":true}}`,
+		),
+	})
+	if err != nil {
+		t.Fatalf("send sync input: %v", err)
+	}
+
+	select {
+	case event := <-engine.events:
+		if event.GetSyncID() != "sync-skip-1" {
+			t.Fatalf("sync id = %q, want sync-skip-1", event.GetSyncID())
+		}
+		if event.GetSyncType() != "skip_subtask_in_plan" {
+			t.Fatalf("sync type = %q", event.GetSyncType())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("active turn did not receive sync input")
+	}
+}
+
 func TestStatelessTaskScopedCapabilityHotpatchDoesNotPersist(t *testing.T) {
 	engine := newFakeStatelessTurnEngine()
 	handle := &statelessAIEngineRuntimeHandle{

--- a/scannode/legion_ai_runtime_yak.go
+++ b/scannode/legion_ai_runtime_yak.go
@@ -241,6 +241,12 @@ func (h *yakAIEngineRuntimeHandle) sendMessage(queued yakAIQueuedMessage) {
 	}
 
 	err := h.engine.SendMsg(queued.content, queued.options...)
+	if err == nil {
+		// SendMsg 只等待本次根任务。用户可能在它执行期间已经
+		// 追加了 ReAct 队列任务；Stop 会让根任务进入 Skipped，但
+		// 平台 Turn 必须等这些同一 runtime 内的任务排空后才能完成。
+		err = h.engine.WaitTaskFinish()
+	}
 	h.finishMessageTurn(queued.turnID, err, yakAISendFailureCode(err), map[string]string{
 		"runtime": "yak_ai_engine",
 	})

--- a/scannode/legion_ai_runtime_yak_test.go
+++ b/scannode/legion_ai_runtime_yak_test.go
@@ -63,6 +63,49 @@ func TestStatefulDriverKeepsConversationRuntimeAfterTurnFailure(t *testing.T) {
 	}
 }
 
+func TestStatefulTurnWaitsForReActQueueDrainBeforeCompleting(t *testing.T) {
+	engine := newFakeStatelessTurnEngine()
+	engine.drainStarted = make(chan struct{})
+	engine.drainRelease = make(chan struct{})
+	emitter := recordingConversationTurnEmitter{
+		completed: make(chan conversationTurnResult, 1),
+		failed:    make(chan conversationTurnResult, 1),
+	}
+	handle := &yakAIEngineRuntimeHandle{
+		engine:       engine,
+		emitter:      emitter,
+		messageQueue: make(chan yakAIQueuedMessage, 1),
+	}
+
+	go handle.sendMessage(yakAIQueuedMessage{turnID: "turn-with-queued-follow-up", content: "first"})
+	select {
+	case <-engine.started:
+	case <-time.After(time.Second):
+		t.Fatal("root task did not start")
+	}
+	close(engine.release)
+	select {
+	case <-engine.drainStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stateful runtime did not wait for the ReAct queue to drain")
+	}
+	select {
+	case completed := <-emitter.completed:
+		t.Fatalf("turn completed before queued follow-up drained: %#v", completed)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(engine.drainRelease)
+	select {
+	case completed := <-emitter.completed:
+		if completed.turnID != "turn-with-queued-follow-up" {
+			t.Fatalf("completed turn = %q", completed.turnID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("turn did not complete after queued follow-up drained")
+	}
+}
+
 func TestStatefulControlInputIsLinearizedWithTerminalClose(t *testing.T) {
 	engine := newFakeStatelessTurnEngine()
 	engine.eventStarted = make(chan struct{})

--- a/scannode/runtime_host.go
+++ b/scannode/runtime_host.go
@@ -41,35 +41,37 @@ var runtimeHostSHA256Pattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
 var runtimeHostReleaseIDPattern = regexp.MustCompile(`^sha256-[a-f0-9]{64}$`)
 
 type RuntimeHostConfig struct {
-	Enabled             bool
-	BaseDir             string
-	PlatformAPIBaseURL  string
-	EnrollmentToken     string
-	AgentInstallationID string
-	EngineReleaseID     string
-	EngineDigest        string
-	Network             string
-	HTTPClient          *http.Client
-	NodeIDProvider      func() string
-	SessionProvider     func() (node.SessionState, bool)
-	docker              runtimeHostDocker
+	Enabled                   bool
+	BaseDir                   string
+	PlatformAPIBaseURL        string
+	RuntimePlatformAPIBaseURL string
+	EnrollmentToken           string
+	AgentInstallationID       string
+	EngineReleaseID           string
+	EngineDigest              string
+	Network                   string
+	HTTPClient                *http.Client
+	NodeIDProvider            func() string
+	SessionProvider           func() (node.SessionState, bool)
+	docker                    runtimeHostDocker
 }
 
 type runtimeHostExecutor struct {
-	docker              runtimeHostDocker
-	baseDir             string
-	platformAPIBaseURL  string
-	enrollmentToken     string
-	agentInstallationID string
-	engineReleaseID     string
-	engineDigest        string
-	network             string
-	httpClient          *http.Client
-	nodeIDProvider      func() string
-	sessionProvider     func() (node.SessionState, bool)
-	operations          map[string]runtimeHostOperationRecord
-	images              map[string]runtimeHostImageRecord
-	mu                  sync.Mutex
+	docker                    runtimeHostDocker
+	baseDir                   string
+	platformAPIBaseURL        string
+	runtimePlatformAPIBaseURL string
+	enrollmentToken           string
+	agentInstallationID       string
+	engineReleaseID           string
+	engineDigest              string
+	network                   string
+	httpClient                *http.Client
+	nodeIDProvider            func() string
+	sessionProvider           func() (node.SessionState, bool)
+	operations                map[string]runtimeHostOperationRecord
+	images                    map[string]runtimeHostImageRecord
+	mu                        sync.Mutex
 }
 
 type runtimeHostStatusDetail struct {
@@ -106,21 +108,31 @@ func newRuntimeHostExecutor(cfg RuntimeHostConfig) (*runtimeHostExecutor, error)
 	if client == nil {
 		client = &http.Client{Timeout: 5 * time.Minute}
 	}
+	platformAPIBaseURL := strings.TrimRight(strings.TrimSpace(cfg.PlatformAPIBaseURL), "/")
+	runtimePlatformAPIBaseURL := strings.TrimRight(strings.TrimSpace(cfg.RuntimePlatformAPIBaseURL), "/")
+	if runtimePlatformAPIBaseURL == "" {
+		runtimePlatformAPIBaseURL = platformAPIBaseURL
+	}
 	executor := &runtimeHostExecutor{
-		docker:              dockerClient,
-		baseDir:             strings.TrimSpace(cfg.BaseDir),
-		platformAPIBaseURL:  strings.TrimRight(strings.TrimSpace(cfg.PlatformAPIBaseURL), "/"),
-		enrollmentToken:     strings.TrimSpace(cfg.EnrollmentToken),
-		agentInstallationID: strings.TrimSpace(cfg.AgentInstallationID),
-		engineReleaseID:     strings.TrimSpace(cfg.EngineReleaseID),
-		engineDigest:        strings.ToLower(strings.TrimSpace(cfg.EngineDigest)),
-		network:             network,
-		httpClient:          client,
-		nodeIDProvider:      cfg.NodeIDProvider,
-		sessionProvider:     cfg.SessionProvider,
+		docker:                    dockerClient,
+		baseDir:                   strings.TrimSpace(cfg.BaseDir),
+		platformAPIBaseURL:        platformAPIBaseURL,
+		runtimePlatformAPIBaseURL: runtimePlatformAPIBaseURL,
+		enrollmentToken:           strings.TrimSpace(cfg.EnrollmentToken),
+		agentInstallationID:       strings.TrimSpace(cfg.AgentInstallationID),
+		engineReleaseID:           strings.TrimSpace(cfg.EngineReleaseID),
+		engineDigest:              strings.ToLower(strings.TrimSpace(cfg.EngineDigest)),
+		network:                   network,
+		httpClient:                client,
+		nodeIDProvider:            cfg.NodeIDProvider,
+		sessionProvider:           cfg.SessionProvider,
 	}
 	if executor.baseDir == "" {
 		return nil, fmt.Errorf("runtime host base directory is required")
+	}
+	if !runtimeHostURLHasScheme(executor.platformAPIBaseURL, "http", "https") ||
+		!runtimeHostURLHasScheme(executor.runtimePlatformAPIBaseURL, "http", "https") {
+		return nil, fmt.Errorf("runtime host platform API URLs must use http or https")
 	}
 	if executor.enrollmentToken == "" || executor.agentInstallationID == "" ||
 		executor.nodeIDProvider == nil || executor.sessionProvider == nil {
@@ -316,7 +328,11 @@ func (e *runtimeHostExecutor) validateContainerSpec(spec *nodev1.AIRuntimeContai
 	if spec.Environment["LEGION_AI_SESSION_ID"] != sessionID || strings.TrimSpace(spec.Environment["LEGION_ENROLLMENT_TOKEN"]) == "" {
 		return fmt.Errorf("runtime container startup credential is missing")
 	}
-	if strings.TrimRight(spec.Environment["LEGION_API_URL"], "/") != e.platformAPIBaseURL ||
+	runtimePlatformAPIBaseURL := e.runtimePlatformAPIBaseURL
+	if runtimePlatformAPIBaseURL == "" {
+		runtimePlatformAPIBaseURL = e.platformAPIBaseURL
+	}
+	if strings.TrimRight(spec.Environment["LEGION_API_URL"], "/") != runtimePlatformAPIBaseURL ||
 		spec.Environment["LEGION_AI_RUNTIME"] != "stateless" ||
 		!runtimeHostURLHasScheme(spec.Environment["LEGION_SESSIONMGR_URL"], "http", "https") ||
 		!runtimeHostURLHasScheme(spec.Environment["LEGION_NATS_URL"], "nats") {

--- a/scannode/runtime_host.go
+++ b/scannode/runtime_host.go
@@ -39,6 +39,7 @@ const (
 var runtimeHostIdentifierPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.:-]{0,191}$`)
 var runtimeHostSHA256Pattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
 var runtimeHostReleaseIDPattern = regexp.MustCompile(`^sha256-[a-f0-9]{64}$`)
+var errRuntimeHostReleaseMismatch = errors.New("runtime release does not match the installed node release")
 
 type RuntimeHostConfig struct {
 	Enabled                   bool
@@ -213,12 +214,25 @@ func (b *legionJobBridge) handleAIRuntimeHostCommand(ctx context.Context, payloa
 		return rejectRuntimeHostCommand(fmt.Errorf("node session is unavailable"))
 	}
 	if err := b.agent.runtimeHost.validateCommand(command, session); err != nil {
+		if errors.Is(err, errRuntimeHostReleaseMismatch) {
+			// The command was authenticated for this live Node session, but it
+			// belongs to a container pinned to an older release. Return a signed
+			// terminal result so Session Manager can release its cleanup claim and
+			// continue reconciling new sessions instead of waiting forever.
+			return b.publishRuntimeHostResult(
+				runtimeHostRejectedResult(command, session, "release_mismatch", err),
+				session,
+			)
+		}
 		// Authentication, expiry, target-session and fixed-spec failures cannot
 		// become valid on redelivery. Mark them terminal so an old node-session
 		// message cannot occupy the durable consumer after a restart.
 		return rejectRuntimeHostCommand(err)
 	}
-	result := b.agent.runtimeHost.execute(ctx, command, session)
+	return b.publishRuntimeHostResult(b.agent.runtimeHost.execute(ctx, command, session), session)
+}
+
+func (b *legionJobBridge) publishRuntimeHostResult(result *nodev1.AIRuntimeResult, session node.SessionState) error {
 	if err := signRuntimeHostResult(result, b.agent.runtimeHost.enrollmentToken, session.SessionID); err != nil {
 		return err
 	}
@@ -232,7 +246,7 @@ func (b *legionJobBridge) handleAIRuntimeHostCommand(ctx context.Context, payloa
 	if consumer == nil || consumer.conn == nil {
 		return fmt.Errorf("runtime host reply transport is unavailable")
 	}
-	return consumer.conn.Publish(command.ReplySubject, encoded)
+	return consumer.conn.Publish(runtimeHostReplyPrefix+result.CommandId, encoded)
 }
 
 func (e *runtimeHostExecutor) validateCommand(command *nodev1.AIRuntimeCommand, session node.SessionState) error {
@@ -270,7 +284,7 @@ func (e *runtimeHostExecutor) validateCommand(command *nodev1.AIRuntimeCommand, 
 	}
 	if command.Release.ReleaseId != e.engineReleaseID ||
 		!strings.EqualFold(command.Release.EngineDigest, e.engineDigest) {
-		return fmt.Errorf("runtime release does not match the installed node release")
+		return errRuntimeHostReleaseMismatch
 	}
 	if command.Operation == nodev1.AIRuntimeOperation_AI_RUNTIME_OPERATION_START {
 		return e.validateContainerSpec(command.Container, command.AiSessionId)
@@ -388,15 +402,7 @@ func runtimeHostArgumentsMatch(arguments []string, flag, expected string) bool {
 }
 
 func (e *runtimeHostExecutor) execute(ctx context.Context, command *nodev1.AIRuntimeCommand, session node.SessionState) *nodev1.AIRuntimeResult {
-	result := &nodev1.AIRuntimeResult{
-		Metadata: &nodev1.EventMetadata{
-			EventId: uuid.NewString(), EventType: "ai.runtime.result", CausationId: command.Metadata.CommandId,
-			CorrelationId: command.AiSessionId, EmittedAt: timestamppb.Now(),
-			Node: &nodev1.NodeRef{NodeId: command.Target.NodeId, NodeSessionId: session.SessionID},
-		},
-		CommandId: command.Metadata.CommandId, Operation: command.Operation,
-		AiSessionId: command.AiSessionId, CleanupKey: command.CleanupKey, LeaseToken: command.LeaseToken,
-	}
+	result := newRuntimeHostResult(command, session)
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	var err error
@@ -415,6 +421,27 @@ func (e *runtimeHostExecutor) execute(ctx context.Context, command *nodev1.AIRun
 	result.Success = err == nil
 	if err != nil {
 		result.ErrorCode = runtimeHostOperationErrorCode(err)
+		result.ErrorMessage = err.Error()
+	}
+	return result
+}
+
+func newRuntimeHostResult(command *nodev1.AIRuntimeCommand, session node.SessionState) *nodev1.AIRuntimeResult {
+	return &nodev1.AIRuntimeResult{
+		Metadata: &nodev1.EventMetadata{
+			EventId: uuid.NewString(), EventType: "ai.runtime.result", CausationId: command.Metadata.CommandId,
+			CorrelationId: command.AiSessionId, EmittedAt: timestamppb.Now(),
+			Node: &nodev1.NodeRef{NodeId: command.Target.NodeId, NodeSessionId: session.SessionID},
+		},
+		CommandId: command.Metadata.CommandId, Operation: command.Operation,
+		AiSessionId: command.AiSessionId, CleanupKey: command.CleanupKey, LeaseToken: command.LeaseToken,
+	}
+}
+
+func runtimeHostRejectedResult(command *nodev1.AIRuntimeCommand, session node.SessionState, code string, err error) *nodev1.AIRuntimeResult {
+	result := newRuntimeHostResult(command, session)
+	result.ErrorCode = strings.TrimSpace(code)
+	if err != nil {
 		result.ErrorMessage = err.Error()
 	}
 	return result

--- a/scannode/runtime_host_test.go
+++ b/scannode/runtime_host_test.go
@@ -230,6 +230,31 @@ func TestRuntimeHostCommandAuthenticationRejectsTampering(t *testing.T) {
 	}
 }
 
+func TestRuntimeHostAcceptsPinnedContainerAPIOriginDistinctFromHostBootstrap(t *testing.T) {
+	command := runtimeHostTestCommand(t)
+	const runtimeAPIURL = "http://host.docker.internal:8080"
+	command.Container.Environment["LEGION_API_URL"] = runtimeAPIURL
+	command.Container.Arguments[1] = runtimeAPIURL
+	runtimeHostSignTestCommand(t, command)
+	executor := &runtimeHostExecutor{
+		enrollmentToken: "enrollment-ticket", network: "bridge",
+		platformAPIBaseURL: "http://127.0.0.1:8080", runtimePlatformAPIBaseURL: runtimeAPIURL,
+		engineReleaseID: command.Release.ReleaseId, engineDigest: command.Release.EngineDigest,
+		nodeIDProvider: func() string { return "node-1" },
+	}
+	session := node.SessionState{NodeID: "node-1", SessionID: "node-session-1"}
+	if err := executor.validateCommand(command, session); err != nil {
+		t.Fatalf("validateCommand() rejected the pinned container API origin: %v", err)
+	}
+
+	command.Container.Environment["LEGION_API_URL"] = "http://another.invalid"
+	command.Container.Arguments[1] = "http://another.invalid"
+	runtimeHostSignTestCommand(t, command)
+	if err := executor.validateCommand(command, session); err == nil {
+		t.Fatal("validateCommand() accepted a container API origin outside the pinned startup contract")
+	}
+}
+
 func TestRuntimeHostCommandRejectionIsTerminallyTyped(t *testing.T) {
 	cause := errors.New("targets another node session")
 	err := rejectRuntimeHostCommand(cause)
@@ -249,6 +274,22 @@ func TestRuntimeHostCannotEnableWithoutAuthenticatedNodeIdentity(t *testing.T) {
 		},
 	})
 	if err == nil || !strings.Contains(err.Error(), "authenticated node identity") {
+		t.Fatalf("newRuntimeHostExecutor() error = %v", err)
+	}
+}
+
+func TestRuntimeHostRejectsInvalidRuntimePlatformAPIURL(t *testing.T) {
+	_, err := newRuntimeHostExecutor(RuntimeHostConfig{
+		Enabled: true, BaseDir: t.TempDir(), PlatformAPIBaseURL: "http://platform.invalid",
+		RuntimePlatformAPIBaseURL: "file:///tmp/platform.sock",
+		EnrollmentToken:           "enrollment-ticket", AgentInstallationID: "host-installation-1",
+		EngineReleaseID: "sha256-" + strings.Repeat("d", 64), EngineDigest: strings.Repeat("a", 64),
+		Network: "bridge", docker: &runtimeHostDockerStub{}, NodeIDProvider: func() string { return "node-1" },
+		SessionProvider: func() (node.SessionState, bool) {
+			return node.SessionState{NodeID: "node-1", SessionID: "node-session-1"}, true
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "platform API URLs") {
 		t.Fatalf("newRuntimeHostExecutor() error = %v", err)
 	}
 }

--- a/scannode/runtime_host_test.go
+++ b/scannode/runtime_host_test.go
@@ -334,8 +334,17 @@ func TestRuntimeHostRejectsReleaseDifferentFromInstalledNode(t *testing.T) {
 	session := node.SessionState{NodeID: "node-1", SessionID: "node-session-1"}
 	command.Release.EngineDigest = strings.Repeat("e", 64)
 	runtimeHostSignTestCommand(t, command)
-	if err := executor.validateCommand(command, session); err == nil {
+	err := executor.validateCommand(command, session)
+	if !errors.Is(err, errRuntimeHostReleaseMismatch) {
 		t.Fatal("validateCommand() accepted a release different from the installed node")
+	}
+	result := runtimeHostRejectedResult(command, session, "release_mismatch", err)
+	if result.Success || result.ErrorCode != "release_mismatch" || result.ErrorMessage != err.Error() ||
+		result.CommandId != command.Metadata.CommandId || result.Metadata.Node.NodeSessionId != session.SessionID {
+		t.Fatalf("release mismatch result lost its command binding: %+v", result)
+	}
+	if signErr := signRuntimeHostResult(result, executor.enrollmentToken, session.SessionID); signErr != nil || len(result.AuthTag) == 0 {
+		t.Fatalf("release mismatch result was not signed: tag=%x err=%v", result.AuthTag, signErr)
 	}
 }
 


### PR DESCRIPTION
## 改动摘要

- 修复无状态 AI Runtime 的同步控制路由，保留控制命令身份并向调用方返回明确确认。
- 停止当前任务时取消进行中的模型请求，并确保已排队的用户输入在当前任务结束后继续出队。
- 收敛过期清理命令与嵌套 ReAct 循环的终止行为，避免停止命令悬空或队列提前结束。
- 固定 Runtime 容器回连平台 API 的地址契约。

## 主要文件

- `common/ai/aid/aireact/`：任务取消、队列排空与同步控制。
- `common/aiengine/`：模型请求终止语义。
- `scannode/`：无状态 Runtime 输入路由、确认与容器启动契约。
- `cmd/legion-smoke-node/`：Runtime Host 启动参数。

## 验证方式

- 变更包的聚焦 Go 单元测试与竞态测试在 rebase 前通过。
- 本地隔离 AI Dev 栈曾验证真实 Provider 生成 Plan、消息入队、Stop 确认、当前任务取消、队列消息出队及会话回到等待状态。
- 分支已无冲突 rebase 到最新 `origin/main`；最新提交的完整验证交由本 PR CI 执行。

