### PR TITLE
fix(scannode): 严格校验节点并发覆盖配置

### DIFF
--- a/docs/legion-node-session-transport-refactor.md
+++ b/docs/legion-node-session-transport-refactor.md
@@ -174,8 +174,9 @@
 
 `BaseConfig.MaxRunningJobs` 是主配置，最终生效值按下面优先级计算：
 
-1. `SCANNODE_MAX_PARALLEL` 为正整数时，作为旧部署兼容 override
-2. env 未设置、不是整数、为负数或为 `0` 时，回退到 `BaseConfig.MaxRunningJobs`
+1. `SCANNODE_MAX_PARALLEL` 显式设置为 `0..uint32` 时，作为旧部署兼容 override；`0` 表示 unlimited
+2. env 未设置时，使用 `BaseConfig.MaxRunningJobs`
+3. env 已设置但为空、不是整数、为负数或超出 `uint32` 时，节点启动失败；不会静默回退到另一个容量
 
 最终 effective max 同时用于执行 limiter 和 heartbeat 的 `max_running_jobs`，不会出现“实际只跑 1 个、heartbeat 却上报其他值”的分叉。
 
@@ -321,7 +322,7 @@ yak node \
 - `--max-running-jobs`
 - `--heartbeat-interval`
 
-`--max-running-jobs` 默认 1；传 0 表示 unlimited。正整数 `SCANNODE_MAX_PARALLEL` 只用于兼容旧部署，并覆盖 CLI 写入的主配置；无效值和 0 不覆盖。
+`--max-running-jobs` 默认 1；传 0 表示 unlimited。`SCANNODE_MAX_PARALLEL` 只用于兼容旧部署，并在显式设置为合法 `0..uint32` 时覆盖 CLI 写入的主配置；无效值会阻止节点启动。
 
 ## 当前结论
 

--- a/scannode/invoke_limiter.go
+++ b/scannode/invoke_limiter.go
@@ -1,6 +1,7 @@
 package scannode
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -69,22 +70,22 @@ func (l *invokeLimiter) TryAcquire() (release func(), acquired bool) {
 	}, true
 }
 
