### PR TITLE
fix(mcp): reset live flow state after delete all

### DIFF
--- a/common/mcp/httpflow.go
+++ b/common/mcp/httpflow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
 	"github.com/yaklang/yaklang/common/mcp/mcp-go/server"
 	"github.com/yaklang/yaklang/common/schema"
@@ -343,10 +344,18 @@ func deleteHTTPFlows(ctx context.Context, s *MCPServer, req *ypb.DeleteHTTPFlowR
 		return err
 	}
 	if req.GetDeleteAll() {
+		projectBinding := consts.CaptureProjectDatabaseBinding()
+		usesCurrentProjectDatabase := sameGormDatabase(db, projectBinding.Database)
 		yakit.DropWebsocketFlowTable(db)
 		yakit.DropExtractedDataTable(db)
 		grpcmodel.DropHTTPFlowCacheGRPCModelByFlow()
-		return yakit.DeleteHTTPFlow(db, req)
+		if err := yakit.DeleteHTTPFlow(db, req); err != nil {
+			return err
+		}
+		if usesCurrentProjectDatabase {
+			yakit.FinalizeHTTPFlowTableRecreation(projectBinding)
+		}
+		return nil
 	}
 
 	queryDB := yakit.QueryWebsocketFlowsByHTTPFlowHash(db, req).Select([]string{"id", "websocket_hash", "hash"})
@@ -378,6 +387,17 @@ func deleteHTTPFlows(ctx context.Context, s *MCPServer, req *ypb.DeleteHTTPFlowR
 		}
 	}
 	return yakit.DeleteHTTPFlow(db, req)
