### PR TITLE
fix(webfuzzer): identify HTTPFlow body download by HiddenIndex

### DIFF
--- a/common/yakgrpc/grpc_fuzzer.go
+++ b/common/yakgrpc/grpc_fuzzer.go
@@ -48,6 +48,16 @@ var (
 	fuzzerSessionPreFix  = "__FUZZER_SESSION__"
 )
 
+func ensureLowhttpHiddenIndex(r *lowhttp.LowhttpResponse) string {
+	if r == nil {
+		return uuid.NewString()
+	}
+	if strings.TrimSpace(r.HiddenIndex) == "" {
+		r.HiddenIndex = uuid.NewString()
+	}
+	return r.HiddenIndex
+}
+
 func Chardet(raw []byte) string {
 	res, err := chardet.NewTextDetector().DetectBest(raw)
 	if err != nil {
@@ -1368,6 +1378,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 					TaskId:      int64(taskID),
 					Payloads:    result.Payloads,
 					RuntimeID:   runtimeID,
+					HiddenIndex: ensureLowhttpHiddenIndex(result.LowhttpResponse),
 					BodyLength:  totalLen,
 					DurationMs:  result.DurationMs,
 				}
@@ -1414,7 +1425,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 
 			if result.Error != nil {
 				log.Errorf("http pool error: %s", result.Error)
-				hiddenIndex := ""
+				hiddenIndex := ensureLowhttpHiddenIndex(result.LowhttpResponse)
 				rsp := &ypb.FuzzerResponse{}
 				rsp.RequestRaw = result.RequestRaw
 				rsp.UUID = uuid.New().String()
@@ -1424,14 +1435,11 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 				rsp.TaskId = int64(taskID)
 				rsp.Payloads = payloads
 				rsp.RuntimeID = runtimeID
+				rsp.HiddenIndex = hiddenIndex
 				rsp.ResponseRaw = result.ResponseRaw
 				if result.LowhttpResponse != nil && result.LowhttpResponse.TraceInfo != nil {
 					SetFuzzerRespTraceInfo(rsp, result.LowhttpResponse.TraceInfo)
 					rsp.RemoteAddr = result.LowhttpResponse.RemoteAddr
-					hiddenIndex = result.LowhttpResponse.HiddenIndex
-				}
-				if hiddenIndex == "" {
-					hiddenIndex = uuid.NewString()
 				}
 
 				task.HTTPFlowFailedCount++
@@ -1510,6 +1518,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 			}
 
 			if consts.GLOBAL_HTTP_FLOW_SAVE.IsSet() && result.LowhttpResponse != nil {
+				ensureLowhttpHiddenIndex(result.LowhttpResponse)
 				yakit.SaveLowHTTPFlow(result.LowhttpResponse, false)
 			}
 
@@ -1557,6 +1566,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 				TooLargeResponseHeaderFile: tooLargeHeaderFile,
 				DisableRenderStyles:        len(body) > 1024*1024*2,
 				RuntimeID:                  runtimeID,
+				HiddenIndex:                ensureLowhttpHiddenIndex(result.LowhttpResponse),
 				IsAutoFixContentType:       isAutoFixContentType,
 				OriginalContentType:        originContentType,
 				FixContentType:             fixContentType,
@@ -1710,6 +1720,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 					}
 
 					if consts.GLOBAL_HTTP_FLOW_SAVE.IsSet() {
+						ensureLowhttpHiddenIndex(redirectRes)
 						yakit.SaveLowHTTPFlow(redirectRes, false)
 					}
 
@@ -1722,6 +1733,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 						Payloads:              payloads,
 						IsHTTPS:               redirectRes.Https,
 						RuntimeID:             runtimeID,
+						HiddenIndex:           ensureLowhttpHiddenIndex(redirectRes),
 					}
 					if redirectRes != nil && redirectRes.TraceInfo != nil {
 						SetFuzzerRespTraceInfo(redirectRsp, redirectRes.TraceInfo)
@@ -1780,7 +1792,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 					}
 					redirectRsp.TaskId = int64(taskID)
 					// yakit.SaveWebFuzzerResponse(s.GetProjectDatabase(), int(task.ID), redirectRes.Uuid, redirectRsp)
