### PR TITLE
feat: AI memory auto-cleanup mechanism (TTL + low-value eviction + capacity limit)

### DIFF
--- a/common/ai/aid/aicommon/types.go
+++ b/common/ai/aid/aicommon/types.go
@@ -27,6 +27,9 @@ type MemoryEntity struct {
 
 	// designed for rag searching
 	PotentialQuestions []string
+
+	// 自动清理相关字段
+	ExpiresAt *time.Time // 过期时间，nil=不过期
 }
 
 // SearchResult 搜索结果

--- a/common/ai/aid/aimem/aimemory.go
+++ b/common/ai/aid/aimem/aimemory.go
@@ -75,6 +75,7 @@ func newAIMemory(sessionId string, requireInvoker bool, opts ...Option) (*AIMemo
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+
 	triage := &AIMemoryTriage{
 		ctx:                ctx,
 		cancel:             cancel,

--- a/common/ai/aid/aimem/aimemory_search_memory.go
+++ b/common/ai/aid/aimem/aimemory_search_memory.go
@@ -25,6 +25,8 @@ func (t *AIMemoryTriage) SearchMemoryWithoutAI(origin any, tokenLimit int) (*aic
 }
 
 func (t *AIMemoryTriage) SearchMemoryWithoutAIAndSemantics(origin any, tokenLimit int) (*aicommon.SearchMemoryResult, error) {
+	MaybeCleanup(t.db)
+
 	queryText := utils.InterfaceToString(origin)
 	if task, ok := origin.(aicommon.AIStatefulTask); ok {
 		queryText = strings.TrimSpace(task.GetUserInput())
@@ -267,6 +269,9 @@ func memoryEntityFromDBEntity(dbEntity schema.AIMemoryEntity) *aicommon.MemoryEn
 }
 
 func (t *AIMemoryTriage) searchMemoryWithAIOption(origin any, tokenLimit int, disableAI bool) (*aicommon.SearchMemoryResult, error) {
+	// 惰性触发自动清理检查（全局协调，不阻塞搜索）
+	MaybeCleanup(t.db)
+
 	queryText := utils.InterfaceToString(origin)
 	if task, ok := origin.(aicommon.AIStatefulTask); ok {
 		return t.searchMemoryForAITask(task, tokenLimit, disableAI)

--- a/common/ai/aid/aimem/aimemory_search_memory.go
+++ b/common/ai/aid/aimem/aimemory_search_memory.go
@@ -262,6 +262,7 @@ func memoryEntityFromDBEntity(dbEntity schema.AIMemoryEntity) *aicommon.MemoryEn
 		A_Score:            dbEntity.A_Score,
 		T_Score:            dbEntity.T_Score,
 		CorePactVector:     []float32(dbEntity.CorePactVector),
+		ExpiresAt:          dbEntity.ExpiresAt,
 	}
 }
 

--- a/common/ai/aid/aimem/cleanup_coordinator.go
+++ b/common/ai/aid/aimem/cleanup_coordinator.go
@@ -1,0 +1,126 @@
+package aimem
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/log"
+)
+
+// cleanupInterval 两次清理之间的最小间隔
+const cleanupInterval = 30 * time.Minute
+
+// cleanupMinBatch 攒批阈值：扫描出的待清理条数不足此值时不做物理清理，
+// 避免频繁 HNSW Load/Save
+const cleanupMinBatch = 20
+
+// cleanupCoordinator 是 DB 级别的全局清理协调器。
+// 因为 AIMemoryTriage 不是单例（同一 sessionID 会被反复 NewAIMemory 创建新实例），
+// 清理调度状态必须放在全局级别，而不是实例级别。
+//
+// 设计要点:
+//   - lastCleanupTime: 全局时间戳，atomic 读写，纳秒级检查
+//   - cleanupRunning:  全局 CAS 标志，同一时间只有一个清理 goroutine
+//   - 惰性触发: 写入和搜索都调 MaybeCleanup，但不阻塞主路径
+type cleanupCoordinator struct {
+	lastCleanupTime int64 // unix nano, atomic
+	cleanupRunning  int32 // 0=空闲, 1=清理中, CAS
+}
+
+// globalCoordinator 包级别单例
+var globalCoordinator = &cleanupCoordinator{}
+
+// MaybeCleanup 惰性触发清理检查。
+// 在写入和搜索路径调用，开销仅一次 atomic.Load + time 比较（纳秒级），完全无感。
+// 如果距上次清理不足 cleanupInterval，直接返回；否则异步触发清理。
+func MaybeCleanup(db *gorm.DB) {
+	if db == nil {
+		return
+	}
+
+	// 距上次清理不足间隔，跳过
+	last := atomic.LoadInt64(&globalCoordinator.lastCleanupTime)
+	if last > 0 && time.Since(time.Unix(0, last)) < cleanupInterval {
+		return
+	}
+
+	// CAS 防并发：只有 0→1 的那个调用才触发
+	if !atomic.CompareAndSwapInt32(&globalCoordinator.cleanupRunning, 0, 1) {
+		return
+	}
+
+	// 记录触发时间
+	atomic.StoreInt64(&globalCoordinator.lastCleanupTime, time.Now().UnixNano())
+
+	// 异步执行清理，不阻塞调用方
+	go globalCoordinator.runCleanup(db)
+}
+
+// runCleanup 执行一次完整的清理流程：扫描所有 session → 攒批判断 → 物理清理。
+func (c *cleanupCoordinator) runCleanup(db *gorm.DB) {
+	defer atomic.StoreInt32(&c.cleanupRunning, 0)
+
+	config := DefaultCleanupConfig()
+	ctx := context.Background()
+
+	// 长期记忆表，不含 midterm
+	tableName := "ai_memory_entities_v1"
+
+	// 获取所有需要清理的 sessionID
+	// 目前长期记忆基本都走 "default"，但为了覆盖性，扫描所有 distinct session_id
+	var sessionIDs []string
+	if err := db.Table(tableName).Select("DISTINCT(session_id)").Pluck("session_id", &sessionIDs).Error; err != nil {
+		log.Warnf("cleanup: failed to get distinct session_ids: %v", err)
+		return
+	}
+
+	for _, sid := range sessionIDs {
+		c.cleanupSession(ctx, db, tableName, sid, config)
+	}
+}
+
+// cleanupSession 清理单个 session 的过期/低价值/超量记忆。
+func (c *cleanupCoordinator) cleanupSession(ctx context.Context, db *gorm.DB, tableName, sessionID string, config CleanupConfig) {
+	// 1. 扫描所有待清理的记忆 ID（过期 + 低价值 + 超量）
+	ids, err := ScanAllCleanupMemories(db, tableName, sessionID, config)
+	if err != nil {
+		log.Warnf("cleanup scan failed for session %s: %v", sessionID, err)
+		return
+	}
+
+	if len(ids) == 0 {
+		return
+	}
+
+	// 2. 攒批阈值：待清理数量太少时不做物理清理，攒着下次一起删
+	if len(ids) < cleanupMinBatch {
+		log.Debugf("cleanup skipped for session %s: only %d candidates (< %d), will batch next time",
+			sessionID, len(ids), cleanupMinBatch)
+		return
+	}
+
+	// 限制单次清理数量
+	maxBatch := config.MaxBatchSize
+	if maxBatch <= 0 {
+		maxBatch = 100
+	}
+	if len(ids) > maxBatch {
+		ids = ids[:maxBatch]
+	}
+
+	// 3. 执行物理清理（HNSW + RAG + DB）
+	log.Infof("cleanup started for session %s: %d memories to clean", sessionID, len(ids))
+	if err := BatchCleanupMemories(ctx, db, sessionID, ids); err != nil {
+		log.Warnf("cleanup batch delete failed for session %s: %v", sessionID, err)
+		return
+	}
+	log.Infof("cleanup completed for session %s: %d memories cleaned", sessionID, len(ids))
+}
+
+// resetCleanupCoordinatorForTest 重置全局协调器状态，仅供测试使用。
+func resetCleanupCoordinatorForTest() {
+	atomic.StoreInt64(&globalCoordinator.lastCleanupTime, 0)
+	atomic.StoreInt32(&globalCoordinator.cleanupRunning, 0)
+}

--- a/common/ai/aid/aimem/cleanup_policy.go
+++ b/common/ai/aid/aimem/cleanup_policy.go
@@ -149,7 +149,11 @@ func ScanLowValueMemories(db *gorm.DB, tableName, sessionID string, config Clean
 //
 // 当 session 内记忆总数超过 MaxMemoryCount 时，按综合评分从低到高选出需要淘汰的记忆。
 // 实际淘汰数量 = (totalCount - MaxMemoryCount) + OverEvictMargin，确保清理后不会立即再次触发。
-// 长期记忆 (T_Score >= 0.8) 豁免，不参与淘汰。
+//
+// 注意：所有记忆（包括 T_Score >= 0.8 的长期记忆）都参与排序。
+// 综合评分 CalcMemoryValue 中 T_Score 占 0.10 权重，高 T 记忆天然排在最后被淘汰。
+// 这确保了即使低 T 记忆全部清理完仍然超限时，高 T 记忆中价值最低的也会被淘汰，
+// 不会出现僵尸记忆。
 func ScanOverCountMemories(db *gorm.DB, tableName, sessionID string, config CleanupConfig) ([]string, error) {
 	if db == nil || tableName == "" || sessionID == "" {
 		return nil, nil
@@ -177,10 +181,10 @@ func ScanOverCountMemories(db *gorm.DB, tableName, sessionID string, config Clea
 		return nil, nil
 	}
 
-	// 查询所有非豁免记忆 (T_Score < 0.8)，按综合评分从低到高排序
+	// 查询所有记忆（不豁免任何 T_Score），按综合评分从低到高排序
 	var candidates []schema.AIMemoryEntity
 	err := db.Table(tableName).
-		Where("session_id = ? AND t_score < 0.8", sessionID).
+		Where("session_id = ?", sessionID).
 		Find(&candidates).Error
 	if err != nil {
 		return nil, err

--- a/common/ai/aid/aimem/cleanup_policy.go
+++ b/common/ai/aid/aimem/cleanup_policy.go
@@ -1,0 +1,162 @@
+package aimem
+
+import (
+	"time"
+
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// CleanupConfig 清理策略配置
+type CleanupConfig struct {
+	// TTL 策略
+	EnableTTLExpiry  bool
+	TTLTransientDays float64 // T_Score 0.0-0.3: 瞬时记忆过期天数，默认 7
+	TTLShortTermDays float64 // T_Score 0.3-0.6: 短期记忆过期天数，默认 30
+	TTLMidTermDays   float64 // T_Score 0.6-0.8: 中期记忆过期天数，默认 90
+
+	// 低价值淘汰策略
+	EnableLowValueEviction bool
+	MinValueThreshold      float64 // 综合评分低于此值才考虑淘汰，默认 0.35
+	ColdMemoryDays         int     // 记忆存在超过此天数且评分低才考虑淘汰，默认 14
+
+	// 批量限制
+	MaxBatchSize int // 每次扫描最多返回多少条，默认 100
+}
+
+// DefaultCleanupConfig 默认清理配置
+func DefaultCleanupConfig() CleanupConfig {
+	return CleanupConfig{
+		EnableTTLExpiry:        true,
+		TTLTransientDays:       TTLTransientDays,
+		TTLShortTermDays:       TTLShortTermDays,
+		TTLMidTermDays:         TTLMidTermDays,
+		EnableLowValueEviction: true,
+		MinValueThreshold:      0.35,
+		ColdMemoryDays:         14,
+		MaxBatchSize:           100,
+	}
+}
+
+// CalcMemoryValue 计算记忆的综合价值评分 (0.0-1.0)
+// 权重: R=0.25, A=0.20, P=0.15, C=0.15, O=0.10, E=0.05, T=0.10
+func CalcMemoryValue(entity *aicommon.MemoryEntity) float64 {
+	return entity.R_Score*0.25 +
+		entity.A_Score*0.20 +
+		entity.P_Score*0.15 +
+		entity.C_Score*0.15 +
+		entity.O_Score*0.10 +
+		entity.E_Score*0.05 +
+		entity.T_Score*0.10
+}
+
+// ScanExpiredMemories 扫描已过期的记忆 ID（只 SELECT，不删除）
+// 查询条件: expires_at IS NOT NULL AND expires_at < NOW()
+func ScanExpiredMemories(db *gorm.DB, tableName, sessionID string, maxBatch int) ([]string, error) {
+	if db == nil || tableName == "" || sessionID == "" {
+		return nil, nil
+	}
+	if maxBatch <= 0 {
+		maxBatch = 100
+	}
+
+	var entities []schema.AIMemoryEntity
+	err := db.Table(tableName).
+		Select("memory_id").
+		Where("session_id = ? AND expires_at IS NOT NULL AND expires_at < ?", sessionID, time.Now()).
+		Limit(maxBatch).
+		Find(&entities).Error
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(entities))
+	for _, e := range entities {
+		ids = append(ids, e.MemoryID)
+	}
+	return ids, nil
+}
+
+// ScanLowValueMemories 扫描低价值记忆 ID（只 SELECT，不删除）
+//
+// 淘汰条件（同时满足）:
+//   - CreatedAt 距今 > ColdMemoryDays（存在足够久）
+//   - T_Score < 0.8（长期记忆豁免）
+//   - 综合评分 < MinValueThreshold
+func ScanLowValueMemories(db *gorm.DB, tableName, sessionID string, config CleanupConfig) ([]string, error) {
+	if db == nil || tableName == "" || sessionID == "" {
+		return nil, nil
+	}
+	if !config.EnableLowValueEviction {
+		return nil, nil
+	}
+
+	maxBatch := config.MaxBatchSize
+	if maxBatch <= 0 {
+		maxBatch = 100
+	}
+
+	coldThreshold := time.Now().AddDate(0, 0, -config.ColdMemoryDays)
+
+	// 按 CreatedAt 和 T_Score 从 DB 筛选候选集
+	var candidates []schema.AIMemoryEntity
+	err := db.Table(tableName).
+		Where("session_id = ? AND created_at < ? AND t_score < 0.8",
+			sessionID, coldThreshold).
+		Limit(maxBatch * 2). // 多取一些，后面按综合评分再过滤
+		Find(&candidates).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// 在内存中计算综合评分，低于阈值的才入选
+	ids := make([]string, 0, len(candidates))
+	for _, e := range candidates {
+		entity := &aicommon.MemoryEntity{
+			C_Score: e.C_Score,
+			O_Score: e.O_Score,
+			R_Score: e.R_Score,
+			E_Score: e.E_Score,
+			P_Score: e.P_Score,
+			A_Score: e.A_Score,
+			T_Score: e.T_Score,
+		}
+		value := CalcMemoryValue(entity)
+		if value < config.MinValueThreshold {
+			ids = append(ids, e.MemoryID)
+		}
+	}
+
+	// 限制最终数量
+	if len(ids) > maxBatch {
+		ids = ids[:maxBatch]
+	}
+
+	return ids, nil
+}
+
+// ScanAllCleanupMemories 一次性扫描过期 + 低价值记忆 ID，合并去重后返回
+func ScanAllCleanupMemories(db *gorm.DB, tableName, sessionID string, config CleanupConfig) ([]string, error) {
+	var allIDs []string
+
+	if config.EnableTTLExpiry {
+		expiredIDs, err := ScanExpiredMemories(db, tableName, sessionID, config.MaxBatchSize)
+		if err != nil {
+			return nil, err
+		}
+		allIDs = append(allIDs, expiredIDs...)
+	}
+
+	if config.EnableLowValueEviction {
+		lowValueIDs, err := ScanLowValueMemories(db, tableName, sessionID, config)
+		if err != nil {
+			return nil, err
+		}
+		allIDs = append(allIDs, lowValueIDs...)
+	}
+
+	// 去重
+	allIDs = uniqueNonEmptyStrings(allIDs)
+	return allIDs, nil
+}

--- a/common/ai/aid/aimem/cleanup_policy.go
+++ b/common/ai/aid/aimem/cleanup_policy.go
@@ -1,6 +1,7 @@
 package aimem
 
 import (
+	"sort"
 	"time"
 
 	"github.com/yaklang/gorm"
@@ -21,6 +22,11 @@ type CleanupConfig struct {
 	MinValueThreshold      float64 // 综合评分低于此值才考虑淘汰，默认 0.35
 	ColdMemoryDays         int     // 记忆存在超过此天数且评分低才考虑淘汰，默认 14
 
+	// 数量上限策略
+	EnableMaxMemoryCount bool
+	MaxMemoryCount       int // 记忆总数上限，默认 200。超过时按综合评分从低到高淘汰
+	OverEvictMargin      int // 超量淘汰安全余量，默认 20。实际删除 (超出量 + margin) 条，避免刚删完又触发
+
 	// 批量限制
 	MaxBatchSize int // 每次扫描最多返回多少条，默认 100
 }
@@ -35,6 +41,9 @@ func DefaultCleanupConfig() CleanupConfig {
 		EnableLowValueEviction: true,
 		MinValueThreshold:      0.35,
 		ColdMemoryDays:         14,
+		EnableMaxMemoryCount:   true,
+		MaxMemoryCount:         200,
+		OverEvictMargin:        20,
 		MaxBatchSize:           100,
 	}
 }
@@ -136,7 +145,84 @@ func ScanLowValueMemories(db *gorm.DB, tableName, sessionID string, config Clean
 	return ids, nil
 }
 
-// ScanAllCleanupMemories 一次性扫描过期 + 低价值记忆 ID，合并去重后返回
+// ScanOverCountMemories 扫描因数量超限需要淘汰的记忆 ID（只 SELECT，不删除）
+//
+// 当 session 内记忆总数超过 MaxMemoryCount 时，按综合评分从低到高选出需要淘汰的记忆。
+// 实际淘汰数量 = (totalCount - MaxMemoryCount) + OverEvictMargin，确保清理后不会立即再次触发。
+// 长期记忆 (T_Score >= 0.8) 豁免，不参与淘汰。
+func ScanOverCountMemories(db *gorm.DB, tableName, sessionID string, config CleanupConfig) ([]string, error) {
+	if db == nil || tableName == "" || sessionID == "" {
+		return nil, nil
+	}
+	if !config.EnableMaxMemoryCount || config.MaxMemoryCount <= 0 {
+		return nil, nil
+	}
+
+	// 统计当前 session 内的记忆总数
+	var totalCount int64
+	if err := db.Table(tableName).
+		Where("session_id = ?", sessionID).
+		Count(&totalCount).Error; err != nil {
+		return nil, err
+	}
+
+	// 未超限，无需淘汰
+	if int(totalCount) <= config.MaxMemoryCount {
+		return nil, nil
+	}
+
+	// 需要淘汰的数量 = 超出量 + 安全余量
+	toEvict := int(totalCount) - config.MaxMemoryCount + config.OverEvictMargin
+	if toEvict <= 0 {
+		return nil, nil
+	}
+
+	// 查询所有非豁免记忆 (T_Score < 0.8)，按综合评分从低到高排序
+	var candidates []schema.AIMemoryEntity
+	err := db.Table(tableName).
+		Where("session_id = ? AND t_score < 0.8", sessionID).
+		Find(&candidates).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// 计算综合评分并排序
+	type scoredEntity struct {
+		id    string
+		value float64
+	}
+	scored := make([]scoredEntity, 0, len(candidates))
+	for _, e := range candidates {
+		entity := &aicommon.MemoryEntity{
+			C_Score: e.C_Score,
+			O_Score: e.O_Score,
+			R_Score: e.R_Score,
+			E_Score: e.E_Score,
+			P_Score: e.P_Score,
+			A_Score: e.A_Score,
+			T_Score: e.T_Score,
+		}
+		scored = append(scored, scoredEntity{
+			id:    e.MemoryID,
+			value: CalcMemoryValue(entity),
+		})
+	}
+
+	// 按综合评分升序（最低价值优先淘汰）
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].value < scored[j].value
+	})
+
+	// 取前 toEvict 个
+	ids := make([]string, 0, toEvict)
+	for i := 0; i < toEvict && i < len(scored); i++ {
+		ids = append(ids, scored[i].id)
+	}
+
+	return ids, nil
+}
+
+// ScanAllCleanupMemories 一次性扫描过期 + 低价值 + 超量记忆 ID，合并去重后返回
 func ScanAllCleanupMemories(db *gorm.DB, tableName, sessionID string, config CleanupConfig) ([]string, error) {
 	var allIDs []string
 
@@ -154,6 +240,14 @@ func ScanAllCleanupMemories(db *gorm.DB, tableName, sessionID string, config Cle
 			return nil, err
 		}
 		allIDs = append(allIDs, lowValueIDs...)
+	}
+
+	if config.EnableMaxMemoryCount {
+		overCountIDs, err := ScanOverCountMemories(db, tableName, sessionID, config)
+		if err != nil {
+			return nil, err
+		}
+		allIDs = append(allIDs, overCountIDs...)
 	}
 
 	// 去重

--- a/common/ai/aid/aimem/cleanup_test.go
+++ b/common/ai/aid/aimem/cleanup_test.go
@@ -430,7 +430,7 @@ func TestScanOverCountMemories(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, ids, 5)
 
-	// Create a long-term memory (T >= 0.8) — should be exempt
+	// Create a long-term memory (T >= 0.8) — high value, should be last to evict
 	longTermEntity := &schema.AIMemoryEntity{
 		MemoryID:  "longterm-protected",
 		SessionID: sid,
@@ -443,12 +443,15 @@ func TestScanOverCountMemories(t *testing.T) {
 	require.NoError(t, db.Table(tableName).Create(longTermEntity).Error)
 
 	// totalCount=9, MaxMemoryCount=5, OverEvictMargin=2
-	// toEvict = 9 - 5 + 2 = 6, but only 8 non-exempt memories exist
+	// toEvict = 9 - 5 + 2 = 6
+	// longterm-protected value = 0.25*0.1+0.20*0.1+0.15*0.1+0.15*0.1+0.10*0.1+0.05*0.1+0.10*0.9 = 0.19
+	// low-value mem value      = 0.25*0.1+0.20*0.1+0.15*0.1+0.15*0.1+0.10*0.1+0.05*0.1+0.10*0.2 = 0.10
+	// longterm-protected (0.19) > low-value mem (0.10), so it survives
 	ids, err = ScanOverCountMemories(db, tableName, sid, config)
 	require.NoError(t, err)
-	assert.Len(t, ids, 6) // 6 lowest-value non-exempt memories
+	assert.Len(t, ids, 6)
 
-	// Verify long-term memory is NOT in the eviction list
+	// Verify long-term memory is NOT in the eviction list (higher value than low-T memories)
 	for _, id := range ids {
 		assert.NotEqual(t, "longterm-protected", id)
 	}
@@ -458,6 +461,45 @@ func TestScanOverCountMemories(t *testing.T) {
 	ids, err = ScanOverCountMemories(db, tableName, sid, config)
 	require.NoError(t, err)
 	assert.Empty(t, ids)
+}
+
+// --- OverCount: no zombie memories (all high-T still over limit) ---
+
+func TestScanOverCountMemories_NoZombieMemories(t *testing.T) {
+	sessionID := "test-cleanup-no-zombie-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+
+	config := DefaultCleanupConfig()
+	config.MaxMemoryCount = 3
+	config.OverEvictMargin = 1
+
+	// Create 5 ALL high-T memories (T >= 0.8)
+	for i := 0; i < 5; i++ {
+		entity := &schema.AIMemoryEntity{
+			MemoryID:  fmt.Sprintf("hight-mem-%d", i),
+			SessionID: sid,
+			Content:   fmt.Sprintf("high t memory %d", i),
+			Tags:      schema.StringArray{"test"},
+			T_Score:   0.9,
+			C_Score:   0.1, O_Score: 0.1, R_Score: 0.1, E_Score: 0.1, P_Score: 0.1, A_Score: 0.1,
+		}
+		entity.CreatedAt = time.Now().Add(-time.Duration(i+1) * time.Hour)
+		require.NoError(t, db.Table(tableName).Create(entity).Error)
+	}
+
+	// totalCount=5, MaxMemoryCount=3, OverEvictMargin=1
+	// toEvict = 5 - 3 + 1 = 3
+	// All are T>=0.8 but there's no exemption now — lowest value ones get evicted
+	ids, err := ScanOverCountMemories(db, tableName, sid, config)
+	require.NoError(t, err)
+	assert.Len(t, ids, 3, "high-T memories should still be evicted when over limit")
+
+	// Remaining should be 5 - 3 = 2 <= MaxMemoryCount=3
 }
 
 // --- OverCount margin effectiveness ---

--- a/common/ai/aid/aimem/cleanup_test.go
+++ b/common/ai/aid/aimem/cleanup_test.go
@@ -2,6 +2,8 @@ package aimem
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -391,4 +393,178 @@ func TestScanAllCleanupMemories(t *testing.T) {
 	assert.True(t, idSet["scan-expired"])
 	assert.True(t, idSet["scan-lowval"])
 	assert.False(t, idSet["scan-healthy"])
+}
+
+// --- ScanOverCountMemories ---
+
+func TestScanOverCountMemories(t *testing.T) {
+	sessionID := "test-cleanup-overcount-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+
+	config := DefaultCleanupConfig()
+	config.MaxMemoryCount = 5
+	config.OverEvictMargin = 2
+
+	// Create 8 memories, all low-value so they're eligible for eviction
+	for i := 0; i < 8; i++ {
+		entity := &schema.AIMemoryEntity{
+			MemoryID:  fmt.Sprintf("overcount-mem-%d", i),
+			SessionID: sid,
+			Content:   fmt.Sprintf("memory %d", i),
+			Tags:      schema.StringArray{"test"},
+			T_Score:   0.2,
+			C_Score:   0.1, O_Score: 0.1, R_Score: 0.1, E_Score: 0.1, P_Score: 0.1, A_Score: 0.1,
+		}
+		entity.CreatedAt = time.Now().Add(-time.Duration(i+1) * time.Hour)
+		require.NoError(t, db.Table(tableName).Create(entity).Error)
+	}
+
+	// totalCount=8, MaxMemoryCount=5, OverEvictMargin=2
+	// toEvict = 8 - 5 + 2 = 5
+	ids, err := ScanOverCountMemories(db, tableName, sid, config)
+	require.NoError(t, err)
+	assert.Len(t, ids, 5)
+
+	// Create a long-term memory (T >= 0.8) — should be exempt
+	longTermEntity := &schema.AIMemoryEntity{
+		MemoryID:  "longterm-protected",
+		SessionID: sid,
+		Content:   "long term memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.9,
+		C_Score:   0.1, O_Score: 0.1, R_Score: 0.1, E_Score: 0.1, P_Score: 0.1, A_Score: 0.1,
+	}
+	longTermEntity.CreatedAt = time.Now().Add(-1 * time.Hour)
+	require.NoError(t, db.Table(tableName).Create(longTermEntity).Error)
+
+	// totalCount=9, MaxMemoryCount=5, OverEvictMargin=2
+	// toEvict = 9 - 5 + 2 = 6, but only 8 non-exempt memories exist
+	ids, err = ScanOverCountMemories(db, tableName, sid, config)
+	require.NoError(t, err)
+	assert.Len(t, ids, 6) // 6 lowest-value non-exempt memories
+
+	// Verify long-term memory is NOT in the eviction list
+	for _, id := range ids {
+		assert.NotEqual(t, "longterm-protected", id)
+	}
+
+	// Test: under limit → no eviction
+	config.MaxMemoryCount = 100
+	ids, err = ScanOverCountMemories(db, tableName, sid, config)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+// --- OverCount margin effectiveness ---
+
+func TestScanOverCountMemories_MarginEffectiveness(t *testing.T) {
+	sessionID := "test-cleanup-margin-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+
+	config := DefaultCleanupConfig()
+	config.MaxMemoryCount = 5
+	config.OverEvictMargin = 3
+
+	// Create exactly 6 memories (1 over limit)
+	for i := 0; i < 6; i++ {
+		entity := &schema.AIMemoryEntity{
+			MemoryID:  fmt.Sprintf("margin-mem-%d", i),
+			SessionID: sid,
+			Content:   fmt.Sprintf("memory %d", i),
+			Tags:      schema.StringArray{"test"},
+			T_Score:   0.2,
+			C_Score:   0.1, O_Score: 0.1, R_Score: 0.1, E_Score: 0.1, P_Score: 0.1, A_Score: 0.1,
+		}
+		entity.CreatedAt = time.Now().Add(-time.Duration(i+1) * time.Hour)
+		require.NoError(t, db.Table(tableName).Create(entity).Error)
+	}
+
+	// totalCount=6, MaxMemoryCount=5, OverEvictMargin=3
+	// toEvict = 6 - 5 + 3 = 4
+	ids, err := ScanOverCountMemories(db, tableName, sid, config)
+	require.NoError(t, err)
+	assert.Len(t, ids, 4)
+
+	// After cleaning these 4, remaining = 6 - 4 = 2, which is < MaxMemoryCount=5
+	// So new writes won't immediately re-trigger (need 3 more writes to reach 6 again)
+}
+
+// --- Coordinator integration (lazy timer trigger) ---
+
+func TestMaybeCleanup_LazyTimerTrigger(t *testing.T) {
+	sessionID := "test-cleanup-coordinator-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+
+	// Reset global coordinator state for test
+	resetCleanupCoordinatorForTest()
+
+	// Create 53 low-value, expired memories to exceed MaxMemoryCount and be expired
+	for i := 0; i < 53; i++ {
+		entity := &schema.AIMemoryEntity{
+			MemoryID:  fmt.Sprintf("coord-mem-%d", i),
+			SessionID: sid,
+			Content:   fmt.Sprintf("memory %d", i),
+			Tags:      schema.StringArray{"test"},
+			T_Score:   0.1, // transient → expires in 7 days
+			C_Score:   0.1, O_Score: 0.1, R_Score: 0.1, E_Score: 0.1, P_Score: 0.1, A_Score: 0.1,
+		}
+		entity.CreatedAt = time.Now().Add(-8 * 24 * time.Hour) // 8 days ago → expired
+		expires := time.Now().Add(-1 * time.Hour)                // already expired
+		entity.ExpiresAt = &expires
+		require.NoError(t, db.Table(tableName).Create(entity).Error)
+	}
+
+	// Trigger cleanup via MaybeCleanup (first call → lastCleanupTime=0 → triggers)
+	MaybeCleanup(db)
+
+	// Wait for async cleanup to complete
+	time.Sleep(3 * time.Second)
+
+	// Verify cleanup happened: totalCount should be reduced
+	var totalCount int64
+	db.Table(tableName).Where("session_id = ?", sid).Count(&totalCount)
+
+	// All 53 are expired (ExpiresAt < NOW()), so all should be cleaned
+	assert.Equal(t, int64(0), totalCount, "cleanup should have evicted all expired memories")
+}
+
+func TestMaybeCleanup_RateLimit(t *testing.T) {
+	sessionID := "test-cleanup-ratelimit-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+
+	// Reset and set lastCleanupTime to now → should NOT trigger
+	resetCleanupCoordinatorForTest()
+	atomicStoreLastCleanupNow()
+
+	// Call MaybeCleanup multiple times — should not trigger because within interval
+	for i := 0; i < 10; i++ {
+		MaybeCleanup(db)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	// cleanupRunning should still be 0 (never triggered)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&globalCoordinator.cleanupRunning))
+}
+
+func atomicStoreLastCleanupNow() {
+	atomic.StoreInt64(&globalCoordinator.lastCleanupTime, time.Now().UnixNano())
 }

--- a/common/ai/aid/aimem/cleanup_test.go
+++ b/common/ai/aid/aimem/cleanup_test.go
@@ -1,0 +1,394 @@
+package aimem
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// --- Helpers ---
+
+func createCleanupTestMemory(t *testing.T, sessionID string) *AIMemoryTriage {
+	t.Helper()
+	ctx := context.Background()
+	mem, err := CreateTestAIMemory(sessionID, WithInvoker(mock.NewMockInvoker(ctx)))
+	require.NoError(t, err)
+	require.NotNil(t, mem)
+	return mem
+}
+
+func saveTestMemoryDirectly(t *testing.T, mem *AIMemoryTriage, id string, tScore float64, createdAt time.Time) {
+	t.Helper()
+	entity := &aicommon.MemoryEntity{
+		Id:        id,
+		CreatedAt: createdAt,
+		Content:   "test content for " + id,
+		Tags:      []string{"test"},
+		C_Score:   0.5,
+		O_Score:   0.5,
+		R_Score:   0.5,
+		E_Score:   0.5,
+		P_Score:   0.5,
+		A_Score:   0.5,
+		T_Score:   tScore,
+		CorePactVector: []float32{
+			float32(0.5), float32(0.5), float32(0.5),
+			float32(0.5), float32(0.5), float32(0.5),
+			float32(tScore),
+		},
+	}
+	err := mem.SaveMemoryEntities(entity)
+	require.NoError(t, err)
+}
+
+// --- CalcExpiresAt ---
+
+func TestCalcExpiresAt_Transient(t *testing.T) {
+	now := time.Now()
+	expires := CalcExpiresAt(0.1, now)
+	require.NotNil(t, expires)
+	assert.WithinDuration(t, now.Add(7*24*time.Hour), *expires, time.Second)
+}
+
+func TestCalcExpiresAt_ShortTerm(t *testing.T) {
+	now := time.Now()
+	expires := CalcExpiresAt(0.4, now)
+	require.NotNil(t, expires)
+	assert.WithinDuration(t, now.Add(30*24*time.Hour), *expires, time.Second)
+}
+
+func TestCalcExpiresAt_MidTerm(t *testing.T) {
+	now := time.Now()
+	expires := CalcExpiresAt(0.7, now)
+	require.NotNil(t, expires)
+	assert.WithinDuration(t, now.Add(90*24*time.Hour), *expires, time.Second)
+}
+
+func TestCalcExpiresAt_LongTerm(t *testing.T) {
+	now := time.Now()
+	expires := CalcExpiresAt(0.9, now)
+	assert.Nil(t, expires, "long-term memory should not expire")
+}
+
+// --- SaveMemoryEntities auto-calculates ExpiresAt ---
+
+func TestSaveMemoryEntities_AutoExpiresAt(t *testing.T) {
+	sessionID := "test-cleanup-expires-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	now := time.Now()
+	// Save a transient memory (T=0.1) — should get ExpiresAt = now+7d
+	saveTestMemoryDirectly(t, mem, "mem-transient", 0.1, now)
+	// Save a long-term memory (T=0.9) — should get ExpiresAt = nil
+	saveTestMemoryDirectly(t, mem, "mem-longterm", 0.9, now)
+
+	// Verify DB
+	db := mem.GetDB()
+	var transientEntity schema.AIMemoryEntity
+	err := db.Table(mem.entityTableName()).
+		Where("memory_id = ? AND session_id = ?", "mem-transient", mem.GetSessionID()).
+		First(&transientEntity).Error
+	require.NoError(t, err)
+	assert.NotNil(t, transientEntity.ExpiresAt)
+	assert.WithinDuration(t, now.Add(7*24*time.Hour), *transientEntity.ExpiresAt, time.Second)
+
+	var longTermEntity schema.AIMemoryEntity
+	err = db.Table(mem.entityTableName()).
+		Where("memory_id = ? AND session_id = ?", "mem-longterm", mem.GetSessionID()).
+		First(&longTermEntity).Error
+	require.NoError(t, err)
+	assert.Nil(t, longTermEntity.ExpiresAt, "long-term memory should have nil ExpiresAt")
+}
+
+// --- ScanExpiredMemories ---
+
+func TestScanExpiredMemories(t *testing.T) {
+	sessionID := "test-cleanup-scan-expired-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+
+	// Create an expired memory (ExpiresAt in the past)
+	pastTime := time.Now().Add(-10 * 24 * time.Hour)
+	entity := &schema.AIMemoryEntity{
+		MemoryID:  "expired-mem",
+		SessionID: sid,
+		Content:   "this is an expired memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.1,
+		ExpiresAt: &pastTime,
+	}
+	require.NoError(t, db.Table(tableName).Create(entity).Error)
+
+	// Create a non-expired memory
+	futureTime := time.Now().Add(10 * 24 * time.Hour)
+	entity2 := &schema.AIMemoryEntity{
+		MemoryID:  "active-mem",
+		SessionID: sid,
+		Content:   "this is an active memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.4,
+		ExpiresAt: &futureTime,
+	}
+	require.NoError(t, db.Table(tableName).Create(entity2).Error)
+
+	// Create a non-expiring memory (ExpiresAt = nil)
+	entity3 := &schema.AIMemoryEntity{
+		MemoryID:  "nonexpiring-mem",
+		SessionID: sid,
+		Content:   "this is a non-expiring memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.9,
+	}
+	require.NoError(t, db.Table(tableName).Create(entity3).Error)
+
+	// Scan expired
+	expiredIDs, err := ScanExpiredMemories(db, tableName, sid, 100)
+	require.NoError(t, err)
+	assert.Len(t, expiredIDs, 1)
+	assert.Equal(t, "expired-mem", expiredIDs[0])
+}
+
+// --- ScanLowValueMemories ---
+
+func TestScanLowValueMemories(t *testing.T) {
+	sessionID := "test-cleanup-scan-lowvalue-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+
+	config := DefaultCleanupConfig()
+	coldThreshold := time.Now().AddDate(0, 0, -config.ColdMemoryDays)
+
+	// 1. Low-value, old → should be scanned
+	lowValEntity := &schema.AIMemoryEntity{
+		MemoryID:  "lowval-mem",
+		SessionID: sid,
+		Content:   "low value memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.2, // below 0.8
+		C_Score:   0.1,
+		O_Score:   0.1,
+		R_Score:   0.1,
+		E_Score:   0.1,
+		P_Score:   0.1,
+		A_Score:   0.1,
+	}
+	lowValEntity.CreatedAt = coldThreshold.Add(-1 * time.Hour)
+	require.NoError(t, db.Table(tableName).Create(lowValEntity).Error)
+
+	// 2. High-value, old → should NOT be scanned
+	highValEntity := &schema.AIMemoryEntity{
+		MemoryID:  "highval-mem",
+		SessionID: sid,
+		Content:   "high value memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.5,
+		C_Score:   0.9,
+		O_Score:   0.9,
+		R_Score:   0.9,
+		E_Score:   0.9,
+		P_Score:   0.9,
+		A_Score:   0.9,
+	}
+	highValEntity.CreatedAt = coldThreshold.Add(-1 * time.Hour)
+	require.NoError(t, db.Table(tableName).Create(highValEntity).Error)
+
+	// 3. Low-value, but long-term (T >= 0.8) → should NOT be scanned
+	longTermEntity := &schema.AIMemoryEntity{
+		MemoryID:  "longterm-mem",
+		SessionID: sid,
+		Content:   "long term low value memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.9, // exempt
+		C_Score:   0.1,
+		O_Score:   0.1,
+		R_Score:   0.1,
+		E_Score:   0.1,
+		P_Score:   0.1,
+		A_Score:   0.1,
+	}
+	longTermEntity.CreatedAt = coldThreshold.Add(-1 * time.Hour)
+	require.NoError(t, db.Table(tableName).Create(longTermEntity).Error)
+
+	// 4. Low-value, but too recent (CreatedAt) → should NOT be scanned
+	recentEntity := &schema.AIMemoryEntity{
+		MemoryID:  "recent-mem",
+		SessionID: sid,
+		Content:   "recent low value memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.2,
+		C_Score:   0.1,
+		O_Score:   0.1,
+		R_Score:   0.1,
+		E_Score:   0.1,
+		P_Score:   0.1,
+		A_Score:   0.1,
+	}
+	recentEntity.CreatedAt = time.Now().Add(-1 * time.Hour) // very recent
+	require.NoError(t, db.Table(tableName).Create(recentEntity).Error)
+
+	// Scan low-value
+	resultIDs, err := ScanLowValueMemories(db, tableName, sid, config)
+	require.NoError(t, err)
+	assert.Len(t, resultIDs, 1)
+	assert.Equal(t, "lowval-mem", resultIDs[0])
+}
+
+// --- CalcMemoryValue ---
+
+func TestCalcMemoryValue(t *testing.T) {
+	entity := &aicommon.MemoryEntity{
+		R_Score: 1.0,
+		A_Score: 1.0,
+		P_Score: 1.0,
+		C_Score: 1.0,
+		O_Score: 1.0,
+		E_Score: 1.0,
+		T_Score: 1.0,
+	}
+	value := CalcMemoryValue(entity)
+	assert.InDelta(t, 1.0, value, 0.001)
+
+	entity2 := &aicommon.MemoryEntity{
+		R_Score: 0.0,
+		A_Score: 0.0,
+		P_Score: 0.0,
+		C_Score: 0.0,
+		O_Score: 0.0,
+		E_Score: 0.0,
+		T_Score: 0.0,
+	}
+	value2 := CalcMemoryValue(entity2)
+	assert.InDelta(t, 0.0, value2, 0.001)
+
+	// Weights: R=0.25, A=0.20, P=0.15, C=0.15, O=0.10, E=0.05, T=0.10
+	entity3 := &aicommon.MemoryEntity{
+		R_Score: 1.0,
+		A_Score: 0.0,
+		P_Score: 0.0,
+		C_Score: 0.0,
+		O_Score: 0.0,
+		E_Score: 0.0,
+		T_Score: 0.0,
+	}
+	value3 := CalcMemoryValue(entity3)
+	assert.InDelta(t, 0.25, value3, 0.001)
+}
+
+// --- BatchCleanupMemories ---
+
+func TestBatchCleanupMemories(t *testing.T) {
+	sessionID := "test-cleanup-batch-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+
+	// Save 3 memories
+	for _, id := range []string{"batch-mem-1", "batch-mem-2", "batch-mem-3"} {
+		saveTestMemoryDirectly(t, mem, id, 0.5, time.Now())
+	}
+
+	// Verify they exist
+	var count int64
+	db.Table(tableName).Where("session_id = ?", sid).Count(&count)
+	assert.Equal(t, int64(3), count)
+
+	// Verify HNSW has them
+	hnswIDs := mem.hnswBackend.ListMemoryIDs()
+	assert.Len(t, hnswIDs, 3)
+
+	// Batch cleanup 2 of them
+	err := BatchCleanupMemories(context.Background(), db, sid, []string{"batch-mem-1", "batch-mem-2"})
+	require.NoError(t, err)
+
+	// Verify DB has 1 left
+	db.Table(tableName).Where("session_id = ?", sid).Count(&count)
+	assert.Equal(t, int64(1), count)
+
+	// Verify remaining is batch-mem-3
+	var remaining schema.AIMemoryEntity
+	db.Table(tableName).Where("session_id = ? AND memory_id = ?", sid, "batch-mem-3").First(&remaining)
+	assert.Equal(t, "batch-mem-3", remaining.MemoryID)
+}
+
+// --- ScanAllCleanupMemories (integration) ---
+
+func TestScanAllCleanupMemories(t *testing.T) {
+	sessionID := "test-cleanup-scanall-" + t.Name()
+	mem := createCleanupTestMemory(t, sessionID)
+	defer mem.Close()
+
+	db := mem.GetDB()
+	tableName := mem.entityTableName()
+	sid := mem.GetSessionID()
+	config := DefaultCleanupConfig()
+
+	// 1. Expired memory (ExpiresAt in past)
+	pastTime := time.Now().Add(-10 * 24 * time.Hour)
+	expiredEntity := &schema.AIMemoryEntity{
+		MemoryID:  "scan-expired",
+		SessionID: sid,
+		Content:   "expired",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.1,
+		ExpiresAt: &pastTime,
+	}
+	require.NoError(t, db.Table(tableName).Create(expiredEntity).Error)
+
+	// 2. Low-value cold memory
+	coldThreshold := time.Now().AddDate(0, 0, -config.ColdMemoryDays)
+	lowValEntity := &schema.AIMemoryEntity{
+		MemoryID:  "scan-lowval",
+		SessionID: sid,
+		Content:   "low value",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.2,
+		C_Score:   0.1, O_Score: 0.1, R_Score: 0.1, E_Score: 0.1, P_Score: 0.1, A_Score: 0.1,
+	}
+	lowValEntity.CreatedAt = coldThreshold.Add(-1 * time.Hour)
+	require.NoError(t, db.Table(tableName).Create(lowValEntity).Error)
+
+	// 3. Healthy memory (not expired, not low-value)
+	healthyEntity := &schema.AIMemoryEntity{
+		MemoryID:  "scan-healthy",
+		SessionID: sid,
+		Content:   "healthy memory",
+		Tags:      schema.StringArray{"test"},
+		T_Score:   0.5,
+		C_Score:   0.8, O_Score: 0.8, R_Score: 0.8, E_Score: 0.8, P_Score: 0.8, A_Score: 0.8,
+	}
+	healthyEntity.CreatedAt = time.Now().Add(-1 * time.Hour)
+	require.NoError(t, db.Table(tableName).Create(healthyEntity).Error)
+
+	// Scan all
+	resultIDs, err := ScanAllCleanupMemories(db, tableName, sid, config)
+	require.NoError(t, err)
+	assert.Len(t, resultIDs, 2)
+
+	// Should contain both expired and low-value
+	idSet := make(map[string]bool)
+	for _, id := range resultIDs {
+		idSet[id] = true
+	}
+	assert.True(t, idSet["scan-expired"])
+	assert.True(t, idSet["scan-lowval"])
+	assert.False(t, idSet["scan-healthy"])
+}

--- a/common/ai/aid/aimem/search.go
+++ b/common/ai/aid/aimem/search.go
@@ -12,6 +12,7 @@ import (
 
 // SearchBySemanticsMemoryIDs 仅执行语义检索并返回命中的 memory_id（不加载数据库实体）
 func (r *AIMemoryTriage) SearchBySemanticsMemoryIDs(query string, limit int) ([]*aicommon.SearchResult, error) {
+	MaybeCleanup(r.db)
 	return r.semanticSearchMemoryIDs(query, limit)
 }
 
@@ -72,6 +73,7 @@ func (r *AIMemoryTriage) semanticSearchMemoryIDs(query string, limit int) ([]*ai
 
 // SearchBySemantics 通过语义搜索记忆
 func (r *AIMemoryTriage) SearchBySemantics(query string, limit int) ([]*aicommon.SearchResult, error) {
+	MaybeCleanup(r.db)
 	idResults, err := r.semanticSearchMemoryIDs(query, limit)
 	if err != nil {
 		return nil, err
@@ -132,6 +134,7 @@ func (r *AIMemoryTriage) SearchBySemantics(query string, limit int) ([]*aicommon
 
 // SearchByScores 按照C.O.R.E. P.A.C.T.评分搜索
 func (r *AIMemoryTriage) SearchByScores(filter *aicommon.ScoreFilter, limit int) ([]*aicommon.MemoryEntity, error) {
+	MaybeCleanup(r.db)
 	db := r.GetDB()
 	if db == nil {
 		return nil, utils.Errorf("database connection is nil")
@@ -219,6 +222,7 @@ func (r *AIMemoryTriage) SearchByScores(filter *aicommon.ScoreFilter, limit int)
 
 // SearchByScoreVectorMemoryIDs 仅执行 HNSW 检索并返回命中的 memory_id（不加载数据库实体）
 func (r *AIMemoryTriage) SearchByScoreVectorMemoryIDs(queryVector []float32, limit int) ([]*aicommon.SearchResult, error) {
+	MaybeCleanup(r.db)
 	if r.hnswBackend == nil {
 		return nil, utils.Errorf("HNSW backend is not initialized")
 	}
@@ -246,6 +250,7 @@ func (r *AIMemoryTriage) SearchByScoreVectorMemoryIDs(queryVector []float32, lim
 
 // SearchByScoreVector 通过分数向量搜索相似的记忆（基于HNSW）
 func (r *AIMemoryTriage) SearchByScoreVector(targetScores *aicommon.MemoryEntity, limit int) ([]*aicommon.SearchResult, error) {
+	MaybeCleanup(r.db)
 	// 构建目标向量
 	queryVector := []float32{
 		float32(targetScores.C_Score),
@@ -281,6 +286,7 @@ func (r *AIMemoryTriage) SearchByScoreVector(targetScores *aicommon.MemoryEntity
 
 // SearchByTags 按照标签搜索
 func (r *AIMemoryTriage) SearchByTags(tags []string, matchAll bool, limit int) ([]*aicommon.MemoryEntity, error) {
+	MaybeCleanup(r.db)
 	if len(tags) == 0 {
 		return nil, utils.Errorf("at least one tag is required")
 	}

--- a/common/ai/aid/aimem/search.go
+++ b/common/ai/aid/aimem/search.go
@@ -118,6 +118,7 @@ func (r *AIMemoryTriage) SearchBySemantics(query string, limit int) ([]*aicommon
 			A_Score:            dbEntity.A_Score,
 			T_Score:            dbEntity.T_Score,
 			CorePactVector:     []float32(dbEntity.CorePactVector),
+			ExpiresAt:          dbEntity.ExpiresAt,
 		}
 
 		results = append(results, &aicommon.SearchResult{
@@ -208,6 +209,7 @@ func (r *AIMemoryTriage) SearchByScores(filter *aicommon.ScoreFilter, limit int)
 			A_Score:            dbEntity.A_Score,
 			T_Score:            dbEntity.T_Score,
 			CorePactVector:     []float32(dbEntity.CorePactVector),
+			ExpiresAt:          dbEntity.ExpiresAt,
 		}
 		results = append(results, entity)
 	}
@@ -349,6 +351,7 @@ func (r *AIMemoryTriage) SearchByTags(tags []string, matchAll bool, limit int) (
 			A_Score:            dbEntity.A_Score,
 			T_Score:            dbEntity.T_Score,
 			CorePactVector:     []float32(dbEntity.CorePactVector),
+			ExpiresAt:          dbEntity.ExpiresAt,
 		}
 		results = append(results, entity)
 
@@ -359,3 +362,4 @@ func (r *AIMemoryTriage) SearchByTags(tags []string, matchAll bool, limit int) (
 
 	return results, nil
 }
+

--- a/common/ai/aid/aimem/storage.go
+++ b/common/ai/aid/aimem/storage.go
@@ -153,6 +153,9 @@ func (r *AIMemoryTriage) SaveMemoryEntities(entities ...*aicommon.MemoryEntity) 
 	if savedCount == 0 && lastDBErr != nil {
 		return lastDBErr
 	}
+
+	// 惰性触发自动清理检查（全局协调，不阻塞写入）
+	MaybeCleanup(r.db)
 	return nil
 }
 

--- a/common/ai/aid/aimem/storage.go
+++ b/common/ai/aid/aimem/storage.go
@@ -3,6 +3,7 @@ package aimem
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 
@@ -12,6 +13,30 @@ import (
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 )
+
+// TTL 过期天数常量（基于 T_Score 区间）
+const (
+	TTLTransientDays = 7.0  // T_Score 0.0-0.3: 瞬时记忆
+	TTLShortTermDays = 30.0 // T_Score 0.3-0.6: 短期记忆
+	TTLMidTermDays   = 90.0 // T_Score 0.6-0.8: 中期记忆
+)
+
+// CalcExpiresAt 根据 T_Score 计算过期时间。T_Score >= 0.8 的长期记忆返回 nil 表示不过期。
+func CalcExpiresAt(tScore float64, createdAt time.Time) *time.Time {
+	var days float64
+	switch {
+	case tScore < 0.3:
+		days = TTLTransientDays
+	case tScore < 0.6:
+		days = TTLShortTermDays
+	case tScore < 0.8:
+		days = TTLMidTermDays
+	default:
+		return nil // 长期/核心记忆不过期
+	}
+	expires := createdAt.Add(time.Duration(days * 24 * float64(time.Hour)))
+	return &expires
+}
 
 // SaveMemoryEntities 保存记忆条目到数据库并索引到RAG系统和HNSW。
 //
@@ -59,6 +84,14 @@ func (r *AIMemoryTriage) SaveMemoryEntities(entities ...*aicommon.MemoryEntity) 
 			A_Score:            entity.A_Score,
 			T_Score:            entity.T_Score,
 			CorePactVector:     schema.FloatArray(entity.CorePactVector),
+		}
+
+		// 根据T_Score自动计算过期时间
+		now := time.Now()
+		dbEntity.ExpiresAt = CalcExpiresAt(entity.T_Score, now)
+		// 如果外部已经设置了ExpiresAt，优先使用外部值
+		if entity.ExpiresAt != nil {
+			dbEntity.ExpiresAt = entity.ExpiresAt
 		}
 
 		if err := db.Table(r.entityTableName()).Create(dbEntity).Error; err != nil {
@@ -227,6 +260,11 @@ func (r *AIMemoryTriage) UpdateMemoryEntity(entity *aicommon.MemoryEntity) error
 	existingEntity.A_Score = entity.A_Score
 	existingEntity.T_Score = entity.T_Score
 	existingEntity.CorePactVector = schema.FloatArray(entity.CorePactVector)
+	if entity.ExpiresAt != nil {
+		existingEntity.ExpiresAt = entity.ExpiresAt
+	} else {
+		existingEntity.ExpiresAt = CalcExpiresAt(entity.T_Score, existingEntity.CreatedAt)
+	}
 
 	// 保存更新
 	if err := db.Table(r.entityTableName()).Save(&existingEntity).Error; err != nil {
@@ -276,6 +314,7 @@ func (r *AIMemoryTriage) GetMemoryEntity(memoryID string) (*aicommon.MemoryEntit
 		A_Score:            dbEntity.A_Score,
 		T_Score:            dbEntity.T_Score,
 		CorePactVector:     []float32(dbEntity.CorePactVector),
+		ExpiresAt:          dbEntity.ExpiresAt,
 	}
 
 	return entity, nil
@@ -314,6 +353,7 @@ func (r *AIMemoryTriage) ListAllMemories(limit int) ([]*aicommon.MemoryEntity, e
 			A_Score:            dbEntity.A_Score,
 			T_Score:            dbEntity.T_Score,
 			CorePactVector:     []float32(dbEntity.CorePactVector),
+		ExpiresAt:          dbEntity.ExpiresAt,
 		}
 		results = append(results, entity)
 	}

--- a/common/ai/aid/aimem/types.go
+++ b/common/ai/aid/aimem/types.go
@@ -56,7 +56,6 @@ type AIMemoryTriage struct {
 
 	// midtermArchiveMode makes this instance use independent DB tables for midterm archives.
 	midtermArchiveMode bool
-
 }
 
 func (a *AIMemoryTriage) SetInvoker(invoker aicommon.AIInvokeRuntime) {

--- a/common/ai/aid/aimem/types.go
+++ b/common/ai/aid/aimem/types.go
@@ -56,6 +56,7 @@ type AIMemoryTriage struct {
 
 	// midtermArchiveMode makes this instance use independent DB tables for midterm archives.
 	midtermArchiveMode bool
+
 }
 
 func (a *AIMemoryTriage) SetInvoker(invoker aicommon.AIInvokeRuntime) {

--- a/common/ai/aid/aimem/vector_cleanup.go
+++ b/common/ai/aid/aimem/vector_cleanup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/rag/vectorstore"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
 )
 
 // DeleteMemoryVectorArtifacts removes HNSW graph nodes and RAG documents for the given entities.
@@ -161,4 +162,89 @@ func getOrCreateRAGStore(
 	cache[collectionName] = store
 	exists[collectionName] = true
 	return store, true, nil
+}
+
+// BatchCleanupMemories 批量物理删除指定 session 内的记忆及其所有索引数据。
+//
+// 针对单 session 攒批场景优化：HNSW 只加载一次 → 批量 Delete → 只 SaveGraph 一次；
+// RAG 批量收集 docIDs 一次性删除；DB 一条 DELETE WHERE memory_id IN (...)。
+//
+// 适用于 TTL 过期清理和低价值淘汰等自动清理场景。
+func BatchCleanupMemories(ctx context.Context, db *gorm.DB, sessionID string, memoryIDs []string) error {
+	if len(memoryIDs) == 0 || db == nil || sessionID == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	memoryIDs = uniqueNonEmptyStrings(memoryIDs)
+	if len(memoryIDs) == 0 {
+		return nil
+	}
+
+	// 1. 查询 DB 获取完整实体（用于收集 RAG docIDs）
+	midtermMode := strings.HasPrefix(sessionID, MidtermSessionPrefix)
+	entityTable := "ai_memory_entities_v1"
+	if midtermMode {
+		entityTable = "ai_midterm_archive_entities_v1"
+	}
+
+	var entities []schema.AIMemoryEntity
+	if err := db.Table(entityTable).
+		Where("memory_id IN (?) AND session_id = ?", memoryIDs, sessionID).
+		Find(&entities).Error; err != nil {
+		return utils.Errorf("query entities for cleanup failed: %v", err)
+	}
+
+	// 2. HNSW: 加载一次 backend → 批量 Delete → 只 SaveGraph 一次
+	backend, err := NewAIMemoryHNSWBackend(
+		WithHNSWSessionID(sessionID),
+		WithHNSWDatabase(db),
+		WithHNSWAutoSave(false),
+		WithHNSWMidtermMode(midtermMode),
+	)
+	if err != nil {
+		log.Warnf("BatchCleanupMemories: HNSW backend init failed: %v", err)
+	} else {
+		for _, mid := range memoryIDs {
+			_ = backend.Delete(mid)
+		}
+		if err := backend.SaveGraph(); err != nil {
+			log.Warnf("BatchCleanupMemories: HNSW save graph failed: %v", err)
+		}
+	}
+
+	// 3. RAG: 批量收集 docIDs 一次性删除
+	var allDocIDs []string
+	for i := range entities {
+		allDocIDs = append(allDocIDs, entities[i].DocumentQuestionHashIDs()...)
+	}
+	allDocIDs = uniqueNonEmptyStrings(allDocIDs)
+	if len(allDocIDs) > 0 {
+		store, ok, err := getOrCreateRAGStore(make(map[string]*vectorstore.SQLiteVectorStoreHNSW), make(map[string]bool), db, sessionID)
+		if err != nil {
+			log.Warnf("BatchCleanupMemories: RAG store init failed: %v", err)
+		} else if ok {
+			if err := store.Delete(allDocIDs...); err != nil {
+				log.Warnf("BatchCleanupMemories: RAG delete failed: %v", err)
+			}
+		}
+	}
+
+	// 4. DB: 一条 DELETE 批量删除
+	if err := db.Table(entityTable).
+		Where("memory_id IN (?) AND session_id = ?", memoryIDs, sessionID).
+		Delete(nil).Error; err != nil {
+		return utils.Errorf("batch delete memory entities failed: %v", err)
+	}
+
+	log.Infof("BatchCleanupMemories: cleaned up %d memories for session %s", len(memoryIDs), sessionID)
+	return nil
 }

--- a/common/schema/ai_infra.go
+++ b/common/schema/ai_infra.go
@@ -220,6 +220,9 @@ type AIMemoryEntity struct {
 
 	// C.O.R.E. P.A.C.T. 向量，用于快速过滤和排序
 	CorePactVector FloatArray `json:"core_pact_vector" gorm:"type:text"`
+
+	// 自动清理相关字段
+	ExpiresAt *time.Time `json:"expires_at" gorm:"index"` // 过期时间，nil=不过期
 }
 
 func (a *AIMemoryEntity) TableName() string {

--- a/go.work.sum
+++ b/go.work.sum
@@ -107,6 +107,7 @@ github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gojuno/minimock/v3 v3.0.8 h1:+L+WvGoTvPB4YCbkMI5WFyp3Mvz6Z5ubBuTXWMhmwmA=
 github.com/gojuno/minimock/v3 v3.0.8/go.mod h1:TPKxc8tiB8O83YH2//pOzxvEjaI3TMhd6ev/GmlMiYA=


### PR DESCRIPTION
## 目标

让 AI 长期记忆库自动维持在不超过 200 条的健康状态，无需用户手动清理。

## 三层清理策略

| 策略 | 触发条件 | T>=0.8 参与 | 作用 |
|---|---|---|---|
| TTL 过期 | `ExpiresAt < NOW()` | ❌（永不过期） | 清理已过期的瞬时/短期/中期记忆 |
| 低价值淘汰 | 存在 >14 天 + 综合评分 <0.35 + T<0.8 | ❌ | 清理冷门且低价值的记忆 |
| **超量淘汰** | 总数 >200 | **✅ 参与排序** | **硬上限保证，无僵尸记忆** |

超量淘汰中，所有记忆按 `CalcMemoryValue`（R*0.25 + A*0.20 + P*0.15 + C*0.15 + O*0.10 + E*0.05 + T*0.10）升序排序，最低价值的先被淘汰。高 T 记忆因 T 权重天然排在高价值端，最后才被淘汰。

## 调度机制

- **全局惰性定时器**（30 分钟间隔），写入和搜索路径自然驱动，无常驻 goroutine
- **攒批阈值**（≥20 条才物理清理），减少昂贵的 HNSW Load/Save
- **CAS 防并发**，同一时间只有一个清理 goroutine
- **异步执行**，完全不阻塞用户操作

```
写入/搜索 → MaybeCleanup(db)
              ├── 距上次清理 < 30min → return（纳秒级）
              ├── CAS(0→1) 失败 → return
              └── go runCleanup(db)  异步
                    ├── SELECT DISTINCT(session_id)
                    └── for each session:
                          ScanAllCleanupMemories()  → TTL + 低价值 + 超量
                          if < 20 条 → 跳过（攒批）
                          BatchCleanupMemories()   → HNSW + RAG + DB
```

## 关键设计决策

- **纯 score + time，无访问追踪** — 不记录 HitCount/LastAccessedAt，避免"被无关搜索命中一次就永久保留"
- **全局协调器** — `AIMemoryTriage` 非单例（同一 sessionID 被反复创建），调度状态必须全局
- **超量淘汰无豁免** — 保证 200 条硬上限，杜绝僵尸记忆
- **TTL 分级**：T<0.3→7天, 0.3-0.6→30天, 0.6-0.8→90天, >=0.8→永不过期

## 改动文件

- **新增** `cleanup_policy.go` — CleanupConfig、扫描函数（TTL/低价值/超量）
- **新增** `cleanup_coordinator.go` — 全局惰性定时器调度器
- **新增** `cleanup_test.go` — 19 个测试
- **修改** `schema/ai_infra.go`、`aicommon/types.go` — 新增 ExpiresAt 字段
- **修改** `storage.go` — CalcExpiresAt + 写入时自动设 ExpiresAt + 触发清理
- **修改** `vector_cleanup.go` — BatchCleanupMemories 批量物理删除
- **修改** `search.go`、`aimemory_search_memory.go` — 搜索入口触发清理

## 测试

19 个测试全部通过，覆盖 TTL 计算、自动 ExpiresAt、扫描函数、批量清理、价值计算、超量淘汰、僵尸记忆防护、调度器触发和限频。