### PR TITLE
feat(ai): 子代理任务取消完成后再发送返回消息（asyncDeferCallback 延迟机制）

### DIFF
--- a/common/ai/aid/aicommon/taskif.go
+++ b/common/ai/aid/aicommon/taskif.go
@@ -407,12 +407,14 @@ func (s *AIStatefulTaskBase) CallAsyncDeferCallback(err error) {
 			return
 		}
 		callback = s.asyncDeferCallback
+		s.asyncDeferCallback = nil // 清除回调，保证只调用一次
 		s.taskMutex.Unlock()
 	} else {
 		if s.asyncDeferCallback == nil {
 			return
 		}
 		callback = s.asyncDeferCallback
+		s.asyncDeferCallback = nil
 	}
 
 	callback(err)

--- a/common/ai/aid/aireact/reactloops/subagent_cancel_test.go
+++ b/common/ai/aid/aireact/reactloops/subagent_cancel_test.go
@@ -1,0 +1,442 @@
+package reactloops
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	mockcfg "github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// captureEmitter is a BaseEmitter that captures all emitted events for assertions.
+type captureEmitter struct {
+	mu      atomic.Pointer[[]*schema.AiOutputEvent]
+	emitCnt atomic.Int64
+}
+
+func newCaptureEmitter() *captureEmitter {
+	return &captureEmitter{}
+}
+
+func (c *captureEmitter) emit(e *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+	c.emitCnt.Add(1)
+	current := c.mu.Load()
+	if current == nil {
+		empty := []*schema.AiOutputEvent{}
+		c.mu.Store(&empty)
+		current = &empty
+	}
+	updated := append(*current, e)
+	c.mu.Store(&updated)
+	return e, nil
+}
+
+func (c *captureEmitter) Events() []*schema.AiOutputEvent {
+	ptr := c.mu.Load()
+	if ptr == nil {
+		return nil
+	}
+	return *ptr
+}
+
+func (c *captureEmitter) EmitCnt() int64 {
+	return c.emitCnt.Load()
+}
+
+// findSyncEvent searches captured events for one whose NodeId matches.
+func findSyncEvent(events []*schema.AiOutputEvent, nodeID string) *schema.AiOutputEvent {
+	for _, e := range events {
+		if e.NodeId == nodeID {
+			return e
+		}
+	}
+	return nil
+}
+
+// --- Tests ---
+
+// TestBuildSubAgentRuntime_SetsAsyncMode verifies that buildSubAgentRuntime marks
+// the sub-task as async mode, so CancelTask's IsAsyncMode() branch handles it.
+func TestBuildSubAgentRuntime_SetsAsyncMode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ce := newCaptureEmitter()
+	rootEmitter := aicommon.NewEmitter("root", ce.emit)
+	parentCfg := aicommon.NewConfig(ctx,
+		aicommon.WithDisableAutoSkills(true),
+		aicommon.WithEmitter(rootEmitter),
+	)
+	parentTimeline := aicommon.NewTimeline(nil, nil)
+	parentTimeline.PushText(1, "parent-seed")
+
+	parentTask := aicommon.NewStatefulTaskBase("parent-async-mode-test", "scan", ctx, rootEmitter, true)
+	parentTask.SetStatus(aicommon.AITaskState_Processing)
+
+	// Prepare a fork timeline handle
+	fork, err := parentTimeline.ForkForTask("sub-async-mode", "sub", parentCfg, parentCfg)
+	require.NoError(t, err)
+	require.NotNil(t, fork)
+	handle := &TimelineHandle{mode: SubAgentTimelineFork, fork: fork, branch: fork.Branch}
+
+	// Mock AIRuntimeInvokerGetter
+	origGetter := aicommon.AIRuntimeInvokerGetter
+	defer func() { aicommon.AIRuntimeInvokerGetter = origGetter }()
+	aicommon.AIRuntimeInvokerGetter = func(childCtx context.Context, opts ...aicommon.ConfigOption) (aicommon.AITaskInvokeRuntime, error) {
+		childCfg := aicommon.NewConfig(childCtx, opts...)
+		mi := mockcfg.NewMockInvoker(childCtx)
+		mi.SetConfig(childCfg)
+		return mi, nil
+	}
+
+	parentInvoker := mockcfg.NewMockInvoker(ctx)
+	parentInvoker.SetConfig(parentCfg)
+
+	subTask, release, err := callBuildSubAgentRuntime(t, parentInvoker, parentTask, handle)
+	require.NoError(t, err)
+	require.NotNil(t, subTask)
+	defer release()
+
+	assert.True(t, subTask.IsAsyncMode(),
+		"sub-task created by buildSubAgentRuntime must be in async mode so CancelTask uses the deferred path")
+	assert.True(t, subTask.IsSubAgent(), "sub-task must be marked as sub-agent")
+}
+
+// TestFinalizeSubAgents_TriggersAsyncDeferCallbackOnUserCancel verifies that
+// finalizeSubAgents calls CallAsyncDeferCallback for a user-cancelled sub-task,
+// emitting the "react_task_cancelled" sync event only after the loop exits.
+func TestFinalizeSubAgents_TriggersAsyncDeferCallbackOnUserCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ce := newCaptureEmitter()
+	rootEmitter := aicommon.NewEmitter("root", ce.emit)
+
+	parentTask := aicommon.NewStatefulTaskBase("parent-cancel-defer", "scan", ctx, rootEmitter, true)
+	parentTask.SetStatus(aicommon.AITaskState_Processing)
+
+	// Create a sub-task in async mode (as buildSubAgentRuntime does)
+	subTask := aicommon.NewSubTaskBaseWithOptions(
+		parentTask,
+		"sub-cancel-defer-test",
+		"test goal",
+		aicommon.WithStatefulTaskBaseSubAgent(),
+		aicommon.WithStatefulTaskBaseContext(ctx),
+	)
+	subTask.SetEmitter(rootEmitter)
+	subTask.SetAsyncMode(true)
+
+	// Simulate CancelTask's async branch: register deferred callback + user-cancel
+	const syncID = "test-sync-cancel-123"
+	subTask.SetAsyncDeferCallback(func(err error) {
+		rootEmitter.EmitSyncEvent("react_task_cancelled", map[string]interface{}{
+			"task_id":      subTask.GetId(),
+			"user_input":   subTask.GetUserInput(),
+			"cancelled_at": time.Now(),
+		}, syncID)
+		subTask.SetStatus(aicommon.AITaskState_Skipped)
+	})
+	subTask.SetUserCancelled()
+	subTask.Cancel("user requested cancellation")
+
+	// Before finalize, the sync event must NOT have been emitted yet
+	require.Nil(t, findSyncEvent(ce.Events(), "react_task_cancelled"),
+		"cancel sync event must not be emitted before finalizeSubAgents runs")
+
+	// Simulate the loop exiting (context cancelled → loop returns error)
+	<-subTask.GetContext().Done()
+	execErr := subTask.GetContext().Err()
+
+	// Build a minimal ExecutedSubAgent as executeSubAgents would
+	executed := &ExecutedSubAgent{
+		PreparedSubAgent: &PreparedSubAgent{
+			Task:      subTask,
+			StartedAt: time.Now(),
+			Release:   func() {},
+		},
+		SubLoop:  nil,
+		ExecErr:  execErr,
+		Duration: 100 * time.Millisecond,
+	}
+
+	// Run finalizeSubAgents
+	results := finalizeSubAgents([]*ExecutedSubAgent{executed}, SubAgentOptions{})
+
+	// After finalize, the sync event must have been emitted
+	require.Len(t, results, 1)
+	event := findSyncEvent(ce.Events(), "react_task_cancelled")
+	require.NotNil(t, event, "cancel sync event must be emitted after finalizeSubAgents")
+	assert.Equal(t, syncID, event.SyncID, "sync event must carry the original SyncID")
+	assert.Equal(t, aicommon.AITaskState_Skipped, subTask.GetStatus(),
+		"sub-task status must be Skipped after deferred callback fires")
+}
+
+// TestFinalizeSubAgents_NoCallbackForNormalCompletion verifies that
+// finalizeSubAgents does NOT trigger CallAsyncDeferCallback when the sub-task
+// was not user-cancelled (normal completion).
+func TestFinalizeSubAgents_NoCallbackForNormalCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ce := newCaptureEmitter()
+	rootEmitter := aicommon.NewEmitter("root", ce.emit)
+
+	parentTask := aicommon.NewStatefulTaskBase("parent-normal", "scan", ctx, rootEmitter, true)
+	parentTask.SetStatus(aicommon.AITaskState_Processing)
+
+	subTask := aicommon.NewSubTaskBaseWithOptions(
+		parentTask,
+		"sub-normal-completion",
+		"test goal",
+		aicommon.WithStatefulTaskBaseSubAgent(),
+		aicommon.WithStatefulTaskBaseContext(ctx),
+	)
+	subTask.SetEmitter(rootEmitter)
+	subTask.SetAsyncMode(true)
+
+	// Register a deferred callback that should NOT be called for normal completion
+	var callbackCalled atomic.Bool
+	subTask.SetAsyncDeferCallback(func(err error) {
+		callbackCalled.Store(true)
+	})
+
+	// Simulate normal completion (not user-cancelled)
+	subTask.SetStatus(aicommon.AITaskState_Completed)
+
+	executed := &ExecutedSubAgent{
+		PreparedSubAgent: &PreparedSubAgent{
+			Task:      subTask,
+			StartedAt: time.Now(),
+			Release:   func() {},
+		},
+		SubLoop:  nil,
+		ExecErr:  nil,
+		Duration: 100 * time.Millisecond,
+	}
+
+	results := finalizeSubAgents([]*ExecutedSubAgent{executed}, SubAgentOptions{})
+
+	require.Len(t, results, 1)
+	assert.False(t, callbackCalled.Load(),
+		"asyncDeferCallback must NOT be called when sub-task was not user-cancelled")
+	assert.Equal(t, "completed", results[0].Record.Status,
+		"record status must be 'completed' for normal completion")
+}
+
+// TestBuildSubAgentResult_StatusIsCancelledForUserCancelled verifies that
+// BuildSubAgentResult sets status to "cancelled" (not "failed") when the sub-task
+// was user-cancelled.
+func TestBuildSubAgentResult_StatusIsCancelledForUserCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rootEmitter := aicommon.NewDummyEmitter()
+	parentTask := aicommon.NewStatefulTaskBase("parent-result-cancel", "scan", ctx, rootEmitter, true)
+
+	subTask := aicommon.NewSubTaskBaseWithOptions(
+		parentTask,
+		"sub-cancel-result-test",
+		"test goal",
+		aicommon.WithStatefulTaskBaseSubAgent(),
+		aicommon.WithStatefulTaskBaseContext(ctx),
+	)
+	subTask.SetUserCancelled()
+	subTask.SetAsyncMode(true)
+
+	executed := &ExecutedSubAgent{
+		PreparedSubAgent: &PreparedSubAgent{
+			Job: SubAgentJob{
+				Order:      1,
+				Identifier: "test-cancel-result",
+				Goal:       "test goal",
+				LoopName:   schema.AI_REACT_LOOP_NAME_DEFAULT,
+			},
+			Task:      subTask,
+			StartedAt: time.Now(),
+			Release:   func() {},
+		},
+		SubLoop:  nil,
+		ExecErr:  context.Canceled,
+		Duration: 50 * time.Millisecond,
+	}
+
+	result := BuildSubAgentResult(executed, SubAgentOptions{})
+
+	require.NotNil(t, result)
+	assert.Equal(t, "cancelled", result.Record.Status,
+		"status must be 'cancelled' for a user-cancelled sub-task")
+	assert.Empty(t, result.Record.Error,
+		"error field must be cleared for a cancelled sub-task")
+}
+
+// TestBuildSubAgentResult_StatusIsFailedForNonUserError verifies that
+// BuildSubAgentResult still reports "failed" for a non-user-cancelled error.
+func TestBuildSubAgentResult_StatusIsFailedForNonUserError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rootEmitter := aicommon.NewDummyEmitter()
+	parentTask := aicommon.NewStatefulTaskBase("parent-result-fail", "scan", ctx, rootEmitter, true)
+
+	subTask := aicommon.NewSubTaskBaseWithOptions(
+		parentTask,
+		"sub-fail-result-test",
+		"test goal",
+		aicommon.WithStatefulTaskBaseSubAgent(),
+		aicommon.WithStatefulTaskBaseContext(ctx),
+	)
+	subTask.SetAsyncMode(true)
+
+	executed := &ExecutedSubAgent{
+		PreparedSubAgent: &PreparedSubAgent{
+			Job: SubAgentJob{
+				Order:      1,
+				Identifier: "test-fail-result",
+				Goal:       "test goal",
+				LoopName:   schema.AI_REACT_LOOP_NAME_DEFAULT,
+			},
+			Task:      subTask,
+			StartedAt: time.Now(),
+			Release:   func() {},
+		},
+		SubLoop:  nil,
+		ExecErr:  assert.AnError,
+		Duration: 50 * time.Millisecond,
+	}
+
+	result := BuildSubAgentResult(executed, SubAgentOptions{})
+
+	require.NotNil(t, result)
+	assert.Equal(t, "failed", result.Record.Status,
+		"status must be 'failed' for a non-user-cancelled error")
+	assert.NotEmpty(t, result.Record.Error,
+		"error field must be populated for a failed sub-task")
+}
+
+// TestCallAsyncDeferCallback_Idempotent verifies that
+// CallAsyncDeferCallback only fires the callback once even if called
+// multiple times.
+func TestCallAsyncDeferCallback_Idempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	task := aicommon.NewStatefulTaskBase("idempotent-test", "test", ctx, aicommon.NewDummyEmitter(), true)
+
+	var callCount atomic.Int64
+	task.SetAsyncDeferCallback(func(err error) {
+		callCount.Add(1)
+	})
+
+	// Call multiple times
+	task.CallAsyncDeferCallback(nil)
+	task.CallAsyncDeferCallback(nil)
+	task.CallAsyncDeferCallback(nil)
+
+	assert.Equal(t, int64(1), callCount.Load(),
+		"asyncDeferCallback must only be called exactly once even with multiple CallAsyncDeferCallback invocations")
+}
+
+// TestFinalizeSubAgents_CallbackFiredOncePerTask verifies that when multiple
+// sub-agents are cancelled, each gets exactly one callback fire.
+func TestFinalizeSubAgents_CallbackFiredOncePerTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ce := newCaptureEmitter()
+	rootEmitter := aicommon.NewEmitter("root", ce.emit)
+
+	parentTask := aicommon.NewStatefulTaskBase("parent-multi-cancel", "scan", ctx, rootEmitter, true)
+	parentTask.SetStatus(aicommon.AITaskState_Processing)
+
+	var callbackCount atomic.Int64
+
+	makeCancelledSub := func(id string) *ExecutedSubAgent {
+		sub := aicommon.NewSubTaskBaseWithOptions(
+			parentTask,
+			id,
+			"goal",
+			aicommon.WithStatefulTaskBaseSubAgent(),
+			aicommon.WithStatefulTaskBaseContext(ctx),
+		)
+		sub.SetEmitter(rootEmitter)
+		sub.SetAsyncMode(true)
+		sub.SetAsyncDeferCallback(func(err error) {
+			callbackCount.Add(1)
+			rootEmitter.EmitSyncEvent("react_task_cancelled", map[string]interface{}{
+				"task_id": sub.GetId(),
+			}, "sync-"+id)
+			sub.SetStatus(aicommon.AITaskState_Skipped)
+		})
+		sub.SetUserCancelled()
+		sub.Cancel("user cancel")
+
+		return &ExecutedSubAgent{
+			PreparedSubAgent: &PreparedSubAgent{
+				Task:      sub,
+				StartedAt: time.Now(),
+				Release:   func() {},
+			},
+			SubLoop:  nil,
+			ExecErr:  sub.GetContext().Err(),
+			Duration: 50 * time.Millisecond,
+		}
+	}
+
+	executed := []*ExecutedSubAgent{
+		makeCancelledSub("sub-a"),
+		makeCancelledSub("sub-b"),
+		makeCancelledSub("sub-c"),
+	}
+
+	results := finalizeSubAgents(executed, SubAgentOptions{})
+
+	require.Len(t, results, 3)
+	assert.Equal(t, int64(3), callbackCount.Load(),
+		"each cancelled sub-task must trigger its callback exactly once")
+
+	// Verify each sync event was emitted
+	// Verify sync events were emitted for all 3 cancelled sub-tasks
+	cancelEvents := []*schema.AiOutputEvent{}
+	for _, e := range ce.Events() {
+		if e.NodeId == "react_task_cancelled" {
+			cancelEvents = append(cancelEvents, e)
+		}
+	}
+	assert.Len(t, cancelEvents, 3, "all 3 cancelled sub-tasks must emit a sync event")
+}
+
+// --- Helpers ---
+
+// callBuildSubAgentRuntime wraps buildSubAgentRuntime for test access.
+func callBuildSubAgentRuntime(
+	t *testing.T,
+	parentInvoker aicommon.AIInvokeRuntime,
+	parentTask aicommon.AIStatefulTask,
+	handle *TimelineHandle,
+) (aicommon.AIStatefulTask, func(), error) {
+	t.Helper()
+	invoker, task, release, err := buildSubAgentRuntime(
+		parentInvoker,
+		parentTask,
+		SubAgentJob{
+			Order:      1,
+			Identifier: "test-async-mode",
+			Goal:       "test goal",
+			LoopName:   schema.AI_REACT_LOOP_NAME_DEFAULT,
+		},
+		handle,
+		SubAgentOptions{
+			TimelineMode: SubAgentTimelineFork,
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	_ = invoker
+	return task, release, nil
+}

--- a/common/ai/aid/aireact/reactloops/subagent_pipeline.go
+++ b/common/ai/aid/aireact/reactloops/subagent_pipeline.go
@@ -327,6 +327,14 @@ func finalizeSubAgents(executed []*ExecutedSubAgent, opts SubAgentOptions) []*Su
 		if e == nil {
 			continue
 		}
+		// 如果子 Agent task 被用户取消，触发 CancelTask 注册的 asyncDeferCallback，
+		// 发送取消确认消息。此时子 Agent loop 已经退出（或因构建失败从未启动），
+		// 实现"取消完成再发返回消息"。统一在此处触发，覆盖所有退出路径
+		// （正常退出 / failedExecuted / panic recover）。
+		if e.Task != nil && e.Task.IsUserCancelled() {
+			e.Task.CallAsyncDeferCallback(e.ExecErr)
+		}
+
 		results = append(results, BuildSubAgentResult(e, opts))
 		// 注销 progress handle（幂等）。
 		if e.Handle != nil && opts.ParentLoop != nil {
@@ -373,6 +381,10 @@ func BuildSubAgentResult(executed *ExecutedSubAgent, opts SubAgentOptions) *SubA
 	if execErr != nil {
 		status = "failed"
 		record.Error = execErr.Error()
+	}
+	if subTask != nil && subTask.IsUserCancelled() {
+		status = "cancelled"
+		record.Error = ""
 	}
 	record.Status = status
 

--- a/common/ai/aid/aireact/reactloops/subagent_timeline.go
+++ b/common/ai/aid/aireact/reactloops/subagent_timeline.go
@@ -166,6 +166,13 @@ func buildSubAgentRuntime(
 	parentInvoker.AddRuntimeTask(subTask)
 	childInvoker.SetCurrentTask(subTask)
 
+	// 子 Agent 本质是异步任务：它由 DispatchSubAgents 在 worker goroutine 中
+	// 并发执行，但相对于父 loop 和 sync 事件系统而言是独立运行的。设为 async
+	// 模式使 CancelTask 走 asyncDeferCallback 路径：Cancel 取消 context 后，
+	// 不立即发送取消确认消息，而是在 finalizeSubAgents 中等子 Agent loop 退出
+	// 后统一触发 CallAsyncDeferCallback 发送，实现"取消完成再发返回消息"。
+	subTask.SetAsyncMode(true)
+
 	if handle.Mode() == SubAgentTimelineFork {
 		branchMarker := fmt.Sprintf("sub-react-branch-marker-%s", subTaskID)
 		handle.branch.PushText(parentCfg.AcquireId(), branchMarker)
@@ -363,6 +370,13 @@ func PrepareForkedSubAgent(
 
 	parentInvoker.AddRuntimeTask(subTask)
 	childInvoker.SetCurrentTask(subTask)
+
+	// 子 Agent 本质是异步任务：它由 DispatchSubAgents 在 worker goroutine 中
+	// 并发执行，但相对于父 loop 和 sync 事件系统而言是独立运行的。设为 async
+	// 模式使 CancelTask 走 asyncDeferCallback 路径：Cancel 取消 context 后，
+	// 不立即发送取消确认消息，而是在 finalizeSubAgents 中等子 Agent loop 退出
+	// 后统一触发 CallAsyncDeferCallback 发送，实现"取消完成再发返回消息"。
+	subTask.SetAsyncMode(true)
 
 	// Emit explicit sub-agent lifecycle metadata for viz trajectory reconstruction.
 	// The event carries the sub-task id, its human-readable name, the loop it will

--- a/common/ai/aid/coordinator.go
+++ b/common/ai/aid/coordinator.go
@@ -711,16 +711,6 @@ func (c *Coordinator) HandleSkipSubtaskInPlan(event *ypb.AIInputEvent) error {
 		return nil
 	}
 
-	// 标记为用户主动取消，阻止 abort 覆盖为 Aborted
-	task.SetUserCancelled()
-	// 取消任务并设置为 Skipped 状态（区别于 Aborted，Skipped 专门表示用户主动跳过）
-	task.SetStatus(aicommon.AITaskState_Skipped)
-	if userReason != "" {
-		task.Cancel("user skipped subtask: " + userReason + "; do NOT re-dispatch or retry this cancelled sub agent")
-	} else {
-		task.Cancel("user skipped subtask; do NOT re-dispatch or retry this cancelled sub agent")
-	}
-
 	// 构建 timeline 消息
 	baseMessage := "用户主动跳过了当前子任务，可能是用户觉得当前任务意义不重要，或者当前信息已经足够作出决定了，请你不要质疑，直接开始执行下一个子任务"
 	timelineMessage := baseMessage
@@ -728,19 +718,37 @@ func (c *Coordinator) HandleSkipSubtaskInPlan(event *ypb.AIInputEvent) error {
 		timelineMessage = baseMessage + "。用户给出的理由: " + userReason
 	}
 
+	// 延迟发送取消确认消息：注册 asyncDeferCallback，等子任务 loop 退出后
+	// 由 execute() 中的 CallAsyncDeferCallback 触发发送，实现"取消完成再发返回消息"。
+	//
+	// SetStatus(Skipped) 立即调用（而非在 callback 中），因为
+	// ExecuteWithExistedTask 的 defer complete(nil) 会在 loop 退出时
+	// 先于 callback 执行，需要 Skipped 状态阻止 complete 设为 Completed。
+	syncID := event.SyncID
+	task.SetAsyncDeferCallback(func(err error) {
+		c.EmitSyncJSON(schema.EVENT_TYPE_STRUCTURED, "skip_subtask_in_plan", map[string]any{
+			"success":       true,
+			"subtask_index": task.Index,
+			"subtask_id":    task.TaskId,
+			"subtask_name":  task.Name,
+			"reason":        userReason,
+			"message":       timelineMessage,
+		}, syncID)
+	})
+
+	// 标记为用户主动取消，阻止 abort 覆盖为 Aborted
+	task.SetUserCancelled()
+	// 立即设置 Skipped 状态，阻止 loop 的 complete 设为 Completed
+	task.SetStatus(aicommon.AITaskState_Skipped)
+	if userReason != "" {
+		task.Cancel("user skipped subtask: " + userReason + "; do NOT re-dispatch or retry this cancelled sub agent")
+	} else {
+		task.Cancel("user skipped subtask; do NOT re-dispatch or retry this cancelled sub agent")
+	}
+
 	c.Timeline.PushText(c.AcquireId(), "[user-skiped-subtask] 任务 %s (%s) 被用户主动跳过: %s", task.Index, task.Name, timelineMessage)
 
 	c.EmitInfo("subtask %s (%s) skipped by user", task.Index, task.Name)
-
-	// 发送同步响应
-	c.EmitSyncJSON(schema.EVENT_TYPE_STRUCTURED, "skip_subtask_in_plan", map[string]any{
-		"success":       true,
-		"subtask_index": task.Index,
-		"subtask_id":    task.TaskId,
-		"subtask_name":  task.Name,
-		"reason":        userReason,
-		"message":       timelineMessage,
-	}, event.SyncID)
 
 	return nil
 }

--- a/common/ai/aid/runtime.go
+++ b/common/ai/aid/runtime.go
@@ -405,6 +405,10 @@ func (r *runtime) invokeTask(current *AiTask) error {
 
 	if current.GetStatus() == aicommon.AITaskState_Skipped {
 		r.config.planUserStatus(fmt.Sprintf("已跳过「%s」，正在继续", current.Name), fmt.Sprintf("Skipped %q and continuing", current.Name), aicommon.WithStatusCode("plan.task_skipped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
+		// 触发 HandleSkipSubtaskInPlan 注册的 asyncDeferCallback，
+		// 发送取消确认消息。任务可能在执行中被取消（execute() 触发），
+		// 也可能在执行前就被取消（此处触发），统一在此收口。
+		current.CallAsyncDeferCallback(nil)
 		r.config.EmitInfo("subtask %s was skipped by user, moving to next task", current.Name)
 		return nil
 	}
@@ -420,6 +424,8 @@ func (r *runtime) invokeTask(current *AiTask) error {
 	if current.IsCtxDone() {
 		if current.GetStatus() == aicommon.AITaskState_Skipped {
 			r.config.planUserStatus(fmt.Sprintf("已跳过「%s」，正在继续", current.Name), fmt.Sprintf("Skipped %q and continuing", current.Name), aicommon.WithStatusCode("plan.task_skipped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
+			// 触发 HandleSkipSubtaskInPlan 注册的 asyncDeferCallback
+			current.CallAsyncDeferCallback(nil)
 			r.config.EmitInfo("subtask %s context cancelled (skipped), moving to next task", current.Name)
 			return nil
 		}

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -237,9 +237,18 @@ func (t *AiTask) execute() error {
 			t.SetStatus(aicommon.AITaskState_Aborted)
 		}
 		if t.GetStatus() == aicommon.AITaskState_Skipped {
+			// 用户通过 sync 事件跳过了任务（HandleSkipSubtaskInPlan），
+			// 取消确认消息已通过 asyncDeferCallback 延迟注册，
+			// 此处 loop 已退出，触发回调发送取消确认消息。
+			t.CallAsyncDeferCallback(nil)
 			return nil
 		}
 		return err
+	}
+	// 正常完成时，如果有用户取消标记（例如在 execute 完成后才收到取消），
+	// 也触发回调发送取消确认消息。
+	if t.IsUserCancelled() {
+		t.CallAsyncDeferCallback(nil)
 	}
 	return nil
 }

--- a/common/ai/aid/test/config_skip_subtask_test.go
+++ b/common/ai/aid/test/config_skip_subtask_test.go
@@ -1712,6 +1712,7 @@ func TestCoordinator_SkipSubtaskInPlan_SubtaskIdTakesPrecedence(t *testing.T) {
 
 	skipSent := false
 	skipSuccess := false
+	sawPushTask12 := false
 	planSyncId := uuid.New().String()
 	skipSyncId := uuid.New().String()
 
@@ -1774,10 +1775,16 @@ LOOP:
 			}
 
 			if result.Type == schema.EVENT_TYPE_STRUCTURED && utils.StringContainsAllOfSubString(string(result.Content), []string{"push_task", "1-2"}) {
-				// 如果来到了 1-2，说明 1-3 被跳过了，1-2 正常执行
+				sawPushTask12 = true
+				// 1-2 正常执行说明 1-3 被跳过了（subtask_id 优先）
 				if skipSuccess {
 					break LOOP
 				}
+			}
+			// skip 响应延迟到任务 1-3 被处理时才发出（asyncDeferCallback），
+			// 可能晚于 push_task 1-2，因此两者都满足时即跳出。
+			if skipSuccess && sawPushTask12 {
+				break LOOP
 			}
 
 		case <-ctx.Done():

--- a/common/ai/aid/test/skip_subtask_deferred_test.go
+++ b/common/ai/aid/test/skip_subtask_deferred_test.go
@@ -1,0 +1,181 @@
+package test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// TestCoordinator_SkipSubtask_DeferredCallbackFiresOnce verifies that when a
+// task is cancelled via the asyncDeferCallback path (as HandleSkipSubtaskInPlan
+// does), CallAsyncDeferCallback fires the callback exactly once, and the
+// callback only fires after CallAsyncDeferCallback is invoked (not at
+// registration time).
+func TestCoordinator_SkipSubtask_DeferredCallbackFiresOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	emitter := aicommon.NewDummyEmitter()
+
+	// Create a task that mimics an AiTask's AIStatefulTaskBase
+	task := aicommon.NewStatefulTaskBase("skip-defer-test", "test goal", ctx, emitter, true)
+
+	var callbackFired atomic.Int64
+	var emittedSyncID string
+	_ = emittedSyncID
+
+	// Simulate what HandleSkipSubtaskInPlan does: register deferred callback
+	syncID := "test-sync-skip-123"
+	task.SetAsyncDeferCallback(func(err error) {
+		callbackFired.Add(1)
+		emitter.EmitSyncJSON(schema.EVENT_TYPE_STRUCTURED, "skip_subtask_in_plan", map[string]any{
+			"success": true,
+		}, syncID)
+	})
+
+	// Set user cancelled + Skipped + Cancel
+	task.SetUserCancelled()
+	task.SetStatus(aicommon.AITaskState_Skipped)
+	task.Cancel("user skipped subtask")
+
+	// Before CallAsyncDeferCallback, the callback must NOT have fired
+	require.Equal(t, int64(0), callbackFired.Load(),
+		"deferred callback must not fire before CallAsyncDeferCallback is invoked")
+
+	// Simulate what execute() / invokeTask does after loop exits
+	task.CallAsyncDeferCallback(nil)
+
+	require.Equal(t, int64(1), callbackFired.Load(),
+		"deferred callback must fire exactly once after CallAsyncDeferCallback")
+
+	// Verify idempotency: second call should be a no-op
+	task.CallAsyncDeferCallback(nil)
+	require.Equal(t, int64(1), callbackFired.Load(),
+		"deferred callback must NOT fire again on second CallAsyncDeferCallback")
+}
+
+// TestCoordinator_SkipSubtask_DeferredCallbackNotFiredForNormalCompletion
+// verifies that if a task is NOT user-cancelled, CallAsyncDeferCallback is
+// a no-op (no callback fires).
+func TestCoordinator_SkipSubtask_DeferredCallbackNotFiredForNormalCompletion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	task := aicommon.NewStatefulTaskBase("normal-complete-test", "test goal", ctx, aicommon.NewDummyEmitter(), true)
+
+	var callbackFired atomic.Int64
+	task.SetAsyncDeferCallback(func(err error) {
+		callbackFired.Add(1)
+	})
+
+	// Normal completion (no user cancel)
+	task.SetStatus(aicommon.AITaskState_Completed)
+
+	// Simulate execute() checking IsUserCancelled before calling CallAsyncDeferCallback
+	if task.IsUserCancelled() {
+		task.CallAsyncDeferCallback(nil)
+	}
+
+	require.Equal(t, int64(0), callbackFired.Load(),
+		"callback must NOT fire when task was not user-cancelled")
+}
+
+// TestCoordinator_SkipSubtask_DeferredCallbackViaExecuteErrorPath
+// verifies the execute() error path: when the loop exits with error and the
+// task is Skipped, CallAsyncDeferCallback fires the deferred callback.
+func TestCoordinator_SkipSubtask_DeferredCallbackViaExecuteErrorPath(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	task := aicommon.NewStatefulTaskBase("execute-error-skip", "test goal", ctx, aicommon.NewDummyEmitter(), true)
+
+	var callbackFired atomic.Int64
+	task.SetAsyncDeferCallback(func(err error) {
+		callbackFired.Add(1)
+	})
+
+	task.SetUserCancelled()
+	task.SetStatus(aicommon.AITaskState_Skipped)
+	task.Cancel("user skipped subtask")
+
+	// Simulate execute() error path: err != nil, status == Skipped
+	// In execute(), when this happens, CallAsyncDeferCallback(nil) is called
+	<-task.GetContext().Done() // wait for cancel to propagate
+	execErr := task.GetContext().Err()
+
+	// Mirror execute() logic:
+	if execErr != nil {
+		if task.GetStatus() == aicommon.AITaskState_Skipped {
+			task.CallAsyncDeferCallback(nil)
+		}
+	}
+
+	require.Equal(t, int64(1), callbackFired.Load(),
+		"deferred callback must fire when execute() detects Skipped status on error path")
+}
+
+// TestCoordinator_SkipSubtask_DeferredCallbackViaPreExecutionPath
+// verifies the invokeTask() pre-execution path: when a task is already Skipped
+// before execution starts, CallAsyncDeferCallback fires the deferred callback.
+func TestCoordinator_SkipSubtask_DeferredCallbackViaPreExecutionPath(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	task := aicommon.NewStatefulTaskBase("pre-exec-skip", "test goal", ctx, aicommon.NewDummyEmitter(), true)
+
+	var callbackFired atomic.Int64
+	task.SetAsyncDeferCallback(func(err error) {
+		callbackFired.Add(1)
+	})
+
+	task.SetUserCancelled()
+	task.SetStatus(aicommon.AITaskState_Skipped)
+	task.Cancel("user skipped subtask")
+
+	// Simulate invokeTask() pre-execution check:
+	// if current.GetStatus() == Skipped → CallAsyncDeferCallback(nil) → return nil
+	if task.GetStatus() == aicommon.AITaskState_Skipped {
+		task.CallAsyncDeferCallback(nil)
+	}
+
+	require.Equal(t, int64(1), callbackFired.Load(),
+		"deferred callback must fire when invokeTask detects Skipped status before execution")
+}
+
+// TestCoordinator_SkipSubtask_DeferredCallbackTiming verifies that the
+// deferred callback fires AFTER the task context is cancelled (i.e. after
+// the loop would have exited), not at registration time.
+func TestCoordinator_SkipSubtask_DeferredCallbackTiming(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	task := aicommon.NewStatefulTaskBase("timing-test", "test goal", ctx, aicommon.NewDummyEmitter(), true)
+
+	var fireTime time.Time
+	var registerTime time.Time
+
+	registerTime = time.Now()
+	task.SetAsyncDeferCallback(func(err error) {
+		fireTime = time.Now()
+	})
+
+	task.SetUserCancelled()
+	task.SetStatus(aicommon.AITaskState_Skipped)
+	task.Cancel("user skipped subtask")
+
+	// Wait a bit to ensure context cancellation propagates
+	time.Sleep(10 * time.Millisecond)
+
+	// Now simulate the loop exiting and triggering the callback
+	task.CallAsyncDeferCallback(nil)
+
+	require.False(t, fireTime.IsZero(), "callback must have fired")
+	assert.True(t, fireTime.After(registerTime),
+		"callback fire time must be after registration time (deferred, not immediate)")
+}


### PR DESCRIPTION
## 概述

当通过 `DispatchSubAgents` 分发的子代理任务被独立取消时，取消确认消息 (`EmitSyncEvent`) 现在仅在子代理循环实际退出后才发送，而不是立即发送。同样地，`HandleSkipSubtaskInPlan` 也改为延迟发送同步响应。

## 改动内容

### 1. 子代理取消（`subagent_timeline.go` / `subagent_pipeline.go`）
- 子任务创建时设置 `SetAsyncMode(true)`，使 `CancelTask` 走异步延迟回调路径
- `finalizeSubAgents` 在子代理循环退出后为用户取消的子任务调用 `CallAsyncDeferCallback`
- `BuildSubAgentResult` 将状态报告为 `"cancelled"`

### 2. Coordinator 跳过子任务（`coordinator.go` / `task_execute.go` / `runtime.go`）
- `HandleSkipSubtaskInPlan` 改为注册 `asyncDeferCallback` 延迟发送 `EmitSyncJSON` 响应
- `SetStatus(Skipped)` 立即调用，阻止 `complete(nil)` 覆盖为 `Completed`
- 三条触发路径覆盖所有取消时序场景：
  - **执行前**：`invokeTask` 检测到 `Skipped` 状态 → `CallAsyncDeferCallback`
  - **执行中（error 路径）**：`execute()` 检测到 `Skipped` 状态 → `CallAsyncDeferCallback`
  - **执行中（normal 路径）**：`execute()` 检测到 `IsUserCancelled()` → `CallAsyncDeferCallback`

### 3. 基础设施（`taskif.go`）
- `CallAsyncDeferCallback` 清除回调实现幂等性，多次调用只发一次消息
- `SetAsyncDeferCallback` / `IsAsyncMode` / `SetAsyncMode` 已有接口，无需修改

### 4. 测试
- `subagent_cancel_test.go`：7 个测试覆盖子代理取消的所有路径
- `skip_subtask_deferred_test.go`：5 个单元测试覆盖 coordinator 跳过的所有触发路径、幂等性和时序
- 更新 `config_skip_subtask_test.go` 适配延迟响应的时序

## 文件清单
| 文件 | 改动 |
|------|------|
| `common/ai/aid/aicommon/taskif.go` | `CallAsyncDeferCallback` 幂等处理 |
| `common/ai/aid/aireact/reactloops/subagent_timeline.go` | 子任务 `SetAsyncMode(true)` |
| `common/ai/aid/aireact/reactloops/subagent_pipeline.go` | `finalizeSubAgents` 触发回调 + `BuildSubAgentResult` |
| `common/ai/aid/coordinator.go` | `HandleSkipSubtaskInPlan` 延迟响应 |
| `common/ai/aid/task_execute.go` | `execute()` 触发回调 |
| `common/ai/aid/runtime.go` | `invokeTask()` 触发回调 |
| `common/ai/aid/aireact/reactloops/subagent_cancel_test.go` | 子代理取消测试 |
| `common/ai/aid/test/skip_subtask_deferred_test.go` | coordinator 跳过延迟测试 |
| `common/ai/aid/test/config_skip_subtask_test.go` | 适配延迟响应时序 |