-					yakit.SaveWebFuzzerResponseEx(int(task.ID), redirectRes.HiddenIndex, redirectRsp)
+					yakit.SaveWebFuzzerResponseEx(int(task.ID), redirectRsp.HiddenIndex, redirectRsp)
 					err := feedbackResponse(redirectRsp, false, false)
 					if err != nil {
 						log.Errorf("send to client failed: %s", err)
@@ -1794,7 +1806,7 @@ func (r *httpFuzzerRun) handleExecutionMode() error {
 			}
 			rsp.TaskId = int64(taskID)
 			// yakit.SaveWebFuzzerResponse(s.GetProjectDatabase(), int(task.ID), result.LowhttpResponse.Uuid, rsp)
-			yakit.SaveWebFuzzerResponseEx(int(task.ID), result.LowhttpResponse.HiddenIndex, rsp)
+			yakit.SaveWebFuzzerResponseEx(int(task.ID), rsp.HiddenIndex, rsp)
 			err := feedbackResponse(rsp, false, skipSendForSSEFinal)
 			if du := time.Now().Sub(feedbackNormalResponseStart); du > time.Second {
 				log.Warnf("feedbackNormalResponse cost too much time, try investigate it, cost: %v", du)

--- a/common/yakgrpc/grpc_fuzzer_test.go
+++ b/common/yakgrpc/grpc_fuzzer_test.go
@@ -309,6 +309,83 @@ Host: %v
 	}
 }
 
