### PR TITLE
fix(scannode): 建立节点执行容量准入闭环

### DIFF
--- a/cmd/legion-smoke-node/main.go
+++ b/cmd/legion-smoke-node/main.go
@@ -82,6 +82,7 @@ func runNode(args []string) error {
 		node.DefaultHeartbeatInterval,
 		"Heartbeat interval",
 	)
+	maxRunningJobs := smokeNodeMaxRunningJobsFlag(flags)
 	pprofAddr := flags.String("pprof-addr", "", "Optional pprof HTTP listen address, e.g. 127.0.0.1:18080")
 	heapMonitorInterval := flags.Duration(
 		"heap-monitor-interval",
@@ -124,6 +125,10 @@ func runNode(args []string) error {
 		"Optional host identity instance_id override for isolated local testing",
 	)
 	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	resolvedMaxRunningJobs, err := smokeNodeMaxRunningJobs(*maxRunningJobs)
+	if err != nil {
 		return err
 	}
 	if err := initializeAISessionCapabilities(*kind, syncAISessionCapabilities); err != nil {
@@ -200,6 +205,7 @@ func runNode(args []string) error {
 		EngineReleaseID:      hostEngineValue(*kind, *engineReleaseID),
 		EngineDigest:         hostEngineValue(*kind, *engineDigest),
 		HeartbeatInterval:    *heartbeatInterval,
+		MaxRunningJobs:       resolvedMaxRunningJobs,
 		HostIdentityProvider: hostIdentityProvider,
 		PostBootstrapHook:    postBootstrapHook,
 	}, scanNodeOptions...)
@@ -217,6 +223,21 @@ func runNode(args []string) error {
 	scanNode.Shutdown()
 	<-done
 	return nil
+}
+
+func smokeNodeMaxRunningJobsFlag(flags *flag.FlagSet) *uint64 {
+	return flags.Uint64(
+		"max-running-jobs",
+		1,
+		"Maximum concurrent jobs; zero means unlimited",
+	)
+}
+
+func smokeNodeMaxRunningJobs(value uint64) (uint32, error) {
+	if value > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("max-running-jobs exceeds uint32 range")
+	}
+	return uint32(value), nil
 }
 
 func environmentBool(name string) bool {

--- a/cmd/legion-smoke-node/main_test.go
+++ b/cmd/legion-smoke-node/main_test.go
@@ -2,8 +2,32 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"testing"
 )
+
+func TestSmokeNodeMaxRunningJobsFlag(t *testing.T) {
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	maximum := smokeNodeMaxRunningJobsFlag(flags)
+	if err := flags.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if *maximum != 1 {
+		t.Fatalf("default max-running-jobs = %d, want 1", *maximum)
+	}
+	if err := flags.Parse([]string{"--max-running-jobs", "0"}); err != nil {
+		t.Fatal(err)
+	}
+	if *maximum != 0 {
+		t.Fatalf("explicit max-running-jobs = %d, want unlimited 0", *maximum)
+	}
+}
+
+func TestSmokeNodeMaxRunningJobsRejectsOverflow(t *testing.T) {
+	if _, err := smokeNodeMaxRunningJobs(uint64(^uint32(0)) + 1); err == nil {
+		t.Fatal("expected uint32 overflow to be rejected")
+	}
+}
 
 func TestHostDockerEndpoint(t *testing.T) {
 	t.Parallel()

--- a/common/yak/cmd/yakcmds/node_capacity_test.go
+++ b/common/yak/cmd/yakcmds/node_capacity_test.go
@@ -1,0 +1,26 @@
+package yakcmds
+
+import "testing"
+
+func TestNodeMaxRunningJobsFromInt(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		value   int
+		want    uint32
+		wantErr bool
+	}{
+		{name: "default", value: 1, want: 1},
+		{name: "unlimited", value: 0, want: 0},
+		{name: "negative", value: -1, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := nodeMaxRunningJobsFromInt(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("max = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/common/yak/cmd/yakcmds/utils.go
+++ b/common/yak/cmd/yakcmds/utils.go
@@ -969,6 +969,10 @@ var DistributionCommands = []*cli.Command{
 		Before: nil,
 		After:  nil,
 		Action: func(c *cli.Context) error {
+			maxRunningJobs, err := nodeMaxRunningJobsFromInt(c.Int("max-running-jobs"))
+			if err != nil {
+				return err
+			}
 			scanNode, err := scannode.NewScanNode(node.BaseConfig{
 				NodeType:            spec.NodeType_Scanner,
 				NodeID:              c.String("id"),
@@ -978,7 +982,7 @@ var DistributionCommands = []*cli.Command{
 				EnrollmentToken:     c.String("enrollment-token"),
 				PlatformAPIBaseURL:  c.String("api-url"),
 				Version:             c.String("version"),
-				MaxRunningJobs:      uint32(c.Int("max-running-jobs")),
+				MaxRunningJobs:      maxRunningJobs,
 				HeartbeatInterval:   c.Duration("heartbeat-interval"),
 			}, scannode.WithRuleSnapshotCacheDir(c.String("rule-snapshot-cache-dir")))
 			if err != nil {
@@ -1139,6 +1143,16 @@ var DistributionCommands = []*cli.Command{
 			return nil
 		},
 	},
+}
+
+func nodeMaxRunningJobsFromInt(value int) (uint32, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("max-running-jobs must be zero or a positive integer")
+	}
+	if uint64(value) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("max-running-jobs exceeds uint32 range")
+	}
+	return uint32(value), nil
 }
 
 var XPathCommand = &cli.Command{

--- a/docs/legion-node-session-transport-refactor.md
+++ b/docs/legion-node-session-transport-refactor.md
@@ -1,6 +1,6 @@
 # Legion Node Session And Job Bridge Refactor
 
-更新时间：2026-03-28
+更新时间：2026-08-20
 
 ## 本轮已经落地的边界
 
@@ -135,10 +135,14 @@
 处理过程是：
 
 1. 校验 `command_id/job_id/subtask_id/attempt_id/target_node_id/plugin_release_id`
-2. 按 `plugin_release_id` 从本地 Legion 插件缓存读取脚本内容
-3. 先发 `job.claimed`
-4. 再发 `job.started`
-5. 调用本地脚本执行服务
+2. 用 session 内存 registry 按 `attempt_id` 预留 dispatch identity；同一 `command_id + attempt_id + payload` 的重投只确认、不重复执行，身份冲突直接 `Term`
+3. 非阻塞申请执行 slot；满载时不发 `job.claimed/job.started`，而是 `NakWithDelay(1s)`
+4. 在 `TaskManager` 以 `attempt_id` 原子登记 claimed attempt
+5. 发布 `job.claimed`
+6. 对 dispatch 消息执行 `AckSync`
+7. 只有 `AckSync` 成功后才发布 `job.started`，随后调用本地脚本执行服务
+
+满载 reservation 的截止时间是 `command.issued_at + 当前 heartbeat interval`。截止后或 node session 已切换时，消息直接 `Term`，由 Legion 的 lease/reclaim 流程收敛。节点不把满载命令变成本地 claimed waiting queue，也不把 reservation 写入磁盘；进程重启后的恢复仍由 Legion 负责，因此这里不承诺跨重启 exactly-once。
 
 桥接关系如下：
 
@@ -161,6 +165,33 @@
 - `script-task-<subtask_id>`
 
 然后通过 `TaskManager` 找到任务，写入取消原因并调用 `Cancel()`。
+
+如果取消发生在 slot 可用之前，registry 会把 pending reservation 变为当前 session 内的 tombstone，并发布 `job.cancelled`；即使 cancel 先于首次 dispatch 到达，也会按 `attempt_id` 预登记 tombstone，迟到的 dispatch 只补发 cancelled 并确认，不会执行。取消首先校验 consumer session，并按 `job_id + subtask_id + attempt_id` 精确匹配；只有旧协议明确缺少 `attempt_id` 时才回退到 subtask 查询，避免旧 session 或旧 Attempt 的 cancel 误杀新执行。tombstone 不持久化，终态会清除 Task/context/release 等执行对象，并只在 command stream 的 24 小时 MaxAge 窗口内保留轻量 identity，之后惰性回收；session 切换会整体清空。
+
+`AckSync` 返回错误时不能确定服务端是否已经接受 ACK。节点不会在这个不确定窗口执行任务：它会幂等释放 slot、移除 ActiveAttempt，但保留已发布 claimed 的 identity。若消息随后重投，节点重新申请 slot，只重试 ACK 确认，不重复发布 claimed；确认成功后才 started/execute。如果服务端实际已接受 ACK 而不再重投，节点停止该 Attempt 的 heartbeat，由 Legion lease/reclaim 收敛。
+
+## Node 容量与 heartbeat 口径
+
+`BaseConfig.MaxRunningJobs` 是主配置，最终生效值按下面优先级计算：
+
+1. `SCANNODE_MAX_PARALLEL` 为正整数时，作为旧部署兼容 override
+2. env 未设置、不是整数、为负数或为 `0` 时，回退到 `BaseConfig.MaxRunningJobs`
+
+最终 effective max 同时用于执行 limiter 和 heartbeat 的 `max_running_jobs`，不会出现“实际只跑 1 个、heartbeat 却上报其他值”的分叉。
+
+- `max_running_jobs = 1`：默认串行执行；`yak node` 和 Legion Smoke Node 均默认 1
+- `max_running_jobs > 1`：最多并发对应数量的作业
+- `max_running_jobs = 0`：显式 unlimited；limiter 不设上限，但仍准确统计 `running_jobs`
+- `yak node --max-running-jobs` 拒绝负数和超出 `uint32` 的值，避免有符号转无符号溢出
+- Legion Smoke Node 支持 `--max-running-jobs`，默认 1，显式传 0 表示 unlimited
+
+三个运行态口径彼此不同：
+
+- reservation：session 内存中的投递身份与 pending/cancel tombstone；不代表平台已 claimed
+- slot / `running_jobs`：已经成功占用本地执行容量的数量，包括 unlimited 模式下的实际占用数
+- `active_attempts`：仅包含已经登记为 `claimed`、`running` 或 `cancel_requested` 的 attempt；满载 pending reservation 不进入 heartbeat
+
+当 effective max 为 unlimited 或大于 1 时，节点为每个 child runtime 隔离隐式本地 project/SSA SQLite 文件；平台显式注入的共享 SSA DSN 保持不变。这样本地默认数据库不会因为并行 child process 相互覆盖。
 
 ### 5. 节点回传 `job.* / plugin.*`
 
@@ -289,6 +320,8 @@ yak node \
 - `--version`
 - `--max-running-jobs`
 - `--heartbeat-interval`
+
+`--max-running-jobs` 默认 1；传 0 表示 unlimited。正整数 `SCANNODE_MAX_PARALLEL` 只用于兼容旧部署，并覆盖 CLI 写入的主配置；无效值和 0 不覆盖。
 
 ## 当前结论
 

--- a/scannode/dispatch_admission.go
+++ b/scannode/dispatch_admission.go
@@ -1,0 +1,471 @@
+package scannode
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const dispatchReservationRetention = 24 * time.Hour
+
+type dispatchAdmissionState uint8
+
+const (
+	dispatchAdmissionPending dispatchAdmissionState = iota
+	dispatchAdmissionClaimed
+	dispatchAdmissionRunning
+	dispatchAdmissionTerminal
+)
+
+type dispatchReservation struct {
+	ref       jobExecutionRef
+	identity  string
+	sessionID string
+	deadline  time.Time
+
+	task             *Task
+	release          func()
+	state            dispatchAdmissionState
+	preparing        bool
+	claimedPublished bool
+	capacityDeferred bool
+	finishedAt       time.Time
+	cancelReason     string
+	cancelPublished  bool
+	stale            atomic.Bool
+}
+
+type pendingDispatchCancel struct {
+	jobID     string
+	subtaskID string
+	reason    string
+	createdAt time.Time
+}
+
+type dispatchReserveResult uint8
+
+const (
+	dispatchReserved dispatchReserveResult = iota
+	dispatchDuplicate
+	dispatchConflict
+	dispatchStaleSession
+	dispatchCancelled
+)
+
+type dispatchAdmissionRegistry struct {
+	mu sync.Mutex
+
+	sessionID     string
+	shuttingDown  bool
+	byAttempt     map[string]*dispatchReservation
+	byCommand     map[string]string
+	bySubtask     map[string]map[string]*dispatchReservation
+	pendingCancel map[string]pendingDispatchCancel
+}
+
+func newDispatchAdmissionRegistry() *dispatchAdmissionRegistry {
+	return &dispatchAdmissionRegistry{
+		byAttempt:     make(map[string]*dispatchReservation),
+		byCommand:     make(map[string]string),
+		bySubtask:     make(map[string]map[string]*dispatchReservation),
+		pendingCancel: make(map[string]pendingDispatchCancel),
+	}
+}
+
+func (r *dispatchAdmissionRegistry) SwitchSession(sessionID string) []*dispatchReservation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sessionID == sessionID {
+		return nil
+	}
+	stale := make([]*dispatchReservation, 0, len(r.byAttempt))
+	for _, reservation := range r.byAttempt {
+		reservation.stale.Store(true)
+		stale = append(stale, reservation)
+	}
+	r.sessionID = sessionID
+	r.byAttempt = make(map[string]*dispatchReservation)
+	r.byCommand = make(map[string]string)
+	r.bySubtask = make(map[string]map[string]*dispatchReservation)
+	r.pendingCancel = make(map[string]pendingDispatchCancel)
+	return stale
+}
+
+func (r *dispatchAdmissionRegistry) Reserve(
+	sessionID string,
+	ref jobExecutionRef,
+	identity string,
+	deadline time.Time,
+) (*dispatchReservation, dispatchReserveResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneLocked(time.Now().UTC())
+	if r.shuttingDown || (r.sessionID != "" && sessionID != r.sessionID) {
+		return nil, dispatchStaleSession
+	}
+	if r.sessionID == "" {
+		r.sessionID = sessionID
+	}
+	if attemptID, exists := r.byCommand[ref.CommandID]; exists && attemptID != ref.AttemptID {
+		return nil, dispatchConflict
+	}
+	if existing := r.byAttempt[ref.AttemptID]; existing != nil {
+		if existing.ref.CommandID != ref.CommandID || existing.identity != identity {
+			return existing, dispatchConflict
+		}
+		return existing, dispatchDuplicate
+	}
+	if cancelled, exists := r.pendingCancel[ref.AttemptID]; exists {
+		if cancelled.jobID != ref.JobID || cancelled.subtaskID != ref.SubtaskID {
+			return nil, dispatchConflict
+		}
+		reservation := r.addReservationLocked(sessionID, ref, identity, deadline)
+		reservation.cancelReason = cancelled.reason
+		delete(r.pendingCancel, ref.AttemptID)
+		return reservation, dispatchCancelled
+	}
+	return r.addReservationLocked(sessionID, ref, identity, deadline), dispatchReserved
+}
+
+func (r *dispatchAdmissionRegistry) addReservationLocked(
+	sessionID string,
+	ref jobExecutionRef,
+	identity string,
+	deadline time.Time,
+) *dispatchReservation {
+	reservation := &dispatchReservation{
+		ref:       ref,
+		identity:  identity,
+		sessionID: sessionID,
+		deadline:  deadline,
+		state:     dispatchAdmissionPending,
+	}
+	r.byAttempt[ref.AttemptID] = reservation
+	r.byCommand[ref.CommandID] = ref.AttemptID
+	items := r.bySubtask[ref.SubtaskID]
+	if items == nil {
+		items = make(map[string]*dispatchReservation)
+		r.bySubtask[ref.SubtaskID] = items
+	}
+	items[ref.AttemptID] = reservation
+	return reservation
+}
+
+func (r *dispatchAdmissionRegistry) Snapshot(
+	reservation *dispatchReservation,
+) (state dispatchAdmissionState, preparing bool, claimedPublished bool, stale bool) {
+	if reservation == nil {
+		return dispatchAdmissionTerminal, false, false, true
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return reservation.state, reservation.preparing, reservation.claimedPublished, reservation.stale.Load()
+}
+
+func (r *dispatchAdmissionRegistry) BeginPrepare(reservation *dispatchReservation) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.stale.Load() ||
+		reservation.state != dispatchAdmissionPending || reservation.preparing {
+		return false
+	}
+	reservation.preparing = true
+	return true
+}
+
+func (r *dispatchAdmissionRegistry) PrepareFailed(reservation *dispatchReservation) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation != nil && reservation.state == dispatchAdmissionPending {
+		reservation.preparing = false
+		reservation.capacityDeferred = true
+	}
+}
+
+func (r *dispatchAdmissionRegistry) AttachClaim(
+	reservation *dispatchReservation,
+	task *Task,
+	release func(),
+) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.stale.Load() ||
+		reservation.state != dispatchAdmissionPending {
+		return false
+	}
+	reservation.task = task
+	reservation.release = release
+	reservation.preparing = false
+	reservation.capacityDeferred = false
+	return true
+}
+
+func (r *dispatchAdmissionRegistry) Prepared(reservation *dispatchReservation) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return reservation != nil && reservation.state == dispatchAdmissionPending &&
+		reservation.task != nil && reservation.release != nil
+}
+
+func (r *dispatchAdmissionRegistry) DetachPrepared(
+	reservation *dispatchReservation,
+) (*Task, func(), bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.state != dispatchAdmissionPending ||
+		reservation.task == nil {
+		return nil, nil, false
+	}
+	task := reservation.task
+	release := reservation.release
+	reservation.task = nil
+	reservation.release = nil
+	reservation.preparing = false
+	return task, release, true
+}
+
+func (r *dispatchAdmissionRegistry) MarkClaimedPublished(reservation *dispatchReservation) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.stale.Load() ||
+		reservation.state != dispatchAdmissionPending {
+		return false
+	}
+	reservation.claimedPublished = true
+	reservation.state = dispatchAdmissionClaimed
+	return true
+}
+
+func (r *dispatchAdmissionRegistry) MarkRunning(reservation *dispatchReservation) (*Task, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.stale.Load() ||
+		reservation.state != dispatchAdmissionClaimed {
+		return nil, false
+	}
+	reservation.state = dispatchAdmissionRunning
+	return reservation.task, true
+}
+
+func (r *dispatchAdmissionRegistry) MarkExpired(reservation *dispatchReservation) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation != nil && reservation.state == dispatchAdmissionPending {
+		reservation.preparing = false
+		reservation.state = dispatchAdmissionTerminal
+		reservation.finishedAt = time.Now().UTC()
+	}
+}
+
+func (r *dispatchAdmissionRegistry) MarkTerminal(reservation *dispatchReservation) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.stale.Load() ||
+		reservation.state == dispatchAdmissionTerminal {
+		return false
+	}
+	reservation.state = dispatchAdmissionTerminal
+	reservation.preparing = false
+	reservation.finishedAt = time.Now().UTC()
+	return true
+}
+
+func (r *dispatchAdmissionRegistry) CancelJob(
+	sessionID string,
+	ref jobExecutionRef,
+) (beforeStart, running []*dispatchReservation, matched bool, staleSession bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sessionID != "" && sessionID != "" && sessionID != r.sessionID {
+		return nil, nil, false, true
+	}
+	reservations := make([]*dispatchReservation, 0, 1)
+	if strings.TrimSpace(ref.AttemptID) != "" {
+		if reservation := r.byAttempt[ref.AttemptID]; reservation != nil &&
+			reservation.ref.JobID == ref.JobID && reservation.ref.SubtaskID == ref.SubtaskID {
+			reservations = append(reservations, reservation)
+		}
+	} else {
+		for _, reservation := range r.bySubtask[ref.SubtaskID] {
+			if reservation != nil && (ref.JobID == "" || reservation.ref.JobID == ref.JobID) {
+				reservations = append(reservations, reservation)
+			}
+		}
+	}
+	for _, reservation := range reservations {
+		if reservation == nil || reservation.stale.Load() {
+			continue
+		}
+		matched = true
+		switch reservation.state {
+		case dispatchAdmissionPending, dispatchAdmissionClaimed:
+			reservation.state = dispatchAdmissionTerminal
+			reservation.preparing = false
+			reservation.finishedAt = time.Now().UTC()
+			beforeStart = append(beforeStart, reservation)
+		case dispatchAdmissionRunning:
+			running = append(running, reservation)
+		}
+	}
+	return beforeStart, running, matched, false
+}
+
+func (r *dispatchAdmissionRegistry) BeginShutdown() (beforeStart, running []*dispatchReservation) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.shuttingDown = true
+	for _, reservation := range r.byAttempt {
+		if reservation == nil || reservation.stale.Load() {
+			continue
+		}
+		switch reservation.state {
+		case dispatchAdmissionPending, dispatchAdmissionClaimed:
+			reservation.state = dispatchAdmissionTerminal
+			reservation.preparing = false
+			reservation.finishedAt = time.Now().UTC()
+			beforeStart = append(beforeStart, reservation)
+		case dispatchAdmissionRunning:
+			running = append(running, reservation)
+		}
+	}
+	return beforeStart, running
+}
+
+func (r *dispatchAdmissionRegistry) Deadline(reservation *dispatchReservation) time.Time {
+	if reservation == nil {
+		return time.Time{}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return reservation.deadline
+}
+
+func (r *dispatchAdmissionRegistry) TaskAndRelease(
+	reservation *dispatchReservation,
+) (*Task, func()) {
+	if reservation == nil {
+		return nil, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return reservation.task, reservation.release
+}
+
+func (r *dispatchAdmissionRegistry) RollbackClaimedAck(
+	reservation *dispatchReservation,
+) (*Task, func(), bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.stale.Load() || reservation.state != dispatchAdmissionClaimed {
+		return nil, nil, false
+	}
+	task := reservation.task
+	release := reservation.release
+	reservation.task = nil
+	reservation.release = nil
+	reservation.state = dispatchAdmissionPending
+	reservation.preparing = false
+	reservation.capacityDeferred = false
+	return task, release, true
+}
+
+func (r *dispatchAdmissionRegistry) CapacityRetryExpired(
+	reservation *dispatchReservation,
+	now time.Time,
+) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return reservation != nil && reservation.capacityDeferred &&
+		!reservation.deadline.IsZero() && !now.Before(reservation.deadline)
+}
+
+func (r *dispatchAdmissionRegistry) RecordPendingCancel(
+	sessionID string,
+	ref jobExecutionRef,
+	reason string,
+) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneLocked(time.Now().UTC())
+	if r.shuttingDown || (r.sessionID != "" && sessionID != "" && sessionID != r.sessionID) ||
+		strings.TrimSpace(ref.AttemptID) == "" ||
+		strings.TrimSpace(ref.JobID) == "" || strings.TrimSpace(ref.SubtaskID) == "" {
+		return false
+	}
+	if r.sessionID == "" && sessionID != "" {
+		r.sessionID = sessionID
+	}
+	if existing := r.byAttempt[ref.AttemptID]; existing != nil {
+		return false
+	}
+	r.pendingCancel[ref.AttemptID] = pendingDispatchCancel{
+		jobID:     ref.JobID,
+		subtaskID: ref.SubtaskID,
+		reason:    reason,
+		createdAt: time.Now().UTC(),
+	}
+	return true
+}
+
+func (r *dispatchAdmissionRegistry) PendingCancel(
+	reservation *dispatchReservation,
+) (reason string, published bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil {
+		return "", false
+	}
+	return reservation.cancelReason, reservation.cancelPublished
+}
+
+func (r *dispatchAdmissionRegistry) MarkPendingCancelPublished(
+	reservation *dispatchReservation,
+) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.stale.Load() || reservation.cancelReason == "" {
+		return false
+	}
+	reservation.cancelPublished = true
+	reservation.state = dispatchAdmissionTerminal
+	reservation.finishedAt = time.Now().UTC()
+	return true
+}
+
+func (r *dispatchAdmissionRegistry) CompactTerminal(reservation *dispatchReservation) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reservation == nil || reservation.state != dispatchAdmissionTerminal {
+		return
+	}
+	reservation.task = nil
+	reservation.release = nil
+	reservation.preparing = false
+	reservation.capacityDeferred = false
+}
+
+func (r *dispatchAdmissionRegistry) pruneLocked(now time.Time) {
+	cutoff := now.Add(-dispatchReservationRetention)
+	for attemptID, reservation := range r.byAttempt {
+		if reservation == nil || reservation.state != dispatchAdmissionTerminal ||
+			reservation.finishedAt.IsZero() || reservation.finishedAt.After(cutoff) {
+			continue
+		}
+		delete(r.byAttempt, attemptID)
+		if r.byCommand[reservation.ref.CommandID] == attemptID {
+			delete(r.byCommand, reservation.ref.CommandID)
+		}
+		if items := r.bySubtask[reservation.ref.SubtaskID]; items != nil {
+			delete(items, attemptID)
+			if len(items) == 0 {
+				delete(r.bySubtask, reservation.ref.SubtaskID)
+			}
+		}
+	}
+	for attemptID, cancelled := range r.pendingCancel {
+		if !cancelled.createdAt.After(cutoff) {
+			delete(r.pendingCancel, attemptID)
+		}
+	}
+}