-func effectiveMaxRunningJobs(configured uint32) uint32 {
-	raw := strings.TrimSpace(os.Getenv(envScanNodeMaxParallel))
-	if raw == "" {
-		return configured
+func effectiveMaxRunningJobs(configured uint32) (uint32, error) {
+	rawValue, configuredByEnvironment := os.LookupEnv(envScanNodeMaxParallel)
+	if !configuredByEnvironment {
+		return configured, nil
 	}
+	raw := strings.TrimSpace(rawValue)
 	override, err := strconv.ParseUint(raw, 10, 32)
-	if err != nil || override == 0 {
-		log.Warnf(
-			"ignore invalid %s=%q; using configured max_running_jobs=%d",
+	if err != nil {
+		return 0, fmt.Errorf(
+			"%s must be an integer between 0 and %d: %q",
 			envScanNodeMaxParallel,
-			raw,
-			configured,
+			uint64(^uint32(0)),
+			rawValue,
 		)
-		return configured
 	}
-	return uint32(override)
+	return uint32(override), nil
 }
 
 func (s *ScanNode) initInvokeLimiter(maximum uint32) {

--- a/scannode/invoke_limiter_test.go
+++ b/scannode/invoke_limiter_test.go
@@ -1,6 +1,12 @@
 package scannode
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/node"
+)
 
 func TestInvokeLimiterMaxOneIsNonBlockingAndReleaseIsIdempotent(t *testing.T) {
 	limiter := newInvokeLimiter(1)
@@ -44,23 +50,70 @@ func TestInvokeLimiterMaxZeroIsUnlimitedAndStillCountsRunningJobs(t *testing.T) 
 func TestEffectiveMaxRunningJobsEnvOverride(t *testing.T) {
 	tests := []struct {
 		name       string
-		env        string
+		env        *string
 		configured uint32
 		want       uint32
+		wantError  bool
 	}{
 		{name: "unset uses config", configured: 3, want: 3},
-		{name: "positive overrides", env: "5", configured: 3, want: 5},
-		{name: "zero falls back", env: "0", configured: 3, want: 3},
-		{name: "negative falls back", env: "-1", configured: 3, want: 3},
-		{name: "invalid falls back", env: "many", configured: 3, want: 3},
+		{name: "positive overrides", env: stringPointer("5"), configured: 3, want: 5},
+		{name: "zero means unlimited", env: stringPointer("0"), configured: 3, want: 0},
+		{name: "surrounding whitespace is accepted", env: stringPointer(" 4 "), configured: 3, want: 4},
+		{name: "negative is rejected", env: stringPointer("-1"), configured: 3, wantError: true},
+		{name: "non numeric is rejected", env: stringPointer("many"), configured: 3, wantError: true},
+		{name: "overflow is rejected", env: stringPointer("4294967296"), configured: 3, wantError: true},
+		{name: "explicit empty is rejected", env: stringPointer(""), configured: 3, wantError: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(envScanNodeMaxParallel, tt.env)
-			if got := effectiveMaxRunningJobs(tt.configured); got != tt.want {
+			setOptionalEnvironment(t, envScanNodeMaxParallel, tt.env)
+			got, err := effectiveMaxRunningJobs(tt.configured)
+			if tt.wantError {
+				if err == nil || !strings.Contains(err.Error(), envScanNodeMaxParallel) {
+					t.Fatalf("effective max error = %v, want %s validation error", err, envScanNodeMaxParallel)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("effective max error = %v", err)
+			}
+			if got != tt.want {
 				t.Fatalf("effective max = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewScanNodeRejectsInvalidMaxParallelOverride(t *testing.T) {
+	t.Setenv(envScanNodeMaxParallel, "invalid")
+	if _, err := NewScanNode(node.BaseConfig{}); err == nil ||
+		!strings.Contains(err.Error(), envScanNodeMaxParallel) {
+		t.Fatalf("NewScanNode error = %v, want %s validation error", err, envScanNodeMaxParallel)
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func setOptionalEnvironment(t *testing.T, name string, value *string) {
+	t.Helper()
+	previous, existed := os.LookupEnv(name)
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(name, previous)
+			return
+		}
+		_ = os.Unsetenv(name)
+	})
+	if value == nil {
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("unset %s: %v", name, err)
+		}
+		return
+	}
+	if err := os.Setenv(name, *value); err != nil {
+		t.Fatalf("set %s: %v", name, err)
 	}
 }
 

--- a/scannode/node.go
+++ b/scannode/node.go
@@ -57,7 +57,11 @@ func NewScanNode(cfg node.BaseConfig, options ...ScanNodeOption) (*ScanNode, err
 	if cfg.HeartbeatInterval <= 0 {
 		cfg.HeartbeatInterval = node.DefaultHeartbeatInterval
 	}
-	cfg.MaxRunningJobs = effectiveMaxRunningJobs(cfg.MaxRunningJobs)
+	maxRunningJobs, err := effectiveMaxRunningJobs(cfg.MaxRunningJobs)
+	if err != nil {
+		return nil, err
+	}
+	cfg.MaxRunningJobs = maxRunningJobs
 	var resolvedOptions scanNodeOptions
 	for _, option := range options {
 		if option != nil {


### PR DESCRIPTION
## 关联任务

- Linear INT-39：节点管理建立节点并发配置管理闭环
- Legion 配套 Draft PR：VillanCh/legion#381

## 改动摘要

- 明确节点并发配置优先级：显式设置的 `SCANNODE_MAX_PARALLEL` 覆盖 `BaseConfig.MaxRunningJobs`，未设置时沿用 BaseConfig。
- 接受合法的 `0..uint32`；其中 `0` 表示不限并发，不再被误判为无效值并静默回退。
- 空字符串、负数、非数字和 uint32 溢出会阻止节点启动，避免节点以意外容量继续运行。
- 心跳继续上报 limiter 最终实际生效的并发值，供 Legion 对比期望配置与实际配置。

## 改动文件

- `scannode/invoke_limiter.go`
- `scannode/invoke_limiter_test.go`
- `scannode/node.go`
- `docs/legion-node-session-transport-refactor.md`

## 验证方式

- `go test -count=1 ./scannode`：通过。
- `go test -count=1 ./cmd/legion-smoke-node`：通过。
- `go test -race -count=1 ./scannode`：通过。
- 真实 Scan Dev 节点已验证默认配置下 limiter 与心跳实际值为 1；Legion 将期望值更新为 0 后，重启前正确保持实际值 1 并显示漂移。

## 当前边界

- 完整跨仓 T2 尚未完成：既有节点 distribution manifest 缺少 `ssa.rule_snapshot.execution.v2`，会阻止新 enrollment；该发布契约漂移作为独立前置修复处理。
- 本 PR 保持 Draft，不自动合并、不发布节点版本。
