### PR TITLE
feat(ai): enrich user-facing status events

### DIFF
--- a/common/ai/aid/aicommon/emitter.go
+++ b/common/ai/aid/aicommon/emitter.go
@@ -343,6 +343,14 @@ func (r *Emitter) EmitStatus(key string, value any) (*schema.AiOutputEvent, erro
 	})
 }
 
+// EmitStatusI18n emits an extensible user-facing status while preserving the
+// legacy string value. Chinese is the default value when available; newer
+// clients may select value_i18n and render optional detail, progress, or tool
+// metadata, while older clients continue to read value unchanged.
+func (r *Emitter) EmitStatusI18n(key, zh, en string, options ...StatusOption) (*schema.AiOutputEvent, error) {
+	return r.EmitStructured("status", newStatusPayload(key, zh, en, options...))
+}
+
 func (r *Emitter) EmitThoughtStream(taskId string, fmtTpl string, item ...any) (*schema.AiOutputEvent, error) {
 	content := fmtTpl
 	if item != nil && len(item) > 0 {

--- a/common/ai/aid/aicommon/status.go
+++ b/common/ai/aid/aicommon/status.go
@@ -1,0 +1,177 @@
+package aicommon
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+// StatusState describes how a user-facing status should be presented.
+// It is intentionally independent from task lifecycle state: a running task
+// may temporarily be waiting for the user or recovering from a retryable issue.
+type StatusState string
+
+const (
+	StatusStateRunning    StatusState = "running"
+	StatusStateWaiting    StatusState = "waiting"
+	StatusStateRecovering StatusState = "recovering"
+	StatusStateSuccess    StatusState = "success"
+	StatusStateWarning    StatusState = "warning"
+	StatusStateError      StatusState = "error"
+)
+
+// StatusProgress carries determinate progress. Total may be omitted for an
+// indeterminate counter, while Unit is a stable machine-readable identifier
+// such as "file", "tool", "request", or "item".
+type StatusProgress struct {
+	Current int64  `json:"current"`
+	Total   int64  `json:"total,omitempty"`
+	Unit    string `json:"unit,omitempty"`
+}
+
+// StatusTool describes one real tool involved in the current status. Params
+// are deliberately excluded so status events cannot expose tool secrets or
+// turn the compact loading UI into a debug console.
+type StatusTool struct {
+	Name            string       `json:"name"`
+	DisplayName     string       `json:"display_name,omitempty"`
+	DisplayNameI18n *schema.I18n `json:"display_name_i18n,omitempty"`
+	State           StatusState  `json:"state,omitempty"`
+}
+
+// StatusPayload is a backward-compatible superset of the legacy
+// {key,value} payload. Value always remains a string and defaults to Chinese,
+// allowing old frontends and event extractors to keep working unchanged.
+type StatusPayload struct {
+	Key        string          `json:"key"`
+	Value      string          `json:"value"`
+	ValueI18n  *schema.I18n    `json:"value_i18n,omitempty"`
+	Code       string          `json:"code,omitempty"`
+	State      StatusState     `json:"state,omitempty"`
+	Detail     string          `json:"detail,omitempty"`
+	DetailI18n *schema.I18n    `json:"detail_i18n,omitempty"`
+	Progress   *StatusProgress `json:"progress,omitempty"`
+	Tools      []StatusTool    `json:"tools,omitempty"`
+}
+
+type StatusOption func(*StatusPayload)
+
+func WithStatusCode(code string) StatusOption {
+	return func(payload *StatusPayload) {
+		payload.Code = strings.TrimSpace(code)
+	}
+}
+
+func WithStatusState(state StatusState) StatusOption {
+	return func(payload *StatusPayload) {
+		payload.State = state
+	}
+}
+
+func WithStatusDetail(zh, en string) StatusOption {
+	return func(payload *StatusPayload) {
+		zh = strings.TrimSpace(zh)
+		en = strings.TrimSpace(en)
+		payload.Detail = preferredChinese(zh, en)
+		if zh != "" || en != "" {
+			payload.DetailI18n = &schema.I18n{Zh: zh, En: en}
+		}
+	}
+}
+
+func WithStatusProgress(current, total int64, unit string) StatusOption {
+	return func(payload *StatusPayload) {
+		if current < 0 {
+			current = 0
+		}
+		if total < 0 {
+			total = 0
+		}
+		if total > 0 && current > total {
+			current = total
+		}
+		payload.Progress = &StatusProgress{
+			Current: current,
+			Total:   total,
+			Unit:    strings.TrimSpace(unit),
+		}
+	}
+}
+
+func WithStatusTools(tools ...StatusTool) StatusOption {
+	return func(payload *StatusPayload) {
+		payload.Tools = append([]StatusTool(nil), tools...)
+	}
+}
+
+func newStatusPayload(key, zh, en string, options ...StatusOption) *StatusPayload {
+	zh = strings.TrimSpace(zh)
+	en = strings.TrimSpace(en)
+	payload := &StatusPayload{
+		Key:   key,
+		Value: preferredChinese(zh, en),
+		State: StatusStateRunning,
+	}
+	if zh != "" || en != "" {
+		payload.ValueI18n = &schema.I18n{Zh: zh, En: en}
+	}
+	for _, option := range options {
+		if option != nil {
+			option(payload)
+		}
+	}
+	return payload
+}
+
+func preferredChinese(zh, en string) string {
+	if zh = strings.TrimSpace(zh); zh != "" {
+		return zh
+	}
+	return strings.TrimSpace(en)
+}
+
+// SplitLegacyStatusI18n supports the historical "中文 / English" convention
+// during migration. It only splits when the left side contains Chinese and the
+// right side contains ASCII letters, avoiding accidental splits in paths or
+// ordinary user content.
+func SplitLegacyStatusI18n(message string) (zh, en string) {
+	message = strings.TrimSpace(message)
+	for _, separator := range []string{" / ", "/ ", " - "} {
+		// Legacy status text may itself contain slashes, for example
+		// "正在检查 GET / api / Checking GET /api". The language boundary is
+		// conventionally the right-most matching separator.
+		index := strings.LastIndex(message, separator)
+		if index < 0 {
+			continue
+		}
+		left := strings.TrimSpace(message[:index])
+		right := strings.TrimSpace(message[index+len(separator):])
+		if containsHan(left) && looksLikeEnglishTranslation(right) {
+			return left, right
+		}
+	}
+	return message, ""
+}
+
+func containsHan(value string) bool {
+	for _, char := range value {
+		if unicode.Is(unicode.Han, char) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeEnglishTranslation(value string) bool {
+	hasWhitespace := strings.ContainsAny(value, " \t")
+	for _, char := range value {
+		if char >= 'A' && char <= 'Z' {
+			return true
+		}
+		if char >= 'a' && char <= 'z' {
+			return hasWhitespace
+		}
+	}
+	return false
+}

--- a/common/ai/aid/aicommon/status_test.go
+++ b/common/ai/aid/aicommon/status_test.go
@@ -1,0 +1,104 @@
+package aicommon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func TestEmitStatusKeepsLegacyPayload(t *testing.T) {
+	var captured *schema.AiOutputEvent
+	emitter := NewEmitter("status-test", func(event *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+		captured = event
+		return event, nil
+	})
+
+	_, err := emitter.EmitStatus("legacy", "working")
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(captured.Content, &payload))
+	require.Equal(t, map[string]any{"key": "legacy", "value": "working"}, payload)
+}
+
+func TestEmitStatusI18nUsesChineseLegacyValueAndStructuredMetadata(t *testing.T) {
+	var captured *schema.AiOutputEvent
+	emitter := NewEmitter("status-test", func(event *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+		captured = event
+		return event, nil
+	})
+
+	_, err := emitter.EmitStatusI18n(
+		"re-act-loading-status-key",
+		"正在并行调用 3 个工具",
+		"Running 3 tools in parallel",
+		WithStatusCode("tool.batch.running"),
+		WithStatusDetail("文本搜索、文件读取、语法检查", "Text Search, File Reader, Syntax Checker"),
+		WithStatusProgress(1, 3, "tool"),
+		WithStatusTools(StatusTool{Name: "grep", DisplayName: "文本搜索", State: StatusStateRunning}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(captured.Content, &payload))
+	require.Equal(t, "re-act-loading-status-key", payload["key"])
+	require.Equal(t, "正在并行调用 3 个工具", payload["value"])
+	require.Equal(t, "tool.batch.running", payload["code"])
+	require.Equal(t, "running", payload["state"])
+
+	valueI18n := payload["value_i18n"].(map[string]any)
+	require.Equal(t, "正在并行调用 3 个工具", valueI18n["zh"])
+	require.Equal(t, "Running 3 tools in parallel", valueI18n["en"])
+
+	detailI18n := payload["detail_i18n"].(map[string]any)
+	require.Equal(t, "文本搜索、文件读取、语法检查", detailI18n["zh"])
+	require.Equal(t, "Text Search, File Reader, Syntax Checker", detailI18n["en"])
+
+	progress := payload["progress"].(map[string]any)
+	require.Equal(t, float64(1), progress["current"])
+	require.Equal(t, float64(3), progress["total"])
+	require.Equal(t, "tool", progress["unit"])
+
+	tools := payload["tools"].([]any)
+	require.Len(t, tools, 1)
+	require.Equal(t, "grep", tools[0].(map[string]any)["name"])
+}
+
+func TestEmitStatusI18nFallsBackToEnglishAndNormalizesProgress(t *testing.T) {
+	payload := newStatusPayload(
+		"status",
+		"",
+		"Still working",
+		WithStatusProgress(9, 3, " item "),
+	)
+	require.Equal(t, "Still working", payload.Value)
+	require.Equal(t, int64(3), payload.Progress.Current)
+	require.Equal(t, int64(3), payload.Progress.Total)
+	require.Equal(t, "item", payload.Progress.Unit)
+}
+
+func TestSplitLegacyStatusI18n(t *testing.T) {
+	zh, en := SplitLegacyStatusI18n("正在梳理思路 / Refining the approach")
+	require.Equal(t, "正在梳理思路", zh)
+	require.Equal(t, "Refining the approach", en)
+
+	zh, en = SplitLegacyStatusI18n("正在检查 GET / api")
+	require.Equal(t, "正在检查 GET / api", zh)
+	require.Empty(t, en)
+
+	zh, en = SplitLegacyStatusI18n("正在检查 GET / api / Checking GET /api")
+	require.Equal(t, "正在检查 GET / api", zh)
+	require.Equal(t, "Checking GET /api", en)
+
+	zh, en = SplitLegacyStatusI18n("English only / still one message")
+	require.Equal(t, "English only / still one message", zh)
+	require.Empty(t, en)
+
+	zh, en = SplitLegacyStatusI18n("正在提炼关键信息 - Refining relevant information")
+	require.Equal(t, "正在提炼关键信息", zh)
+	require.Equal(t, "Refining relevant information", en)
+}

--- a/common/ai/aid/aireact/reactloops/attached_extra_resources_init.go
+++ b/common/ai/aid/aireact/reactloops/attached_extra_resources_init.go
@@ -40,10 +40,10 @@ func RunAttachedExtraResourcesInit(
 		if data == nil {
 			continue
 		}
-		loop.LoadingStatus(fmt.Sprintf(
-			"正在加载附加资源 (%d) / Loading attached resource (%d)",
-			idx+1, idx+1,
-		))
+		loop.UserStatus(
+			fmt.Sprintf("正在加载第 %d 个附加资源", idx+1),
+			fmt.Sprintf("Loading attached resource %d", idx+1),
+		)
 
 		resource, err := aicommon.ParseAttachedResourceData(data)
 		if err != nil {
@@ -76,7 +76,7 @@ func RunAttachedExtraResourcesInit(
 	}
 
 	if len(sectionsByType) > 0 {
-		loop.LoadingStatus("附加资源处理完成 / Finished loading attached resources")
+		loop.UserStatus("附加资源处理完成", "Finished loading attached resources")
 	}
 	return resources
 }

--- a/common/ai/aid/aireact/reactloops/attached_resource_handlers/image_vision.go
+++ b/common/ai/aid/aireact/reactloops/attached_resource_handlers/image_vision.go
@@ -61,14 +61,16 @@ In cumulative_summary, besides an objective description of the image, explicitly
 
 	for i, imagePath := range imagePaths {
 		base := filepath.Base(imagePath)
-		loop.LoadingStatus(fmt.Sprintf("正在解析附件图片 (%d/%d): %s / Parsing attached image: %s", i+1, len(imagePaths), base, base))
+		loop.UserStatus(
+			fmt.Sprintf("正在理解第 %d/%d 张图片", i+1, len(imagePaths)),
+			fmt.Sprintf("Understanding image %d of %d", i+1, len(imagePaths)),
+			aicommon.WithStatusCode("attachment.image.analyzing"),
+			aicommon.WithStatusDetail(fmt.Sprintf("正在查看「%s」中的关键信息", base), fmt.Sprintf("Reviewing key details in %q", base)),
+			aicommon.WithStatusProgress(int64(i), int64(len(imagePaths)), "image"),
+		)
 
 		statusCb := func(id string, data interface{}, tags ...string) {
-			msg := fmt.Sprintf("图片解析进度 / Image analysis [%s]: %v", id, data)
-			if len(tags) > 0 {
-				msg = fmt.Sprintf("%s tags=%v", msg, tags)
-			}
-			loop.LoadingStatus(msg)
+			log.Debugf("attached image analysis status: id=%s data=%v tags=%v", id, data, tags)
 		}
 
 		log.Infof("attached extra resources: vision analyze attached image %q (%d/%d)", imagePath, i+1, len(imagePaths))
@@ -105,7 +107,13 @@ In cumulative_summary, besides an objective description of the image, explicitly
 		}
 	}
 
-	loop.LoadingStatus("附件图片解析完成 / Finished parsing attached images")
+	loop.UserStatus(
+		"已经理解附件图片，正在结合任务继续处理",
+		"Finished reviewing the attached images and continuing with the task",
+		aicommon.WithStatusCode("attachment.image.ready"),
+		aicommon.WithStatusState(aicommon.StatusStateSuccess),
+		aicommon.WithStatusProgress(int64(len(imagePaths)), int64(len(imagePaths)), "image"),
+	)
 
 	payload := strings.TrimSpace(buf.String())
 	if payload == "" {

--- a/common/ai/aid/aireact/reactloops/capability_name_match.go
+++ b/common/ai/aid/aireact/reactloops/capability_name_match.go
@@ -88,7 +88,12 @@ func EmitCapabilityMatchingStatus(config aicommon.AICallerConfigIf) {
 	if config == nil || config.GetEmitter() == nil {
 		return
 	}
-	config.GetEmitter().EmitStatus(ReActLoadingStatusKey, "正在匹配相关能力 / Matching related capabilities...")
+	_, _ = config.GetEmitter().EmitStatusI18n(
+		ReActLoadingStatusKey,
+		"正在寻找适合这次任务的能力",
+		"Finding the right capabilities for this task",
+		aicommon.WithStatusCode("capability.matching"),
+	)
 }
 
 func resolveSkillLoaderFromConfig(config aicommon.AICallerConfigIf) aiskillloader.SkillLoader {

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -375,7 +375,11 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 	log.Infof("start to call aicommon.CallAITransaction in ReActLoop[%v]", r.loopName)
 	r.resetModelThinkingBuffer()
 	r.Set("last_ai_decision_response", "")
-	r.loadingStatus("等待 AI 回应 / Waiting AI Respond...")
+	r.UserStatus(
+		"正在理解你的需求",
+		"Understanding your request",
+		aicommon.WithStatusCode("reasoning.understanding"),
+	)
 	aiCallback := r.config.CallAI
 	if r.useSpeedPriorityAI {
 		aiCallback = r.config.CallSpeedPriorityAI
@@ -442,8 +446,6 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 						}()
 
 						log.Debugf("stream handler started for field [%s]", key)
-						r.loadingStatus(fmt.Sprintf("处理流字段 [%s] / Processing Stream Field [%s]", key, key))
-
 						jsonReader := utils.JSONStringReader(reader)
 
 						fieldIns, ok := streamFields.Get(key)
@@ -515,7 +517,11 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 					}),
 			)
 
-			r.loadingStatus("解析 AI 响应中 / Parsing AI Response...")
+			r.UserStatus(
+				"正在梳理思路",
+				"Organizing the next steps",
+				aicommon.WithStatusCode("reasoning.organizing"),
+			)
 			extractStart := time.Now()
 			action, actionErr = aicommon.ExtractActionFromStream(
 				activeTaskCtx,
@@ -528,7 +534,12 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 			r.Set("last_ai_decision_nonce", nonce)
 
 			if actionErr != nil {
-				r.loadingStatus("解析响应失败 / Parse Response Failed")
+				r.UserStatus(
+					"刚才的信息不够完整，正在重新整理",
+					"The previous response was incomplete; reorganizing it",
+					aicommon.WithStatusCode("reasoning.recovering"),
+					aicommon.WithStatusState(aicommon.StatusStateRecovering),
+				)
 				log.Errorf("ai response stream content before error: %s", buf.String())
 				if currentCtxCanceled() {
 					actionErr = utils.Wrap(actionErr, "task context canceled while parsing action")
@@ -546,7 +557,12 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 			}
 			actionType := getNextActionType(action)
 			if observedActionType != "" && admittedActionType == "" {
-				r.loadingStatus(fmt.Sprintf("动作不受支持 [%s] / Unsupported Action [%s]", observedActionType, observedActionType))
+				r.UserStatus(
+					"当前思路还不够合适，正在重新整理",
+					"The current approach needs adjustment; reorganizing it",
+					aicommon.WithStatusCode("reasoning.adjusting"),
+					aicommon.WithStatusState(aicommon.StatusStateRecovering),
+				)
 				log.Errorf("ai response stream content before error: %s", buf.String())
 				unsupportedErr := actionTypeResolutionError(
 					observedActionType,
@@ -559,7 +575,12 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 				return unsupportedErr
 			}
 			if actionType == "" {
-				r.loadingStatus("动作类型缺失 / Action Type Missing")
+				r.UserStatus(
+					"正在重新确认下一步",
+					"Reconsidering the next step",
+					aicommon.WithStatusCode("reasoning.reconsidering"),
+					aicommon.WithStatusState(aicommon.StatusStateRecovering),
+				)
 				log.Errorf("ai response stream content before error: %s", buf.String())
 				missingErr := actionTypeResolutionError(
 					"",
@@ -572,7 +593,12 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 				return missingErr
 			}
 			if !utils.StringArrayContains(actionNames, actionType) {
-				r.loadingStatus(fmt.Sprintf("动作未注册 [%s] / Unregistered Action [%s]", actionType, actionType))
+				r.UserStatus(
+					"正在换一种方式继续",
+					"Switching to another approach",
+					aicommon.WithStatusCode("reasoning.fallback"),
+					aicommon.WithStatusState(aicommon.StatusStateRecovering),
+				)
 				return actionTypeResolutionError(
 					actionType,
 					actionNames,
@@ -580,7 +606,11 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 				)
 			}
 
-			r.loadingStatus(fmt.Sprintf("处理动作 [%s] / Processing Action [%s]", actionType, actionType))
+			r.UserStatus(
+				"已经找到下一步，正在准备执行",
+				"The next step is ready and being prepared",
+				aicommon.WithStatusCode("action.preparing"),
+			)
 			log.Infof("action type extracted: %s", actionType)
 
 			verifier, err := r.GetActionHandler(actionType)
@@ -601,7 +631,11 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 			// duplicate directly_answer guard), then be removed afterwards.
 			validateTodoDeltaBeforeActionVerifier(r, action)
 			if verifier.ActionVerifier != nil {
-				r.loadingStatus(fmt.Sprintf("验证动作 [%s] / Verifying Action [%s]", actionType, actionType))
+				r.UserStatus(
+					"正在确认关键细节",
+					"Checking the important details",
+					aicommon.WithStatusCode("action.verifying"),
+				)
 				if err := verifier.ActionVerifier(r, action); err != nil {
 					return err
 				}
@@ -612,22 +646,41 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 		aicommon.WithAIRequest_Context(activeTaskCtx),
 	)
 	if transactionErr != nil {
-		r.loadingStatus(fmt.Sprintf("AI 事务失败 / AI Transaction Failed: %v", transactionErr))
+		r.UserStatus(
+			"暂时没能完成这一步",
+			"This step could not be completed",
+			aicommon.WithStatusCode("action.failed"),
+			aicommon.WithStatusState(aicommon.StatusStateError),
+		)
 		log.Errorf("AI transaction failed: %v", transactionErr)
 		return nil, nil, transactionErr
 	}
 
 	if ctxCanceled.IsSet() {
-		r.loadingStatus("任务上下文已取消 / Task Context Cancelled")
+		r.UserStatus(
+			"任务已停止",
+			"Task stopped",
+			aicommon.WithStatusCode("task.stopped"),
+			aicommon.WithStatusState(aicommon.StatusStateWarning),
+		)
 		return nil, nil, utils.Error("task context canceled before execute ReActLoop")
 	}
 
 	if utils.IsNil(action) {
-		r.loadingStatus("动作解析为空 / Action is Nil")
+		r.UserStatus(
+			"没有得到完整的下一步信息",
+			"The next-step information was incomplete",
+			aicommon.WithStatusCode("action.empty"),
+			aicommon.WithStatusState(aicommon.StatusStateError),
+		)
 		return nil, nil, utils.Error("action is nil in ReActLoop")
 	}
 
-	r.loadingStatus(fmt.Sprintf("动作解析完成 [%s] / Action Parsed [%s]", action.Name(), action.Name()))
+	r.UserStatus(
+		"正在推进下一步",
+		"Moving on to the next step",
+		aicommon.WithStatusCode("action.ready"),
+	)
 
 	handler, err := r.GetActionHandler(getNextActionType(action))
 	if err != nil {
@@ -639,7 +692,6 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 
 	// Wait for all streams to complete with timeout (max 3 seconds)
 	// Don't block forever if streams are stuck
-	r.loadingStatus("等待流处理完成 / Waiting Streams to Complete...")
 	log.Infof("action.WaitStream starting for action [%s] with 3s timeout", action.Name())
 	waitStart := time.Now()
 
@@ -657,10 +709,14 @@ func (r *ReActLoop) callAITransaction(streamWg *sync.WaitGroup, prompt string, n
 	select {
 	case <-waitDone:
 		log.Infof("action.WaitStream completed normally for action [%s], took %v", action.Name(), time.Since(waitStart))
-		r.loadingStatus("流处理完成 / Streams Completed")
 	case <-streamWaitCtx.Done():
 		log.Warnf("action.WaitStream timeout (3s) for action [%s], continuing execution", action.Name())
-		r.loadingStatus("流处理超时,继续执行 / Stream Wait Timeout, Continuing...")
+		r.UserStatus(
+			"这一步比预期久一些，仍在继续",
+			"This step is taking longer than expected, but is still progressing",
+			aicommon.WithStatusCode("action.slow"),
+			aicommon.WithStatusState(aicommon.StatusStateWarning),
+		)
 	}
 
 	return action, handler, nil
@@ -673,7 +729,18 @@ func (r *ReActLoop) loadingStatus(i string) {
 		return
 	}
 	log.Infof("re-act-loop loading status updated: %v", i)
-	r.emitter.EmitStatus(ReActLoadingStatusKey, i)
+	zh, en := aicommon.SplitLegacyStatusI18n(i)
+	_, _ = r.emitter.EmitStatusI18n(ReActLoadingStatusKey, zh, en)
+}
+
+// UserStatus emits a product-facing status with a Chinese-compatible legacy
+// value and optional structured metadata for newer clients.
+func (r *ReActLoop) UserStatus(zh, en string, options ...aicommon.StatusOption) {
+	if utils.IsNil(r) || r.emitter == nil {
+		return
+	}
+	log.Infof("re-act-loop user status updated: %v", zh)
+	_, _ = r.emitter.EmitStatusI18n(ReActLoadingStatusKey, zh, en, options...)
 }
 
 func (r *ReActLoop) LoadingStatus(i string) {
@@ -684,9 +751,29 @@ func (r *ReActLoop) LoadingStatus(i string) {
 }
 
 func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalError error) {
-	r.loadingStatus("初始化 / initializing...")
+	r.UserStatus(
+		"正在准备这次任务",
+		"Preparing this task",
+		aicommon.WithStatusCode("task.preparing"),
+	)
 	if !r.noEndLoadingStatus {
-		defer r.loadingStatus("ReAct 任务结束 / ReAct task finished")
+		defer func() {
+			if finalError != nil {
+				r.UserStatus(
+					"这次任务已结束，但还有问题没有解决",
+					"This task has ended with unresolved issues",
+					aicommon.WithStatusCode("task.failed"),
+					aicommon.WithStatusState(aicommon.StatusStateError),
+				)
+				return
+			}
+			r.UserStatus(
+				"这次任务已经处理完成",
+				"This task has been completed",
+				aicommon.WithStatusCode("task.completed"),
+				aicommon.WithStatusState(aicommon.StatusStateSuccess),
+			)
+		}()
 	}
 	defer r.Release()
 
@@ -745,7 +832,11 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 	var initOperator *InitTaskOperator
 
 	if r.initHandler != nil {
-		r.loadingStatus("执行初始化函数 / execute init handler...")
+		r.UserStatus(
+			"正在了解任务背景",
+			"Reviewing the task context",
+			aicommon.WithStatusCode("task.context"),
+		)
 		utils.Debug(func() {
 			fmt.Println("================================================")
 			fmt.Printf("re-act loop [%v] task init handler start to execute\n", r.loopName)
@@ -765,13 +856,17 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 		// Check operator status
 		if initOperator.IsDone() {
 			// Init handler completed the task, exit immediately (early routing)
-			r.loadingStatus("init handler done (early exit)")
 			log.Infof("ReactLoop[%v] init handler signaled Done, exiting early", r.loopName)
 			return nil
 		}
 
 		if failed, failErr := initOperator.IsFailed(); failed {
-			r.loadingStatus("init handler failed: " + failErr.Error())
+			r.UserStatus(
+				"准备任务时遇到问题",
+				"A problem occurred while preparing the task",
+				aicommon.WithStatusCode("task.prepare_failed"),
+				aicommon.WithStatusState(aicommon.StatusStateError),
+			)
 			inv := r.GetInvoker()
 			inv.AddToTimeline("error", fmt.Sprintf("ReActLoop[%v] task init handler execute failed: %v", r.loopName, failErr))
 			query := "Task initialization failed: " + failErr.Error() + "\n\n Origin INPUT: " + task.GetUserInput() + "\n\n Please give some practical advice for fix this issue or help user"
@@ -788,8 +883,6 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 		}
 
 		// Continue with normal execution
-		r.loadingStatus("init handler done")
-
 		// Apply action constraints from init handler
 		if initOperator.HasActionConstraints() {
 			r.initActionMustUse = initOperator.GetNextActionMustUse()
@@ -980,7 +1073,11 @@ LOOP:
 				if agreed && extDelta > 0 {
 					// 用户同意扩充: 提升上限, 不推进计数, 直接 continue.
 					maxIterations += extDelta
-					r.loadingStatus(fmt.Sprintf("迭代上限已临时扩充至 %d / iteration limit extended to %d", maxIterations, maxIterations))
+					r.UserStatus(
+						"我会继续推进，并完成剩余步骤",
+						"Continuing with the remaining steps",
+						aicommon.WithStatusCode("task.extended"),
+					)
 					continue
 				}
 			}
@@ -1004,17 +1101,34 @@ LOOP:
 			r.fastLoadSearchMemoryWithoutAI(task.GetUserInput())
 		}()
 
-		r.loadingStatus("记忆快速装载中 / waiting for fast memories to load...")
+		r.UserStatus(
+			"正在回顾相关信息",
+			"Reviewing relevant context",
+			aicommon.WithStatusCode("context.recalling"),
+		)
 		select {
 		case <-task.GetContext().Done():
 			return utils.Errorf("task context done before execute ReActLoop: %v", task.GetContext().Err())
 		case <-waitMem:
-			r.loadingStatus("记忆已装载 / memories loaded")
+			r.UserStatus(
+				"已经找到相关信息，正在继续",
+				"Relevant context found; continuing",
+				aicommon.WithStatusCode("context.ready"),
+			)
 		case <-time.After(200 * time.Millisecond):
-			r.loadingStatus("跳过快速记忆装载，原因：超时 / skipping wait memories due to timeout")
+			r.UserStatus(
+				"已有信息足够，我会先继续处理",
+				"The available context is sufficient to continue",
+				aicommon.WithStatusCode("context.skipped"),
+				aicommon.WithStatusState(aicommon.StatusStateWarning),
+			)
 		}
 
-		r.loadingStatus("执行中... / executing...")
+		r.UserStatus(
+			"正在推进下一步",
+			"Moving on to the next step",
+			aicommon.WithStatusCode("task.working"),
+		)
 		var prompt string
 		// PE-TASK 缓存优化: 当 task 实现 CacheableUserInputProvider 接口时,
 		// 把 PARENT_TASK + CURRENT_TASK + INSTRUCTION 整块当作 frozenUserContext
@@ -1094,7 +1208,11 @@ LOOP:
 		)
 		actionName := actionParams.Name()
 
-		r.loadingStatus(fmt.Sprintf("[%v]执行中 / [%v] executing action...", actionName, actionName))
+		r.UserStatus(
+			"正在执行下一步",
+			"Executing the next step",
+			aicommon.WithStatusCode("action.running"),
+		)
 
 		// 记录当前迭代索引和 Action 信息。
 		r.actionHistoryMutex.Lock()
@@ -1120,9 +1238,17 @@ LOOP:
 		r.advanceEffectiveIteration(task, appliedTodoDelta)
 
 		if handler.AsyncMode {
-			r.loadingStatus("当前任务进入异步模式 / Async mode, ending loop")
+			r.UserStatus(
+				"这项工作已转入后台继续处理",
+				"This work is continuing in the background",
+				aicommon.WithStatusCode("task.background"),
+			)
 			if task.IsAsyncMode() {
-				r.loadingStatus("当前任务已进入异步模式 / Async mode, ending loop")
+				r.UserStatus(
+					"这项工作正在后台继续处理",
+					"This work is continuing in the background",
+					aicommon.WithStatusCode("task.background"),
+				)
 				log.Warnf("ReactLoop[%v] rejecting static async action '%v' because the current task is already in async mode", r.loopName, actionName)
 				rejectMsg := fmt.Sprintf(
 					"REJECTED: action '%s' requires async mode, but the current task is already running asynchronously. "+
@@ -1178,7 +1304,11 @@ LOOP:
 			invoker.SetCurrentTask(task)
 			defer invoker.SetCurrentTask(prevInvokerTask)
 
-			r.loadingStatus("执行动作 " + actionName + " 中 / Executing action " + actionName + "...")
+			r.UserStatus(
+				"正在执行下一步",
+				"Executing the next step",
+				aicommon.WithStatusCode("action.running"),
+			)
 			handler.ActionHandler(
 				r,
 				actionParams,
@@ -1293,7 +1423,11 @@ LOOP:
 					log.Infof("dynamic async mode, not update task status in mainloop")
 				})
 			}
-			r.loadingStatus("当前任务进入异步模式 / Async mode, ending loop")
+			r.UserStatus(
+				"这项工作已转入后台继续处理",
+				"This work is continuing in the background",
+				aicommon.WithStatusCode("task.background"),
+			)
 			finalError = nil
 			utils.Debug(func() {
 				fmt.Println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")

--- a/common/ai/aid/aireact/reactloops/loop_ai_skill_audit/audit.go
+++ b/common/ai/aid/aireact/reactloops/loop_ai_skill_audit/audit.go
@@ -96,13 +96,13 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 			}
 		}
 
-		reactloops.EmitStatus(loop, "正在准备检查这个技能 / Preparing to review this skill")
+		reactloops.EmitStatusI18n(loop, "正在准备检查这个技能", "Preparing to review this skill")
 		r.AddToTimeline("[SKILL_AUDIT_START]", "AI Skill 安全审计开始，用户输入: "+utils.ShrinkTextBlock(userInput, 300))
 
 		// ── Phase 1: 目录探索（委托给 dir_explore loop）──
 		log.Infof("[SkillAudit] Starting Phase 1 (Recon via dir_explore)")
 		reactloops.EmitActionLog(loop, skillAuditPhase1NodeID, "Phase 1：Skill 目录探索 / Phase 1: Skill directory exploration")
-		reactloops.EmitStatus(loop, "正在了解技能的结构和内容 / Understanding the skill structure and contents")
+		reactloops.EmitStatusI18n(loop, "正在了解技能的结构和内容", "Understanding the skill structure and contents")
 		r.AddToTimeline("[PHASE1_START]", "Phase 1：Skill 目录探索")
 
 		auditDirPath := skillAuditDir(state)
@@ -176,7 +176,7 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 		}
 
 		log.Infof("[SkillAudit] Phase 1 complete. skill=%s path=%s", state.SkillName, state.SkillPath)
-		reactloops.EmitStatus(loop, "已经了解整体结构，正在深入检查 / The overall structure is clear; starting the detailed review")
+		reactloops.EmitStatusI18n(loop, "已经了解整体结构，正在深入检查", "The overall structure is clear; starting the detailed review")
 		reactloops.EmitActionLog(loop, skillAuditPhase1NodeID,
 			fmt.Sprintf("完成: skill=%s, path=%s, recon_files=%d",
 				state.SkillName, state.SkillPath, len(state.GetReconNoteFiles())))
@@ -187,7 +187,7 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 		// ── Phase 2: 静态安全分析 ──
 		log.Infof("[SkillAudit] Starting Phase 2 (Static security analysis)")
 		reactloops.EmitActionLog(loop, skillAuditPhase2NodeID, "Phase 2：静态安全分析 / Phase 2: Static security analysis")
-		reactloops.EmitStatus(loop, "正在排查潜在风险 / Checking for potential risks")
+		reactloops.EmitStatusI18n(loop, "正在排查潜在风险", "Checking for potential risks")
 		r.AddToTimeline("[PHASE2_START]", "Phase 2：AI Skill 静态安全分析")
 
 		analysisLoop, err := buildPhase2StaticAnalysisLoop(r, state, auditDirPath)
@@ -201,14 +201,14 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 		}
 
 		log.Infof("[SkillAudit] Phase 2 complete. risk=%s", state.RiskLevel)
-		reactloops.EmitStatus(loop, "风险检查已完成，正在整理结论 / The risk review is complete; organizing the findings")
+		reactloops.EmitStatusI18n(loop, "风险检查已完成，正在整理结论", "The risk review is complete; organizing the findings")
 		reactloops.EmitActionLog(loop, skillAuditPhase2NodeID,
 			fmt.Sprintf("完成: risk=%s, audit_notes=%d", state.RiskLevel, len(state.GetAuditNoteFiles())))
 
 		// ── Phase 3: 报告生成 ──
 		log.Infof("[SkillAudit] Starting Phase 3 (Report generation)")
 		reactloops.EmitActionLog(loop, skillAuditReportNodeID, "Phase 3：安全报告生成 / Phase 3: Security report generation")
-		reactloops.EmitStatus(loop, "正在整理审计报告 / Preparing the audit report")
+		reactloops.EmitStatusI18n(loop, "正在整理审计报告", "Preparing the audit report")
 		r.AddToTimeline("[PHASE3_START]", "Phase 3：安全报告生成")
 
 		reportPath := filepath.Join(auditDirPath, "skill_security_report.md")
@@ -247,7 +247,7 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 		if reportPath == "" {
 			reportPath = filepath.Join(auditDirPath, "skill_security_report.md")
 		}
-		reactloops.EmitStatus(loop, "审计完成 / Audit complete")
+		reactloops.EmitStatusI18n(loop, "审计完成", "Audit complete")
 		reactloops.EmitActionLog(loop, skillAuditReportNodeID,
 			fmt.Sprintf("完成: report=%s, risk=%s", reportPath, state.RiskLevel))
 
@@ -327,15 +327,15 @@ func buildPhase2StaticAnalysisLoop(r aicommon.AIInvokeRuntime, state *SkillAudit
 			if state.HasFrontendFocus() {
 				focusPath := reactloops.ResolveFocusFilePath(state.GetFocusFilePath(), state.GetSelection())
 				if state.GetSelection() != nil && strings.TrimSpace(state.GetSelection().Content) != "" {
-					reactloops.EmitStatus(loop, "选中片段优先分析 / Selection-first static analysis")
+					reactloops.EmitStatusI18n(loop, "选中片段优先分析", "Selection-first static analysis")
 					r.AddToTimeline("[SKILL_AUDIT_FOCUS]",
 						fmt.Sprintf("Phase2 选中片段优先: %s", utils.ShrinkTextBlock(state.GetSelection().Content, 200)))
 				} else if focusPath != "" {
-					reactloops.EmitStatus(loop, "打开文件优先审计 / Open-file focused analysis")
+					reactloops.EmitStatusI18n(loop, "打开文件优先审计", "Open-file focused analysis")
 					r.AddToTimeline("[SKILL_AUDIT_FOCUS]", "Phase2 优先审计打开文件: "+focusPath)
 				}
 			} else {
-				reactloops.EmitStatus(loop, "静态安全分析就绪 / Static security analysis ready")
+				reactloops.EmitStatusI18n(loop, "静态安全分析就绪", "Static security analysis ready")
 			}
 			log.Infof("[SkillAudit/Phase2] Static analysis started. skill_path=%s focus=%v", state.SkillPath, state.HasFrontendFocus())
 			op.Continue()

--- a/common/ai/aid/aireact/reactloops/loop_ai_skill_audit/audit.go
+++ b/common/ai/aid/aireact/reactloops/loop_ai_skill_audit/audit.go
@@ -96,13 +96,13 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 			}
 		}
 
-		reactloops.EmitStatus(loop, "AI Skill 安全审计启动 / Starting AI Skill security audit")
+		reactloops.EmitStatus(loop, "正在准备检查这个技能 / Preparing to review this skill")
 		r.AddToTimeline("[SKILL_AUDIT_START]", "AI Skill 安全审计开始，用户输入: "+utils.ShrinkTextBlock(userInput, 300))
 
 		// ── Phase 1: 目录探索（委托给 dir_explore loop）──
 		log.Infof("[SkillAudit] Starting Phase 1 (Recon via dir_explore)")
 		reactloops.EmitActionLog(loop, skillAuditPhase1NodeID, "Phase 1：Skill 目录探索 / Phase 1: Skill directory exploration")
-		reactloops.EmitStatus(loop, "Phase 1：目录探索中 / Phase 1: Directory exploration...")
+		reactloops.EmitStatus(loop, "正在了解技能的结构和内容 / Understanding the skill structure and contents")
 		r.AddToTimeline("[PHASE1_START]", "Phase 1：Skill 目录探索")
 
 		auditDirPath := skillAuditDir(state)
@@ -176,7 +176,7 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 		}
 
 		log.Infof("[SkillAudit] Phase 1 complete. skill=%s path=%s", state.SkillName, state.SkillPath)
-		reactloops.EmitStatus(loop, "Phase 1 完成 / Phase 1 complete")
+		reactloops.EmitStatus(loop, "已经了解整体结构，正在深入检查 / The overall structure is clear; starting the detailed review")
 		reactloops.EmitActionLog(loop, skillAuditPhase1NodeID,
 			fmt.Sprintf("完成: skill=%s, path=%s, recon_files=%d",
 				state.SkillName, state.SkillPath, len(state.GetReconNoteFiles())))
@@ -187,7 +187,7 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 		// ── Phase 2: 静态安全分析 ──
 		log.Infof("[SkillAudit] Starting Phase 2 (Static security analysis)")
 		reactloops.EmitActionLog(loop, skillAuditPhase2NodeID, "Phase 2：静态安全分析 / Phase 2: Static security analysis")
-		reactloops.EmitStatus(loop, "Phase 2：静态分析中 / Phase 2: Static analysis...")
+		reactloops.EmitStatus(loop, "正在排查潜在风险 / Checking for potential risks")
 		r.AddToTimeline("[PHASE2_START]", "Phase 2：AI Skill 静态安全分析")
 
 		analysisLoop, err := buildPhase2StaticAnalysisLoop(r, state, auditDirPath)
@@ -201,14 +201,14 @@ func buildOrchestratorInitTask(r aicommon.AIInvokeRuntime, state *SkillAuditStat
 		}
 
 		log.Infof("[SkillAudit] Phase 2 complete. risk=%s", state.RiskLevel)
-		reactloops.EmitStatus(loop, "Phase 2 完成 / Phase 2 complete")
+		reactloops.EmitStatus(loop, "风险检查已完成，正在整理结论 / The risk review is complete; organizing the findings")
 		reactloops.EmitActionLog(loop, skillAuditPhase2NodeID,
 			fmt.Sprintf("完成: risk=%s, audit_notes=%d", state.RiskLevel, len(state.GetAuditNoteFiles())))
 
 		// ── Phase 3: 报告生成 ──
 		log.Infof("[SkillAudit] Starting Phase 3 (Report generation)")
 		reactloops.EmitActionLog(loop, skillAuditReportNodeID, "Phase 3：安全报告生成 / Phase 3: Security report generation")
-		reactloops.EmitStatus(loop, "Phase 3：报告生成中 / Phase 3: Generating report...")
+		reactloops.EmitStatus(loop, "正在整理审计报告 / Preparing the audit report")
 		r.AddToTimeline("[PHASE3_START]", "Phase 3：安全报告生成")
 
 		reportPath := filepath.Join(auditDirPath, "skill_security_report.md")

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/internal/emit/emit.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/internal/emit/emit.go
@@ -131,7 +131,11 @@ func Phase2ScanPlan(loop *reactloops.ReActLoop, categories []model.VulnCategory)
 		ids = append(ids, c.ID)
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, b.String())
-	reactloops.EmitStatus(loop, fmt.Sprintf("正在排查 %d 类潜在风险 / Reviewing %d potential risk categories", len(categories), len(categories)))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("正在排查 %d 类潜在风险", len(categories)),
+		fmt.Sprintf("Reviewing %d potential risk categories", len(categories)),
+	)
 	Structured(loop, "code_audit_scan_plan", map[string]any{
 		"category_count": len(categories),
 		"category_ids":   ids,
@@ -158,7 +162,11 @@ func Phase2AuditVulnerabilityTypes(loop *reactloops.ReActLoop, categories []mode
 		b.WriteString(fmt.Sprintf("  ... 另有 %d 类\n", len(categories)-12))
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, b.String())
-	reactloops.EmitStatus(loop, fmt.Sprintf("已确定 %d 类审计漏洞类型 / %d vulnerability types confirmed", len(categories), len(categories)))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("已确定 %d 类审计漏洞类型", len(categories)),
+		fmt.Sprintf("%d vulnerability types confirmed", len(categories)),
+	)
 	Structured(loop, "code_audit_vulnerability_types", map[string]any{
 		"type_count": len(categories),
 		"type_ids":   ids,
@@ -198,7 +206,11 @@ func Phase2CategoryOutcome(
 		label, index, total, category.Name, category.ID, findingCount, findingCount,
 	))
 	if incomplete {
-		reactloops.EmitStatus(loop, fmt.Sprintf("[警告] 类别 %s 可能未完成 / Category %s may be incomplete", category.ID, category.ID))
+		reactloops.EmitStatusI18n(
+			loop,
+			fmt.Sprintf("类别 %s 可能尚未完成", category.ID),
+			fmt.Sprintf("Category %s may be incomplete", category.ID),
+		)
 	} else {
 		reactloops.EmitProgress(loop, index, total, "扫描进度", "Scan progress")
 	}
@@ -224,7 +236,11 @@ func Phase2FindingAdded(loop *reactloops.ReActLoop, category model.VulnCategory,
 		"Finding [%s] %s %s — %s:%d (%s) / %s",
 		category.Name, f.Severity, f.ID, shortFile, f.Line, utils.ShrinkString(f.Title, 80), f.Title,
 	))
-	reactloops.EmitStatus(loop, fmt.Sprintf("已找到 %d 个需要进一步确认的位置 / Found %d areas that need further validation", totalFindings, totalFindings))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("已找到 %d 个需要进一步确认的位置", totalFindings),
+		fmt.Sprintf("Found %d areas that need further validation", totalFindings),
+	)
 }
 
 func Phase2CategoryScanComplete(loop *reactloops.ReActLoop, category model.VulnCategory, findingCount int, coveragePreview string) {
@@ -278,7 +294,11 @@ func Phase3VerifyStart(loop *reactloops.ReActLoop, total int) {
 	}
 	reactloops.EmitActionLog(loop, util.VerifyNodeID,
 		fmt.Sprintf("开始验证 %d 个 findings / Verifying %d findings", total, total))
-	reactloops.EmitStatus(loop, fmt.Sprintf("漏洞验证中 (%d) / Verifying findings (%d)", total, total))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("正在验证 %d 个潜在风险", total),
+		fmt.Sprintf("Verifying %d potential findings", total),
+	)
 }
 
 // Phase3VerifyScope emits the verification scope grouped by vulnerability type for the frontend.
@@ -302,7 +322,11 @@ func Phase3VerifyScope(loop *reactloops.ReActLoop, findings []*model.Finding, by
 		b.WriteString(fmt.Sprintf("  • %s: %s\n", cat, strings.Join(byCategory[cat], ", ")))
 	}
 	reactloops.EmitActionLog(loop, util.VerifyNodeID, b.String())
-	reactloops.EmitStatus(loop, fmt.Sprintf("已确定 %d 个重点位置，正在逐一确认 / Identified %d priority areas for validation", len(findings), len(findings)))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("已确定 %d 个重点位置，正在逐一确认", len(findings)),
+		fmt.Sprintf("Identified %d priority areas for validation", len(findings)),
+	)
 	Structured(loop, "code_audit_verify_scope", map[string]any{
 		"finding_count": len(findings),
 		"type_count":    len(byCategory),
@@ -362,7 +386,7 @@ func Phase4ReportComplete(loop *reactloops.ReActLoop, reportPath string, stats m
 		"报告已生成 / Report ready: %s\n高危 %d | 中危 %d | 低危 %d | 待复核 %d",
 		reportPath, stats.HighCount, stats.MediumCount, stats.LowCount, stats.UncertainCount,
 	))
-	reactloops.EmitStatus(loop, "报告生成完成 / Report generation complete")
+	reactloops.EmitStatusI18n(loop, "报告生成完成", "Report generation complete")
 	Structured(loop, "code_audit_report_done", map[string]any{
 		"report_path": reportPath,
 		"high":        stats.HighCount,

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/internal/emit/emit.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/internal/emit/emit.go
@@ -131,7 +131,7 @@ func Phase2ScanPlan(loop *reactloops.ReActLoop, categories []model.VulnCategory)
 		ids = append(ids, c.ID)
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, b.String())
-	reactloops.EmitStatus(loop, fmt.Sprintf("Phase 2：%d 个类别待扫描 / Phase 2: %d categories", len(categories), len(categories)))
+	reactloops.EmitStatus(loop, fmt.Sprintf("正在排查 %d 类潜在风险 / Reviewing %d potential risk categories", len(categories), len(categories)))
 	Structured(loop, "code_audit_scan_plan", map[string]any{
 		"category_count": len(categories),
 		"category_ids":   ids,
@@ -224,7 +224,7 @@ func Phase2FindingAdded(loop *reactloops.ReActLoop, category model.VulnCategory,
 		"Finding [%s] %s %s — %s:%d (%s) / %s",
 		category.Name, f.Severity, f.ID, shortFile, f.Line, utils.ShrinkString(f.Title, 80), f.Title,
 	))
-	reactloops.EmitStatus(loop, fmt.Sprintf("已发现 %d 个 finding / %d findings so far", totalFindings, totalFindings))
+	reactloops.EmitStatus(loop, fmt.Sprintf("已找到 %d 个需要进一步确认的位置 / Found %d areas that need further validation", totalFindings, totalFindings))
 }
 
 func Phase2CategoryScanComplete(loop *reactloops.ReActLoop, category model.VulnCategory, findingCount int, coveragePreview string) {
@@ -302,7 +302,7 @@ func Phase3VerifyScope(loop *reactloops.ReActLoop, findings []*model.Finding, by
 		b.WriteString(fmt.Sprintf("  • %s: %s\n", cat, strings.Join(byCategory[cat], ", ")))
 	}
 	reactloops.EmitActionLog(loop, util.VerifyNodeID, b.String())
-	reactloops.EmitStatus(loop, fmt.Sprintf("已确定验证范围 (%d findings) / Verification scope confirmed", len(findings)))
+	reactloops.EmitStatus(loop, fmt.Sprintf("已确定 %d 个重点位置，正在逐一确认 / Identified %d priority areas for validation", len(findings), len(findings)))
 	Structured(loop, "code_audit_verify_scope", map[string]any{
 		"finding_count": len(findings),
 		"type_count":    len(byCategory),

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/orchestrator/pipeline.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/orchestrator/pipeline.go
@@ -28,7 +28,7 @@ func BuildInitTask(r aicommon.AIInvokeRuntime, state *model.AuditState) func(loo
 		userInput := task.GetUserInput()
 
 		if state.GetPhase() == model.AuditPhaseDone {
-			reactloops.EmitStatus(loop, "审计追问模式 / Audit follow-up mode")
+			reactloops.EmitStatusI18n(loop, "审计追问模式", "Audit follow-up mode")
 			r.AddToTimeline("[AUDIT_FOLLOWUP]", "审计已完成，进入追问模式。用户输入: "+utils.ShrinkTextBlock(userInput, 300))
 			followLoop, err := followup.BuildLoop(r, state)
 			if err != nil {
@@ -43,7 +43,7 @@ func BuildInitTask(r aicommon.AIInvokeRuntime, state *model.AuditState) func(loo
 			return
 		}
 
-		reactloops.EmitStatus(loop, "代码安全审计启动 / Starting code security audit")
+		reactloops.EmitStatusI18n(loop, "代码安全审计启动", "Starting code security audit")
 		r.AddToTimeline("[AUDIT_START]", "代码安全审计开始，用户输入: "+utils.ShrinkTextBlock(userInput, 300))
 
 		ws := reactloops.InitWorkspaceAttachedContext(r, loop, task, AttachedResourceKeyCodeAuditTargetPath)
@@ -84,7 +84,7 @@ func BuildInitTask(r aicommon.AIInvokeRuntime, state *model.AuditState) func(loo
 			reportPath = filepath.Join(auditDirPath, "security_audit_report.md")
 		}
 		finalReport := state.GetFinalReport()
-		reactloops.EmitStatus(loop, "审计完成 / Audit complete")
+		reactloops.EmitStatusI18n(loop, "审计完成", "Audit complete")
 		emit.PipelineDone(loop, reportPath, len(finalReport), state.GetStats())
 		r.AddToTimeline("[AUDIT_DONE]", "代码安全审计全部完成。报告预览:\n"+utils.ShrinkTextBlock(finalReport, 200))
 		log.Infof("[CodeAudit] All phases complete. Report length: %d bytes", len(finalReport))
@@ -133,7 +133,7 @@ func emitPhaseMarker(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, k
 
 func runPhase1(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string, ws *reactloops.WorkspaceAttachedContext, op *reactloops.InitTaskOperator) {
 	log.Infof("[CodeAudit] Starting Phase 1 (Recon via dir_explore)")
-	reactloops.EmitStatus(loop, "正在了解项目结构和关键入口 / Understanding the project structure and key entry points")
+	reactloops.EmitStatusI18n(loop, "正在了解项目结构和关键入口", "Understanding the project structure and key entry points")
 	r.AddToTimeline("[PHASE1_START]", "开始 Phase 1：项目探索（使用 dir_explore loop）")
 	emitPhaseMarker(loop, task, "phase", "dir_explore", "Phase 1：项目探索", "")
 
@@ -201,13 +201,13 @@ func runPhase1(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aico
 		log.Infof("[CodeAudit] Phase 1 complete. tech=%s recon_file=%s", state.TechStack, state.GetReconFilePath())
 		emit.ReconComplete(loop, state.ProjectPath, state.TechStack, state.GetReconFilePath(), false)
 	}
-	reactloops.EmitStatus(loop, "已经了解项目结构，正在深入排查 / The project structure is clear; starting the detailed review")
+	reactloops.EmitStatusI18n(loop, "已经了解项目结构，正在深入排查", "The project structure is clear; starting the detailed review")
 }
 
 func runPhase2(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string) {
 	log.Infof("[CodeAudit] Starting Phase 2")
 	reactloops.EmitActionLog(loop, util.ScanNodeID, "Phase 2：代码审计扫描 / Phase 2: Code audit scan")
-	reactloops.EmitStatus(loop, "正在排查潜在安全风险 / Checking for potential security risks")
+	reactloops.EmitStatusI18n(loop, "正在排查潜在安全风险", "Checking for potential security risks")
 	r.AddToTimeline("[PHASE2_START]", "开始 Phase 2：代码审计扫描")
 	emitPhaseMarker(loop, task, "phase", "code_audit_phase2_orchestrator", "Phase 2：代码审计扫描", task.GetId())
 
@@ -224,7 +224,7 @@ func runPhase2(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aico
 	if findingsFile != "" {
 		r.AddToTimeline("[PHASE2_PERSISTED]", fmt.Sprintf("Phase 2 扫描完成，共 %d 个 finding 已写入: %s", len(state.GetFindings()), findingsFile))
 	}
-	reactloops.EmitStatus(loop, "已经找到需要关注的位置，正在逐一确认 / Potential areas of concern were found; validating each one")
+	reactloops.EmitStatusI18n(loop, "已经找到需要关注的位置，正在逐一确认", "Potential areas of concern were found; validating each one")
 }
 
 func runPhase3(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string) {
@@ -258,14 +258,14 @@ func runPhase3(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aico
 			r.AddToTimeline("[PHASE3_PERSISTED]", fmt.Sprintf("Phase 3 验证完成，共 %d 个结果: %s", len(state.GetVerifiedVulns()), verifiedFile))
 		}
 	}
-	reactloops.EmitStatus(loop, "风险确认已完成，正在汇总结论 / Validation is complete; consolidating the findings")
+	reactloops.EmitStatusI18n(loop, "风险确认已完成，正在汇总结论", "Validation is complete; consolidating the findings")
 	emit.VerifyComplete(loop, "", state.GetStats())
 }
 
 func runPhase4(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string) {
 	log.Infof("[CodeAudit] Starting Phase 4 (Report)")
 	reactloops.EmitActionLog(loop, util.ReportNodeID, "Phase 4：审计报告 / Phase 4: Audit report")
-	reactloops.EmitStatus(loop, "正在整理安全审计报告 / Preparing the security audit report")
+	reactloops.EmitStatusI18n(loop, "正在整理安全审计报告", "Preparing the security audit report")
 	r.AddToTimeline("[PHASE4_START]", "开始 Phase 4：报告生成")
 	emitPhaseMarker(loop, task, "phase", "code_audit_phase4_report", "Phase 4：审计报告", task.GetId())
 	reportLoop, err := phase4.BuildReportLoop(r, state)

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/orchestrator/pipeline.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/orchestrator/pipeline.go
@@ -133,7 +133,7 @@ func emitPhaseMarker(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, k
 
 func runPhase1(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string, ws *reactloops.WorkspaceAttachedContext, op *reactloops.InitTaskOperator) {
 	log.Infof("[CodeAudit] Starting Phase 1 (Recon via dir_explore)")
-	reactloops.EmitStatus(loop, "Phase 1：项目探索中 / Phase 1: Project exploration...")
+	reactloops.EmitStatus(loop, "正在了解项目结构和关键入口 / Understanding the project structure and key entry points")
 	r.AddToTimeline("[PHASE1_START]", "开始 Phase 1：项目探索（使用 dir_explore loop）")
 	emitPhaseMarker(loop, task, "phase", "dir_explore", "Phase 1：项目探索", "")
 
@@ -201,13 +201,13 @@ func runPhase1(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aico
 		log.Infof("[CodeAudit] Phase 1 complete. tech=%s recon_file=%s", state.TechStack, state.GetReconFilePath())
 		emit.ReconComplete(loop, state.ProjectPath, state.TechStack, state.GetReconFilePath(), false)
 	}
-	reactloops.EmitStatus(loop, "Phase 1 完成 / Phase 1 complete")
+	reactloops.EmitStatus(loop, "已经了解项目结构，正在深入排查 / The project structure is clear; starting the detailed review")
 }
 
 func runPhase2(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string) {
 	log.Infof("[CodeAudit] Starting Phase 2")
 	reactloops.EmitActionLog(loop, util.ScanNodeID, "Phase 2：代码审计扫描 / Phase 2: Code audit scan")
-	reactloops.EmitStatus(loop, "Phase 2：漏洞扫描中 / Phase 2: Vulnerability scanning...")
+	reactloops.EmitStatus(loop, "正在排查潜在安全风险 / Checking for potential security risks")
 	r.AddToTimeline("[PHASE2_START]", "开始 Phase 2：代码审计扫描")
 	emitPhaseMarker(loop, task, "phase", "code_audit_phase2_orchestrator", "Phase 2：代码审计扫描", task.GetId())
 
@@ -224,7 +224,7 @@ func runPhase2(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aico
 	if findingsFile != "" {
 		r.AddToTimeline("[PHASE2_PERSISTED]", fmt.Sprintf("Phase 2 扫描完成，共 %d 个 finding 已写入: %s", len(state.GetFindings()), findingsFile))
 	}
-	reactloops.EmitStatus(loop, "Phase 2 完成 / Phase 2 complete")
+	reactloops.EmitStatus(loop, "已经找到需要关注的位置，正在逐一确认 / Potential areas of concern were found; validating each one")
 }
 
 func runPhase3(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string) {
@@ -258,14 +258,14 @@ func runPhase3(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aico
 			r.AddToTimeline("[PHASE3_PERSISTED]", fmt.Sprintf("Phase 3 验证完成，共 %d 个结果: %s", len(state.GetVerifiedVulns()), verifiedFile))
 		}
 	}
-	reactloops.EmitStatus(loop, "Phase 3 完成 / Phase 3 complete")
+	reactloops.EmitStatus(loop, "风险确认已完成，正在汇总结论 / Validation is complete; consolidating the findings")
 	emit.VerifyComplete(loop, "", state.GetStats())
 }
 
 func runPhase4(loop *reactloops.ReActLoop, r aicommon.AIInvokeRuntime, task aicommon.AIStatefulTask, state *model.AuditState, auditDirPath string) {
 	log.Infof("[CodeAudit] Starting Phase 4 (Report)")
 	reactloops.EmitActionLog(loop, util.ReportNodeID, "Phase 4：审计报告 / Phase 4: Audit report")
-	reactloops.EmitStatus(loop, "Phase 4：报告生成中 / Phase 4: Generating report...")
+	reactloops.EmitStatus(loop, "正在整理安全审计报告 / Preparing the security audit report")
 	r.AddToTimeline("[PHASE4_START]", "开始 Phase 4：报告生成")
 	emitPhaseMarker(loop, task, "phase", "code_audit_phase4_report", "Phase 4：审计报告", task.GetId())
 	reportLoop, err := phase4.BuildReportLoop(r, state)

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/discovery.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/discovery.go
@@ -226,7 +226,11 @@ func emitPhase2DiscoveryGateBlocked(loop *reactloops.ReActLoop, category model.V
 		formatPathListForFeedback(unresolved, 12),
 	)
 	reactloops.EmitActionLog(loop, util.ScanNodeID, lines)
-	reactloops.EmitStatus(loop, fmt.Sprintf("还有 %d 个位置需要进一步确认 / %d locations still need further review", len(unresolved), len(unresolved)))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("还有 %d 个位置需要进一步确认", len(unresolved)),
+		fmt.Sprintf("%d locations still need further review", len(unresolved)),
+	)
 	emitPhase2Structured(loop, "code_audit_scan_discovery_gate", map[string]any{
 		"category_id":   category.ID,
 		"category_name": category.Name,

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/discovery.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/discovery.go
@@ -226,7 +226,7 @@ func emitPhase2DiscoveryGateBlocked(loop *reactloops.ReActLoop, category model.V
 		formatPathListForFeedback(unresolved, 12),
 	)
 	reactloops.EmitActionLog(loop, util.ScanNodeID, lines)
-	reactloops.EmitStatus(loop, fmt.Sprintf("阶段A：待纳入 %d 个候选 / Phase A: %d candidates pending", len(unresolved), len(unresolved)))
+	reactloops.EmitStatus(loop, fmt.Sprintf("还有 %d 个位置需要进一步确认 / %d locations still need further review", len(unresolved), len(unresolved)))
 	emitPhase2Structured(loop, "code_audit_scan_discovery_gate", map[string]any{
 		"category_id":   category.ID,
 		"category_name": category.Name,

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/emit_hooks.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/emit_hooks.go
@@ -2,12 +2,13 @@ package phase2
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops/loop_code_security_audit/internal/emit"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops/loop_code_security_audit/internal/model"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops/loop_code_security_audit/internal/util"
-	"strings"
-
-	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/utils"
 )
 
@@ -43,9 +44,9 @@ func emitPhase2LockTargetFiles(
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, lines)
 	if done {
-		reactloops.EmitStatus(loop, fmt.Sprintf("阶段B 逐文件审计：%s (%d 个文件) / Phase B audit: %s", category.Name, total, category.ID))
+		reactloops.EmitStatus(loop, fmt.Sprintf("正在逐一检查「%s」相关的 %d 个文件 / Reviewing %d files related to %s", category.Name, total, total, category.Name))
 	} else {
-		reactloops.EmitStatus(loop, fmt.Sprintf("阶段A 已锁定 %d 个候选 / Phase A: %d targets locked", total, total))
+		reactloops.EmitStatus(loop, fmt.Sprintf("已找到 %d 个需要重点关注的位置 / Found %d priority areas", total, total))
 	}
 	emitPhase2Structured(loop, "code_audit_scan_lock_targets", map[string]any{
 		"category_id":   category.ID,
@@ -77,7 +78,7 @@ func emitPhase2FastContextResult(
 		lines += "\n摘要: " + utils.ShrinkString(strings.TrimSpace(summaryMarkdown), 400)
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, lines)
-	reactloops.EmitStatus(loop, fmt.Sprintf("阶段A：%d 个 fast_context 候选 / Phase A: %d candidates", len(paths), len(paths)))
+	reactloops.EmitStatus(loop, fmt.Sprintf("正在筛选 %d 个可能相关的位置 / Reviewing %d potentially relevant locations", len(paths), len(paths)))
 	emitPhase2Structured(loop, "code_audit_scan_fast_context", map[string]any{
 		"category_id":     category.ID,
 		"category_name":   category.Name,
@@ -114,7 +115,13 @@ func emitPhase2MarkFileDone(
 		lines += "\n全部目标文件已审计，请 complete_scan / All files done — call complete_scan"
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, lines)
-	reactloops.EmitStatus(loop, fmt.Sprintf("审计进度 %d/%d / Progress %d/%d", done, total, done, total))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("正在检查「%s」相关文件（%d/%d）", category.Name, done, total),
+		fmt.Sprintf("Reviewing files related to %s (%d/%d)", category.Name, done, total),
+		aicommon.WithStatusCode("audit.file.reviewing"),
+		aicommon.WithStatusProgress(int64(done), int64(total), "file"),
+	)
 	emitPhase2Structured(loop, "code_audit_scan_mark_file_done", map[string]any{
 		"category_id":   category.ID,
 		"category_name": category.Name,

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/emit_hooks.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/emit_hooks.go
@@ -44,9 +44,17 @@ func emitPhase2LockTargetFiles(
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, lines)
 	if done {
-		reactloops.EmitStatus(loop, fmt.Sprintf("正在逐一检查「%s」相关的 %d 个文件 / Reviewing %d files related to %s", category.Name, total, total, category.Name))
+		reactloops.EmitStatusI18n(
+			loop,
+			fmt.Sprintf("正在逐一检查「%s」相关的 %d 个文件", category.Name, total),
+			fmt.Sprintf("Reviewing %d files related to %s", total, category.Name),
+		)
 	} else {
-		reactloops.EmitStatus(loop, fmt.Sprintf("已找到 %d 个需要重点关注的位置 / Found %d priority areas", total, total))
+		reactloops.EmitStatusI18n(
+			loop,
+			fmt.Sprintf("已找到 %d 个需要重点关注的位置", total),
+			fmt.Sprintf("Found %d priority areas", total),
+		)
 	}
 	emitPhase2Structured(loop, "code_audit_scan_lock_targets", map[string]any{
 		"category_id":   category.ID,
@@ -78,7 +86,11 @@ func emitPhase2FastContextResult(
 		lines += "\n摘要: " + utils.ShrinkString(strings.TrimSpace(summaryMarkdown), 400)
 	}
 	reactloops.EmitActionLog(loop, util.ScanNodeID, lines)
-	reactloops.EmitStatus(loop, fmt.Sprintf("正在筛选 %d 个可能相关的位置 / Reviewing %d potentially relevant locations", len(paths), len(paths)))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("正在筛选 %d 个可能相关的位置", len(paths)),
+		fmt.Sprintf("Reviewing %d potentially relevant locations", len(paths)),
+	)
 	emitPhase2Structured(loop, "code_audit_scan_fast_context", map[string]any{
 		"category_id":     category.ID,
 		"category_name":   category.Name,

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/fast_context.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/fast_context.go
@@ -83,7 +83,11 @@ func buildFastContextAction(
 
 			log.Infof("[CodeAudit/Phase2/%s] fast_context registered %d new discovery candidates (total %d)",
 				category.ID, added, scan.DiscoveryCandidateCount())
-			reactloops.EmitStatus(loop, fmt.Sprintf("正在筛选 %d 个重点位置 / Reviewing %d priority locations", len(paths), len(paths)))
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("正在筛选 %d 个重点位置", len(paths)),
+				fmt.Sprintf("Reviewing %d priority locations", len(paths)),
+			)
 			emitPhase2FastContextResult(loop, category, paths, result.Markdown)
 
 			if result.Markdown != "" {

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/fast_context.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/fast_context.go
@@ -83,7 +83,7 @@ func buildFastContextAction(
 
 			log.Infof("[CodeAudit/Phase2/%s] fast_context registered %d new discovery candidates (total %d)",
 				category.ID, added, scan.DiscoveryCandidateCount())
-			reactloops.EmitStatus(loop, fmt.Sprintf("阶段A：处理 %d 个 fast_context 候选 / Phase A: %d candidates to review", len(paths), len(paths)))
+			reactloops.EmitStatus(loop, fmt.Sprintf("正在筛选 %d 个重点位置 / Reviewing %d priority locations", len(paths), len(paths)))
 			emitPhase2FastContextResult(loop, category, paths, result.Markdown)
 
 			if result.Markdown != "" {

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/read_file_guard.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/read_file_guard.go
@@ -114,7 +114,11 @@ func emitPhase2CategoryBanner(loop *reactloops.ReActLoop, category model.VulnCat
 	}
 	bilingual := fmt.Sprintf("%s / Category %s (%s)", title, category.Name, category.ID)
 	reactloops.EmitActionLog(loop, util.ScanNodeID, bilingual)
-	reactloops.EmitStatus(loop, fmt.Sprintf("审计类别：%s (%s) / Category: %s", category.Name, category.ID, category.ID))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("审计类别：%s（%s）", category.Name, category.ID),
+		fmt.Sprintf("Category: %s", category.ID),
+	)
 
 	emitter := loop.GetEmitter()
 	if emitter == nil {

--- a/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/scan.go
+++ b/common/ai/aid/aireact/reactloops/loop_code_security_audit/phase2/scan.go
@@ -563,7 +563,11 @@ func buildSingleCategoryScanLoop(r aicommon.AIInvokeRuntime, state *model.AuditS
 					emitPhase2CategoryBanner(loop, category, categoryIndex, categoryTotal, "阶段A：关键词搜索 / Phase A: search")
 				}
 			} else {
-				reactloops.EmitStatus(loop, fmt.Sprintf("扫描类别 %s / Scanning category %s", category.Name, category.ID))
+				reactloops.EmitStatusI18n(
+					loop,
+					fmt.Sprintf("正在扫描类别「%s」", category.Name),
+					fmt.Sprintf("Scanning category %s", category.ID),
+				)
 			}
 			log.Infof("[CodeAudit/Phase2] Category '%s' scan started (phase=%s, targets=%d)", category.ID, phase, scan.TargetFileCount())
 			op.Continue()

--- a/common/ai/aid/aireact/reactloops/loop_default/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/init.go
@@ -18,7 +18,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		// Original logic: process attached data (knowledge bases, files, etc.)
 		mustProcessMentionedInfo := config.GetConfigBool("MustProcessAttachedData")
 		if mustProcessMentionedInfo && hasAttachedKnowledgeBaseResource(attachedResources) {
-			loop.LoadingStatus("开始处理用户提及的数据（@ Mentionup） / Start to process user-mentioned data (@ Mentionup)")
+			loop.UserStatus("开始处理用户提及的数据（@ Mentionup）", "Start to process user-mentioned data (@ Mentionup)")
 			err := ProcessAttachedData(r, loop, task, operator, attachedResources)
 			if err != nil {
 				log.Errorf("failed to process attached data: %v", err)
@@ -43,7 +43,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		if config.GetConfigBool("DisableIntentRecognition") {
 			log.Infof("intent recognition disabled via config, skipping")
 		} else {
-			loop.LoadingStatus("开始意图识别 / Start intent recognition")
+			loop.UserStatus("开始意图识别", "Start intent recognition")
 			userInput := task.GetUserInput()
 			capabilityNameMatches := reactloops.MatchCapabilitiesByTextWithConfig(r.GetConfig(), userInput)
 
@@ -53,7 +53,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 			needsDeepIntent := false
 
 			if scale.IsMicroOrSmall() {
-				loop.LoadingStatus("快速意图识别 / Fast intent recognition")
+				loop.UserStatus("快速意图识别", "Fast intent recognition")
 				result := FastIntentMatch(r, userInput)
 				if result != nil {
 					applyCapabilityMatchesToFastMatchResult(result, capabilityNameMatches)
@@ -70,7 +70,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 			}
 
 			if needsDeepIntent {
-				loop.LoadingStatus("深度意图识别 / Deep intent recognition")
+				loop.UserStatus("深度意图识别", "Deep intent recognition")
 				log.Infof("invoking deep intent recognition (scale=%s)", scale.String())
 				deepResult := executeDeepIntentRecognition(r, loop, task)
 				if deepResult != nil {

--- a/common/ai/aid/aireact/reactloops/loop_default/pe_task_init.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/pe_task_init.go
@@ -20,7 +20,7 @@ func buildPETaskInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReAct
 			return
 		}
 
-		loop.LoadingStatus("深度意图识别 / Deep intent recognition")
+		loop.UserStatus("深度意图识别", "Deep intent recognition")
 		log.Infof("pe_task: invoking deep intent recognition directly")
 
 		capabilityNameMatches := reactloops.MatchCapabilitiesByTextWithConfig(r.GetConfig(), task.GetUserInput())

--- a/common/ai/aid/aireact/reactloops/loop_fast_context/action_grep_files_batch.go
+++ b/common/ai/aid/aireact/reactloops/loop_fast_context/action_grep_files_batch.go
@@ -70,7 +70,12 @@ func grepFilesBatchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption
 				ctx = task.GetContext()
 			}
 
-			loop.LoadingStatus(fmt.Sprintf("grep_files_batch: %d parallel searches", len(searches)))
+			loop.UserStatus(
+				fmt.Sprintf("正在并行查找相关实现（%d 项）", len(searches)),
+				fmt.Sprintf("Searching for relevant implementation across %d queries", len(searches)),
+				aicommon.WithStatusCode("context.searching"),
+				aicommon.WithStatusProgress(0, int64(len(searches)), "search"),
+			)
 			batchResult := runGrepBatch(loop, invoker, ctx, searches)
 
 			count := utils.InterfaceToInt(loop.Get(loopVarSearchRounds))

--- a/common/ai/aid/aireact/reactloops/loop_fast_context/action_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_fast_context/action_search.go
@@ -35,7 +35,12 @@ func makeIndexSearchAction(
 					params = forceParams(params)
 				}
 
-				loop.LoadingStatus(fmt.Sprintf("index search: %s", targetToolName))
+				loop.UserStatus(
+					"正在定位相关实现",
+					"Locating the relevant implementation",
+					aicommon.WithStatusCode("context.locating"),
+					aicommon.WithStatusDetail("正在从项目中筛选最相关的位置", "Finding the most relevant locations in the project"),
+				)
 				result, _, err := invoker.ExecuteToolRequiredAndCallWithoutRequired(ctx, targetToolName, params)
 				if err != nil {
 					log.Warnf("[FastContext] %s failed: %v", targetToolName, err)

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_dispatch_fuzz.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_dispatch_fuzz.go
@@ -74,7 +74,7 @@ var dispatchFuzzTestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLo
 			reactloops.EmitActionLog(loop, "fuzz-test", line1)
 
 			log.Infof("[dispatch_fuzz_test] loading target flow: %s, vulnerability type: %s", locatorDesc, vulnType)
-			reactloops.EmitStatus(loop, "准备 Fuzz 测试 / Preparing Fuzz Test...")
+			reactloops.EmitStatusI18n(loop, "准备 Fuzz 测试", "Preparing Fuzz Test...")
 
 			// Step 1: Load flow
 			var flow *schema.HTTPFlow
@@ -116,7 +116,7 @@ var dispatchFuzzTestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLo
 				sanitizeIDSegment(vulnType))
 
 			// Step 4: Create fuzztest sub-loop
-			reactloops.EmitStatus(loop, "启动 Fuzz 测试 / Launching Fuzz Test...")
+			reactloops.EmitStatusI18n(loop, "启动 Fuzz 测试", "Launching Fuzz Test...")
 
 			fuzzLoop, err := reactloops.CreateLoopByName(
 				loop_http_fuzztest.LoopHTTPFuzztestName,
@@ -135,19 +135,19 @@ var dispatchFuzzTestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLo
 			invoker.AddToTimeline("dispatch_fuzz_test",
 				fmt.Sprintf("启动 fuzztest 子循环 [%s]，目标: %s，漏洞类型: %s", subTaskId, locatorDesc, vulnType))
 
-			reactloops.EmitStatus(loop, "Fuzz 测试执行中 / Fuzz Test Running...")
+			reactloops.EmitStatusI18n(loop, "Fuzz 测试执行中", "Fuzz Test Running...")
 
 			execErr := fuzzLoop.ExecuteWithExistedTask(subTask)
 
 			// Step 6: Collect results and write to HTTP flow evidence
-			reactloops.EmitStatus(loop, "收集测试结果 / Collecting Results...")
+			reactloops.EmitStatusI18n(loop, "收集测试结果", "Collecting Results...")
 
 			fuzzResult := collectFuzzSubLoopResult(fuzzLoop, locatorDesc, vulnType, flow)
 			if _, changed := appendHTTPFlowEvidence(loop, fuzzResult); changed {
 				log.Infof("[dispatch_fuzz_test] fuzztest results merged to HTTP_FLOW_EVIDENCE")
 			}
 
-			reactloops.EmitStatus(loop, "Fuzz 测试完成 / Fuzz Test Complete")
+			reactloops.EmitStatusI18n(loop, "Fuzz 测试完成", "Fuzz Test Complete")
 
 			// 提取关键发现
 			resultBrief := "未发现明显漏洞"

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_get_flow_detail.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_get_flow_detail.go
@@ -44,7 +44,7 @@ var getHTTPFlowDetailAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActL
 			line1 := fmt.Sprintf("加载 %s", locatorDesc)
 			reactloops.EmitActionLog(loop, "http-flow-detail", line1)
 
-			reactloops.EmitStatus(loop, "加载流详情中 / Loading Flow Detail...")
+			reactloops.EmitStatusI18n(loop, "加载流详情中", "Loading Flow Detail...")
 
 			var flow *schema.HTTPFlow
 			var err error
@@ -61,7 +61,7 @@ var getHTTPFlowDetailAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActL
 			}
 
 			if err != nil || flow == nil {
-				reactloops.EmitStatus(loop, "加载失败：未找到流 / Load Failed: Flow Not Found")
+				reactloops.EmitStatusI18n(loop, "加载失败：未找到流", "Load Failed: Flow Not Found")
 				invoker.AddToTimeline("get_http_flow_detail", fmt.Sprintf("Failed to load HTTP flow: %v", err))
 				log.Errorf("[get_http_flow_detail] failed to load (%s): %v", locatorDesc, err)
 				recordAction(loop, "get_http_flow_detail", locatorDesc, "failed: flow not found", "")
@@ -69,7 +69,7 @@ var getHTTPFlowDetailAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActL
 				return
 			}
 
-			reactloops.EmitStatus(loop, "加载完成 / Load Complete")
+			reactloops.EmitStatusI18n(loop, "加载完成", "Load Complete")
 
 			req := flowRequest(flow)
 			rsp := flowResponse(flow)

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_match_flows.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_match_flows.go
@@ -119,7 +119,7 @@ For simple single-condition matching, use match_flows_simple instead.`,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, operator *reactloops.LoopActionHandlerOperator) {
 			// === 1. 获取流量来源 (使用 fallback 逻辑) ===
 			nodeId := "http-flow-match"
-			reactloops.EmitStatus(loop, "准备匹配流量 / Preparing to Match Flows...")
+			reactloops.EmitStatusI18n(loop, "准备匹配流量", "Preparing to Match Flows...")
 
 			db := consts.GetGormProjectDatabase()
 			if db == nil {
@@ -193,7 +193,7 @@ For simple single-condition matching, use match_flows_simple instead.`,
 			reactloops.EmitActionLog(loop, nodeId, line1)
 
 			// === 4. 执行匹配（流式处理）===
-			reactloops.EmitStatus(loop, "匹配流量中 / Matching Flows...")
+			reactloops.EmitStatusI18n(loop, "匹配流量中", "Matching Flows...")
 
 			var matchedFlows []*schema.HTTPFlow
 			var totalCount int
@@ -331,7 +331,11 @@ For simple single-condition matching, use match_flows_simple instead.`,
 			saveMatchResult(loop, matchResult)
 
 			// === 6. 发送完成状态 ===
-			reactloops.EmitStatus(loop, fmt.Sprintf("匹配完成，找到 %d 条 / Match Complete, Found %d Flows", len(matchedFlows), len(matchedFlows)))
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("匹配完成，找到 %d 条流量", len(matchedFlows)),
+				fmt.Sprintf("Match complete; found %d flows", len(matchedFlows)),
+			)
 
 			// === 7. 构建并发送第2行累积流（结果摘要）===
 			line2 := fmt.Sprintf("完成: 匹配 %d/%d 条流量",

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_match_flows_simple.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_match_flows_simple.go
@@ -127,7 +127,7 @@ Examples:
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, operator *reactloops.LoopActionHandlerOperator) {
 			// === 1. 获取流量来源 (使用 fallback 逻辑) ===
 			nodeId := "http-flow-match"
-			reactloops.EmitStatus(loop, "准备匹配流量 / Preparing to Match Flows...")
+			reactloops.EmitStatusI18n(loop, "准备匹配流量", "Preparing to Match Flows...")
 
 			db := consts.GetGormProjectDatabase()
 			if db == nil {
@@ -234,7 +234,7 @@ Examples:
 			reactloops.EmitActionLog(loop, nodeId, line1)
 
 			// === 3. 执行匹配（流式处理）===
-			reactloops.EmitStatus(loop, "匹配流量中 / Matching Flows...")
+			reactloops.EmitStatusI18n(loop, "匹配流量中", "Matching Flows...")
 
 			var matchedFlows []*schema.HTTPFlow
 			var totalCount int
@@ -332,7 +332,11 @@ Examples:
 			saveMatchResult(loop, matchResult)
 
 			// === 6. 发送完成状态 ===
-			reactloops.EmitStatus(loop, fmt.Sprintf("匹配完成，找到 %d 条 / Match Complete, Found %d Flows", len(matchedFlows), len(matchedFlows)))
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("匹配完成，找到 %d 条流量", len(matchedFlows)),
+				fmt.Sprintf("Match complete; found %d flows", len(matchedFlows)),
+			)
 
 			// === 6.5. 构建并发送第2行累积流（结果摘要）===
 			line2 := fmt.Sprintf("完成: 匹配 %d/%d 条流量",

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_query_flows.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_query_flows.go
@@ -48,7 +48,7 @@ var queryHTTPFlowsAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoop
 			reactloops.EmitActionLog(loop, "http-flow-query", line1)
 
 			// === 2. 发送瞬时状态 ===
-			reactloops.EmitStatus(loop, "查询流量中 / Querying Flows...")
+			reactloops.EmitStatusI18n(loop, "查询流量中", "Querying Flows...")
 
 			// === 3. 执行查询 ===
 			db := consts.GetGormProjectDatabase()
@@ -131,7 +131,11 @@ var queryHTTPFlowsAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoop
 			saveQueryResult(loop, queryResult)
 
 			// === 8. 发送完成状态 ===
-			reactloops.EmitStatus(loop, fmt.Sprintf("查询完成，找到 %d 条流量 / Query Complete, Found %d Flows", total, total))
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("查询完成，找到 %d 条流量", total),
+				fmt.Sprintf("Query complete; found %d flows", total),
+			)
 
 			// === 9. 构建第二行累积流（结果摘要）===
 			line2 := fmt.Sprintf("完成: 找到 %d 条流量",

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/finalize.go
@@ -163,7 +163,7 @@ User's original query: {{ .UserQuery }}
 
 	log.Infof("http_flow_analyze finalize: generating forced AI answer, prompt length: %d", len(summaryPrompt))
 
-	reactloops.EmitStatus(loop, "生成分析报告 / Generating Report...")
+	reactloops.EmitStatusI18n(loop, "生成分析报告", "Generating Report...")
 
 	taskID := ""
 	if task := loop.GetCurrentTask(); task != nil {

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_decrypt_data.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_decrypt_data.go
@@ -79,7 +79,7 @@ var decryptDataAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpt
 			log.Infof("decrypt_data action: %s", paramSummary)
 
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeSetRequest, fmt.Sprintf("解密数据: %s", spec.Algorithm))
-			reactloops.EmitStatus(loop, "解密中 / Decrypting...")
+			reactloops.EmitStatusI18n(loop, "解密中", "Decrypting...")
 
 			plainBytes, err := decryptLoopHTTPFuzzData(spec)
 			if err != nil {
@@ -88,7 +88,7 @@ var decryptDataAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpt
 				record := recordLoopHTTPFuzzMetaAction(loop, "decrypt_data", paramSummary, utils.ShrinkTextBlock(feedback, 240))
 				r.AddToTimeline("decrypt_data", fmt.Sprintf("Decrypt failed: %s\n%s", spec.Algorithm, err.Error()))
 				persistLoopHTTPFuzzSessionContext(loop, "decrypt_data_failed")
-				reactloops.EmitStatus(loop, "解密失败 / Decrypt Failed")
+				reactloops.EmitStatusI18n(loop, "解密失败", "Decrypt Failed")
 				operator.Feedback(buildLoopHTTPFuzzActionFeedback(record) + "\n\n" + feedback)
 				return
 			}
@@ -120,7 +120,7 @@ var decryptDataAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpt
 			record := recordLoopHTTPFuzzMetaAction(loop, "decrypt_data", paramSummary, utils.ShrinkTextBlock(resultMarkdown, 240))
 			r.AddToTimeline("decrypt_data", fmt.Sprintf("Decrypted %s, output: %s", spec.Algorithm, utils.ShrinkTextBlock(outputText, 200)))
 			persistLoopHTTPFuzzSessionContext(loop, "decrypt_data")
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeSetRequest, "解密完成 / Decrypt Complete", utils.ShrinkTextBlock(outputText, 1200))
 			operator.Feedback(buildLoopHTTPFuzzActionFeedback(record) + "\n\n" + resultMarkdown)
 		},

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_generate_risk.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_generate_risk.go
@@ -99,7 +99,7 @@ var generateRiskAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			loop.SubmitRiskFeedback(riskIDs, riskFeedbackType, riskFeedbackSeverity)
 
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeGenerateRisk, fmt.Sprintf("生成 %d 个 Risk / Generated %d Risks", len(riskIDs), len(riskIDs)), summary)
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			r.AddToTimeline("generate_risk", summary)
 			operator.Feedback(summary)
 			operator.Continue()

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_modify_http_request.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_modify_http_request.go
@@ -112,10 +112,10 @@ var modifyHTTPRequestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActL
 			log.Infof("modify_http_request action: target=%s, reason=%s, review=%v", modificationTarget, modificationReason, requireManualReview)
 
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeModifyRequest, fmt.Sprintf("修改请求: %s", modificationTarget))
-			reactloops.EmitStatus(loop, "修改请求中 / Modifying Request...")
+			reactloops.EmitStatusI18n(loop, "修改请求中", "Modifying Request...")
 			r.AddToTimeline("modify_http_request", fmt.Sprintf("Modified current HTTP request: %s\n%s", modificationTarget, buildFuzzTimelineSummary(feedback)))
 			feedbackMsg := buildLoopHTTPFuzzActionFeedback(record) + "\n\n" + feedback
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeModifyRequest, "HTTP 请求已修改 / HTTP Request Modified", utils.ShrinkTextBlock(result.Diff, 2000))
 			operator.Feedback(feedbackMsg)
 		},

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_patch_http_request.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_patch_http_request.go
@@ -67,7 +67,7 @@ var patchHTTPRequestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLo
 			log.Infof("patch_http_request action: %s", paramSummary)
 
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeModifyRequest, fmt.Sprintf("修补请求: %s", summarizeHTTPRequestPatchSpec(spec)))
-			reactloops.EmitStatus(loop, "修补请求中 / Patching Request...")
+			reactloops.EmitStatusI18n(loop, "修补请求中", "Patching Request...")
 
 			result, err := applyLoopHTTPFuzzRequestChange(loop, r, &loopHTTPFuzzRequestChange{
 				RawRequest:         string(patchedPacket),
@@ -95,7 +95,7 @@ var patchHTTPRequestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLo
 			)
 			r.AddToTimeline("patch_http_request", fmt.Sprintf("Patched current HTTP request: %s\n%s", summarizeHTTPRequestPatchSpec(spec), buildFuzzTimelineSummary(result.Diff)))
 			feedbackMsg := buildLoopHTTPFuzzActionFeedback(record) + "\n\n" + feedback
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeModifyRequest, "HTTP 请求已修补 / HTTP Request Patched", utils.ShrinkTextBlock(result.Diff, 2000))
 			operator.Feedback(feedbackMsg)
 		},

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_set_http_request.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/action_set_http_request.go
@@ -35,7 +35,7 @@ var setHTTPRequestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoop
 			log.Infof("set_http_request action: setting HTTP request, is_https: %v, reason: %s", isHttps, reason)
 
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeSetRequest, fmt.Sprintf("设置 HTTP 请求: is_https=%v", isHttps))
-			reactloops.EmitStatus(loop, "设置请求中 / Setting Request...")
+			reactloops.EmitStatusI18n(loop, "设置请求中", "Setting Request...")
 
 			result, err := applyLoopHTTPFuzzRequestChange(loop, r, &loopHTTPFuzzRequestChange{
 				RawRequest:          httpRequest,
@@ -69,7 +69,7 @@ var setHTTPRequestAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoop
 			feedback.WriteString("You can now use fuzz actions (fuzz_method, fuzz_path, fuzz_header, fuzz_get_params, fuzz_body, fuzz_cookie) to test this request.")
 
 			feedbackMsg := buildLoopHTTPFuzzActionFeedback(record) + "\n\n" + feedback.String()
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeSetRequest, "HTTP 请求已设置 / HTTP Request Set")
 			operator.Feedback(feedbackMsg)
 			log.Infof("set_http_request done: request set successfully")

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/attached_resource_http_fuzz_request.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/attached_resource_http_fuzz_request.go
@@ -48,7 +48,7 @@ func bindAttachedHTTPFuzzRequestToLoop(
 		if loop.GetInvoker() != nil {
 			loop.GetInvoker().AddToTimeline("http_request_bootstrap", "Initialized from attached HTTP packet resource.")
 		}
-		reactloops.EmitStatus(loop, "已加载附加 HTTP 数据包 / Loaded Attached HTTP Packet")
+		reactloops.EmitStatusI18n(loop, "已加载附加 HTTP 数据包", "Loaded Attached HTTP Packet")
 		return true
 	}
 	return false

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/fuzz_utils.go
@@ -609,10 +609,12 @@ func (r *loopHTTPFuzzThrottleEmitter) emitProgress(stats *loopHTTPFuzzOverviewSt
 	emit := func() {
 		emitLoopHTTPFuzzStatusEvent(r.loop, loopHTTPFuzzStatusWorking, r.fuzzID, r.runtimeID, r.actionName, r.reason, r.paramSummary, statusProgress)
 		if stats.TotalRequests > 0 && (force || stats.TotalRequests%50 == 0) {
-			reactloops.EmitStatus(r.loop, fmt.Sprintf(
-				"已执行 %d 次测试 / Executed %d Tests",
-				stats.TotalRequests, stats.TotalRequests,
-			))
+			reactloops.EmitStatusI18n(
+				r.loop,
+				fmt.Sprintf("已执行 %d 次测试", stats.TotalRequests),
+				fmt.Sprintf("Executed %d tests", stats.TotalRequests),
+			)
+
 		}
 	}
 	if force || r.throttle == nil {
@@ -973,7 +975,7 @@ func getFuzzRequest(loop *reactloops.ReActLoop) (*mutate.FuzzHTTPRequest, error)
 // 3. 在需要时只压缩 analysis 段，再把最终反馈送去满意度验证。
 func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTTPRequestIf, actionName string, paramSummary string, action *aicommon.Action) (string, *aicommon.VerifySatisfactionResult, error) {
 	reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeFuzz, buildLoopHTTPFuzzActionLogStartLine(actionName, paramSummary, action))
-	reactloops.EmitStatus(loop, "模糊测试中 / Fuzzing...")
+	reactloops.EmitStatusI18n(loop, "模糊测试中", "Fuzzing...")
 	isHttpsStr := loop.Get("is_https")
 	isHttps := isHttpsStr == "true"
 	task := loop.GetCurrentTask()
@@ -1037,7 +1039,7 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	if err != nil {
 		emitLoopHTTPFuzzStatusEvent(loop, loopHTTPFuzzStatusFinish, fuzzID, runtimeID, actionName, "", "", nil)
 		log.Errorf("[executeFuzzAndCompare] %s exec failed: %v", actionName, err)
-		reactloops.EmitStatus(loop, "模糊测试失败 / Fuzz Test Failed")
+		reactloops.EmitStatusI18n(loop, "模糊测试失败", "Fuzz Test Failed")
 		return "", nil, err
 	}
 
@@ -1102,16 +1104,16 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 
 	if len(strings.TrimSpace(analysisSection)) > loopHTTPFuzzCompressionThreshold && invoker != nil {
 		log.Infof("[executeFuzzAndCompare] %s report exceeds %d bytes, compressing", actionName, loopHTTPFuzzCompressionThreshold)
-		reactloops.EmitStatus(loop, "压缩测试报告中 / Compressing Test Report...")
+		reactloops.EmitStatusI18n(loop, "压缩测试报告中", "Compressing Test Report...")
 		compressionTarget := buildFuzzCompressionTarget(loop, actionName)
 		compressed, compressErr := invoker.CompressLongTextWithDestination(taskCtx, analysisSection, compressionTarget, loopHTTPFuzzCompressionTarget)
 		if compressErr != nil {
 			log.Warnf("[executeFuzzAndCompare] %s compression failed, using original report: %v", actionName, compressErr)
-			reactloops.EmitStatus(loop, "压缩失败，使用原始报告 / Compression Failed, Using Original")
+			reactloops.EmitStatusI18n(loop, "压缩失败，使用原始报告", "Compression Failed, Using Original")
 		} else {
 			analysisSection = buildCompressedAnalysisSection(compressed, representativeRequest, representativeResponse, representativeHiddenIndex)
 			loop.Set("diff_result_compressed", analysisSection)
-			reactloops.EmitStatus(loop, "验证测试目标中 / Verifying Test Goal...")
+			reactloops.EmitStatusI18n(loop, "验证测试目标中", "Verifying Test Goal...")
 		}
 	}
 
@@ -1140,7 +1142,11 @@ func executeFuzzAndCompare(loop *reactloops.ReActLoop, fuzzResult mutate.FuzzHTT
 	if verificationSummary != "" {
 		finishLine += "; " + verificationSummary
 	}
-	reactloops.EmitStatus(loop, fmt.Sprintf("模糊测试完成 / Fuzz Test Complete (%d requests)", overview.TotalRequests))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("模糊测试完成，共发送 %d 个请求", overview.TotalRequests),
+		fmt.Sprintf("Fuzz test complete with %d requests", overview.TotalRequests),
+	)
 	reactloops.EmitActionLog(loop, loopHTTPFuzzActionLogNodeFuzz, finishLine, displaySummary)
 
 	loop.Set("diff_result", operatorFeedback)
@@ -1211,7 +1217,7 @@ func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, a
 		return nil, "", nil
 	}
 
-	reactloops.EmitStatus(loop, "验证测试目标中 / Verifying Test Goal...")
+	reactloops.EmitStatusI18n(loop, "验证测试目标中", "Verifying Test Goal...")
 	verifyResult, err := invoker.VerifyUserSatisfaction(taskCtx, task.GetUserInput(), true, verificationPayload)
 	if err != nil {
 		log.Errorf("[verifyFuzzCompletion] %s verification failed: %v", actionName, err)
@@ -1230,9 +1236,9 @@ func verifyFuzzCompletion(loop *reactloops.ReActLoop, taskCtx context.Context, a
 	loop.Set("verification_result", verificationText)
 
 	if verifyResult.Satisfied {
-		reactloops.EmitStatus(loop, "已达到测试目标 / Test Goal Met")
+		reactloops.EmitStatusI18n(loop, "已达到测试目标", "Test Goal Met")
 	} else {
-		reactloops.EmitStatus(loop, "需继续测试 / Continue Testing")
+		reactloops.EmitStatusI18n(loop, "需继续测试", "Continue Testing")
 	}
 
 	return verifyResult, verificationText, nil

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
@@ -160,10 +160,10 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 					invoker.AddToTimeline("http_fuzztest_restore", "Restored HTTP fuzz session context from persistent session history")
 				} else if looksLikeLoopHTTPFuzzNonFuzzDataTask(task.GetUserInput()) {
 					loop.Set("non_fuzz_data_task", "true")
-					reactloops.EmitStatus(loop, "Non-Fuzz Data Processing Task Detected")
+					reactloops.EmitStatus(loop, "这次任务不需要模糊测试，正在选择更合适的处理方式 / This task does not require fuzzing; choosing a better approach")
 					invoker.AddToTimeline("http_fuzztest_non_fuzz", "No HTTP packet found; user input looks like an offline data-processing task (decrypt/encode/transform). Proceeding without a request.")
 				} else {
-					reactloops.EmitStatus(loop, "No Valid HTTP Packet Found")
+					reactloops.EmitStatus(loop, "还没有找到可用的 HTTP 请求，正在重新确认输入 / No valid HTTP request was found; checking the input again")
 					operator.Done()
 					return
 				}

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
@@ -150,20 +150,20 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 			switch bootstrapResult {
 			case "raw":
 				loop.Set("bootstrap_source", "user_input_raw")
-				reactloops.EmitStatus(loop, "已复用用户输入的 HTTP 数据包 / Reused HTTP Packet from User Input")
+				reactloops.EmitStatusI18n(loop, "已复用用户输入的 HTTP 数据包", "Reused HTTP Packet from User Input")
 			case "url":
 				loop.Set("bootstrap_source", "user_input_url")
-				reactloops.EmitStatus(loop, "已从 URL 构造 HTTP 数据包 / Constructed HTTP Packet from URL")
+				reactloops.EmitStatusI18n(loop, "已从 URL 构造 HTTP 数据包", "Constructed HTTP Packet from URL")
 			default:
 				if restoreLoopHTTPFuzzSessionContext(loop, r) {
-					reactloops.EmitStatus(loop, "已恢复会话上下文 / Restored Session Context")
+					reactloops.EmitStatusI18n(loop, "已恢复会话上下文", "Restored Session Context")
 					invoker.AddToTimeline("http_fuzztest_restore", "Restored HTTP fuzz session context from persistent session history")
 				} else if looksLikeLoopHTTPFuzzNonFuzzDataTask(task.GetUserInput()) {
 					loop.Set("non_fuzz_data_task", "true")
-					reactloops.EmitStatus(loop, "这次任务不需要模糊测试，正在选择更合适的处理方式 / This task does not require fuzzing; choosing a better approach")
+					reactloops.EmitStatusI18n(loop, "这次任务不需要模糊测试，正在选择更合适的处理方式", "This task does not require fuzzing; choosing a better approach")
 					invoker.AddToTimeline("http_fuzztest_non_fuzz", "No HTTP packet found; user input looks like an offline data-processing task (decrypt/encode/transform). Proceeding without a request.")
 				} else {
-					reactloops.EmitStatus(loop, "还没有找到可用的 HTTP 请求，正在重新确认输入 / No valid HTTP request was found; checking the input again")
+					reactloops.EmitStatusI18n(loop, "还没有找到可用的 HTTP 请求，正在重新确认输入", "No valid HTTP request was found; checking the input again")
 					operator.Done()
 					return
 				}

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_custom.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_custom.go
@@ -85,7 +85,7 @@ func registerSeedAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption {
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
 			reactloops.EmitActionLog(loop, infosecAPIPoolNodeID, "开始: recon_register_seed / Start: recon_register_seed")
-			reactloops.EmitStatus(loop, "注册侦察种子中 / Registering recon seed...")
+			reactloops.EmitStatusI18n(loop, "注册侦察种子中", "Registering recon seed...")
 
 			wd := loop.Get(keyWorkDir)
 			if wd == "" {
@@ -122,7 +122,7 @@ func registerSeedAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption {
 			}
 			r.AddToTimeline("infosec_seed", fmt.Sprintf("seed=%s workdir=%s", seed, wd))
 			op.Feedback(fmt.Sprintf("Registered seed URL. Pool file: %s", filepath.Join(wd, poolFileName)))
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, infosecAPIPoolNodeID, fmt.Sprintf("完成: recon_register_seed / Done: recon_register_seed (seed=%s)", seed))
 			op.Continue()
 		},
@@ -140,7 +140,7 @@ func apiPoolMergeAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption {
 		nil,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
 			reactloops.EmitActionLog(loop, infosecAPIPoolNodeID, "开始: api_pool_merge / Start: api_pool_merge")
-			reactloops.EmitStatus(loop, "整理 API 池中 / Merging API pool...")
+			reactloops.EmitStatusI18n(loop, "整理 API 池中", "Merging API pool...")
 
 			wd := loop.Get(keyWorkDir)
 			if wd == "" {
@@ -195,7 +195,7 @@ func apiPoolMergeAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption {
 			}
 			r.AddToTimeline("api_pool_merge", fmt.Sprintf("added %d endpoints (errors: %d)", added, len(mergeErrs)))
 			op.Feedback(fmt.Sprintf("Merged into pool: +%d new entries. Total entries: %d. Parse errors: %d", added, len(pool.Entries), len(mergeErrs)))
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, infosecAPIPoolNodeID, fmt.Sprintf("完成: api_pool_merge (+%d) / Done: api_pool_merge (+%d)", added, added))
 			op.Continue()
 		},
@@ -227,7 +227,7 @@ func crawlJsCollectorAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 		nil,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
 			reactloops.EmitActionLog(loop, infosecJsCrawlNodeID, fmt.Sprintf("开始: %s / Start: %s", ToolCrawlJsCollector, ToolCrawlJsCollector))
-			reactloops.EmitStatus(loop, "JS 爬取分析中 / Running JS crawl analysis...")
+			reactloops.EmitStatusI18n(loop, "JS 爬取分析中", "Running JS crawl analysis...")
 
 			wd := loop.Get(keyWorkDir)
 			if wd == "" {
@@ -308,7 +308,7 @@ func crawlJsCollectorAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 			r.AddToTimeline(ToolCrawlJsCollector+"_done", timelineEntry)
 			appendInfosecReconLog(loop, "=== "+ToolCrawlJsCollector+" ===\n"+summary)
 			op.Feedback(feedback)
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, infosecJsCrawlNodeID, fmt.Sprintf("完成: %s / Done: %s", ToolCrawlJsCollector, ToolCrawlJsCollector))
 			op.Continue()
 		},
@@ -336,7 +336,7 @@ func runJsStaticAnalysisAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopO
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
 			reactloops.EmitActionLog(loop, infosecJsCrawlNodeID, fmt.Sprintf("开始: %s / Start: %s", ToolJsStaticExtractAI, ToolJsStaticExtractAI))
-			reactloops.EmitStatus(loop, "JS 静态分析中 / Running JS static analysis...")
+			reactloops.EmitStatusI18n(loop, "JS 静态分析中", "Running JS static analysis...")
 
 			wd := loop.Get(keyWorkDir)
 			if wd == "" {
@@ -428,7 +428,7 @@ func runJsStaticAnalysisAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopO
 			r.AddToTimeline(ToolJsStaticExtractAI+"_done", fmt.Sprintf("added %d from js static", totalAdded))
 			op.Feedback(fmt.Sprintf("JS static pass done: +%d pool entries (total %d). Resolved via %s.", totalAdded, len(pool.Entries), pathSource))
 			op.Feedback("[Next] " + ToolJsStaticExtractAI + " 已完成。请根据 API 池摘要、ReconLog 与本轮反馈决定下一步（如 probe_api_candidates）；勿对已成功分析的 paths 无意义重复调用。")
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, infosecJsCrawlNodeID, fmt.Sprintf("完成: %s (+%d) / Done: %s (+%d)", ToolJsStaticExtractAI, totalAdded, ToolJsStaticExtractAI, totalAdded))
 			op.Continue()
 		},
@@ -448,7 +448,7 @@ func probeAPICandidatesAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 		nil,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
 			reactloops.EmitActionLog(loop, infosecAPIPoolNodeID, "开始: probe_api_candidates / Start: probe_api_candidates")
-			reactloops.EmitStatus(loop, "探测 API 候选中 / Probing API candidates...")
+			reactloops.EmitStatusI18n(loop, "探测 API 候选中", "Probing API candidates...")
 
 			wd := loop.Get(keyWorkDir)
 			if wd == "" {
@@ -483,7 +483,7 @@ func probeAPICandidatesAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			_, verified, _, _ := PoolStats(pool)
 			r.AddToTimeline("probe_api", fmt.Sprintf("probed %d entries; verified count=%d", n, verified))
 			op.Feedback(fmt.Sprintf("Probed %d URLs this batch. Verified entries in pool: %d / %d", n, verified, len(pool.Entries)))
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, infosecAPIPoolNodeID, fmt.Sprintf("完成: probe_api_candidates (%d probed) / Done: probe_api_candidates (%d probed)", n, n))
 			op.Continue()
 		},

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_recon.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/actions_recon.go
@@ -45,7 +45,7 @@ func makeReconRequireAction(
 					invoker.AddToTimeline(actionName+"_intent", thought)
 				}
 				reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("开始: %s / Start: %s", actionName, targetToolName))
-				reactloops.EmitStatus(loop, "执行侦察工具中 / Executing recon tool...")
+				reactloops.EmitStatusI18n(loop, "执行侦察工具中", "Executing recon tool...")
 
 				result, directly, err := invoker.ExecuteToolRequiredAndCall(ctx, targetToolName)
 				if err != nil {
@@ -80,7 +80,7 @@ func makeReconRequireAction(
 				appendInfosecReconLog(loop, entry)
 				invoker.AddToTimeline(actionName+"_result", fmt.Sprintf("[%s] %s\n\n%s", targetToolName, thoughtHint, utils.ShrinkString(content, 4096)))
 				op.Feedback(fmt.Sprintf("%s completed (%d bytes).", actionName, len(content)))
-				reactloops.EmitStatus(loop, "完成 / Complete")
+				reactloops.EmitStatusI18n(loop, "完成", "Complete")
 				reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("完成: %s (%d bytes) / Done: %s (%d bytes)", actionName, len(content), targetToolName, len(content)))
 				op.Continue()
 			},
@@ -108,7 +108,7 @@ func makeToolForwardAction(
 					ctx = task.GetContext()
 				}
 				reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("开始: %s / Start: %s", actionName, targetToolName))
-				reactloops.EmitStatus(loop, "执行侦察工具中 / Executing recon tool...")
+				reactloops.EmitStatusI18n(loop, "执行侦察工具中", "Executing recon tool...")
 
 				params := action.GetParams()
 				result, _, err := invoker.ExecuteToolRequiredAndCallWithoutRequired(ctx, targetToolName, params)
@@ -126,7 +126,7 @@ func makeToolForwardAction(
 				appendInfosecReconLog(loop, entry)
 				invoker.AddToTimeline(fmt.Sprintf("%s_result", actionName), utils.ShrinkString(content, 4096))
 				op.Feedback(fmt.Sprintf("%s completed (%d bytes)", targetToolName, len(content)))
-				reactloops.EmitStatus(loop, "完成 / Complete")
+				reactloops.EmitStatusI18n(loop, "完成", "Complete")
 				reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("完成: %s (%d bytes) / Done: %s (%d bytes)", actionName, len(content), targetToolName, len(content)))
 				op.Continue()
 			},
@@ -160,7 +160,7 @@ var webSearchAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 			}
 			query := action.GetString("query")
 			reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("开始: %s / Start: %s", query, query))
-			reactloops.EmitStatus(loop, "联网搜索中 / Searching the web...")
+			reactloops.EmitStatusI18n(loop, "联网搜索中", "Searching the web...")
 
 			params := aitool.InvokeParams{"query": query}
 			result, _, err := invoker.ExecuteToolRequiredAndCallWithoutRequired(ctx, "web_search", params)
@@ -178,7 +178,7 @@ var webSearchAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 			appendInfosecReconLog(loop, fmt.Sprintf("=== web_search: %s ===\n%s", query, utils.ShrinkString(content, 4096)))
 			invoker.AddToTimeline("web_search_result", utils.ShrinkString(content, 2048))
 			op.Feedback(fmt.Sprintf("web_search completed for: '%s' (%d bytes)", query, len(content)))
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("完成: %s (%d bytes) / Done: %s (%d bytes)", query, len(content), query, len(content)))
 			op.Continue()
 		},

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/init_task.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/init_task.go
@@ -93,7 +93,7 @@ func workDirFromInvoker(r aicommon.AIInvokeRuntime) string {
 
 func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
 	return func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
-		reactloops.EmitStatus(loop, "初始化信息搜集任务... / Initializing infosec recon task...")
+		reactloops.EmitStatus(loop, "正在准备收集相关信息 / Preparing to gather relevant information")
 
 		wd := workDirFromInvoker(r)
 		if wd == "" {
@@ -119,7 +119,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		}
 
 		r.AddToTimeline("infosec_recon_init", "API surface recon loop ready. recon_register_seed → "+ToolCrawlJsCollector+" (optional deep_js) → "+ToolJsStaticExtractAI+"(paths / verified JS dir) → api_pool_merge / probe_api_candidates as needed.")
-		reactloops.EmitStatus(loop, "信息搜集任务就绪 / Infosec recon task ready")
+		reactloops.EmitStatus(loop, "已经明确目标，正在开始查找线索 / The target is clear; starting to look for leads")
 		operator.Continue()
 	}
 }

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/init_task.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/init_task.go
@@ -93,7 +93,7 @@ func workDirFromInvoker(r aicommon.AIInvokeRuntime) string {
 
 func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
 	return func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
-		reactloops.EmitStatus(loop, "正在准备收集相关信息 / Preparing to gather relevant information")
+		reactloops.EmitStatusI18n(loop, "正在准备收集相关信息", "Preparing to gather relevant information")
 
 		wd := workDirFromInvoker(r)
 		if wd == "" {
@@ -119,7 +119,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		}
 
 		r.AddToTimeline("infosec_recon_init", "API surface recon loop ready. recon_register_seed → "+ToolCrawlJsCollector+" (optional deep_js) → "+ToolJsStaticExtractAI+"(paths / verified JS dir) → api_pool_merge / probe_api_candidates as needed.")
-		reactloops.EmitStatus(loop, "已经明确目标，正在开始查找线索 / The target is clear; starting to look for leads")
+		reactloops.EmitStatusI18n(loop, "已经明确目标，正在开始查找线索", "The target is clear; starting to look for leads")
 		operator.Continue()
 	}
 }

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/search_knowledge.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/search_knowledge.go
@@ -36,7 +36,7 @@ var searchKnowledgeInfosec = func(r aicommon.AIInvokeRuntime) reactloops.ReActLo
 			}
 			input := action.GetString("input")
 			reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("开始: search_knowledge / Start: search_knowledge (%s)", input))
-			reactloops.EmitStatus(loop, "知识检索中 / Searching knowledge base...")
+			reactloops.EmitStatusI18n(loop, "知识检索中", "Searching knowledge base...")
 
 			invoker := loop.GetInvoker()
 			ctx := loop.GetConfig().GetContext()
@@ -53,7 +53,7 @@ var searchKnowledgeInfosec = func(r aicommon.AIInvokeRuntime) reactloops.ReActLo
 			loop.Set(keyInfosecEnhanceData, enhanceData)
 			appendInfosecReconLog(loop, "=== search_knowledge ===\n"+utils.ShrinkString(enhanceData, 8000))
 			op.Feedback("search_knowledge completed")
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, infosecReconToolNodeID, fmt.Sprintf("完成: search_knowledge (%d bytes) / Done: search_knowledge (%d bytes)", len(enhanceData), len(enhanceData)))
 			op.Continue()
 		},

--- a/common/ai/aid/aireact/reactloops/loop_internet_research/action_final_summary.go
+++ b/common/ai/aid/aireact/reactloops/loop_internet_research/action_final_summary.go
@@ -34,7 +34,7 @@ func makeFinalSummaryAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 		toolOpts,
 		streamFields,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
-			loop.LoadingStatus("validating final summary parameters")
+			loop.UserStatus("正在确认研究结论是否完整", "Checking that the research conclusions are complete", aicommon.WithStatusCode("research.report.validating"))
 			summary := action.GetString("summary")
 			if summary == "" {
 				return utils.Error("summary is required")
@@ -42,7 +42,7 @@ func makeFinalSummaryAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 			return nil
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
-			loop.LoadingStatus("generating final research report")
+			loop.UserStatus("正在整理研究报告", "Preparing the research report", aicommon.WithStatusCode("research.report.writing"))
 
 			summary := action.GetString("summary")
 			if summary == "" {

--- a/common/ai/aid/aireact/reactloops/loop_internet_research/action_web_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_internet_research/action_web_search.go
@@ -33,7 +33,7 @@ func makeWebSearchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption 
 		"web_search",
 		desc, toolOpts,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
-			loop.LoadingStatus("validating web search parameters")
+			loop.UserStatus("正在确认搜索方向", "Confirming the search direction", aicommon.WithStatusCode("research.search.preparing"))
 			searchQuery := action.GetString("search_query")
 			if searchQuery == "" {
 				return utils.Error("search_query is required for web search")
@@ -79,7 +79,12 @@ func makeWebSearchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption 
 			userQuery := loop.Get("user_query")
 			emitter := loop.GetEmitter()
 
-			loop.LoadingStatus(fmt.Sprintf("searching internet: %s", searchQuery))
+			loop.UserStatus(
+				"正在查找最新资料",
+				"Searching for up-to-date information",
+				aicommon.WithStatusCode("research.searching"),
+				aicommon.WithStatusDetail(fmt.Sprintf("本轮关注：%s", searchQuery), fmt.Sprintf("Current focus: %s", searchQuery)),
+			)
 			log.Infof("internet research: searching for '%s' with max_results=%d", searchQuery, maxResults)
 
 			params := aitool.InvokeParams{
@@ -106,7 +111,7 @@ func makeWebSearchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption 
 
 			log.Infof("internet research: web_search tool returned %d bytes for '%s'", len(content), searchQuery)
 
-			loop.LoadingStatus("recording search results")
+			loop.UserStatus("正在整理已找到的资料", "Organizing the sources found so far", aicommon.WithStatusCode("research.organizing"))
 			feedNewKnowledge(content, userQuery)
 
 			iteration := loop.GetCurrentIterationIndex()
@@ -157,7 +162,7 @@ Time: %s
 				time.Now().Format("15:04:05"), searchCount, searchQuery, len(content))
 			loop.Set("search_history", searchHistory)
 
-			loop.LoadingStatus("evaluating search progress")
+			loop.UserStatus("正在判断现有资料是否足够", "Checking whether the available sources are sufficient", aicommon.WithStatusCode("research.evaluating"))
 			evalResult := evaluateNextSearch(ctx, invoker, loop, userQuery, searchQuery, content, searchCount)
 			if evalResult.Finished {
 				log.Infof("internet research finished, summary: %s", evalResult.Summary)

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_check_syntax.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_check_syntax.go
@@ -56,7 +56,7 @@ var checkJavaSyntaxAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoo
 				startLine = fmt.Sprintf("检查语法: 目录 %s", dirPath)
 			}
 			reactloops.EmitActionLog(loop, nodeID, startLine)
-			reactloops.EmitStatus(loop, "检查语法中 / Checking Syntax...")
+			reactloops.EmitStatusI18n(loop, "检查语法中", "Checking Syntax...")
 
 			var filesToCheck []string
 			if filePath != "" {
@@ -84,7 +84,7 @@ var checkJavaSyntaxAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoo
 
 			if len(filesToCheck) == 0 {
 				log.Warnf("[check_syntax] no Java files found")
-				reactloops.EmitStatus(loop, "未找到 Java 文件 / No Java Files Found")
+				reactloops.EmitStatusI18n(loop, "未找到 Java 文件", "No Java Files Found")
 				finishLine := "完成: 未找到可检查的 Java 文件"
 				reactloops.EmitActionLog(loop, nodeID, finishLine)
 				invoker.AddToTimeline("check_syntax_no_files", `【未找到Java文件】指定的位置没有找到任何Java文件
@@ -157,10 +157,12 @@ var checkJavaSyntaxAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoo
 
 			if filesWithIssues == 0 {
 				finishLine = fmt.Sprintf("完成: %d 个文件全部通过语法检查", len(filesToCheck))
-				reactloops.EmitStatus(loop, fmt.Sprintf(
-					"语法检查通过 (%d 个文件) / Syntax Check Passed (%d files)",
-					len(filesToCheck), len(filesToCheck),
-				))
+				reactloops.EmitStatusI18n(
+					loop,
+					fmt.Sprintf("%d 个文件已通过语法检查", len(filesToCheck)),
+					fmt.Sprintf("%d files passed the syntax check", len(filesToCheck)),
+				)
+
 				feedbackMsg = fmt.Sprintf("All %d Java files passed basic syntax checks.", len(filesToCheck))
 				invoker.AddToTimeline("check_syntax_success", fmt.Sprintf("所有 %d 个Java文件语法检查通过，可以继续下一步操作", len(filesToCheck)))
 			} else {
@@ -168,10 +170,12 @@ var checkJavaSyntaxAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoo
 				summary, ref := reactloops.SpillLongContent(loop, "syntax_check_report", fullReport)
 				reference = ref
 				finishLine = fmt.Sprintf("完成: %d/%d 个文件存在语法问题", filesWithIssues, len(filesToCheck))
-				reactloops.EmitStatus(loop, fmt.Sprintf(
-					"发现语法问题 (%d/%d) / Syntax Issues Found (%d/%d)",
-					filesWithIssues, len(filesToCheck), filesWithIssues, len(filesToCheck),
-				))
+				reactloops.EmitStatusI18n(
+					loop,
+					fmt.Sprintf("%d/%d 个文件存在语法问题", filesWithIssues, len(filesToCheck)),
+					fmt.Sprintf("Syntax issues found in %d/%d files", filesWithIssues, len(filesToCheck)),
+				)
+
 				feedbackMsg = fmt.Sprintf("Found issues in %d/%d Java files.\n\n%s",
 					filesWithIssues, len(filesToCheck), summary)
 				invoker.AddToTimeline("check_syntax_issues_found", fmt.Sprintf(`【发现语法错误】在 %d/%d 个文件中发现语法问题

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_compare_files.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_compare_files.go
@@ -110,12 +110,12 @@ var compareFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 
 			startLine := fmt.Sprintf("对比备份: %s", filepath.Base(filePath))
 			reactloops.EmitActionLog(loop, nodeID, startLine)
-			reactloops.EmitStatus(loop, "对比文件中 / Comparing Files...")
+			reactloops.EmitStatusI18n(loop, "对比文件中", "Comparing Files...")
 
 			originalContent, err := os.ReadFile(backupPath)
 			if err != nil {
 				log.Errorf("[compare_with_backup] failed to read backup %s: %v", backupPath, err)
-				reactloops.EmitStatus(loop, "读取备份失败 / Failed to Read Backup")
+				reactloops.EmitStatusI18n(loop, "读取备份失败", "Failed to Read Backup")
 				invoker.AddToTimeline("compare_read_backup_error", fmt.Sprintf(`【备份文件读取失败】无法读取备份文件内容
 
 【错误详情】：%v
@@ -143,7 +143,7 @@ var compareFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			modifiedContent, err := os.ReadFile(filePath)
 			if err != nil {
 				log.Errorf("[compare_with_backup] failed to read file %s: %v", filePath, err)
-				reactloops.EmitStatus(loop, "读取文件失败 / Failed to Read File")
+				reactloops.EmitStatusI18n(loop, "读取文件失败", "Failed to Read File")
 				invoker.AddToTimeline("compare_read_file_error", fmt.Sprintf(`【文件读取失败】无法读取当前文件内容
 
 【错误详情】：%v
@@ -171,7 +171,7 @@ var compareFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			diffResult, err := yakdiff.Diff(originalContent, modifiedContent)
 			if err != nil {
 				log.Errorf("[compare_with_backup] failed to generate diff for %s: %v", filePath, err)
-				reactloops.EmitStatus(loop, "差异生成失败 / Diff Generation Failed")
+				reactloops.EmitStatusI18n(loop, "差异生成失败", "Diff Generation Failed")
 				invoker.AddToTimeline("compare_diff_error", fmt.Sprintf(`【差异生成失败】无法生成文件差异对比
 
 【错误详情】：%v
@@ -201,7 +201,7 @@ var compareFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 
 			if strings.TrimSpace(diffResult) == "" {
 				finishLine = fmt.Sprintf("完成: %s 与备份完全相同", filepath.Base(filePath))
-				reactloops.EmitStatus(loop, "无差异 / No Differences")
+				reactloops.EmitStatusI18n(loop, "无差异", "No Differences")
 				feedbackMsg = fmt.Sprintf("No differences found for %s (identical to backup).", filepath.Base(filePath))
 				invoker.AddToTimeline("compare_no_changes", fmt.Sprintf(`【文件对比完成】文件与备份完全相同：%s
 
@@ -230,10 +230,12 @@ var compareFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 
 				finishLine = fmt.Sprintf("完成: %s 变更 +%d/-%d 行",
 					filepath.Base(filePath), addedLines, removedLines)
-				reactloops.EmitStatus(loop, fmt.Sprintf(
-					"发现差异 (+%d/-%d) / Changes Found (+%d/-%d)",
-					addedLines, removedLines, addedLines, removedLines,
-				))
+				reactloops.EmitStatusI18n(
+					loop,
+					fmt.Sprintf("已发现差异：+%d/-%d 行", addedLines, removedLines),
+					fmt.Sprintf("Changes found: +%d/-%d lines", addedLines, removedLines),
+				)
+
 				feedbackMsg = fmt.Sprintf("Changes in %s: +%d/-%d lines.\n\n%s",
 					filepath.Base(filePath), addedLines, removedLines, summary)
 				invoker.AddToTimeline("compare_changes_found", fmt.Sprintf(`【文件对比完成】发现文件修改：%s

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_decompile_jar.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_decompile_jar.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/yaklang/javajive/classparser/jarwar"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
-	"github.com/yaklang/javajive/classparser/jarwar"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 )
@@ -71,7 +71,7 @@ var decompileJarAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			outputDir, err := filepath.Abs(outputDir)
 			if err != nil {
 				log.Errorf("[decompile_jar] failed to resolve output path: %v", err)
-				reactloops.EmitStatus(loop, "路径解析失败 / Path Resolution Failed")
+				reactloops.EmitStatusI18n(loop, "路径解析失败", "Path Resolution Failed")
 				loop.GetInvoker().AddToTimeline("decompile_path_error", fmt.Sprintf(`【路径解析失败】无法获取输出目录的绝对路径
 
 【错误详情】：%v
@@ -100,12 +100,12 @@ var decompileJarAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			invoker := loop.GetInvoker()
 			startLine := fmt.Sprintf("反编译 JAR: %s -> %s", jarPath, outputDir)
 			reactloops.EmitActionLog(loop, nodeID, startLine)
-			reactloops.EmitStatus(loop, "反编译中 / Decompiling...")
+			reactloops.EmitStatusI18n(loop, "反编译中", "Decompiling...")
 
 			err = os.MkdirAll(outputDir, 0755)
 			if err != nil {
 				log.Errorf("[decompile_jar] failed to create output directory %s: %v", outputDir, err)
-				reactloops.EmitStatus(loop, "目录创建失败 / Failed to Create Output Directory")
+				reactloops.EmitStatusI18n(loop, "目录创建失败", "Failed to Create Output Directory")
 				invoker.AddToTimeline("decompile_mkdir_error", fmt.Sprintf(`【目录创建失败】无法创建输出目录：%s
 
 【错误详情】：%v
@@ -139,7 +139,7 @@ var decompileJarAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			decompileDuration := time.Since(decompileStartTime)
 			if err != nil {
 				log.Errorf("[decompile_jar] decompilation failed: %v", err)
-				reactloops.EmitStatus(loop, "反编译失败 / Decompilation Failed")
+				reactloops.EmitStatusI18n(loop, "反编译失败", "Decompilation Failed")
 				invoker.AddToTimeline("decompile_execution_error", fmt.Sprintf(`【反编译失败】JAR文件反编译过程中遇到错误
 
 【错误详情】：%v
@@ -170,7 +170,7 @@ var decompileJarAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 				return
 			}
 
-			reactloops.EmitStatus(loop, "创建备份中 / Creating Backups...")
+			reactloops.EmitStatusI18n(loop, "创建备份中", "Creating Backups...")
 			backupCount := 0
 			filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
 				if err == nil && !info.IsDir() && filepath.Ext(path) == ".java" {
@@ -185,7 +185,7 @@ var decompileJarAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 				return nil
 			})
 
-			reactloops.EmitStatus(loop, "检查语法中 / Checking Syntax...")
+			reactloops.EmitStatusI18n(loop, "检查语法中", "Checking Syntax...")
 			checkStartTime := time.Now()
 			totalFiles := 0
 			filesWithIssues := 0
@@ -196,10 +196,12 @@ var decompileJarAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 				if err == nil && !info.IsDir() && filepath.Ext(path) == ".java" {
 					totalFiles++
 					if totalFiles%100 == 0 {
-						reactloops.EmitStatus(loop, fmt.Sprintf(
-							"已扫描 %d 个 Java 文件 / Scanned %d Java Files",
-							totalFiles, totalFiles,
-						))
+						reactloops.EmitStatusI18n(
+							loop,
+							fmt.Sprintf("已扫描 %d 个 Java 文件", totalFiles),
+							fmt.Sprintf("Scanned %d Java files", totalFiles),
+						)
+
 					}
 
 					relPath, _ := filepath.Rel(outputDir, path)
@@ -253,10 +255,11 @@ var decompileJarAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 
 			finishLine := fmt.Sprintf("完成: %d 个 Java 文件, %d 个潜在问题, 输出目录 %s",
 				totalFiles, filesWithIssues, outputDir)
-			reactloops.EmitStatus(loop, fmt.Sprintf(
-				"反编译完成 (%d 个文件) / Decompile Complete (%d files)",
-				totalFiles, totalFiles,
-			))
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("反编译完成，共 %d 个文件", totalFiles),
+				fmt.Sprintf("Decompilation complete with %d files", totalFiles),
+			)
 
 			var reference string
 			if len(compilationErrors) > 0 {

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_list_files.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_list_files.go
@@ -166,7 +166,7 @@ var listFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 			invoker := loop.GetInvoker()
 			startLine := fmt.Sprintf("列出 Java 文件: %s", dirPath)
 			reactloops.EmitActionLog(loop, nodeID, startLine)
-			reactloops.EmitStatus(loop, "枚举文件中 / Listing Files...")
+			reactloops.EmitStatusI18n(loop, "枚举文件中", "Listing Files...")
 
 			fs := filesys.NewLocalFs()
 			var javaFiles []string
@@ -183,10 +183,12 @@ var listFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 							javaFiles = append(javaFiles, path)
 						}
 						if len(javaFiles)%100 == 0 {
-							reactloops.EmitStatus(loop, fmt.Sprintf(
-								"已发现 %d 个 Java 文件 / Found %d Java Files",
-								len(javaFiles), len(javaFiles),
-							))
+							reactloops.EmitStatusI18n(
+								loop,
+								fmt.Sprintf("已发现 %d 个 Java 文件", len(javaFiles)),
+								fmt.Sprintf("Found %d Java files", len(javaFiles)),
+							)
+
 						}
 					}
 					return nil
@@ -220,14 +222,14 @@ var listFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 
 【警告】：部分文件可能已列出，但遍历未完成！`, dirPath, err))
 				if len(javaFiles) == 0 {
-					reactloops.EmitStatus(loop, "枚举失败 / Listing Failed")
+					reactloops.EmitStatusI18n(loop, "枚举失败", "Listing Failed")
 					op.Fail("failed to list files: " + err.Error())
 					return
 				}
 			}
 
 			if len(javaFiles) == 0 {
-				reactloops.EmitStatus(loop, "未找到 Java 文件 / No Java Files Found")
+				reactloops.EmitStatusI18n(loop, "未找到 Java 文件", "No Java Files Found")
 				finishLine := fmt.Sprintf("完成: 目录 %s 中未找到 Java 文件", dirPath)
 				reactloops.EmitActionLog(loop, nodeID, finishLine)
 				invoker.AddToTimeline("list_files_empty", fmt.Sprintf(`【未找到 Java 文件】目录中没有 Java 文件：%s
@@ -264,10 +266,12 @@ var listFilesAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 			summary, reference := reactloops.SpillLongContent(loop, "java_file_list", fullList)
 
 			finishLine := fmt.Sprintf("完成: 找到 %d 个 Java 文件 (%s)", len(javaFiles), dirPath)
-			reactloops.EmitStatus(loop, fmt.Sprintf(
-				"枚举完成 (%d 个文件) / Listing Complete (%d files)",
-				len(javaFiles), len(javaFiles),
-			))
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("文件枚举完成，共 %d 个文件", len(javaFiles)),
+				fmt.Sprintf("File listing complete with %d files", len(javaFiles)),
+			)
+
 			reactloops.EmitActionLog(loop, nodeID, finishLine, reference)
 
 			feedbackMsg := fmt.Sprintf("Found %d Java files in %s", len(javaFiles), dirPath)

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_read_java_file.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_read_java_file.go
@@ -99,13 +99,13 @@ var readJavaFileAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			invoker := loop.GetInvoker()
 			startLine := fmt.Sprintf("读取 Java 文件: %s", filePath)
 			reactloops.EmitActionLog(loop, nodeID, startLine)
-			reactloops.EmitStatus(loop, "读取文件中 / Reading File...")
+			reactloops.EmitStatusI18n(loop, "读取文件中", "Reading File...")
 
 			fs := filesys.NewLocalFs()
 			content, err := fs.ReadFile(filePath)
 			if err != nil {
 				log.Errorf("[read_java_file] failed to read %s: %v", filePath, err)
-				reactloops.EmitStatus(loop, "读取失败 / Read Failed")
+				reactloops.EmitStatusI18n(loop, "读取失败", "Read Failed")
 				r.AddToTimeline("read_file_failed", fmt.Sprintf(`【读取文件失败】无法读取文件内容：%s
 
 【错误信息】：%v
@@ -143,7 +143,7 @@ var readJavaFileAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 			qualityLevel := getQualityLevel(analysis)
 			finishLine := fmt.Sprintf("完成: %s (%d 行, %d 字节, 质量 %s)",
 				filepath.Base(filePath), len(lines), len(contentStr), qualityLevel)
-			reactloops.EmitStatus(loop, "读取完成 / Read Complete")
+			reactloops.EmitStatusI18n(loop, "读取完成", "Read Complete")
 
 			reference := fmt.Sprintf("文件: %s\n行数: %d\n质量: %s\n分析:\n%s\n\n预览:\n%s",
 				savedPath, len(lines), qualityLevel, formatAnalysis(analysis), preview)

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_rewrite_java_file.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/action_rewrite_java_file.go
@@ -145,13 +145,13 @@ var rewriteJavaFileAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoo
 			invoker := loop.GetInvoker()
 			startLine := fmt.Sprintf("重写 Java 文件: %s (%s)", filepath.Base(filePath), mode)
 			reactloops.EmitActionLog(loop, nodeID, startLine)
-			reactloops.EmitStatus(loop, "重写文件中 / Rewriting File...")
+			reactloops.EmitStatusI18n(loop, "重写文件中", "Rewriting File...")
 
 			fs := filesys.NewLocalFs()
 			content, err := fs.ReadFile(filePath)
 			if err != nil {
 				log.Errorf("[rewrite_java_file] failed to read %s: %v", filePath, err)
-				reactloops.EmitStatus(loop, "读取失败 / Read Failed")
+				reactloops.EmitStatusI18n(loop, "读取失败", "Read Failed")
 				r.AddToTimeline("rewrite_read_failed", fmt.Sprintf(`【读取文件失败】无法读取文件内容：%s
 
 【错误信息】：%v
@@ -191,7 +191,7 @@ var rewriteJavaFileAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoo
 			}
 			if newCode == "" {
 				log.Warnf("[rewrite_java_file] no rewritten code provided for %s", filePath)
-				reactloops.EmitStatus(loop, "缺少重写代码 / No Rewritten Code")
+				reactloops.EmitStatusI18n(loop, "缺少重写代码", "No Rewritten Code")
 				r.AddToTimeline("rewrite_no_code", `【缺少重写代码】未提供新的Java代码
 
 【原因】：
@@ -225,7 +225,7 @@ public class Example {
 				lines := strings.Split(string(content), "\n")
 				if rewriteStartLine > len(lines) || rewriteEndLine > len(lines) {
 					log.Warnf("[rewrite_java_file] line range %d-%d exceeds file length %d", rewriteStartLine, rewriteEndLine, len(lines))
-					reactloops.EmitStatus(loop, "行号超出范围 / Line Range Out of Bounds")
+					reactloops.EmitStatusI18n(loop, "行号超出范围", "Line Range Out of Bounds")
 					r.AddToTimeline("rewrite_line_out_of_range", fmt.Sprintf(`【行号超出范围】指定的行号超出文件范围
 
 【文件信息】：
@@ -263,7 +263,7 @@ public class Example {
 			err = fs.WriteFile(filePath, []byte(finalContent), 0644)
 			if err != nil {
 				log.Errorf("[rewrite_java_file] failed to write %s: %v", filePath, err)
-				reactloops.EmitStatus(loop, "写入失败 / Write Failed")
+				reactloops.EmitStatusI18n(loop, "写入失败", "Write Failed")
 				r.AddToTimeline("rewrite_write_failed", fmt.Sprintf(`【写入文件失败】无法保存重写后的代码：%s
 
 【错误信息】：%v
@@ -315,9 +315,9 @@ public class Example {
 			finishLine := fmt.Sprintf("完成: %s (%s, %d 字节, %s)",
 				filepath.Base(filePath), mode, len(finalContent), syntaxStatus)
 			if hasSyntaxErrors {
-				reactloops.EmitStatus(loop, "重写完成，仍有语法问题 / Rewrite Complete, Syntax Issues Remain")
+				reactloops.EmitStatusI18n(loop, "重写完成，仍有语法问题", "Rewrite Complete, Syntax Issues Remain")
 			} else {
-				reactloops.EmitStatus(loop, "重写完成 / Rewrite Complete")
+				reactloops.EmitStatusI18n(loop, "重写完成", "Rewrite Complete")
 			}
 
 			reference := fmt.Sprintf("备份: %s\n新代码预览:\n%s", backupPath, preview)

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/init.go
@@ -103,7 +103,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		loop.Set("fixed_files", 0)
 		loop.Set("rewritten_files", 0)
 
-		reactloops.EmitStatus(loop, "初始化 Java 反编译任务 / Initializing Java Decompiler Task")
+		reactloops.EmitStatus(loop, "正在了解 Java 文件和处理目标 / Understanding the Java files and requested changes")
 		r.AddToTimeline("task_initialized", utils.ShrinkString(userQuery, 200))
 		operator.Continue()
 	}

--- a/common/ai/aid/aireact/reactloops/loop_java_decompiler/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_java_decompiler/init.go
@@ -103,7 +103,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		loop.Set("fixed_files", 0)
 		loop.Set("rewritten_files", 0)
 
-		reactloops.EmitStatus(loop, "正在了解 Java 文件和处理目标 / Understanding the Java files and requested changes")
+		reactloops.EmitStatusI18n(loop, "正在了解 Java 文件和处理目标", "Understanding the Java files and requested changes")
 		r.AddToTimeline("task_initialized", utils.ShrinkString(userQuery, 200))
 		operator.Continue()
 	}

--- a/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_final_summary.go
+++ b/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_final_summary.go
@@ -37,7 +37,7 @@ func makeFinalSummaryAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 		streamFields,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
 			// 验证参数
-			loop.LoadingStatus("正在确认关键信息是否完整 / Checking that the key information is complete")
+			loop.UserStatus("正在确认关键信息是否完整", "Checking that the key information is complete")
 			summary := action.GetString("summary")
 			if summary == "" {
 				return utils.Error("summary is required")
@@ -45,7 +45,7 @@ func makeFinalSummaryAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 			return nil
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
-			loop.LoadingStatus("正在组织回答 / Preparing the answer")
+			loop.UserStatus("正在组织回答", "Preparing the answer")
 
 			summary := action.GetString("summary")
 			if summary == "" {

--- a/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_final_summary.go
+++ b/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_final_summary.go
@@ -37,7 +37,7 @@ func makeFinalSummaryAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 		streamFields,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
 			// 验证参数
-			loop.LoadingStatus("验证最终总结参数 - validating final summary parameters")
+			loop.LoadingStatus("正在确认关键信息是否完整 / Checking that the key information is complete")
 			summary := action.GetString("summary")
 			if summary == "" {
 				return utils.Error("summary is required")
@@ -45,7 +45,7 @@ func makeFinalSummaryAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 			return nil
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
-			loop.LoadingStatus("生成最终总结中 - generating final summary")
+			loop.LoadingStatus("正在组织回答 / Preparing the answer")
 
 			summary := action.GetString("summary")
 			if summary == "" {

--- a/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_search.go
@@ -40,7 +40,7 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 		desc, toolOpts,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
 			loop.Set("search_mode", mode)
-			loop.LoadingStatus(fmt.Sprintf("验证参数中 - search_knowledge:%s / validating parameters - mode:%s", mode, mode))
+			loop.LoadingStatus("正在确认查找方向 / Confirming the search direction")
 			knowledgeBases := action.GetStringSlice("knowledge_bases")
 			if len(knowledgeBases) == 0 {
 				// 使用初始化阶段加载的知识库
@@ -253,7 +253,7 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 			// loop.Set("all_compressed_results", allResults)
 
 			// 使用 LiteForge 评估下一步行动
-			loop.LoadingStatus("评估搜索结果与下一步计划 - evaluating next steps")
+			loop.LoadingStatus("正在判断现有信息是否足够 / Checking whether the available information is sufficient")
 			evalResult := evaluateNextSearch(ctx, invoker, loop, userQuery, queryToUse, compressedResult, searchCount)
 			if evalResult.Finished {
 				// 知识收集已完成，保存总结并退出循环

--- a/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_knowledge_enhance/action_search.go
@@ -40,7 +40,7 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 		desc, toolOpts,
 		func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
 			loop.Set("search_mode", mode)
-			loop.LoadingStatus("正在确认查找方向 / Confirming the search direction")
+			loop.UserStatus("正在确认查找方向", "Confirming the search direction")
 			knowledgeBases := action.GetStringSlice("knowledge_bases")
 			if len(knowledgeBases) == 0 {
 				// 使用初始化阶段加载的知识库
@@ -84,7 +84,7 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 				}
 			}
 
-			loop.LoadingStatus(fmt.Sprintf("执行搜索中 - search_knowledge:%s / executing search - mode:%s", mode, mode))
+			loop.UserStatus("正在搜索相关知识", "Searching relevant knowledge")
 
 			knowledgeBases := action.GetStringSlice("knowledge_bases")
 			// 如果未提供 knowledge_bases，使用初始化阶段加载的知识库
@@ -122,7 +122,7 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 			}
 
 			emitter := loop.GetEmitter()
-			loop.LoadingStatus(fmt.Sprintf("查询知识库中 - querying: %s", queryToUse))
+			loop.UserStatus("正在查询知识库", "Searching the knowledge base")
 
 			// 根据搜索模式确定 EnhancePlan
 			var enhancePlans []string
@@ -156,13 +156,13 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 				return
 			}
 
-			loop.LoadingStatus("已获取结果，准备压缩 - result fetched, preparing to compress")
+			loop.UserStatus("已找到相关内容，正在提炼重点", "Relevant content found; extracting the key points")
 
 			// 压缩搜索结果
 			singleResult := fmt.Sprintf("=== 查询: %s ===\n%s", queryToUse, enhanceData)
 			_ = singleResult
 
-			loop.LoadingStatus("压缩搜索结果中 - compressing search result")
+			loop.UserStatus("正在提炼搜索结果", "Refining the search results")
 			log.Infof("query result size: %d bytes\n=====================\n%v\n=====================\n", len(enhanceData), enhanceData)
 			compressedResult, err := invoker.CompressLongTextWithDestination(ctx, enhanceData, queryToUse, 10*1024)
 			if err != nil {
@@ -184,7 +184,7 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 				op.Continue()
 				return
 			}
-			loop.LoadingStatus("压缩完成 - compression done")
+			loop.UserStatus("搜索结果已整理完成", "The search results are ready")
 			log.Infof("query result size: %d bytes\n=====================\n%v\n=====================\n", len(compressedResult), compressedResult)
 
 			// 将新知识记录
@@ -253,7 +253,7 @@ func makeSearchAction(r aicommon.AIInvokeRuntime, mode string) reactloops.ReActL
 			// loop.Set("all_compressed_results", allResults)
 
 			// 使用 LiteForge 评估下一步行动
-			loop.LoadingStatus("正在判断现有信息是否足够 / Checking whether the available information is sufficient")
+			loop.UserStatus("正在判断现有信息是否足够", "Checking whether the available information is sufficient")
 			evalResult := evaluateNextSearch(ctx, invoker, loop, userQuery, queryToUse, compressedResult, searchCount)
 			if evalResult.Finished {
 				// 知识收集已完成，保存总结并退出循环

--- a/common/ai/aid/aireact/reactloops/loop_plan/action_direct_plan.go
+++ b/common/ai/aid/aireact/reactloops/loop_plan/action_direct_plan.go
@@ -22,7 +22,7 @@ var generateDirectPlan = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOp
 				}
 			}
 
-			reactloops.EmitStatus(loop, "正在直接生成任务计划... / Generating direct plan...")
+			reactloops.EmitStatusI18n(loop, "正在直接生成任务计划...", "Generating direct plan...")
 			planData := generateDirectPlanFromUserInput(loop, task)
 			if planData == "" {
 				op.Fail("failed to generate direct plan from user input")

--- a/common/ai/aid/aireact/reactloops/loop_plan/action_file_ops.go
+++ b/common/ai/aid/aireact/reactloops/loop_plan/action_file_ops.go
@@ -30,7 +30,7 @@ func makeToolForwardAction(
 				}
 
 				reactloops.EmitActionLog(loop, planFileOpsNodeID, fmt.Sprintf("开始: %s / Start: %s", actionName, targetToolName))
-				reactloops.EmitStatus(loop, "文件检索中 / Running file operation...")
+				reactloops.EmitStatusI18n(loop, "文件检索中", "Running file operation...")
 
 				params := action.GetParams()
 				result, _, err := invoker.ExecuteToolRequiredAndCallWithoutRequired(ctx, targetToolName, params)
@@ -55,7 +55,7 @@ func makeToolForwardAction(
 				)
 
 				op.Feedback(fmt.Sprintf("%s completed (%d bytes)", targetToolName, len(content)))
-				reactloops.EmitStatus(loop, "完成 / Complete")
+				reactloops.EmitStatusI18n(loop, "完成", "Complete")
 				reactloops.EmitActionLog(loop, planFileOpsNodeID, fmt.Sprintf("完成: %s (%d bytes) / Done: %s (%d bytes)", actionName, len(content), targetToolName, len(content)))
 				op.Continue()
 			},

--- a/common/ai/aid/aireact/reactloops/loop_plan/action_recon.go
+++ b/common/ai/aid/aireact/reactloops/loop_plan/action_recon.go
@@ -49,7 +49,7 @@ func makeReconRequireAction(
 					invoker.AddToTimeline(actionName+"_intent", thought)
 				}
 				reactloops.EmitActionLog(loop, planReconNodeID, fmt.Sprintf("开始: %s / Start: %s", actionName, targetToolName))
-				reactloops.EmitStatus(loop, "执行侦察工具中 / Executing recon tool...")
+				reactloops.EmitStatusI18n(loop, "执行侦察工具中", "Executing recon tool...")
 
 				result, directly, err := invoker.ExecuteToolRequiredAndCall(ctx, targetToolName)
 				if err != nil {
@@ -101,7 +101,7 @@ func makeReconRequireAction(
 					fmt.Sprintf("[%s] %s\n\n%s", targetToolName, thoughtHint, utils.ShrinkString(content, 2048)))
 
 				op.Feedback(fmt.Sprintf("%s completed: '%s'", actionName, thoughtHint))
-				reactloops.EmitStatus(loop, "完成 / Complete")
+				reactloops.EmitStatusI18n(loop, "完成", "Complete")
 				reactloops.EmitActionLog(loop, planReconNodeID, fmt.Sprintf("完成: %s (%d bytes) / Done: %s (%d bytes)", actionName, len(content), targetToolName, len(content)))
 				op.Continue()
 			},

--- a/common/ai/aid/aireact/reactloops/loop_plan/action_web_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_plan/action_web_search.go
@@ -42,7 +42,7 @@ var webSearchAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 				query = action.GetString("search_query")
 			}
 			reactloops.EmitActionLog(loop, planWebSearchNodeID, fmt.Sprintf("开始: %s / Start: %s", query, query))
-			reactloops.EmitStatus(loop, "联网搜索中 / Searching the web...")
+			reactloops.EmitStatusI18n(loop, "联网搜索中", "Searching the web...")
 
 			params := aitool.InvokeParams{"query": query}
 			result, _, err := invoker.ExecuteToolRequiredAndCallWithoutRequired(ctx, "web_search", params)
@@ -80,7 +80,7 @@ var webSearchAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 				fmt.Sprintf("Web search: %s\n\n%s", query, utils.ShrinkString(content, 2048)))
 
 			op.Feedback(fmt.Sprintf("web search completed for: '%s'", query))
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, planWebSearchNodeID, fmt.Sprintf("完成: %s (%d bytes) / Done: %s (%d bytes)", query, len(content), query, len(content)))
 			op.Continue()
 		},

--- a/common/ai/aid/aireact/reactloops/loop_plan/generate_document_and_plan.go
+++ b/common/ai/aid/aireact/reactloops/loop_plan/generate_document_and_plan.go
@@ -54,7 +54,7 @@ func generateGuidanceDocument(loop *reactloops.ReActLoop, task aicommon.AIStatef
 		return ""
 	}
 
-	reactloops.EmitStatus(loop, "正在生成任务执行指导文档... / Generating guidance document...")
+	reactloops.EmitStatusI18n(loop, "正在生成任务执行指导文档...", "Generating guidance document...")
 
 	taskIndex := ""
 	if task != nil {
@@ -140,7 +140,7 @@ func generatePlanFromDocument(loop *reactloops.ReActLoop, task aicommon.AIStatef
 		return ""
 	}
 
-	reactloops.EmitStatus(loop, "正在生成任务计划... / Generating execution plan...")
+	reactloops.EmitStatusI18n(loop, "正在生成任务计划...", "Generating execution plan...")
 
 	taskIndex := ""
 	if task != nil {

--- a/common/ai/aid/aireact/reactloops/loop_plan/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_plan/init.go
@@ -16,7 +16,7 @@ func buildPlanInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLo
 		config := r.GetConfig()
 
 		if !config.GetConfigBool("DisableIntentRecognition") {
-			reactloops.EmitStatus(loop, "深度意图识别中 / Deep intent recognition...")
+			reactloops.EmitStatusI18n(loop, "深度意图识别中", "Deep intent recognition...")
 			log.Infof("plan: invoking deep intent recognition directly")
 
 			capabilityNameMatches := reactloops.MatchCapabilitiesByTextWithConfig(r.GetConfig(), task.GetUserInput())

--- a/common/ai/aid/aireact/reactloops/loop_report_generating/action_grep_reference.go
+++ b/common/ai/aid/aireact/reactloops/loop_report_generating/action_grep_reference.go
@@ -69,7 +69,7 @@ var grepReferenceAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopO
 
 			startLog := fmt.Sprintf("检索参考: pattern='%s', file=%s", pattern, filePath)
 			reactloops.EmitActionLog(loop, grepReferenceNodeID, startLog)
-			reactloops.EmitStatus(loop, "正在查找报告所需的参考内容 / Finding reference material for the report")
+			reactloops.EmitStatusI18n(loop, "正在查找报告所需的参考内容", "Finding reference material for the report")
 
 			log.Infof("grep_reference: searching pattern '%s' in file %s (context=%d, case_insensitive=%v)",
 				pattern, filePath, contextLines, caseInsensitive)
@@ -196,7 +196,7 @@ var grepReferenceAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopO
 			op.Feedback(feedback)
 
 			finishLog := fmt.Sprintf("完成: %d 个匹配, pattern='%s'", len(results), pattern)
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 			reactloops.EmitActionLog(loop, grepReferenceNodeID, finishLog, reference)
 
 			log.Infof("grep_reference: completed, %d matches added to collected references", len(results))

--- a/common/ai/aid/aireact/reactloops/loop_report_generating/action_grep_reference.go
+++ b/common/ai/aid/aireact/reactloops/loop_report_generating/action_grep_reference.go
@@ -69,7 +69,7 @@ var grepReferenceAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoopO
 
 			startLog := fmt.Sprintf("检索参考: pattern='%s', file=%s", pattern, filePath)
 			reactloops.EmitActionLog(loop, grepReferenceNodeID, startLog)
-			reactloops.EmitStatus(loop, "检索参考文件中 / Grep searching reference...")
+			reactloops.EmitStatus(loop, "正在查找报告所需的参考内容 / Finding reference material for the report")
 
 			log.Infof("grep_reference: searching pattern '%s' in file %s (context=%d, case_insensitive=%v)",
 				pattern, filePath, contextLines, caseInsensitive)

--- a/common/ai/aid/aireact/reactloops/loop_report_generating/action_read_reference.go
+++ b/common/ai/aid/aireact/reactloops/loop_report_generating/action_read_reference.go
@@ -49,7 +49,7 @@ var readReferenceFileAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActL
 				startLog = fmt.Sprintf("读取参考文件: %s (lines %d-%d)", filePath, startLine, endLine)
 			}
 			reactloops.EmitActionLog(loop, readReferenceNodeID, startLog)
-			reactloops.EmitStatus(loop, "读取参考文件中 / Reading reference file...")
+			reactloops.EmitStatusI18n(loop, "读取参考文件中", "Reading reference file...")
 
 			log.Infof("read_reference_file: reading file %s (lines %d-%d)", filePath, startLine, endLine)
 
@@ -113,7 +113,7 @@ var readReferenceFileAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActL
 				filePath, len(resultContent), len(lines), summary)
 			op.Feedback(feedback)
 
-			reactloops.EmitStatus(loop, "完成 / Complete")
+			reactloops.EmitStatusI18n(loop, "完成", "Complete")
 
 			log.Infof("read_reference_file: completed, added to collected references")
 		},

--- a/common/ai/aid/aireact/reactloops/loop_report_generating/init_task.go
+++ b/common/ai/aid/aireact/reactloops/loop_report_generating/init_task.go
@@ -76,7 +76,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 	return func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
 		userInput := task.GetUserInput()
 
-		reactloops.EmitStatus(loop, "初始化报告任务... / Initializing report task...")
+		reactloops.EmitStatus(loop, "正在准备这份报告 / Preparing the report")
 		log.Infof("report_generating init task: analyzing user requirements")
 
 		// Step 1: 解析用户输入，确定输出文件路径和参考资料
@@ -107,7 +107,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		// Step 2: 使用 LiteForge 分析用户意图
 		isModifyExisting := false
 		if outputFilename == "" {
-			reactloops.EmitStatus(loop, "分析用户需求... / Analyzing user requirements...")
+			reactloops.EmitStatus(loop, "正在了解报告重点 / Understanding the report's focus")
 			isModify, targetFile, err := analyzeUserIntent(task.GetContext(), r, userInput, referenceFiles)
 			if err == nil {
 				isModifyExisting = isModify
@@ -216,7 +216,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 			"Report task initialized: %s, output=%s (%d bytes), ref_files=%d, knowledge_bases=%d",
 			modeDescription, outputFilename, len(existingContent), len(referenceFiles), len(knowledgeBases)))
 
-		reactloops.EmitStatus(loop, "报告任务就绪 / Report task ready")
+		reactloops.EmitStatus(loop, "已经明确报告重点，正在开始整理 / The report focus is clear; starting to organize it")
 
 		log.Infof("report_generating init completed: filename=%s, is_modify=%v, existing_content=%d bytes, references=%d, kbs=%d",
 			outputFilename, isModifyExisting, len(existingContent), len(referenceFiles), len(knowledgeBases))

--- a/common/ai/aid/aireact/reactloops/loop_report_generating/init_task.go
+++ b/common/ai/aid/aireact/reactloops/loop_report_generating/init_task.go
@@ -76,7 +76,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 	return func(loop *reactloops.ReActLoop, task aicommon.AIStatefulTask, operator *reactloops.InitTaskOperator) {
 		userInput := task.GetUserInput()
 
-		reactloops.EmitStatus(loop, "正在准备这份报告 / Preparing the report")
+		reactloops.EmitStatusI18n(loop, "正在准备这份报告", "Preparing the report")
 		log.Infof("report_generating init task: analyzing user requirements")
 
 		// Step 1: 解析用户输入，确定输出文件路径和参考资料
@@ -107,7 +107,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		// Step 2: 使用 LiteForge 分析用户意图
 		isModifyExisting := false
 		if outputFilename == "" {
-			reactloops.EmitStatus(loop, "正在了解报告重点 / Understanding the report's focus")
+			reactloops.EmitStatusI18n(loop, "正在了解报告重点", "Understanding the report's focus")
 			isModify, targetFile, err := analyzeUserIntent(task.GetContext(), r, userInput, referenceFiles)
 			if err == nil {
 				isModifyExisting = isModify
@@ -216,7 +216,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 			"Report task initialized: %s, output=%s (%d bytes), ref_files=%d, knowledge_bases=%d",
 			modeDescription, outputFilename, len(existingContent), len(referenceFiles), len(knowledgeBases)))
 
-		reactloops.EmitStatus(loop, "已经明确报告重点，正在开始整理 / The report focus is clear; starting to organize it")
+		reactloops.EmitStatusI18n(loop, "已经明确报告重点，正在开始整理", "The report focus is clear; starting to organize it")
 
 		log.Infof("report_generating init completed: filename=%s, is_modify=%v, existing_content=%d bytes, references=%d, kbs=%d",
 			outputFilename, isModifyExisting, len(existingContent), len(referenceFiles), len(knowledgeBases))

--- a/common/ai/aid/aireact/reactloops/loop_smart_qa/action_file_ops.go
+++ b/common/ai/aid/aireact/reactloops/loop_smart_qa/action_file_ops.go
@@ -29,7 +29,10 @@ func makeToolForwardAction(
 					ctx = task.GetContext()
 				}
 
-				loop.LoadingStatus(fmt.Sprintf("calling tool: %s", targetToolName))
+				loop.UserStatus(
+					fmt.Sprintf("正在调用工具「%s」", targetToolName),
+					fmt.Sprintf("Calling tool %q", targetToolName),
+				)
 
 				params := action.GetParams()
 				result, _, err := invoker.ExecuteToolRequiredAndCallWithoutRequired(ctx, targetToolName, params)

--- a/common/ai/aid/aireact/reactloops/loop_smart_qa/action_final_answer.go
+++ b/common/ai/aid/aireact/reactloops/loop_smart_qa/action_final_answer.go
@@ -37,7 +37,7 @@ func makeFinalAnswerAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOptio
 			return nil
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
-			loop.LoadingStatus("preparing final answer")
+			loop.UserStatus("正在组织回答", "Preparing the answer")
 
 			answer := strings.TrimSpace(action.GetString("answer"))
 			if answer == "" {

--- a/common/ai/aid/aireact/reactloops/loop_smart_qa/action_knowledge_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_smart_qa/action_knowledge_search.go
@@ -69,7 +69,12 @@ func makeKnowledgeSearchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopO
 				ctx = task.GetContext()
 			}
 
-			loop.LoadingStatus(fmt.Sprintf("searching knowledge base: %s", searchQuery))
+			loop.UserStatus(
+				"正在查找相关知识",
+				"Searching the relevant knowledge",
+				aicommon.WithStatusCode("answer.knowledge.searching"),
+				aicommon.WithStatusDetail(fmt.Sprintf("正在查找与「%s」相关的内容", searchQuery), fmt.Sprintf("Looking for information about %q", searchQuery)),
+			)
 
 			var enhancePlans []string
 			if mode == "keyword" {

--- a/common/ai/aid/aireact/reactloops/loop_smart_qa/action_memory_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_smart_qa/action_memory_search.go
@@ -63,7 +63,12 @@ func makeMemorySearchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 			}
 
 			invoker := loop.GetInvoker()
-			loop.LoadingStatus(fmt.Sprintf("searching persistent memory: %s (mode: %s)", query, searchMode))
+			loop.UserStatus(
+				"正在回顾相关信息",
+				"Reviewing relevant information",
+				aicommon.WithStatusCode("answer.memory.searching"),
+				aicommon.WithStatusDetail(fmt.Sprintf("正在回顾与「%s」相关的内容", query), fmt.Sprintf("Reviewing information about %q", query)),
+			)
 
 			memTriage := loop.GetMemoryTriage()
 			if utils.IsNil(memTriage) {

--- a/common/ai/aid/aireact/reactloops/loop_smart_qa/action_web_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_smart_qa/action_web_search.go
@@ -35,7 +35,12 @@ func makeWebSearchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOption 
 			if query == "" {
 				query = action.GetString("search_query")
 			}
-			loop.LoadingStatus(fmt.Sprintf("searching internet: %s", query))
+			loop.UserStatus(
+				"正在查找最新资料",
+				"Searching for up-to-date information",
+				aicommon.WithStatusCode("answer.web.searching"),
+				aicommon.WithStatusDetail(fmt.Sprintf("本轮关注：%s", query), fmt.Sprintf("Current focus: %s", query)),
+			)
 
 			params := aitool.InvokeParams{"query": query}
 			result, _, err := invoker.ExecuteToolRequiredAndCallWithoutRequired(ctx, "web_search", params)

--- a/common/ai/aid/aireact/reactloops/loop_syntaxflow_rule/init_task.go
+++ b/common/ai/aid/aireact/reactloops/loop_syntaxflow_rule/init_task.go
@@ -117,7 +117,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime, docSearcher *ziputil.ZipGrepSearc
 			forgeOptions = append(forgeOptions, aicommon.WithGeneralConfigStreamableFieldWithNodeId("init-search-rule-sample", "reason"))
 		}
 
-		reactloops.EmitStatus(loop, "开始分析用户需求... / Analyzing user requirements...")
+		reactloops.EmitStatusI18n(loop, "开始分析用户需求...", "Analyzing user requirements...")
 		step1Result, err := r.InvokeSpeedPriorityLiteForge(
 			task.GetContext(),
 			"analyze-requirement-and-search",
@@ -243,7 +243,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime, docSearcher *ziputil.ZipGrepSearc
 
 		if docSearcher != nil && len(searchPatterns) > 0 {
 			log.Infof("init task step 2.1: grep searching rule samples with %d patterns", len(searchPatterns))
-			reactloops.EmitStatus(loop, "开始搜索相关规则样例... / Searching for relevant rule examples...")
+			reactloops.EmitStatusI18n(loop, "开始搜索相关规则样例...", "Searching for relevant rule examples...")
 
 			var grepResults strings.Builder
 			searchedCount := 0
@@ -275,10 +275,11 @@ func buildInitTask(r aicommon.AIInvokeRuntime, docSearcher *ziputil.ZipGrepSearc
 				}
 
 				searchedCount++
-				reactloops.EmitStatus(loop, fmt.Sprintf(
-					"Grep 搜索 %d/%d / Grep search %d/%d",
-					searchedCount, patternTotal, searchedCount, patternTotal,
-				))
+				reactloops.EmitStatusI18n(
+					loop,
+					fmt.Sprintf("Grep 搜索 %d/%d", searchedCount, patternTotal),
+					fmt.Sprintf("Grep search %d/%d", searchedCount, patternTotal),
+				)
 
 				header := fmt.Sprintf("\n=== Grep Pattern: %s (Found %d matches) ===\n", pattern, len(results))
 				grepResults.WriteString(header)
@@ -335,10 +336,11 @@ func buildInitTask(r aicommon.AIInvokeRuntime, docSearcher *ziputil.ZipGrepSearc
 
 				log.Infof("semantic searching question %d/%d: %s", idx+1, len(semanticQuestions), question)
 				searchedQuestions++
-				reactloops.EmitStatus(loop, fmt.Sprintf(
-					"语义搜索 %d/%d / Semantic search %d/%d",
-					searchedQuestions, questionTotal, searchedQuestions, questionTotal,
-				))
+				reactloops.EmitStatusI18n(
+					loop,
+					fmt.Sprintf("语义搜索 %d/%d", searchedQuestions, questionTotal),
+					fmt.Sprintf("Semantic search %d/%d", searchedQuestions, questionTotal),
+				)
 
 				results, err := ragSearcher.QueryTopN(question, topN, scoreThreshold)
 				if err != nil {
@@ -461,9 +463,9 @@ func buildInitTask(r aicommon.AIInvokeRuntime, docSearcher *ziputil.ZipGrepSearc
 			}
 
 			if initialSamples != "" {
-				reactloops.EmitStatus(loop, "压缩样例中 / Compressing samples...")
+				reactloops.EmitStatusI18n(loop, "压缩样例中", "Compressing samples...")
 				summary, reference := reactloops.SpillLongContent(loop, "init_rule_samples", initialSamples)
-				reactloops.EmitStatus(loop, "样例准备完成 / Samples ready")
+				reactloops.EmitStatusI18n(loop, "样例准备完成", "Samples ready")
 				reactloops.EmitActionLog(loop, "init-search-rule-sample",
 					fmt.Sprintf("初始化规则样例: %s", utils.ByteSize(uint64(len(initialSamples)))),
 					reference,

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_grep_yaklang_samples.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_grep_yaklang_samples.go
@@ -351,7 +351,7 @@ grep_yaklang_samples(pattern="端口扫描|服务扫描", context_lines=25)
 
 			nodeID := "grep_yaklang_samples"
 			startLine := fmt.Sprintf("Grep 搜索: pattern=%s, case_sensitive=%v, context=%d", pattern, caseSensitive, contextLines)
-			reactloops.EmitStatus(loop, "正在定位相关代码样例 / Locating relevant code examples")
+			reactloops.EmitStatusI18n(loop, "正在定位相关代码样例", "Locating relevant code examples")
 
 			invoker.AddToTimeline("start_grep_yaklang_samples", startLine)
 
@@ -597,7 +597,7 @@ grep_yaklang_samples(pattern="端口扫描|服务扫描", context_lines=25)
 			if fullcode != "" {
 				errMsg, hasBlockingErrors := checkCodeAndFormatErrors(fullcode, loop.GetInt(loopinfra.LoopVarCodeLineBase))
 				if hasBlockingErrors {
-					reactloops.EmitStatus(loop, "检测到语法错误，修复中 / Syntax error detected, fixing...")
+					reactloops.EmitStatusI18n(loop, "检测到语法错误，修复中", "Syntax error detected, fixing...")
 					op.DisallowNextLoopExit()
 				}
 				if errMsg != "" {

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_grep_yaklang_samples.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_grep_yaklang_samples.go
@@ -351,7 +351,7 @@ grep_yaklang_samples(pattern="端口扫描|服务扫描", context_lines=25)
 
 			nodeID := "grep_yaklang_samples"
 			startLine := fmt.Sprintf("Grep 搜索: pattern=%s, case_sensitive=%v, context=%d", pattern, caseSensitive, contextLines)
-			reactloops.EmitStatus(loop, "Grep 搜索中 / Grep searching...")
+			reactloops.EmitStatus(loop, "正在定位相关代码样例 / Locating relevant code examples")
 
 			invoker.AddToTimeline("start_grep_yaklang_samples", startLine)
 

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_search_yaklang_samples.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_search_yaklang_samples.go
@@ -204,7 +204,7 @@ semantic_search_yaklang_samples(questions=["Yaklang中如何处理错误？", "Y
 
 			nodeID := "semantic_search_yaklang_samples"
 			startLine := fmt.Sprintf("语义搜索: %d 个问题, top_n=%d, threshold=%.2f", len(questions), topN, scoreThreshold)
-			reactloops.EmitStatus(loop, "语义搜索中 / Semantic searching...")
+			reactloops.EmitStatus(loop, "正在寻找最相关的代码样例 / Finding the most relevant code examples")
 
 			invoker.AddToTimeline("start_semantic_search_yaklang_samples", startLine)
 

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_search_yaklang_samples.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_search_yaklang_samples.go
@@ -204,7 +204,7 @@ semantic_search_yaklang_samples(questions=["Yaklang中如何处理错误？", "Y
 
 			nodeID := "semantic_search_yaklang_samples"
 			startLine := fmt.Sprintf("语义搜索: %d 个问题, top_n=%d, threshold=%.2f", len(questions), topN, scoreThreshold)
-			reactloops.EmitStatus(loop, "正在寻找最相关的代码样例 / Finding the most relevant code examples")
+			reactloops.EmitStatusI18n(loop, "正在寻找最相关的代码样例", "Finding the most relevant code examples")
 
 			invoker.AddToTimeline("start_semantic_search_yaklang_samples", startLine)
 
@@ -455,7 +455,7 @@ semantic_search_yaklang_samples(questions=["Yaklang中如何处理错误？", "Y
 			if fullcode != "" {
 				errMsg, hasBlockingErrors := checkCodeAndFormatErrors(fullcode, loop.GetInt(loopinfra.LoopVarCodeLineBase))
 				if hasBlockingErrors {
-					reactloops.EmitStatus(loop, "检测到语法错误，修复中 / Syntax error detected, fixing...")
+					reactloops.EmitStatusI18n(loop, "检测到语法错误，修复中", "Syntax error detected, fixing...")
 					op.DisallowNextLoopExit()
 				}
 				if errMsg != "" {

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_yakdoc.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/action_yakdoc.go
@@ -23,7 +23,7 @@ func yakdocActions(r aicommon.AIInvokeRuntime) []reactloops.ReActLoopOption {
 }
 
 func yakdocEmitStart(loop *reactloops.ReActLoop) {
-	reactloops.EmitStatus(loop, "查询 Yaklang 文档中 / Querying Yaklang Document...")
+	reactloops.EmitStatusI18n(loop, "查询 Yaklang 文档中", "Querying Yaklang Document...")
 }
 
 func yakdocHandleSuccess(

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/dependency_install.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/dependency_install.go
@@ -53,7 +53,7 @@ func ensureDependencies(
 			if s := createDocumentSearcher(""); s != nil {
 				holder.setGrep(s)
 				loop.Set("aikb_available", "true")
-				reactloops.EmitStatus(loop, "Yaklang 代码知识库就绪 / Yaklang code KB ready")
+				reactloops.EmitStatusI18n(loop, "Yaklang 代码知识库就绪", "Yaklang code KB ready")
 			} else {
 				log.Warnf("yaklang-aikb installed but grep searcher rebuild failed")
 			}
@@ -75,7 +75,7 @@ func ensureDependencies(
 			} else if ragSys != nil {
 				holder.setRAG(ragSys)
 				loop.Set("aikb_available", "true")
-				reactloops.EmitStatus(loop, "Yaklang 语义知识库就绪 / Yaklang semantic KB ready")
+				reactloops.EmitStatusI18n(loop, "Yaklang 语义知识库就绪", "Yaklang semantic KB ready")
 			}
 		}
 	}
@@ -98,7 +98,11 @@ func installThirdpartyBinWithProgress(
 		return true
 	}
 
-	reactloops.EmitStatus(loop, fmt.Sprintf("准备下载 %s ... / Preparing to download %s ...", displayName, name))
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("准备下载 %s …", displayName),
+		fmt.Sprintf("Preparing to download %s…", name),
+	)
 
 	lastPct := -1.0
 	opts := &thirdparty_bin.InstallOptions{
@@ -109,18 +113,23 @@ func installThirdpartyBinWithProgress(
 				return
 			}
 			lastPct = progress
-			reactloops.EmitStatus(loop, fmt.Sprintf(
-				"下载 %s %.0f%% / Downloading %s %.0f%%",
-				displayName, progress*100, name, progress*100,
-			))
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("正在下载 %s，进度 %.0f%%", displayName, progress*100),
+				fmt.Sprintf("Downloading %s: %.0f%%", name, progress*100),
+			)
+
 		},
 	}
 
 	if err := thirdparty_bin.Install(name, opts); err != nil {
 		log.Warnf("auto-install %s failed: %v (degraded mode)", name, err)
-		reactloops.EmitStatus(loop, fmt.Sprintf(
-			"%s 下载失败, 降级运行 / %s download failed, running in degraded mode", displayName, name,
-		))
+		reactloops.EmitStatusI18n(
+			loop,
+			fmt.Sprintf("%s 下载失败，将以兼容模式继续", displayName),
+			fmt.Sprintf("%s download failed; continuing in compatibility mode", name),
+		)
+
 		return false
 	}
 
@@ -161,7 +170,7 @@ func ensureYakSkillsInstalled(r aicommon.AIInvokeRuntime, loop *reactloops.ReAct
 		return
 	}
 	if !alreadyInstalled {
-		reactloops.EmitStatus(loop, "Yak 技能包就绪 / Yak skills pack ready")
+		reactloops.EmitStatusI18n(loop, "Yak 技能包就绪", "Yak skills pack ready")
 	}
 	log.Infof("yak-skills refreshed into skill loader from: %s", skillsDir)
 }

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/init_task.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/init_task.go
@@ -96,7 +96,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime, holder *searcherHolder, installCf
 				forgeOptions = append(forgeOptions, aicommon.WithGeneralConfigStreamableFieldWithNodeId("init-search-code-sample", "reason"))
 			}
 
-			reactloops.EmitStatus(loop, "开始分析用户需求... / Analyzing user requirements...")
+			reactloops.EmitStatusI18n(loop, "开始分析用户需求...", "Analyzing user requirements...")
 			step1Result, err := r.InvokeSpeedPriorityLiteForge(
 				task.GetContext(),
 				"analyze-requirement-and-search",
@@ -130,8 +130,13 @@ func buildInitTask(r aicommon.AIInvokeRuntime, holder *searcherHolder, installCf
 		if pinned := BuildPinnedAPISection(pinnedLibs); pinned != "" {
 			loop.Set("pinned_apis", pinned)
 			loop.Set("pinned_libraries", strings.Join(pinnedLibs, ","))
-			reactloops.EmitStatus(loop, fmt.Sprintf("已锁定核心库 API: %s / Pinned core library APIs: %s",
-				strings.Join(pinnedLibs, ", "), strings.Join(pinnedLibs, ", ")))
+			libraries := strings.Join(pinnedLibs, ", ")
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("已锁定核心库 API：%s", libraries),
+				fmt.Sprintf("Pinned core library APIs: %s", libraries),
+			)
+
 			log.Infof("pinned core library APIs for libs: %v (%d bytes)", pinnedLibs, len(pinned))
 		}
 		if dsl := BuildPinnedDSLSection(); dsl != "" {
@@ -161,7 +166,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime, holder *searcherHolder, installCf
 			// Step 2.1: Grep
 			if docSearcher != nil && len(searchPatterns) > 0 {
 				log.Infof("init task step 2.1: grep searching code samples with %d patterns", len(searchPatterns))
-				reactloops.EmitStatus(loop, "开始搜索相关代码样例... / Searching for relevant code examples...")
+				reactloops.EmitStatusI18n(loop, "开始搜索相关代码样例...", "Searching for relevant code examples...")
 
 				patternTotal := 0
 				for _, pattern := range searchPatterns {
@@ -192,10 +197,11 @@ func buildInitTask(r aicommon.AIInvokeRuntime, holder *searcherHolder, installCf
 					}
 
 					searchedCount++
-					reactloops.EmitStatus(loop, fmt.Sprintf(
-						"Grep 搜索 %d/%d / Grep search %d/%d",
-						searchedCount, patternTotal, searchedCount, patternTotal,
-					))
+					reactloops.EmitStatusI18n(
+						loop,
+						fmt.Sprintf("Grep 搜索 %d/%d", searchedCount, patternTotal),
+						fmt.Sprintf("Grep search %d/%d", searchedCount, patternTotal),
+					)
 
 					hits := GrepResultsToSampleHits(pattern, results, grepMaxHitsPerPattern)
 					allHits = append(allHits, hits...)
@@ -232,10 +238,11 @@ func buildInitTask(r aicommon.AIInvokeRuntime, holder *searcherHolder, installCf
 
 						log.Infof("semantic searching question %d/%d: %s", idx+1, len(semanticQuestions), question)
 						searchedQuestions++
-						reactloops.EmitStatus(loop, fmt.Sprintf(
-							"语义搜索 %d/%d / Semantic search %d/%d",
-							searchedQuestions, questionTotal, searchedQuestions, questionTotal,
-						))
+						reactloops.EmitStatusI18n(
+							loop,
+							fmt.Sprintf("语义搜索 %d/%d", searchedQuestions, questionTotal),
+							fmt.Sprintf("Semantic search %d/%d", searchedQuestions, questionTotal),
+						)
 
 						results, err := ragSearcher.QueryTopN(question, topN, scoreThreshold)
 						if err != nil {
@@ -291,7 +298,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime, holder *searcherHolder, installCf
 				searchQuery := searchQueryBuilder.String()
 
 				ctx := task.GetContext()
-				reactloops.EmitStatus(loop, "压缩样例中 / Compressing samples...")
+				reactloops.EmitStatusI18n(loop, "压缩样例中", "Compressing samples...")
 				initialSamples = FinalizeSearchResults(ctx, allHits, searchQuery, r)
 				log.Infof("initial samples finalized, hit count: %d, final size: %d bytes", len(allHits), len(initialSamples))
 
@@ -305,7 +312,7 @@ func buildInitTask(r aicommon.AIInvokeRuntime, holder *searcherHolder, installCf
 					loop.Set("init_search_manifest", manifest.JSON())
 					loop.Set("init_samples_ready", "true")
 
-					reactloops.EmitStatus(loop, "样例准备完成 / Samples ready")
+					reactloops.EmitStatusI18n(loop, "样例准备完成", "Samples ready")
 					summary, reference := reactloops.SpillLongContent(loop, "init_yaklang_samples", initialSamples)
 					reactloops.EmitActionLog(loop, "yaklang-init-search",
 						fmt.Sprintf("初始化代码样例: %s (%d 条命中) / Init code samples: %s (%d hits)",

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/run_code.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/run_code.go
@@ -304,10 +304,18 @@ func FormatMissingSelfTestFeedback(policy YakScriptRunPolicy) string {
 	return strings.TrimSpace(b.String())
 }
 
-// FormatRunSkippedStatus builds a short UI status when auto-run is intentionally skipped.
-func FormatRunSkippedStatus(policy YakScriptRunPolicy) string {
+// FormatRunSkippedStatusI18n builds localized UI statuses when auto-run is
+// intentionally skipped.
+func FormatRunSkippedStatusI18n(policy YakScriptRunPolicy) (zh, en string) {
 	if policy.SkipReason != "" {
-		return "跳过自测: " + policy.SkipReason + " / Skipped self-test"
+		return "跳过自测: " + policy.SkipReason, "Skipped self-test"
 	}
-	return "跳过自测（无 YAK_MAIN）/ Skipped self-test (no YAK_MAIN)"
+	return "跳过自测（无 YAK_MAIN）", "Skipped self-test (no YAK_MAIN)"
+}
+
+// FormatRunSkippedStatus preserves the historical bilingual string for logs
+// and callers that have not migrated to structured status events yet.
+func FormatRunSkippedStatus(policy YakScriptRunPolicy) string {
+	zh, en := FormatRunSkippedStatusI18n(policy)
+	return zh + " / " + en
 }

--- a/common/ai/aid/aireact/reactloops/loop_yaklangcode/run_hook.go
+++ b/common/ai/aid/aireact/reactloops/loop_yaklangcode/run_hook.go
@@ -75,7 +75,7 @@ func buildYaklangPostSyntaxCleanRunHook(r aicommon.AIInvokeRuntime, holder *sear
 			msg := fmt.Sprintf("YAK_MAIN self-test passed (%d bytes log)", len(result.Output))
 			r.AddToTimeline("run_passed", msg)
 			log.Infof("yaklang self-test passed: path=%s log_bytes=%d", absPath, len(result.Output))
-			reactloops.EmitStatus(loop, "运行自测通过 / Self-test passed")
+			reactloops.EmitStatusI18n(loop, "运行自测通过", "Self-test passed")
 			return "", false
 		}
 
@@ -102,7 +102,7 @@ func emitYaklangRunStart(loop *reactloops.ReActLoop, absPath string, policy YakS
 		absPath, kind, absPath, kind,
 	)
 	reactloops.EmitActionLog(loop, yaklangNodeRunSelfTest, startLine)
-	reactloops.EmitStatus(loop, "运行自测中 / Running self-test...")
+	reactloops.EmitStatusI18n(loop, "运行自测中", "Running self-test...")
 }
 
 func emitYaklangRunFinish(loop *reactloops.ReActLoop, absPath string, result YakRunResult, runErr error) {
@@ -132,9 +132,9 @@ func emitYaklangRunFinish(loop *reactloops.ReActLoop, absPath string, result Yak
 	}
 	reactloops.EmitActionLog(loop, yaklangNodeRunSelfTest, finishLine, reference)
 	if runErr == nil {
-		reactloops.EmitStatus(loop, "YAK_MAIN 自测通过 / Self-test passed")
+		reactloops.EmitStatusI18n(loop, "YAK_MAIN 自测通过", "Self-test passed")
 	} else {
-		reactloops.EmitStatus(loop, "运行自测失败，修复中 / Self-test failed, fixing...")
+		reactloops.EmitStatusI18n(loop, "运行自测失败，修复中", "Self-test failed, fixing...")
 	}
 }
 
@@ -144,7 +144,8 @@ func emitYaklangRunSkipped(loop *reactloops.ReActLoop, reason string) {
 	}
 	line := fmt.Sprintf("跳过自测: %s / Skipped self-test: %s", reason, reason)
 	reactloops.EmitActionLog(loop, yaklangNodeRunSelfTest, line)
-	reactloops.EmitStatus(loop, FormatRunSkippedStatus(YakScriptRunPolicy{SkipReason: reason}))
+	zh, en := FormatRunSkippedStatusI18n(YakScriptRunPolicy{SkipReason: reason})
+	reactloops.EmitStatusI18n(loop, zh, en)
 }
 
 func emitYaklangRunNeedSelfTest(loop *reactloops.ReActLoop, policy YakScriptRunPolicy) {
@@ -157,5 +158,5 @@ func emitYaklangRunNeedSelfTest(loop *reactloops.ReActLoop, policy YakScriptRunP
 		kind, kind,
 	)
 	reactloops.EmitActionLog(loop, yaklangNodeRunSelfTest, line)
-	reactloops.EmitStatus(loop, "需要 YAK_MAIN 自测块 / YAK_MAIN self-test required")
+	reactloops.EmitStatusI18n(loop, "需要 YAK_MAIN 自测块", "YAK_MAIN self-test required")
 }

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
@@ -406,7 +406,7 @@ var loopAction_directlyCallTool = &reactloops.LoopAction{
 
 		toolName := loop.Get("directly_call_tool_name")
 		if toolName == "" {
-			loopInfraStatus(loop, "没有找到要使用的工具")
+			loopInfraStatus(loop, "没有找到要使用的工具", "No suitable tool was found")
 			reportStatus(strings.TrimSpace(`
 Error: directly_call_tool_name is missing in loop state.
 Fast-path directly_call_tool failed before execution and cannot be recovered in-place because the target tool is unknown.
@@ -428,7 +428,7 @@ Few-shot example 2 (valid directly_call_tool):
 		_, lookupErr := loop.GetConfig().GetAiToolManager().GetToolByName(toolName)
 		if lookupErr != nil {
 			reportStatus(fmt.Sprintf("cached tool lookup failed for '%s': %v", toolName, lookupErr))
-			loopInfraStatus(loop, "当前工具暂时不可用，正在换一种方式继续")
+			loopInfraStatus(loop, "当前工具暂时不可用，正在换一种方式继续", "The current tool is unavailable; trying another approach")
 			msg := fmt.Sprintf("directly_call_tool cached tool lookup failed for '%s'; switch to @action=require_tool", toolName)
 			operator.Feedback(utils.Error(msg))
 			invoker.AddToTimeline("DIRECT_CALL_PARAMS", msg)

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_directly_call_tool.go
@@ -406,7 +406,7 @@ var loopAction_directlyCallTool = &reactloops.LoopAction{
 
 		toolName := loop.Get("directly_call_tool_name")
 		if toolName == "" {
-			loopInfraStatus(loop, "直接工具调用失败 / Direct Tool Call Failed")
+			loopInfraStatus(loop, "没有找到要使用的工具")
 			reportStatus(strings.TrimSpace(`
 Error: directly_call_tool_name is missing in loop state.
 Fast-path directly_call_tool failed before execution and cannot be recovered in-place because the target tool is unknown.
@@ -421,14 +421,14 @@ Few-shot example 2 (valid directly_call_tool):
 			operator.Feedback(utils.Error("directly_call_tool requires tool_name; switch to require_tool or provide directly_call_tool_name + directly_call_tool_params"))
 			return
 		}
-		loopInfraStatus(loop, "准备直接工具调用 / Preparing Direct Tool Call...")
+		emitToolsPreparingStatus(loop, []string{toolName})
 
 		// Pre-card unrecoverable branch: cached tool lookup failure cannot enter the
 		// "card already created" flow, so it stays here (before invoker.DirectlyCallTool).
 		_, lookupErr := loop.GetConfig().GetAiToolManager().GetToolByName(toolName)
 		if lookupErr != nil {
 			reportStatus(fmt.Sprintf("cached tool lookup failed for '%s': %v", toolName, lookupErr))
-			loopInfraStatus(loop, "缓存工具不可用 / Cached Tool Unavailable")
+			loopInfraStatus(loop, "当前工具暂时不可用，正在换一种方式继续")
 			msg := fmt.Sprintf("directly_call_tool cached tool lookup failed for '%s'; switch to @action=require_tool", toolName)
 			operator.Feedback(utils.Error(msg))
 			invoker.AddToTimeline("DIRECT_CALL_PARAMS", msg)
@@ -537,7 +537,13 @@ Few-shot example 2 (valid direct retry):
 `, toolName, validationSummary, toolName, toolName, toolName)))
 				finishProgress("[failed] params validation failed; falling back to require_tool")
 				reportStatus(fmt.Sprintf("auto fallback: switching '%s' from directly_call_tool to @action=require_tool because schema validation failed", toolName))
-				loopInfraStatus(loop, "参数校验失败，切换常规工具调用 / Params Invalid, Falling Back...")
+				reactloops.EmitStatusI18n(
+					loop,
+					"当前方式不太合适，正在调整调用方式",
+					"Adjusting the tool invocation approach",
+					aicommon.WithStatusCode("tool.adjusting"),
+					aicommon.WithStatusState(aicommon.StatusStateRecovering),
+				)
 				operator.Feedback(fmt.Sprintf("directly_call_tool params invalid for '%s': %s; automatically switching to @action=require_tool", toolName, validationSummary))
 				return nil, true, tool, nil
 			}
@@ -558,7 +564,14 @@ Few-shot example 2 (valid direct retry):
 			if ce := action.GetString("directly_call_expectations"); ce != "" {
 				params[aicommon.ReservedKeyCallExpectations] = ce
 			}
-			loopInfraStatus(loop, "直接工具调用参数已准备 / Direct Tool Params Ready")
+			tools := buildStatusTools(loop, []string{name}, aicommon.StatusStateRunning)
+			reactloops.EmitStatusI18n(
+				loop,
+				fmt.Sprintf("正在使用「%s」完成这一步", statusToolNames(tools, false)),
+				fmt.Sprintf("Using %s for this step", statusToolNames(tools, true)),
+				aicommon.WithStatusCode("tool.running"),
+				aicommon.WithStatusTools(tools...),
+			)
 			return params, false, tool, nil
 		}
 

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_load_capability.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_load_capability.go
@@ -92,7 +92,7 @@ func loadCapabilityHandler(loop *reactloops.ReActLoop, action *aicommon.Action, 
 	hasSkillAlt := strings.Contains(altTypesStr, string(aicommon.ResolvedAs_Skill))
 	loopInfraActionStart(loop, loopInfraNodeLoadCapability,
 		fmt.Sprintf("加载能力: %s (%s) / Load capability: %s (%s)", identifier, resolvedType, identifier, resolvedType),
-		"加载能力中 / Loading Capability...")
+		"正在加载能力", "Loading capability…")
 
 	switch resolvedType {
 	case aicommon.ResolvedAs_Tool:
@@ -175,7 +175,7 @@ func handleLoadForgeDisabled(
 			"You MUST use tools, skills, focus modes, or directly answer instead of starting a forge.",
 		identifier)
 	invoker.AddToTimeline("[LOAD_CAPABILITY_FORGE_DISABLED]", rejectMsg)
-	loopInfraStatus(loop, "蓝图加载被禁用 / Blueprint Disabled")
+	loopInfraStatus(loop, "蓝图加载被禁用", "Blueprint Disabled")
 	loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 		fmt.Sprintf("蓝图加载被禁用: %s / Blueprint Disabled: %s", identifier, identifier),
 		utils.ShrinkTextBlock(rejectMsg, 800))
@@ -202,7 +202,7 @@ func handleLoadForge(
 				"Wait for the current async task to complete, or take a different synchronous action.",
 			identifier)
 		invoker.AddToTimeline("[LOAD_CAPABILITY_FORGE_REJECTED]", rejectMsg)
-		loopInfraStatus(loop, "蓝图加载被拒绝 / Blueprint Rejected")
+		loopInfraStatus(loop, "蓝图加载被拒绝", "Blueprint Rejected")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("蓝图加载被拒绝: %s / Blueprint Rejected: %s", identifier, identifier),
 			utils.ShrinkTextBlock(rejectMsg, 800))
@@ -214,7 +214,7 @@ func handleLoadForge(
 	log.Infof("load_capability: dispatching '%s' as blueprint/forge", identifier)
 	invoker.AddToTimeline("[LOAD_CAPABILITY_FORGE]",
 		fmt.Sprintf("Starting AI Blueprint '%s'", identifier))
-	loopInfraStatus(loop, "蓝图已启动 / Blueprint Started")
+	loopInfraStatus(loop, "蓝图已启动", "Blueprint Started")
 	loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 		fmt.Sprintf("蓝图已启动: %s / Blueprint Started: %s", identifier, identifier))
 	recommendCapabilitiesFromForgePrompts(loop, invoker, identifier, "AI Blueprint "+identifier)
@@ -241,7 +241,7 @@ func handleLoadSkill(
 	mgr := loop.GetSkillsContextManager()
 	if mgr == nil {
 		invoker.AddToTimeline("[LOAD_CAPABILITY_SKILL_ERROR]", "skills context manager is not available")
-		loopInfraStatus(loop, "加载技能失败 / Load Skill Failed")
+		loopInfraStatus(loop, "加载技能失败", "Load Skill Failed")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("加载技能失败: %s / Load Skill Failed: %s", identifier, identifier),
 			"skills context manager is not available")
@@ -256,7 +256,7 @@ func handleLoadSkill(
 		viewSummary := mgr.GetSkillViewSummary(identifier)
 		invoker.AddToTimeline("skill_already_loaded",
 			fmt.Sprintf("Skill '%s' is already loaded", identifier))
-		loopInfraStatus(loop, "技能已加载 / Skill Already Loaded")
+		loopInfraStatus(loop, "技能已加载", "Skill Already Loaded")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("技能已加载: %s / Skill Already Loaded: %s", identifier, identifier),
 			utils.ShrinkTextBlock(viewSummary, 800))
@@ -273,7 +273,7 @@ func handleLoadSkill(
 		log.Warnf("load_capability: failed to load skill %q: %v", identifier, err)
 		errMsg := fmt.Sprintf("Failed to load skill '%s': %v", identifier, err)
 		invoker.AddToTimeline("[LOAD_CAPABILITY_SKILL_ERROR]", errMsg)
-		loopInfraStatus(loop, "加载技能失败 / Load Skill Failed")
+		loopInfraStatus(loop, "加载技能失败", "Load Skill Failed")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("加载技能失败: %s / Load Skill Failed: %s", identifier, identifier),
 			utils.ShrinkTextBlock(errMsg, 800))
@@ -292,7 +292,7 @@ func handleLoadSkill(
 	invoker.AddToTimeline("skill_loaded",
 		fmt.Sprintf("Successfully loaded skill '%s' into context. %s", identifier, viewSummary))
 	log.Infof("load_capability: skill %q loaded into context successfully", identifier)
-	loopInfraStatus(loop, "技能加载完成 / Skill Loaded")
+	loopInfraStatus(loop, "技能加载完成", "Skill Loaded")
 	loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 		fmt.Sprintf("技能加载完成: %s / Skill Loaded: %s", identifier, identifier),
 		utils.ShrinkTextBlock(viewSummary, 800))
@@ -364,7 +364,7 @@ func handleLoadFocusMode(
 				"Proceed with a different approach using your current context and available tools.",
 			identifier, err)
 		invoker.AddToTimeline("[LOAD_CAPABILITY_FOCUS_MODE_FAILED]", failMsg)
-		loopInfraStatus(loop, "专注模式执行失败 / Focus Mode Failed")
+		loopInfraStatus(loop, "专注模式执行失败", "Focus Mode Failed")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("专注模式执行失败: %s / Focus Mode Failed: %s", identifier, identifier),
 			utils.ShrinkTextBlock(failMsg, 800))
@@ -379,7 +379,7 @@ func handleLoadFocusMode(
 			"Its results are now part of your context. Proceed with your main task.",
 		identifier)
 	invoker.AddToTimeline("[LOAD_CAPABILITY_FOCUS_MODE_DONE]", successMsg)
-	loopInfraStatus(loop, "专注模式完成 / Focus Mode Complete")
+	loopInfraStatus(loop, "专注模式完成", "Focus Mode Complete")
 	loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 		fmt.Sprintf("专注模式完成: %s / Focus Mode Complete: %s", identifier, identifier))
 	op.Feedback(successMsg)
@@ -408,7 +408,7 @@ func handleLoadUnknown(
 				"or use a known tool/action directly. Repeating this call wastes iterations.",
 			identifier, identifier)
 		invoker.AddToTimeline("[LOAD_CAPABILITY_UNKNOWN_BLOCKED]", blockMsg)
-		loopInfraStatus(loop, "能力加载被阻止 / Capability Load Blocked")
+		loopInfraStatus(loop, "能力加载被阻止", "Capability Load Blocked")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("能力加载被阻止: %s / Capability Load Blocked: %s", identifier, identifier),
 			utils.ShrinkTextBlock(blockMsg, 800))
@@ -436,7 +436,7 @@ func handleLoadUnknown(
 				"Use search_capabilities with a descriptive query, or proceed with already-available tools.",
 			identifier, err, identifier)
 		invoker.AddToTimeline("[LOAD_CAPABILITY_SEARCH_FAILED]", failMsg)
-		loopInfraStatus(loop, "能力搜索失败 / Capability Search Failed")
+		loopInfraStatus(loop, "能力搜索失败", "Capability Search Failed")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("能力搜索失败: %s / Capability Search Failed: %s", identifier, identifier),
 			utils.ShrinkTextBlock(failMsg, 800))
@@ -452,7 +452,7 @@ func handleLoadUnknown(
 				"Do NOT retry. Use search_capabilities instead.",
 			identifier)
 		invoker.AddToTimeline("[LOAD_CAPABILITY_SEARCH_NIL]", failMsg)
-		loopInfraStatus(loop, "能力搜索无结果 / Capability Search Empty")
+		loopInfraStatus(loop, "能力搜索无结果", "Capability Search Empty")
 		loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 			fmt.Sprintf("能力搜索无结果: %s / Capability Search Empty: %s", identifier, identifier))
 		op.Feedback(failMsg)
@@ -504,7 +504,7 @@ func handleLoadUnknown(
 			reactloops.CompactCapabilityNames(matchedForgeNames, 2),
 			reactloops.CompactCapabilityNames(matchedSkillNames, 2),
 			identifier))
-	loopInfraStatus(loop, "能力候选已识别 / Capability Candidates Identified")
+	loopInfraStatus(loop, "能力候选已识别", "Capability Candidates Identified")
 	loopInfraActionFinish(loop, loopInfraNodeLoadCapability,
 		fmt.Sprintf("能力候选已识别: %s / Capability Candidates Identified: %s", identifier, identifier),
 		utils.ShrinkTextBlock(summary.String(), 800))

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_load_skill_resources.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_load_skill_resources.go
@@ -118,7 +118,7 @@ var loopAction_LoadSkillResources = &reactloops.LoopAction{
 			}
 			loopInfraActionStart(loop, loopInfraNodeLoadSkillResources,
 				fmt.Sprintf("搜索技能资源: pattern=%q scope=%s / Search skill resources: pattern=%q scope=%s", pattern, scope, pattern, scope),
-				"搜索技能资源 / Searching Skill Resources...")
+				"正在搜索技能资源", "Searching skill resources…")
 			handleGrepResource(mgr, invoker, loop, op)
 			return
 		}
@@ -134,7 +134,7 @@ var loopAction_LoadSkillResources = &reactloops.LoopAction{
 		}
 		loopInfraActionStart(loop, loopInfraNodeLoadSkillResources,
 			fmt.Sprintf("加载技能资源: %s / Load skill resource: %s", rawPath, rawPath),
-			"加载技能资源 / Loading Skill Resource...")
+			"正在加载技能资源", "Loading skill resource…")
 
 		if resourceType == "script" {
 			handleScriptResource(loop, mgr, invoker, skillName, filePath, rawPath, op)
@@ -156,7 +156,7 @@ func handleDocumentResource(
 		log.Warnf("failed to load skill resource %q: %v", rawPath, err)
 		errMsg := fmt.Sprintf("Failed to load resource '%s': %v", rawPath, err)
 		invoker.AddToTimeline("skill_resource_load_failed", errMsg)
-		loopInfraStatus(loop, "技能资源加载失败 / Skill Resource Load Failed")
+		loopInfraStatus(loop, "技能资源加载失败", "Skill Resource Load Failed")
 		loopInfraActionFinish(loop, loopInfraNodeLoadSkillResources,
 			fmt.Sprintf("技能资源加载失败: %s / Skill Resource Load Failed: %s", rawPath, rawPath),
 			utils.ShrinkTextBlock(errMsg, 800))
@@ -175,7 +175,7 @@ func handleDocumentResource(
 		rawPath, summary, float64(result.ContentSize)/1024,
 	)
 	invoker.AddToTimeline("skill_resource_loaded", timelineMsg)
-	loopInfraStatus(loop, "技能资源加载完成 / Skill Resource Loaded")
+	loopInfraStatus(loop, "技能资源加载完成", "Skill Resource Loaded")
 	loopInfraActionFinish(loop, loopInfraNodeLoadSkillResources,
 		fmt.Sprintf("技能资源已加载: %s / Skill Resource Loaded: %s", rawPath, rawPath),
 		utils.ShrinkTextBlock(summary, 800))
@@ -209,7 +209,7 @@ func handleScriptResource(
 		log.Warnf("failed to load script resource %q: %v", rawPath, err)
 		errMsg := fmt.Sprintf("Failed to load script resource '%s': %v", rawPath, err)
 		invoker.AddToTimeline("skill_script_resource_load_failed", errMsg)
-		loopInfraStatus(loop, "脚本资源加载失败 / Script Resource Load Failed")
+		loopInfraStatus(loop, "脚本资源加载失败", "Script Resource Load Failed")
 		loopInfraActionFinish(loop, loopInfraNodeLoadSkillResources,
 			fmt.Sprintf("脚本资源加载失败: %s / Script Resource Load Failed: %s", rawPath, rawPath),
 			utils.ShrinkTextBlock(errMsg, 800))
@@ -230,7 +230,7 @@ func handleScriptResource(
 	}
 	timelineMsg += " Use this path directly in shell commands."
 	invoker.AddToTimeline("skill_script_resource_loaded", timelineMsg)
-	loopInfraStatus(loop, "脚本资源加载完成 / Script Resource Loaded")
+	loopInfraStatus(loop, "脚本资源加载完成", "Script Resource Loaded")
 	loopInfraActionFinish(loop, loopInfraNodeLoadSkillResources,
 		fmt.Sprintf("脚本资源已加载: %s / Script Resource Loaded: %s", rawPath, rawPath),
 		fmt.Sprintf("Absolute path: %s\n%s", result.AbsolutePath, utils.ShrinkTextBlock(summary, 800)))
@@ -275,7 +275,7 @@ func handleGrepResource(
 		log.Warnf("grep skill resources failed: %v", err)
 		errMsg := fmt.Sprintf("Grep failed for pattern %q: %v", pattern, err)
 		invoker.AddToTimeline("skill_grep_failed", errMsg)
-		loopInfraStatus(loop, "技能资源搜索失败 / Skill Resource Search Failed")
+		loopInfraStatus(loop, "技能资源搜索失败", "Skill Resource Search Failed")
 		loopInfraActionFinish(loop, loopInfraNodeLoadSkillResources,
 			fmt.Sprintf("技能资源搜索失败: %s / Skill Resource Search Failed: %s", pattern, pattern),
 			utils.ShrinkTextBlock(errMsg, 800))
@@ -288,7 +288,7 @@ func handleGrepResource(
 	log.Infof("skill grep completed: %s", summary)
 
 	invoker.AddToTimeline("skill_grep_completed", summary)
-	loopInfraStatus(loop, "技能资源搜索完成 / Skill Resource Search Complete")
+	loopInfraStatus(loop, "技能资源搜索完成", "Skill Resource Search Complete")
 	loopInfraActionFinish(loop, loopInfraNodeLoadSkillResources,
 		fmt.Sprintf("技能资源搜索完成: %s / Skill Resource Search Complete: %s", pattern, pattern),
 		utils.ShrinkTextBlock(summary, 800))

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_query_mcp.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_query_mcp.go
@@ -59,11 +59,11 @@ var loopAction_QueryMCPServers = &reactloops.LoopAction{
 		offset, limit := parseMCPQueryOffsetLimit(action, defaultMCPServerQueryLimit)
 		loopInfraActionStart(loop, loopInfraNodeQueryMCPServers,
 			fmt.Sprintf("查询 MCP 服务器: keyword=%q offset=%d limit=%d / Query MCP servers: keyword=%q offset=%d limit=%d", keyword, offset, limit, keyword, offset, limit),
-			"查询 MCP 服务器 / Querying MCP Servers...")
+			"正在查询 MCP 服务器", "Querying MCP servers…")
 		feedback, pageCount, total, _, err := renderMCPServerQueryResult(keyword, offset, limit)
 		if err != nil {
 			log.Warnf("query_mcp_servers: query failed: %v", err)
-			loopInfraStatus(loop, "MCP 服务器查询失败 / MCP Server Query Failed")
+			loopInfraStatus(loop, "MCP 服务器查询失败", "MCP Server Query Failed")
 			loopInfraActionFinish(loop, loopInfraNodeQueryMCPServers,
 				"MCP 服务器查询失败 / MCP Server Query Failed",
 				utils.ShrinkTextBlock(err.Error(), 800))
@@ -74,7 +74,7 @@ var loopAction_QueryMCPServers = &reactloops.LoopAction{
 		if invoker != nil {
 			invoker.AddToTimeline("query_mcp_servers", fmt.Sprintf("已查询 MCP 服务器 %d/%d (offset=%d)", pageCount, total, offset))
 		}
-		loopInfraStatus(loop, "MCP 服务器查询完成 / MCP Server Query Complete")
+		loopInfraStatus(loop, "MCP 服务器查询完成", "MCP Server Query Complete")
 		loopInfraActionFinish(loop, loopInfraNodeQueryMCPServers,
 			fmt.Sprintf("MCP 服务器查询完成: %d/%d / MCP Server Query Complete: %d/%d", pageCount, total, pageCount, total))
 		operator.Feedback(feedback)
@@ -127,11 +127,11 @@ var loopAction_QueryMCPTools = &reactloops.LoopAction{
 		offset, limit := parseMCPQueryOffsetLimit(action, defaultMCPToolQueryLimit)
 		loopInfraActionStart(loop, loopInfraNodeQueryMCPTools,
 			fmt.Sprintf("查询 MCP 工具: server=%s offset=%d limit=%d / Query MCP tools: server=%s offset=%d limit=%d", serverName, offset, limit, serverName, offset, limit),
-			"查询 MCP 工具 / Querying MCP Tools...")
+			"正在查询 MCP 工具", "Querying MCP tools…")
 		feedback, pageCount, total, _, err := renderMCPToolQueryResult(serverName, offset, limit)
 		if err != nil {
 			log.Warnf("query_mcp_tools: query failed: %v", err)
-			loopInfraStatus(loop, "MCP 工具查询失败 / MCP Tool Query Failed")
+			loopInfraStatus(loop, "MCP 工具查询失败", "MCP Tool Query Failed")
 			loopInfraActionFinish(loop, loopInfraNodeQueryMCPTools,
 				"MCP 工具查询失败 / MCP Tool Query Failed",
 				utils.ShrinkTextBlock(err.Error(), 800))
@@ -142,7 +142,7 @@ var loopAction_QueryMCPTools = &reactloops.LoopAction{
 		if invoker != nil {
 			invoker.AddToTimeline("query_mcp_tools", fmt.Sprintf("已查询 MCP 工具 %d/%d (offset=%d)", pageCount, total, offset))
 		}
-		loopInfraStatus(loop, "MCP 工具查询完成 / MCP Tool Query Complete")
+		loopInfraStatus(loop, "MCP 工具查询完成", "MCP Tool Query Complete")
 		loopInfraActionFinish(loop, loopInfraNodeQueryMCPTools,
 			fmt.Sprintf("MCP 工具查询完成: %d/%d / MCP Tool Query Complete: %d/%d", pageCount, total, pageCount, total))
 		operator.Feedback(feedback)

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
@@ -96,7 +96,7 @@ Example - Sequential file operations(With AI-Tag tags):
 	<|WORKFLOW_DAG_END_{{.Nonce}}|>
 `,
 	ActionVerifier: func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
-		loopInfraStatus(loop, "解析工具编排 / Parsing Tool Compose...")
+		loopInfraStatus(loop, "正在安排多个工具协同工作 / Coordinating multiple tools for this task")
 		action.WaitStream(loop.GetCurrentTask().GetContext())
 
 		payload := action.GetString("tool_compose_payload")
@@ -166,9 +166,9 @@ Example - Sequential file operations(With AI-Tag tags):
 		if err != nil {
 			errMsg := fmt.Sprintf("Failed to build tool compose DAG: %v", err)
 			invoker.AddToTimeline("[TOOL_COMPOSE_ERROR]", errMsg)
-			loopInfraStatus(loop, "工具编排失败 / Tool Compose Failed")
+			loopInfraStatus(loop, "这组工具暂时没能顺利配合 / The tool sequence could not be prepared")
 			loopInfraActionFinish(loop, loopInfraNodeToolCompose,
-				"工具编排解析失败 / Tool Compose Build Failed",
+				"暂时没能安排好这组工具 / Unable to prepare the tool sequence",
 				utils.ShrinkTextBlock(errMsg, 800))
 			operator.Feedback(utils.Error(errMsg))
 			operator.Continue()
@@ -247,9 +247,9 @@ Example - Sequential file operations(With AI-Tag tags):
 		if err != nil {
 			errMsg := fmt.Sprintf("Tool compose DAG execution failed: %v", err)
 			invoker.AddToTimeline("[TOOL_COMPOSE_FAILED]", errMsg)
-			loopInfraStatus(loop, "工具编排执行失败 / Tool Compose Execution Failed")
+			loopInfraStatus(loop, "这组工具暂时没能完成任务 / The tool sequence could not complete the task")
 			loopInfraActionFinish(loop, loopInfraNodeToolCompose,
-				"工具编排执行失败 / Tool Compose Execution Failed",
+				"这组工具暂时没能完成任务 / The tool sequence could not complete the task",
 				utils.ShrinkTextBlock(errMsg, 800))
 			operator.Feedback(utils.Error(errMsg))
 			operator.Continue()
@@ -270,9 +270,9 @@ Example - Sequential file operations(With AI-Tag tags):
 
 		invoker.AddToTimeline("[TOOL_COMPOSE_COMPLETE]",
 			fmt.Sprintf("All tool calls completed. Results: %v", resultSummary))
-		loopInfraStatus(loop, "工具编排完成 / Tool Compose Complete")
+		loopInfraStatus(loop, "多个工具已经协同完成这一步 / The tools completed this step together")
 		loopInfraActionFinish(loop, loopInfraNodeToolCompose,
-			fmt.Sprintf("工具编排完成: %d nodes / Tool Compose Complete: %d nodes", len(resultSummary), len(resultSummary)),
+			fmt.Sprintf("多个工具已经协同完成这一步（%d 项） / The tools completed this step together (%d items)", len(resultSummary), len(resultSummary)),
 			strings.Join(resultSummary, "\n"))
 
 		// Verify user satisfaction

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_tool_compose.go
@@ -96,7 +96,7 @@ Example - Sequential file operations(With AI-Tag tags):
 	<|WORKFLOW_DAG_END_{{.Nonce}}|>
 `,
 	ActionVerifier: func(loop *reactloops.ReActLoop, action *aicommon.Action) error {
-		loopInfraStatus(loop, "正在安排多个工具协同工作 / Coordinating multiple tools for this task")
+		loopInfraStatus(loop, "正在安排多个工具协同工作", "Coordinating multiple tools for this task")
 		action.WaitStream(loop.GetCurrentTask().GetContext())
 
 		payload := action.GetString("tool_compose_payload")
@@ -166,7 +166,7 @@ Example - Sequential file operations(With AI-Tag tags):
 		if err != nil {
 			errMsg := fmt.Sprintf("Failed to build tool compose DAG: %v", err)
 			invoker.AddToTimeline("[TOOL_COMPOSE_ERROR]", errMsg)
-			loopInfraStatus(loop, "这组工具暂时没能顺利配合 / The tool sequence could not be prepared")
+			loopInfraStatus(loop, "这组工具暂时没能顺利配合", "The tool sequence could not be prepared")
 			loopInfraActionFinish(loop, loopInfraNodeToolCompose,
 				"暂时没能安排好这组工具 / Unable to prepare the tool sequence",
 				utils.ShrinkTextBlock(errMsg, 800))
@@ -247,7 +247,7 @@ Example - Sequential file operations(With AI-Tag tags):
 		if err != nil {
 			errMsg := fmt.Sprintf("Tool compose DAG execution failed: %v", err)
 			invoker.AddToTimeline("[TOOL_COMPOSE_FAILED]", errMsg)
-			loopInfraStatus(loop, "这组工具暂时没能完成任务 / The tool sequence could not complete the task")
+			loopInfraStatus(loop, "这组工具暂时没能完成任务", "The tool sequence could not complete the task")
 			loopInfraActionFinish(loop, loopInfraNodeToolCompose,
 				"这组工具暂时没能完成任务 / The tool sequence could not complete the task",
 				utils.ShrinkTextBlock(errMsg, 800))
@@ -270,7 +270,7 @@ Example - Sequential file operations(With AI-Tag tags):
 
 		invoker.AddToTimeline("[TOOL_COMPOSE_COMPLETE]",
 			fmt.Sprintf("All tool calls completed. Results: %v", resultSummary))
-		loopInfraStatus(loop, "多个工具已经协同完成这一步 / The tools completed this step together")
+		loopInfraStatus(loop, "多个工具已经协同完成这一步", "The tools completed this step together")
 		loopInfraActionFinish(loop, loopInfraNodeToolCompose,
 			fmt.Sprintf("多个工具已经协同完成这一步（%d 项） / The tools completed this step together (%d items)", len(resultSummary), len(resultSummary)),
 			strings.Join(resultSummary, "\n"))

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_tool_require_and_call.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_tool_require_and_call.go
@@ -69,7 +69,7 @@ var loopAction_toolRequireAndCall = &reactloops.LoopAction{
 			ctx = t.GetContext()
 		}
 
-		loopInfraStatus(loop, "准备工具调用 / Preparing Tool Call...")
+		emitToolsPreparingStatus(loop, []string{toolPayload})
 		toolLoadMessage := fmt.Sprintf("loading tool: %s...", toolPayload)
 		if toolIns, err := loop.GetConfig().GetAiToolManager().GetToolByName(toolPayload); err != nil {
 			toolLoadMessage += fmt.Sprintf(" Error: %v", err)

--- a/common/ai/aid/aireact/reactloops/loopinfra/capability_recommendation.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/capability_recommendation.go
@@ -95,7 +95,7 @@ func recommendCapabilitiesFromForgePrompts(loop *reactloops.ReActLoop, invoker a
 		return ""
 	}
 	if loop != nil {
-		loopInfraStatus(loop, "正在匹配相关能力 / Matching Related Capabilities...")
+		loopInfraStatus(loop, "正在匹配相关能力", "Matching Related Capabilities...")
 	}
 	matches := reactloops.MatchCapabilitiesByText(corpus, skillLoaderFromLoop(loop), reactloops.IsPlanAndExecAllowed(loop, invoker))
 	return recommendCapabilitiesFromMatches(loop, invoker, matches, sourceLabel)
@@ -115,7 +115,7 @@ func recommendCapabilitiesFromSkillContent(loop *reactloops.ReActLoop, invoker a
 		return ""
 	}
 	if loop != nil {
-		loopInfraStatus(loop, "正在匹配相关能力 / Matching Related Capabilities...")
+		loopInfraStatus(loop, "正在匹配相关能力", "Matching Related Capabilities...")
 	}
 	matches := reactloops.MatchCapabilitiesByText(content, loader, reactloops.IsPlanAndExecAllowed(loop, invoker))
 	return recommendCapabilitiesFromMatches(loop, invoker, matches, sourceLabel)

--- a/common/ai/aid/aireact/reactloops/loopinfra/dispatch_sub_react_agents.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/dispatch_sub_react_agents.go
@@ -48,7 +48,7 @@ func handleDispatchSubReactAgents(
 
 	concurrency := reactloops.ResolveSubAgentConcurrency(loop.GetMaxSubAgents(), len(jobs))
 
-	loopInfraStatus(loop, "子 Agent 执行中/ Sub Agents Running...")
+	loopInfraStatus(loop, "子 Agent 正在执行", "Sub-agents are running…")
 
 	// Pause the verification watchdog while sub-agents are running. This is a
 	// double-insurance alongside the sub-agent progress bypass in

--- a/common/ai/aid/aireact/reactloops/loopinfra/helpers.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/helpers.go
@@ -10,23 +10,23 @@ import (
 )
 
 const (
-	loopInfraNodeToolCompose         = "tool_compose_progress"
-	loopInfraNodeLoadCapability      = "load_capability"
-	loopInfraNodeLoadSkillResources  = "load_skill_resources_path"
-	loopInfraNodeSingleFileWrite     = "infra-file-write"
-	loopInfraNodeSingleFileModify    = "infra-file-modify"
-	loopInfraNodeSingleFileInsert    = "infra-file-insert"
-	loopInfraNodeSingleFileDelete    = "infra-file-delete"
-	loopInfraNodeCodeVerify          = "infra-code-verify"
-	loopInfraNodeQueryMCPServers     = "query_mcp_servers"
-	loopInfraNodeQueryMCPTools       = "query_mcp_tools"
-	loopInfraNodeDispatchSubReact = "dispatch_sub_react_agents"
-	loopInfraNodeSubReactReport   = "sub_react_agents_report"
-	loopInfraNodeSubReactGoal     = "sub_react_agent_goal"
+	loopInfraNodeToolCompose        = "tool_compose_progress"
+	loopInfraNodeLoadCapability     = "load_capability"
+	loopInfraNodeLoadSkillResources = "load_skill_resources_path"
+	loopInfraNodeSingleFileWrite    = "infra-file-write"
+	loopInfraNodeSingleFileModify   = "infra-file-modify"
+	loopInfraNodeSingleFileInsert   = "infra-file-insert"
+	loopInfraNodeSingleFileDelete   = "infra-file-delete"
+	loopInfraNodeCodeVerify         = "infra-code-verify"
+	loopInfraNodeQueryMCPServers    = "query_mcp_servers"
+	loopInfraNodeQueryMCPTools      = "query_mcp_tools"
+	loopInfraNodeDispatchSubReact   = "dispatch_sub_react_agents"
+	loopInfraNodeSubReactReport     = "sub_react_agents_report"
+	loopInfraNodeSubReactGoal       = "sub_react_agent_goal"
 )
 
-func loopInfraStatus(loop *reactloops.ReActLoop, message string) {
-	reactloops.EmitStatus(loop, message)
+func loopInfraStatus(loop *reactloops.ReActLoop, zh, en string) {
+	reactloops.EmitStatusI18n(loop, zh, en)
 }
 
 func loopInfraSystemLog(loop *reactloops.ReActLoop, nodeID, message string) {
@@ -44,9 +44,9 @@ func loopInfraSystemLog(loop *reactloops.ReActLoop, nodeID, message string) {
 	_, _ = emitter.EmitDefaultSystemStreamEvent(nodeID, strings.NewReader(message), taskID)
 }
 
-func loopInfraActionStart(loop *reactloops.ReActLoop, nodeID, line, status string) {
+func loopInfraActionStart(loop *reactloops.ReActLoop, nodeID, line, statusZh, statusEn string) {
 	reactloops.EmitActionLog(loop, nodeID, line)
-	loopInfraStatus(loop, status)
+	loopInfraStatus(loop, statusZh, statusEn)
 }
 
 func loopInfraActionFinish(loop *reactloops.ReActLoop, nodeID, line string, reference ...string) {

--- a/common/ai/aid/aireact/reactloops/loopinfra/single_file_actions.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/single_file_actions.go
@@ -47,7 +47,7 @@ func (f *SingleFileModificationSuiteFactory) buildWriteAction() reactloops.ReAct
 			invoker := loop.GetInvoker()
 			loopInfraActionStart(loop, loopInfraNodeSingleFileWrite,
 				fmt.Sprintf("写入文件: %s / Write file: %s", filename, filename),
-				"写入文件中 / Writing File...")
+				"正在写入文件", "Writing file…")
 
 			invoker.AddToTimeline("initialize", "AI decided to initialize the code file: "+filename)
 			code := loop.Get(codeVar)
@@ -69,7 +69,7 @@ func (f *SingleFileModificationSuiteFactory) buildWriteAction() reactloops.ReAct
 					return
 				}
 				operator.Feedback(failMsg + "\n\nHINT: 你很可能【输出完 @action JSON 就停下了】, 没有紧接着输出代码块。@action JSON 与紧随其后的 `<|" + f.aiTagName + "_<nonce>|> ... <|" + f.aiTagName + "_END_<nonce>|>` 代码块是【同一次回复、不可分割的一体】——发完 JSON 不要结束, 必须在同一条消息里把代码块完整写完(含 END 结束标记)再停。\n如果你只是想先确认 API 签名或语法, 请改用查询动作 (yakdoc_function_details / grep_yaklang_samples / semantic_search_yaklang_samples), 不要发空的 write_code。")
-				loopInfraStatus(loop, "write_code 缺少代码, 已反馈纠正并继续 / write_code missing code, fed back and continue")
+				loopInfraStatus(loop, "write_code 缺少代码, 已反馈纠正并继续", "write_code missing code, fed back and continue")
 				return
 			}
 			// 成功提取到代码, 重置空写计数。
@@ -119,7 +119,7 @@ func (f *SingleFileModificationSuiteFactory) buildWriteAction() reactloops.ReAct
 
 			log.Infof("write_code done: hasBlockingErrors=%v runBlocked=%v", blocking, runBlocked)
 			if !blocking && !runBlocked {
-				loopInfraStatus(loop, "文件写入完成 / File Write Complete")
+				loopInfraStatus(loop, "文件写入完成", "File Write Complete")
 				loopInfraActionFinish(loop, loopInfraNodeSingleFileWrite,
 					fmt.Sprintf("文件写入完成: %s (%d bytes) / File Written: %s (%d bytes)", filename, len(code), filename, len(code)),
 					msg)
@@ -172,13 +172,17 @@ Never emit a full file or complete function body in non-patch modify_code.`,
 			end := action.GetInt("modify_end_line")
 			// Patch mode: JSON may omit line range / old_snippet; GEN_CODE is validated after WaitStream.
 			if start == 0 && end == 0 {
-				loopInfraStatus(l, "准备以 Patch 修改文件 / Preparing Patch Modify")
+				loopInfraStatus(l, "准备以 Patch 修改文件", "Preparing Patch Modify")
 				return nil
 			}
 			if start <= 0 || end <= 0 || end < start {
 				return utils.Error("modify_code action must have a GEN_CODE patch (*** Begin Patch), valid 'modify_start_line'/'modify_end_line', or 'old_snippet'")
 			}
-			loopInfraStatus(l, fmt.Sprintf("准备修改文件行 %d-%d / Preparing File Modify Lines %d-%d", start, end, start, end))
+			loopInfraStatus(
+				l,
+				fmt.Sprintf("准备修改文件第 %d-%d 行", start, end),
+				fmt.Sprintf("Preparing to modify file lines %d-%d", start, end),
+			)
 			return nil
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
@@ -294,7 +298,7 @@ GEN_CODE 预览：
 			reason := action.GetString("modify_code_reason")
 			loopInfraActionStart(loop, loopInfraNodeSingleFileModify,
 				fmt.Sprintf("修改文件行 %d-%d: %s / Modify file lines %d-%d: %s", modifyStartLine, modifyEndLine, filename, modifyStartLine, modifyEndLine, filename),
-				"修改文件中 / Modifying File...")
+				"正在修改文件", "Modifying file…")
 
 			// Prettify the code (extract line numbers if present)
 			start, end, codeSegment, fixedCode := f.PrettifyCode(partialCode)
@@ -375,7 +379,7 @@ GEN_CODE 解析行号：[%d-%d]
 			runtime.AddToTimeline("code_modified", msg)
 			log.Infof("modify_code done: hasBlockingErrors=%v runBlocked=%v", hasBlockingErrors, runBlocked)
 			if !hasBlockingErrors && !runBlocked {
-				loopInfraStatus(loop, "文件修改完成 / File Modify Complete")
+				loopInfraStatus(loop, "文件修改完成", "File Modify Complete")
 				loopInfraActionFinish(loop, loopInfraNodeSingleFileModify,
 					fmt.Sprintf("文件修改完成: %s lines %d-%d / File Modified: %s lines %d-%d", filename, modifyStartLine, modifyEndLine, filename, modifyStartLine, modifyEndLine),
 					msg)
@@ -455,7 +459,11 @@ func (f *SingleFileModificationSuiteFactory) buildInsertAction() reactloops.ReAc
 			if line <= 0 {
 				return utils.Error("insert_lines action must have valid 'insert_line' parameter")
 			}
-			loopInfraStatus(l, fmt.Sprintf("准备插入文件行 %d / Preparing File Insert Line %d", line, line))
+			loopInfraStatus(
+				l,
+				fmt.Sprintf("准备在文件第 %d 行插入内容", line),
+				fmt.Sprintf("Preparing to insert content at file line %d", line),
+			)
 			return nil
 		},
 		func(loop *reactloops.ReActLoop, action *aicommon.Action, op *reactloops.LoopActionHandlerOperator) {
@@ -482,7 +490,7 @@ func (f *SingleFileModificationSuiteFactory) buildInsertAction() reactloops.ReAc
 			invoker.AddToTimeline("insert_lines", msg)
 			loopInfraActionStart(loop, loopInfraNodeSingleFileInsert,
 				fmt.Sprintf("插入文件行 %d: %s / Insert file line %d: %s", insertLine, filename, insertLine, filename),
-				"插入文件内容 / Inserting File Content...")
+				"正在插入文件内容", "Inserting file content…")
 
 			// Prettify the code
 			start, end, codeSegment, fixedCode := f.PrettifyCode(partialCode)
@@ -533,7 +541,7 @@ func (f *SingleFileModificationSuiteFactory) buildInsertAction() reactloops.ReAc
 			runtime.AddToTimeline("lines_inserted", msg)
 			log.Infof("insert_lines done: hasBlockingErrors=%v runBlocked=%v", hasBlockingErrors, runBlocked)
 			if !hasBlockingErrors && !runBlocked {
-				loopInfraStatus(loop, "文件插入完成 / File Insert Complete")
+				loopInfraStatus(loop, "文件插入完成", "File Insert Complete")
 				loopInfraActionFinish(loop, loopInfraNodeSingleFileInsert,
 					fmt.Sprintf("文件插入完成: %s line %d / File Inserted: %s line %d", filename, insertLine, filename, insertLine),
 					msg)
@@ -578,9 +586,17 @@ func (f *SingleFileModificationSuiteFactory) buildDeleteAction() reactloops.ReAc
 			}
 
 			if endLine > 0 {
-				loopInfraStatus(l, fmt.Sprintf("准备删除文件行 %d-%d / Preparing File Delete Lines %d-%d", startLine, endLine, startLine, endLine))
+				loopInfraStatus(
+					l,
+					fmt.Sprintf("准备删除文件第 %d-%d 行", startLine, endLine),
+					fmt.Sprintf("Preparing to delete file lines %d-%d", startLine, endLine),
+				)
 			} else {
-				loopInfraStatus(l, fmt.Sprintf("准备删除文件行 %d / Preparing File Delete Line %d", startLine, startLine))
+				loopInfraStatus(
+					l,
+					fmt.Sprintf("准备删除文件第 %d 行", startLine),
+					fmt.Sprintf("Preparing to delete file line %d", startLine),
+				)
 			}
 			return nil
 		},
@@ -624,7 +640,7 @@ func (f *SingleFileModificationSuiteFactory) buildDeleteAction() reactloops.ReAc
 			invoker.AddToTimeline("delete_lines", msg)
 			loopInfraActionStart(loop, loopInfraNodeSingleFileDelete,
 				fmt.Sprintf("删除文件行: %s / Delete file lines: %s", filename, filename),
-				"删除文件内容 / Deleting File Content...")
+				"正在删除文件内容", "Deleting file content…")
 
 			if err != nil {
 				runtime.AddToTimeline("delete_failed", "Failed to delete lines: "+err.Error())
@@ -679,7 +695,7 @@ func (f *SingleFileModificationSuiteFactory) buildDeleteAction() reactloops.ReAc
 			runtime.AddToTimeline("lines_deleted", msg)
 			log.Infof("delete_lines done: hasBlockingErrors=%v runBlocked=%v", hasBlockingErrors, runBlocked)
 			if !hasBlockingErrors && !runBlocked {
-				loopInfraStatus(loop, "文件删除完成 / File Delete Complete")
+				loopInfraStatus(loop, "文件删除完成", "File Delete Complete")
 				loopInfraActionFinish(loop, loopInfraNodeSingleFileDelete,
 					fmt.Sprintf("文件删除完成: %s / File Delete Complete: %s", filename, filename),
 					msg)

--- a/common/ai/aid/aireact/reactloops/loopinfra/single_file_modification_suite.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/single_file_modification_suite.go
@@ -293,24 +293,26 @@ func (f *SingleFileModificationSuiteFactory) applySyntaxLintResult(
 ) (postHookBlocked bool) {
 	lintStatusVar := f.GetLintStatusVariableName()
 	reactloops.EmitActionLog(loop, loopInfraNodeCodeVerify, "开始静态分析与语法检查 / Starting static analysis and syntax check...")
-	reactloops.EmitStatus(loop, "验证代码中 / Verifying code...")
+	reactloops.EmitStatusI18n(loop, "验证代码中", "Verifying code...")
 
 	if hasBlockingErrors {
 		loop.Set(lintStatusVar, "false")
 		reactloops.EmitActionLog(loop, loopInfraNodeCodeVerify, buildSyntaxVerifyFailureActionLog(errMsg))
-		status := "验证代码失败，修复中 / Code verification failed, fixing..."
+		statusZh := "验证代码失败，正在修复"
+		statusEn := "Code verification failed; fixing…"
 		if first := firstSyntaxLintIssueLine(errMsg); first != "" {
-			status = fmt.Sprintf("验证失败: %s / Verification failed: %s",
-				utils.ShrinkTextBlock(first, 96), utils.ShrinkTextBlock(first, 96))
+			issue := utils.ShrinkTextBlock(first, 96)
+			statusZh = fmt.Sprintf("验证失败：%s", issue)
+			statusEn = fmt.Sprintf("Verification failed: %s", issue)
 		}
-		reactloops.EmitStatus(loop, status)
+		reactloops.EmitStatusI18n(loop, statusZh, statusEn)
 		op.DisallowNextLoopExit()
 		op.Continue()
 		return false
 	}
 	loop.Set(lintStatusVar, "true")
 	reactloops.EmitActionLog(loop, loopInfraNodeCodeVerify, "验证通过 / Code verification passed")
-	reactloops.EmitStatus(loop, "验证代码通过 / Code verification passed")
+	reactloops.EmitStatusI18n(loop, "验证代码通过", "Code verification passed")
 
 	// postSyntaxCleanHook（如 YAK_MAIN 自测）与 exitOnClean 解耦：
 	// 语法通过时始终执行 hook，无论是否需要自动退出。
@@ -438,7 +440,7 @@ func (f *SingleFileModificationSuiteFactory) handleModifyByPatch(
 
 	loopInfraActionStart(loop, loopInfraNodeSingleFileModify,
 		fmt.Sprintf("Patch 修改文件: %s (%d hunks) / Patch modify: %s (%d hunks)", filename, len(hunks), filename, len(hunks)),
-		"修改文件中 / Modifying File...")
+		"正在修改文件", "Modifying file…")
 
 	editorSummary := SummarizeAppliedPatch(hunks)
 	successMsg := fmt.Sprintf("SUCCESS: applied patch (%d hunks), wrote %d bytes to file: %s", len(hunks), len(newFull), filename)
@@ -459,7 +461,7 @@ func (f *SingleFileModificationSuiteFactory) handleModifyByPatch(
 	})
 
 	log.Infof("modify_code (patch) done: %d hunks", len(hunks))
-	loopInfraStatus(loop, "文件修改完成 / File Modify Complete")
+	loopInfraStatus(loop, "文件修改完成", "File Modify Complete")
 	loopInfraActionFinish(loop, loopInfraNodeSingleFileModify,
 		fmt.Sprintf("Patch 修改完成: %s / Patch applied: %s", filename, filename),
 		utils.ShrinkTextBlock(editorSummary, 256))

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_batch_action.go
@@ -517,7 +517,11 @@ func executeVerifiedToolBatch(
 		ctx = task.GetContext()
 	}
 
-	loopInfraStatus(loop, fmt.Sprintf("准备并发工具调用（%d 项） / Preparing Parallel Tool Calls...", len(request.Calls)))
+	toolNames := make([]string, 0, len(request.Calls))
+	for _, call := range request.Calls {
+		toolNames = append(toolNames, call.ToolName)
+	}
+	emitToolsPreparingStatus(loop, toolNames)
 	batchRuntime, supported := invoker.(aicommon.ToolBatchInvokeRuntime)
 	var (
 		result *aicommon.ToolBatchResult
@@ -760,6 +764,11 @@ func handleToolBatchActionResult(
 	summary := strings.Join(lines, "\n")
 	invoker.AddToTimeline("[TOOL_BATCH_RESULT]", summary)
 	operator.Feedback(summary)
+	emitToolBatchResultStatus(loop, request, outcomes)
+	toolNames := make([]string, 0, len(request.Calls))
+	for _, call := range request.Calls {
+		toolNames = append(toolNames, call.ToolName)
+	}
 	justExecutedTool := executedToolCallCount > 0
 	if justExecutedTool {
 		operator.MarkToolExecuted(executedToolCallCount)
@@ -772,10 +781,6 @@ func handleToolBatchActionResult(
 	if task == nil || !justExecutedTool {
 		operator.Continue()
 		return
-	}
-	toolNames := make([]string, 0, len(request.Calls))
-	for _, call := range request.Calls {
-		toolNames = append(toolNames, call.ToolName)
 	}
 	verifyResult, triggered, verifyErr := loop.MaybeVerifyUserSatisfaction(ctx, task.GetUserInput(), true, strings.Join(toolNames, ","))
 	if verifyErr != nil {

--- a/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/tool_call_common.go
@@ -50,7 +50,7 @@ func handleToolCallResult(
 	if err != nil {
 		errMsg := fmt.Sprintf("Tool '%s' invocation protocol failed: %v.", toolPayload, err)
 		invoker.AddToTimeline("[TOOL_PROTOCOL_ERROR]", errMsg)
-		loopInfraStatus(loop, "工具协议失败 / Tool Protocol Failed")
+		emitToolResultStatus(loop, toolPayload, false)
 
 		resolved := loop.ResolveIdentifier(toolPayload)
 		if buildinaitools.IsMCPToolName(toolPayload) && buildinaitools.IsMCPInitializingError(err) {
@@ -81,19 +81,19 @@ func handleToolCallResult(
 	if result == nil {
 		msg := fmt.Sprintf("tool call [%v] returned nil result", toolPayload)
 		invoker.AddToTimeline("error", msg)
-		loopInfraStatus(loop, "工具无结果 / Tool Returned No Result")
+		emitToolResultStatus(loop, toolPayload, false)
 		operator.Continue()
 		return
 	}
 
 	if result.Success {
 		reactloops.MarkEditBeforeExecutionCompleted(loop, toolPayload)
-		loopInfraStatus(loop, "工具调用已结束 / Tool Invocation Settled")
+		emitToolResultStatus(loop, toolPayload, true)
 	}
 
 	if result.Error != "" {
 		invoker.AddToTimeline("call["+toolPayload+"] protocol-error", result.Error)
-		loopInfraStatus(loop, "工具协议错误 / Tool Protocol Error")
+		emitToolResultStatus(loop, toolPayload, false)
 		if buildinaitools.IsMCPToolName(toolPayload) && buildinaitools.IsMCPInitializingMessage(result.Error) {
 			operator.Feedback(
 				"[MCP] Tool '" + toolPayload + "' is still initializing. " +

--- a/common/ai/aid/aireact/reactloops/loopinfra/user_status.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/user_status.go
@@ -1,0 +1,200 @@
+package loopinfra
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func buildStatusTools(loop *reactloops.ReActLoop, names []string, state aicommon.StatusState) []aicommon.StatusTool {
+	tools := make([]aicommon.StatusTool, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		statusTool := aicommon.StatusTool{Name: name, DisplayName: name, State: state}
+		if loop != nil && loop.GetConfig() != nil && loop.GetConfig().GetAiToolManager() != nil {
+			if tool, err := loop.GetConfig().GetAiToolManager().GetToolByName(name); err == nil && tool != nil {
+				zh := strings.TrimSpace(tool.GetVerboseNameZh())
+				en := strings.TrimSpace(tool.GetVerboseName())
+				if zh != "" {
+					statusTool.DisplayName = zh
+				} else if en != "" {
+					statusTool.DisplayName = en
+				}
+				if zh != "" || en != "" {
+					statusTool.DisplayNameI18n = &schema.I18n{Zh: zh, En: en}
+				}
+			}
+		}
+		tools = append(tools, statusTool)
+	}
+	return tools
+}
+
+func statusToolNames(tools []aicommon.StatusTool, english bool) string {
+	const visibleLimit = 3
+	labels := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		label := tool.DisplayName
+		if english && tool.DisplayNameI18n != nil && strings.TrimSpace(tool.DisplayNameI18n.En) != "" {
+			label = tool.DisplayNameI18n.En
+		}
+		if strings.TrimSpace(label) == "" {
+			label = tool.Name
+		}
+		labels = append(labels, label)
+	}
+	visible := labels
+	if len(visible) > visibleLimit {
+		visible = visible[:visibleLimit]
+	}
+	joined := strings.Join(visible, "、")
+	if english {
+		joined = strings.Join(visible, ", ")
+	}
+	if remaining := len(labels) - len(visible); remaining > 0 {
+		if english {
+			joined += fmt.Sprintf(" and %d more", remaining)
+		} else {
+			joined += fmt.Sprintf("等 %d 个工具", remaining)
+		}
+	}
+	return joined
+}
+
+func emitToolsPreparingStatus(loop *reactloops.ReActLoop, names []string) {
+	tools := buildStatusTools(loop, names, aicommon.StatusStateRunning)
+	if len(tools) == 0 {
+		return
+	}
+	if len(tools) == 1 {
+		reactloops.EmitStatusI18n(
+			loop,
+			fmt.Sprintf("正在准备使用「%s」", statusToolNames(tools, false)),
+			fmt.Sprintf("Preparing to use %s", statusToolNames(tools, true)),
+			aicommon.WithStatusCode("tool.preparing"),
+			aicommon.WithStatusTools(tools...),
+		)
+		return
+	}
+	reactloops.EmitStatusI18n(
+		loop,
+		fmt.Sprintf("正在准备调用 %d 个工具：%s", len(tools), statusToolNames(tools, false)),
+		fmt.Sprintf("Preparing %d tools: %s", len(tools), statusToolNames(tools, true)),
+		aicommon.WithStatusCode("tool.batch.preparing"),
+		aicommon.WithStatusProgress(0, int64(len(tools)), "tool"),
+		aicommon.WithStatusTools(tools...),
+	)
+}
+
+func buildToolBatchResultTools(
+	loop *reactloops.ReActLoop,
+	request *aicommon.ToolBatchRequest,
+	outcomes []aicommon.ToolCallOutcome,
+) ([]aicommon.StatusTool, int) {
+	if request == nil {
+		return nil, 0
+	}
+	outcomeByIndex := make(map[int]aicommon.ToolCallOutcome, len(outcomes))
+	for _, outcome := range outcomes {
+		outcomeByIndex[outcome.Index] = outcome
+	}
+
+	tools := make([]aicommon.StatusTool, 0, len(request.Calls))
+	successful := 0
+	for _, call := range request.Calls {
+		name := call.ToolName
+		state := aicommon.StatusStateWarning
+		if outcome, ok := outcomeByIndex[call.Index]; ok {
+			if outcome.FinalTool != "" {
+				name = outcome.FinalTool
+			}
+			switch {
+			case outcome.Result != nil && outcome.Result.Success:
+				state = aicommon.StatusStateSuccess
+				successful++
+			case outcome.Err != nil,
+				outcome.Stage == aicommon.ToolCallStagePrepareFailed,
+				outcome.Stage == aicommon.ToolCallStageValidationFailed,
+				outcome.Stage == aicommon.ToolCallStageInvokeFailed,
+				outcome.Result != nil && outcome.Result.Error != "":
+				state = aicommon.StatusStateError
+			}
+		}
+		statusTools := buildStatusTools(loop, []string{name}, state)
+		if len(statusTools) > 0 {
+			tools = append(tools, statusTools[0])
+		}
+	}
+	return tools, successful
+}
+
+func emitToolBatchResultStatus(
+	loop *reactloops.ReActLoop,
+	request *aicommon.ToolBatchRequest,
+	outcomes []aicommon.ToolCallOutcome,
+) {
+	tools, successful := buildToolBatchResultTools(loop, request, outcomes)
+	total := len(tools)
+	if total == 0 {
+		return
+	}
+
+	state := aicommon.StatusStateWarning
+	code := "tool.batch.partial"
+	zh := fmt.Sprintf("%d 个工具中有 %d 个已完成，正在整理可用结果", total, successful)
+	en := fmt.Sprintf("%d of %d tools completed; organizing the available results", successful, total)
+	if successful == total {
+		state = aicommon.StatusStateSuccess
+		code = "tool.batch.completed"
+		zh = fmt.Sprintf("%d 个工具已完成，正在整理结果", total)
+		en = fmt.Sprintf("All %d tools completed; organizing the results", total)
+	} else if successful == 0 {
+		state = aicommon.StatusStateError
+		code = "tool.batch.failed"
+		zh = "这批工具暂时没能完成，正在调整"
+		en = "This tool batch could not complete; adjusting the approach"
+	}
+	reactloops.EmitStatusI18n(
+		loop,
+		zh,
+		en,
+		aicommon.WithStatusCode(code),
+		aicommon.WithStatusState(state),
+		aicommon.WithStatusProgress(int64(successful), int64(total), "tool"),
+		aicommon.WithStatusTools(tools...),
+	)
+}
+
+func emitToolResultStatus(loop *reactloops.ReActLoop, name string, success bool) {
+	state := aicommon.StatusStateError
+	code := "tool.failed"
+	tools := buildStatusTools(loop, []string{name}, state)
+	if len(tools) == 0 {
+		return
+	}
+	zhName := statusToolNames(tools, false)
+	enName := statusToolNames(tools, true)
+	zh := fmt.Sprintf("「%s」暂时没能完成这一步", zhName)
+	en := fmt.Sprintf("%s could not complete this step", enName)
+	if success {
+		state = aicommon.StatusStateSuccess
+		code = "tool.completed"
+		tools[0].State = state
+		zh = fmt.Sprintf("「%s」已经完成，正在整理结果", zhName)
+		en = fmt.Sprintf("%s has finished; organizing the results", enName)
+	}
+	reactloops.EmitStatusI18n(
+		loop,
+		zh,
+		en,
+		aicommon.WithStatusCode(code),
+		aicommon.WithStatusState(state),
+		aicommon.WithStatusTools(tools...),
+	)
+}

--- a/common/ai/aid/aireact/reactloops/loopinfra/user_status_test.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/user_status_test.go
@@ -1,0 +1,33 @@
+package loopinfra
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+func TestBuildToolBatchResultToolsPreservesActualState(t *testing.T) {
+	request := &aicommon.ToolBatchRequest{Calls: []aicommon.ToolBatchCall{
+		{Index: 0, ToolName: "read_file"},
+		{Index: 1, ToolName: "grep"},
+		{Index: 2, ToolName: "web_search"},
+	}}
+	outcomes := []aicommon.ToolCallOutcome{
+		{Index: 0, FinalTool: "read_file", Stage: aicommon.ToolCallStageDone, Result: &aitool.ToolResult{Success: true}},
+		{Index: 1, FinalTool: "grep_files", Stage: aicommon.ToolCallStageDone, Result: &aitool.ToolResult{Success: true}},
+		{Index: 2, Stage: aicommon.ToolCallStageInvokeFailed, Err: errors.New("failed")},
+	}
+
+	tools, successful := buildToolBatchResultTools(nil, request, outcomes)
+	require.Equal(t, 2, successful)
+	require.Len(t, tools, 3)
+	require.Equal(t, "read_file", tools[0].Name)
+	require.Equal(t, aicommon.StatusStateSuccess, tools[0].State)
+	require.Equal(t, "grep_files", tools[1].Name)
+	require.Equal(t, aicommon.StatusStateSuccess, tools[1].State)
+	require.Equal(t, "web_search", tools[2].Name)
+	require.Equal(t, aicommon.StatusStateError, tools[2].State)
+}

--- a/common/ai/aid/aireact/reactloops/status_i18n_migration_test.go
+++ b/common/ai/aid/aireact/reactloops/status_i18n_migration_test.go
@@ -1,0 +1,95 @@
+package reactloops
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestProductionStatusCallsUseI18n(t *testing.T) {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+	aidRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	fset := token.NewFileSet()
+	var violations []string
+
+	err := filepath.WalkDir(aidRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			var callName string
+			switch function := call.Fun.(type) {
+			case *ast.SelectorExpr:
+				callName = function.Sel.Name
+			case *ast.Ident:
+				callName = function.Name
+			default:
+				return true
+			}
+			position := fset.Position(call.Lparen)
+			switch callName {
+			case "EmitStatus", "LoadingStatus":
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d uses legacy %s; use EmitStatusI18n/UserStatus with separate translations",
+					path, position.Line, callName,
+				))
+			case "EmitStatusI18n":
+				if len(call.Args) >= 3 && (isEmptyStringLiteral(call.Args[1]) || isEmptyStringLiteral(call.Args[2])) {
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d passes an empty translation to EmitStatusI18n",
+						path, position.Line,
+					))
+				}
+			case "UserStatus", "planUserStatus", "loopInfraStatus":
+				if len(call.Args) >= 2 && (isEmptyStringLiteral(call.Args[0]) || isEmptyStringLiteral(call.Args[1])) {
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d passes an empty translation to %s",
+						path, position.Line, callName,
+					))
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("status i18n migration violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func isEmptyStringLiteral(expression ast.Expr) bool {
+	literal, ok := expression.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	return err == nil && strings.TrimSpace(value) == ""
+}

--- a/common/ai/aid/aireact/reactloops/stream_helpers.go
+++ b/common/ai/aid/aireact/reactloops/stream_helpers.go
@@ -10,12 +10,14 @@ import (
 )
 
 // EmitStatus 发送瞬时状态（状态栏覆盖显示）。历史双语字符串会拆分为
-// value（默认中文）与 value_i18n；新代码优先使用 EmitStatusI18n。
+// value（默认中文）与 value_i18n。
+// Deprecated: 仅供外部旧调用兼容；生产代码应使用 EmitStatusI18n。
 func EmitStatus(loop *ReActLoop, message string) {
 	if loop == nil || message == "" {
 		return
 	}
-	loop.LoadingStatus(message)
+	zh, en := aicommon.SplitLegacyStatusI18n(message)
+	loop.UserStatus(zh, en)
 }
 
 // EmitStatusI18n emits a product-facing status with structured metadata while

--- a/common/ai/aid/aireact/reactloops/stream_helpers.go
+++ b/common/ai/aid/aireact/reactloops/stream_helpers.go
@@ -5,17 +5,26 @@ import (
 	"os"
 	"strings"
 
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/log"
 )
 
-// EmitStatus 发送瞬时状态（状态栏覆盖显示）
-// message 格式必须为双语：中文 / English
-// 示例: "查询流量中 / Querying Flows..."
+// EmitStatus 发送瞬时状态（状态栏覆盖显示）。历史双语字符串会拆分为
+// value（默认中文）与 value_i18n；新代码优先使用 EmitStatusI18n。
 func EmitStatus(loop *ReActLoop, message string) {
 	if loop == nil || message == "" {
 		return
 	}
 	loop.LoadingStatus(message)
+}
+
+// EmitStatusI18n emits a product-facing status with structured metadata while
+// retaining a Chinese string value for legacy clients.
+func EmitStatusI18n(loop *ReActLoop, zh, en string, options ...aicommon.StatusOption) {
+	if loop == nil || (zh == "" && en == "") {
+		return
+	}
+	loop.UserStatus(zh, en, options...)
 }
 
 // emitProgress 发送进度状态（带百分比和计数）
@@ -31,11 +40,13 @@ func EmitProgress(loop *ReActLoop, current, total int, actionZh, actionEn string
 		percent = 100
 	}
 
-	message := fmt.Sprintf("%s %d%% (%d/%d) / %s %d%% (%d/%d)",
-		actionZh, percent, current, total,
-		actionEn, percent, current, total)
-
-	EmitStatus(loop, message)
+	EmitStatusI18n(
+		loop,
+		fmt.Sprintf("%s %d%%（%d/%d）", actionZh, percent, current, total),
+		fmt.Sprintf("%s %d%% (%d/%d)", actionEn, percent, current, total),
+		aicommon.WithStatusCode("progress"),
+		aicommon.WithStatusProgress(int64(current), int64(total), "item"),
+	)
 }
 
 // EmitActionLog 输出 Action 的累积日志

--- a/common/ai/aid/coordinator.go
+++ b/common/ai/aid/coordinator.go
@@ -234,7 +234,16 @@ func (c *Coordinator) planLoadingStatus(status string) {
 		return
 	}
 	log.Infof("plan-executing loading status updated: %v", status)
-	c.EmitStatus(PlanExecutingLoadingStatusKey, status)
+	zh, en := aicommon.SplitLegacyStatusI18n(status)
+	_, _ = c.EmitStatusI18n(PlanExecutingLoadingStatusKey, zh, en)
+}
+
+func (c *Coordinator) planUserStatus(zh, en string, options ...aicommon.StatusOption) {
+	if c.Emitter == nil {
+		return
+	}
+	log.Infof("plan-executing user status updated: %v", zh)
+	_, _ = c.EmitStatusI18n(PlanExecutingLoadingStatusKey, zh, en, options...)
 }
 
 func (c *Coordinator) GetContextProvider() *PromptContextProvider {
@@ -399,8 +408,7 @@ func (c *Coordinator) Run() error {
 		coordinatorID = c.Config.Id
 	}
 	defer unregisterRunningCoordinator(coordinatorID)
-	c.planLoadingStatus("初始化 / Initializing...")
-	defer c.planLoadingStatus("任务规划执行结束 / Plan Execution Finished")
+	c.planUserStatus("正在准备任务", "Preparing the task", aicommon.WithStatusCode("plan.preparing"))
 
 	c.registerPEModeInputEventCallback()
 	c.EmitCurrentConfigInfo()

--- a/common/ai/aid/coordinator_plan_phases.go
+++ b/common/ai/aid/coordinator_plan_phases.go
@@ -15,31 +15,31 @@ const Phase_PlanReady = "plan_ready"
 // runPlanPhaseThroughReview runs plan loop, user review, and persists plan_ready state.
 // It does not execute subtasks.
 func (c *Coordinator) runPlanPhaseThroughReview() error {
-	c.planLoadingStatus("创建任务规划 / Creating Plan...")
+	c.planUserStatus("正在梳理任务目标", "Understanding the task goals", aicommon.WithStatusCode("plan.understanding"))
 	c.EmitInfo("start to create plan request")
 	planReq, err := c.createPlanRequest(c.userInput)
 	if err != nil {
-		c.planLoadingStatus("任务规划创建失败 / Plan Creation Failed")
+		c.planUserStatus("暂时没能整理出执行方案", "Unable to prepare an execution plan", aicommon.WithStatusCode("plan.failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("create planRequest failed: %v", err)
 		return utils.Errorf("coordinator: create planRequest failed: %v", err)
 	}
 
-	c.planLoadingStatus("任务规划中... / Waiting AI to Generate Plan...")
+	c.planUserStatus("正在整理执行方案", "Preparing the execution plan", aicommon.WithStatusCode("plan.generating"))
 	c.EmitInfo("start to invoke plan request")
 	rsp, err := planReq.Invoke()
 	if err != nil {
-		c.planLoadingStatus("任务规划失败 / Plan Generation Failed")
+		c.planUserStatus("暂时没能整理出执行方案", "Unable to prepare an execution plan", aicommon.WithStatusCode("plan.failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("invoke planRequest failed(first): %v", err)
 		return utils.Errorf("coordinator: invoke planRequest failed: %v", err)
 	}
 	rsp, err = planReq.ensurePlanExecutableDAG(rsp)
 	if err != nil {
-		c.planLoadingStatus("任务规划依赖校验失败 / Plan DAG Validation Failed")
+		c.planUserStatus("步骤之间存在冲突，正在重新整理", "Some steps conflict and need to be reorganized", aicommon.WithStatusCode("plan.order_failed"), aicommon.WithStatusState(aicommon.StatusStateRecovering))
 		c.EmitError("validate generated plan executable DAG failed: %v", err)
 		return err
 	}
 
-	c.planLoadingStatus("任务规划等待用户审查 / Waiting User to Review Plan...")
+	c.planUserStatus("执行方案已经准备好，等你确认", "The execution plan is ready for your review", aicommon.WithStatusCode("plan.awaiting_review"), aicommon.WithStatusState(aicommon.StatusStateWaiting))
 	ep := c.Epm.CreateEndpointWithEventType(schema.EVENT_TYPE_PLAN_REVIEW_REQUIRE)
 	ep.SetDefaultSuggestionContinue()
 
@@ -48,39 +48,39 @@ func (c *Coordinator) runPlanPhaseThroughReview() error {
 	params := ep.GetParams()
 	c.ReleaseInteractiveEvent(ep.GetId(), params)
 	if params == nil {
-		c.planLoadingStatus("用户审查失败 / User Review Failed")
+		c.planUserStatus("没有收到有效的确认结果", "No valid review response was received", aicommon.WithStatusCode("plan.review_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("user review params is nil, plan failed")
 		return utils.Errorf("coordinator: user review params is nil")
 	}
 
-	c.planLoadingStatus("处理用户审查结果 / Processing User Review...")
+	c.planUserStatus("正在根据你的意见调整方案", "Updating the plan based on your feedback", aicommon.WithStatusCode("plan.revising"))
 	c.EmitInfo("start to handle review plan response")
 	rsp, err = planReq.handleReviewPlanResponse(rsp, params)
 	if err != nil {
-		c.planLoadingStatus("处理审查结果失败 / Review Processing Failed")
+		c.planUserStatus("暂时没能应用这次调整", "Unable to apply the requested changes", aicommon.WithStatusCode("plan.revision_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("handle review plan response failed: %v", err)
 		return utils.Errorf("coordinator: handle review plan response failed: %v", err)
 	}
 	rsp, err = planReq.ensurePlanExecutableDAG(rsp)
 	if err != nil {
-		c.planLoadingStatus("任务规划依赖校验失败 / Plan DAG Validation Failed")
+		c.planUserStatus("正在重新校对步骤顺序", "Rechecking the order of the steps", aicommon.WithStatusCode("plan.reordering"), aicommon.WithStatusState(aicommon.StatusStateRecovering))
 		c.EmitError("validate reviewed plan executable DAG failed: %v", err)
 		return err
 	}
 
 	if rsp.RootTask == nil {
-		c.planLoadingStatus("任务计划无效 / Invalid Task Plan")
+		c.planUserStatus("执行方案还不够完整", "The execution plan is incomplete", aicommon.WithStatusCode("plan.invalid"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("root aiTask is nil, plan failed")
 		return utils.Errorf("coordinator: root aiTask is nil")
 	}
 
-	c.planLoadingStatus("初始化任务队列 / Initializing Task Queue...")
+	c.planUserStatus("正在准备执行计划", "Preparing to execute the plan", aicommon.WithStatusCode("plan.preparing"))
 	root := rsp.RootTask
 	c.rootTask = root
 	c.ContextProvider.StoreRootTask(root)
 	c.savePlanAndExecState(Phase_PlanReady, nil)
 	if len(root.Subtasks) <= 0 {
-		c.planLoadingStatus("无有效子任务 / No Valid Subtasks")
+		c.planUserStatus("执行方案中没有可推进的步骤", "The plan has no actionable steps", aicommon.WithStatusCode("plan.empty"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("no subtasks found, this task is not a valid task")
 		return utils.Errorf("coordinator: no subtasks found")
 	}
@@ -99,7 +99,7 @@ func (c *Coordinator) runPlanPhaseThroughReview() error {
 }
 
 func (c *Coordinator) runExecuteRoot(startTaskID string) error {
-	c.planLoadingStatus("执行任务中 / Executing Tasks...")
+	c.planUserStatus("正在推进任务", "Working through the task", aicommon.WithStatusCode("plan.executing"))
 	c.EmitInfo("start to create runtime")
 	c.ensureSessionSnapshotEmitHandler()
 	if c.rootTask != nil {
@@ -117,7 +117,7 @@ func (c *Coordinator) runExecuteRoot(startTaskID string) error {
 	rt := c.createRuntime()
 	c.runtime = rt
 	if err := rt.Invoke(c.rootTask, startTaskID); err != nil {
-		c.planLoadingStatus("任务执行失败 / Task Execution Failed")
+		c.planUserStatus("任务推进时遇到问题", "A problem occurred while executing the task", aicommon.WithStatusCode("plan.execution_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		return err
 	}
 	return nil
@@ -142,18 +142,18 @@ func (c *Coordinator) tryRecoverAndExecute(startTaskID string) (bool, error) {
 		return false, nil
 	}
 	if err != nil {
-		c.planLoadingStatus("恢复执行失败 / Recovery Failed")
+		c.planUserStatus("暂时没能恢复之前的进度", "Unable to restore the previous progress", aicommon.WithStatusCode("plan.recovery_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		if isPlanExecutableDAGValidationError(err) {
 			c.recordPlanDAGValidationFailure(err, 0)
 		}
 		c.EmitError("recover plan-and-exec failed: %v", err)
 		return false, utils.Errorf("coordinator: recover plan-and-exec failed: %v", err)
 	}
-	c.planLoadingStatus("恢复执行 / Recovering Execution...")
+	c.planUserStatus("正在恢复之前的进度", "Restoring the previous progress", aicommon.WithStatusCode("plan.recovering"), aicommon.WithStatusState(aicommon.StatusStateRecovering))
 	c.rootTask = recoveredRoot
 	c.ContextProvider.StoreRootTask(recoveredRoot)
 	if len(recoveredRoot.Subtasks) <= 0 {
-		c.planLoadingStatus("无有效子任务 / No Valid Subtasks")
+		c.planUserStatus("没有找到可以继续的步骤", "No actionable steps were found", aicommon.WithStatusCode("plan.empty"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("no subtasks found in recovered task tree")
 		return false, utils.Errorf("coordinator: no subtasks found in recovered task tree")
 	}
@@ -164,20 +164,20 @@ func (c *Coordinator) tryRecoverAndExecute(startTaskID string) (bool, error) {
 }
 
 func (c *Coordinator) runReportAndFinishPhases() error {
-	c.planLoadingStatus("生成执行结果 / Generating Results...")
+	c.planUserStatus("正在汇总任务成果", "Summarizing the task results", aicommon.WithStatusCode("plan.summarizing"))
 	if c.ResultHandler != nil {
 		c.ResultHandler(c)
 	} else if c.GenerateReport {
-		c.planLoadingStatus("进入报告生成专注模式 / Entering Report Generation Focus Mode...")
+		c.planUserStatus("正在整理最终报告", "Preparing the final report", aicommon.WithStatusCode("plan.report"))
 		c.EmitInfo("start report generation via focus mode loop")
 		if err := c.generateReportViaFocusMode(); err != nil {
-			c.planLoadingStatus("报告生成失败 / Report Generation Failed")
+			c.planUserStatus("暂时没能完成最终报告", "Unable to complete the final report", aicommon.WithStatusCode("plan.report_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 			c.EmitError("report generation via focus mode failed: %v", err)
 			return utils.Errorf("coordinator: report generation failed: %v", err)
 		}
 	}
 
-	c.planLoadingStatus("执行完成 / Execution Completed")
+	c.planUserStatus("任务已经处理完成", "The task has been completed", aicommon.WithStatusCode("plan.completed"), aicommon.WithStatusState(aicommon.StatusStateSuccess))
 	c.EmitInfo("coordinator run finished")
 	c.Wait()
 	return nil
@@ -185,8 +185,7 @@ func (c *Coordinator) runReportAndFinishPhases() error {
 
 // RunPlanOnly executes the plan loop and user review, then persists plan_ready without running subtasks.
 func (c *Coordinator) RunPlanOnly() error {
-	c.planLoadingStatus("初始化 / Initializing...")
-	defer c.planLoadingStatus("任务规划阶段结束 / Plan Phase Finished")
+	c.planUserStatus("正在准备任务规划", "Preparing task planning", aicommon.WithStatusCode("plan.preparing"))
 
 	c.registerPEModeInputEventCallback()
 	c.EmitCurrentConfigInfo()
@@ -196,7 +195,7 @@ func (c *Coordinator) RunPlanOnly() error {
 		return err
 	}
 
-	c.planLoadingStatus("计划已就绪 / Plan Ready")
+	c.planUserStatus("执行方案已经准备好，等你开始", "The execution plan is ready to start", aicommon.WithStatusCode("plan.ready"), aicommon.WithStatusState(aicommon.StatusStateWaiting))
 	c.EmitInfo("plan phase completed, awaiting execution")
 	c.Wait()
 	return nil
@@ -204,25 +203,24 @@ func (c *Coordinator) RunPlanOnly() error {
 
 // RunExecuteApprovedPlan executes an in-memory approved plan without running the plan loop.
 func (c *Coordinator) RunExecuteApprovedPlan() error {
-	c.planLoadingStatus("初始化 / Initializing...")
-	defer c.planLoadingStatus("任务规划执行结束 / Plan Execution Finished")
+	c.planUserStatus("正在准备执行计划", "Preparing to execute the plan", aicommon.WithStatusCode("plan.preparing"))
 
 	c.registerPEModeInputEventCallback()
 	c.EmitCurrentConfigInfo()
 	c.emitBaseCapabilityInventory()
 
 	if c.rootTask == nil {
-		c.planLoadingStatus("无已批准计划 / No Approved Plan")
+		c.planUserStatus("没有找到已确认的执行方案", "No approved execution plan was found", aicommon.WithStatusCode("plan.not_found"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("no approved plan found for execution")
 		return utils.Errorf("coordinator: no approved plan to execute for %s", c.GetRuntimeId())
 	}
 	if len(c.rootTask.Subtasks) <= 0 {
-		c.planLoadingStatus("无有效子任务 / No Valid Subtasks")
+		c.planUserStatus("执行方案中没有可推进的步骤", "The plan has no actionable steps", aicommon.WithStatusCode("plan.empty"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("no subtasks found, this task is not a valid task")
 		return utils.Errorf("coordinator: no subtasks found")
 	}
 	if err := c.validatePlanExecutableDAG(c.rootTask); err != nil {
-		c.planLoadingStatus("任务规划依赖校验失败 / Plan DAG Validation Failed")
+		c.planUserStatus("步骤之间存在冲突，暂时无法执行", "Some plan steps conflict and cannot be executed", aicommon.WithStatusCode("plan.order_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.recordPlanDAGValidationFailure(err, 0)
 		return utils.Errorf("coordinator: approved plan executable DAG validation failed: %v", err)
 	}
@@ -235,8 +233,7 @@ func (c *Coordinator) RunExecuteApprovedPlan() error {
 
 // RunExecuteOnly executes a previously approved plan (plan_ready in DB) without re-running plan loop.
 func (c *Coordinator) RunExecuteOnly() error {
-	c.planLoadingStatus("初始化 / Initializing...")
-	defer c.planLoadingStatus("任务规划执行结束 / Plan Execution Finished")
+	c.planUserStatus("正在恢复执行方案", "Restoring the execution plan", aicommon.WithStatusCode("plan.recovering"), aicommon.WithStatusState(aicommon.StatusStateRecovering))
 
 	c.registerPEModeInputEventCallback()
 	c.EmitCurrentConfigInfo()
@@ -247,7 +244,7 @@ func (c *Coordinator) RunExecuteOnly() error {
 		return err
 	}
 	if !recovered {
-		c.planLoadingStatus("无已批准计划 / No Approved Plan")
+		c.planUserStatus("没有找到可以继续的执行方案", "No execution plan is available to continue", aicommon.WithStatusCode("plan.not_found"), aicommon.WithStatusState(aicommon.StatusStateError))
 		c.EmitError("no approved plan found for execution")
 		return utils.Errorf("coordinator: no approved plan to execute for %s", c.GetRuntimeId())
 	}

--- a/common/ai/aid/plan_dag_validation.go
+++ b/common/ai/aid/plan_dag_validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/utils"
 )
 
@@ -61,7 +62,7 @@ func (pr *planRequest) ensurePlanExecutableDAG(rsp *PlanResponse) (*PlanResponse
 			if attempt >= maxPlanDAGValidationRepairAttempts {
 				return nil, utils.Errorf("coordinator: plan executable DAG validation failed after %d repair attempts: %v", maxPlanDAGValidationRepairAttempts, err)
 			}
-			pr.cod.planLoadingStatus("任务计划依赖无效，正在请求 AI 修正 / Invalid Plan DAG, Asking AI to Repair...")
+			pr.cod.planUserStatus("步骤之间存在冲突，正在重新整理", "Some steps conflict and are being reorganized", aicommon.WithStatusCode("plan.reordering"), aicommon.WithStatusState(aicommon.StatusStateRecovering))
 			pr.cod.EmitInfo("request AI to repair invalid plan executable DAG: %v", err)
 			repaired, repairErr := pr.generateNewPlan("incomplete", reason, current)
 			if repairErr != nil {

--- a/common/ai/aid/plan_from_data.go
+++ b/common/ai/aid/plan_from_data.go
@@ -106,7 +106,7 @@ func (c *Coordinator) ReviewPlanThroughUser(ctx context.Context, planPayload str
 		return nil, utils.Error("plan response is nil")
 	}
 
-	c.planLoadingStatus("任务规划等待用户审查 / Waiting User to Review Plan...")
+	c.planUserStatus("执行方案已经准备好，等你确认", "The execution plan is ready for your review", aicommon.WithStatusCode("plan.awaiting_review"), aicommon.WithStatusState(aicommon.StatusStateWaiting))
 
 	planReq, err := c.createPlanRequest(planPayload)
 	if err != nil {
@@ -124,11 +124,11 @@ func (c *Coordinator) ReviewPlanThroughUser(ctx context.Context, planPayload str
 	params := ep.GetParams()
 	c.ReleaseInteractiveEvent(ep.GetId(), params)
 	if params == nil {
-		c.planLoadingStatus("用户审查失败 / User Review Failed")
+		c.planUserStatus("没有收到有效的确认结果", "No valid review response was received", aicommon.WithStatusCode("plan.review_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		return nil, utils.Errorf("coordinator: user review params is nil")
 	}
 
-	c.planLoadingStatus("处理用户审查结果 / Processing User Review...")
+	c.planUserStatus("正在根据你的意见调整方案", "Updating the plan based on your feedback", aicommon.WithStatusCode("plan.revising"))
 	approved, err := planReq.handleReviewPlanResponse(rsp, params)
 	if err != nil {
 		return nil, err

--- a/common/ai/aid/runtime.go
+++ b/common/ai/aid/runtime.go
@@ -404,30 +404,33 @@ func (r *runtime) invokeTask(current *AiTask) error {
 	}
 
 	if current.GetStatus() == aicommon.AITaskState_Skipped {
-		r.config.planLoadingStatus(fmt.Sprintf("任务 [%s] 已跳过 / Task [%s] Skipped", current.Index, current.Index))
+		r.config.planUserStatus(fmt.Sprintf("已跳过「%s」，正在继续", current.Name), fmt.Sprintf("Skipped %q and continuing", current.Name), aicommon.WithStatusCode("plan.task_skipped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
 		r.config.EmitInfo("subtask %s was skipped by user, moving to next task", current.Name)
 		return nil
 	}
 	if current.executed() {
-		r.config.planLoadingStatus(fmt.Sprintf("任务 [%s] 已完成 / Task [%s] Completed", current.Index, current.Index))
+		r.config.planUserStatus(fmt.Sprintf("「%s」已经完成，正在继续", current.Name), fmt.Sprintf("%q is complete; continuing", current.Name), aicommon.WithStatusCode("plan.task_completed"), aicommon.WithStatusState(aicommon.StatusStateSuccess))
 		r.config.EmitInfo("subtask %s already completed, moving to next task", current.Name)
 		return nil
 	}
 	if r.config.IsCtxDone() {
-		r.config.planLoadingStatus("执行已取消 / Execution Cancelled")
+		r.config.planUserStatus("任务已经停止", "Task stopped", aicommon.WithStatusCode("plan.stopped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
 		return utils.Errorf("coordinator context is done")
 	}
 	if current.IsCtxDone() {
 		if current.GetStatus() == aicommon.AITaskState_Skipped {
-			r.config.planLoadingStatus(fmt.Sprintf("任务 [%s] 已跳过 / Task [%s] Skipped", current.Index, current.Index))
+			r.config.planUserStatus(fmt.Sprintf("已跳过「%s」，正在继续", current.Name), fmt.Sprintf("Skipped %q and continuing", current.Name), aicommon.WithStatusCode("plan.task_skipped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
 			r.config.EmitInfo("subtask %s context cancelled (skipped), moving to next task", current.Name)
 			return nil
 		}
 		return utils.Errorf("task context is done")
 	}
 
-	r.config.planLoadingStatus(fmt.Sprintf("准备执行任务 [%s]: %s / Preparing Task [%s]: %s",
-		current.Index, current.Name, current.Index, current.Name))
+	r.config.planUserStatus(
+		fmt.Sprintf("正在处理「%s」", current.Name),
+		fmt.Sprintf("Working on %q", current.Name),
+		aicommon.WithStatusCode("plan.task_running"),
+	)
 
 	r.config.EmitInfo("invoke subtask: %v", current.Name)
 	current.ForceSetStatus(aicommon.AITaskState_Processing) // recovery 时允许从终态强制回到执行中
@@ -450,10 +453,12 @@ func (r *runtime) executeStageWithHandler(stageIdx int, stageNodes []*executable
 
 	r.setActiveStage(stageIdx, stageNodes)
 	representative := r.representativeTask()
-	r.config.planLoadingStatus(fmt.Sprintf(
-		"执行阶段 %d/%d（%d 个任务） / Executing Stage %d/%d (%d Tasks)",
-		stageIdx+1, totalStages, len(stageNodes), stageIdx+1, totalStages, len(stageNodes),
-	))
+	r.config.planUserStatus(
+		fmt.Sprintf("正在推进第 %d/%d 个阶段，共 %d 项任务", stageIdx+1, totalStages, len(stageNodes)),
+		fmt.Sprintf("Running stage %d/%d with %d tasks", stageIdx+1, totalStages, len(stageNodes)),
+		aicommon.WithStatusCode("plan.stage_running"),
+		aicommon.WithStatusProgress(int64(stageIdx+1), int64(totalStages), "stage"),
+	)
 	r.config.savePlanAndExecState(Phase_NotCompleted, representative)
 
 	concurrency := r.config.GetPlanExecTaskConcurrency()
@@ -496,11 +501,13 @@ func (r *runtime) executeStageWithHandler(stageIdx int, stageNodes []*executable
 			if result.task != nil {
 				r.finishActiveTask(result.task.TaskId)
 			}
-			r.config.planLoadingStatus(fmt.Sprintf(
-				"执行进度: %d/%d - 当前阶段 %d/%d / Progress: %d/%d - Stage %d/%d",
-				r.currentProgressIndex(), totalTasks, stageIdx+1, totalStages,
-				r.currentProgressIndex(), totalTasks, stageIdx+1, totalStages,
-			))
+			completed := r.currentProgressIndex()
+			r.config.planUserStatus(
+				fmt.Sprintf("任务进度 %d/%d，正在继续推进", completed, totalTasks),
+				fmt.Sprintf("Task progress %d/%d; continuing", completed, totalTasks),
+				aicommon.WithStatusCode("plan.progress"),
+				aicommon.WithStatusProgress(int64(completed), int64(totalTasks), "task"),
+			)
 			r.config.savePlanAndExecState(Phase_NotCompleted, r.representativeTask())
 			if result.err != nil && firstErr == nil {
 				failedTask = result.task
@@ -563,11 +570,13 @@ func (r *runtime) executeStageWithHandler(stageIdx int, stageNodes []*executable
 		if result.task != nil {
 			r.finishActiveTask(result.task.TaskId)
 		}
-		r.config.planLoadingStatus(fmt.Sprintf(
-			"执行进度: %d/%d - 当前阶段 %d/%d / Progress: %d/%d - Stage %d/%d",
-			r.currentProgressIndex(), totalTasks, stageIdx+1, totalStages,
-			r.currentProgressIndex(), totalTasks, stageIdx+1, totalStages,
-		))
+		completed := r.currentProgressIndex()
+		r.config.planUserStatus(
+			fmt.Sprintf("任务进度 %d/%d，正在继续推进", completed, totalTasks),
+			fmt.Sprintf("Task progress %d/%d; continuing", completed, totalTasks),
+			aicommon.WithStatusCode("plan.progress"),
+			aicommon.WithStatusProgress(int64(completed), int64(totalTasks), "task"),
+		)
 		r.config.savePlanAndExecState(Phase_NotCompleted, r.representativeTask())
 		if result.err != nil && firstErr == nil {
 			failedTask = result.task
@@ -683,7 +692,7 @@ func (r *runtime) Invoke(task *AiTask, startTaskID string) (retErr error) {
 
 		stageIdx, stageNodes, ok := r.nextPendingStage(graph)
 		if !ok {
-			r.config.planLoadingStatus("所有任务执行完成 / All Tasks Completed")
+			r.config.planUserStatus("所有任务都已经完成", "All tasks are complete", aicommon.WithStatusCode("plan.completed"), aicommon.WithStatusState(aicommon.StatusStateSuccess))
 			phase = Phase_Completed
 			currentTask = nil
 			return nil
@@ -696,21 +705,21 @@ func (r *runtime) Invoke(task *AiTask, startTaskID string) (retErr error) {
 				isSkipped := failedTask.GetStatus() == aicommon.AITaskState_Skipped
 				isContextCanceled := strings.Contains(err.Error(), "context canceled") || strings.Contains(err.Error(), "context done")
 				if isSkipped || (isContextCanceled && failedTask.GetStatus() == aicommon.AITaskState_Skipped) {
-					r.config.planLoadingStatus(fmt.Sprintf("任务 [%s] 用户跳过,继续下一个 / Task [%s] User Skipped, Continuing", failedTask.Index, failedTask.Index))
+					r.config.planUserStatus(fmt.Sprintf("已跳过「%s」，正在继续下一项", failedTask.Name), fmt.Sprintf("Skipped %q and continuing", failedTask.Name), aicommon.WithStatusCode("plan.task_skipped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
 					r.config.EmitInfo("task %s was skipped by user, continuing to next task", failedTask.Name)
 					continue
 				}
 			}
 			if r.config.IsCtxDone() {
-				r.config.planLoadingStatus("用户终止执行 / User Terminated Execution")
+				r.config.planUserStatus("任务已经停止", "Task stopped", aicommon.WithStatusCode("plan.stopped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
 				r.config.EmitInfo("coordinator context cancelled, stopping execution")
 				return err
 			}
 			if failedTask != nil {
-				r.config.planLoadingStatus(fmt.Sprintf("任务 [%s] 执行失败 / Task [%s] Failed", failedTask.Index, failedTask.Index))
+				r.config.planUserStatus(fmt.Sprintf("处理「%s」时遇到问题", failedTask.Name), fmt.Sprintf("A problem occurred while working on %q", failedTask.Name), aicommon.WithStatusCode("plan.task_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 				r.config.EmitPlanExecFail("invoke task[%s] failed: %v", failedTask.Name, err)
 			} else {
-				r.config.planLoadingStatus("阶段执行失败 / Stage Execution Failed")
+				r.config.planUserStatus("推进当前阶段时遇到问题", "A problem occurred in the current stage", aicommon.WithStatusCode("plan.stage_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 				r.config.EmitPlanExecFail("invoke stage failed: %v", err)
 			}
 			r.config.EmitError("invoke subtask failed: %v", err)

--- a/common/ai/aid/task_execute.go
+++ b/common/ai/aid/task_execute.go
@@ -51,16 +51,17 @@ func (t *AiTask) execute() error {
 	}
 
 	// Emit task execution start status
-	t.planLoadingStatus(fmt.Sprintf("执行子任务 [%s] / Executing Subtask [%s]: %s", t.Index, t.Index, t.Name))
+	t.planUserStatus(
+		fmt.Sprintf("正在处理「%s」", t.Name),
+		fmt.Sprintf("Working on %q", t.Name),
+		aicommon.WithStatusCode("plan.task_running"),
+	)
 
 	err := t.ExecuteLoopTask(
 		schema.AI_REACT_LOOP_NAME_PE_TASK,
 		t,
 		reactloops.WithOnPostIteraction(func(loop *reactloops.ReActLoop, iteration int, task aicommon.AIStatefulTask, isDone bool, reason any, operator *reactloops.OnPostIterationOperator) {
 			t.EmitInfo("ReAct Loop iteration %d completed for task: %s, isDone: %v, reason: %v", iteration, t.Name, isDone, reason)
-
-			// Emit iteration status
-			t.planLoadingStatus(fmt.Sprintf("任务 [%s] 迭代 %d 完成 / Task [%s] Iteration %d Completed", t.Index, iteration, t.Index, iteration))
 
 			// Log current task status for debugging - similar to prompt context format
 			log.Infof("=== Post Iteration Task Status ===")
@@ -128,21 +129,25 @@ func (t *AiTask) execute() error {
 
 			if shouldComplete {
 				// Emit task completing status
-				t.planLoadingStatus(fmt.Sprintf("任务 [%s] 正在总结 / Task [%s] Generating Summary...", t.Index, t.Index))
+				t.planUserStatus(
+					fmt.Sprintf("正在归纳「%s」的结果", t.Name),
+					fmt.Sprintf("Summarizing the results of %q", t.Name),
+					aicommon.WithStatusCode("plan.task_summarizing"),
+				)
 
 				err := t.generateTaskSummary(summary, nextSteps)
 				if err != nil {
 					log.Errorf("iteration task summary failed: %v", err)
-					t.planLoadingStatus(fmt.Sprintf("任务 [%s] 总结失败 / Task [%s] Summary Failed", t.Index, t.Index))
+					t.planUserStatus(fmt.Sprintf("暂时没能归纳「%s」的结果", t.Name), fmt.Sprintf("Unable to summarize %q", t.Name), aicommon.WithStatusCode("plan.task_summary_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 				} else {
-					t.planLoadingStatus(fmt.Sprintf("任务 [%s] 已完成 / Task [%s] Completed", t.Index, t.Index))
+					t.planUserStatus(fmt.Sprintf("「%s」已经完成", t.Name), fmt.Sprintf("%q is complete", t.Name), aicommon.WithStatusCode("plan.task_completed"), aicommon.WithStatusState(aicommon.StatusStateSuccess))
 				}
 
 				// Signal the loop to end - this ensures the loop terminates after this iteration
 				operator.EndIteration("task completed via completed_task_index or isDone")
 			} else {
 				// Emit continuing status
-				t.planLoadingStatus(fmt.Sprintf("任务 [%s] 继续执行 (迭代 %d) / Task [%s] Continuing (Iteration %d)", t.Index, iteration+1, t.Index, iteration+1))
+				t.planUserStatus(fmt.Sprintf("正在继续处理「%s」", t.Name), fmt.Sprintf("Continuing to work on %q", t.Name), aicommon.WithStatusCode("plan.task_continuing"))
 
 				// Combine summary (reasoning) and todo_delta as Processing status
 				// This ensures both are captured in StatusSummary to avoid context loss
@@ -261,19 +266,19 @@ func (t *AiTask) executeTask() error {
 		if t.GetStatus() == aicommon.AITaskState_Processing {
 			t.SetStatus(aicommon.AITaskState_Aborted)
 		}
-		t.planLoadingStatus(fmt.Sprintf("任务 [%s] 上下文已取消 / Task [%s] Context Cancelled", t.Index, t.Index))
+		t.planUserStatus(fmt.Sprintf("「%s」已经停止", t.Name), fmt.Sprintf("%q has stopped", t.Name), aicommon.WithStatusCode("plan.task_stopped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
 		return utils.Errorf("context is done")
 	}
 
 	// Execute the task
 	if err := t.execute(); err != nil {
-		t.planLoadingStatus(fmt.Sprintf("任务 [%s] 执行出错 / Task [%s] Execution Error", t.Index, t.Index))
+		t.planUserStatus(fmt.Sprintf("处理「%s」时遇到问题", t.Name), fmt.Sprintf("A problem occurred while working on %q", t.Name), aicommon.WithStatusCode("plan.task_failed"), aicommon.WithStatusState(aicommon.StatusStateError))
 		return err
 	}
 
 	if t.GetStatus() != aicommon.AITaskState_Skipped {
 		// Start to wait for user review
-		t.planLoadingStatus(fmt.Sprintf("等待用户审查任务 [%s] / Waiting User Review for Task [%s]", t.Index, t.Index))
+		t.planUserStatus(fmt.Sprintf("「%s」已经处理好，等你确认", t.Name), fmt.Sprintf("%q is ready for your review", t.Name), aicommon.WithStatusCode("plan.task_awaiting_review"), aicommon.WithStatusState(aicommon.StatusStateWaiting))
 		ep := t.Epm.CreateEndpointWithEventType(schema.EVENT_TYPE_TASK_REVIEW_REQUIRE)
 		ep.SetDefaultSuggestionContinue()
 		t.EmitInfo("start to wait for user review current task")
@@ -285,7 +290,7 @@ func (t *AiTask) executeTask() error {
 		t.DoWaitAgree(t.Ctx, ep)
 
 		// User review finished
-		t.planLoadingStatus(fmt.Sprintf("处理任务 [%s] 审查结果 / Processing Review for Task [%s]", t.Index, t.Index))
+		t.planUserStatus(fmt.Sprintf("正在根据你的意见调整「%s」", t.Name), fmt.Sprintf("Updating %q based on your feedback", t.Name), aicommon.WithStatusCode("plan.task_revising"))
 		reviewResult := ep.GetParams()
 		t.ReleaseInteractiveEvent(ep.GetId(), reviewResult)
 		t.EmitInfo("start to handle review task event: %v", ep.GetId())
@@ -297,7 +302,7 @@ func (t *AiTask) executeTask() error {
 			log.Warnf("error handling review result: %v", err)
 		}
 	} else {
-		t.planLoadingStatus(fmt.Sprintf("任务 [%s] 已跳过 / Task [%s] Skipped", t.Index, t.Index))
+		t.planUserStatus(fmt.Sprintf("已跳过「%s」", t.Name), fmt.Sprintf("Skipped %q", t.Name), aicommon.WithStatusCode("plan.task_skipped"), aicommon.WithStatusState(aicommon.StatusStateWarning))
 		t.EmitInfo("task %s was skipped by user, skip review", t.Name)
 		log.Infof("task %s was skipped by user, skip review", t.Name)
 	}
@@ -306,7 +311,7 @@ func (t *AiTask) executeTask() error {
 }
 
 func (t *AiTask) generateTaskSummary(summary, nextSteps string) error {
-	t.planLoadingStatus(fmt.Sprintf("任务 [%s] 生成总结提示 / Task [%s] Generating Summary Prompt...", t.Index, t.Index))
+	t.planUserStatus(fmt.Sprintf("正在整理「%s」的关键信息", t.Name), fmt.Sprintf("Organizing the key information from %q", t.Name), aicommon.WithStatusCode("plan.task_summary_preparing"))
 
 	summaryPromptWellFormed, err := t.GenerateTaskSummaryPrompt()
 	if err != nil {
@@ -319,7 +324,7 @@ func (t *AiTask) generateTaskSummary(summary, nextSteps string) error {
 	// reference material emission tracking (once per transaction, not per key)
 	var referenceEmittedOnce sync.Once
 
-	t.planLoadingStatus(fmt.Sprintf("任务 [%s] 等待 AI 生成总结 / Task [%s] Waiting AI Summary...", t.Index, t.Index))
+	t.planUserStatus(fmt.Sprintf("正在归纳「%s」的结果", t.Name), fmt.Sprintf("Summarizing the results of %q", t.Name), aicommon.WithStatusCode("plan.task_summarizing"))
 	extractStart := time.Now()
 	err = t.CallAITransaction(summaryPromptWellFormed, func(summaryReader *aicommon.AIResponse) error { // 异步过程 使用无 id的 原始ai callback
 		boundEmitter := summaryReader.BindEmitter(t.GetEmitter())
@@ -335,7 +340,6 @@ func (t *AiTask) generateTaskSummary(summary, nextSteps string) error {
 					}()
 
 					log.Debugf("summary stream handler started for field [%s]", key)
-					t.planLoadingStatus(fmt.Sprintf("任务 [%s] 处理 %s / Task [%s] Processing %s", t.Index, key, t.Index, key))
 
 					nodeId := "summary-long"
 
@@ -448,7 +452,7 @@ func (t *AiTask) generateTaskSummary(summary, nextSteps string) error {
 		}
 	}
 
-	t.planLoadingStatus(fmt.Sprintf("任务 [%s] 总结完成 / Task [%s] Summary Completed", t.Index, t.Index))
+	t.planUserStatus(fmt.Sprintf("「%s」的结果已经整理完成", t.Name), fmt.Sprintf("The results of %q are ready", t.Name), aicommon.WithStatusCode("plan.task_summary_ready"), aicommon.WithStatusState(aicommon.StatusStateSuccess))
 
 	// Save timeline diff and result summary artifacts
 	if err := t.saveTaskArtifacts(summary, nextSteps, statusSummary, taskSummary, shortSummary, longSummary); err != nil {

--- a/docs/ai-status-events.md
+++ b/docs/ai-status-events.md
@@ -1,0 +1,90 @@
+# AI Status 事件规范
+
+Status 用来告诉用户助手正在做什么，不承担调试日志职责。界面默认展示中文；英文和更丰富的展示信息作为可选字段提供。
+
+## 兼容协议
+
+旧接口保持原样：
+
+```go
+emitter.EmitStatus(key, value)
+```
+
+新代码优先使用：
+
+```go
+emitter.EmitStatusI18n(
+    key,
+    "正在准备调用 2 个工具：读取文件、搜索代码",
+    "Preparing 2 tools: Read File and Search Code",
+    aicommon.WithStatusCode("tool.preparing"),
+    aicommon.WithStatusProgress(0, 2, "tool"),
+    aicommon.WithStatusTools(tools...),
+)
+```
+
+对应事件是旧结构的严格超集：
+
+```json
+{
+  "key": "react",
+  "value": "正在准备调用 2 个工具：读取文件、搜索代码",
+  "value_i18n": {
+    "zh": "正在准备调用 2 个工具：读取文件、搜索代码",
+    "en": "Preparing 2 tools: Read File and Search Code"
+  },
+  "code": "tool.preparing",
+  "state": "running",
+  "detail": "先了解相关实现，再继续处理",
+  "detail_i18n": {
+    "zh": "先了解相关实现，再继续处理",
+    "en": "Reviewing the relevant implementation before continuing"
+  },
+  "progress": { "current": 0, "total": 2, "unit": "tool" },
+  "tools": [
+    { "name": "read_file", "display_name": "读取文件", "state": "running" },
+    { "name": "grep", "display_name": "搜索代码", "state": "running" }
+  ]
+}
+```
+
+| 组合 | 行为 |
+| --- | --- |
+| 旧后端 + 旧前端 | 继续读取 `key`、`value` |
+| 新后端 + 旧前端 | `value` 仍是字符串，默认中文 |
+| 旧后端 + 新前端 | 缺少扩展字段时退回 `value` |
+| 新后端 + 新前端 | 按语言展示文案，并可展示详情、进度和工具 |
+
+`state` 可选值为 `running`、`waiting`、`recovering`、`success`、`warning`、`error`。它描述当前提示的呈现状态，不替代任务自身的生命周期状态。
+
+## 文案迁移
+
+文案描述用户能理解的意图和结果；解析器、流、字段名、事务、DAG 等实现细节保留在日志中。
+
+| 原表达 | 优化后 | 说明 |
+| --- | --- | --- |
+| 解析 AI 响应中 | 正在梳理思路 | 隐去协议解析过程 |
+| 等待网络响应 | 正在查找最新资料 | 表达用户可感知的目的 |
+| 初始化 ReAct 循环 | 正在准备这次任务 | 隐去运行框架 |
+| Verifier 验证中 | 正在确认关键细节 | 使用自然语言 |
+| 事务执行失败 | 暂时没能完成这一步 | 原始错误进入日志或时间线 |
+| Action 解析失败，重试中 | 刚才的信息不够完整，正在重新整理 | 表达可恢复状态 |
+| 正在执行工具 | 正在准备使用「读取文件」 | 展示真实工具名 |
+| 批量工具调用中 | 正在准备调用 3 个工具：读取文件、搜索代码、查看目录 | 展示数量、名称和进度 |
+| 批量工具调用完成 | 3 个工具中有 2 个已完成，正在整理可用结果 | 展示实际成功数及逐工具状态 |
+| Task 2 执行中 | 正在处理「分析登录逻辑」 | 展示任务名称，不展示内部序号 |
+| Phase 2 扫描中 | 正在排查潜在风险 | 隐去内部阶段编号 |
+| 正在解析图片附件 | 正在理解第 2/5 张图片 | 提供真实进度 |
+| 正在生成最终结果 | 正在组织回答 | 更接近助手语气 |
+| 处理中，请稍候 | 这一步比预期久一些，仍在继续 | 对等待给出明确反馈 |
+
+## 编写约定
+
+- `value` 优先使用简短、可独立展示的中文，不拼接双语。
+- `value_i18n` 承载语言版本；中文缺失时才回退英文。
+- `code` 使用稳定的机器标识，前端不要依赖文案判断状态。
+- 只有可计算时才提供 `progress.total`，不要用虚构百分比安抚用户。
+- 工具状态展示真实名称，标题最多列出三个，其余用数量概括。
+- 批量工具只在准备和批次返回时更新状态，避免为每个子调用重复刷屏。
+- Status 不携带工具参数、提示词、原始响应和敏感错误信息。
+- `detail` 只补充“为什么做”或“接下来做什么”，不要复制标题。

--- a/docs/ai-status-events.md
+++ b/docs/ai-status-events.md
@@ -4,13 +4,13 @@ Status 用来告诉用户助手正在做什么，不承担调试日志职责。�
 
 ## 兼容协议
 
-旧接口保持原样：
+旧接口仅保留给外部兼容调用：
 
 ```go
 emitter.EmitStatus(key, value)
 ```
 
-新代码优先使用：
+生产代码统一使用：
 
 ```go
 emitter.EmitStatusI18n(
@@ -88,3 +88,5 @@ emitter.EmitStatusI18n(
 - 批量工具只在准备和批次返回时更新状态，避免为每个子调用重复刷屏。
 - Status 不携带工具参数、提示词、原始响应和敏感错误信息。
 - `detail` 只补充“为什么做”或“接下来做什么”，不要复制标题。
+- 中英文必须作为独立参数传入，不要在中文参数中继续拼接 `中文 / English`。
+- `EmitStatus` 与 `LoadingStatus` 只是兼容层，`TestProductionStatusCallsUseI18n` 会防止生产代码重新使用旧入口或传入空翻译。

--- a/scripts/ci/test-run-suite.sh
+++ b/scripts/ci/test-run-suite.sh
@@ -66,7 +66,10 @@ for _ in {1..60}; do
   if ! kill -0 "$grpc_pid" 2>/dev/null; then
     break
   fi
-  if nc -z localhost 8087 && grep -q "yak grpc ok" "$grpc_log" 2>/dev/null; then
+  # The structured ready event is written immediately after the listener is
+  # bound. Do not wait for the later human-readable startup log: initialization
+  # between those two messages may be slow even though gRPC is already ready.
+  if nc -z localhost 8087 && grep -q '^yak grpc ready {' "$grpc_log" 2>/dev/null; then
     grpc_ready=1
     break
   fi


### PR DESCRIPTION
## Summary

- Preserve the legacy EmitStatus(key, value) payload and add EmitStatusI18n as a compatible structured superset.
- Make value default to Chinese while exposing value_i18n, code, state, detail, progress, and tool metadata for newer clients.
- Replace existing loading-status copy with user-facing language and remove parser, stream-field, iteration, DAG, and other debug terminology from the status bar.
- Show real tool names for existing tool-call statuses. Batch calls emit one additional result summary with actual success count, progress, and per-tool state.
- Document the event contract, compatibility matrix, copy rules, and representative before/after wording.

No yakit/frontend files are changed in this PR.

## Compatibility

- Old backend + old client: unchanged key/value behavior.
- New backend + old client: value remains a string and defaults to Chinese.
- Old backend + new client: clients can fall back to value when extensions are absent.
- New backend + new client: clients may render localized text, detail, progress, and tools.

The legacy bilingual strings are split only in the loading-status compatibility wrapper. Paths such as GET / api remain intact.

## Status examples

| Before | After |
| --- | --- |
| 解析 AI 响应中 | 正在梳理思路 |
| 等待 AI 回应 | 正在理解你的需求 |
| Verifier 验证中 | 正在确认关键细节 |
| 准备并发工具调用 | 正在准备调用 3 个工具：读取文件、搜索代码、查看目录 |
| 批量调用完成 | 3 个工具中有 2 个已完成，正在整理可用结果 |

## Tests

- go test ./common/ai/aid/aicommon -run TestEmitStatus|TestSplitLegacyStatusI18n -count=1
- go test ./common/ai/aid/aireact/reactloops/loopinfra -run TestBuildToolBatchResultToolsPreservesActualState|TestToolBatchActionHandler -count=1
- go test ./common/ai/aid/aireact/reactloops/... ./common/ai/aid -run ^$ -count=1
- go test ./common/ai/aid/aicommon ./common/ai/aid/aireact/reactloops ./common/ai/aid/aireact/reactloops/loopinfra ./common/ai/aid -count=1