--- a/scannode/dispatch_admission_test.go
+++ b/scannode/dispatch_admission_test.go
@@ -1,0 +1,771 @@
+package scannode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	jobv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/job/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type recordingDispatchReporter struct {
+	mu            sync.Mutex
+	events        []string
+	failureCodes  map[string]string
+	failureDetail map[string]map[string]string
+	failStarted   bool
+	failSucceeded bool
+	cancelBlock   <-chan struct{}
+}
+
+func (r *recordingDispatchReporter) record(kind string, ref jobExecutionRef) {
+	r.mu.Lock()
+	r.events = append(r.events, kind+":"+ref.AttemptID)
+	r.mu.Unlock()
+}
+
+func (r *recordingDispatchReporter) PublishClaimed(_ context.Context, ref jobExecutionRef) error {
+	r.record("claimed", ref)
+	return nil
+}
+
+func (r *recordingDispatchReporter) PublishStarted(_ context.Context, ref jobExecutionRef) error {
+	r.record("started", ref)
+	if r.failStarted {
+		return errors.New("started unavailable")
+	}
+	return nil
+}
+
+func (r *recordingDispatchReporter) PublishSucceeded(_ context.Context, ref jobExecutionRef, _ any) error {
+	r.record("succeeded", ref)
+	if r.failSucceeded {
+		return errors.New("terminal unavailable")
+	}
+	return nil
+}
+
+func (r *recordingDispatchReporter) PublishFailed(
+	_ context.Context,
+	ref jobExecutionRef,
+	code string,
+	_ string,
+	detail map[string]string,
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, "failed:"+ref.AttemptID)
+	if r.failureCodes == nil {
+		r.failureCodes = make(map[string]string)
+	}
+	if r.failureDetail == nil {
+		r.failureDetail = make(map[string]map[string]string)
+	}
+	r.failureCodes[ref.AttemptID] = code
+	r.failureDetail[ref.AttemptID] = detail
+	return nil
+}
+
+func (r *recordingDispatchReporter) PublishCancelled(
+	_ context.Context,
+	ref jobExecutionRef,
+	_ string,
+) error {
+	r.record("cancelled", ref)
+	if r.cancelBlock != nil {
+		<-r.cancelBlock
+	}
+	return nil
+}
+
+func (r *recordingDispatchReporter) count(kind, attemptID string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	want := kind + ":" + attemptID
+	count := 0
+	for _, event := range r.events {
+		if event == want {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *recordingDispatchReporter) failure(attemptID string) (string, map[string]string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.failureCodes[attemptID], r.failureDetail[attemptID]
+}
+
+func newAdmissionTestBridge(
+	maximum uint32,
+	executor dispatchExecutor,
+) (*legionJobBridge, *recordingDispatchReporter) {
+	agent := &ScanNode{
+		manager:           newTaskManager(),
+		invokeLimiter:     newInvokeLimiter(maximum),
+		maxRunningJobs:    maximum,
+		heartbeatInterval: 100 * time.Millisecond,
+	}
+	reporter := &recordingDispatchReporter{}
+	bridge := &legionJobBridge{
+		agent:               agent,
+		dispatchEvents:      reporter,
+		dispatchExecutor:    executor,
+		dispatchAdmissions:  newDispatchAdmissionRegistry(),
+		nodeIDProvider:      func() string { return "node-a" },
+		rootContextProvider: context.Background,
+	}
+	return bridge, reporter
+}
+
+func admissionTestCommand(commandID, jobID, subtaskID, attemptID string) *jobv1.DispatchJobCommand {
+	command := validDispatchCommand()
+	command.Metadata.CommandId = commandID
+	command.Metadata.IssuedAt = timestamppb.Now()
+	command.Job.JobId = jobID
+	command.Job.SubtaskId = subtaskID
+	command.Job.AttemptId = attemptID
+	return command
+}
+
+func marshalAdmissionCommand(t *testing.T, command *jobv1.DispatchJobCommand) []byte {
+	t.Helper()
+	raw, err := proto.Marshal(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func waitForAdmission(t *testing.T, condition func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal(message)
+}
+
+func TestDispatchStartsOnlyAfterAckSyncCallback(t *testing.T) {
+	executed := make(chan struct{}, 1)
+	bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executed <- struct{}{}
+		return &ScriptExecutionResult{}, nil
+	})
+	command := admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1")
+	disposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, command))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disposition.kind != messageAckSync || disposition.afterAck == nil {
+		t.Fatalf("disposition = %+v, want AckSync with after-ack callback", disposition)
+	}
+	if reporter.count("claimed", "attempt-1") != 1 || reporter.count("started", "attempt-1") != 0 {
+		t.Fatalf("events before AckSync callback = %+v", reporter.events)
+	}
+	select {
+	case <-executed:
+		t.Fatal("executor ran before AckSync callback")
+	default:
+	}
+	disposition.afterAck()
+	waitForAdmission(t, func() bool { return reporter.count("started", "attempt-1") == 1 }, "started was not published")
+	select {
+	case <-executed:
+	case <-time.After(time.Second):
+		t.Fatal("executor did not run after started")
+	}
+	waitForAdmission(t, func() bool {
+		return bridge.agent.invokeLimiter.activeCount() == 0 && bridge.agent.manager.Count() == 0
+	}, "successful dispatch did not release its slot and active attempt")
+}
+
+func TestDispatchAckSyncErrorRollsBackSlotAndRetriesConfirmation(t *testing.T) {
+	executed := make(chan struct{}, 1)
+	bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executed <- struct{}{}
+		return &ScriptExecutionResult{}, nil
+	})
+	command := admissionTestCommand("cmd-ack", "job-ack", "subtask-ack", "attempt-ack")
+	raw := marshalAdmissionCommand(t, command)
+	disposition, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bridge.agent.invokeLimiter.activeCount() != 1 || bridge.agent.manager.Count() != 1 {
+		t.Fatal("dispatch was not registered before AckSync")
+	}
+	if err := applyMessageDisposition(&nats.Msg{}, disposition); err == nil {
+		t.Fatal("unbound message AckSync unexpectedly succeeded")
+	}
+	if bridge.agent.invokeLimiter.activeCount() != 0 || bridge.agent.manager.Count() != 0 {
+		t.Fatal("AckSync error leaked slot or active attempt")
+	}
+	if reporter.count("claimed", "attempt-ack") != 1 || reporter.count("started", "attempt-ack") != 0 {
+		t.Fatalf("events after AckSync error = %+v", reporter.events)
+	}
+
+	retry, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry.kind != messageAckSync || retry.afterAck == nil {
+		t.Fatalf("retry disposition = %+v, want AckSync", retry)
+	}
+	if reporter.count("claimed", "attempt-ack") != 1 {
+		t.Fatal("AckSync retry republished claimed")
+	}
+	retry.afterAck()
+	select {
+	case <-executed:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch did not execute after retry confirmation")
+	}
+}
+
+func TestMaxOneTwoDispatchesPublishAtMostOneStarted(t *testing.T) {
+	releaseExecution := make(chan struct{})
+	var executions atomic.Int32
+	bridge, reporter := newAdmissionTestBridge(1, func(task *Task, _ ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executions.Add(1)
+		select {
+		case <-releaseExecution:
+			return &ScriptExecutionResult{}, nil
+		case <-task.Ctx.Done():
+			return nil, &TaskCancelledError{}
+		}
+	})
+	first := admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1")
+	firstDisposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, first))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDisposition.afterAck()
+	waitForAdmission(t, func() bool { return reporter.count("started", "attempt-1") == 1 }, "first dispatch did not start")
+
+	second := admissionTestCommand("cmd-2", "job-2", "subtask-2", "attempt-2")
+	secondDisposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondDisposition.kind != messageNakDelayed || secondDisposition.delay != time.Second {
+		t.Fatalf("second disposition = %+v, want delayed NAK", secondDisposition)
+	}
+	if reporter.count("claimed", "attempt-2") != 0 || reporter.count("started", "attempt-2") != 0 {
+		t.Fatalf("full dispatch emitted lifecycle events: %+v", reporter.events)
+	}
+	if executions.Load() != 1 {
+		t.Fatalf("executions = %d, want 1", executions.Load())
+	}
+	close(releaseExecution)
+}
+
+func TestDispatchSameIdentityRedeliveryExecutesOnceAndConflictTerms(t *testing.T) {
+	releaseExecution := make(chan struct{})
+	var executions atomic.Int32
+	bridge, reporter := newAdmissionTestBridge(1, func(task *Task, _ ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executions.Add(1)
+		select {
+		case <-releaseExecution:
+			return &ScriptExecutionResult{}, nil
+		case <-task.Ctx.Done():
+			return nil, &TaskCancelledError{}
+		}
+	})
+	command := admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1")
+	raw := marshalAdmissionCommand(t, command)
+	first, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duplicate, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicate.kind != messageAckSync || duplicate.afterAck == nil {
+		t.Fatalf("duplicate disposition = %+v", duplicate)
+	}
+	first.afterAck()
+	duplicate.afterAck()
+	waitForAdmission(t, func() bool { return reporter.count("started", "attempt-1") == 1 }, "same-ID dispatch did not start")
+	if executions.Load() != 1 || reporter.count("claimed", "attempt-1") != 1 {
+		t.Fatalf("same-ID counts: executions=%d events=%+v", executions.Load(), reporter.events)
+	}
+
+	conflictingAttempt := proto.Clone(command).(*jobv1.DispatchJobCommand)
+	conflictingAttempt.Metadata.CommandId = "cmd-other"
+	if disposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, conflictingAttempt)); err != nil || disposition.kind != messageTerm {
+		t.Fatalf("attempt conflict disposition=%+v err=%v", disposition, err)
+	}
+	conflictingCommand := proto.Clone(command).(*jobv1.DispatchJobCommand)
+	conflictingCommand.Job.AttemptId = "attempt-other"
+	if disposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, conflictingCommand)); err != nil || disposition.kind != messageTerm {
+		t.Fatalf("command conflict disposition=%+v err=%v", disposition, err)
+	}
+	close(releaseExecution)
+}
+
+func TestFullDispatchNAKExpiresAtIssuedHeartbeatDeadline(t *testing.T) {
+	releaseExecution := make(chan struct{})
+	bridge, _ := newAdmissionTestBridge(1, func(task *Task, _ ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		select {
+		case <-releaseExecution:
+			return &ScriptExecutionResult{}, nil
+		case <-task.Ctx.Done():
+			return nil, &TaskCancelledError{}
+		}
+	})
+	bridge.agent.heartbeatInterval = 40 * time.Millisecond
+	first := admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1")
+	firstDisposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, first))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDisposition.afterAck()
+	waitForAdmission(t, func() bool { return bridge.agent.invokeLimiter.activeCount() == 1 }, "first slot was not occupied")
+	second := admissionTestCommand("cmd-2", "job-2", "subtask-2", "attempt-2")
+	raw := marshalAdmissionCommand(t, second)
+	if disposition, err := bridge.handleDispatch(context.Background(), "session-a", raw); err != nil || disposition.kind != messageNakDelayed {
+		t.Fatalf("full disposition=%+v err=%v", disposition, err)
+	}
+	time.Sleep(60 * time.Millisecond)
+	if disposition, err := bridge.handleDispatch(context.Background(), "session-a", raw); err != nil || disposition.kind != messageTerm {
+		t.Fatalf("expired disposition=%+v err=%v", disposition, err)
+	}
+	close(releaseExecution)
+}
+
+func TestLateFirstDispatchUsesFreeSlotDespiteAdmissionDeadline(t *testing.T) {
+	executed := make(chan struct{}, 1)
+	bridge, _ := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executed <- struct{}{}
+		return &ScriptExecutionResult{}, nil
+	})
+	bridge.agent.heartbeatInterval = 10 * time.Millisecond
+	command := admissionTestCommand("cmd-late", "job-late", "subtask-late", "attempt-late")
+	command.Metadata.IssuedAt = timestamppb.New(time.Now().Add(-time.Minute))
+
+	disposition, err := bridge.handleDispatch(
+		context.Background(),
+		"session-a",
+		marshalAdmissionCommand(t, command),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disposition.kind != messageAckSync || disposition.afterAck == nil {
+		t.Fatalf("late first delivery disposition = %+v, want AckSync", disposition)
+	}
+	disposition.afterAck()
+	select {
+	case <-executed:
+	case <-time.After(time.Second):
+		t.Fatal("late first delivery did not execute with a free slot")
+	}
+}
+
+func TestDispatchFromReplacedSessionTerms(t *testing.T) {
+	bridge, _ := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		return &ScriptExecutionResult{}, nil
+	})
+	command := admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1")
+	raw := marshalAdmissionCommand(t, command)
+	if disposition, err := bridge.handleDispatch(context.Background(), "session-a", raw); err != nil || disposition.kind != messageAckSync {
+		t.Fatalf("initial disposition=%+v err=%v", disposition, err)
+	}
+	bridge.switchDispatchSession("session-b")
+	if disposition, err := bridge.handleDispatch(context.Background(), "session-a", raw); err != nil || disposition.kind != messageTerm {
+		t.Fatalf("stale session disposition=%+v err=%v", disposition, err)
+	}
+}
+
+func TestCancelBeforeStartCreatesSessionTombstoneAndDoesNotExecute(t *testing.T) {
+	releaseExecution := make(chan struct{})
+	var executions atomic.Int32
+	bridge, reporter := newAdmissionTestBridge(1, func(task *Task, input ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executions.Add(1)
+		if input.RuntimeID == "attempt-1" {
+			select {
+			case <-releaseExecution:
+				return &ScriptExecutionResult{}, nil
+			case <-task.Ctx.Done():
+				return nil, &TaskCancelledError{}
+			}
+		}
+		return nil, fmt.Errorf("cancelled attempt unexpectedly executed")
+	})
+	first := admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1")
+	firstDisposition, _ := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, first))
+	firstDisposition.afterAck()
+	waitForAdmission(t, func() bool { return bridge.agent.invokeLimiter.activeCount() == 1 }, "first slot was not occupied")
+	second := admissionTestCommand("cmd-2", "job-2", "subtask-2", "attempt-2")
+	raw := marshalAdmissionCommand(t, second)
+	disposition, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil || disposition.kind != messageNakDelayed {
+		t.Fatalf("pending disposition=%+v err=%v", disposition, err)
+	}
+	cancelRaw, err := proto.Marshal(&jobv1.CancelJobCommand{
+		Job:    second.Job,
+		Reason: "cancel before capacity",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.handleCancel(cancelRaw); err != nil {
+		t.Fatal(err)
+	}
+	waitForAdmission(t, func() bool { return reporter.count("cancelled", "attempt-2") == 1 }, "pending cancellation was not published")
+	redelivery, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil || redelivery.kind != messageAckSync || redelivery.afterAck != nil {
+		t.Fatalf("cancel tombstone disposition=%+v err=%v", redelivery, err)
+	}
+	if executions.Load() != 1 {
+		t.Fatalf("executions = %d, want only the first dispatch", executions.Load())
+	}
+	close(releaseExecution)
+}
+
+func TestCancelBeforeFirstDispatchTombstonesAttempt(t *testing.T) {
+	var executions atomic.Int32
+	bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executions.Add(1)
+		return &ScriptExecutionResult{}, nil
+	})
+	command := admissionTestCommand("cmd-late", "job-late", "subtask-late", "attempt-late")
+	cancelRaw, err := proto.Marshal(&jobv1.CancelJobCommand{
+		Job:    command.Job,
+		Reason: "cancel before dispatch delivery",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.handleCancelForSession("session-a", cancelRaw); err != nil {
+		t.Fatal(err)
+	}
+
+	raw := marshalAdmissionCommand(t, command)
+	disposition, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disposition.kind != messageAckSync || disposition.afterAck != nil {
+		t.Fatalf("late cancelled dispatch disposition = %+v", disposition)
+	}
+	if executions.Load() != 0 || reporter.count("claimed", "attempt-late") != 0 ||
+		reporter.count("started", "attempt-late") != 0 || reporter.count("cancelled", "attempt-late") != 1 {
+		t.Fatalf("late cancelled dispatch executed or emitted wrong events: executions=%d events=%+v", executions.Load(), reporter.events)
+	}
+	redelivery, err := bridge.handleDispatch(context.Background(), "session-a", raw)
+	if err != nil || redelivery.kind != messageAckSync || reporter.count("cancelled", "attempt-late") != 1 {
+		t.Fatalf("cancelled redelivery disposition=%+v err=%v events=%+v", redelivery, err, reporter.events)
+	}
+}
+
+func TestCancelTargetsAttemptWithoutCancellingSameSubtaskRetry(t *testing.T) {
+	releaseNew := make(chan struct{})
+	bridge, reporter := newAdmissionTestBridge(2, func(task *Task, input ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		if input.RuntimeID == "attempt-new" {
+			select {
+			case <-releaseNew:
+				return &ScriptExecutionResult{}, nil
+			case <-task.Ctx.Done():
+				return nil, &TaskCancelledError{Reason: task.CancelReason()}
+			}
+		}
+		<-task.Ctx.Done()
+		return nil, &TaskCancelledError{Reason: task.CancelReason()}
+	})
+	oldCommand := admissionTestCommand("cmd-old", "job-shared", "subtask-shared", "attempt-old")
+	newCommand := admissionTestCommand("cmd-new", "job-shared", "subtask-shared", "attempt-new")
+	startAdmissionDispatch(t, bridge, oldCommand)
+	startAdmissionDispatch(t, bridge, newCommand)
+	waitForAdmission(t, func() bool { return bridge.agent.invokeLimiter.activeCount() == 2 }, "both attempts did not start")
+
+	cancelRaw, err := proto.Marshal(&jobv1.CancelJobCommand{Job: oldCommand.Job, Reason: "cancel old only"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.handleCancelForSession("session-a", cancelRaw); err != nil {
+		t.Fatal(err)
+	}
+	waitForAdmission(t, func() bool { return reporter.count("cancelled", "attempt-old") == 1 }, "old attempt was not cancelled")
+	if _, err := bridge.agent.manager.GetTaskByAttemptID("attempt-new"); err != nil {
+		t.Fatal("cancel for old attempt removed the new retry")
+	}
+	if reporter.count("cancelled", "attempt-new") != 0 || bridge.agent.invokeLimiter.activeCount() != 1 {
+		t.Fatalf("new retry was affected: events=%+v active=%d", reporter.events, bridge.agent.invokeLimiter.activeCount())
+	}
+	close(releaseNew)
+}
+
+func TestStaleSessionCancelDoesNotAffectCurrentAttempt(t *testing.T) {
+	releaseExecution := make(chan struct{})
+	bridge, reporter := newAdmissionTestBridge(1, func(task *Task, _ ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		select {
+		case <-releaseExecution:
+			return &ScriptExecutionResult{}, nil
+		case <-task.Ctx.Done():
+			return nil, &TaskCancelledError{Reason: task.CancelReason()}
+		}
+	})
+	bridge.switchDispatchSession("session-a")
+	bridge.switchDispatchSession("session-b")
+	current := admissionTestCommand("cmd-current", "job-current", "subtask-shared", "attempt-current")
+	disposition, err := bridge.handleDispatch(context.Background(), "session-b", marshalAdmissionCommand(t, current))
+	if err != nil {
+		t.Fatal(err)
+	}
+	disposition.afterAck()
+	waitForAdmission(t, func() bool { return reporter.count("started", "attempt-current") == 1 }, "current attempt did not start")
+
+	staleCancel, err := proto.Marshal(&jobv1.CancelJobCommand{
+		Job: &jobv1.JobRef{
+			JobId:     "job-old",
+			SubtaskId: "subtask-shared",
+			AttemptId: "attempt-old",
+		},
+		Reason: "stale session cancel",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.handleCancelForSession("session-a", staleCancel); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bridge.agent.manager.GetTaskByAttemptID("attempt-current"); err != nil {
+		t.Fatal("stale-session cancel removed current attempt")
+	}
+	if reporter.count("cancelled", "attempt-current") != 0 || bridge.agent.invokeLimiter.activeCount() != 1 {
+		t.Fatalf("stale-session cancel affected current attempt: events=%+v active=%d", reporter.events, bridge.agent.invokeLimiter.activeCount())
+	}
+	close(releaseExecution)
+}
+
+func TestSessionScopedCancelNeverFallsBackToUnregisteredTask(t *testing.T) {
+	bridge, _ := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		return &ScriptExecutionResult{}, nil
+	})
+	bridge.switchDispatchSession("session-a")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	task := newScriptTask(ctx, cancel, "legacy-task", "job-a", "subtask-a", "attempt-a")
+	if _, loaded, accepted := bridge.agent.manager.LoadOrStoreAttempt(task); !accepted || loaded {
+		t.Fatal("unregistered TaskManager fixture was not added")
+	}
+	cancelRaw, err := proto.Marshal(&jobv1.CancelJobCommand{
+		Job: &jobv1.JobRef{
+			JobId:     "job-a",
+			SubtaskId: "subtask-a",
+			AttemptId: "attempt-a",
+		},
+		Reason: "session-scoped cancel",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.handleCancelForSession("session-a", cancelRaw); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("session-scoped cancel used the unfenced TaskManager fallback")
+	default:
+	}
+	bridge.agent.manager.RemoveAttempt(task.AttemptID)
+}
+
+func TestDispatchFailurePanicCancelAndShutdownReleaseSlot(t *testing.T) {
+	t.Run("failure", func(t *testing.T) {
+		bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+			return nil, errors.New("execution failed")
+		})
+		startAdmissionDispatch(t, bridge, admissionTestCommand("cmd-f", "job-f", "sub-f", "attempt-f"))
+		waitForAdmission(t, func() bool { return reporter.count("failed", "attempt-f") == 1 && bridge.agent.manager.Count() == 0 }, "failure did not drain")
+		if bridge.agent.invokeLimiter.activeCount() != 0 {
+			t.Fatal("failure leaked slot")
+		}
+	})
+
+	t.Run("rule snapshot preparation failure", func(t *testing.T) {
+		bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+			return nil, &ruleSnapshotPreparationError{
+				Expectation: RuleSnapshotExpectation{
+					SnapshotID:    "snapshot-a",
+					ContentSHA256: "sha256-a",
+				},
+				Err: errors.New("snapshot unavailable"),
+			}
+		})
+		startAdmissionDispatch(t, bridge, admissionTestCommand("cmd-rs", "job-rs", "sub-rs", "attempt-rs"))
+		waitForAdmission(t, func() bool {
+			return reporter.count("failed", "attempt-rs") == 1 && bridge.agent.manager.Count() == 0
+		}, "rule snapshot preparation failure did not drain")
+		if bridge.agent.invokeLimiter.activeCount() != 0 {
+			t.Fatal("rule snapshot preparation failure leaked slot")
+		}
+		code, detail := reporter.failure("attempt-rs")
+		if code != "rule_snapshot_prepare_failed" {
+			t.Fatalf("failure code = %q, want rule_snapshot_prepare_failed", code)
+		}
+		if detail["rule_snapshot_id"] != "snapshot-a" || detail["rule_snapshot_content_sha256"] != "sha256-a" {
+			t.Fatalf("failure detail = %#v, want snapshot identity", detail)
+		}
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+			panic("boom")
+		})
+		startAdmissionDispatch(t, bridge, admissionTestCommand("cmd-p", "job-p", "sub-p", "attempt-p"))
+		waitForAdmission(t, func() bool { return reporter.count("failed", "attempt-p") == 1 && bridge.agent.manager.Count() == 0 }, "panic did not drain")
+		if bridge.agent.invokeLimiter.activeCount() != 0 {
+			t.Fatal("panic leaked slot")
+		}
+	})
+
+	for _, mode := range []string{"cancel", "shutdown"} {
+		t.Run(mode, func(t *testing.T) {
+			bridge, reporter := newAdmissionTestBridge(1, func(task *Task, _ ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+				<-task.Ctx.Done()
+				return nil, &TaskCancelledError{Reason: task.CancelReason()}
+			})
+			command := admissionTestCommand("cmd-"+mode, "job-"+mode, "sub-"+mode, "attempt-"+mode)
+			startAdmissionDispatch(t, bridge, command)
+			waitForAdmission(t, func() bool { return reporter.count("started", command.Job.AttemptId) == 1 }, "dispatch did not start")
+			if mode == "cancel" {
+				raw, _ := proto.Marshal(&jobv1.CancelJobCommand{Job: command.Job, Reason: "stop"})
+				if err := bridge.handleCancel(raw); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				bridge.BeginShutdown()
+			}
+			waitForAdmission(t, func() bool {
+				return reporter.count("cancelled", command.Job.AttemptId) == 1 && bridge.agent.manager.Count() == 0
+			}, mode+" did not drain")
+			if bridge.agent.invokeLimiter.activeCount() != 0 {
+				t.Fatalf("%s leaked slot", mode)
+			}
+		})
+	}
+}
+
+func TestStartedPublishFailureIsBoundedAndDoesNotExecute(t *testing.T) {
+	var executions atomic.Int32
+	bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		executions.Add(1)
+		return &ScriptExecutionResult{}, nil
+	})
+	reporter.failStarted = true
+	startAdmissionDispatch(t, bridge, admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1"))
+	waitForAdmission(t, func() bool { return reporter.count("failed", "attempt-1") == 1 && bridge.agent.manager.Count() == 0 }, "started failure did not terminate")
+	if got := reporter.count("started", "attempt-1"); got != dispatchEventRetryAttempts {
+		t.Fatalf("started attempts = %d, want %d", got, dispatchEventRetryAttempts)
+	}
+	if executions.Load() != 0 || bridge.agent.invokeLimiter.activeCount() != 0 {
+		t.Fatalf("started failure executed=%d active=%d", executions.Load(), bridge.agent.invokeLimiter.activeCount())
+	}
+}
+
+func TestTerminalPublishFailureRetriesBoundedlyThenRemovesActiveAttempt(t *testing.T) {
+	bridge, reporter := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		return &ScriptExecutionResult{}, nil
+	})
+	reporter.failSucceeded = true
+	startAdmissionDispatch(t, bridge, admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1"))
+	waitForAdmission(t, func() bool { return bridge.agent.manager.Count() == 0 }, "terminal retry did not remove active attempt")
+	if got := reporter.count("succeeded", "attempt-1"); got != dispatchEventRetryAttempts {
+		t.Fatalf("terminal attempts = %d, want %d", got, dispatchEventRetryAttempts)
+	}
+	if bridge.agent.invokeLimiter.activeCount() != 0 {
+		t.Fatal("terminal publish failure leaked slot")
+	}
+}
+
+func TestTerminalReservationCompactsAndPrunes(t *testing.T) {
+	bridge, _ := newAdmissionTestBridge(1, func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		return &ScriptExecutionResult{}, nil
+	})
+	command := admissionTestCommand("cmd-old", "job-old", "subtask-old", "attempt-old")
+	startAdmissionDispatch(t, bridge, command)
+	waitForAdmission(t, func() bool { return bridge.agent.manager.Count() == 0 }, "dispatch did not finish")
+
+	registry := bridge.admissions()
+	registry.mu.Lock()
+	old := registry.byAttempt["attempt-old"]
+	if old == nil || old.task != nil || old.release != nil {
+		registry.mu.Unlock()
+		t.Fatal("terminal reservation retained execution objects")
+	}
+	old.finishedAt = time.Now().Add(-dispatchReservationRetention - time.Minute)
+	registry.mu.Unlock()
+
+	newCommand := admissionTestCommand("cmd-new", "job-new", "subtask-new", "attempt-new")
+	if _, result := registry.Reserve(
+		"session-a",
+		jobExecutionRefFromCommand(newCommand),
+		"identity-new",
+		time.Now().Add(time.Minute),
+	); result != dispatchReserved {
+		t.Fatalf("new reservation result = %v", result)
+	}
+	registry.mu.Lock()
+	_, retained := registry.byAttempt["attempt-old"]
+	registry.mu.Unlock()
+	if retained {
+		t.Fatal("expired terminal tombstone was not pruned")
+	}
+}
+
+func TestFullAdmissionAndPendingCancelDoNotBlockConsumer(t *testing.T) {
+	releaseExecution := make(chan struct{})
+	cancelPublisher := make(chan struct{})
+	bridge, reporter := newAdmissionTestBridge(1, func(task *Task, _ ScriptExecutionRequest) (*ScriptExecutionResult, error) {
+		select {
+		case <-releaseExecution:
+			return &ScriptExecutionResult{}, nil
+		case <-task.Ctx.Done():
+			return nil, &TaskCancelledError{}
+		}
+	})
+	reporter.cancelBlock = cancelPublisher
+	first := admissionTestCommand("cmd-1", "job-1", "subtask-1", "attempt-1")
+	startAdmissionDispatch(t, bridge, first)
+	waitForAdmission(t, func() bool { return bridge.agent.invokeLimiter.activeCount() == 1 }, "first slot was not occupied")
+	second := admissionTestCommand("cmd-2", "job-2", "subtask-2", "attempt-2")
+	startedAt := time.Now()
+	disposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, second))
+	if err != nil || disposition.kind != messageNakDelayed || time.Since(startedAt) > 100*time.Millisecond {
+		t.Fatalf("full admission blocked: disposition=%+v err=%v elapsed=%s", disposition, err, time.Since(startedAt))
+	}
+	cancelRaw, _ := proto.Marshal(&jobv1.CancelJobCommand{Job: second.Job, Reason: "stop pending"})
+	startedAt = time.Now()
+	if err := bridge.handleCancel(cancelRaw); err != nil || time.Since(startedAt) > 100*time.Millisecond {
+		t.Fatalf("pending cancel blocked consumer: err=%v elapsed=%s", err, time.Since(startedAt))
+	}
+	close(cancelPublisher)
+	close(releaseExecution)
+}
+
+func startAdmissionDispatch(t *testing.T, bridge *legionJobBridge, command *jobv1.DispatchJobCommand) {
+	t.Helper()
+	disposition, err := bridge.handleDispatch(context.Background(), "session-a", marshalAdmissionCommand(t, command))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disposition.kind != messageAckSync || disposition.afterAck == nil {
+		t.Fatalf("start disposition = %+v", disposition)
+	}
+	disposition.afterAck()
+}