+}
+
+func sameGormDatabase(left, right *gorm.DB) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	if left == right {
+		return true
+	}
+	leftSQLDB, rightSQLDB := left.DB(), right.DB()
+	return leftSQLDB != nil && leftSQLDB == rightSQLDB
 }
 
 func handleQueryHTTPFlows(s *MCPServer) server.ToolHandlerFunc {

--- a/common/mcp/httpflow_defaults_test.go
+++ b/common/mcp/httpflow_defaults_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yaklang/gorm"
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/mcp"
 	rawmcp "github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
@@ -254,6 +254,73 @@ func TestDeleteHTTPFlowUsesBoundProjectDatabase(t *testing.T) {
 
 	_, err = yakit.GetHTTPFlow(db, int64(flow.ID))
 	require.Error(t, err)
+}
+
+func TestDeleteAllHTTPFlowsOnCurrentProjectResetsLiveFlowState(t *testing.T) {
+	originalBinding := consts.CaptureProjectDatabaseBinding()
+	projectPath := t.TempDir() + "/project.db"
+	projectDB, err := consts.CreateProjectDatabase(projectPath)
+	require.NoError(t, err)
+	consts.BindProjectDatabaseWithReader(projectDB, nil, projectPath)
+	projectBinding := consts.CaptureProjectDatabaseBinding()
+	databaseIdentity := yakit.HTTPFlowDatabaseIdentity(projectBinding.Path)
+	t.Cleanup(func() {
+		currentBinding := consts.CaptureProjectDatabaseBinding()
+		yakit.ResetHTTPFlowRuntimeState(databaseIdentity, projectBinding.Generation)
+		yakit.ResetHTTPFlowRuntimeState(databaseIdentity, currentBinding.Generation)
+		consts.BindProjectDatabaseWithReader(
+			originalBinding.Database,
+			originalBinding.ReadDatabase,
+			originalBinding.Path,
+		)
+		_ = projectDB.Close()
+	})
+
+	flow, err := insertHTTPFlowForMCPTest(projectDB, "https://delete-all.example", time.Now())
+	require.NoError(t, err)
+	flow.RuntimeTiming = &schema.HTTPFlowRuntimeTiming{
+		DatabaseIdentity:  databaseIdentity,
+		ProjectGeneration: projectBinding.Generation,
+		PersistedAtUnixMs: time.Now().UnixMilli(),
+	}
+	yakit.RecordHTTPFlowPersisted(flow)
+	_, published := yakit.PublishHTTPFlowLiveCommitted(flow)
+	require.True(t, published)
+	require.Equal(
+		t,
+		uint64(flow.ID),
+		yakit.SnapshotHTTPFlowPipelineHighWater(databaseIdentity, projectBinding.Generation).LatestPersistedID,
+	)
+
+	client := &recordingHTTPFlowClient{}
+	srv, err := mcp.NewMCPServer(
+		mcp.WithEnableHTTPFlowToolSet(),
+		mcp.WithGRPCClient(client),
+		mcp.WithDatabaseProvider(nil, consts.GetGormProjectDatabase),
+	)
+	require.NoError(t, err)
+
+	_, err = mcp.CallBuiltinTool(srv, context.Background(), "delete_http_flow", map[string]any{
+		"deleteAll": true,
+	})
+	require.NoError(t, err)
+	require.Zero(t, client.deletes, "current project DB should be deleted directly")
+
+	currentBinding := consts.CaptureProjectDatabaseBinding()
+	require.Greater(t, currentBinding.Generation, projectBinding.Generation)
+	require.Zero(
+		t,
+		yakit.SnapshotHTTPFlowPipelineHighWater(databaseIdentity, projectBinding.Generation).LatestPersistedID,
+	)
+	require.Equal(
+		t,
+		yakit.HTTPFlowLiveState{OldestAvailableSequence: 1},
+		yakit.SnapshotHTTPFlowLive(databaseIdentity, projectBinding.Generation),
+	)
+
+	newFlow, err := insertHTTPFlowForMCPTest(projectDB, "https://after-delete-all.example", time.Now())
+	require.NoError(t, err)
+	require.Equal(t, uint(1), newFlow.ID, "recreated table should restart SQLite IDs")
 }
 
 func insertHTTPFlowForMCPTest(db *gorm.DB, url string, ts time.Time, sourceType ...string) (*schema.HTTPFlow, error) {

--- a/common/yakgrpc/grpc_httpflow.go
+++ b/common/yakgrpc/grpc_httpflow.go
@@ -103,11 +103,7 @@ func (s *Server) DeleteHTTPFlows(ctx context.Context, r *ypb.DeleteHTTPFlowReque
 		// DropRecreateTable resets SQLite IDs. Rotate the logical database
 		// generation before invalidating the old stream so a concurrent frontend
 		// bootstrap can never pair lower IDs with the previous generation.
-		_, _ = consts.AdvanceProjectDatabaseGeneration(projectBinding.Generation)
-		yakit.ResetHTTPFlowRuntimeState(
-			yakit.HTTPFlowDatabaseIdentity(projectBinding.Path),
-			projectBinding.Generation,
-		)
+		yakit.FinalizeHTTPFlowTableRecreation(projectBinding)
 	}
 	return &ypb.Empty{}, nil
 }

--- a/common/yakgrpc/yakit/httpflow.go
+++ b/common/yakgrpc/yakit/httpflow.go
@@ -1249,6 +1249,21 @@ func DeleteHTTPFlow(db *gorm.DB, req *ypb.DeleteHTTPFlowRequest) error {
 	return nil
 }
 
+// FinalizeHTTPFlowTableRecreation rotates the logical project generation and
+// clears process-local live-flow state after the HTTP flow table has been
+// dropped and recreated. Callers must pass the binding captured for the
+// database on which the recreation succeeded.
+func FinalizeHTTPFlowTableRecreation(binding consts.ProjectDatabaseBinding) {
+	if binding.Generation == 0 {
+		return
+	}
+	_, _ = consts.AdvanceProjectDatabaseGeneration(binding.Generation)
+	ResetHTTPFlowRuntimeState(
+		HTTPFlowDatabaseIdentity(binding.Path),
+		binding.Generation,
+	)
+}
+
 func FilterHTTPFlow(db *gorm.DB, params *ypb.QueryHTTPFlowRequest) *gorm.DB {
 	subQuery := db
 	db = db.Model(&schema.HTTPFlow{}) //.Debug()


### PR DESCRIPTION
## Summary

- finalize MCP direct HTTP-flow DeleteAll operations by advancing the active project generation and clearing stale live-flow runtime state
- share the table-recreation finalizer with the Yak gRPC deletion path to keep both execution modes consistent
- add a regression test covering generation rotation, live-state reset, and SQLite ID reuse after table recreation

## Testing

- `go test ./common/mcp -count=1`
- `go test ./common/yakgrpc -run "^(TestGRPCMUSTPASS_Delete_HTTPFlow|TestGRPC_StartMcpServer_(ProjectDatabaseTools|FollowsProjectSwitchFromDefault))$" -count=1`
- `go test ./common/yakgrpc/yakit -run "^(TestResetHTTPFlowRuntimeStateClearsReusedIDTimingAndHighWater|TestHTTPFlowObservabilitySeparatesReopenedDatabaseGeneration)$" -count=1`