### PR TITLE
fix(ai): add exponential retry backoff

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -214,6 +214,7 @@ type Config struct {
 	AiCallTokenLimit       int64
 	AiAutoRetry            int64
 	AiTransactionAutoRetry int64
+	aiRetryWaitFunc        func(context.Context, time.Duration) error
 	PromptHook             func(string) string
 
 	/*
@@ -679,6 +680,7 @@ func newConfig(ctx context.Context) *Config {
 		m:                                  new(sync.Mutex),
 		InitStatus:                         initStatus,
 		AiCallTokenLimit:                   40 * 1024, // Default to 40 k
+		aiRetryWaitFunc:                    aiRetryWaitFuncFromContext(ctx),
 		SessionPromptState:                 NewSessionPromptState(),
 	}
 	config.AiToolManagerOption = append(config.AiToolManagerOption,
@@ -1130,6 +1132,31 @@ func WithAITransactionAutoRetry(n int64) ConfigOption {
 		c.m.Unlock()
 		return nil
 	}
+}
+
+// WithAIRetryWaitFunc overrides how retry delays are waited. It is primarily
+// useful for deterministic tests that need to observe retries without sleeping
+// for the production backoff duration. A nil function restores the default,
+// context-aware timer.
+func WithAIRetryWaitFunc(wait func(context.Context, time.Duration) error) ConfigOption {
+	return func(c *Config) error {
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		defer c.m.Unlock()
+		c.aiRetryWaitFunc = wait
+		c.Ctx = withAIRetryWaitFuncContext(c.Ctx, wait)
+		return nil
+	}
+}
+
+// GetAIRetryWaitFunc returns the configured retry waiter for child runtimes.
+func (c *Config) GetAIRetryWaitFunc() func(context.Context, time.Duration) error {
+	if c == nil {
+		return nil
+	}
+	return c.aiRetryWaitFunc
 }
 
 func WithAiCallTokenLimit(limit int64) ConfigOption {
@@ -4042,6 +4069,9 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 	}
 	if i.AiAutoRetry > 0 {
 		opts = append(opts, WithAIAutoRetry(i.AiAutoRetry))
+	}
+	if i.aiRetryWaitFunc != nil {
+		opts = append(opts, WithAIRetryWaitFunc(i.aiRetryWaitFunc))
 	}
 	if i.AiCallTokenLimit > 0 {
 		opts = append(opts, WithAiCallTokenLimit(i.AiCallTokenLimit))

--- a/common/ai/aid/aicommon/config_ai_wrapper.go
+++ b/common/ai/aid/aicommon/config_ai_wrapper.go
@@ -170,11 +170,8 @@ func (c *Config) wrapper(i AICallbackType, tier consts.ModelTier) AICallbackType
 				}
 				if err != nil || rsp == nil {
 					_idx++
-					c.EmitWarning("ai request err: %v, retry auto time: [%v]", err, _idx)
-					select {
-					case <-requestCtx.Done():
-						return nil, requestCtx.Err()
-					case <-time.After(500 * time.Millisecond):
+					if waitErr := c.waitBeforeNextAIRequestRetry(requestCtx, err, _idx, int(c.AiAutoRetry)); waitErr != nil {
+						return nil, waitErr
 					}
 					continue
 				}
@@ -249,11 +246,8 @@ func (c *Config) wrapper(i AICallbackType, tier consts.ModelTier) AICallbackType
 			}
 			if err != nil || rsp == nil {
 				_idx++
-				c.EmitWarning("ai request err: %v, retry auto time: [%v]", err, _idx)
-				select {
-				case <-requestCtx.Done():
-					return nil, requestCtx.Err()
-				case <-time.After(500 * time.Millisecond):
+				if waitErr := c.waitBeforeNextAIRequestRetry(requestCtx, err, _idx, int(c.AiAutoRetry)); waitErr != nil {
+					return nil, waitErr
 				}
 				continue
 			}

--- a/common/ai/aid/aicommon/retry_backoff.go
+++ b/common/ai/aid/aicommon/retry_backoff.go
@@ -1,0 +1,95 @@
+package aicommon
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	aiRetryInitialBackoff = 2 * time.Second
+	aiRetryMaxBackoff     = 32 * time.Second
+)
+
+// aiRetryBackoff returns the delay before the numbered retry. The first retry
+// waits two seconds, then the delay doubles until it reaches 32 seconds.
+func aiRetryBackoff(retryNumber int64) time.Duration {
+	if retryNumber <= 0 {
+		return 0
+	}
+	if retryNumber >= 5 {
+		return aiRetryMaxBackoff
+	}
+	return aiRetryInitialBackoff << (retryNumber - 1)
+}
+
+type aiRetryWaiter interface {
+	waitBeforeAIRetry(context.Context, time.Duration) error
+}
+
+type aiRetryWaitFuncContextKey struct{}
+
+type aiRetryWaitFuncContextValue struct {
+	wait func(context.Context, time.Duration) error
+}
+
+func withAIRetryWaitFuncContext(ctx context.Context, wait func(context.Context, time.Duration) error) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, aiRetryWaitFuncContextKey{}, aiRetryWaitFuncContextValue{wait: wait})
+}
+
+func aiRetryWaitFuncFromContext(ctx context.Context) func(context.Context, time.Duration) error {
+	if ctx == nil {
+		return nil
+	}
+	value, ok := ctx.Value(aiRetryWaitFuncContextKey{}).(aiRetryWaitFuncContextValue)
+	if !ok {
+		return nil
+	}
+	return value.wait
+}
+
+// waitBeforeAIRetry keeps retry delays context-aware and gives package tests a
+// clock seam, so the production schedule can be verified without sleeping for
+// the full backoff duration.
+func waitBeforeAIRetry(ctx context.Context, owner any, delay time.Duration) error {
+	if waiter, ok := owner.(aiRetryWaiter); ok {
+		return waiter.waitBeforeAIRetry(ctx, delay)
+	}
+	return waitBeforeAIRetryDefault(ctx, delay)
+}
+
+func waitBeforeAIRetryDefault(ctx context.Context, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (c *Config) waitBeforeAIRetry(ctx context.Context, delay time.Duration) error {
+	if c.aiRetryWaitFunc != nil {
+		return c.aiRetryWaitFunc(ctx, delay)
+	}
+	return waitBeforeAIRetryDefault(ctx, delay)
+}
+
+func (c *Config) waitBeforeNextAIRequestRetry(ctx context.Context, err error, failedAttempt, maxAttempts int) error {
+	if failedAttempt >= maxAttempts {
+		c.EmitWarning("ai request err: %v, retry auto time: [%v/%v]", err, failedAttempt, maxAttempts)
+		return nil
+	}
+	retryDelay := aiRetryBackoff(int64(failedAttempt))
+	c.EmitWarning("ai request err: %v, retry auto time: [%v/%v], retrying in %s", err, failedAttempt, maxAttempts, retryDelay)
+	return waitBeforeAIRetry(ctx, c, retryDelay)
+}

--- a/common/ai/aid/aicommon/retry_backoff_test.go
+++ b/common/ai/aid/aicommon/retry_backoff_test.go
@@ -1,0 +1,216 @@
+package aicommon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/consts"
+)
+
+func TestAIRetryBackoffSchedule(t *testing.T) {
+	tests := []struct {
+		retryNumber int64
+		want        time.Duration
+	}{
+		{retryNumber: 0, want: 0},
+		{retryNumber: 1, want: 2 * time.Second},
+		{retryNumber: 2, want: 4 * time.Second},
+		{retryNumber: 3, want: 8 * time.Second},
+		{retryNumber: 4, want: 16 * time.Second},
+		{retryNumber: 5, want: 32 * time.Second},
+		{retryNumber: 6, want: 32 * time.Second},
+		{retryNumber: 100, want: 32 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("retry_%d", tt.retryNumber), func(t *testing.T) {
+			require.Equal(t, tt.want, aiRetryBackoff(tt.retryNumber))
+		})
+	}
+}
+
+func TestCallAITransaction_502UsesExponentialBackoff(t *testing.T) {
+	cfg := newTransactionTestConfig(context.Background())
+	cfg.retryMax = 6
+
+	var waits []time.Duration
+	cfg.retryWait = func(_ context.Context, delay time.Duration) error {
+		waits = append(waits, delay)
+		return nil
+	}
+
+	callCount := 0
+	callAI := func(*AIRequest) (*AIResponse, error) {
+		callCount++
+		return make502Response(), fmt.Errorf("HTTP 502: bad gateway")
+	}
+
+	err := CallAITransaction(cfg, "test 502 backoff", callAI, func(*AIResponse) error {
+		t.Fatal("post handler must not run after an API error")
+		return nil
+	})
+	require.ErrorContains(t, err, "502")
+	require.Equal(t, 6, callCount)
+	require.Equal(t, []time.Duration{
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+	}, waits, "the final failed attempt must not add a useless sleep")
+}
+
+func TestCallAITransaction_PostHandlerErrorUsesExponentialBackoff(t *testing.T) {
+	cfg := newTransactionTestConfig(context.Background())
+	cfg.retryMax = 4
+
+	var waits []time.Duration
+	cfg.retryWait = func(_ context.Context, delay time.Duration) error {
+		waits = append(waits, delay)
+		return nil
+	}
+
+	callCount := 0
+	err := CallAITransaction(cfg, "test post-handler backoff", func(*AIRequest) (*AIResponse, error) {
+		callCount++
+		rsp := NewUnboundAIResponse()
+		rsp.Close()
+		return rsp, nil
+	}, func(*AIResponse) error {
+		return fmt.Errorf("invalid model action")
+	})
+
+	require.ErrorContains(t, err, "invalid model action")
+	require.Equal(t, 4, callCount)
+	require.Equal(t, []time.Duration{
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+	}, waits)
+}
+
+func TestCallAITransaction_429KeepsRetryAfterBackoff(t *testing.T) {
+	cfg := newTransactionTestConfig(context.Background())
+	cfg.retryMax = 1
+
+	var waits []time.Duration
+	cfg.retryWait = func(_ context.Context, delay time.Duration) error {
+		waits = append(waits, delay)
+		return nil
+	}
+
+	callCount := 0
+	err := CallAITransaction(cfg, "test 429 backoff", func(*AIRequest) (*AIResponse, error) {
+		callCount++
+		if callCount == 1 {
+			return make429Response("Retry-After: 10"), fmt.Errorf("HTTP 429: rate limited")
+		}
+		rsp := NewUnboundAIResponse()
+		rsp.Close()
+		return rsp, nil
+	}, func(*AIResponse) error { return nil })
+
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "retryable 429 must not consume the transaction attempt")
+	require.Len(t, waits, 1)
+	require.GreaterOrEqual(t, waits[0], 10*time.Second)
+	require.LessOrEqual(t, waits[0], 12*time.Second)
+}
+
+func TestCallAITransaction_BackoffStopsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := newTransactionTestConfig(ctx)
+	cfg.retryMax = 6
+	cfg.retryWait = waitBeforeAIRetryDefault
+
+	callCount := 0
+	time.AfterFunc(20*time.Millisecond, cancel)
+	start := time.Now()
+	err := CallAITransaction(cfg, "test canceled backoff", func(*AIRequest) (*AIResponse, error) {
+		callCount++
+		return make502Response(), fmt.Errorf("HTTP 502: bad gateway")
+	}, func(*AIResponse) error { return nil })
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, callCount, "cancellation during backoff must prevent the next request")
+	require.Less(t, time.Since(start), time.Second)
+}
+
+func TestAIRequestWrapper_502UsesExponentialBackoff(t *testing.T) {
+	cfg := newConfig(context.Background())
+	cfg.AiAutoRetry = 6
+
+	var waits []time.Duration
+	cfg.aiRetryWaitFunc = func(_ context.Context, delay time.Duration) error {
+		waits = append(waits, delay)
+		return nil
+	}
+
+	callCount := 0
+	callback := cfg.wrapper(func(AICallerConfigIf, *AIRequest) (*AIResponse, error) {
+		callCount++
+		return make502Response(), fmt.Errorf("HTTP 502: bad gateway")
+	}, consts.TierIntelligent)
+	request := NewAIRequest("test request backoff")
+	request.SetDetachCheckpoint(true)
+
+	_, err := callback(cfg, request)
+	require.ErrorContains(t, err, "502")
+	require.Equal(t, 6, callCount)
+	require.Equal(t, []time.Duration{
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+	}, waits)
+}
+
+func TestWaitBeforeAIRetryDefault_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := waitBeforeAIRetryDefault(ctx, 32*time.Second)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, time.Since(start), 100*time.Millisecond)
+}
+
+func TestConvertConfigToOptions_PreservesAIRetryWaitFunc(t *testing.T) {
+	var waited time.Duration
+	waitFunc := func(ctx context.Context, delay time.Duration) error {
+		waited = delay
+		return ctx.Err()
+	}
+
+	parent := NewConfig(context.Background(), WithAIRetryWaitFunc(waitFunc))
+	child := NewConfig(context.Background(), ConvertConfigToOptions(parent)...)
+	require.NoError(t, child.waitBeforeAIRetry(context.Background(), 8*time.Second))
+	require.Equal(t, 8*time.Second, waited)
+}
+
+func TestNewConfig_PreservesAIRetryWaitFuncFromContext(t *testing.T) {
+	var waited time.Duration
+	waitFunc := func(ctx context.Context, delay time.Duration) error {
+		waited = delay
+		return ctx.Err()
+	}
+
+	parent := NewConfig(context.Background(), WithAIRetryWaitFunc(waitFunc))
+	child := NewConfig(parent.GetContext())
+	require.NoError(t, child.waitBeforeAIRetry(context.Background(), 16*time.Second))
+	require.Equal(t, 16*time.Second, waited)
+}
+
+func make502Response() *AIResponse {
+	rsp := NewUnboundAIResponse()
+	rsp.SetRawHTTPResponseData(
+		[]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\n\r\n"),
+		[]byte(`{"error":"bad gateway"}`),
+	)
+	return rsp
+}

--- a/common/ai/aid/aicommon/transaction.go
+++ b/common/ai/aid/aicommon/transaction.go
@@ -164,12 +164,10 @@ func callAITransaction(
 					attemptHistory = append(attemptHistory, buildAttemptRecord(i+1, finalPrompt, err, rsp))
 					retryAfter := parseRetryAfterSeconds(rsp, 5)
 					waitSec := capRetryAfterSeconds(jitterSeconds(retryAfter, 3), 1, 120)
-					select {
-					case <-transactionCtx.Done():
-						return transactionCtx.Err()
-					case <-time.After(time.Duration(waitSec) * time.Second):
-						continue
+					if waitErr := waitBeforeAIRetry(transactionCtx, c, time.Duration(waitSec)*time.Second); waitErr != nil {
+						return waitErr
 					}
+					continue
 				}
 				// 额度耗尽类 429：不可重试，消耗重试次数让上层暴露错误。
 				rspEmitter.EmitWarning("429 quota exceeded in transaction layer (seq=%d), not retryable", getSeq())
@@ -178,21 +176,12 @@ func callAITransaction(
 			i++
 			attemptHistory = append(attemptHistory, buildAttemptRecord(i, finalPrompt, err, rsp))
 			rspEmitter.EmitError("call ai api error (attempt %d/%d): %v", i, trcRetry, err)
-			select {
-			case <-transactionCtx.Done():
-				return transactionCtx.Err()
-			case <-time.After(100 * time.Millisecond):
-				if len(attemptHistory) > 0 {
-					if failedOutput := attemptHistory[len(attemptHistory)-1].FailedAIOutput(); failedOutput != "" {
-						rspEmitter.EmitWarning("call ai transaction retry (attempt %d/%d, previous AI output: %s)", i, trcRetry, failedOutput)
-					} else {
-						rspEmitter.EmitWarning("call ai transaction retry (attempt %d/%d)", i, trcRetry)
-					}
-				} else {
-					rspEmitter.EmitWarning("call ai transaction retry (attempt %d/%d)", i, trcRetry)
+			if i < trcRetry {
+				if waitErr := waitBeforeTransactionRetry(transactionCtx, c, rspEmitter, i, trcRetry, attemptHistory); waitErr != nil {
+					return waitErr
 				}
-				continue
 			}
+			continue
 		}
 		if err := transactionCtx.Err(); err != nil {
 			return err
@@ -230,21 +219,12 @@ func callAITransaction(
 			attemptHistory = append(attemptHistory, rec)
 			rspEmitter := bindEmitter(rsp)
 			rspEmitter.EmitError("ai transaction postHandler error (attempt %d/%d): %v", i, trcRetry, postHandlerErr)
-			select {
-			case <-transactionCtx.Done():
-				return transactionCtx.Err()
-			case <-time.After(100 * time.Millisecond):
-				if len(attemptHistory) > 0 {
-					if failedOutput := attemptHistory[len(attemptHistory)-1].FailedAIOutput(); failedOutput != "" {
-						rspEmitter.EmitWarning("call ai transaction retry (attempt %d/%d, previous AI output: %s)", i, trcRetry, failedOutput)
-					} else {
-						rspEmitter.EmitWarning("call ai transaction retry (attempt %d/%d)", i, trcRetry)
-					}
-				} else {
-					rspEmitter.EmitWarning("call ai transaction retry (attempt %d/%d)", i, trcRetry)
+			if i < trcRetry {
+				if waitErr := waitBeforeTransactionRetry(transactionCtx, c, rspEmitter, i, trcRetry, attemptHistory); waitErr != nil {
+					return waitErr
 				}
-				continue
 			}
+			continue
 		}
 		transactionStateMu.Lock()
 		checkpointSaver := saver
@@ -318,4 +298,26 @@ func callAITransaction(
 		return utils.Wrap(finalErr, fmt.Sprintf("max retry count[%v] reached in transaction", trcRetry))
 	}
 	return utils.Errorf("max retry count[%v] reached in transaction", trcRetry)
+}
+
+func waitBeforeTransactionRetry(
+	ctx context.Context,
+	c AICallerConfigIf,
+	emitter *Emitter,
+	failedAttempt int64,
+	maxAttempts int64,
+	attemptHistory []transactionAttemptRecord,
+) error {
+	retryDelay := aiRetryBackoff(failedAttempt)
+	nextAttempt := failedAttempt + 1
+	if len(attemptHistory) > 0 {
+		if failedOutput := attemptHistory[len(attemptHistory)-1].FailedAIOutput(); failedOutput != "" {
+			emitter.EmitWarning("call ai transaction retry (next attempt %d/%d in %s, previous AI output: %s)", nextAttempt, maxAttempts, retryDelay, failedOutput)
+		} else {
+			emitter.EmitWarning("call ai transaction retry (next attempt %d/%d in %s)", nextAttempt, maxAttempts, retryDelay)
+		}
+	} else {
+		emitter.EmitWarning("call ai transaction retry (next attempt %d/%d in %s)", nextAttempt, maxAttempts, retryDelay)
+	}
+	return waitBeforeAIRetry(ctx, c, retryDelay)
 }

--- a/common/ai/aid/aicommon/transaction_429_test.go
+++ b/common/ai/aid/aicommon/transaction_429_test.go
@@ -20,10 +20,11 @@ type transactionTestConfig struct {
 	*KeyValueConfig
 	*BaseInteractiveHandler
 	*BaseCheckpointableStorage
-	ctx      context.Context
-	emitter  *Emitter
-	idSeq    int64
-	retryMax int64
+	ctx       context.Context
+	emitter   *Emitter
+	idSeq     int64
+	retryMax  int64
+	retryWait func(context.Context, time.Duration) error
 }
 
 var _ AICallerConfigIf = (*transactionTestConfig)(nil)
@@ -62,6 +63,12 @@ func (t *transactionTestConfig) IsCtxDone() bool {
 func (t *transactionTestConfig) GetContext() context.Context           { return t.ctx }
 func (t *transactionTestConfig) CallAIResponseConsumptionCallback(int) {}
 func (t *transactionTestConfig) GetAITransactionAutoRetryCount() int64 { return t.retryMax }
+func (t *transactionTestConfig) waitBeforeAIRetry(ctx context.Context, delay time.Duration) error {
+	if t.retryWait != nil {
+		return t.retryWait(ctx, delay)
+	}
+	return nil
+}
 func (t *transactionTestConfig) GetToolComposeConcurrency() int        { return 2 }
 func (t *transactionTestConfig) GetPlanExecTaskConcurrency() int       { return 1 }
 func (t *transactionTestConfig) GetTimelineContentSizeLimit() int64    { return 1000 }

--- a/common/ai/aid/aireact/invoke_liteforge.go
+++ b/common/ai/aid/aireact/invoke_liteforge.go
@@ -69,6 +69,9 @@ func (r *ReAct) invokeLiteForgeWithCallback(cb aicommon.AICallbackType, ctx cont
 		aicommon.WithPersistentSessionId(r.config.PersistentSessionId),
 		aicommon.WithDisableCreateDBRuntime(true), // disable create db runtime because ReAct loop will create it before invoking liteforge, and creating it again in liteforge may
 	}
+	if retryWait := r.config.GetAIRetryWaitFunc(); retryWait != nil {
+		execOpts = append(execOpts, aicommon.WithAIRetryWaitFunc(retryWait))
+	}
 	if userUsageCb := r.config.GetUserUsageCallback(); userUsageCb != nil {
 		execOpts = append(execOpts, aicommon.WithUserUsageCallback(userUsageCb))
 	}

--- a/common/ai/aid/aireact/invoke_toolcall_for_mcp_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_for_mcp_test.go
@@ -240,6 +240,7 @@ func TestReAct_MCPToolUse(t *testing.T) {
 		aicommon.WithDisallowMCPServers(false),           // Important: enable MCP servers
 		aicommon.WithDisableIntentRecognition(true),      // Prevent intent sub-loop from consuming mock responses
 		aicommon.WithDisableSessionTitleGeneration(true), // Prevent title generation from consuming mock responses
+		testAIRetryWaitOption(),
 	)
 	if err != nil {
 		t.Fatalf("failed to create ReAct instance: %v", err)

--- a/common/ai/aid/aireact/tools.go
+++ b/common/ai/aid/aireact/tools.go
@@ -1,6 +1,9 @@
 package aireact
 
 import (
+	"context"
+	"time"
+
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aimem"
 )
@@ -19,6 +22,9 @@ func NewTestReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 		aicommon.WithDisableIncreaseIteration(true),
 	}
 	basicOption = append(basicOption, opts...)
+	// Keep the legacy transaction retry cadence for async test coordination,
+	// while avoiding production-scale exponential waits in nested test configs.
+	basicOption = append(basicOption, testAIRetryWaitOption())
 	ins, err := NewReAct(
 		basicOption...,
 	)
@@ -28,4 +34,17 @@ func NewTestReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 	ins.memoryTriage.SetInvoker(ins)
 	ins.config.SetConfig("test_yaklang_aikb_rag", true)
 	return ins, nil
+}
+
+func testAIRetryWaitOption() aicommon.ConfigOption {
+	return aicommon.WithAIRetryWaitFunc(func(ctx context.Context, _ time.Duration) error {
+		timer := time.NewTimer(100 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return nil
+		}
+	})
 }

--- a/common/ai/aid/test/config_ai_call_summary_test.go
+++ b/common/ai/aid/test/config_ai_call_summary_test.go
@@ -28,6 +28,7 @@ func TestCoordinator_AICallSummaryEvent(t *testing.T) {
 
 	ins, err := aid.NewCoordinator(
 		"test-ai-call-summary",
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {
 			outChan.SafeFeed(event)

--- a/common/ai/aid/test/config_ai_wrapper_random_error_test.go
+++ b/common/ai/aid/test/config_ai_wrapper_random_error_test.go
@@ -85,6 +85,7 @@ func TestCoordinator_RandomAICallbackError(t *testing.T) {
 
 	ins, err := aid.NewCoordinator(
 		"test",
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithAIAutoRetry(1),
 		aicommon.WithAITransactionAutoRetry(3),

--- a/common/ai/aid/test/config_skip_subtask_test.go
+++ b/common/ai/aid/test/config_skip_subtask_test.go
@@ -1110,6 +1110,7 @@ func TestCoordinator_RedoSubtaskInPlan_MissingUserMessage(t *testing.T) {
 
 	ins, err := aid.NewCoordinator(
 		"测试重做子任务缺少用户消息",
+		testAIRetryWaitOption(),
 		aicommon.WithAgreeYOLO(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {

--- a/common/ai/aid/test/config_syncevent_test.go
+++ b/common/ai/aid/test/config_syncevent_test.go
@@ -21,6 +21,7 @@ func TestCoordinator_SyncPing(t *testing.T) {
 	outputChan := make(chan *schema.AiOutputEvent)
 	ins, err := aid.NewCoordinator(
 		"test",
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {
 			outputChan <- event

--- a/common/ai/aid/test/database_test.go
+++ b/common/ai/aid/test/database_test.go
@@ -27,6 +27,7 @@ func TestCoordinator_SyncTaskInDatabase(t *testing.T) {
 	outputChan := make(chan *schema.AiOutputEvent)
 	ins, err := aid.NewCoordinator(
 		uuid.New().String(),
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {
 			outputChan <- event

--- a/common/ai/aid/test/plan_autoretry_test.go
+++ b/common/ai/aid/test/plan_autoretry_test.go
@@ -33,6 +33,7 @@ func TestPlanRetry(t *testing.T) {
 	outputChan := make(chan *schema.AiOutputEvent, 100)
 	ins, err := aid.NewCoordinator(
 		"test",
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
 			outputChan <- e

--- a/common/ai/aid/test/plan_with_interaction_test.go
+++ b/common/ai/aid/test/plan_with_interaction_test.go
@@ -28,6 +28,7 @@ func TestCoordinator_PlanInteraction_Timeline(t *testing.T) {
 
 	ins, err := aid.NewCoordinator(
 		"test",
+		testAIRetryWaitOption(),
 		aicommon.WithAllowPlanUserInteract(true),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {

--- a/common/ai/aid/test/recovery_plan_recover_test.go
+++ b/common/ai/aid/test/recovery_plan_recover_test.go
@@ -70,6 +70,7 @@ func recoverPlan(t *testing.T, uuid string) {
 	ord, err := aid.NewFastRecoverCoordinatorContext(
 		recoverCtx,
 		uuid,
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(safeTestEventHandler(outputChan, stopEvents)),
 		aicommon.WithAICallback(func(config aicommon.AICallerConfigIf, request *aicommon.AIRequest) (*aicommon.AIResponse, error) {
@@ -161,6 +162,7 @@ func TestCoordinator_RecoverCase(t *testing.T) {
 
 	ins, err := aid.NewCoordinator(
 		"test",
+		testAIRetryWaitOption(),
 		aicommon.WithContext(ctx),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(safeTestEventHandler(outputChan, stopEvents)),

--- a/common/ai/aid/test/report_focus_mode_test.go
+++ b/common/ai/aid/test/report_focus_mode_test.go
@@ -29,6 +29,7 @@ func TestCoordinator_ReportGenerationAfterPlanExecution(t *testing.T) {
 
 	ins, err := aid.NewCoordinator(
 		"generate a report after plan execution test",
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {
 			select {
@@ -207,6 +208,7 @@ func TestCoordinator_DefaultReportGenerationEnabled(t *testing.T) {
 
 		ins, err := aid.NewCoordinator(
 			"verify default report generation is enabled",
+			testAIRetryWaitOption(),
 			aicommon.WithEventInputChanx(inputChan),
 			aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {
 				select {

--- a/common/ai/aid/test/retry_test_helper_test.go
+++ b/common/ai/aid/test/retry_test_helper_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"context"
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+)
+
+func testAIRetryWaitOption() aicommon.ConfigOption {
+	return aicommon.WithAIRetryWaitFunc(func(ctx context.Context, _ time.Duration) error {
+		timer := time.NewTimer(100 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return nil
+		}
+	})
+}

--- a/common/ai/aid/test/review_plan_test.go
+++ b/common/ai/aid/test/review_plan_test.go
@@ -40,6 +40,7 @@ func TestCoordinator_ReviewPlan(t *testing.T) {
 	outputChan := make(chan *schema.AiOutputEvent, 100)
 	ins, err := aid.NewCoordinator(
 		"test",
+		testAIRetryWaitOption(),
 		aicommon.WithEventInputChanx(inputChan),
 		aicommon.WithEventHandler(func(event *schema.AiOutputEvent) {
 			outputChan <- event


### PR DESCRIPTION
## Summary

- replace near-immediate non-429 AI request and transaction retry waits with a capped 2s, 4s, 8s, 16s, 32s exponential schedule
- preserve the existing Retry-After-driven 429 policy, configured attempt counts, and context cancellation behavior
- avoid sleeping after the final failed attempt and include the next attempt plus delay in retry warnings
- provide an explicit retry-wait test seam and propagate it to child ReAct/LiteForge configs, so integration tests keep their legacy 100ms cadence without weakening production backoff
- cover HTTP 502, post-handler failures, 429 compatibility, cancellation, cap behavior, config propagation, and both request-wrapper and transaction paths

## Tests

- `go test ./common/ai/aid/aicommon -count=1` (pass, 150.169s)
- `go test ./common/ai/aid/aireact -count=1` (pass, 385.142s)
- `go test ./common/ai/aid/test -count=1` (pass, 437.491s)
- targeted retry/backoff suite with `-count=5` (pass)
- targeted retry/backoff suite with `-race -count=1` (pass)
- `go test ./common/ai/aid/... -run '^$'` (pass)
- `git diff --check` (pass)

## Notes

- The first Essential Tests run exposed integration tests waiting on the new production-scale backoff. The updated test-only waiter is explicit, context-aware, and inherited by child configs; the full affected packages now pass locally.
- `go vet ./common/ai/aid/aicommon` still reports the pre-existing `taskif_test.go:65` non-pointer `json.Unmarshal` issue; this PR does not touch that test.