--- a/scannode/invoke_limiter.go
+++ b/scannode/invoke_limiter.go
@@ -1,88 +1,97 @@
 package scannode
 
 import (
-	"context"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/yaklang/yaklang/common/log"
 )
 
-const (
-	envScanNodeMaxParallel = "SCANNODE_MAX_PARALLEL"
-)
+const envScanNodeMaxParallel = "SCANNODE_MAX_PARALLEL"
 
+// invokeLimiter is deliberately non-blocking. A nil slots channel means that
+// the Node is unbounded, while active still tracks the jobs that actually own
+// an execution slot for heartbeat reporting.
 type invokeLimiter struct {
-	total  chan struct{}
-	totalN int
+	slots   chan struct{}
+	maximum uint32
+	active  atomic.Uint32
 }
 
-func (l *invokeLimiter) activeCount() int {
-	if l == nil || l.total == nil {
-		return 0
+func newInvokeLimiter(maximum uint32) *invokeLimiter {
+	limiter := &invokeLimiter{maximum: maximum}
+	if maximum > 0 {
+		limiter.slots = make(chan struct{}, int(maximum))
 	}
-	return len(l.total)
+	return limiter
 }
 
-func (l *invokeLimiter) capacity() int {
+func (l *invokeLimiter) activeCount() uint32 {
 	if l == nil {
 		return 0
 	}
-	return l.totalN
+	return l.active.Load()
 }
 
-func (l *invokeLimiter) acquire(ctx context.Context) (release func(), err error) {
+func (l *invokeLimiter) capacity() uint32 {
 	if l == nil {
-		return func() {}, nil
+		return 0
 	}
-	if err := acquireToken(ctx, l.total); err != nil {
-		return nil, err
+	return l.maximum
+}
+
+// TryAcquire reserves capacity without turning the command consumer into a
+// local waiting queue. The returned release function is safe to call more than
+// once, which lets every terminal path share the same cleanup code.
+func (l *invokeLimiter) TryAcquire() (release func(), acquired bool) {
+	if l == nil {
+		return func() {}, true
 	}
+	if l.slots != nil {
+		select {
+		case l.slots <- struct{}{}:
+		default:
+			return nil, false
+		}
+	}
+	l.active.Add(1)
+	var once sync.Once
 	return func() {
-		releaseToken(l.total)
-	}, nil
+		once.Do(func() {
+			l.active.Add(^uint32(0))
+			if l.slots != nil {
+				<-l.slots
+			}
+		})
+	}, true
 }
 
-func acquireToken(ctx context.Context, ch chan struct{}) error {
-	if ch == nil {
-		return nil
+func effectiveMaxRunningJobs(configured uint32) uint32 {
+	raw := strings.TrimSpace(os.Getenv(envScanNodeMaxParallel))
+	if raw == "" {
+		return configured
 	}
-	select {
-	case ch <- struct{}{}:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	override, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil || override == 0 {
+		log.Warnf(
+			"ignore invalid %s=%q; using configured max_running_jobs=%d",
+			envScanNodeMaxParallel,
+			raw,
+			configured,
+		)
+		return configured
 	}
+	return uint32(override)
 }
 
-func releaseToken(ch chan struct{}) {
-	if ch == nil {
+func (s *ScanNode) initInvokeLimiter(maximum uint32) {
+	s.invokeLimiter = newInvokeLimiter(maximum)
+	if maximum == 0 {
+		log.Infof("invoke limiter initialized: total=unlimited")
 		return
 	}
-	select {
-	case <-ch:
-	default:
-	}
-}
-
-func readIntEnv(name string, def int) int {
-	v := strings.TrimSpace(os.Getenv(name))
-	if v == "" {
-		return def
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n <= 0 {
-		return def
-	}
-	return n
-}
-
-func (s *ScanNode) initInvokeLimiter() {
-	totalN := readIntEnv(envScanNodeMaxParallel, 1)
-	s.invokeLimiter = &invokeLimiter{
-		total:  make(chan struct{}, totalN),
-		totalN: totalN,
-	}
-	log.Infof("invoke limiter initialized: total=%d", totalN)
+	log.Infof("invoke limiter initialized: total=%d", maximum)
 }

--- a/scannode/invoke_limiter_test.go
+++ b/scannode/invoke_limiter_test.go
@@ -1,0 +1,100 @@
+package scannode
+
+import "testing"
+
+func TestInvokeLimiterMaxOneIsNonBlockingAndReleaseIsIdempotent(t *testing.T) {
+	limiter := newInvokeLimiter(1)
+	release, acquired := limiter.TryAcquire()
+	if !acquired || release == nil {
+		t.Fatal("first slot was not acquired")
+	}
+	if limiter.activeCount() != 1 {
+		t.Fatalf("active count = %d, want 1", limiter.activeCount())
+	}
+	if _, acquired := limiter.TryAcquire(); acquired {
+		t.Fatal("second slot unexpectedly blocked/acquired at max=1")
+	}
+	release()
+	release()
+	if limiter.activeCount() != 0 {
+		t.Fatalf("active count after idempotent release = %d, want 0", limiter.activeCount())
+	}
+}
+
+func TestInvokeLimiterMaxZeroIsUnlimitedAndStillCountsRunningJobs(t *testing.T) {
+	limiter := newInvokeLimiter(0)
+	first, acquired := limiter.TryAcquire()
+	if !acquired {
+		t.Fatal("first unlimited slot was not acquired")
+	}
+	second, acquired := limiter.TryAcquire()
+	if !acquired {
+		t.Fatal("second unlimited slot was not acquired")
+	}
+	if limiter.activeCount() != 2 || limiter.capacity() != 0 {
+		t.Fatalf("unlimited limiter snapshot = active %d capacity %d", limiter.activeCount(), limiter.capacity())
+	}
+	first()
+	second()
+	if limiter.activeCount() != 0 {
+		t.Fatalf("active count after releases = %d, want 0", limiter.activeCount())
+	}
+}
+
+func TestEffectiveMaxRunningJobsEnvOverride(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		configured uint32
+		want       uint32
+	}{
+		{name: "unset uses config", configured: 3, want: 3},
+		{name: "positive overrides", env: "5", configured: 3, want: 5},
+		{name: "zero falls back", env: "0", configured: 3, want: 3},
+		{name: "negative falls back", env: "-1", configured: 3, want: 3},
+		{name: "invalid falls back", env: "many", configured: 3, want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envScanNodeMaxParallel, tt.env)
+			if got := effectiveMaxRunningJobs(tt.configured); got != tt.want {
+				t.Fatalf("effective max = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSARuntimeDBIsolationFollowsEffectiveCapacity(t *testing.T) {
+	tests := []struct {
+		maximum uint32
+		want    bool
+	}{
+		{maximum: 0, want: true},
+		{maximum: 1, want: false},
+		{maximum: 2, want: true},
+	}
+	for _, tt := range tests {
+		node := &ScanNode{invokeLimiter: newInvokeLimiter(tt.maximum)}
+		if got := node.needIsolateSSARuntimeDB(); got != tt.want {
+			t.Fatalf("max=%d isolation=%t, want %t", tt.maximum, got, tt.want)
+		}
+	}
+}
+
+func TestScanNodeSnapshotUsesSlotCountAndEffectiveMaximum(t *testing.T) {
+	limiter := newInvokeLimiter(4)
+	release, acquired := limiter.TryAcquire()
+	if !acquired {
+		t.Fatal("slot was not acquired")
+	}
+	defer release()
+	node := &ScanNode{
+		manager:        newTaskManager(),
+		invokeLimiter:  limiter,
+		maxRunningJobs: 4,
+	}
+	snapshot := node.Snapshot()
+	if snapshot.RunningJobs != 1 || snapshot.MaxRunningJobs != 4 {
+		t.Fatalf("snapshot = %+v", snapshot)
+	}
+}

--- a/scannode/legion_command_consumer.go
+++ b/scannode/legion_command_consumer.go
@@ -13,6 +13,40 @@ import (
 
 const commandPollInterval = time.Second
 
+type messageDispositionKind uint8
+
+const (
+	messageAck messageDispositionKind = iota
+	messageAckSync
+	messageNak
+	messageNakDelayed
+	messageTerm
+)
+
+type messageDisposition struct {
+	kind       messageDispositionKind
+	delay      time.Duration
+	afterAck   func()
+	onAckError func()
+}
+
+func ackMessage() messageDisposition { return messageDisposition{kind: messageAck} }
+func ackSyncMessage(afterAck func()) messageDisposition {
+	return messageDisposition{kind: messageAckSync, afterAck: afterAck}
+}
+func ackSyncDispatchMessage(afterAck, onAckError func()) messageDisposition {
+	return messageDisposition{
+		kind:       messageAckSync,
+		afterAck:   afterAck,
+		onAckError: onAckError,
+	}
+}
+func nakMessage() messageDisposition { return messageDisposition{kind: messageNak} }
+func nakDelayedMessage(delay time.Duration) messageDisposition {
+	return messageDisposition{kind: messageNakDelayed, delay: delay}
+}
+func termMessage() messageDisposition { return messageDisposition{kind: messageTerm} }
+
 type commandConsumer struct {
 	sessionID string
 	cancel    context.CancelFunc
@@ -113,9 +147,14 @@ func (b *legionJobBridge) forwardCapabilityAlerts(ctx context.Context) {
 }
 
 func (b *legionJobBridge) syncConsumer(parent context.Context) {
+	if b.shuttingDown.Load() {
+		b.stopConsumer()
+		return
+	}
 	session, ok := b.agent.node.GetSessionState()
 	if !ok {
 		b.stopConsumer()
+		b.switchDispatchSession("")
 		b.resetCapabilityStatusSync()
 		return
 	}
@@ -128,6 +167,7 @@ func (b *legionJobBridge) syncConsumer(parent context.Context) {
 	}
 
 	b.stopConsumer()
+	b.switchDispatchSession(session.SessionID)
 	consumer, err := b.startConsumer(parent, session.NATSURL, session.SessionID, session.CommandSubject)
 	if err != nil {
 		log.Errorf("start legion command consumer failed: %v", err)
@@ -230,18 +270,38 @@ func (b *legionJobBridge) consumeLoop(ctx context.Context, consumer *commandCons
 			continue
 		}
 		for _, message := range messages {
-			if err := b.handleMessage(ctx, message); err != nil {
+			disposition, err := b.handleMessageWithDisposition(ctx, consumer.sessionID, message)
+			if err != nil {
 				log.Errorf("handle legion command failed: %v", err)
-				var rejected *runtimeHostCommandRejectedError
-				if errors.As(err, &rejected) {
-					_ = message.Term()
-					continue
-				}
-				_ = message.Nak()
-				continue
 			}
-			_ = message.Ack()
+			if err := applyMessageDisposition(message, disposition); err != nil {
+				log.Errorf("apply legion command disposition failed: %v", err)
+			}
 		}
+	}
+}
+
+func applyMessageDisposition(message *nats.Msg, disposition messageDisposition) error {
+	switch disposition.kind {
+	case messageAckSync:
+		if err := message.AckSync(); err != nil {
+			if disposition.onAckError != nil {
+				disposition.onAckError()
+			}
+			return err
+		}
+		if disposition.afterAck != nil {
+			disposition.afterAck()
+		}
+		return nil
+	case messageNak:
+		return message.Nak()
+	case messageNakDelayed:
+		return message.NakWithDelay(disposition.delay)
+	case messageTerm:
+		return message.Term()
+	default:
+		return message.Ack()
 	}
 }
 
@@ -254,15 +314,41 @@ func isCommandConsumerResetError(err error) bool {
 		errors.Is(err, nats.ErrSubscriptionClosed)
 }
 
-func (b *legionJobBridge) handleMessage(
+func (b *legionJobBridge) handleMessageWithDisposition(
 	ctx context.Context,
+	sessionID string,
+	message *nats.Msg,
+) (messageDisposition, error) {
+	if strings.HasSuffix(message.Subject, "."+legionCommandDispatch) {
+		return b.handleDispatch(ctx, sessionID, message.Data)
+	}
+	err := b.handleMessagePayload(ctx, sessionID, message)
+	if err == nil {
+		return ackMessage(), nil
+	}
+	var rejected *runtimeHostCommandRejectedError
+	if errors.As(err, &rejected) {
+		return termMessage(), err
+	}
+	return nakMessage(), err
+}
+
+// handleMessage remains the direct, non-consumer test/adapter entry. The
+// consume loop uses handleMessageWithDisposition so it can apply AckSync and
+// run dispatch only after the server confirms the acknowledgement.
+func (b *legionJobBridge) handleMessage(ctx context.Context, message *nats.Msg) error {
+	_, err := b.handleMessageWithDisposition(ctx, "", message)
+	return err
+}
+
+func (b *legionJobBridge) handleMessagePayload(
+	ctx context.Context,
+	sessionID string,
 	message *nats.Msg,
 ) error {
 	switch {
-	case strings.HasSuffix(message.Subject, "."+legionCommandDispatch):
-		return b.handleDispatch(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandCancel):
-		return b.handleCancel(message.Data)
+		return b.handleCancelForSession(sessionID, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandCapabilityApply):
 		return b.handleCapabilityApply(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandAIRuntimeImageEnsure),

--- a/scannode/legion_dispatch_bridge.go
+++ b/scannode/legion_dispatch_bridge.go
@@ -2,9 +2,13 @@ package scannode
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -12,18 +16,26 @@ import (
 	jobv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/job/v1"
 )
 
+const dispatchCapacityNakDelay = time.Second
+
+var (
+	dispatchEventRetryAttempts = 3
+	dispatchEventRetryDelay    = 100 * time.Millisecond
+)
+
 func (b *legionJobBridge) handleDispatch(
 	ctx context.Context,
+	sessionID string,
 	raw []byte,
-) error {
+) (messageDisposition, error) {
 	var command jobv1.DispatchJobCommand
 	if err := proto.Unmarshal(raw, &command); err != nil {
-		return fmt.Errorf("unmarshal dispatch command: %w", err)
+		return termMessage(), fmt.Errorf("unmarshal dispatch command: %w", err)
 	}
 
 	ref := jobExecutionRefFromCommand(&command)
-	if err := validateDispatchCommand(b.agent.node.CurrentNodeID(), &command); err != nil {
-		return b.publishDispatchFailure(
+	if err := validateDispatchCommand(b.currentNodeID(), &command); err != nil {
+		return termMessage(), b.publishDispatchFailure(
 			ctx,
 			ref,
 			"invalid_dispatch_command",
@@ -31,28 +43,244 @@ func (b *legionJobBridge) handleDispatch(
 			&command,
 		)
 	}
+	identity, err := dispatchCommandIdentity(&command)
+	if err != nil {
+		return termMessage(), err
+	}
+	now := time.Now().UTC()
+	deadline := dispatchAdmissionDeadline(&command, b.heartbeatInterval(), now)
+	reservation, reserveResult := b.admissions().Reserve(sessionID, ref, identity, deadline)
+	switch reserveResult {
+	case dispatchConflict, dispatchStaleSession:
+		return termMessage(), nil
+	case dispatchCancelled:
+		return b.publishPendingCancellation(ctx, reservation)
+	case dispatchDuplicate:
+		if reason, published := b.admissions().PendingCancel(reservation); reason != "" {
+			if published {
+				return ackSyncMessage(nil), nil
+			}
+			return b.publishPendingCancellation(ctx, reservation)
+		}
+		state, preparing, _, stale := b.admissions().Snapshot(reservation)
+		if stale {
+			return termMessage(), nil
+		}
+		switch state {
+		case dispatchAdmissionTerminal, dispatchAdmissionRunning:
+			return ackSyncMessage(nil), nil
+		case dispatchAdmissionClaimed:
+			return b.dispatchAckDisposition(reservation, &command), nil
+		case dispatchAdmissionPending:
+			// The issued-at deadline bounds only the full-capacity retry path.
+			// A first delivery may legitimately arrive later because it waited in
+			// Legion's outbox or JetStream and must still run when a slot is free.
+			if b.admissions().CapacityRetryExpired(reservation, now) {
+				b.expirePendingReservation(reservation)
+				return termMessage(), nil
+			}
+			if preparing {
+				return nakDelayedMessage(dispatchCapacityNakDelay), nil
+			}
+		}
+	}
+	if b.admissions().Prepared(reservation) {
+		return b.publishClaimedForReservation(ctx, reservation, &command)
+	}
+	if !b.admissions().BeginPrepare(reservation) {
+		return nakDelayedMessage(dispatchCapacityNakDelay), nil
+	}
+	release, acquired := b.agent.invokeLimiter.TryAcquire()
+	if !acquired {
+		b.admissions().PrepareFailed(reservation)
+		if b.admissions().CapacityRetryExpired(reservation, time.Now().UTC()) {
+			b.admissions().MarkExpired(reservation)
+			return termMessage(), nil
+		}
+		return nakDelayedMessage(dispatchCapacityNakDelay), nil
+	}
 
-	if err := b.publisher.PublishClaimed(ctx, ref); err != nil {
-		return err
+	execCtx := withLegionJobExecutionRef(b.rootContext(), ref)
+	taskCtx, cancel := context.WithCancel(execCtx)
+	task := newScriptTask(
+		taskCtx,
+		cancel,
+		taskIDForSubtask(ref.SubtaskID),
+		ref.JobID,
+		ref.SubtaskID,
+		ref.AttemptID,
+	)
+	_, loaded, accepted := b.agent.manager.LoadOrStoreAttempt(task)
+	if !accepted || loaded {
+		cancel()
+		release()
+		b.admissions().MarkExpired(reservation)
+		return termMessage(), nil
 	}
-	if err := b.publisher.PublishStarted(ctx, ref); err != nil {
-		return err
+	if !b.admissions().AttachClaim(reservation, task, release) {
+		cancel()
+		release()
+		b.agent.manager.RemoveAttempt(task.AttemptID)
+		_, _, _, stale := b.admissions().Snapshot(reservation)
+		if stale {
+			return termMessage(), nil
+		}
+		return ackSyncMessage(nil), nil
 	}
-	go b.executeDispatch(ref, &command)
-	return nil
+	return b.publishClaimedForReservation(ctx, reservation, &command)
+}
+
+func (b *legionJobBridge) publishClaimedForReservation(
+	ctx context.Context,
+	reservation *dispatchReservation,
+	command *jobv1.DispatchJobCommand,
+) (messageDisposition, error) {
+	_, _, claimedPublished, stale := b.admissions().Snapshot(reservation)
+	if stale {
+		return termMessage(), nil
+	}
+	if !claimedPublished {
+		if err := b.dispatchReporter().PublishClaimed(ctx, reservation.ref); err != nil {
+			b.rollbackPreparedReservation(reservation)
+			return nakMessage(), err
+		}
+	}
+	if !b.admissions().MarkClaimedPublished(reservation) {
+		_, _, _, stale := b.admissions().Snapshot(reservation)
+		if stale {
+			return termMessage(), nil
+		}
+		return ackSyncMessage(nil), nil
+	}
+	return b.dispatchAckDisposition(reservation, command), nil
+}
+
+func (b *legionJobBridge) dispatchAckDisposition(
+	reservation *dispatchReservation,
+	command *jobv1.DispatchJobCommand,
+) messageDisposition {
+	return ackSyncDispatchMessage(
+		func() { b.startDispatch(reservation, command) },
+		func() { b.rollbackClaimedAcknowledgement(reservation) },
+	)
+}
+
+func (b *legionJobBridge) rollbackClaimedAcknowledgement(reservation *dispatchReservation) {
+	task, release, rolledBack := b.admissions().RollbackClaimedAck(reservation)
+	if !rolledBack {
+		return
+	}
+	if task != nil {
+		task.Cancel()
+		b.agent.manager.RemoveAttempt(task.AttemptID)
+	}
+	if release != nil {
+		release()
+	}
+}
+
+func (b *legionJobBridge) publishPendingCancellation(
+	ctx context.Context,
+	reservation *dispatchReservation,
+) (messageDisposition, error) {
+	reason, published := b.admissions().PendingCancel(reservation)
+	if published {
+		return ackSyncMessage(nil), nil
+	}
+	if err := b.dispatchReporter().PublishCancelled(ctx, reservation.ref, reason); err != nil {
+		return nakMessage(), err
+	}
+	b.admissions().MarkPendingCancelPublished(reservation)
+	b.admissions().CompactTerminal(reservation)
+	return ackSyncMessage(nil), nil
+}
+
+func (b *legionJobBridge) rollbackPreparedReservation(reservation *dispatchReservation) {
+	task, release, detached := b.admissions().DetachPrepared(reservation)
+	if !detached {
+		return
+	}
+	if task != nil {
+		task.Cancel()
+		b.agent.manager.RemoveAttempt(task.AttemptID)
+	}
+	if release != nil {
+		release()
+	}
+}
+
+func (b *legionJobBridge) expirePendingReservation(reservation *dispatchReservation) {
+	b.admissions().MarkExpired(reservation)
+	task, release := b.admissions().TaskAndRelease(reservation)
+	if task != nil {
+		task.Cancel()
+		b.agent.manager.RemoveAttempt(task.AttemptID)
+	}
+	if release != nil {
+		release()
+	}
+	b.admissions().CompactTerminal(reservation)
+}
+
+func (b *legionJobBridge) startDispatch(
+	reservation *dispatchReservation,
+	command *jobv1.DispatchJobCommand,
+) {
+	task, start := b.admissions().MarkRunning(reservation)
+	if !start || task == nil {
+		return
+	}
+	task.MarkRunning()
+	command = proto.Clone(command).(*jobv1.DispatchJobCommand)
+	go func() {
+		if err := retryDispatchEvent(func(ctx context.Context) error {
+			return b.dispatchReporter().PublishStarted(ctx, reservation.ref)
+		}); err != nil {
+			b.finishDispatch(reservation, task, func(ctx context.Context) error {
+				return b.dispatchReporter().PublishFailed(
+					ctx,
+					reservation.ref,
+					"started_event_publish_failed",
+					err.Error(),
+					dispatchFailureDetail(command),
+				)
+			})
+			return
+		}
+		b.executeDispatch(reservation, task, command)
+	}()
 }
 
 func (b *legionJobBridge) executeDispatch(
-	ref jobExecutionRef,
+	reservation *dispatchReservation,
+	task *Task,
 	command *jobv1.DispatchJobCommand,
 ) {
-	execCtx := withLegionJobExecutionRef(b.agent.node.GetRootContext(), ref)
-	response, err := b.agent.executeScriptTask(
-		execCtx,
+	finished := false
+	defer func() {
+		if recovered := recover(); recovered != nil && !finished {
+			b.finishDispatch(reservation, task, func(ctx context.Context) error {
+				return b.dispatchReporter().PublishFailed(
+					ctx,
+					reservation.ref,
+					"script_execution_panic",
+					fmt.Sprintf("panic: %v", recovered),
+					map[string]string{"stack": string(debug.Stack())},
+				)
+			})
+		}
+	}()
+
+	executor := b.dispatchExecutor
+	if executor == nil {
+		executor = b.agent.executeScriptTask
+	}
+	response, err := executor(
+		task,
 		ScriptExecutionRequest{
-			TaskID:          ref.JobID,
-			RuntimeID:       ref.AttemptID,
-			SubTaskID:       ref.SubtaskID,
+			TaskID:          reservation.ref.JobID,
+			RuntimeID:       reservation.ref.AttemptID,
+			SubTaskID:       reservation.ref.SubtaskID,
 			ScriptContent:   command.GetScript().GetContent(),
 			ScriptJSONParam: normalizeInputJSON(command.GetInputJson()),
 			ScriptLabels:    command.GetLabels(),
@@ -60,26 +288,34 @@ func (b *legionJobBridge) executeDispatch(
 			DebugDir:        resolveDebugDir(command.GetLabels()),
 			RuleSnapshot:    ruleSnapshotExpectationFromCommand(command),
 			RuleSnapshotPrepared: func(ctx context.Context, receipt RuleSnapshotPreparationReceipt) error {
-				return b.publisher.PublishRuleSnapshotPrepared(ctx, ref, receipt)
+				return b.publisher.PublishRuleSnapshotPrepared(ctx, reservation.ref, receipt)
 			},
 		},
 	)
 	if err == nil {
-		if publishErr := b.publisher.PublishSucceeded(
-			b.agent.node.GetRootContext(),
-			ref,
-			response,
-		); publishErr != nil {
-			logDispatchPublishError("success", publishErr)
-		}
+		finished = true
+		b.finishDispatch(reservation, task, func(ctx context.Context) error {
+			return b.dispatchReporter().PublishSucceeded(ctx, reservation.ref, response)
+		})
 		return
 	}
 
 	var cancelled *TaskCancelledError
 	if errors.As(err, &cancelled) {
-		b.publishCancelled(ref, cancelled)
+		finished = true
+		reason := cancelled.Reason
+		if reason == "" {
+			reason = task.CancelReason()
+		}
+		if reason == "" {
+			reason = "cancel requested"
+		}
+		b.finishDispatch(reservation, task, func(ctx context.Context) error {
+			return b.dispatchReporter().PublishCancelled(ctx, reservation.ref, reason)
+		})
 		return
 	}
+	finished = true
 	failureCode := "script_execution_failed"
 	failureDetail := dispatchFailureDetail(command)
 	var preparationErr *ruleSnapshotPreparationError
@@ -92,18 +328,58 @@ func (b *legionJobBridge) executeDispatch(
 			failureDetail["rule_snapshot_content_sha256"] = preparationErr.Expectation.ContentSHA256
 		}
 	}
-	if publishErr := b.publisher.PublishFailed(
-		b.agent.node.GetRootContext(),
-		ref,
-		failureCode,
-		err.Error(),
-		failureDetail,
-	); publishErr != nil {
-		logDispatchPublishError("failed", publishErr)
+	b.finishDispatch(reservation, task, func(ctx context.Context) error {
+		return b.dispatchReporter().PublishFailed(
+			ctx,
+			reservation.ref,
+			failureCode,
+			err.Error(),
+			failureDetail,
+		)
+	})
+}
+
+func (b *legionJobBridge) finishDispatch(
+	reservation *dispatchReservation,
+	task *Task,
+	publish func(context.Context) error,
+) {
+	_, release := b.admissions().TaskAndRelease(reservation)
+	if release != nil {
+		release()
 	}
+	if b.admissions().MarkTerminal(reservation) {
+		if err := retryDispatchEvent(publish); err != nil {
+			logDispatchPublishError("terminal", err)
+		}
+	}
+	if task != nil {
+		b.agent.manager.RemoveAttempt(task.AttemptID)
+	}
+	b.admissions().CompactTerminal(reservation)
+}
+
+func retryDispatchEvent(publish func(context.Context) error) error {
+	if publish == nil {
+		return nil
+	}
+	var err error
+	for attempt := 0; attempt < dispatchEventRetryAttempts; attempt++ {
+		if err = publish(context.Background()); err == nil {
+			return nil
+		}
+		if attempt+1 < dispatchEventRetryAttempts && dispatchEventRetryDelay > 0 {
+			time.Sleep(dispatchEventRetryDelay)
+		}
+	}
+	return err
 }
 
 func (b *legionJobBridge) handleCancel(raw []byte) error {
+	return b.handleCancelForSession("", raw)
+}
+
+func (b *legionJobBridge) handleCancelForSession(sessionID string, raw []byte) error {
 	var command jobv1.CancelJobCommand
 	if err := proto.Unmarshal(raw, &command); err != nil {
 		return fmt.Errorf("unmarshal cancel command: %w", err)
@@ -113,19 +389,169 @@ func (b *legionJobBridge) handleCancel(raw []byte) error {
 		return fmt.Errorf("cancel command subtask_id is required")
 	}
 
-	task, err := b.agent.manager.GetTaskById(taskIDForSubtask(subtaskID))
-	if err != nil {
-		logCancelTargetMissing(subtaskID)
-		return nil
-	}
 	reason := strings.TrimSpace(command.GetReason())
 	if reason == "" {
 		reason = "platform cancel requested"
 	}
+	jobRef := command.GetJob()
+	ref := jobExecutionRef{
+		CommandID: command.GetMetadata().GetCommandId(),
+		JobID:     jobRef.GetJobId(),
+		SubtaskID: jobRef.GetSubtaskId(),
+		AttemptID: jobRef.GetAttemptId(),
+	}
+	beforeStart, running, matched, staleSession := b.admissions().CancelJob(sessionID, ref)
+	if staleSession {
+		return nil
+	}
+	for _, reservation := range beforeStart {
+		b.cancelBeforeStart(reservation, reason)
+	}
+	for _, reservation := range running {
+		b.cancelRunning(reservation, reason)
+	}
+	if matched || len(beforeStart)+len(running) > 0 {
+		return nil
+	}
+	// Consumer-delivered cancellation is session-scoped. Every Legion dispatch
+	// is registered before entering TaskManager, so falling back to the global
+	// task indexes here would reopen a TOCTOU window: the old consumer could
+	// pass its registry fence, a session switch could register a retry, and the
+	// old cancel could then kill the new task. Preserve TaskManager fallback only
+	// for the direct legacy adapter, which has no session identity.
+	if sessionID != "" {
+		if b.admissions().RecordPendingCancel(sessionID, ref, reason) {
+			return nil
+		}
+		logCancelTargetMissing(subtaskID)
+		return nil
+	}
+
+	var tasks []*Task
+	if strings.TrimSpace(ref.AttemptID) != "" {
+		if task, err := b.agent.manager.GetTaskByAttemptID(ref.AttemptID); err == nil &&
+			task.JobID == ref.JobID && task.SubtaskID == ref.SubtaskID {
+			tasks = append(tasks, task)
+		}
+	} else {
+		tasks = b.agent.manager.TasksBySubtask(subtaskID)
+	}
+	if len(tasks) == 0 && strings.TrimSpace(ref.AttemptID) == "" {
+		if task, err := b.agent.manager.GetTaskById(taskIDForSubtask(subtaskID)); err == nil {
+			tasks = append(tasks, task)
+		}
+	}
+	if len(tasks) == 0 {
+		if b.admissions().RecordPendingCancel("", ref, reason) {
+			return nil
+		}
+		logCancelTargetMissing(subtaskID)
+		return nil
+	}
+	for _, task := range tasks {
+		task.SetCancelReason(reason)
+		task.MarkCancelRequested()
+		task.Cancel()
+	}
+	return nil
+}
+
+func (b *legionJobBridge) cancelBeforeStart(reservation *dispatchReservation, reason string) {
+	task, release := b.admissions().TaskAndRelease(reservation)
+	if release != nil {
+		release()
+	}
+	if task != nil {
+		task.SetCancelReason(reason)
+		task.MarkCancelRequested()
+		task.Cancel()
+	}
+	go func() {
+		if err := retryDispatchEvent(func(ctx context.Context) error {
+			return b.dispatchReporter().PublishCancelled(ctx, reservation.ref, reason)
+		}); err != nil {
+			logDispatchPublishError("cancelled", err)
+		}
+		if task != nil {
+			b.agent.manager.RemoveAttempt(task.AttemptID)
+		}
+		b.admissions().CompactTerminal(reservation)
+	}()
+}
+
+func (b *legionJobBridge) cancelRunning(reservation *dispatchReservation, reason string) {
+	task, _ := b.admissions().TaskAndRelease(reservation)
+	if task == nil {
+		return
+	}
 	task.SetCancelReason(reason)
 	task.MarkCancelRequested()
 	task.Cancel()
-	return nil
+}
+
+func dispatchCommandIdentity(command *jobv1.DispatchJobCommand) (string, error) {
+	raw, err := proto.MarshalOptions{Deterministic: true}.Marshal(command)
+	if err != nil {
+		return "", fmt.Errorf("marshal dispatch identity: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func dispatchAdmissionDeadline(
+	command *jobv1.DispatchJobCommand,
+	heartbeatInterval time.Duration,
+	now time.Time,
+) time.Time {
+	if heartbeatInterval <= 0 {
+		heartbeatInterval = time.Second
+	}
+	issuedAt := command.GetMetadata().GetIssuedAt()
+	if issuedAt != nil && issuedAt.IsValid() {
+		return issuedAt.AsTime().UTC().Add(heartbeatInterval)
+	}
+	return now.Add(heartbeatInterval)
+}
+
+func (b *legionJobBridge) heartbeatInterval() time.Duration {
+	if b.agent != nil && b.agent.heartbeatInterval > 0 {
+		return b.agent.heartbeatInterval
+	}
+	return time.Second
+}
+
+func (b *legionJobBridge) switchDispatchSession(sessionID string) {
+	for _, reservation := range b.admissions().SwitchSession(sessionID) {
+		state, _, _, _ := b.admissions().Snapshot(reservation)
+		task, release := b.admissions().TaskAndRelease(reservation)
+		if task != nil {
+			task.SetCancelReason("node session replaced")
+			task.MarkCancelRequested()
+			task.Cancel()
+		}
+		if state != dispatchAdmissionRunning {
+			if release != nil {
+				release()
+			}
+			if task != nil {
+				b.agent.manager.RemoveAttempt(task.AttemptID)
+			}
+		}
+	}
+}
+
+func (b *legionJobBridge) BeginShutdown() {
+	if b == nil || !b.shuttingDown.CompareAndSwap(false, true) {
+		return
+	}
+	b.stopConsumer()
+	beforeStart, running := b.admissions().BeginShutdown()
+	for _, reservation := range beforeStart {
+		b.cancelBeforeStart(reservation, "node shutdown")
+	}
+	for _, reservation := range running {
+		b.cancelRunning(reservation, "node shutdown")
+	}
 }
 
 func validateDispatchCommand(
@@ -171,24 +597,7 @@ func (b *legionJobBridge) publishDispatchFailure(
 	message string,
 	command *jobv1.DispatchJobCommand,
 ) error {
-	return b.publisher.PublishFailed(ctx, ref, code, message, dispatchFailureDetail(command))
-}
-
-func (b *legionJobBridge) publishCancelled(
-	ref jobExecutionRef,
-	cancelled *TaskCancelledError,
-) {
-	reason := cancelled.Reason
-	if reason == "" {
-		reason = "cancel requested"
-	}
-	if publishErr := b.publisher.PublishCancelled(
-		b.agent.node.GetRootContext(),
-		ref,
-		reason,
-	); publishErr != nil {
-		logDispatchPublishError("cancelled", publishErr)
-	}
+	return b.dispatchReporter().PublishFailed(ctx, ref, code, message, dispatchFailureDetail(command))
 }
 
 func validateDispatchExecutionKind(value string) error {

--- a/scannode/legion_job_bridge.go
+++ b/scannode/legion_job_bridge.go
@@ -3,6 +3,7 @@ package scannode
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -20,20 +21,37 @@ type hidsDesiredSpecDryRunReporter interface {
 	PublishDesiredSpecDryRunResult(context.Context, capabilityCommandRef, CapabilityDryRunResult) error
 }
 
+type dispatchEventReporter interface {
+	PublishClaimed(context.Context, jobExecutionRef) error
+	PublishStarted(context.Context, jobExecutionRef) error
+	PublishSucceeded(context.Context, jobExecutionRef, any) error
+	PublishFailed(context.Context, jobExecutionRef, string, string, map[string]string) error
+	PublishCancelled(context.Context, jobExecutionRef, string) error
+}
+
+type dispatchExecutor func(*Task, ScriptExecutionRequest) (*ScriptExecutionResult, error)
+
 type legionJobBridge struct {
-	agent                  *ScanNode
-	publisher              *jobEventPublisher
-	capabilityPublisher    capabilityEventReporter
-	hidsDryRunPublisher    hidsDesiredSpecDryRunReporter
-	ruleSyncPublisher      *ssaRuleSyncEventPublisher
-	aiPublisher            *aiSessionEventPublisher
-	aiRuntime              *aiSessionRuntimeManager
-	aiLocalModelOps        *aiLocalModelOperationManager
-	aiKnowledgeBaseQueries *aiKnowledgeBaseQueryManager
+	agent                          *ScanNode
+	publisher                      *jobEventPublisher
+	dispatchEvents                 dispatchEventReporter
+	dispatchExecutor               dispatchExecutor
+	dispatchAdmissions             *dispatchAdmissionRegistry
+	dispatchAdmissionsOnce         sync.Once
+	nodeIDProvider                 func() string
+	rootContextProvider            func() context.Context
+	capabilityPublisher            capabilityEventReporter
+	hidsDryRunPublisher            hidsDesiredSpecDryRunReporter
+	ruleSyncPublisher              *ssaRuleSyncEventPublisher
+	aiPublisher                    *aiSessionEventPublisher
+	aiRuntime                      *aiSessionRuntimeManager
+	aiLocalModelOps                *aiLocalModelOperationManager
+	aiKnowledgeBaseQueries         *aiKnowledgeBaseQueryManager
 	aiKnowledgeBaseQuestionIndexes *aiKnowledgeBaseQueryManager
 
-	mu       sync.Mutex
-	consumer *commandConsumer
+	mu           sync.Mutex
+	consumer     *commandConsumer
+	shuttingDown atomic.Bool
 
 	statusMu            sync.Mutex
 	lastStatusSessionID string
@@ -42,16 +60,58 @@ type legionJobBridge struct {
 
 func newLegionJobBridge(agent *ScanNode) *legionJobBridge {
 	capabilityPublisher := newCapabilityEventPublisher(agent.node)
-	return &legionJobBridge{
-		agent:                  agent,
-		publisher:              newJobEventPublisher(agent.node),
-		capabilityPublisher:    capabilityPublisher,
-		hidsDryRunPublisher:    capabilityPublisher,
-		ruleSyncPublisher:      newSSARuleSyncEventPublisher(agent.node),
-		aiPublisher:            newAISessionEventPublisher(agent.node),
-		aiRuntime:              newAISessionRuntimeManager(selectAISessionRuntimeDriver()),
-		aiLocalModelOps:        newAILocalModelOperationManager(),
-		aiKnowledgeBaseQueries: newAIKnowledgeBaseQueryManager(),
+	bridge := &legionJobBridge{
+		agent:                          agent,
+		publisher:                      newJobEventPublisher(agent.node),
+		capabilityPublisher:            capabilityPublisher,
+		hidsDryRunPublisher:            capabilityPublisher,
+		ruleSyncPublisher:              newSSARuleSyncEventPublisher(agent.node),
+		aiPublisher:                    newAISessionEventPublisher(agent.node),
+		aiRuntime:                      newAISessionRuntimeManager(selectAISessionRuntimeDriver()),
+		aiLocalModelOps:                newAILocalModelOperationManager(),
+		aiKnowledgeBaseQueries:         newAIKnowledgeBaseQueryManager(),
 		aiKnowledgeBaseQuestionIndexes: newAIKnowledgeBaseQueryManager(),
+		dispatchAdmissions:             newDispatchAdmissionRegistry(),
 	}
+	bridge.dispatchEvents = bridge.publisher
+	bridge.dispatchExecutor = agent.executeScriptTask
+	bridge.nodeIDProvider = agent.node.CurrentNodeID
+	bridge.rootContextProvider = agent.node.GetRootContext
+	return bridge
+}
+
+func (b *legionJobBridge) dispatchReporter() dispatchEventReporter {
+	if b.dispatchEvents != nil {
+		return b.dispatchEvents
+	}
+	return b.publisher
+}
+
+func (b *legionJobBridge) admissions() *dispatchAdmissionRegistry {
+	b.dispatchAdmissionsOnce.Do(func() {
+		if b.dispatchAdmissions == nil {
+			b.dispatchAdmissions = newDispatchAdmissionRegistry()
+		}
+	})
+	return b.dispatchAdmissions
+}
+
+func (b *legionJobBridge) currentNodeID() string {
+	if b.nodeIDProvider != nil {
+		return b.nodeIDProvider()
+	}
+	if b.agent != nil && b.agent.node != nil {
+		return b.agent.node.CurrentNodeID()
+	}
+	return ""
+}
+
+func (b *legionJobBridge) rootContext() context.Context {
+	if b.rootContextProvider != nil {
+		return b.rootContextProvider()
+	}
+	if b.agent != nil && b.agent.node != nil {
+		return b.agent.node.GetRootContext()
+	}
+	return context.Background()
 }

--- a/scannode/legion_reporter_events.go
+++ b/scannode/legion_reporter_events.go
@@ -172,7 +172,11 @@ func (r *ScannerAgentReporter) updateActiveAttemptProgress(process float64) {
 	if r == nil || r.agent == nil || r.agent.manager == nil || r.SubTaskId == "" {
 		return
 	}
-	task, err := r.agent.manager.GetTaskById(taskIDForSubtask(r.SubTaskId))
+	task, err := r.agent.manager.GetTaskByAttemptID(r.RuntimeId)
+	if err != nil {
+		// Non-Legion and legacy reporter callers may not carry an AttemptID.
+		task, err = r.agent.manager.GetTaskById(taskIDForSubtask(r.SubTaskId))
+	}
 	if err != nil {
 		return
 	}
@@ -388,6 +392,10 @@ func ssaSizeToUint64(value int64) uint64 {
 
 func (r *ScannerAgentReporter) touchActiveAttempt() {
 	if r == nil || r.agent == nil || r.agent.manager == nil || r.SubTaskId == "" {
+		return
+	}
+	if r.RuntimeId != "" {
+		r.agent.manager.TouchAttempt(r.RuntimeId)
 		return
 	}
 	r.agent.manager.Touch(taskIDForSubtask(r.SubTaskId))

--- a/scannode/node.go
+++ b/scannode/node.go
@@ -23,6 +23,7 @@ type ScanNode struct {
 	httpClient        *http.Client
 	invokeLimiter     *invokeLimiter
 	maxRunningJobs    uint32
+	heartbeatInterval time.Duration
 	bridge            *legionJobBridge
 	ssaGitOwnerScope  string
 	ssaGitScopeLock   *ssagitworkdir.OwnerScopeLock
@@ -53,6 +54,10 @@ func WithRuleSnapshotCacheDir(cacheDir string) ScanNodeOption {
 }
 
 func NewScanNode(cfg node.BaseConfig, options ...ScanNodeOption) (*ScanNode, error) {
+	if cfg.HeartbeatInterval <= 0 {
+		cfg.HeartbeatInterval = node.DefaultHeartbeatInterval
+	}
+	cfg.MaxRunningJobs = effectiveMaxRunningJobs(cfg.MaxRunningJobs)
 	var resolvedOptions scanNodeOptions
 	for _, option := range options {
 		if option != nil {
@@ -63,8 +68,9 @@ func NewScanNode(cfg node.BaseConfig, options ...ScanNodeOption) (*ScanNode, err
 		cfg.CapabilityKeys = append(cfg.CapabilityKeys, AIRuntimeHostCapabilityKey)
 	}
 	agent := &ScanNode{
-		manager:        newTaskManager(),
-		maxRunningJobs: cfg.MaxRunningJobs,
+		manager:           newTaskManager(),
+		maxRunningJobs:    cfg.MaxRunningJobs,
+		heartbeatInterval: cfg.HeartbeatInterval,
 	}
 	if cfg.NodeType == "" {
 		cfg.NodeType = spec.NodeType_Scanner
@@ -126,7 +132,7 @@ func NewScanNode(cfg node.BaseConfig, options ...ScanNodeOption) (*ScanNode, err
 		)
 	}
 	agent.httpClient = cfg.HTTPClient
-	agent.initInvokeLimiter()
+	agent.initInvokeLimiter(cfg.MaxRunningJobs)
 	agent.bridge = newLegionJobBridge(agent)
 	return agent, nil
 }
@@ -178,6 +184,9 @@ func (s *ScanNode) Shutdown() {
 	if s == nil || s.node == nil {
 		return
 	}
+	if s.bridge != nil {
+		s.bridge.BeginShutdown()
+	}
 	s.manager.BeginShutdown()
 	if s.capabilityManager != nil {
 		if err := s.capabilityManager.Close(); err != nil {
@@ -212,7 +221,7 @@ func (s *ScanNode) releaseSSAGitScopeLockAfterTasks() {
 func (s *ScanNode) Snapshot() node.RuntimeStatus {
 	return node.RuntimeStatus{
 		LifecycleState: node.DefaultLifecycleState,
-		RunningJobs:    uint32(s.manager.Count()),
+		RunningJobs:    s.invokeLimiter.activeCount(),
 		MaxRunningJobs: s.maxRunningJobs,
 		ActiveAttempts: s.manager.ActiveAttemptHeartbeats(time.Now().UTC()),
 	}

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -63,27 +63,16 @@ func (e *ruleSnapshotPreparationError) Unwrap() error {
 }
 
 func (s *ScanNode) executeScriptTask(
-	ctx context.Context,
+	task *Task,
 	input ScriptExecutionRequest,
 ) (*ScriptExecutionResult, error) {
 	if strings.TrimSpace(input.ScriptContent) == "" {
 		return nil, utils.Error("empty script_content")
 	}
-
-	taskID := taskIDForSubtask(input.SubTaskID)
-	taskCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	if !s.manager.Add(taskID, newScriptTask(
-		taskCtx,
-		cancel,
-		taskID,
-		input.TaskID,
-		input.SubTaskID,
-		input.RuntimeID,
-	)) {
-		return nil, utils.Error("scan node is shutting down")
+	if task == nil || task.Ctx == nil {
+		return nil, utils.Error("claimed script task is required")
 	}
-	defer s.manager.Remove(taskID)
+	taskCtx := task.Ctx
 
 	reporter := NewScannerAgentReporter(
 		input.TaskID,
@@ -117,6 +106,17 @@ func (s *ScanNode) executeScriptTask(
 		defer reporter.ssaCollector.Cleanup()
 	}
 	ssaDBEnv := extractSSADatabaseEnv(keyValues)
+	ssaDBCleanup := func() {}
+	if s.needIsolateSSARuntimeDB() {
+		ssaOverride := environmentValueFromEntries(ssaDBEnv, consts.ENV_SSA_DATABASE_RAW)
+		isolatedEnv, cleanup := buildSSARuntimeDBEnv(input.RuntimeID, ssaOverride)
+		if environmentValueFromEntries(ssaDBEnv, consts.ENV_SSA_DB_SKIP_MIGRATE) != "" {
+			isolatedEnv = append(isolatedEnv, fmt.Sprintf("%s=1", consts.ENV_SSA_DB_SKIP_MIGRATE))
+		}
+		ssaDBEnv = isolatedEnv
+		ssaDBCleanup = cleanup
+	}
+	defer ssaDBCleanup()
 	if preparedSnapshot != nil {
 		ssaDBEnv = append(ssaDBEnv, "YAKIT_HOME="+preparedSnapshot.taskYakitHome)
 	}
@@ -193,7 +193,7 @@ func (s *ScanNode) executeScriptTask(
 			s.finalizeDebugRun(taskCtx, reporter, debugDir, "failed")
 			debugFinalized = true
 		}
-		return nil, s.handleScriptFailure(err, result, taskID)
+		return nil, s.handleScriptFailure(err, result, task.AttemptID)
 	}
 	logReporterEventError("final progress checkpoint", reporter.flushSuccessfulJobProgress())
 	if err := s.finalizeSSAArtifactUpload(taskCtx, reporter, result); err != nil {
@@ -210,6 +210,16 @@ func (s *ScanNode) executeScriptTask(
 		debugFinalized = true
 	}
 	return result, nil
+}
+
+func environmentValueFromEntries(entries []string, key string) string {
+	prefix := key + "="
+	for i := len(entries) - 1; i >= 0; i-- {
+		if strings.HasPrefix(entries[i], prefix) {
+			return strings.TrimPrefix(entries[i], prefix)
+		}
+	}
+	return ""
 }
 
 func newScriptTask(
@@ -243,12 +253,12 @@ func (s *ScanNode) buildScriptParams(
 func (s *ScanNode) handleScriptFailure(
 	err error,
 	result *ScriptExecutionResult,
-	taskID string,
+	attemptID string,
 ) error {
 	if err == nil {
 		return nil
 	}
-	if reason := s.cancelReasonForTask(taskID); reason != "" {
+	if reason := s.cancelReasonForAttempt(attemptID); reason != "" {
 		return &TaskCancelledError{Reason: reason}
 	}
 	if errors.Is(err, context.Canceled) {
@@ -266,8 +276,8 @@ func (s *ScanNode) handleScriptFailure(
 	return utils.Errorf("exec yak script failed: %s", err)
 }
 
-func (s *ScanNode) cancelReasonForTask(taskID string) string {
-	task, err := s.manager.GetTaskById(taskID)
+func (s *ScanNode) cancelReasonForAttempt(attemptID string) string {
+	task, err := s.manager.GetTaskByAttemptID(attemptID)
 	if err != nil {
 		return ""
 	}

--- a/scannode/ssa_runtime_db.go
+++ b/scannode/ssa_runtime_db.go
@@ -16,14 +16,17 @@ func (s *ScanNode) needIsolateSSARuntimeDB() bool {
 	if s == nil || s.invokeLimiter == nil {
 		return false
 	}
-	// Only enable isolation when parallelism is explicitly increased.
-	return s.invokeLimiter.totalN > 1
+	// Unlimited and explicitly parallel Nodes must never let child processes
+	// share the implicit local project/SSA SQLite files.
+	return s.invokeLimiter.capacity() == 0 || s.invokeLimiter.capacity() > 1
 }
 
 func buildSSARuntimeDBPaths(runtimeID string) (projectDB string, ssaDB string) {
 	runtimeID = strings.TrimSpace(runtimeID)
 	if runtimeID == "" {
 		runtimeID = fmt.Sprintf("runtime-%d", time.Now().UnixNano())
+	} else {
+		runtimeID = sanitizeLogName(runtimeID)
 	}
 	base := filepath.Join(consts.GetDefaultYakitBaseTempDir(), ssaRuntimeDBDirName)
 	_ = os.MkdirAll(base, 0o755)

--- a/scannode/task_manager.go
+++ b/scannode/task_manager.go
@@ -3,6 +3,7 @@ package scannode
 import (
 	"context"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,20 +12,55 @@ import (
 )
 
 type TaskManager struct {
-	tasks        *sync.Map
+	mu           sync.RWMutex
+	byAttempt    map[string]*Task
+	byTaskID     map[string]string
+	bySubtask    map[string]map[string]struct{}
 	stateMu      sync.Mutex
 	shuttingDown bool
 }
 
 func newTaskManager() *TaskManager {
-	return &TaskManager{tasks: new(sync.Map)}
+	return &TaskManager{
+		byAttempt: make(map[string]*Task),
+		byTaskID:  make(map[string]string),
+		bySubtask: make(map[string]map[string]struct{}),
+	}
 }
 
 func (t *TaskManager) Add(taskID string, task *Task) bool {
+	if task == nil {
+		return false
+	}
+	task.TaskId = taskID
+	if strings.TrimSpace(task.AttemptID) == "" {
+		task.AttemptID = taskID
+	}
+	_, loaded, accepted := t.LoadOrStoreAttempt(task)
+	if !accepted || loaded {
+		return false
+	}
+	task.MarkRunning()
+	return true
+}
+
+// LoadOrStoreAttempt atomically claims AttemptID as the primary execution
+// identity. The subtask/task indexes are secondary lookup paths used by cancel
+// and legacy progress reporting; they never replace an existing attempt.
+func (t *TaskManager) LoadOrStoreAttempt(task *Task) (actual *Task, loaded bool, accepted bool) {
+	if t == nil || task == nil || strings.TrimSpace(task.AttemptID) == "" {
+		return nil, false, false
+	}
 	t.stateMu.Lock()
 	defer t.stateMu.Unlock()
 	if t.shuttingDown {
-		return false
+		return nil, false, false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if existing, ok := t.byAttempt[task.AttemptID]; ok {
+		return existing, true, true
 	}
 	now := time.Now().UTC()
 	task.StartTimestamp = now.Unix()
@@ -32,9 +68,20 @@ func (t *TaskManager) Add(taskID string, task *Task) bool {
 	if ok {
 		task.DeadlineTimestamp = ddl.Unix()
 	}
-	task.MarkRunningAt(now)
-	t.tasks.Store(taskID, task)
-	return true
+	task.MarkClaimedAt(now)
+	t.byAttempt[task.AttemptID] = task
+	if task.TaskId != "" {
+		t.byTaskID[task.TaskId] = task.AttemptID
+	}
+	if task.SubtaskID != "" {
+		attempts := t.bySubtask[task.SubtaskID]
+		if attempts == nil {
+			attempts = make(map[string]struct{})
+			t.bySubtask[task.SubtaskID] = attempts
+		}
+		attempts[task.AttemptID] = struct{}{}
+	}
+	return task, false, true
 }
 
 func (t *TaskManager) BeginShutdown() {
@@ -43,12 +90,13 @@ func (t *TaskManager) BeginShutdown() {
 	}
 	t.stateMu.Lock()
 	t.shuttingDown = true
-	t.tasks.Range(func(_, value any) bool {
-		if task, ok := value.(*Task); ok && task != nil && task.Cancel != nil {
+	t.mu.RLock()
+	for _, task := range t.byAttempt {
+		if task != nil && task.Cancel != nil {
 			task.Cancel()
 		}
-		return true
-	})
+	}
+	t.mu.RUnlock()
 	t.stateMu.Unlock()
 }
 
@@ -71,28 +119,101 @@ func (t *TaskManager) WaitForEmpty(ctx context.Context) error {
 }
 
 func (t *TaskManager) Remove(taskID string) {
-	t.tasks.Delete(taskID)
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	attemptID := t.byTaskID[taskID]
+	t.removeAttemptLocked(attemptID)
+	t.mu.Unlock()
+}
+
+func (t *TaskManager) RemoveAttempt(attemptID string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.removeAttemptLocked(attemptID)
+	t.mu.Unlock()
+}
+
+func (t *TaskManager) removeAttemptLocked(attemptID string) {
+	task := t.byAttempt[attemptID]
+	if task == nil {
+		return
+	}
+	delete(t.byAttempt, attemptID)
+	if task.TaskId != "" && t.byTaskID[task.TaskId] == attemptID {
+		delete(t.byTaskID, task.TaskId)
+	}
+	if attempts := t.bySubtask[task.SubtaskID]; attempts != nil {
+		delete(attempts, attemptID)
+		if len(attempts) == 0 {
+			delete(t.bySubtask, task.SubtaskID)
+		}
+	}
 }
 
 func (t *TaskManager) GetTaskById(taskID string) (*Task, error) {
-	ins, ok := t.tasks.Load(taskID)
-	if ok {
-		return ins.(*Task), nil
+	if t != nil {
+		t.mu.RLock()
+		attemptID := t.byTaskID[taskID]
+		task := t.byAttempt[attemptID]
+		t.mu.RUnlock()
+		if task != nil {
+			return task, nil
+		}
 	}
 	return nil, utils.Errorf("no existed task: %s", taskID)
 }
 
+func (t *TaskManager) GetTaskByAttemptID(attemptID string) (*Task, error) {
+	if t != nil {
+		t.mu.RLock()
+		task := t.byAttempt[attemptID]
+		t.mu.RUnlock()
+		if task != nil {
+			return task, nil
+		}
+	}
+	return nil, utils.Errorf("no existed attempt: %s", attemptID)
+}
+
+func (t *TaskManager) TasksBySubtask(subtaskID string) []*Task {
+	if t == nil {
+		return nil
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	attempts := t.bySubtask[subtaskID]
+	result := make([]*Task, 0, len(attempts))
+	for attemptID := range attempts {
+		if task := t.byAttempt[attemptID]; task != nil {
+			result = append(result, task)
+		}
+	}
+	return result
+}
+
 func (t *TaskManager) Count() int {
-	count := 0
-	t.tasks.Range(func(_, _ interface{}) bool {
-		count++
-		return true
-	})
-	return count
+	if t == nil {
+		return 0
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.byAttempt)
 }
 
 func (t *TaskManager) Touch(taskID string) {
 	task, err := t.GetTaskById(taskID)
+	if err != nil {
+		return
+	}
+	task.Touch()
+}
+
+func (t *TaskManager) TouchAttempt(attemptID string) {
+	task, err := t.GetTaskByAttemptID(attemptID)
 	if err != nil {
 		return
 	}
@@ -112,18 +233,15 @@ func (t *TaskManager) ActiveAttemptHeartbeats(now time.Time) []node.ActiveAttemp
 		now = time.Now().UTC()
 	}
 
-	items := make([]node.ActiveAttemptHeartbeat, 0)
-	t.tasks.Range(func(_, value interface{}) bool {
-		task, ok := value.(*Task)
-		if !ok {
-			return true
-		}
+	t.mu.RLock()
+	items := make([]node.ActiveAttemptHeartbeat, 0, len(t.byAttempt))
+	for _, task := range t.byAttempt {
 		item, ok := task.activeAttemptHeartbeat(now)
 		if ok {
 			items = append(items, item)
 		}
-		return true
-	})
+	}
+	t.mu.RUnlock()
 	sort.Slice(items, func(i, j int) bool {
 		if items[i].AttemptID == items[j].AttemptID {
 			return items[i].SubtaskID < items[j].SubtaskID
@@ -168,6 +286,13 @@ func (t *Task) CancelReason() string {
 
 func (t *Task) MarkRunning() {
 	t.MarkRunningAt(time.Now().UTC())
+}
+
+func (t *Task) MarkClaimedAt(now time.Time) {
+	t.statusMu.Lock()
+	t.status = "claimed"
+	t.statusMu.Unlock()
+	t.TouchAt(now)
 }
 
 func (t *Task) MarkRunningAt(now time.Time) {
@@ -236,7 +361,12 @@ func (t *Task) activeAttemptHeartbeat(now time.Time) (node.ActiveAttemptHeartbea
 	}
 	status := t.Status()
 	if status == "" {
-		status = "running"
+		status = "claimed"
+	}
+	switch status {
+	case "claimed", "running", "cancel_requested":
+	default:
+		return node.ActiveAttemptHeartbeat{}, false
 	}
 	completedUnits, totalUnits := t.Progress()
 	return node.ActiveAttemptHeartbeat{

--- a/scannode/task_manager_test.go
+++ b/scannode/task_manager_test.go
@@ -2,6 +2,7 @@ package scannode
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -50,6 +51,78 @@ func TestTaskManagerActiveAttemptHeartbeats(t *testing.T) {
 	if beats[0].Status != "cancel_requested" {
 		t.Fatalf("unexpected cancel_requested status: %s", beats[0].Status)
 	}
+}
+
+func TestTaskManagerLoadOrStoreAttemptIsAtomicAndAttemptAware(t *testing.T) {
+	manager := newTaskManager()
+	const workers = 16
+	var wg sync.WaitGroup
+	accepted := make(chan *Task, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithCancel(context.Background())
+			task := newScriptTask(ctx, cancel, "task", "job", "subtask", "attempt")
+			actual, loaded, ok := manager.LoadOrStoreAttempt(task)
+			if !ok || actual == nil {
+				t.Errorf("LoadOrStoreAttempt rejected active manager")
+				return
+			}
+			if !loaded {
+				accepted <- task
+			} else {
+				cancel()
+			}
+		}()
+	}
+	wg.Wait()
+	close(accepted)
+	winners := 0
+	var winner *Task
+	for task := range accepted {
+		winners++
+		winner = task
+	}
+	if winners != 1 {
+		t.Fatalf("stored attempts = %d, want 1", winners)
+	}
+	if manager.Count() != 1 {
+		t.Fatalf("manager count = %d, want 1", manager.Count())
+	}
+	beats := manager.ActiveAttemptHeartbeats(time.Now().UTC())
+	if len(beats) != 1 || beats[0].Status != "claimed" {
+		t.Fatalf("claimed heartbeat = %+v", beats)
+	}
+	winner.Cancel()
+	manager.RemoveAttempt(winner.AttemptID)
+}
+
+func TestTaskManagerAttemptLookupSurvivesSameSubtaskRetry(t *testing.T) {
+	manager := newTaskManager()
+	firstCtx, firstCancel := context.WithCancel(context.Background())
+	defer firstCancel()
+	secondCtx, secondCancel := context.WithCancel(context.Background())
+	defer secondCancel()
+	first := newScriptTask(firstCtx, firstCancel, "task-shared", "job", "subtask", "attempt-first")
+	second := newScriptTask(secondCtx, secondCancel, "task-shared", "job", "subtask", "attempt-second")
+	if _, loaded, accepted := manager.LoadOrStoreAttempt(first); !accepted || loaded {
+		t.Fatal("first attempt was not registered")
+	}
+	if _, loaded, accepted := manager.LoadOrStoreAttempt(second); !accepted || loaded {
+		t.Fatal("second attempt was not registered")
+	}
+	if got, err := manager.GetTaskByAttemptID(first.AttemptID); err != nil || got != first {
+		t.Fatalf("first attempt lookup got=%p err=%v", got, err)
+	}
+	if got, err := manager.GetTaskByAttemptID(second.AttemptID); err != nil || got != second {
+		t.Fatalf("second attempt lookup got=%p err=%v", got, err)
+	}
+	manager.RemoveAttempt(first.AttemptID)
+	if got, err := manager.GetTaskById("task-shared"); err != nil || got != second {
+		t.Fatalf("legacy subtask lookup lost current attempt: got=%p err=%v", got, err)
+	}
+	manager.RemoveAttempt(second.AttemptID)
 }
 
 func TestTaskManagerShutdownRejectsNewTasksAndDrains(t *testing.T) {


### PR DESCRIPTION
## 关联

- [Linear INT-37：建立 `max_running_jobs` 端到端容量闭环](https://linear.app/intsheep/issue/INT-37/节点调度-建立-max-running-jobs-端到端容量闭环)
- [Legion 配套 Draft PR #377](https://github.com/VillanCh/legion/pull/377)

## 改动摘要

- 统一节点 effective max：`BaseConfig.MaxRunningJobs` 为主配置，正整数 `SCANNODE_MAX_PARALLEL` 作为兼容覆盖；无效值回退主配置，显式 0 保持不限并发。
- 为 Scan Node 增加非阻塞执行槽与 session 内存 admission registry，按 AttemptID 原子去重，并维护 SubtaskID 取消索引。
- 固定 dispatch 顺序为校验/去重、`TryAcquire`、登记 claimed Task、发布 claimed、`AckSync`、发布 started、执行。
- 满载时不发布 claimed/started，使用有截止时间的延迟 NAK；Session 切换或截止后交由 Legion lease/reclaim 收敛。
- 支持 cancel-before-start、同 ID 重投确认、冲突 ID 终止；success、failure、panic、cancel、shutdown 与发布失败路径均幂等释放槽位。
- heartbeat `RunningJobs` 来自实际槽位占用，`ActiveAttempts` 仅包含 claimed、running、cancel_requested。
- Smoke Node 增加 `max-running-jobs` 参数并保持默认 1；同步更新 Node Session transport 文档。

## 主要文件

- `scannode/dispatch_admission.go`
- `scannode/task_manager.go`
- `scannode/invoke_limiter.go`
- `scannode/legion_dispatch_bridge.go`
- `scannode/script_execution.go`
- `cmd/legion-smoke-node/main.go`
- `common/yak/cmd/yakcmds/utils.go`
- `docs/legion-node-session-transport-refactor.md`

## 验证

- focused T1：

  ```bash
  go test -count=1 ./scannode ./cmd/legion-smoke-node ./common/yak/cmd/yakcmds
  ```

- focused race：

  ```bash
  go test -race ./scannode ./cmd/legion-smoke-node ./common/yak/cmd/yakcmds
  ```

- 发布前最新基线复核：scannode、legion-smoke-node、yakcmds 的容量精确用例全部通过。
- T2 使用真实 API、Scheduler、PostgreSQL、NATS、Scan Node 链路验证 `max_running_jobs=1`：
  - 在线取消与确定性失败终态前 follower 保持 queued 且无 Attempt/Outbox，终态后 follower 成功。
  - 采样期间 active Attempt 与 `running_jobs` 最大值均为 1。
  - 同 ID 重投、冲突 ID、满载 NAK 截止、cancel-before-start，以及各终态槽位释放均有 focused T1/race 覆盖。

## 范围

不新增 protobuf、数据库 Schema、迁移、磁盘 journal、本地任务队列或 Console 页面。不授权自动 merge、tag 或 release。