+func TestGRPCMUSTPASS_HTTPFuzzer_GetHTTPFlowBodyByHiddenIndex(t *testing.T) {
+	firstBody := "first-" + uuid.NewString()
+	finalBody := "final-" + uuid.NewString()
+	host, port := utils.DebugMockHTTPHandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.RequestURI != "/admin" {
+			writer.Header().Set("Location", "/admin")
+			writer.WriteHeader(http.StatusMovedPermanently)
+			_, _ = writer.Write([]byte(firstBody))
+			return
+		}
+		_, _ = writer.Write([]byte(finalBody))
+	})
+
+	c, err := NewLocalClient()
+	require.NoError(t, err)
+
+	client, err := c.HTTPFuzzer(context.Background(), &ypb.FuzzerRequest{
+		Request: fmt.Sprintf(`GET / HTTP/1.1
+Host: %v
+
+`, utils.HostPort(host, port)),
+		IsHTTPS:                  false,
+		PerRequestTimeoutSeconds: 5,
+		NoFollowRedirect:         false,
+		RedirectTimes:            3,
+	})
+	require.NoError(t, err)
+
+	var responses []*ypb.FuzzerResponse
+	for {
+		rsp, err := client.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+		}
+		responses = append(responses, rsp)
+	}
+	require.GreaterOrEqual(t, len(responses), 2)
+
+	indexes := make(map[string]struct{})
+	runtimeID := responses[0].GetRuntimeID()
+	require.NotEmpty(t, runtimeID)
+	for _, rsp := range responses {
+		require.Equal(t, runtimeID, rsp.GetRuntimeID())
+		require.NotEmpty(t, rsp.GetHiddenIndex(), "FuzzerResponse.HiddenIndex should be set")
+		_, dup := indexes[rsp.GetHiddenIndex()]
+		require.False(t, dup, "each hop should have unique HiddenIndex")
+		indexes[rsp.GetHiddenIndex()] = struct{}{}
+	}
+
+	for _, rsp := range responses {
+		wantBody := string(lowhttp.GetHTTPPacketBody(rsp.ResponseRaw))
+		stream, err := c.GetHTTPFlowBodyById(context.Background(), &ypb.GetHTTPFlowBodyByIdRequest{
+			HiddenIndex: rsp.GetHiddenIndex(),
+			IsRequest:   false,
+		})
+		require.NoError(t, err)
+
+		var gotBody strings.Builder
+		count := 0
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				break
+			}
+			count++
+			if count > 1 {
+				gotBody.Write(msg.GetData())
+			}
+		}
+		require.GreaterOrEqual(t, count, 2)
+		require.Equal(t, wantBody, gotBody.String(), "body by HiddenIndex should match the selected hop")
+	}
+}
+
 func TestGRPCMUSTPASS_HTTPFuzzer_WITHPLUGIN(t *testing.T) {
 	var token string
 	name, clearFunc, err := httptpl.MockEchoPlugin(func(s string) {

--- a/common/yakgrpc/grpc_httpflow.go
+++ b/common/yakgrpc/grpc_httpflow.go
@@ -128,22 +128,6 @@ func (s *Server) GetHTTPFlowById(_ context.Context, r *ypb.GetHTTPFlowByIdReques
 	return model.ToHTTPFlowGRPCModelFull(flow)
 }
 
-func getHTTPFlowByHiddenIndexWait(db *gorm.DB, hiddenIndex string) (*schema.HTTPFlow, error) {
-	var lastErr error
-	for i := 0; i < 20; i++ {
-		flow, err := yakit.GetHTTPFlowByHiddenIndex(db, hiddenIndex)
-		if err == nil && flow != nil {
-			return flow, nil
-		}
-		lastErr = err
-		time.Sleep(50 * time.Millisecond)
-	}
-	if lastErr != nil {
-		return nil, lastErr
-	}
-	return nil, utils.Error("get HTTPFlow by hidden index failed")
-}
-
 func (s *Server) GetHTTPFlowBodyById(r *ypb.GetHTTPFlowBodyByIdRequest, stream ypb.Yak_GetHTTPFlowBodyByIdServer) error {
 	bufSize := int(r.GetBufSize())
 	var (
@@ -165,7 +149,7 @@ func (s *Server) GetHTTPFlowBodyById(r *ypb.GetHTTPFlowBodyByIdRequest, stream y
 	} else if r.Id != 0 {
 		flow, err = yakit.GetHTTPFlow(s.GetProjectDatabase(), r.GetId())
 	} else if r.GetHiddenIndex() != "" {
-		flow, err = getHTTPFlowByHiddenIndexWait(s.GetProjectDatabase(), r.GetHiddenIndex())
+		flow, err = yakit.GetHTTPFlowByHiddenIndex(s.GetProjectDatabase(), r.GetHiddenIndex())
 	} else if r.RuntimeId != "" {
 		flow, err = yakit.GetHttpFlowByRuntimeId(s.GetProjectDatabase(), r.GetRuntimeId())
 	}

--- a/common/yakgrpc/grpc_httpflow.go
+++ b/common/yakgrpc/grpc_httpflow.go
@@ -128,6 +128,22 @@ func (s *Server) GetHTTPFlowById(_ context.Context, r *ypb.GetHTTPFlowByIdReques
 	return model.ToHTTPFlowGRPCModelFull(flow)
 }
 
+func getHTTPFlowByHiddenIndexWait(db *gorm.DB, hiddenIndex string) (*schema.HTTPFlow, error) {
+	var lastErr error
+	for i := 0; i < 20; i++ {
+		flow, err := yakit.GetHTTPFlowByHiddenIndex(db, hiddenIndex)
+		if err == nil && flow != nil {
+			return flow, nil
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, utils.Error("get HTTPFlow by hidden index failed")
+}
+
 func (s *Server) GetHTTPFlowBodyById(r *ypb.GetHTTPFlowBodyByIdRequest, stream ypb.Yak_GetHTTPFlowBodyByIdServer) error {
 	bufSize := int(r.GetBufSize())
 	var (
@@ -148,6 +164,8 @@ func (s *Server) GetHTTPFlowBodyById(r *ypb.GetHTTPFlowBodyByIdRequest, stream y
 		risk, err = yakit.GetRisk(s.GetProjectDatabase(), r.GetId())
 	} else if r.Id != 0 {
 		flow, err = yakit.GetHTTPFlow(s.GetProjectDatabase(), r.GetId())
+	} else if r.GetHiddenIndex() != "" {
+		flow, err = getHTTPFlowByHiddenIndexWait(s.GetProjectDatabase(), r.GetHiddenIndex())
 	} else if r.RuntimeId != "" {
 		flow, err = yakit.GetHttpFlowByRuntimeId(s.GetProjectDatabase(), r.GetRuntimeId())
 	}

--- a/common/yakgrpc/grpc_httpflow_test.go
+++ b/common/yakgrpc/grpc_httpflow_test.go
@@ -1048,6 +1048,39 @@ func TestGRPCMUSTPASS_GetHTTPFlowBodyById(t *testing.T) {
 		}
 		require.Equal(t, 2, count, "should only have 2 messages")
 	})
+	t.Run("by hidden index", func(t *testing.T) {
+		token := utils.RandStringBytes(8)
+		hiddenIndex := uuid.NewString()
+		url := "http://" + token + ".com/a.bin"
+		flow, err := yakit.CreateHTTPFlow(
+			yakit.CreateHTTPFlowWithURL(url),
+			yakit.CreateHTTPFlowWithRequestRaw([]byte("GET / HTTP/1.1\r\nHost: "+token+".com\r\n\r\n")),
+			yakit.CreateHTTPFlowWithResponseRaw([]byte("HTTP/1.1 200 OK\r\nContent-Length: 8\r\nContent-Type: application/octet-stream\r\n\r\n"+token)),
+		)
+		require.NoError(t, err)
+		flow.HiddenIndex = hiddenIndex
+		err = yakit.InsertHTTPFlow(db, flow)
+		require.NoError(t, err)
+		defer yakit.DeleteHTTPFlowByID(db, int64(flow.ID))
+
+		count := 0
+		stream, err := client.GetHTTPFlowBodyById(ctx, &ypb.GetHTTPFlowBodyByIdRequest{HiddenIndex: hiddenIndex})
+		require.NoError(t, err)
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				break
+			}
+			count++
+			if count == 1 {
+				require.Equal(t, "a.bin", msg.GetFilename())
+			} else if count == 2 {
+				require.Equal(t, token, string(msg.GetData()))
+				require.True(t, msg.GetEOF())
+			}
+		}
+		require.Equal(t, 2, count, "should only have 2 messages")
+	})
 	t.Run("get risk body", func(t *testing.T) {
 		target := uuid.NewString()
 		content := uuid.NewString()

--- a/common/yakgrpc/yakgrpc.proto
+++ b/common/yakgrpc/yakgrpc.proto
@@ -7045,6 +7045,8 @@ message FuzzerResponse {
   string FixContentType = 60;
   bool IsSetContentTypeOptions = 61;
   repeated RandomChunkedResponse RandomChunkedData = 62;
+  // 与 http_flows / web_fuzzer_response 对齐的唯一键，下载 body 用它而不是 RuntimeID。
+  string HiddenIndex = 64;
 }
 
 enum ChunkedDataDirection {
@@ -7108,6 +7110,8 @@ message GetHTTPFlowBodyByIdRequest {
   // 未设 = 返回完整 body（multipart 时现场流式重建完整 body）。
   // 用 optional 以区分「未设」与「part 0」。
   optional int32 PartIndex = 6;
+  // WebFuzzer 单条结果：按 HiddenIndex 定位 HTTPFlow，避免 RuntimeId 命中任务内其它 hop。
+  string HiddenIndex = 7;
 }
 
 message MITMExtractAggregateFlowFilterRow {

--- a/common/yakgrpc/ypb/yakgrpc.pb.go
+++ b/common/yakgrpc/ypb/yakgrpc.pb.go
@@ -50554,8 +50554,10 @@ type FuzzerResponse struct {
 	FixContentType             string                   `protobuf:"bytes,60,opt,name=FixContentType,proto3" json:"FixContentType,omitempty"`
 	IsSetContentTypeOptions    bool                     `protobuf:"varint,61,opt,name=IsSetContentTypeOptions,proto3" json:"IsSetContentTypeOptions,omitempty"`
 	RandomChunkedData          []*RandomChunkedResponse `protobuf:"bytes,62,rep,name=RandomChunkedData,proto3" json:"RandomChunkedData,omitempty"`
-	unknownFields              protoimpl.UnknownFields
-	sizeCache                  protoimpl.SizeCache
+	// 与 http_flows / web_fuzzer_response 对齐的唯一键，下载 body 用它而不是 RuntimeID。
+	HiddenIndex   string `protobuf:"bytes,64,opt,name=HiddenIndex,proto3" json:"HiddenIndex,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *FuzzerResponse) Reset() {
@@ -50901,6 +50903,13 @@ func (x *FuzzerResponse) GetRandomChunkedData() []*RandomChunkedResponse {
 		return x.RandomChunkedData
 	}
 	return nil
+}
+
+func (x *FuzzerResponse) GetHiddenIndex() string {
+	if x != nil {
+		return x.HiddenIndex
+	}
+	return ""
 }
 
 type RandomChunkedResponse struct {
@@ -51296,7 +51305,9 @@ type GetHTTPFlowBodyByIdRequest struct {
 	// multipart 请求：指定要流式返回的文件 part 索引（来自 HTTPFlow.MultipartFiles）。
 	// 未设 = 返回完整 body（multipart 时现场流式重建完整 body）。
 	// 用 optional 以区分「未设」与「part 0」。
-	PartIndex     *int32 `protobuf:"varint,6,opt,name=PartIndex,proto3,oneof" json:"PartIndex,omitempty"`
+	PartIndex *int32 `protobuf:"varint,6,opt,name=PartIndex,proto3,oneof" json:"PartIndex,omitempty"`
+	// WebFuzzer 单条结果：按 HiddenIndex 定位 HTTPFlow，避免 RuntimeId 命中任务内其它 hop。
+	HiddenIndex   string `protobuf:"bytes,7,opt,name=HiddenIndex,proto3" json:"HiddenIndex,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -51371,6 +51382,13 @@ func (x *GetHTTPFlowBodyByIdRequest) GetPartIndex() int32 {
 		return *x.PartIndex
 	}
 	return 0
+}
+
+func (x *GetHTTPFlowBodyByIdRequest) GetHiddenIndex() string {
+	if x != nil {
+		return x.HiddenIndex
+	}
+	return ""
 }
 
 type MITMExtractAggregateFlowFilterRow struct {
@@ -79604,7 +79622,7 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x0fUrlWithoutQuery\x18\x02 \x01(\tR\x0fUrlWithoutQuery\"w\n" +
 	"\x16FuzzerSequenceResponse\x12,\n" +
 	"\aRequest\x18\x01 \x01(\v2\x12.ypb.FuzzerRequestR\aRequest\x12/\n" +
-	"\bResponse\x18\x02 \x01(\v2\x13.ypb.FuzzerResponseR\bResponse\"\xed\r\n" +
+	"\bResponse\x18\x02 \x01(\v2\x13.ypb.FuzzerResponseR\bResponse\"\x8f\x0e\n" +
 	"\x0eFuzzerResponse\x12\x16\n" +
 	"\x06Method\x18\x01 \x01(\tR\x06Method\x12\x1e\n" +
 	"\n" +
@@ -79661,7 +79679,8 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x13OriginalContentType\x18; \x01(\tR\x13OriginalContentType\x12&\n" +
 	"\x0eFixContentType\x18< \x01(\tR\x0eFixContentType\x128\n" +
 	"\x17IsSetContentTypeOptions\x18= \x01(\bR\x17IsSetContentTypeOptions\x12H\n" +
-	"\x11RandomChunkedData\x18> \x03(\v2\x1a.ypb.RandomChunkedResponseR\x11RandomChunkedData\"\x9c\x02\n" +
+	"\x11RandomChunkedData\x18> \x03(\v2\x1a.ypb.RandomChunkedResponseR\x11RandomChunkedData\x12 \n" +
+	"\vHiddenIndex\x18@ \x01(\tR\vHiddenIndex\"\x9c\x02\n" +
 	"\x15RandomChunkedResponse\x12\x14\n" +
 	"\x05Index\x18\x01 \x01(\x03R\x05Index\x12\x12\n" +
 	"\x04Data\x18\x02 \x01(\fR\x04Data\x12$\n" +
@@ -79687,14 +79706,15 @@ const file_yakgrpc_proto_rawDesc = "" +
 	"\x16GetHTTPFlowByIdRequest\x12\x0e\n" +
 	"\x02Id\x18\x01 \x01(\x03R\x02Id\"+\n" +
 	"\x17GetHTTPFlowByIdsRequest\x12\x10\n" +
-	"\x03Ids\x18\x02 \x03(\x03R\x03Ids\"\xcb\x01\n" +
+	"\x03Ids\x18\x02 \x03(\x03R\x03Ids\"\xed\x01\n" +
 	"\x1aGetHTTPFlowBodyByIdRequest\x12\x0e\n" +
 	"\x02Id\x18\x01 \x01(\x03R\x02Id\x12\x1c\n" +
 	"\tIsRequest\x18\x02 \x01(\bR\tIsRequest\x12\x18\n" +
 	"\aBufSize\x18\x03 \x01(\x03R\aBufSize\x12\x1c\n" +
 	"\tRuntimeId\x18\x04 \x01(\tR\tRuntimeId\x12\x16\n" +
 	"\x06IsRisk\x18\x05 \x01(\bR\x06IsRisk\x12!\n" +
-	"\tPartIndex\x18\x06 \x01(\x05H\x00R\tPartIndex\x88\x01\x01B\f\n" +
+	"\tPartIndex\x18\x06 \x01(\x05H\x00R\tPartIndex\x88\x01\x01\x12 \n" +
+	"\vHiddenIndex\x18\a \x01(\tR\vHiddenIndexB\f\n" +
 	"\n" +
 	"_PartIndex\"g\n" +
 	"!MITMExtractAggregateFlowFilterRow\x12 \n" +


### PR DESCRIPTION
## Summary
- Expose `HiddenIndex` on `FuzzerResponse` and accept it on `GetHTTPFlowBodyByIdRequest`.
- Look up HTTPFlow by `HiddenIndex` (with short retry) before falling back to `RuntimeId`, so WebFuzzer download body hits the selected hop/payload instead of the first row of the shared runtime.
- Cover redirect multi-hop and direct HiddenIndex body download with MUSTPASS tests.

## Test plan
- [x] `go test ./common/yakgrpc/ -run 'TestGRPCMUSTPASS_GetHTTPFlowBodyById|TestGRPCMUSTPASS_HTTPFuzzer_GetHTTPFlowBodyByHiddenIndex'`
- [x] WebFuzzer with follow-redirects: download body on an intermediate hop matches that hop, not the final small page
- [x] Pair with yakit PR that passes `HiddenIndex` in download params

ref: https://github.com/yaklang/yakit/pull/4188

Made with [Cursor](https://cursor.com)