### PR TITLE
fix(ssa): code scan hang / progress / debug for Legion

### DIFF
--- a/common/syntaxflow/sfdb/rule_group_op.go
+++ b/common/syntaxflow/sfdb/rule_group_op.go
@@ -2,6 +2,7 @@ package sfdb
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/yaklang/gorm"
 	"github.com/samber/lo"
@@ -26,6 +27,16 @@ func init() {
 	})
 }
 
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "constraint failed")
+}
+
 // CreateGroup 通过组名创建SyntaxFlow规则组
 func CreateGroup(db *gorm.DB, groupName string, isBuildIn ...bool) (*schema.SyntaxFlowGroup, error) {
 	buildIn := false
@@ -33,13 +44,27 @@ func CreateGroup(db *gorm.DB, groupName string, isBuildIn ...bool) (*schema.Synt
 		buildIn = isBuildIn[0]
 	}
 
-	db = db.Model(&schema.SyntaxFlowGroup{})
+	if existing, err := queryGroupByNamePure(db, groupName); err == nil && existing != nil {
+		return existing, nil
+	} else if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
 	i := &schema.SyntaxFlowGroup{
 		GroupName: groupName,
 		IsBuildIn: buildIn,
 	}
-	if db = db.Create(&i); db.Error != nil {
-		return nil, db.Error
+	// Silence GORM's ERROR log for the expected concurrent UNIQUE race; we recover below.
+	silent := db.New().LogMode(false).Model(&schema.SyntaxFlowGroup{})
+	if err := silent.Create(&i).Error; err != nil {
+		if isUniqueConstraintError(err) {
+			existing, qerr := queryGroupByNamePure(db, groupName)
+			if qerr != nil {
+				return nil, qerr
+			}
+			return existing, nil
+		}
+		return nil, err
 	}
 	return i, nil
 }
@@ -50,14 +75,14 @@ func GetOrCreateGroups(db *gorm.DB, groupNames []string) []*schema.SyntaxFlowGro
 	updateBuildInGroup := func(group *schema.SyntaxFlowGroup, isBuildIn bool) (*schema.SyntaxFlowGroup, error) {
 		if group.IsBuildIn != isBuildIn {
 			group.IsBuildIn = isBuildIn
-			err := db.Update(group).Error
+			err := db.Model(group).Update("is_build_in", isBuildIn).Error
 			return group, err
 		}
 		return group, nil
 	}
 	for _, groupName := range groupNames {
 		isBuildIn := isBuildInGroup(groupName)
-		group, err := QueryGroupByName(db, groupName)
+		group, err := queryGroupByNamePure(db, groupName)
 		if err == nil && group != nil {
 			group, err = updateBuildInGroup(group, isBuildIn)
 			if err != nil {
@@ -67,11 +92,11 @@ func GetOrCreateGroups(db *gorm.DB, groupNames []string) []*schema.SyntaxFlowGro
 			groups = append(groups, group)
 			continue
 		}
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			log.Errorf("get group %s failed: %s", groupName, err)
 			continue
 		}
-		// if not found, create it
+		// if not found, create it (race-safe)
 		group, err = CreateGroup(db, groupName, isBuildIn)
 		if err != nil {
 			log.Errorf("create group %s failed: %s", groupName, err)
@@ -99,6 +124,15 @@ func QueryGroupByName(db *gorm.DB, groupName string) (*schema.SyntaxFlowGroup, e
 	i := &schema.SyntaxFlowGroup{}
 	if db = db.Preload("Rules").Where("group_name = ?", groupName).First(i); db.Error != nil {
 		return nil, db.Error
+	}
+	return i, nil
+}
+
+// queryGroupByNamePure looks up a group without preloading Rules (hot path for get-or-create).
+func queryGroupByNamePure(db *gorm.DB, groupName string) (*schema.SyntaxFlowGroup, error) {
+	i := &schema.SyntaxFlowGroup{}
+	if err := db.Model(&schema.SyntaxFlowGroup{}).Where("group_name = ?", groupName).First(i).Error; err != nil {
+		return nil, err
 	}
 	return i, nil
 }
@@ -401,10 +435,33 @@ func CreateOrUpdateGroups(db *gorm.DB, groupNames []string) []*schema.SyntaxFlow
 }
 
 func CreateOrUpdateGroup(db *gorm.DB, groupName string, i *schema.SyntaxFlowGroup) (*schema.SyntaxFlowGroup, error) {
-	db = db.Model(&schema.SyntaxFlowGroup{})
+	if existing, err := queryGroupByNamePure(db, groupName); err == nil && existing != nil {
+		if i != nil {
+			existing.IsBuildIn = i.IsBuildIn
+			if err := db.Model(existing).Update("is_build_in", existing.IsBuildIn).Error; err != nil {
+				return nil, utils.Errorf("update SyntaxFlowGroup failed: %s", err)
+			}
+		}
+		return existing, nil
+	} else if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, utils.Errorf("create/update SyntaxFlowGroup failed: %s", err)
+	}
+
 	group := schema.SyntaxFlowGroup{}
-	if db := db.Where("group_name = ?", groupName).Assign(i).FirstOrCreate(&group); db.Error != nil {
-		return nil, utils.Errorf("create/update SyntaxFlowGroup failed: %s", db.Error)
+	if i != nil {
+		group = *i
+	}
+	group.GroupName = groupName
+	silent := db.New().LogMode(false).Model(&schema.SyntaxFlowGroup{})
+	if err := silent.Where("group_name = ?", groupName).Assign(i).FirstOrCreate(&group).Error; err != nil {
+		if isUniqueConstraintError(err) {
+			existing, qerr := queryGroupByNamePure(db, groupName)
+			if qerr != nil {
+				return nil, utils.Errorf("create/update SyntaxFlowGroup failed: %s", qerr)
+			}
+			return existing, nil
+		}
+		return nil, utils.Errorf("create/update SyntaxFlowGroup failed: %s", err)
 	}
 
 	return &group, nil

--- a/common/syntaxflow/sfdb/rule_group_unique_test.go
+++ b/common/syntaxflow/sfdb/rule_group_unique_test.go
@@ -1,0 +1,69 @@
+package sfdb
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+func TestCreateGroupConcurrentSameNameIsIdempotent(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.SyntaxFlowGroup{}, &schema.SyntaxFlowRule{}).Error)
+
+	name := "concurrent-" + uuid.NewString()
+	const workers = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := CreateGroup(db, name, true)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	var count int64
+	require.NoError(t, db.Model(&schema.SyntaxFlowGroup{}).Where("group_name = ?", name).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+
+	groups := GetOrCreateGroups(db, []string{name, name})
+	require.Len(t, groups, 2)
+	require.Equal(t, name, groups[0].GroupName)
+}
+
+func TestMigrateSyntaxFlowDoesNotCascadeCreateGroups(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.SyntaxFlowGroup{}, &schema.SyntaxFlowRule{}).Error)
+
+	groupName := "java-" + uuid.NewString()
+	_, err = CreateGroup(db, groupName, true)
+	require.NoError(t, err)
+
+	rule := &schema.SyntaxFlowRule{
+		RuleName: "rule-" + uuid.NewString(),
+		Content:  `desc(title: "t") alert $a`,
+		Groups:   []*schema.SyntaxFlowGroup{{GroupName: groupName}},
+	}
+	require.NoError(t, MigrateSyntaxFlowWithDB(db, "", rule))
+	require.Len(t, rule.Groups, 1, "caller Groups slice must be restored")
+
+	var groupCount int64
+	require.NoError(t, db.Model(&schema.SyntaxFlowGroup{}).Where("group_name = ?", groupName).Count(&groupCount).Error)
+	require.Equal(t, int64(1), groupCount)
+
+	var ruleCount int64
+	require.NoError(t, db.Model(&schema.SyntaxFlowRule{}).Where("rule_name = ?", rule.RuleName).Count(&ruleCount).Error)
+	require.Equal(t, int64(1), ruleCount)
+}

--- a/common/syntaxflow/sfdb/rule_op.go
+++ b/common/syntaxflow/sfdb/rule_op.go
@@ -85,15 +85,25 @@ func MigrateSyntaxFlowWithDB(db *gorm.DB, hash string, i *schema.SyntaxFlowRule)
 	if db == nil {
 		return utils.Errorf("profile db is nil")
 	}
+	if i == nil {
+		return utils.Errorf("syntax flow rule is nil")
+	}
 
 	if hash == "" {
 		hash = i.CalcHash()
 	}
 
+	// Never cascade-create Groups through rule Create/Updates. Shared group
+	// names (language/severity/purpose) race under concurrent scan import and
+	// produce UNIQUE constraint failed: syntax_flow_groups.group_name spam.
+	groups := i.Groups
+	i.Groups = nil
+	defer func() { i.Groups = groups }()
+
 	var rules []schema.SyntaxFlowRule
 	if err := db.Where("rule_name = ?", i.RuleName).Find(&rules).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return db.Create(i).Error
+			return createSyntaxFlowRuleWithoutGroups(db, i)
 		}
 		return err
 	}
@@ -111,10 +121,22 @@ func MigrateSyntaxFlowWithDB(db *gorm.DB, hash string, i *schema.SyntaxFlowRule)
 		if err := db.Where("rule_name = ?", i.RuleName).Unscoped().Delete(&schema.SyntaxFlowRule{}).Error; err != nil {
 			return err
 		}
-		return db.Create(i).Error
+		return createSyntaxFlowRuleWithoutGroups(db, i)
 	} else {
-		return db.Create(i).Error
+		return createSyntaxFlowRuleWithoutGroups(db, i)
 	}
+}
+
+func createSyntaxFlowRuleWithoutGroups(db *gorm.DB, i *schema.SyntaxFlowRule) error {
+	silent := db.New().LogMode(false)
+	if err := silent.Create(i).Error; err != nil {
+		if isUniqueConstraintError(err) {
+			// Concurrent migrate of the same rule_name/hash: treat as already present.
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func MigrateSyntaxFlow(hash string, i *schema.SyntaxFlowRule) error {

--- a/common/syntaxflow/sfvm/vm.go
+++ b/common/syntaxflow/sfvm/vm.go
@@ -101,6 +101,12 @@ func (s *SyntaxFlowVirtualMachine) Load(rule *schema.SyntaxFlowRule) (*SFFrame, 
 		if err != nil {
 			return nil, false, utils.Errorf("SyntaxFlow compile error: %v", err)
 		}
+		// Propagate compiled opcodes onto the caller's rule so later Load hits
+		// the fast path in-process. Task-local scans intentionally keep these
+		// rules out of the profile DB (see sf_query GetFrame).
+		if rule != nil && frame != nil && frame.rule != nil && frame.rule.OpCodes != "" {
+			rule.OpCodes = frame.rule.OpCodes
+		}
 		// compile only with rule.Content will lose original rule schema info
 		// so set it back here
 		newFrame := newSfFrameEx(s.vars, rule.Content, frame.Codes, rule, s.config)

--- a/common/utils/yakgit/clone.go
+++ b/common/utils/yakgit/clone.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -200,16 +201,7 @@ func Clone(u string, localPath string, opt ...Option) error {
 		}()
 	}
 
-	respos, err := git.PlainCloneContext(c.Context, localPath, false, &git.CloneOptions{
-		URL:               u,
-		Auth:              c.Auth,
-		Depth:             c.Depth,
-		RecurseSubmodules: c.ToRecursiveSubmodule(),
-		InsecureSkipTLS:   !c.VerifyTLS,
-		Progress:          os.Stdout,
-		ProxyOptions:      c.Proxy,
-		ReferenceName:     plumbing.ReferenceName(c.Branch),
-	})
+	respos, err := git.PlainCloneContext(c.Context, localPath, false, buildCloneOptions(u, c))
 	if err != nil {
 		return utils.Wrapf(err, "git clone: %v to %v failed", u, localPath)
 	}
@@ -221,4 +213,69 @@ func Clone(u string, localPath string, opt ...Option) error {
 		log.Infof("git clone: %v to %v success", u, localPath)
 	}
 	return nil
+}
+
+// buildCloneOptions maps yakgit config to go-git CloneOptions. Branch names
+// without a refs/ prefix are treated as local branch names (refs/heads/...).
+func buildCloneOptions(u string, c *config) *git.CloneOptions {
+	opts := &git.CloneOptions{
+		URL:               u,
+		Auth:              c.Auth,
+		Depth:             c.Depth,
+		RecurseSubmodules: c.ToRecursiveSubmodule(),
+		InsecureSkipTLS:   !c.VerifyTLS,
+		Progress:          os.Stdout,
+		ProxyOptions:      c.Proxy,
+		ReferenceName:     cloneReferenceName(c.Branch),
+		SingleBranch:      c.SingleBranch,
+		Tags:              cloneTagMode(c),
+	}
+	return opts
+}
+
+func cloneReferenceName(branch string) plumbing.ReferenceName {
+	trimmed := strings.TrimSpace(branch)
+	if trimmed == "" {
+		return ""
+	}
+	ref := plumbing.ReferenceName(trimmed)
+	if ref.IsBranch() || ref.IsTag() || ref.IsNote() || ref.IsRemote() {
+		return ref
+	}
+	return plumbing.NewBranchReferenceName(trimmed)
+}
+
+func cloneTagMode(c *config) git.TagMode {
+	if c.NoFetchTags {
+		return git.NoTags
+	}
+	if c.FetchAllTags {
+		return git.AllTags
+	}
+	return git.InvalidTagMode
+}
+
+// CloneSettings is a read-only view of clone options after applying Option
+// funcs. Used by callers/tests that need to assert SSA/default clone policy.
+type CloneSettings struct {
+	Depth              int
+	SingleBranch       bool
+	NoFetchTags        bool
+	Branch             string
+	RecursiveSubmodule bool
+}
+
+// InspectCloneSettings applies Option funcs and returns the resolved settings.
+func InspectCloneSettings(opts ...Option) CloneSettings {
+	c := &config{}
+	for _, opt := range opts {
+		_ = opt(c)
+	}
+	return CloneSettings{
+		Depth:              c.Depth,
+		SingleBranch:       c.SingleBranch,
+		NoFetchTags:        c.NoFetchTags,
+		Branch:             c.Branch,
+		RecursiveSubmodule: c.RecursiveSubmodule,
+	}
 }

--- a/common/utils/yakgit/clone_options_test.go
+++ b/common/utils/yakgit/clone_options_test.go
@@ -1,0 +1,43 @@
+package yakgit
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCloneOptionsUsesSingleBranchShallowDefaults(t *testing.T) {
+	t.Parallel()
+
+	c := &config{
+		Depth:        1,
+		SingleBranch: true,
+		NoFetchTags:  true,
+		Branch:       "release/1.0",
+		VerifyTLS:    true,
+	}
+	opts := buildCloneOptions("https://example.invalid/repo.git", c)
+	require.Equal(t, 1, opts.Depth)
+	require.True(t, opts.SingleBranch)
+	require.Equal(t, git.NoTags, opts.Tags)
+	require.Equal(t, plumbing.NewBranchReferenceName("release/1.0"), opts.ReferenceName)
+}
+
+func TestCloneReferenceNameNormalizesShortBranch(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, plumbing.ReferenceName(""), cloneReferenceName(""))
+	require.Equal(t, plumbing.NewBranchReferenceName("main"), cloneReferenceName("main"))
+	require.Equal(t, plumbing.ReferenceName("refs/heads/main"), cloneReferenceName("refs/heads/main"))
+	require.Equal(t, plumbing.ReferenceName("refs/tags/v1.0.0"), cloneReferenceName("refs/tags/v1.0.0"))
+}
+
+func TestWithSingleBranchOption(t *testing.T) {
+	t.Parallel()
+
+	c := &config{}
+	require.NoError(t, WithSingleBranch(true)(c))
+	require.True(t, c.SingleBranch)
+}

--- a/common/utils/yakgit/config.go
+++ b/common/utils/yakgit/config.go
@@ -34,6 +34,7 @@ type config struct {
 	Force        bool
 	NoFetchTags  bool
 	FetchAllTags bool
+	SingleBranch bool
 
 	CheckoutCreate bool
 	CheckoutForce  bool
@@ -333,6 +334,14 @@ func WithRemote(remote string) Option {
 func WithBranch(branch string) Option {
 	return func(c *config) error {
 		c.Branch = branch
+		return nil
+	}
+}
+
+// WithSingleBranch limits clone/fetch to ReferenceName only (git --single-branch).
+func WithSingleBranch(b bool) Option {
+	return func(c *config) error {
+		c.SingleBranch = b
 		return nil
 	}
 }

--- a/common/utils/yakgit/exports.go
+++ b/common/utils/yakgit/exports.go
@@ -45,6 +45,7 @@ var Exports = map[string]any{
 	"noFetchTags":    WithNoFetchTags,
 	"fetchAllTags":   WithFetchAllTags,
 	"branch":         WithBranch,
+	"singleBranch":   WithSingleBranch,
 
 	// inspect
 	"handleCommit":    WithHandleGitCommit,

--- a/common/yak/ssa/database_cache_instruction.go
+++ b/common/yak/ssa/database_cache_instruction.go
@@ -914,22 +914,27 @@ func (s *instructionStore) saveInstructionPersistRecords(records []*instructionP
 	saveStep := func() error {
 		saveErr = utils.GormTransaction(s.db, func(tx *gorm.DB) error {
 			// Separate insert and upsert paths:
-			// - Insert path: batch all IrCodes and use CreateInBatches for speed
-			// - Upsert path: individual FirstOrCreate (cannot batch upsert)
+			// - Insert path: batch CreateInBatches for speed
+			// - Upsert path: SaveIrCodeBatch (delete+bulk insert) — avoids
+			//   per-row FirstOrCreate SELECT that can miss the (program_name,
+			//   code_id) index on large Postgres IR tables.
 			var insertBatch []*ssadb.IrCode
+			var upsertBatch []*ssadb.IrCode
 			for _, record := range records {
 				if record == nil || record.IrCode == nil {
 					continue
 				}
 				if record.UpdateExisting {
-					if err := ssadb.UpsertIrCode(tx, record.IrCode); err != nil {
-						return err
-					}
+					upsertBatch = append(upsertBatch, record.IrCode)
 					continue
 				}
 				insertBatch = append(insertBatch, record.IrCode)
 			}
-			// Batch insert using CreateInBatches for performance
+			if len(upsertBatch) > 0 {
+				if err := ssadb.SaveIrCodeBatch(tx, upsertBatch); err != nil {
+					return err
+				}
+			}
 			if len(insertBatch) > 0 {
 				batchSize := saveIrCodeInsertBatchSize
 				if len(insertBatch) < batchSize {

--- a/common/yak/ssa/ssadb/code.go
+++ b/common/yak/ssa/ssadb/code.go
@@ -3,6 +3,7 @@ package ssadb
 import (
 	"encoding/json"
 	"slices"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/yaklang/yaklang/common/utils"
@@ -150,13 +151,75 @@ func UpsertIrCode(db *gorm.DB, ir *IrCode) error {
 	if db == nil || ir == nil {
 		return nil
 	}
-	record := &IrCode{
-		ProgramName: ir.ProgramName,
-		CodeID:      ir.CodeID,
+	// Prefer the batched delete+insert path even for one row: FirstOrCreate
+	// issues a SELECT that PG can resolve via the wrong (program_name, opcode)
+	// index on large tables, turning each upsert into a 30ms+ scan.
+	return SaveIrCodeBatch(db, []*IrCode{ir})
+}
+
+// irCodeBatchChunk bounds rows per CreateInBatches call. IrCode is a wide
+// model; 500 matches saveIrCodeInsertBatchSize and stays under SQLite's
+// host-parameter ceiling.
+const irCodeBatchChunk = 500
+
+// SaveIrCodeBatch issues a chunked batched UPSERT for IR codes: per chunk it
+// DELETEs the (program_name, code_id) rows this batch is about to write, then
+// bulk-INSERTs them. Same pattern as SaveIrTypeBatch — replaces N
+// FirstOrCreate round-trips (SELECT+UPDATE) with one DELETE + one multi-row
+// INSERT. Soft-deleted rows are removed with Unscoped so the UNIQUE index
+// ux_ir_codes_program_code cannot block the insert.
+func SaveIrCodeBatch(db *gorm.DB, items []*IrCode) error {
+	if db == nil || len(items) == 0 {
+		return nil
 	}
-	return db.Where("program_name = ? AND code_id = ?", ir.ProgramName, ir.CodeID).
-		Assign(ir).
-		FirstOrCreate(record).Error
+	clean := make([]*IrCode, 0, len(items))
+	for _, it := range items {
+		if it != nil {
+			clean = append(clean, it)
+		}
+	}
+	for start := 0; start < len(clean); start += irCodeBatchChunk {
+		end := start + irCodeBatchChunk
+		if end > len(clean) {
+			end = len(clean)
+		}
+		if err := bulkUpsertIrCode(db, clean[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func bulkUpsertIrCode(db *gorm.DB, items []*IrCode) error {
+	if len(items) == 0 {
+		return nil
+	}
+	progCodeIDs := make(map[string][]interface{}, 1)
+	for _, it := range items {
+		progCodeIDs[it.ProgramName] = append(progCodeIDs[it.ProgramName], it.CodeID)
+		// Fresh insert after delete: clear primary key / soft-delete state so
+		// CreateInBatches allocates a new row instead of colliding on id.
+		it.ID = 0
+		it.CreatedAt = time.Time{}
+		it.UpdatedAt = time.Time{}
+		it.DeletedAt = nil
+	}
+	for prog, ids := range progCodeIDs {
+		for i := 0; i < len(ids); i += 999 {
+			end := i + 999
+			if end > len(ids) {
+				end = len(ids)
+			}
+			if err := db.Where("program_name = ? AND code_id IN (?)", prog, ids[i:end]).
+				Unscoped().Delete(&IrCode{}).Error; err != nil {
+				return err
+			}
+		}
+	}
+	if r := db.CreateInBatches(items, irCodeBatchChunk); r.Error != nil {
+		return r.Error
+	}
+	return nil
 }
 
 var hash = []string{

--- a/common/yak/ssa/ssadb/code.go
+++ b/common/yak/ssa/ssadb/code.go
@@ -122,10 +122,14 @@ func GetIrCodeItemById(db *gorm.DB, progName string, id int64) *IrCode {
 	// Native-SQL fast path: skips GORM's per-query chain (Scope.Fields /
 	// DB.clone / search.clone / buildScanPlan, ~45GB combined on hadoop).
 	// Results are identical to the GORM First() path (same column set,
-	// soft-delete semantics, custom scanners); falls back to GORM only if the
-	// native scan errors or the db doesn't expose CommonDB.
-	if native := nativeGetIrCodeItemById(db, progName, id); native != nil {
+	// soft-delete semantics, custom scanners). Context timeout/cancel on the
+	// native path does not fall back to GORM (that would re-hang).
+	native, err := nativeGetIrCodeItemByIdErr(db, progName, id)
+	if native != nil {
 		return native
+	}
+	if nativeContextErr(err) {
+		return nil
 	}
 	// check cache
 	ir := &IrCode{}

--- a/common/yak/ssa/ssadb/database.go
+++ b/common/yak/ssa/ssadb/database.go
@@ -276,7 +276,9 @@ func ensureUniqueIrOffsetsIndex(db *gorm.DB) {
 }
 
 func GetDB() *gorm.DB {
-	return consts.GetGormSSAProjectDataBase()
+	db := consts.GetGormSSAProjectDataBase()
+	EnsureDBOpCallbacks(db)
+	return db
 }
 
 func SetDB(db *gorm.DB) {

--- a/common/yak/ssa/ssadb/db_op_stats.go
+++ b/common/yak/ssa/ssadb/db_op_stats.go
@@ -1,0 +1,292 @@
+package ssadb
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/yaklang/gorm"
+)
+
+// DBOpKind classifies SSA IR database work by SQL verb / GORM callback.
+// "搜索 / 按 ID 加载 / Count" all fall under query — they are SELECT traffic.
+type DBOpKind string
+
+const (
+	DBOpQuery  DBOpKind = "query"  // SELECT: First/Find/Pluck/Count/native read/search
+	DBOpCreate DBOpKind = "create" // INSERT
+	DBOpUpdate DBOpKind = "update" // UPDATE / Save-as-update
+	DBOpDelete DBOpKind = "delete" // DELETE
+)
+
+// DBOpKinds is the stable display/order for UI and JSON.
+var DBOpKinds = []DBOpKind{DBOpQuery, DBOpCreate, DBOpUpdate, DBOpDelete}
+
+// DBOpBucket is timing for one operation kind.
+type DBOpBucket struct {
+	Count      int64 `json:"count"`
+	TotalMs    int64 `json:"total_ms"`
+	MinMs      int64 `json:"min_ms,omitempty"`
+	MaxMs      int64 `json:"max_ms,omitempty"`
+	AvgMs      int64 `json:"avg_ms,omitempty"`
+	ErrorCount int64 `json:"error_count,omitempty"`
+}
+
+// DBOpStats is a snapshot of SSA IR database operation timings, split by kind.
+type DBOpStats struct {
+	Dialect    string                  `json:"dialect,omitempty"`
+	Ops        map[DBOpKind]DBOpBucket `json:"ops,omitempty"`
+	TotalCount int64                   `json:"total_count"`
+	TotalMs    int64                   `json:"total_ms"`
+	ErrorCount int64                   `json:"error_count,omitempty"`
+}
+
+type dbOpAccumulator struct {
+	count   atomic.Int64
+	totalNs atomic.Int64
+	minNs   atomic.Int64
+	maxNs   atomic.Int64
+	errors  atomic.Int64
+}
+
+func (a *dbOpAccumulator) record(d time.Duration, failed bool) {
+	ns := d.Nanoseconds()
+	if ns < 0 {
+		ns = 0
+	}
+	a.count.Add(1)
+	a.totalNs.Add(ns)
+	if failed {
+		a.errors.Add(1)
+	}
+	for {
+		cur := a.minNs.Load()
+		if cur != 0 && cur <= ns {
+			break
+		}
+		if a.minNs.CompareAndSwap(cur, ns) {
+			break
+		}
+	}
+	for {
+		cur := a.maxNs.Load()
+		if cur >= ns {
+			break
+		}
+		if a.maxNs.CompareAndSwap(cur, ns) {
+			break
+		}
+	}
+}
+
+func (a *dbOpAccumulator) snapshot() DBOpBucket {
+	count := a.count.Load()
+	totalNs := a.totalNs.Load()
+	minNs := a.minNs.Load()
+	maxNs := a.maxNs.Load()
+	errors := a.errors.Load()
+	out := DBOpBucket{
+		Count:      count,
+		TotalMs:    totalNs / int64(time.Millisecond),
+		ErrorCount: errors,
+	}
+	if count > 0 {
+		out.MinMs = minNs / int64(time.Millisecond)
+		out.MaxMs = maxNs / int64(time.Millisecond)
+		out.AvgMs = (totalNs / count) / int64(time.Millisecond)
+	}
+	return out
+}
+
+var (
+	dbOpByKind       = map[DBOpKind]*dbOpAccumulator{}
+	dbOpDialect      atomic.Value // string
+	dbOpCallbackOnce sync.Once
+	dbOpInitOnce     sync.Once
+)
+
+func initDBOpAccumulators() {
+	dbOpInitOnce.Do(func() {
+		dbOpByKind = map[DBOpKind]*dbOpAccumulator{
+			DBOpQuery:  {},
+			DBOpCreate: {},
+			DBOpUpdate: {},
+			DBOpDelete: {},
+		}
+	})
+}
+
+func accumulatorFor(kind DBOpKind) *dbOpAccumulator {
+	initDBOpAccumulators()
+	if acc, ok := dbOpByKind[kind]; ok && acc != nil {
+		return acc
+	}
+	// Unknown kinds fold into query so callers never drop timings.
+	return dbOpByKind[DBOpQuery]
+}
+
+// RecordDBOp records one SSA IR database operation of the given kind.
+func RecordDBOp(kind DBOpKind, d time.Duration, failed bool) {
+	accumulatorFor(kind).record(d, failed)
+}
+
+// RecordDBRead is kept for call-site migration; it records a query.
+func RecordDBRead(d time.Duration, failed bool) {
+	RecordDBOp(DBOpQuery, d, failed)
+}
+
+// RecordDBWrite is kept for call-site migration; prefer RecordDBOp with
+// create/update/delete. Unknown writes default to update.
+func RecordDBWrite(d time.Duration, failed bool) {
+	RecordDBOp(DBOpUpdate, d, failed)
+}
+
+// SetDBOpDialect records the active IR database dialect for stats snapshots.
+func SetDBOpDialect(dialect string) {
+	dbOpDialect.Store(strings.TrimSpace(dialect))
+}
+
+// SnapshotDBOpStats returns cumulative IR DB op stats since process start
+// (or since the last ResetDBOpStats call).
+func SnapshotDBOpStats() DBOpStats {
+	initDBOpAccumulators()
+	stats := DBOpStats{
+		Ops: make(map[DBOpKind]DBOpBucket, len(DBOpKinds)),
+	}
+	if v := dbOpDialect.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			stats.Dialect = s
+		}
+	}
+	for _, kind := range DBOpKinds {
+		bucket := accumulatorFor(kind).snapshot()
+		stats.Ops[kind] = bucket
+		stats.TotalCount += bucket.Count
+		stats.TotalMs += bucket.TotalMs
+		stats.ErrorCount += bucket.ErrorCount
+	}
+	return stats
+}
+
+// DeltaDBOpStats returns stats accumulated between previous and current.
+func DeltaDBOpStats(previous, current DBOpStats) DBOpStats {
+	out := DBOpStats{
+		Dialect: current.Dialect,
+		Ops:     make(map[DBOpKind]DBOpBucket, len(DBOpKinds)),
+	}
+	for _, kind := range DBOpKinds {
+		prev := previous.Ops[kind]
+		cur := current.Ops[kind]
+		bucket := DBOpBucket{
+			Count:      cur.Count - prev.Count,
+			TotalMs:    cur.TotalMs - prev.TotalMs,
+			ErrorCount: cur.ErrorCount - prev.ErrorCount,
+		}
+		if bucket.Count < 0 {
+			bucket.Count = 0
+		}
+		if bucket.TotalMs < 0 {
+			bucket.TotalMs = 0
+		}
+		if bucket.ErrorCount < 0 {
+			bucket.ErrorCount = 0
+		}
+		// Window min/max are not recoverable from cumulative totals alone;
+		// keep current extremes as best-effort peak markers for the UI.
+		if bucket.Count > 0 {
+			bucket.MinMs = cur.MinMs
+			bucket.MaxMs = cur.MaxMs
+			bucket.AvgMs = bucket.TotalMs / bucket.Count
+		}
+		out.Ops[kind] = bucket
+		out.TotalCount += bucket.Count
+		out.TotalMs += bucket.TotalMs
+		out.ErrorCount += bucket.ErrorCount
+	}
+	return out
+}
+
+// ResetDBOpStats clears cumulative counters (tests / isolated runs).
+func ResetDBOpStats() {
+	initDBOpAccumulators()
+	for _, kind := range DBOpKinds {
+		dbOpByKind[kind] = &dbOpAccumulator{}
+	}
+}
+
+func recordScopeOp(kind DBOpKind) func(scope *gorm.Scope) {
+	return func(scope *gorm.Scope) {
+		started, _ := scope.Get("ssadb:stats:started_at")
+		start, _ := started.(time.Time)
+		if start.IsZero() {
+			return
+		}
+		RecordDBOp(kind, time.Since(start), scope.HasError())
+	}
+}
+
+func markScopeStart(scope *gorm.Scope) {
+	scope.Set("ssadb:stats:started_at", time.Now())
+}
+
+// EnsureDBOpCallbacks registers GORM callbacks that time IR DB ops by kind.
+// Safe to call repeatedly.
+func EnsureDBOpCallbacks(db *gorm.DB) {
+	if db == nil {
+		return
+	}
+	if name := strings.TrimSpace(db.Dialect().GetName()); name != "" {
+		SetDBOpDialect(name)
+	}
+	dbOpCallbackOnce.Do(func() {
+		registerDBOpCallbacks(db)
+	})
+	attachSQLLogger(db)
+}
+
+func registerDBOpCallbacks(db *gorm.DB) {
+	db.Callback().Query().Before("gorm:query").Register("ssadb:stats:before_query", markScopeStart)
+	db.Callback().Query().After("gorm:query").Register("ssadb:stats:after_query", recordScopeOp(DBOpQuery))
+	db.Callback().Create().Before("gorm:create").Register("ssadb:stats:before_create", markScopeStart)
+	db.Callback().Create().After("gorm:create").Register("ssadb:stats:after_create", recordScopeOp(DBOpCreate))
+	db.Callback().Update().Before("gorm:update").Register("ssadb:stats:before_update", markScopeStart)
+	db.Callback().Update().After("gorm:update").Register("ssadb:stats:after_update", recordScopeOp(DBOpUpdate))
+	db.Callback().Delete().Before("gorm:delete").Register("ssadb:stats:before_delete", markScopeStart)
+	db.Callback().Delete().After("gorm:delete").Register("ssadb:stats:after_delete", recordScopeOp(DBOpDelete))
+	db.Callback().RowQuery().Before("gorm:row_query").Register("ssadb:stats:before_row_query", markScopeStart)
+	db.Callback().RowQuery().After("gorm:row_query").Register("ssadb:stats:after_row_query", recordScopeOp(DBOpQuery))
+}
+
+// bindSQLPlaceholdersDB rewrites "?" placeholders for the active dialect.
+// database/sql + Postgres requires $1/$2; SQLite accepts "?".
+func bindSQLPlaceholdersDB(db *gorm.DB, query string) string {
+	name := ""
+	if db != nil {
+		name = db.Dialect().GetName()
+	}
+	return bindSQLPlaceholders(name, query)
+}
+
+func bindSQLPlaceholders(dialect, query string) string {
+	if !strings.Contains(query, "?") {
+		return query
+	}
+	name := strings.ToLower(strings.TrimSpace(dialect))
+	if name != "postgres" && name != "postgresql" && name != "cloudsqlpostgres" {
+		return query
+	}
+	var b strings.Builder
+	b.Grow(len(query) + 8)
+	n := 0
+	for i := 0; i < len(query); i++ {
+		if query[i] == '?' {
+			n++
+			fmt.Fprintf(&b, "$%d", n)
+			continue
+		}
+		b.WriteByte(query[i])
+	}
+	return b.String()
+}

--- a/common/yak/ssa/ssadb/db_op_stats.go
+++ b/common/yak/ssa/ssadb/db_op_stats.go
@@ -40,6 +40,10 @@ type DBOpStats struct {
 	Ops        map[DBOpKind]DBOpBucket `json:"ops,omitempty"`
 	TotalCount int64                   `json:"total_count"`
 	TotalMs    int64                   `json:"total_ms"`
+	// WindowMs is the wall-clock span this delta covers (set by the pprof
+	// collector when writing db-stats/*.db.json). UI uses it as the
+	// denominator for "DB time / window · xx%" evaluation.
+	WindowMs   int64                   `json:"window_ms,omitempty"`
 	ErrorCount int64                   `json:"error_count,omitempty"`
 }
 

--- a/common/yak/ssa/ssadb/db_op_stats_test.go
+++ b/common/yak/ssa/ssadb/db_op_stats_test.go
@@ -1,0 +1,41 @@
+package ssadb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBOpStatsAccumulateByKind(t *testing.T) {
+	ResetDBOpStats()
+	SetDBOpDialect("postgres")
+
+	RecordDBOp(DBOpQuery, 10*time.Millisecond, false)
+	RecordDBOp(DBOpQuery, 30*time.Millisecond, false)
+	RecordDBOp(DBOpCreate, 5*time.Millisecond, true)
+	RecordDBOp(DBOpUpdate, 8*time.Millisecond, false)
+	RecordDBOp(DBOpDelete, 2*time.Millisecond, false)
+
+	first := SnapshotDBOpStats()
+	require.Equal(t, "postgres", first.Dialect)
+	require.Equal(t, int64(2), first.Ops[DBOpQuery].Count)
+	require.Equal(t, int64(40), first.Ops[DBOpQuery].TotalMs)
+	require.Equal(t, int64(20), first.Ops[DBOpQuery].AvgMs)
+	require.Equal(t, int64(1), first.Ops[DBOpCreate].Count)
+	require.Equal(t, int64(1), first.Ops[DBOpCreate].ErrorCount)
+	require.Equal(t, int64(1), first.Ops[DBOpUpdate].Count)
+	require.Equal(t, int64(1), first.Ops[DBOpDelete].Count)
+	require.Equal(t, int64(5), first.TotalCount)
+	require.Equal(t, int64(55), first.TotalMs)
+	require.Equal(t, int64(1), first.ErrorCount)
+
+	RecordDBOp(DBOpQuery, 20*time.Millisecond, false)
+	second := SnapshotDBOpStats()
+	delta := DeltaDBOpStats(first, second)
+	require.Equal(t, int64(1), delta.Ops[DBOpQuery].Count)
+	require.Equal(t, int64(0), delta.Ops[DBOpCreate].Count)
+	require.Equal(t, int64(20), delta.Ops[DBOpQuery].TotalMs)
+	require.Equal(t, int64(20), delta.Ops[DBOpQuery].AvgMs)
+	require.Equal(t, int64(1), delta.TotalCount)
+}

--- a/common/yak/ssa/ssadb/ircode_batch_test.go
+++ b/common/yak/ssa/ssadb/ircode_batch_test.go
@@ -1,0 +1,69 @@
+package ssadb
+
+import (
+	"testing"
+
+	"github.com/yaklang/gorm"
+	_ "github.com/yaklang/gorm/dialects/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupIrCodeTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&IrCode{}).Error)
+	// Mirror production UNIQUE key so upsert overwrite is constrained.
+	require.NoError(t, db.Exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS ux_ir_codes_program_code ON ir_codes (program_name, code_id)`,
+	).Error)
+	return db
+}
+
+func TestSaveIrCodeBatch_RoundTrip(t *testing.T) {
+	db := setupIrCodeTestDB(t)
+	n := irCodeBatchChunk + 17
+	items := make([]*IrCode, 0, n)
+	for i := 0; i < n; i++ {
+		items = append(items, &IrCode{
+			CodeID:      int64(i + 1),
+			ProgramName: "prog",
+			Name:        "n",
+			Opcode:      int64(i % 5),
+		})
+	}
+	require.NoError(t, SaveIrCodeBatch(db, items))
+
+	var count int
+	require.NoError(t, db.Model(&IrCode{}).Where("program_name = ?", "prog").Count(&count).Error)
+	assert.Equal(t, n, count)
+}
+
+func TestSaveIrCodeBatch_UpsertOverwritesExisting(t *testing.T) {
+	db := setupIrCodeTestDB(t)
+	first := []*IrCode{{CodeID: 7, ProgramName: "prog", Name: "old", Opcode: 1}}
+	require.NoError(t, SaveIrCodeBatch(db, first))
+
+	second := []*IrCode{{CodeID: 7, ProgramName: "prog", Name: "new", Opcode: 2}}
+	require.NoError(t, SaveIrCodeBatch(db, second))
+
+	var count int
+	require.NoError(t, db.Model(&IrCode{}).Where("program_name = ? AND code_id = ?", "prog", 7).Count(&count).Error)
+	assert.Equal(t, 1, count)
+
+	var got IrCode
+	require.NoError(t, db.Where("program_name = ? AND code_id = ?", "prog", 7).First(&got).Error)
+	assert.Equal(t, "new", got.Name)
+	assert.Equal(t, int64(2), got.Opcode)
+}
+
+func TestUpsertIrCode_UsesBatchPath(t *testing.T) {
+	db := setupIrCodeTestDB(t)
+	require.NoError(t, UpsertIrCode(db, &IrCode{CodeID: 1, ProgramName: "p", Name: "a"}))
+	require.NoError(t, UpsertIrCode(db, &IrCode{CodeID: 1, ProgramName: "p", Name: "b"}))
+
+	var got IrCode
+	require.NoError(t, db.Where("program_name = ? AND code_id = ?", "p", 1).First(&got).Error)
+	assert.Equal(t, "b", got.Name)
+}

--- a/common/yak/ssa/ssadb/native_read.go
+++ b/common/yak/ssa/ssadb/native_read.go
@@ -1,12 +1,33 @@
 package ssadb
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"sync/atomic"
 	"time"
 
 	"github.com/yaklang/gorm"
 )
+
+const defaultNativeQueryTimeout = 30 * time.Second
+
+// nativeQueryTimeout is the default bound for native single-row / batch IR
+// reads. Postgres hangs (e.g. raw "?" placeholders) must not block a scan
+// forever.
+func nativeQueryTimeout() time.Duration {
+	return defaultNativeQueryTimeout
+}
+
+func nativeQueryContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if _, ok := parent.Deadline(); ok {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, nativeQueryTimeout())
+}
 
 // nativeIrCodeBatchReads is a test-only counter incremented every time
 // nativeGetIrCodesByIds performs a batch read. Tests use it to prove that
@@ -40,13 +61,29 @@ func NativeConstTypeIDQueries() int64 {
 //
 // Soft-delete semantics are preserved: the query adds "deleted_at IS NULL"
 // exactly like GORM's non-Unscoped First().
+//
+// All native queries run through bindSQLPlaceholdersDB so Postgres gets $n
+// placeholders (database/sql rejects raw "?").
 func nativeGetIrTypeItemById(db *gorm.DB, progName string, id int64) *IrType {
+	ir, _ := nativeGetIrTypeItemByIdErr(db, progName, id)
+	return ir
+}
+
+func nativeGetIrTypeItemByIdErr(db *gorm.DB, progName string, id int64) (*IrType, error) {
 	if db == nil || id < 0 {
-		return nil
+		return nil, nil
 	}
 	const q = `SELECT id, created_at, updated_at, deleted_at, type_id, kind, program_name, "string", extra_information ` +
 		`FROM ` + TableIrTypes + ` WHERE type_id = ? AND program_name = ? AND deleted_at IS NULL LIMIT 1`
-	row := db.CommonDB().QueryRow(q, id, progName)
+	started := time.Now()
+	ctx, cancel := nativeQueryContext(context.Background())
+	defer cancel()
+	bound := bindSQLPlaceholdersDB(db, q)
+	row := nativeQueryRowContext(db, ctx, bound, id, progName)
+	if row == nil {
+		RecordDBRead(time.Since(started), true)
+		return nil, sql.ErrConnDone
+	}
 	ir := &IrType{}
 	var (
 		deletedAt sql.NullTime
@@ -55,20 +92,32 @@ func nativeGetIrTypeItemById(db *gorm.DB, progName string, id int64) *IrType {
 	)
 	if err := row.Scan(&ir.ID, &createdAt, &updatedAt, &deletedAt,
 		&ir.TypeId, &ir.Kind, &ir.ProgramName, &ir.String, &ir.ExtraInformation); err != nil {
-		return nil
+		RecordDBRead(time.Since(started), true)
+		logNativeSQL(bound, time.Since(started), err)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
 	}
+	RecordDBRead(time.Since(started), false)
+	logNativeSQL(bound, time.Since(started), nil)
 	ir.CreatedAt = createdAt
 	ir.UpdatedAt = updatedAt
 	if deletedAt.Valid {
 		t := deletedAt.Time
 		ir.DeletedAt = &t
 	}
-	return ir
+	return ir, nil
 }
 
 func nativeGetIrCodeItemById(db *gorm.DB, progName string, id int64) *IrCode {
+	ir, _ := nativeGetIrCodeItemByIdErr(db, progName, id)
+	return ir
+}
+
+func nativeGetIrCodeItemByIdErr(db *gorm.DB, progName string, id int64) (*IrCode, error) {
 	if db == nil || id < 0 {
-		return nil
+		return nil, nil
 	}
 	const q = `SELECT id, created_at, updated_at, deleted_at, code_id, program_name, version, ` +
 		`source_code_start_offset, source_code_end_offset, source_code_hash, opcode, opcode_name, opcode_operator, ` +
@@ -79,7 +128,15 @@ func nativeGetIrCodeItemById(db *gorm.DB, progName string, id int64) *IrCode {
 		`is_object, object_members, object_member_pairs, is_object_member, object_parent, object_key, object_owner_pairs, ` +
 		`masked_codes, is_masked, variable, program_compile_hash, type_id, point, pointer, extra_information, const_type ` +
 		`FROM ` + TableIrCodes + ` WHERE code_id = ? AND program_name = ? AND deleted_at IS NULL LIMIT 1`
-	row := db.CommonDB().QueryRow(q, id, progName)
+	started := time.Now()
+	ctx, cancel := nativeQueryContext(context.Background())
+	defer cancel()
+	bound := bindSQLPlaceholdersDB(db, q)
+	row := nativeQueryRowContext(db, ctx, bound, id, progName)
+	if row == nil {
+		RecordDBRead(time.Since(started), true)
+		return nil, sql.ErrConnDone
+	}
 	ir := &IrCode{}
 	var (
 		deletedAt sql.NullTime
@@ -102,15 +159,22 @@ func nativeGetIrCodeItemById(db *gorm.DB, progName string, id int64) *IrCode {
 		&ir.TypeID, &ir.Point, &ir.Pointer, &ir.ExtraInformation, &ir.ConstType,
 	)
 	if err != nil {
-		return nil
+		RecordDBRead(time.Since(started), true)
+		logNativeSQL(bound, time.Since(started), err)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
 	}
+	RecordDBRead(time.Since(started), false)
+	logNativeSQL(bound, time.Since(started), nil)
 	ir.CreatedAt = createdAt
 	ir.UpdatedAt = updatedAt
 	if deletedAt.Valid {
 		t := deletedAt.Time
 		ir.DeletedAt = &t
 	}
-	return ir
+	return ir, nil
 }
 
 // nativeIrCodeColumns is the exact AutoMigrate column list for ir_codes, shared
@@ -160,7 +224,6 @@ func nativeGetIrCodesByIds(db *gorm.DB, progName string, ids []int64) ([]*IrCode
 	}
 	nativeIrCodeBatchReads.Add(1)
 
-	common := db.CommonDB()
 	var out []*IrCode
 	for start := 0; start < len(clean); start += nativeIrCodeBatchChunk {
 		end := start + nativeIrCodeBatchChunk
@@ -175,10 +238,15 @@ func nativeGetIrCodesByIds(db *gorm.DB, progName string, ids []int64) ([]*IrCode
 			placeholders[i] = "?"
 			args = append(args, id)
 		}
-		q := `SELECT ` + nativeIrCodeColumns + ` FROM ` + TableIrCodes +
-			` WHERE program_name = ? AND code_id IN (` + joinPlaceholders(placeholders) + `) AND deleted_at IS NULL ORDER BY code_id`
-		rows, err := common.Query(q, args...)
+		q := bindSQLPlaceholdersDB(db, `SELECT `+nativeIrCodeColumns+` FROM `+TableIrCodes+
+			` WHERE program_name = ? AND code_id IN (`+joinPlaceholders(placeholders)+`) AND deleted_at IS NULL ORDER BY code_id`)
+		started := time.Now()
+		ctx, cancel := nativeQueryContext(context.Background())
+		rows, err := nativeQueryContextDB(db, ctx, q, args...)
 		if err != nil {
+			cancel()
+			RecordDBRead(time.Since(started), true)
+			logNativeSQL(q, time.Since(started), err)
 			return nil, err
 		}
 		for rows.Next() {
@@ -204,6 +272,9 @@ func nativeGetIrCodesByIds(db *gorm.DB, progName string, ids []int64) ([]*IrCode
 				&ir.TypeID, &ir.Point, &ir.Pointer, &ir.ExtraInformation, &ir.ConstType,
 			); err != nil {
 				rows.Close()
+				cancel()
+				RecordDBRead(time.Since(started), true)
+				logNativeSQL(q, time.Since(started), err)
 				return nil, err
 			}
 			ir.CreatedAt = createdAt
@@ -216,9 +287,15 @@ func nativeGetIrCodesByIds(db *gorm.DB, progName string, ids []int64) ([]*IrCode
 		}
 		if err := rows.Err(); err != nil {
 			rows.Close()
+			cancel()
+			RecordDBRead(time.Since(started), true)
+			logNativeSQL(q, time.Since(started), err)
 			return nil, err
 		}
 		rows.Close()
+		cancel()
+		RecordDBRead(time.Since(started), false)
+		logNativeSQL(q, time.Since(started), nil)
 	}
 	return out, nil
 }
@@ -251,16 +328,21 @@ func nativeGetIrCodeIDsByConstType(db *gorm.DB, progName string, compareMode Com
 	var q string
 	var args []interface{}
 	if compareMode == ExactCompare {
-		q = `SELECT code_id FROM ` + TableIrCodes +
-			` WHERE program_name = ? AND opcode = ? AND const_type = ? AND "string" = ? AND deleted_at IS NULL`
+		q = bindSQLPlaceholdersDB(db, `SELECT code_id FROM `+TableIrCodes+
+			` WHERE program_name = ? AND opcode = ? AND const_type = ? AND "string" = ? AND deleted_at IS NULL`)
 		args = []interface{}{progName, 5, "normal", value}
 	} else {
-		q = `SELECT code_id FROM ` + TableIrCodes +
-			` WHERE program_name = ? AND opcode = ? AND const_type = ? AND "string" REGEXP ? AND deleted_at IS NULL`
+		q = bindSQLPlaceholdersDB(db, `SELECT code_id FROM `+TableIrCodes+
+			` WHERE program_name = ? AND opcode = ? AND const_type = ? AND "string" REGEXP ? AND deleted_at IS NULL`)
 		args = []interface{}{progName, 5, "normal", value}
 	}
-	rows, err := db.CommonDB().Query(q, args...)
+	started := time.Now()
+	ctx, cancel := nativeQueryContext(context.Background())
+	defer cancel()
+	rows, err := nativeQueryContextDB(db, ctx, q, args...)
 	if err != nil {
+		RecordDBRead(time.Since(started), true)
+		logNativeSQL(q, time.Since(started), err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -268,12 +350,63 @@ func nativeGetIrCodeIDsByConstType(db *gorm.DB, progName string, compareMode Com
 	for rows.Next() {
 		var id int64
 		if err := rows.Scan(&id); err != nil {
+			RecordDBRead(time.Since(started), true)
+			logNativeSQL(q, time.Since(started), err)
 			return nil, err
 		}
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
+		RecordDBRead(time.Since(started), true)
+		logNativeSQL(q, time.Since(started), err)
 		return nil, err
 	}
+	RecordDBRead(time.Since(started), false)
+	logNativeSQL(q, time.Since(started), nil)
 	return ids, nil
+}
+
+func nativeContextErr(err error) bool {
+	return err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded))
+}
+
+func nativeQueryRowContext(db *gorm.DB, ctx context.Context, query string, args ...interface{}) *sql.Row {
+	if db == nil {
+		return nil
+	}
+	common := db.CommonDB()
+	if common == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	switch q := common.(type) {
+	case *sql.DB:
+		return q.QueryRowContext(ctx, query, args...)
+	case *sql.Tx:
+		return q.QueryRowContext(ctx, query, args...)
+	default:
+		return common.QueryRow(query, args...)
+	}
+}
+
+func nativeQueryContextDB(db *gorm.DB, ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	if db == nil {
+		return nil, sql.ErrConnDone
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	switch q := db.CommonDB().(type) {
+	case *sql.DB:
+		return q.QueryContext(ctx, query, args...)
+	case *sql.Tx:
+		return q.QueryContext(ctx, query, args...)
+	default:
+		return db.CommonDB().Query(query, args...)
+	}
 }

--- a/common/yak/ssa/ssadb/native_read.go
+++ b/common/yak/ssa/ssadb/native_read.go
@@ -92,11 +92,13 @@ func nativeGetIrTypeItemByIdErr(db *gorm.DB, progName string, id int64) (*IrType
 	)
 	if err := row.Scan(&ir.ID, &createdAt, &updatedAt, &deletedAt,
 		&ir.TypeId, &ir.Kind, &ir.ProgramName, &ir.String, &ir.ExtraInformation); err != nil {
-		RecordDBRead(time.Since(started), true)
 		logNativeSQL(bound, time.Since(started), err)
 		if errors.Is(err, sql.ErrNoRows) {
+			// Miss is a normal lookup result, not a DB failure.
+			RecordDBRead(time.Since(started), false)
 			return nil, nil
 		}
+		RecordDBRead(time.Since(started), true)
 		return nil, err
 	}
 	RecordDBRead(time.Since(started), false)
@@ -159,11 +161,13 @@ func nativeGetIrCodeItemByIdErr(db *gorm.DB, progName string, id int64) (*IrCode
 		&ir.TypeID, &ir.Point, &ir.Pointer, &ir.ExtraInformation, &ir.ConstType,
 	)
 	if err != nil {
-		RecordDBRead(time.Since(started), true)
 		logNativeSQL(bound, time.Since(started), err)
 		if errors.Is(err, sql.ErrNoRows) {
+			// Miss is a normal lookup result, not a DB failure.
+			RecordDBRead(time.Since(started), false)
 			return nil, nil
 		}
+		RecordDBRead(time.Since(started), true)
 		return nil, err
 	}
 	RecordDBRead(time.Since(started), false)

--- a/common/yak/ssa/ssadb/native_read_placeholders_test.go
+++ b/common/yak/ssa/ssadb/native_read_placeholders_test.go
@@ -1,0 +1,167 @@
+package ssadb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+	_ "github.com/yaklang/gorm/dialects/sqlite"
+)
+
+func TestBindSQLPlaceholdersPostgres(t *testing.T) {
+	t.Parallel()
+
+	const q = "SELECT 1 WHERE a = ? AND b = ?"
+	require.Equal(t, "SELECT 1 WHERE a = $1 AND b = $2", bindSQLPlaceholders("postgres", q))
+	require.Equal(t, "SELECT 1 WHERE a = $1 AND b = $2", bindSQLPlaceholders("PostgreSQL", q))
+	require.Equal(t, "SELECT 1 WHERE a = $1 AND b = $2", bindSQLPlaceholders("postgresql", q))
+	require.Equal(t, "SELECT 1 WHERE a = $1 AND b = $2", bindSQLPlaceholders("cloudsqlpostgres", q))
+	require.Equal(t, q, bindSQLPlaceholders("sqlite3", q))
+	require.Equal(t, q, bindSQLPlaceholders("sqlite", q))
+	require.Equal(t, q, bindSQLPlaceholders("mysql", q))
+	require.Equal(t, q, bindSQLPlaceholders("", q))
+	require.Equal(t, "SELECT 1", bindSQLPlaceholders("postgres", "SELECT 1"))
+}
+
+func TestBindSQLPlaceholdersINList(t *testing.T) {
+	t.Parallel()
+	got := bindSQLPlaceholders("postgres",
+		`SELECT code_id FROM ir_codes WHERE program_name = ? AND code_id IN (?,?,?) AND deleted_at IS NULL`)
+	require.Equal(t,
+		`SELECT code_id FROM ir_codes WHERE program_name = $1 AND code_id IN ($2,$3,$4) AND deleted_at IS NULL`,
+		got)
+}
+
+func TestBindSQLPlaceholdersQuotedStringColumn(t *testing.T) {
+	t.Parallel()
+	got := bindSQLPlaceholders("postgres",
+		`SELECT code_id FROM ir_codes WHERE program_name = ? AND "string" = ?`)
+	require.Equal(t,
+		`SELECT code_id FROM ir_codes WHERE program_name = $1 AND "string" = $2`,
+		got)
+}
+
+func TestBindSQLPlaceholdersDB_SQLiteLeavesQMark(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	q := `SELECT 1 WHERE a = ? AND b = ?`
+	require.Equal(t, q, bindSQLPlaceholdersDB(db, q))
+	require.Equal(t, "sqlite3", db.Dialect().GetName())
+}
+
+type stubSQLCommon struct{}
+
+func (stubSQLCommon) Exec(string, ...interface{}) (sql.Result, error) {
+	return nil, fmt.Errorf("stub")
+}
+func (stubSQLCommon) Prepare(string) (*sql.Stmt, error) { return nil, fmt.Errorf("stub") }
+func (stubSQLCommon) Query(string, ...interface{}) (*sql.Rows, error) {
+	return nil, fmt.Errorf("stub")
+}
+func (stubSQLCommon) QueryRow(string, ...interface{}) *sql.Row { return nil }
+
+func TestBindSQLPlaceholdersDB_PostgresDialectStub(t *testing.T) {
+	db, err := gorm.Open("postgres", stubSQLCommon{})
+	require.NoError(t, err)
+	require.Equal(t, "postgres", db.Dialect().GetName())
+	got := bindSQLPlaceholdersDB(db, "SELECT 1 WHERE a = ? AND b = ?")
+	require.Equal(t, "SELECT 1 WHERE a = $1 AND b = $2", got)
+
+	// nativeGetIrCodeItemById / nativeGetIrTypeItemById / nativeGetIrCodesByIds
+	// / nativeGetIrCodeIDsByConstType all call bindSQLPlaceholdersDB before
+	// Query/QueryRow, so a postgres-named dialect never sends raw "?" to
+	// database/sql.
+	codeQ := bindSQLPlaceholdersDB(db, `SELECT `+nativeIrCodeColumns+` FROM `+TableIrCodes+
+		` WHERE code_id = ? AND program_name = ? AND deleted_at IS NULL LIMIT 1`)
+	require.Contains(t, codeQ, "$1")
+	require.Contains(t, codeQ, "$2")
+	require.NotContains(t, codeQ, "?")
+}
+
+func TestNativeConstTypeQuery_PostgresPlaceholdersOnSQLite(t *testing.T) {
+	// SQLite accepts $n dollar placeholders. Opening a sqlite *sql.DB with a
+	// postgres GORM dialect proves nativeGetIrCodeIDsByConstType rewrites "?"
+	// and the bound SQL still executes.
+	sqlDB, err := sql.Open("sqlite3", "file:pgbind?mode=memory&cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	_, err = sqlDB.Exec(`CREATE TABLE ir_codes (
+		code_id INTEGER,
+		program_name TEXT,
+		opcode INTEGER,
+		const_type TEXT,
+		"string" TEXT,
+		deleted_at DATETIME
+	)`)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`INSERT INTO ir_codes (code_id, program_name, opcode, const_type, "string", deleted_at)
+		VALUES (11, 'p', 5, 'normal', 'hello', NULL)`)
+	require.NoError(t, err)
+
+	db, err := gorm.Open("postgres", sqlDB)
+	require.NoError(t, err)
+	require.Equal(t, "postgres", db.Dialect().GetName())
+
+	ids, err := nativeGetIrCodeIDsByConstType(db, "p", ExactCompare, "hello")
+	require.NoError(t, err)
+	require.Equal(t, []int64{11}, ids)
+}
+
+func TestNativeQueryTimeoutHelper(t *testing.T) {
+	t.Parallel()
+	require.Greater(t, nativeQueryTimeout(), time.Duration(0))
+	require.Equal(t, 30*time.Second, nativeQueryTimeout())
+}
+
+func TestNativeQueryContextCancelledFailsFast(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	_, err = nativeQueryContextDB(db, ctx, "SELECT 1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, time.Since(started), 2*time.Second)
+
+	row := nativeQueryRowContext(db, ctx, "SELECT 1")
+	require.NotNil(t, row)
+	var n int
+	err = row.Scan(&n)
+	require.Error(t, err)
+}
+
+func TestSQLFileLogWritesNativeAndGorm(t *testing.T) {
+	dir := t.TempDir()
+	cleanup, err := StartSQLFileLog(dir)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	logNativeSQL("SELECT code_id FROM ir_codes WHERE id = $1", 150*time.Millisecond, nil)
+	logNativeSQL("SELECT 1", time.Millisecond, nil) // below threshold, omitted
+
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	attachSQLLogger(db)
+	require.NoError(t, db.Exec("CREATE TABLE t (id INTEGER)").Error)
+	require.NoError(t, db.Exec("INSERT INTO t (id) VALUES (?)", 1).Error)
+
+	raw, err := os.ReadFile(filepath.Join(dir, "db.log"))
+	require.NoError(t, err)
+	body := string(raw)
+	require.Contains(t, body, "SELECT code_id FROM ir_codes")
+	require.Contains(t, body, "INSERT")
+	require.NotContains(t, body, "SELECT 1 status=ok")
+}

--- a/common/yak/ssa/ssadb/sanitize_for_pg_test.go
+++ b/common/yak/ssa/ssadb/sanitize_for_pg_test.go
@@ -181,7 +181,7 @@ func TestBeforeSaveHookStripsNUL_IrNamePool(t *testing.T) {
 }
 
 func TestBeforeSaveHookStripsNUL_UpsertIrCode(t *testing.T) {
-	// UpsertIrCode uses db.Where().Assign().FirstOrCreate() which also
+	// UpsertIrCode goes through SaveIrCodeBatch → CreateInBatches, which still
 	// triggers BeforeSave. Verify the hook covers this path.
 	db, err := gorm.Open("sqlite3", ":memory:")
 	require.NoError(t, err)

--- a/common/yak/ssa/ssadb/sql_log.go
+++ b/common/yak/ssa/ssadb/sql_log.go
@@ -1,0 +1,132 @@
+package ssadb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/yaklang/gorm"
+)
+
+const nativeSQLLogMin = 100 * time.Millisecond
+
+var (
+	sqlLogMu   sync.Mutex
+	sqlLogFile *os.File
+)
+
+// StartSQLFileLog appends GORM SQL (and slow/failed native reads) to
+// {debugDir}/db.log. Info lines with prefix [ssadb] also go to the process
+// log so the node task-log filter can drive a live DB tab.
+func StartSQLFileLog(debugDir string) (func(), error) {
+	debugDir = strings.TrimSpace(debugDir)
+	if debugDir == "" {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(debugDir, "db.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	sqlLogMu.Lock()
+	prev := sqlLogFile
+	sqlLogFile = f
+	sqlLogMu.Unlock()
+	if prev != nil && prev != f {
+		_ = prev.Close()
+	}
+	header := fmt.Sprintf("# ssadb SQL log started %s\n", time.Now().Format(time.RFC3339))
+	_, _ = f.WriteString(header)
+	log.Infof("[ssadb] SQL log: %s", path)
+	return func() {
+		sqlLogMu.Lock()
+		if sqlLogFile == f {
+			sqlLogFile = nil
+		}
+		sqlLogMu.Unlock()
+		_ = f.Close()
+	}, nil
+}
+
+func sqlLogEnabled() bool {
+	sqlLogMu.Lock()
+	defer sqlLogMu.Unlock()
+	return sqlLogFile != nil
+}
+
+func attachSQLLogger(db *gorm.DB) {
+	if db == nil || !sqlLogEnabled() {
+		return
+	}
+	db.SetLogger(ssadbSQLLogger{})
+	db.LogMode(true)
+}
+
+type ssadbSQLLogger struct{}
+
+func (ssadbSQLLogger) Print(values ...interface{}) {
+	line := formatGormSQLLog(values...)
+	if line == "" {
+		return
+	}
+	writeSQLLogLine(line)
+	log.Infof("[ssadb] %s", line)
+}
+
+func formatGormSQLLog(values ...interface{}) string {
+	if len(values) == 0 {
+		return ""
+	}
+	level, _ := values[0].(string)
+	switch level {
+	case "sql":
+		if len(values) < 6 {
+			return fmt.Sprint(values...)
+		}
+		dur, _ := values[2].(time.Duration)
+		query := fmt.Sprint(values[3])
+		return fmt.Sprintf("%s gorm [%s] %s", time.Now().Format("2006-01-02 15:04:05.000"), dur, query)
+	case "error", "log":
+		return fmt.Sprintf("%s gorm-%s %v", time.Now().Format("2006-01-02 15:04:05.000"), level, values[1:])
+	default:
+		return fmt.Sprintf("%s gorm %v", time.Now().Format("2006-01-02 15:04:05.000"), values)
+	}
+}
+
+func writeSQLLogLine(line string) {
+	line = strings.TrimRight(line, "\n")
+	if line == "" {
+		return
+	}
+	sqlLogMu.Lock()
+	f := sqlLogFile
+	sqlLogMu.Unlock()
+	if f == nil {
+		return
+	}
+	_, _ = f.WriteString(line + "\n")
+}
+
+// logNativeSQL records native IR reads. Fast successful reads are omitted so a
+// hadoop-scale scan does not fill db.log; slow or failed statements are kept.
+func logNativeSQL(query string, d time.Duration, err error) {
+	if !sqlLogEnabled() {
+		return
+	}
+	if err == nil && d < nativeSQLLogMin {
+		return
+	}
+	status := "ok"
+	if err != nil {
+		status = err.Error()
+	}
+	line := fmt.Sprintf("%s native [%s] %s status=%s", time.Now().Format("2006-01-02 15:04:05.000"), d, query, status)
+	writeSQLLogLine(line)
+	log.Infof("[ssadb] %s", line)
+}

--- a/common/yak/ssa/ssadb/type.go
+++ b/common/yak/ssa/ssadb/type.go
@@ -145,8 +145,12 @@ func GetIrTypeItemById(db *gorm.DB, progName string, id int64) *IrType {
 	}
 	// Native-SQL fast path (see GetIrCodeItemById comment). Same result as the
 	// GORM First() path; falls back to GORM on any native error.
-	if native := nativeGetIrTypeItemById(db, progName, id); native != nil {
+	native, err := nativeGetIrTypeItemByIdErr(db, progName, id)
+	if native != nil {
 		return native
+	}
+	if nativeContextErr(err) {
+		return nil
 	}
 	// check cache
 	ir := &IrType{}

--- a/common/yak/ssaapi/debug_output.go
+++ b/common/yak/ssaapi/debug_output.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
 )
 
 // DebugOutputCleanup stops the pprof collector and closes the log file.
@@ -51,6 +52,7 @@ func SetupDebugDir(debugDir string, redirectSSADB bool) (cleanup DebugOutputClea
 // It is the shared implementation used by SetupDebugDir and the CLI --debug path:
 //   - creates debugDir (MkdirAll)
 //   - redirects log output to <dir>/log
+//   - writes GORM / slow native SQL to <dir>/db.log
 //   - starts the periodic pprof collector (CPU/heap/goroutine snapshots)
 //   - when redirectSSADB is true, redirects the SSA database to <dir>/ssadb.db
 //
@@ -86,6 +88,12 @@ func StartDebugOutput(debugDir string, redirectSSADB bool) (DebugOutputCleanup, 
 		log.SetOutput(io.MultiWriter(logFile, os.Stdout))
 	}
 
+	sqlLogCleanup, err := ssadb.StartSQLFileLog(debugDir)
+	if err != nil {
+		log.Warnf("[debug] start SSA SQL log failed: %v", err)
+		sqlLogCleanup = func() {}
+	}
+
 	// Start pprof collector (periodic CPU/heap/goroutine snapshots).
 	cleanup, err := StartPprofCollector(debugDir)
 	if err != nil {
@@ -93,11 +101,13 @@ func StartDebugOutput(debugDir string, redirectSSADB bool) (DebugOutputCleanup, 
 		if logFile != nil {
 			_ = logFile.Close()
 		}
+		sqlLogCleanup()
 		return noopDebugCleanup, nil
 	}
 
 	return func() {
 		cleanup()
+		sqlLogCleanup()
 		if logFile != nil {
 			_ = logFile.Close()
 		}

--- a/common/yak/ssaapi/debug_output_test.go
+++ b/common/yak/ssaapi/debug_output_test.go
@@ -31,6 +31,9 @@ func TestSetupDebugDirCreatesLogAndDirs(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(target, "cpu-pprof"))
 	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(target, "db.log"))
+	require.NoError(t, err)
 }
 
 func TestSetupDebugDirPanicDoesNotEscape(t *testing.T) {

--- a/common/yak/ssaapi/pprof_collector.go
+++ b/common/yak/ssaapi/pprof_collector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
 )
 
@@ -38,8 +40,9 @@ type pprofCollector struct {
 }
 
 const (
-	defaultPprofHTTPAddr = "127.0.0.1:18080"
-	memoryThresholdHigh  = 10 * 1024 * 1024 * 1024 // 10 GB
+	// pprof listens on a random free localhost port (not a fixed 18080) so
+	// concurrent debug compiles / leftover servers do not collide.
+	memoryThresholdHigh = 10 * 1024 * 1024 * 1024 // 10 GB
 	// pprofInterval is slightly longer than the high-memory CPU duration so a
 	// periodic profile never starts while the previous 5-minute profile is still
 	// finishing (observed as pprof HTTP 500 on Hadoop run4/run5).
@@ -48,6 +51,7 @@ const (
 	pprofCPUDurationHigh   = 5 * time.Minute
 	pprofInitialDelay      = 30 * time.Second
 	pprofHTTPTimeout       = 10 * time.Minute
+	pprofListenAttempts    = 8
 )
 
 // StartPprofCollector creates the output directories, starts the pprof HTTP server,
@@ -66,8 +70,10 @@ func StartPprofCollector(debugDir string) (func(), error) {
 		}
 	}
 
-	addr := defaultPprofHTTPAddr
-	startPprofHTTPServer(addr)
+	addr, err := startPprofHTTPServer()
+	if err != nil {
+		return nil, err
+	}
 
 	ssadb.EnsureDBOpCallbacks(ssadb.GetDB())
 
@@ -101,22 +107,44 @@ func StartPprofCollector(debugDir string) (func(), error) {
 var (
 	pprofServerMu      sync.Mutex
 	pprofServerStarted bool
+	pprofServerAddr    string
 )
 
-func startPprofHTTPServer(addr string) {
+// startPprofHTTPServer binds net/http/pprof on a random free localhost port.
+// One process shares a single server; later callers reuse the bound address.
+func startPprofHTTPServer() (string, error) {
 	pprofServerMu.Lock()
 	defer pprofServerMu.Unlock()
-	if pprofServerStarted {
-		return
+	if pprofServerStarted && pprofServerAddr != "" {
+		return pprofServerAddr, nil
 	}
-	pprofServerStarted = true
-	go func() {
-		log.Infof("[pprof] starting HTTP server on %s", addr)
-		if err := http.ListenAndServe(addr, nil); err != nil {
-			log.Errorf("[pprof] HTTP server error: %v", err)
+
+	var lastErr error
+	for attempt := 0; attempt < pprofListenAttempts; attempt++ {
+		port := utils.GetRandomAvailableTCPPort()
+		addr := utils.HostPort("127.0.0.1", port)
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			lastErr = err
+			continue
 		}
-	}()
-	time.Sleep(100 * time.Millisecond)
+		bound := ln.Addr().String()
+		pprofServerAddr = bound
+		pprofServerStarted = true
+		go func(listener net.Listener, listenAddr string) {
+			log.Infof("[pprof] starting HTTP server on %s", listenAddr)
+			if err := http.Serve(listener, nil); err != nil {
+				log.Errorf("[pprof] HTTP server error: %v", err)
+			}
+		}(ln, bound)
+		// Brief wait so Accept is ready for the first profile fetch.
+		time.Sleep(50 * time.Millisecond)
+		return bound, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no free localhost port after %d attempts", pprofListenAttempts)
+	}
+	return "", fmt.Errorf("start pprof HTTP server: %w", lastErr)
 }
 
 func (c *pprofCollector) collectLoop(ctx context.Context) {

--- a/common/yak/ssaapi/pprof_collector.go
+++ b/common/yak/ssaapi/pprof_collector.go
@@ -14,6 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/load"
+	"github.com/shirou/gopsutil/v4/mem"
+	"github.com/shirou/gopsutil/v4/process"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
 )
@@ -28,15 +32,17 @@ import (
 //   - An initial snapshot is collected 30 seconds after start
 //   - A final snapshot is collected on shutdown
 type pprofCollector struct {
-	dir          string
-	cpuDir       string
-	memDir       string
-	goroutineDir string
-	dbStatsDir   string
-	httpAddr     string
-	wg           sync.WaitGroup
-	lastDBStats  ssadb.DBOpStats
-	dbStatsMu    sync.Mutex
+	dir             string
+	cpuDir          string
+	memDir          string
+	goroutineDir    string
+	dbStatsDir      string
+	runtimeStatsDir string
+	httpAddr        string
+	wg              sync.WaitGroup
+	lastDBStats     ssadb.DBOpStats
+	lastDBStatsAt   time.Time
+	dbStatsMu       sync.Mutex
 }
 
 const (
@@ -63,8 +69,9 @@ func StartPprofCollector(debugDir string) (func(), error) {
 	memDir := filepath.Join(debugDir, "memory-pprof")
 	goroutineDir := filepath.Join(debugDir, "goroutine-pprof")
 	dbStatsDir := filepath.Join(debugDir, "db-stats")
+	runtimeStatsDir := filepath.Join(debugDir, "runtime-stats")
 
-	for _, dir := range []string{cpuDir, memDir, goroutineDir, dbStatsDir} {
+	for _, dir := range []string{cpuDir, memDir, goroutineDir, dbStatsDir, runtimeStatsDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return nil, fmt.Errorf("create pprof dir %s: %w", dir, err)
 		}
@@ -79,13 +86,15 @@ func StartPprofCollector(debugDir string) (func(), error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	collector := &pprofCollector{
-		dir:          debugDir,
-		cpuDir:       cpuDir,
-		memDir:       memDir,
-		goroutineDir: goroutineDir,
-		dbStatsDir:   dbStatsDir,
-		httpAddr:     addr,
-		lastDBStats:  ssadb.SnapshotDBOpStats(),
+		dir:             debugDir,
+		cpuDir:          cpuDir,
+		memDir:          memDir,
+		goroutineDir:    goroutineDir,
+		dbStatsDir:      dbStatsDir,
+		runtimeStatsDir: runtimeStatsDir,
+		httpAddr:        addr,
+		lastDBStats:     ssadb.SnapshotDBOpStats(),
+		lastDBStatsAt:   time.Now(),
 	}
 
 	collector.wg.Add(1)
@@ -199,6 +208,7 @@ func (c *pprofCollector) collectSnapshot(tag string, syncCPU bool) {
 	c.fetchHeap(label)
 	c.fetchGoroutine(label)
 	c.fetchDBStats(label)
+	c.fetchRuntimeStats(label)
 
 	if syncCPU {
 		// For final snapshot: wait for CPU profile to complete
@@ -240,6 +250,7 @@ func (c *pprofCollector) collectSnapshotFinal(tag string) {
 	c.fetchHeap(label)
 	c.fetchGoroutine(label)
 	c.fetchDBStats(label)
+	c.fetchRuntimeStats(label)
 	c.fetchCPU(label, cpuDuration) // synchronous
 }
 
@@ -247,10 +258,22 @@ func (c *pprofCollector) fetchDBStats(label string) {
 	if c == nil || c.dbStatsDir == "" {
 		return
 	}
+	now := time.Now()
 	current := ssadb.SnapshotDBOpStats()
 	c.dbStatsMu.Lock()
 	delta := ssadb.DeltaDBOpStats(c.lastDBStats, current)
+	// DB counters accumulate across the full interval between snapshots
+	// (~5 minutes), unlike CPU profiles which only sample 1 minute in the
+	// normal-memory path. Record the actual wall window for UI share %.
+	if !c.lastDBStatsAt.IsZero() {
+		windowMs := now.Sub(c.lastDBStatsAt).Milliseconds()
+		if windowMs < 0 {
+			windowMs = 0
+		}
+		delta.WindowMs = windowMs
+	}
 	c.lastDBStats = current
+	c.lastDBStatsAt = now
 	c.dbStatsMu.Unlock()
 
 	raw, err := json.MarshalIndent(delta, "", "  ")
@@ -263,14 +286,109 @@ func (c *pprofCollector) fetchDBStats(label string) {
 		log.Errorf("[pprof] write db stats failed: %v", err)
 		return
 	}
-	log.Infof("[pprof] db stats saved: %s total=%d query=%d create=%d update=%d delete=%d",
+	log.Infof("[pprof] db stats saved: %s window=%dms total_ms=%d total=%d query=%d create=%d update=%d delete=%d",
 		target,
+		delta.WindowMs,
+		delta.TotalMs,
 		delta.TotalCount,
 		delta.Ops[ssadb.DBOpQuery].Count,
 		delta.Ops[ssadb.DBOpCreate].Count,
 		delta.Ops[ssadb.DBOpUpdate].Count,
 		delta.Ops[ssadb.DBOpDelete].Count,
 	)
+}
+
+// RuntimeStatsSnapshot captures host vs scan-task CPU/memory at one sample.
+type RuntimeStatsSnapshot struct {
+	Timestamp             string  `json:"timestamp"`
+	NumCPU                int     `json:"num_cpu"`
+	Load1                 float64 `json:"load1,omitempty"`
+	HostCPUPercent        float64 `json:"host_cpu_percent"`
+	ProcessCPUPercent     float64 `json:"process_cpu_percent"`
+	HostMemTotalBytes     uint64  `json:"host_mem_total_bytes"`
+	HostMemUsedBytes      uint64  `json:"host_mem_used_bytes"`
+	HostMemAvailableBytes uint64  `json:"host_mem_available_bytes"`
+	ProcessRSSBytes       uint64  `json:"process_rss_bytes"`
+	ProcessHeapAllocBytes uint64  `json:"process_heap_alloc_bytes"`
+	ProcessHeapSysBytes   uint64  `json:"process_heap_sys_bytes"`
+	Goroutines            int     `json:"goroutines"`
+}
+
+const runtimeStatsSampleWindow = 200 * time.Millisecond
+
+func (c *pprofCollector) fetchRuntimeStats(label string) {
+	if c == nil || c.runtimeStatsDir == "" {
+		return
+	}
+	snapshot, err := captureRuntimeStats()
+	if err != nil {
+		log.Warnf("[pprof] capture runtime stats failed: %v", err)
+		return
+	}
+	raw, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		log.Errorf("[pprof] marshal runtime stats failed: %v", err)
+		return
+	}
+	target := filepath.Join(c.runtimeStatsDir, label+".runtime.json")
+	if err := os.WriteFile(target, raw, 0o644); err != nil {
+		log.Errorf("[pprof] write runtime stats failed: %v", err)
+		return
+	}
+	log.Infof(
+		"[pprof] runtime stats saved: %s host_cpu=%.1f%% task_cpu=%.1f%% host_mem=%dMiB task_rss=%dMiB",
+		target,
+		snapshot.HostCPUPercent,
+		snapshot.ProcessCPUPercent,
+		snapshot.HostMemUsedBytes/(1024*1024),
+		snapshot.ProcessRSSBytes/(1024*1024),
+	)
+}
+
+func captureRuntimeStats() (*RuntimeStatsSnapshot, error) {
+	snapshot := &RuntimeStatsSnapshot{
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		NumCPU:     runtime.NumCPU(),
+		Goroutines: runtime.NumGoroutine(),
+	}
+
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	snapshot.ProcessHeapAllocBytes = memStats.HeapAlloc
+	snapshot.ProcessHeapSysBytes = memStats.HeapSys
+
+	if vm, err := mem.VirtualMemory(); err == nil && vm != nil {
+		snapshot.HostMemTotalBytes = vm.Total
+		snapshot.HostMemUsedBytes = vm.Used
+		snapshot.HostMemAvailableBytes = vm.Available
+	} else if err != nil {
+		return snapshot, err
+	}
+
+	if avg, err := load.Avg(); err == nil && avg != nil {
+		snapshot.Load1 = avg.Load1
+	}
+
+	hostPercents, err := cpu.Percent(runtimeStatsSampleWindow, false)
+	if err != nil {
+		return snapshot, err
+	}
+	if len(hostPercents) > 0 {
+		snapshot.HostCPUPercent = hostPercents[0]
+	}
+
+	proc, err := process.NewProcess(int32(os.Getpid()))
+	if err != nil {
+		return snapshot, err
+	}
+	if rss, err := proc.MemoryInfo(); err == nil && rss != nil {
+		snapshot.ProcessRSSBytes = rss.RSS
+	}
+	if pct, err := proc.Percent(runtimeStatsSampleWindow); err == nil {
+		snapshot.ProcessCPUPercent = pct
+	}
+
+	return snapshot, nil
 }
 
 func (c *pprofCollector) fetchCPU(label string, duration time.Duration) {

--- a/common/yak/ssaapi/pprof_collector.go
+++ b/common/yak/ssaapi/pprof_collector.go
@@ -2,6 +2,7 @@ package ssaapi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
 )
 
 // pprofCollector manages periodic pprof collection during a scan.
@@ -27,8 +30,11 @@ type pprofCollector struct {
 	cpuDir       string
 	memDir       string
 	goroutineDir string
+	dbStatsDir   string
 	httpAddr     string
 	wg           sync.WaitGroup
+	lastDBStats  ssadb.DBOpStats
+	dbStatsMu    sync.Mutex
 }
 
 const (
@@ -52,8 +58,9 @@ func StartPprofCollector(debugDir string) (func(), error) {
 	cpuDir := filepath.Join(debugDir, "cpu-pprof")
 	memDir := filepath.Join(debugDir, "memory-pprof")
 	goroutineDir := filepath.Join(debugDir, "goroutine-pprof")
+	dbStatsDir := filepath.Join(debugDir, "db-stats")
 
-	for _, dir := range []string{cpuDir, memDir, goroutineDir} {
+	for _, dir := range []string{cpuDir, memDir, goroutineDir, dbStatsDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return nil, fmt.Errorf("create pprof dir %s: %w", dir, err)
 		}
@@ -62,13 +69,17 @@ func StartPprofCollector(debugDir string) (func(), error) {
 	addr := defaultPprofHTTPAddr
 	startPprofHTTPServer(addr)
 
+	ssadb.EnsureDBOpCallbacks(ssadb.GetDB())
+
 	ctx, cancel := context.WithCancel(context.Background())
 	collector := &pprofCollector{
 		dir:          debugDir,
 		cpuDir:       cpuDir,
 		memDir:       memDir,
 		goroutineDir: goroutineDir,
+		dbStatsDir:   dbStatsDir,
 		httpAddr:     addr,
+		lastDBStats:  ssadb.SnapshotDBOpStats(),
 	}
 
 	collector.wg.Add(1)
@@ -159,6 +170,7 @@ func (c *pprofCollector) collectSnapshot(tag string, syncCPU bool) {
 	// Memory and goroutine snapshots are fast (non-blocking)
 	c.fetchHeap(label)
 	c.fetchGoroutine(label)
+	c.fetchDBStats(label)
 
 	if syncCPU {
 		// For final snapshot: wait for CPU profile to complete
@@ -199,7 +211,38 @@ func (c *pprofCollector) collectSnapshotFinal(tag string) {
 
 	c.fetchHeap(label)
 	c.fetchGoroutine(label)
+	c.fetchDBStats(label)
 	c.fetchCPU(label, cpuDuration) // synchronous
+}
+
+func (c *pprofCollector) fetchDBStats(label string) {
+	if c == nil || c.dbStatsDir == "" {
+		return
+	}
+	current := ssadb.SnapshotDBOpStats()
+	c.dbStatsMu.Lock()
+	delta := ssadb.DeltaDBOpStats(c.lastDBStats, current)
+	c.lastDBStats = current
+	c.dbStatsMu.Unlock()
+
+	raw, err := json.MarshalIndent(delta, "", "  ")
+	if err != nil {
+		log.Errorf("[pprof] marshal db stats failed: %v", err)
+		return
+	}
+	target := filepath.Join(c.dbStatsDir, label+".db.json")
+	if err := os.WriteFile(target, raw, 0o644); err != nil {
+		log.Errorf("[pprof] write db stats failed: %v", err)
+		return
+	}
+	log.Infof("[pprof] db stats saved: %s total=%d query=%d create=%d update=%d delete=%d",
+		target,
+		delta.TotalCount,
+		delta.Ops[ssadb.DBOpQuery].Count,
+		delta.Ops[ssadb.DBOpCreate].Count,
+		delta.Ops[ssadb.DBOpUpdate].Count,
+		delta.Ops[ssadb.DBOpDelete].Count,
+	)
 }
 
 func (c *pprofCollector) fetchCPU(label string, duration time.Duration) {

--- a/common/yak/ssaapi/pprof_collector_test.go
+++ b/common/yak/ssaapi/pprof_collector_test.go
@@ -35,3 +35,14 @@ func TestStartPprofHTTPServerUsesRandomFreePort(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, addr, again)
 }
+
+func TestCaptureRuntimeStats(t *testing.T) {
+	snapshot, err := captureRuntimeStats()
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	require.Greater(t, snapshot.NumCPU, 0)
+	require.Greater(t, snapshot.HostMemTotalBytes, uint64(0))
+	require.Greater(t, snapshot.ProcessRSSBytes, uint64(0))
+	require.GreaterOrEqual(t, snapshot.HostCPUPercent, 0.0)
+	require.GreaterOrEqual(t, snapshot.ProcessCPUPercent, 0.0)
+}

--- a/common/yak/ssaapi/pprof_collector_test.go
+++ b/common/yak/ssaapi/pprof_collector_test.go
@@ -1,0 +1,37 @@
+package ssaapi
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartPprofHTTPServerUsesRandomFreePort(t *testing.T) {
+	// Isolate process-global pprof listener state for this test.
+	pprofServerMu.Lock()
+	pprofServerStarted = false
+	pprofServerAddr = ""
+	pprofServerMu.Unlock()
+
+	addr, err := startPprofHTTPServer()
+	require.NoError(t, err)
+	require.NotEmpty(t, addr)
+	require.NotContains(t, addr, ":18080")
+
+	// Server must accept connections on the advertised address.
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	_ = conn.Close()
+
+	resp, err := http.Get("http://" + addr + "/debug/pprof/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Second start reuses the same bound address instead of fighting for a port.
+	again, err := startPprofHTTPServer()
+	require.NoError(t, err)
+	require.Equal(t, addr, again)
+}

--- a/common/yak/ssaapi/sf_query.go
+++ b/common/yak/ssaapi/sf_query.go
@@ -79,8 +79,13 @@ func (config *queryConfig) GetFrame() (*sfvm.SFFrame, error) {
 			return nil, utils.Errorf("SyntaxflowQuery: load rule %s error: %v", config.rule.RuleName, err)
 		}
 		if resave {
-			// save rule to db
-			sfdb.MigrateSyntaxFlow("", config.rule)
+			// Persist recompiled opcodes only for rules already stored in the
+			// profile DB. Task-local / ephemeral rules (ID==0) must not Create
+			// into syntax_flow_rules / syntax_flow_groups — that races on shared
+			// group names and floods scan logs with UNIQUE constraint errors.
+			if config.rule.ID > 0 {
+				sfdb.MigrateSyntaxFlow("", config.rule)
+			}
 		}
 		return frame, nil
 	}

--- a/common/yak/ssaapi/ssa_compile_fs.go
+++ b/common/yak/ssaapi/ssa_compile_fs.go
@@ -37,6 +37,27 @@ func flushCompileUnitThreshold() int {
 	return defaultFlushCompileUnitThreshold
 }
 
+// emitCompileScale publishes an early project-size signal after filesystem scan
+// so Legion/Yakit can show compile scale before AST work starts. Line counts are
+// not available yet; files/bytes come from ScanProjectFiles.
+func emitCompileScale(processCallback func(float64, string, ...any), process float64, scanResult *ScanResult) {
+	if processCallback == nil || scanResult == nil {
+		return
+	}
+	files := scanResult.HandlerTotal
+	if scanResult.PreHandlerTotal > files {
+		files = scanResult.PreHandlerTotal
+	}
+	payload := fmt.Sprintf(
+		`ssa-compile-scale:{"total_files":%d,"handler_files":%d,"prehandler_files":%d,"total_bytes":%d}`,
+		files,
+		scanResult.HandlerTotal,
+		scanResult.PreHandlerTotal,
+		scanResult.HandlerBytes,
+	)
+	processCallback(process, payload)
+}
+
 type SaveFolder struct {
 	name string
 	path []string
@@ -178,6 +199,7 @@ func (c *Config) parseProjectWithFSUnits(
 	}
 	calculateTime = time.Since(start)
 	c.Config.SetCompileProjectBytes(scanResult.HandlerBytes)
+	emitCompileScale(processCallback, process, scanResult)
 	if restoreGC := c.applyLargeProjectGCPercent(); restoreGC != nil {
 		defer restoreGC()
 	}
@@ -286,6 +308,7 @@ func (c *Config) parseProjectWithFSUnits(
 		if process > 0.4 {
 			process = 0.4
 		}
+		processCallback(process, fmt.Sprintf("[%s] pre-handler progress(%d/%d)", compilePhase, preHandlerNum, preHandlerTotal))
 	}
 
 	compilePhase = "f1_units"
@@ -425,6 +448,15 @@ func (c *Config) parseProjectWithFSUnits(
 		flushedUnits := make(map[string]bool)
 		if !prog.RunDeferredBuildsForUnitsWithUnitCallback(unitKeys,
 			func(index int, total int) bool {
+				if total <= 0 {
+					return !c.isStop()
+				}
+				// Match legacy deferred band: pre-handler ends ~0.40, builds fill to ~0.88.
+				process = 0.4 + (float64(index)/float64(total))*0.48
+				if process > 0.88 {
+					process = 0.88
+				}
+				processCallback(process, fmt.Sprintf("[%s] deferred build progress(%d/%d)", compilePhase, index, total))
 				return !c.isStop()
 			},
 			func(unitKey string) bool {
@@ -667,6 +699,7 @@ func (c *Config) parseProjectWithFSLegacy(
 	// Feed the total compile-input bytes into the adaptive IR cache policy.
 	// This is runtime tuning input, not persistent project metadata.
 	c.Config.SetCompileProjectBytes(scanResult.HandlerBytes)
+	emitCompileScale(processCallback, 0, scanResult)
 	if restoreGC := c.applyLargeProjectGCPercent(); restoreGC != nil {
 		defer restoreGC()
 	}
@@ -734,6 +767,7 @@ func (c *Config) parseProjectWithFSLegacy(
 			if process > 0.4 {
 				process = 0.4
 			}
+			processCallback(process, fmt.Sprintf("[%s] pre-handler progress(%d/%d)", compilePhase, preHandlerNum, preHandlerTotal))
 		}
 		prog.SetPreHandler(true)
 		prog.ProcessInfof("pre-handler parse project in fs: %v, path: %v", filesystem, c.GetCodeSource().ToJSONString())

--- a/common/yak/ssaapi/ssa_compile_fs.go
+++ b/common/yak/ssaapi/ssa_compile_fs.go
@@ -58,6 +58,47 @@ func emitCompileScale(processCallback func(float64, string, ...any), process flo
 	processCallback(process, payload)
 }
 
+// deferredBuildProcessFraction maps deferred-build progress into the legacy
+// [0.40, 0.88) band. Unit-mode compile runs many batches; each batch must only
+// own its slice of that band. Mapping every batch onto the full 0.40→0.88 range
+// made the first batch report ~87% within milliseconds while most IR work was
+// still ahead (Legion monitor showed a false compile jump).
+func deferredBuildProcessFraction(batchIndex, batchCount, index, total int) float64 {
+	if batchCount <= 0 {
+		batchCount = 1
+	}
+	if batchIndex < 0 {
+		batchIndex = 0
+	}
+	if batchIndex >= batchCount {
+		batchIndex = batchCount - 1
+	}
+	const (
+		bandStart = 0.40
+		bandEnd   = 0.88
+	)
+	bandSpan := bandEnd - bandStart
+	batchSpan := bandSpan / float64(batchCount)
+	batchBase := bandStart + float64(batchIndex)*batchSpan
+	if total <= 0 {
+		return batchBase + batchSpan
+	}
+	if index < 0 {
+		index = 0
+	}
+	if index > total {
+		index = total
+	}
+	process := batchBase + (float64(index)/float64(total))*batchSpan
+	if process > bandEnd {
+		return bandEnd
+	}
+	if process < bandStart {
+		return bandStart
+	}
+	return process
+}
+
 type SaveFolder struct {
 	name string
 	path []string
@@ -448,15 +489,10 @@ func (c *Config) parseProjectWithFSUnits(
 		flushedUnits := make(map[string]bool)
 		if !prog.RunDeferredBuildsForUnitsWithUnitCallback(unitKeys,
 			func(index int, total int) bool {
-				if total <= 0 {
-					return !c.isStop()
-				}
 				// Match legacy deferred band: pre-handler ends ~0.40, builds fill to ~0.88.
-				process = 0.4 + (float64(index)/float64(total))*0.48
-				if process > 0.88 {
-					process = 0.88
-				}
-				processCallback(process, fmt.Sprintf("[%s] deferred build progress(%d/%d)", compilePhase, index, total))
+				// Spread that band across all batches so batch 1/N cannot claim ~87%.
+				process = deferredBuildProcessFraction(batchIndex, len(batches), index, total)
+				processCallback(process, fmt.Sprintf("[%s] deferred build progress(%d/%d) batch(%d/%d)", compilePhase, index, total, batchIndex+1, len(batches)))
 				return !c.isStop()
 			},
 			func(unitKey string) bool {

--- a/common/yak/ssaapi/ssa_compile_info.go
+++ b/common/yak/ssaapi/ssa_compile_info.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/yaklang/javajive/classparser"
 	"github.com/yaklang/yaklang/common/utils"
@@ -136,7 +137,18 @@ func gitFs(codeSource *Config) (fi.FileSystem, error) {
 	log.Info("git clone workspace: ", local)
 
 	opts := make([]yakgit.Option, 0)
-	opts = append(opts, yakgit.WithBranch(codeSource.GetCodeSourceBranch()))
+	// Scan compiles only need the tip of the configured branch. A full clone
+	// downloads every ref/history and is the main reason large git sources
+	// feel slow; mirror `git clone --depth 1 --single-branch --no-tags -b <branch>`.
+	opts = append(opts,
+		yakgit.WithDepth(1),
+		yakgit.WithSingleBranch(true),
+		yakgit.WithNoFetchTags(true),
+		yakgit.WithRecuriveSubmodule(false),
+	)
+	if branch := strings.TrimSpace(codeSource.GetCodeSourceBranch()); branch != "" {
+		opts = append(opts, yakgit.WithBranch(branch))
+	}
 	if proxyURL := codeSource.GetCodeSourceProxyURL(); proxyURL != "" {
 		proxyUser, proxyPassword := codeSource.GetCodeSourceProxyAuth()
 		opts = append(opts, yakgit.WithProxy(proxyURL, proxyUser, proxyPassword))

--- a/common/yak/ssaapi/ssa_compile_info.go
+++ b/common/yak/ssaapi/ssa_compile_info.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/yaklang/javajive/classparser"
 	"github.com/yaklang/yaklang/common/utils"
@@ -16,7 +17,11 @@ import (
 	"github.com/yaklang/yaklang/common/yak/ssaapi/ssagitworkdir"
 )
 
-var cloneSSAGitRepository = yakgit.Clone
+var (
+	cloneSSAGitRepository = yakgit.Clone
+	// ssaGitCloneSleep is replaced in tests to avoid real backoff delays.
+	ssaGitCloneSleep = time.Sleep
+)
 
 func (c *Config) parseFSFromInfo() (fi.FileSystem, error) {
 	c.Processf(0, "parse info: %s", c.GetCodeSourceKind())
@@ -157,7 +162,14 @@ func gitFs(codeSource *Config) (fi.FileSystem, error) {
 	opts = append(opts, authOpts...)
 	opts = append(opts, yakgit.WithContext(codeSource.GetContext()))
 	opts = append(opts, yakgit.WithHTTPOptions(poc.WithRetryTimes(10)))
-	if err := cloneSSAGitRepository(codeSource.GetCodeSourceURL(), local, opts...); err != nil {
+	if err := cloneSSAGitRepositoryWithRetry(
+		codeSource.GetCodeSourceURL(),
+		local,
+		opts,
+		func(format string, args ...any) {
+			process(0, format, args...)
+		},
+	); err != nil {
 		return nil, ssagitworkdir.WrapCloneError(codeSource.GetContext(), local, err)
 	}
 

--- a/common/yak/ssaapi/ssa_compile_info.go
+++ b/common/yak/ssaapi/ssa_compile_info.go
@@ -142,15 +142,15 @@ func gitFs(codeSource *Config) (fi.FileSystem, error) {
 	log.Info("git clone workspace: ", local)
 
 	opts := make([]yakgit.Option, 0)
-	// Scan compiles only need the tip of the configured branch. A full clone
-	// downloads every ref/history and is the main reason large git sources
-	// feel slow; mirror `git clone --depth 1 --single-branch --no-tags -b <branch>`.
-	opts = append(opts,
+	// Prefer a shallow tip clone for scan throughput. Servers that reject
+	// `shallow` (e.g. minimal test git daemons) fall back to a full clone below.
+	shallowOpts := append([]yakgit.Option{},
 		yakgit.WithDepth(1),
 		yakgit.WithSingleBranch(true),
 		yakgit.WithNoFetchTags(true),
 		yakgit.WithRecuriveSubmodule(false),
 	)
+	opts = append(opts, shallowOpts...)
 	if branch := strings.TrimSpace(codeSource.GetCodeSourceBranch()); branch != "" {
 		opts = append(opts, yakgit.WithBranch(branch))
 	}
@@ -162,13 +162,14 @@ func gitFs(codeSource *Config) (fi.FileSystem, error) {
 	opts = append(opts, authOpts...)
 	opts = append(opts, yakgit.WithContext(codeSource.GetContext()))
 	opts = append(opts, yakgit.WithHTTPOptions(poc.WithRetryTimes(10)))
-	if err := cloneSSAGitRepositoryWithRetry(
+	report := func(format string, args ...any) {
+		process(0, format, args...)
+	}
+	if err := cloneSSAGitRepositoryPreferShallow(
 		codeSource.GetCodeSourceURL(),
 		local,
 		opts,
-		func(format string, args ...any) {
-			process(0, format, args...)
-		},
+		report,
 	); err != nil {
 		return nil, ssagitworkdir.WrapCloneError(codeSource.GetContext(), local, err)
 	}

--- a/common/yak/ssaapi/ssa_compile_info_git_test.go
+++ b/common/yak/ssaapi/ssa_compile_info_git_test.go
@@ -40,6 +40,31 @@ func TestGitFSRemovesWorkspaceWhenCloneFails(t *testing.T) {
 	require.Empty(t, readDirectoryNames(t, root))
 }
 
+func TestGitFSRequestsShallowSingleBranchClone(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(ssagitworkdir.WorkDirEnv, root)
+	t.Setenv(ssagitworkdir.MinFreeBytesEnv, "0")
+
+	var captured []yakgit.Option
+	originalClone := cloneSSAGitRepository
+	cloneSSAGitRepository = func(_, local string, opts ...yakgit.Option) error {
+		captured = append([]yakgit.Option(nil), opts...)
+		return os.WriteFile(filepath.Join(local, "main.yak"), []byte("println(1)"), 0600)
+	}
+	t.Cleanup(func() { cloneSSAGitRepository = originalClone })
+
+	config := newGitSourceConfigForTest(t)
+	_, err := gitFs(config)
+	require.NoError(t, err)
+
+	settings := yakgit.InspectCloneSettings(captured...)
+	require.Equal(t, 1, settings.Depth)
+	require.True(t, settings.SingleBranch)
+	require.True(t, settings.NoFetchTags)
+	require.Equal(t, "main", settings.Branch)
+	require.False(t, settings.RecursiveSubmodule)
+}
+
 func TestGitFSCleanupRemovesSuccessfulCloneWorkspace(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv(ssagitworkdir.WorkDirEnv, root)

--- a/common/yak/ssaapi/ssa_compile_scale_test.go
+++ b/common/yak/ssaapi/ssa_compile_scale_test.go
@@ -1,0 +1,46 @@
+package ssaapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEmitCompileScale(t *testing.T) {
+	t.Parallel()
+
+	var gotProcess float64
+	var gotMsg string
+	emitCompileScale(func(process float64, msg string, _ ...any) {
+		gotProcess = process
+		gotMsg = msg
+	}, 0.0, &ScanResult{
+		HandlerTotal:    12,
+		PreHandlerTotal: 15,
+		HandlerBytes:    4096,
+	})
+
+	if gotProcess != 0 {
+		t.Fatalf("process = %v, want 0", gotProcess)
+	}
+	if !strings.HasPrefix(gotMsg, "ssa-compile-scale:") {
+		t.Fatalf("message prefix missing: %q", gotMsg)
+	}
+	for _, want := range []string{
+		`"total_files":15`,
+		`"handler_files":12`,
+		`"prehandler_files":15`,
+		`"total_bytes":4096`,
+	} {
+		if !strings.Contains(gotMsg, want) {
+			t.Fatalf("message %q missing %s", gotMsg, want)
+		}
+	}
+}
+
+func TestEmitCompileScaleNilSafe(t *testing.T) {
+	t.Parallel()
+	emitCompileScale(nil, 0, &ScanResult{HandlerTotal: 1})
+	emitCompileScale(func(float64, string, ...any) {
+		t.Fatal("should not call callback for nil scan result")
+	}, 0, nil)
+}

--- a/common/yak/ssaapi/ssa_compile_scale_test.go
+++ b/common/yak/ssaapi/ssa_compile_scale_test.go
@@ -44,3 +44,29 @@ func TestEmitCompileScaleNilSafe(t *testing.T) {
 		t.Fatal("should not call callback for nil scan result")
 	}, 0, nil)
 }
+
+func TestDeferredBuildProcessFractionSpreadsAcrossBatches(t *testing.T) {
+	t.Parallel()
+
+	// Completing the first of 10 batches must stay near 0.448, not jump to ~0.88.
+	firstBatchDone := deferredBuildProcessFraction(0, 10, 10, 10)
+	if firstBatchDone < 0.44 || firstBatchDone > 0.45 {
+		t.Fatalf("first batch complete = %v, want ~0.448", firstBatchDone)
+	}
+
+	midBatchStart := deferredBuildProcessFraction(4, 10, 0, 10)
+	if midBatchStart < 0.59 || midBatchStart > 0.60 {
+		t.Fatalf("mid batch start = %v, want ~0.592", midBatchStart)
+	}
+
+	lastBatchDone := deferredBuildProcessFraction(9, 10, 10, 10)
+	if lastBatchDone < 0.87 || lastBatchDone > 0.88 {
+		t.Fatalf("last batch complete = %v, want ~0.88", lastBatchDone)
+	}
+
+	// Legacy single-batch path still fills the full deferred band.
+	legacyDone := deferredBuildProcessFraction(0, 1, 10, 10)
+	if legacyDone < 0.87 || legacyDone > 0.88 {
+		t.Fatalf("legacy single batch = %v, want ~0.88", legacyDone)
+	}
+}

--- a/common/yak/ssaapi/ssa_git_clone_retry.go
+++ b/common/yak/ssaapi/ssa_git_clone_retry.go
@@ -146,3 +146,64 @@ func isRetryableGitCloneError(err error) bool {
 	}
 	return false
 }
+
+// cloneSSAGitRepositoryPreferShallow tries a depth-1 (or default) clone first,
+// then falls back to Depth(0) when the remote rejects shallow fetch. Permanent
+// auth/not-found/disk errors are not retried as full clones.
+func cloneSSAGitRepositoryPreferShallow(
+	url string,
+	local string,
+	opts []yakgit.Option,
+	report func(format string, args ...any),
+) error {
+	err := cloneSSAGitRepositoryWithRetry(url, local, opts, report)
+	if err == nil {
+		return nil
+	}
+	if !shouldFallbackFromShallowClone(err) {
+		return err
+	}
+	if report != nil {
+		report("git clone shallow rejected; falling back to full clone: %v", err)
+	}
+	log.Warnf("SSA Git shallow clone rejected for %s; falling back to full clone: %v", url, err)
+	if resetErr := resetCloneWorkspace(local); resetErr != nil {
+		return fmt.Errorf("reset SSA Git workspace before full clone fallback: %w", resetErr)
+	}
+	return cloneSSAGitRepositoryWithRetry(url, local, withoutShallowCloneOptions(opts), report)
+}
+
+func shouldFallbackFromShallowClone(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, transport.ErrAuthenticationRequired) ||
+		errors.Is(err, transport.ErrAuthorizationFailed) ||
+		errors.Is(err, transport.ErrRepositoryNotFound) ||
+		errors.Is(err, transport.ErrEmptyRemoteRepository) ||
+		errors.Is(err, syscall.ENOSPC) {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	permanent := []string{
+		"authentication required",
+		"authorization failed",
+		"repository not found",
+		"empty repository",
+		"no space left on device",
+		"disk quota exceeded",
+		"invalid proxy url",
+		"remote repository is empty",
+	}
+	for _, needle := range permanent {
+		if strings.Contains(message, needle) {
+			return false
+		}
+	}
+	return true
+}
+
+func withoutShallowCloneOptions(opts []yakgit.Option) []yakgit.Option {
+	// yakgit defaults Depth=1; append Depth(0) last so go-git does a full clone.
+	return append(append([]yakgit.Option{}, opts...), yakgit.WithDepth(0))
+}

--- a/common/yak/ssaapi/ssa_git_clone_retry.go
+++ b/common/yak/ssaapi/ssa_git_clone_retry.go
@@ -1,0 +1,148 @@
+package ssaapi
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/yaklang/yaklang/common/utils/yakgit"
+)
+
+const (
+	ssaGitCloneMaxAttempts = 3
+	ssaGitCloneRetryBase   = time.Second
+)
+
+// cloneSSAGitRepositoryWithRetry clones into local and retries transient network
+// failures. Partial clone debris is cleared between attempts so go-git can reuse
+// the same workspace directory.
+func cloneSSAGitRepositoryWithRetry(
+	url string,
+	local string,
+	opts []yakgit.Option,
+	report func(format string, args ...any),
+) error {
+	var lastErr error
+	for attempt := 1; attempt <= ssaGitCloneMaxAttempts; attempt++ {
+		if attempt > 1 {
+			if err := resetCloneWorkspace(local); err != nil {
+				return fmt.Errorf("reset SSA Git workspace before retry: %w", err)
+			}
+			delay := ssaGitCloneRetryBase * time.Duration(1<<(attempt-2))
+			if report != nil {
+				report("git clone retry %d/%d after %s: %v", attempt, ssaGitCloneMaxAttempts, delay, lastErr)
+			}
+			log.Warnf(
+				"SSA Git clone retry %d/%d after %s for %s: %v",
+				attempt,
+				ssaGitCloneMaxAttempts,
+				delay,
+				url,
+				lastErr,
+			)
+			ssaGitCloneSleep(delay)
+		}
+
+		err := cloneSSAGitRepository(url, local, opts...)
+		if err == nil {
+			if attempt > 1 && report != nil {
+				report("git clone succeeded on attempt %d/%d", attempt, ssaGitCloneMaxAttempts)
+			}
+			return nil
+		}
+		lastErr = err
+		if !isRetryableGitCloneError(err) || attempt == ssaGitCloneMaxAttempts {
+			return err
+		}
+	}
+	return lastErr
+}
+
+func resetCloneWorkspace(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return os.MkdirAll(dir, 0o700)
+		}
+		return err
+	}
+	var joinErr error
+	for _, entry := range entries {
+		joinErr = errors.Join(joinErr, os.RemoveAll(filepath.Join(dir, entry.Name())))
+	}
+	return joinErr
+}
+
+func isRetryableGitCloneError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// EOF / unexpected EOF are transient at the transport edge.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, transport.ErrAuthenticationRequired) ||
+		errors.Is(err, transport.ErrAuthorizationFailed) ||
+		errors.Is(err, transport.ErrRepositoryNotFound) ||
+		errors.Is(err, transport.ErrEmptyRemoteRepository) ||
+		errors.Is(err, syscall.ENOSPC) {
+		return false
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	permanent := []string{
+		"authentication required",
+		"authorization failed",
+		"repository not found",
+		"empty repository",
+		"no space left on device",
+		"disk quota exceeded",
+		"invalid proxy url",
+		"remote repository is empty",
+	}
+	for _, needle := range permanent {
+		if strings.Contains(message, needle) {
+			return false
+		}
+	}
+	transient := []string{
+		"eof",
+		"tls handshake timeout",
+		"i/o timeout",
+		"connection reset",
+		"connection refused",
+		"temporary failure",
+		"server misbehaving",
+		"broken pipe",
+		"http2: client connection lost",
+		"use of closed network connection",
+		"wsarecv",
+		"network is unreachable",
+	}
+	for _, needle := range transient {
+		if strings.Contains(message, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/common/yak/ssaapi/ssa_git_clone_retry_test.go
+++ b/common/yak/ssaapi/ssa_git_clone_retry_test.go
@@ -126,3 +126,53 @@ func TestGitFSWrapsExhaustedCloneRetriesWithoutCompilePrefix(t *testing.T) {
 	require.ErrorContains(t, err, "SSA Git clone failed")
 	require.False(t, strings.Contains(err.Error(), "编译失败"))
 }
+
+func TestCloneSSAGitRepositoryPreferShallowFallsBackToFullClone(t *testing.T) {
+	originalClone := cloneSSAGitRepository
+	originalSleep := ssaGitCloneSleep
+	t.Cleanup(func() {
+		cloneSSAGitRepository = originalClone
+		ssaGitCloneSleep = originalSleep
+	})
+	ssaGitCloneSleep = func(time.Duration) {}
+
+	var depths []int
+	cloneSSAGitRepository = func(_, local string, opts ...yakgit.Option) error {
+		settings := yakgit.InspectCloneSettings(opts...)
+		depths = append(depths, settings.Depth)
+		if settings.Depth != 0 {
+			return errors.New(`unexpected client error: unexpected requesting "http://127.0.0.1/repo.git/git-upload-pack" status code: 500`)
+		}
+		return os.WriteFile(filepath.Join(local, "ok"), []byte("1"), 0o600)
+	}
+
+	dir := t.TempDir()
+	err := cloneSSAGitRepositoryPreferShallow(
+		"https://example.invalid/repo.git",
+		dir,
+		[]yakgit.Option{yakgit.WithDepth(1), yakgit.WithSingleBranch(true)},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 0}, depths)
+}
+
+func TestCloneSSAGitRepositoryPreferShallowKeepsPermanentErrors(t *testing.T) {
+	originalClone := cloneSSAGitRepository
+	t.Cleanup(func() { cloneSSAGitRepository = originalClone })
+
+	var attempts int
+	cloneSSAGitRepository = func(_, _ string, _ ...yakgit.Option) error {
+		attempts++
+		return transport.ErrAuthenticationRequired
+	}
+
+	err := cloneSSAGitRepositoryPreferShallow(
+		"https://example.invalid/repo.git",
+		t.TempDir(),
+		[]yakgit.Option{yakgit.WithDepth(1)},
+		nil,
+	)
+	require.ErrorIs(t, err, transport.ErrAuthenticationRequired)
+	require.Equal(t, 1, attempts)
+}

--- a/common/yak/ssaapi/ssa_git_clone_retry_test.go
+++ b/common/yak/ssaapi/ssa_git_clone_retry_test.go
@@ -1,0 +1,128 @@
+package ssaapi
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils/yakgit"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssagitworkdir"
+)
+
+func TestIsRetryableGitCloneError(t *testing.T) {
+	t.Parallel()
+	require.True(t, isRetryableGitCloneError(io.EOF))
+	require.True(t, isRetryableGitCloneError(io.ErrUnexpectedEOF))
+	require.True(t, isRetryableGitCloneError(errors.New(`Get "https://github.com/dotCMS/core/info/refs?service=git-upload-pack": EOF`)))
+	require.True(t, isRetryableGitCloneError(errors.New("TLS handshake timeout")))
+	require.False(t, isRetryableGitCloneError(transport.ErrAuthenticationRequired))
+	require.False(t, isRetryableGitCloneError(transport.ErrRepositoryNotFound))
+	require.False(t, isRetryableGitCloneError(errors.New("no space left on device")))
+	require.False(t, isRetryableGitCloneError(errors.New("authentication required")))
+}
+
+func TestCloneSSAGitRepositoryWithRetrySucceedsAfterTransientEOF(t *testing.T) {
+	originalClone := cloneSSAGitRepository
+	originalSleep := ssaGitCloneSleep
+	t.Cleanup(func() {
+		cloneSSAGitRepository = originalClone
+		ssaGitCloneSleep = originalSleep
+	})
+	ssaGitCloneSleep = func(time.Duration) {}
+
+	var attempts atomic.Int32
+	cloneSSAGitRepository = func(_, local string, _ ...yakgit.Option) error {
+		n := attempts.Add(1)
+		if n < 3 {
+			_ = os.WriteFile(filepath.Join(local, "partial"), []byte("debris"), 0o600)
+			return errors.New(`git clone: https://example.invalid/repo.git to ` + local + ` failed: EOF`)
+		}
+		require.NoFileExists(t, filepath.Join(local, "partial"))
+		return os.WriteFile(filepath.Join(local, "main.yak"), []byte("println(1)"), 0o600)
+	}
+
+	dir := t.TempDir()
+	err := cloneSSAGitRepositoryWithRetry("https://example.invalid/repo.git", dir, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(3), attempts.Load())
+	require.FileExists(t, filepath.Join(dir, "main.yak"))
+}
+
+func TestCloneSSAGitRepositoryWithRetryDoesNotRetryAuthFailure(t *testing.T) {
+	originalClone := cloneSSAGitRepository
+	originalSleep := ssaGitCloneSleep
+	t.Cleanup(func() {
+		cloneSSAGitRepository = originalClone
+		ssaGitCloneSleep = originalSleep
+	})
+	ssaGitCloneSleep = func(time.Duration) {}
+
+	var attempts atomic.Int32
+	cloneSSAGitRepository = func(_, _ string, _ ...yakgit.Option) error {
+		attempts.Add(1)
+		return transport.ErrAuthenticationRequired
+	}
+
+	err := cloneSSAGitRepositoryWithRetry("https://example.invalid/repo.git", t.TempDir(), nil, nil)
+	require.ErrorIs(t, err, transport.ErrAuthenticationRequired)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestGitFSRetriesTransientCloneFailures(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(ssagitworkdir.WorkDirEnv, root)
+	t.Setenv(ssagitworkdir.MinFreeBytesEnv, "0")
+
+	originalClone := cloneSSAGitRepository
+	originalSleep := ssaGitCloneSleep
+	t.Cleanup(func() {
+		cloneSSAGitRepository = originalClone
+		ssaGitCloneSleep = originalSleep
+	})
+	ssaGitCloneSleep = func(time.Duration) {}
+
+	var attempts atomic.Int32
+	cloneSSAGitRepository = func(_, local string, _ ...yakgit.Option) error {
+		n := attempts.Add(1)
+		if n == 1 {
+			return errors.New(`Get "https://github.com/dotCMS/core/info/refs?service=git-upload-pack": EOF`)
+		}
+		return os.WriteFile(filepath.Join(local, "main.yak"), []byte("println(1)"), 0o600)
+	}
+
+	config := newGitSourceConfigForTest(t)
+	_, err := gitFs(config)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+}
+
+func TestGitFSWrapsExhaustedCloneRetriesWithoutCompilePrefix(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(ssagitworkdir.WorkDirEnv, root)
+	t.Setenv(ssagitworkdir.MinFreeBytesEnv, "0")
+
+	originalClone := cloneSSAGitRepository
+	originalSleep := ssaGitCloneSleep
+	t.Cleanup(func() {
+		cloneSSAGitRepository = originalClone
+		ssaGitCloneSleep = originalSleep
+	})
+	ssaGitCloneSleep = func(time.Duration) {}
+
+	cloneSSAGitRepository = func(_, _ string, _ ...yakgit.Option) error {
+		return errors.New(`Get "https://github.com/dotCMS/core/info/refs?service=git-upload-pack": EOF`)
+	}
+
+	config := newGitSourceConfigForTest(t)
+	_, err := gitFs(config)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "SSA Git clone failed")
+	require.False(t, strings.Contains(err.Error(), "编译失败"))
+}

--- a/scannode/debug_finalize_test.go
+++ b/scannode/debug_finalize_test.go
@@ -1,0 +1,78 @@
+package scannode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDebugFinalizeContextSurvivesParentCancel(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+
+	ctx, cancel := debugFinalizeContext(parent)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("finalize context should not be cancelled with parent: %v", err)
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected finalize context deadline")
+	}
+	if remaining := time.Until(deadline); remaining < 30*time.Second {
+		t.Fatalf("finalize timeout too short: %s", remaining)
+	}
+}
+
+func TestDebugStatusForScriptError(t *testing.T) {
+	t.Parallel()
+
+	manager := newTaskManager()
+	node := &ScanNode{manager: manager}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	task := newScriptTask(ctx, cancel, "job", "job", "sub", "attempt-1")
+	task.SetCancelReason("platform cancel requested")
+	manager.Add(task.TaskId, task)
+
+	if got := debugStatusForScriptError(node, "attempt-1", errors.New("boom")); got != "cancelled" {
+		t.Fatalf("status = %q, want cancelled", got)
+	}
+	if got := debugStatusForScriptError(node, "missing", context.Canceled); got != "cancelled" {
+		t.Fatalf("status = %q, want cancelled for context.Canceled", got)
+	}
+	if got := debugStatusForScriptError(node, "missing", errors.New("script failed")); got != "failed" {
+		t.Fatalf("status = %q, want failed", got)
+	}
+}
+
+func TestPublishDebugAnalysisWritesLocalCacheWithoutUploadConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "cpu-pprof"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "log"), []byte("scan running\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	node := &ScanNode{}
+	reporter := &ScannerAgentReporter{
+		TaskId:    "job-1",
+		RuntimeId: "attempt-1",
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	node.publishDebugAnalysis(cancelled, reporter, dir, "cancelled")
+
+	cached, ok := readCachedDebugAnalysis(dir)
+	if !ok {
+		t.Fatal("expected local analysis.cache.json after finalize without upload config")
+	}
+	if len(cached) == 0 {
+		t.Fatal("expected non-empty analysis cache")
+	}
+}

--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -159,6 +159,22 @@ func AnalyzeDebugRunWithStatus(dir string, taskStatus string) DebugRunAnalysis {
 		result.Status = normalizeTaskStatus(taskStatus)
 	}
 
+	// Child collector logs often only contain ERROR/pprof lines and miss the
+	// SSA phase markers that live in the node task log. Fold that log in when
+	// phase detection came up empty so live/cancel analysis still shows compile.
+	if !hasRecognizedDebugPhases(result.Phases) {
+		if enriched := enrichLogWithTaskLog(dir, logContent); enriched != logContent && strings.TrimSpace(enriched) != "" {
+			logContent = enriched
+			result.setTimesFromLog(logContent)
+			result.setPhasesFromLog(logContent)
+			if taskStatus == "" {
+				result.Status = result.determineStatus(logContent)
+			} else {
+				result.Status = normalizeTaskStatus(taskStatus)
+			}
+		}
+	}
+
 	// Parse pprof samples
 	cpuDir := filepath.Join(dir, "cpu-pprof")
 	memDir := filepath.Join(dir, "memory-pprof")
@@ -280,27 +296,33 @@ func (r *DebugRunAnalysis) setPhasesFromLog(logContent string) {
 	compileStart, scanStart := findPhaseTransitionsInLog(logContent)
 
 	if compileStart != nil {
-		finished := r.FinishedAt
+		var finished *time.Time
+		phaseStatus := "completed"
 		if scanStart != nil {
 			finished = scanStart
+		} else if isActiveDebugStatus(r.Status) {
+			// Still compiling: leave the window open so later samples map here.
+			phaseStatus = "running"
+		} else {
+			finished = r.FinishedAt
 		}
 		phases = append(phases, PhaseAnalysis{
-			Phase:     "compile",
-			Source:    "log_inferred",
-			StartedAt: compileStart,
+			Phase:      "compile",
+			Source:     "log_inferred",
+			StartedAt:  compileStart,
 			FinishedAt: finished,
-			Duration:  durationStr(compileStart, finished),
-			Status:    "completed",
+			Duration:   durationStr(compileStart, finished),
+			Status:     phaseStatus,
 		})
 	}
 	if scanStart != nil {
 		phases = append(phases, PhaseAnalysis{
-			Phase:     "scan",
-			Source:    "log_inferred",
-			StartedAt: scanStart,
+			Phase:      "scan",
+			Source:     "log_inferred",
+			StartedAt:  scanStart,
 			FinishedAt: r.FinishedAt,
-			Duration:  durationStr(scanStart, r.FinishedAt),
-			Status:    r.Status,
+			Duration:   durationStr(scanStart, r.FinishedAt),
+			Status:     r.Status,
 		})
 	}
 
@@ -313,6 +335,44 @@ func (r *DebugRunAnalysis) setPhasesFromLog(logContent string) {
 	}
 
 	r.Phases = phases
+}
+
+func isActiveDebugStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "partial", "cancel_requested", "unknown", "":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasRecognizedDebugPhases(phases []PhaseAnalysis) bool {
+	for _, phase := range phases {
+		name := strings.ToLower(strings.TrimSpace(phase.Phase))
+		if name != "" && name != "unknown" {
+			return true
+		}
+	}
+	return false
+}
+
+func enrichLogWithTaskLog(debugDir, logContent string) string {
+	taskLog := resolveTaskLogByDebugDir(debugDir)
+	if taskLog == "" {
+		return logContent
+	}
+	data, err := os.ReadFile(taskLog)
+	if err != nil || len(data) == 0 {
+		return logContent
+	}
+	taskText := string(data)
+	if strings.TrimSpace(logContent) == "" {
+		return taskText
+	}
+	if strings.Contains(logContent, taskText) {
+		return logContent
+	}
+	return logContent + "\n--- node task log ---\n" + taskText
 }
 
 func (r *DebugRunAnalysis) determineStatus(logContent string) string {
@@ -701,14 +761,12 @@ func findPhaseTransitionsInLog(logContent string) (compileStart, scanStart *time
 		ts := parseLogTimestamp(line)
 
 		if compileStart == nil && ts != nil {
-			if (strings.Contains(lower, "compile") || strings.Contains(lower, "load-program")) &&
-				(strings.Contains(lower, "phase") || strings.Contains(lower, "\u9636\u6bb5")) {
+			if looksLikeCompilePhaseLine(lower) {
 				compileStart = ts
 			}
 		}
 		if scanStart == nil && ts != nil {
-			if (strings.Contains(lower, "scan") || strings.Contains(lower, "ingest")) &&
-				(strings.Contains(lower, "phase") || strings.Contains(lower, "\u9636\u6bb5")) {
+			if looksLikeScanPhaseLine(lower) {
 				scanStart = ts
 			}
 		}
@@ -725,6 +783,38 @@ func findPhaseTransitionsInLog(logContent string) (compileStart, scanStart *time
 		}
 	}
 	return
+}
+
+func looksLikeCompilePhaseLine(lower string) bool {
+	if strings.Contains(lower, `"id":"ssa-phase"`) && strings.Contains(lower, `"data":"compile"`) {
+		return true
+	}
+	if strings.Contains(lower, "ssa 任务阶段: compile") || strings.Contains(lower, "ssa 任务阶段：compile") {
+		return true
+	}
+	if (strings.Contains(lower, "compile") || strings.Contains(lower, "load-program")) &&
+		(strings.Contains(lower, "phase") || strings.Contains(lower, "\u9636\u6bb5")) {
+		return true
+	}
+	return false
+}
+
+func looksLikeScanPhaseLine(lower string) bool {
+	if strings.Contains(lower, `"id":"ssa-phase"`) && strings.Contains(lower, `"data":"scan"`) {
+		return true
+	}
+	if strings.Contains(lower, "ssa 任务阶段: scan") || strings.Contains(lower, "ssa 任务阶段：scan") {
+		return true
+	}
+	if (strings.Contains(lower, "scan") || strings.Contains(lower, "ingest")) &&
+		(strings.Contains(lower, "phase") || strings.Contains(lower, "\u9636\u6bb5")) {
+		// Avoid treating compile-phase lines that also mention scan tooling.
+		if strings.Contains(lower, "compile") && !strings.Contains(lower, `"data":"scan"`) {
+			return false
+		}
+		return true
+	}
+	return false
 }
 
 func assignPhase(ts *time.Time, phases []PhaseAnalysis) (string, string) {

--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -2,6 +2,7 @@ package scannode
 
 import (
 	"archive/zip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -17,21 +18,21 @@ import (
 type DebugRunAnalysis struct {
 	// RunDir is intentionally NOT returned to the frontend (security).
 	// It is kept for internal use but not serialized.
-	RunDir     string             `json:"-"`
-	Status     string             `json:"status"` // running | completed | failed | unknown
-	StartedAt  *time.Time         `json:"started_at,omitempty"`
-	FinishedAt *time.Time         `json:"finished_at,omitempty"`
-	Duration   string             `json:"duration,omitempty"`
-	Phases     []PhaseAnalysis    `json:"phases,omitempty"`
-	Samples    []SampleSummary    `json:"samples,omitempty"`
-	Summary    *RunSummary         `json:"summary,omitempty"`
-	Errors     []string            `json:"errors,omitempty"`
-	Partial    bool               `json:"partial,omitempty"`
+	RunDir     string          `json:"-"`
+	Status     string          `json:"status"` // running | completed | failed | unknown
+	StartedAt  *time.Time      `json:"started_at,omitempty"`
+	FinishedAt *time.Time      `json:"finished_at,omitempty"`
+	Duration   string          `json:"duration,omitempty"`
+	Phases     []PhaseAnalysis `json:"phases,omitempty"`
+	Samples    []SampleSummary `json:"samples,omitempty"`
+	Summary    *RunSummary     `json:"summary,omitempty"`
+	Errors     []string        `json:"errors,omitempty"`
+	Partial    bool            `json:"partial,omitempty"`
 }
 
 // PhaseAnalysis is a per-phase summary.
 type PhaseAnalysis struct {
-	Phase      string     `json:"phase"` // compile | scan | unknown
+	Phase      string     `json:"phase"`  // compile | scan | unknown
 	Source     string     `json:"source"` // log_inferred | status_card | unknown
 	StartedAt  *time.Time `json:"started_at,omitempty"`
 	FinishedAt *time.Time `json:"finished_at,omitempty"`
@@ -65,28 +66,48 @@ type SampleSummary struct {
 	Goroutines     int                `json:"goroutines,omitempty"`
 	LogExcerpt     string             `json:"log_excerpt,omitempty"`
 	Status         string             `json:"status,omitempty"` // available | partial | error | pending
+	DBStats        *DBOpStatsSummary  `json:"db_stats,omitempty"`
+}
+
+// DBOpStatsSummary mirrors ssadb.DBOpStats JSON written to db-stats/*.db.json.
+type DBOpStatsSummary struct {
+	Dialect    string                       `json:"dialect,omitempty"`
+	Ops        map[string]DBOpBucketSummary `json:"ops,omitempty"`
+	TotalCount int64                        `json:"total_count"`
+	TotalMs    int64                        `json:"total_ms"`
+	ErrorCount int64                        `json:"error_count,omitempty"`
+}
+
+// DBOpBucketSummary mirrors ssadb.DBOpBucket JSON.
+type DBOpBucketSummary struct {
+	Count      int64 `json:"count"`
+	TotalMs    int64 `json:"total_ms"`
+	MinMs      int64 `json:"min_ms,omitempty"`
+	MaxMs      int64 `json:"max_ms,omitempty"`
+	AvgMs      int64 `json:"avg_ms,omitempty"`
+	ErrorCount int64 `json:"error_count,omitempty"`
 }
 
 // SampleDetail is the detailed view of a single 5-minute sample.
 type SampleDetail struct {
 	SampleSummary
-	CPUProfile   *PprofTopAnalysis `json:"cpu_profile,omitempty"`
-	HeapProfile  *PprofTopAnalysis  `json:"heap_profile,omitempty"`
-	Goroutines   int                `json:"goroutines,omitempty"`
-	LogExcerpt   string             `json:"log_excerpt,omitempty"`
+	CPUProfile  *PprofTopAnalysis `json:"cpu_profile,omitempty"`
+	HeapProfile *PprofTopAnalysis `json:"heap_profile,omitempty"`
+	Goroutines  int               `json:"goroutines,omitempty"`
+	LogExcerpt  string            `json:"log_excerpt,omitempty"`
 }
 
 // PprofTopAnalysis contains top functions from a pprof profile.
 type PprofTopAnalysis struct {
-	Kind           string            `json:"kind"`
-	TopFunctions   []PprofTopFunction `json:"top_functions,omitempty"`
-	YaklangTop     []PprofTopFunction `json:"yaklang_top,omitempty"`
-	SampleCount    int64             `json:"sample_count"`
-	TotalValue     int64             `json:"total_value"`
-	SampleUnit     string            `json:"sample_unit,omitempty"`
-	ParseError     string            `json:"parse_error,omitempty"`
-	TimeNanos      int64             `json:"time_nanos,omitempty"`
-	DurationNanos  int64             `json:"duration_nanos,omitempty"`
+	Kind          string             `json:"kind"`
+	TopFunctions  []PprofTopFunction `json:"top_functions,omitempty"`
+	YaklangTop    []PprofTopFunction `json:"yaklang_top,omitempty"`
+	SampleCount   int64              `json:"sample_count"`
+	TotalValue    int64              `json:"total_value"`
+	SampleUnit    string             `json:"sample_unit,omitempty"`
+	ParseError    string             `json:"parse_error,omitempty"`
+	TimeNanos     int64              `json:"time_nanos,omitempty"`
+	DurationNanos int64              `json:"duration_nanos,omitempty"`
 }
 
 // PprofTopFunction is a single function entry.
@@ -100,16 +121,17 @@ type PprofTopFunction struct {
 
 // RunSummary is the overall run summary.
 type RunSummary struct {
-	TotalDurationMS  int64  `json:"total_duration_ms"`
-	CPUProfileFiles  int    `json:"cpu_profile_files"`
-	HeapProfileFiles int    `json:"heap_profile_files"`
-	GoroutineFiles   int    `json:"goroutine_files"`
-	HasLog           bool   `json:"has_log"`
-	HasReport        bool   `json:"has_report"`
-	HasSSADB         bool   `json:"has_ssadb"`
-	HasCmd           bool   `json:"has_cmd"`
-	CompilePhaseFound bool  `json:"compile_phase_found"`
-	ScanPhaseFound    bool  `json:"scan_phase_found"`
+	TotalDurationMS   int64             `json:"total_duration_ms"`
+	CPUProfileFiles   int               `json:"cpu_profile_files"`
+	HeapProfileFiles  int               `json:"heap_profile_files"`
+	GoroutineFiles    int               `json:"goroutine_files"`
+	HasLog            bool              `json:"has_log"`
+	HasReport         bool              `json:"has_report"`
+	HasSSADB          bool              `json:"has_ssadb"`
+	HasCmd            bool              `json:"has_cmd"`
+	CompilePhaseFound bool              `json:"compile_phase_found"`
+	ScanPhaseFound    bool              `json:"scan_phase_found"`
+	DBStatsTotal      *DBOpStatsSummary `json:"db_stats_total,omitempty"`
 }
 
 // AnalyzeDebugRun parses a debug run directory and returns structured analysis.
@@ -183,11 +205,7 @@ func AnalyzeDebugRunWithStatus(dir string, taskStatus string) DebugRunAnalysis {
 	}
 
 	// Parse pprof samples
-	cpuDir := filepath.Join(dir, "cpu-pprof")
-	memDir := filepath.Join(dir, "memory-pprof")
-	goroutineDir := filepath.Join(dir, "goroutine-pprof")
-
-	samples := result.collectSamples(cpuDir, memDir, goroutineDir, logContent)
+	samples := result.collectSamples(dir, logContent)
 	result.Samples = samples
 
 	// Build summary
@@ -249,6 +267,8 @@ func AnalyzeSample(dir string, label string) (SampleDetail, error) {
 	if logData, err := os.ReadFile(logPath); err == nil {
 		detail.LogExcerpt = extractLogExcerpt(string(logData), label, 4096)
 	}
+
+	detail.DBStats = loadSampleDBStats(dir, label)
 
 	return detail, nil
 }
@@ -409,17 +429,23 @@ func (r *DebugRunAnalysis) determineStatus(logContent string) string {
 	return "unknown"
 }
 
-func (r *DebugRunAnalysis) collectSamples(cpuDir, memDir, goroutineDir, logContent string) []SampleSummary {
+func (r *DebugRunAnalysis) collectSamples(dir, logContent string) []SampleSummary {
 	type fileEntry struct {
 		dir      string
 		suffix   string
 		fileType string
 	}
 
+	cpuDir := filepath.Join(dir, "cpu-pprof")
+	memDir := filepath.Join(dir, "memory-pprof")
+	goroutineDir := filepath.Join(dir, "goroutine-pprof")
+	dbStatsDir := filepath.Join(dir, "db-stats")
+
 	entries := []fileEntry{
 		{cpuDir, ".cpu.prof", "cpu"},
 		{memDir, ".mem.prof", "heap"},
 		{goroutineDir, ".goroutine.prof", "goroutine"},
+		{dbStatsDir, ".db.json", "db_stats"},
 	}
 
 	// Collect all sample labels
@@ -462,6 +488,8 @@ func (r *DebugRunAnalysis) collectSamples(cpuDir, memDir, goroutineDir, logConte
 			case "goroutine":
 				s.HasGoroutine = true
 				s.GoroutineFile = filepath.Join(entry.dir, name)
+			case "db_stats":
+				s.DBStats = loadDBStatsFile(filepath.Join(entry.dir, name))
 			}
 		}
 	}
@@ -503,22 +531,14 @@ func (r *DebugRunAnalysis) collectSamples(cpuDir, memDir, goroutineDir, logConte
 				s.Goroutines = count
 			}
 		}
+		if s.DBStats == nil {
+			s.DBStats = loadSampleDBStats(dir, s.Label)
+		}
 		// Log excerpt limited to 500 chars
 		if s.Label != "" {
-			firstFile := s.CPUFile
-			if firstFile == "" {
-				firstFile = s.HeapFile
-			}
-			if firstFile == "" {
-				firstFile = s.GoroutineFile
-			}
-			if firstFile == "" {
-				continue
-			}
-			logPath := filepath.Join(filepath.Dir(filepath.Dir(firstFile)), "log")
-			if logData, err := os.ReadFile(logPath); err == nil {
+			if logData, err := os.ReadFile(filepath.Join(dir, "log")); err == nil {
 				s.LogExcerpt = extractLogExcerpt(string(logData), s.Label, 500)
-			} else if taskLog := resolveNodeTaskLogFallback(firstFile); taskLog != "" {
+			} else if taskLog := resolveTaskLogByDebugDir(dir); taskLog != "" {
 				if logData, err := os.ReadFile(taskLog); err == nil {
 					s.LogExcerpt = extractLogExcerpt(string(logData), s.Label, 500)
 				}
@@ -579,7 +599,70 @@ func (r *DebugRunAnalysis) buildSummary(dir string, samples []SampleSummary) *Ru
 		}
 	}
 
+	summary.DBStatsTotal = aggregateDBStats(samples)
+
 	return summary
+}
+
+func loadSampleDBStats(dir, label string) *DBOpStatsSummary {
+	if dir == "" || label == "" {
+		return nil
+	}
+	return loadDBStatsFile(filepath.Join(dir, "db-stats", label+".db.json"))
+}
+
+func loadDBStatsFile(path string) *DBOpStatsSummary {
+	raw, err := os.ReadFile(path)
+	if err != nil || len(raw) == 0 {
+		return nil
+	}
+	var stats DBOpStatsSummary
+	if err := json.Unmarshal(raw, &stats); err != nil {
+		return nil
+	}
+	return &stats
+}
+
+func aggregateDBStats(samples []SampleSummary) *DBOpStatsSummary {
+	ops := make(map[string]DBOpBucketSummary)
+	total := DBOpStatsSummary{Ops: ops}
+	any := false
+	for _, s := range samples {
+		if s.DBStats == nil {
+			continue
+		}
+		any = true
+		if total.Dialect == "" {
+			total.Dialect = s.DBStats.Dialect
+		}
+		total.TotalCount += s.DBStats.TotalCount
+		total.TotalMs += s.DBStats.TotalMs
+		total.ErrorCount += s.DBStats.ErrorCount
+		for kind, bucket := range s.DBStats.Ops {
+			cur := ops[kind]
+			cur.Count += bucket.Count
+			cur.TotalMs += bucket.TotalMs
+			cur.ErrorCount += bucket.ErrorCount
+			if bucket.MaxMs > cur.MaxMs {
+				cur.MaxMs = bucket.MaxMs
+			}
+			if bucket.MinMs > 0 && (cur.MinMs == 0 || bucket.MinMs < cur.MinMs) {
+				cur.MinMs = bucket.MinMs
+			}
+			ops[kind] = cur
+		}
+	}
+	if !any {
+		return nil
+	}
+	for kind, bucket := range ops {
+		if bucket.Count > 0 {
+			bucket.AvgMs = bucket.TotalMs / bucket.Count
+		}
+		ops[kind] = bucket
+	}
+	total.Ops = ops
+	return &total
 }
 
 func parsePprofFile(path string, kind string) *PprofTopAnalysis {

--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -67,6 +67,24 @@ type SampleSummary struct {
 	LogExcerpt     string             `json:"log_excerpt,omitempty"`
 	Status         string             `json:"status,omitempty"` // available | partial | error | pending
 	DBStats        *DBOpStatsSummary  `json:"db_stats,omitempty"`
+	Runtime        *RuntimeStatsSummary `json:"runtime,omitempty"`
+}
+
+// RuntimeStatsSummary mirrors runtime-stats/*.runtime.json written by the
+// scan-task pprof collector (host vs this process CPU/memory).
+type RuntimeStatsSummary struct {
+	Timestamp             string  `json:"timestamp,omitempty"`
+	NumCPU                int     `json:"num_cpu,omitempty"`
+	Load1                 float64 `json:"load1,omitempty"`
+	HostCPUPercent        float64 `json:"host_cpu_percent"`
+	ProcessCPUPercent     float64 `json:"process_cpu_percent"`
+	HostMemTotalBytes     uint64  `json:"host_mem_total_bytes"`
+	HostMemUsedBytes      uint64  `json:"host_mem_used_bytes"`
+	HostMemAvailableBytes uint64  `json:"host_mem_available_bytes"`
+	ProcessRSSBytes       uint64  `json:"process_rss_bytes"`
+	ProcessHeapAllocBytes uint64  `json:"process_heap_alloc_bytes"`
+	ProcessHeapSysBytes   uint64  `json:"process_heap_sys_bytes"`
+	Goroutines            int     `json:"goroutines,omitempty"`
 }
 
 // DBOpStatsSummary mirrors ssadb.DBOpStats JSON written to db-stats/*.db.json.
@@ -75,6 +93,7 @@ type DBOpStatsSummary struct {
 	Ops        map[string]DBOpBucketSummary `json:"ops,omitempty"`
 	TotalCount int64                        `json:"total_count"`
 	TotalMs    int64                        `json:"total_ms"`
+	WindowMs   int64                        `json:"window_ms,omitempty"`
 	ErrorCount int64                        `json:"error_count,omitempty"`
 }
 
@@ -440,12 +459,14 @@ func (r *DebugRunAnalysis) collectSamples(dir, logContent string) []SampleSummar
 	memDir := filepath.Join(dir, "memory-pprof")
 	goroutineDir := filepath.Join(dir, "goroutine-pprof")
 	dbStatsDir := filepath.Join(dir, "db-stats")
+	runtimeStatsDir := filepath.Join(dir, "runtime-stats")
 
 	entries := []fileEntry{
 		{cpuDir, ".cpu.prof", "cpu"},
 		{memDir, ".mem.prof", "heap"},
 		{goroutineDir, ".goroutine.prof", "goroutine"},
 		{dbStatsDir, ".db.json", "db_stats"},
+		{runtimeStatsDir, ".runtime.json", "runtime"},
 	}
 
 	// Collect all sample labels
@@ -490,6 +511,8 @@ func (r *DebugRunAnalysis) collectSamples(dir, logContent string) []SampleSummar
 				s.GoroutineFile = filepath.Join(entry.dir, name)
 			case "db_stats":
 				s.DBStats = loadDBStatsFile(filepath.Join(entry.dir, name))
+			case "runtime":
+				s.Runtime = loadRuntimeStatsFile(filepath.Join(entry.dir, name))
 			}
 		}
 	}
@@ -617,6 +640,18 @@ func loadDBStatsFile(path string) *DBOpStatsSummary {
 		return nil
 	}
 	var stats DBOpStatsSummary
+	if err := json.Unmarshal(raw, &stats); err != nil {
+		return nil
+	}
+	return &stats
+}
+
+func loadRuntimeStatsFile(path string) *RuntimeStatsSummary {
+	raw, err := os.ReadFile(path)
+	if err != nil || len(raw) == 0 {
+		return nil
+	}
+	var stats RuntimeStatsSummary
 	if err := json.Unmarshal(raw, &stats); err != nil {
 		return nil
 	}

--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -59,15 +59,19 @@ type SampleSummary struct {
 	HeapFile      string `json:"-"`
 	GoroutineFile string `json:"-"`
 	// Inline detail (limited to avoid oversized analysis JSON)
-	CPUTop         []PprofTopFunction `json:"cpu_top,omitempty"`
-	CPUTopYaklang  []PprofTopFunction `json:"cpu_top_yaklang,omitempty"`
-	HeapTop        []PprofTopFunction `json:"heap_top,omitempty"`
-	HeapTopYaklang []PprofTopFunction `json:"heap_top_yaklang,omitempty"`
-	Goroutines     int                `json:"goroutines,omitempty"`
-	LogExcerpt     string             `json:"log_excerpt,omitempty"`
-	Status         string             `json:"status,omitempty"` // available | partial | error | pending
-	DBStats        *DBOpStatsSummary  `json:"db_stats,omitempty"`
-	Runtime        *RuntimeStatsSummary `json:"runtime,omitempty"`
+	CPUTop            []PprofTopFunction `json:"cpu_top,omitempty"`
+	CPUTopYaklang     []PprofTopFunction `json:"cpu_top_yaklang,omitempty"`
+	CPUStacks         []PprofStackPath   `json:"cpu_stacks,omitempty"`
+	CPUStacksYaklang  []PprofStackPath   `json:"cpu_stacks_yaklang,omitempty"`
+	HeapTop           []PprofTopFunction `json:"heap_top,omitempty"`
+	HeapTopYaklang    []PprofTopFunction `json:"heap_top_yaklang,omitempty"`
+	HeapStacks        []PprofStackPath   `json:"heap_stacks,omitempty"`
+	HeapStacksYaklang []PprofStackPath   `json:"heap_stacks_yaklang,omitempty"`
+	Goroutines        int                `json:"goroutines,omitempty"`
+	LogExcerpt        string             `json:"log_excerpt,omitempty"`
+	Status            string             `json:"status,omitempty"` // available | partial | error | pending
+	DBStats           *DBOpStatsSummary  `json:"db_stats,omitempty"`
+	Runtime           *RuntimeStatsSummary `json:"runtime,omitempty"`
 }
 
 // RuntimeStatsSummary mirrors runtime-stats/*.runtime.json written by the
@@ -121,6 +125,8 @@ type PprofTopAnalysis struct {
 	Kind          string             `json:"kind"`
 	TopFunctions  []PprofTopFunction `json:"top_functions,omitempty"`
 	YaklangTop    []PprofTopFunction `json:"yaklang_top,omitempty"`
+	TopStacks     []PprofStackPath   `json:"top_stacks,omitempty"`
+	YaklangStacks []PprofStackPath   `json:"yaklang_stacks,omitempty"`
 	SampleCount   int64              `json:"sample_count"`
 	TotalValue    int64              `json:"total_value"`
 	SampleUnit    string             `json:"sample_unit,omitempty"`
@@ -136,6 +142,13 @@ type PprofTopFunction struct {
 	CumPct    string `json:"cum_pct"`
 	FlatValue int64  `json:"flat_value"`
 	FlatPct   string `json:"flat_pct"`
+}
+
+// PprofStackPath is one folded call path (root → leaf) with its sample share.
+type PprofStackPath struct {
+	Frames []string `json:"frames"`
+	Value  int64    `json:"value"`
+	Pct    string   `json:"pct"`
 }
 
 // RunSummary is the overall run summary.
@@ -260,6 +273,8 @@ func AnalyzeSample(dir string, label string) (SampleDetail, error) {
 		if detail.CPUProfile != nil {
 			detail.CPUTop = limitTopFunctions(detail.CPUProfile.TopFunctions, 10)
 			detail.CPUTopYaklang = limitTopFunctions(detail.CPUProfile.YaklangTop, 10)
+			detail.CPUStacks = limitStackPaths(detail.CPUProfile.TopStacks, 10)
+			detail.CPUStacksYaklang = limitStackPaths(detail.CPUProfile.YaklangStacks, 10)
 			ts := parseLabelTimestamp(label)
 			detail.Label = label
 			detail.Timestamp = ts
@@ -273,6 +288,8 @@ func AnalyzeSample(dir string, label string) (SampleDetail, error) {
 		if detail.HeapProfile != nil {
 			detail.HeapTop = limitTopFunctions(detail.HeapProfile.TopFunctions, 10)
 			detail.HeapTopYaklang = limitTopFunctions(detail.HeapProfile.YaklangTop, 10)
+			detail.HeapStacks = limitStackPaths(detail.HeapProfile.TopStacks, 10)
+			detail.HeapStacksYaklang = limitStackPaths(detail.HeapProfile.YaklangStacks, 10)
 		}
 	}
 
@@ -534,6 +551,8 @@ func (r *DebugRunAnalysis) collectSamples(dir, logContent string) []SampleSummar
 				}
 				s.CPUTop = limitTopFunctions(p.TopFunctions, 10)
 				s.CPUTopYaklang = limitTopFunctions(p.YaklangTop, 10)
+				s.CPUStacks = limitStackPaths(p.TopStacks, 10)
+				s.CPUStacksYaklang = limitStackPaths(p.YaklangStacks, 10)
 				applySampleWindow(s, p)
 			}
 		}
@@ -544,6 +563,8 @@ func (r *DebugRunAnalysis) collectSamples(dir, logContent string) []SampleSummar
 				}
 				s.HeapTop = limitTopFunctions(p.TopFunctions, 10)
 				s.HeapTopYaklang = limitTopFunctions(p.YaklangTop, 10)
+				s.HeapStacks = limitStackPaths(p.TopStacks, 10)
+				s.HeapStacksYaklang = limitStackPaths(p.YaklangStacks, 10)
 				// Heap snapshots are instantaneous; only fill window from CPU.
 			}
 		}
@@ -734,6 +755,7 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 	}
 
 	funcMap := make(map[string]*pprofFuncStats)
+	stackMap := make(map[string]*pprofStackStats)
 	var totalValue int64
 
 	for _, sample := range p.Sample {
@@ -775,6 +797,18 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 				}
 			}
 		}
+
+		frames := stackFramesRootToLeaf(sample)
+		if len(frames) == 0 {
+			continue
+		}
+		key := strings.Join(frames, "\x00")
+		ss, ok := stackMap[key]
+		if !ok {
+			ss = &pprofStackStats{frames: frames}
+			stackMap[key] = ss
+		}
+		ss.value += value
 	}
 
 	var stats []*pprofFuncStats
@@ -788,8 +822,21 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 		return stats[i].name < stats[j].name
 	})
 
+	var stacks []*pprofStackStats
+	for _, ss := range stackMap {
+		stacks = append(stacks, ss)
+	}
+	sort.Slice(stacks, func(i, j int) bool {
+		if stacks[i].value != stacks[j].value {
+			return stacks[i].value > stacks[j].value
+		}
+		return strings.Join(stacks[i].frames, "/") < strings.Join(stacks[j].frames, "/")
+	})
+
 	result.TopFunctions = pprofTopFromStats(stats, totalValue, 20, nil)
 	result.YaklangTop = pprofTopFromStats(stats, totalValue, 20, isYaklangPprofFunc)
+	result.TopStacks = pprofStacksFromStats(stacks, totalValue, 20, false)
+	result.YaklangStacks = pprofStacksFromStats(stacks, totalValue, 20, true)
 	result.SampleCount = int64(len(p.Sample))
 	result.TotalValue = totalValue
 	if len(p.SampleType) > sampleTypeIdx {
@@ -802,6 +849,135 @@ type pprofFuncStats struct {
 	name string
 	flat int64
 	cum  int64
+}
+
+type pprofStackStats struct {
+	frames []string
+	value  int64
+}
+
+const pprofStackMaxFrames = 8
+
+// stackFramesRootToLeaf returns the call path outer→inner. Go profiles keep
+// the leaf at location[0]; reverse so the UI reads top-down like a call tree.
+func stackFramesRootToLeaf(sample *profile.Sample) []string {
+	if sample == nil || len(sample.Location) == 0 {
+		return nil
+	}
+	raw := make([]string, 0, len(sample.Location))
+	for i := len(sample.Location) - 1; i >= 0; i-- {
+		loc := sample.Location[i]
+		if loc == nil || len(loc.Line) == 0 {
+			continue
+		}
+		// Prefer the last line on the location (outermost inline frame).
+		line := loc.Line[len(loc.Line)-1]
+		if line.Function == nil || strings.TrimSpace(line.Function.Name) == "" {
+			continue
+		}
+		name := line.Function.Name
+		if len(raw) > 0 && raw[len(raw)-1] == name {
+			continue
+		}
+		raw = append(raw, name)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	if len(raw) <= pprofStackMaxFrames {
+		return raw
+	}
+	// Keep the deepest frames (closest to the leaf where time is spent).
+	trimmed := make([]string, 0, pprofStackMaxFrames+1)
+	trimmed = append(trimmed, "…")
+	trimmed = append(trimmed, raw[len(raw)-pprofStackMaxFrames:]...)
+	return trimmed
+}
+
+func pprofStacksFromStats(
+	stacks []*pprofStackStats,
+	totalValue int64,
+	n int,
+	yaklangOnly bool,
+) []PprofStackPath {
+	selected := stacks
+	if yaklangOnly {
+		merged := make(map[string]*pprofStackStats)
+		for _, ss := range stacks {
+			focused := focusYaklangStackFrames(ss.frames)
+			if len(focused) == 0 {
+				continue
+			}
+			key := strings.Join(focused, "\x00")
+			cur, ok := merged[key]
+			if !ok {
+				cur = &pprofStackStats{frames: focused}
+				merged[key] = cur
+			}
+			cur.value += ss.value
+		}
+		selected = make([]*pprofStackStats, 0, len(merged))
+		for _, ss := range merged {
+			selected = append(selected, ss)
+		}
+		sort.Slice(selected, func(i, j int) bool {
+			if selected[i].value != selected[j].value {
+				return selected[i].value > selected[j].value
+			}
+			return strings.Join(selected[i].frames, "/") < strings.Join(selected[j].frames, "/")
+		})
+	}
+
+	out := make([]PprofStackPath, 0, n)
+	for _, ss := range selected {
+		var pct string
+		if totalValue > 0 {
+			pct = fmt.Sprintf("%.2f%%", float64(ss.value)*100/float64(totalValue))
+		}
+		out = append(out, PprofStackPath{
+			Frames: append([]string(nil), ss.frames...),
+			Value:  ss.value,
+			Pct:    pct,
+		})
+		if len(out) >= n {
+			break
+		}
+	}
+	return out
+}
+
+// focusYaklangStackFrames keeps one parent context plus yaklang frames through
+// the leaf so the path stays readable without runtime noise.
+func focusYaklangStackFrames(frames []string) []string {
+	first := -1
+	for i, name := range frames {
+		if isYaklangPprofFunc(name) {
+			first = i
+			break
+		}
+	}
+	if first < 0 {
+		return nil
+	}
+	start := first
+	if start > 0 {
+		start--
+	}
+	out := append([]string(nil), frames[start:]...)
+	if len(out) <= pprofStackMaxFrames {
+		return out
+	}
+	trimmed := make([]string, 0, pprofStackMaxFrames+1)
+	trimmed = append(trimmed, "…")
+	trimmed = append(trimmed, out[len(out)-pprofStackMaxFrames:]...)
+	return trimmed
+}
+
+func limitStackPaths(paths []PprofStackPath, n int) []PprofStackPath {
+	if n <= 0 || len(paths) <= n {
+		return paths
+	}
+	return paths[:n]
 }
 
 func pprofTopFromStats(

--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -172,9 +172,10 @@ func AnalyzeDebugRun(dir string) DebugRunAnalysis {
 	return AnalyzeDebugRunWithStatus(dir, "")
 }
 
-// AnalyzeDebugRunWithStatus analyzes a debug run directory. When taskStatus
-// is non-empty (e.g. "succeeded"/"failed"), it takes precedence over the
-// log-derived status because the log may not contain a completion marker.
+// AnalyzeDebugRunWithStatus analyzes a debug run directory.
+// Status always comes from the Legion task/attempt status when provided.
+// Logs are never used to invent failed/completed — rule comments contain
+// words like "panic" and previously false-triggered "失败".
 func AnalyzeDebugRunWithStatus(dir string, taskStatus string) DebugRunAnalysis {
 	result := DebugRunAnalysis{
 		RunDir: dir,
@@ -212,12 +213,6 @@ func AnalyzeDebugRunWithStatus(dir string, taskStatus string) DebugRunAnalysis {
 	if strings.TrimSpace(logContent) != "" {
 		result.setTimesFromLog(logContent)
 		result.setPhasesFromLog(logContent)
-		if taskStatus == "" {
-			result.Status = result.determineStatus(logContent)
-		}
-	}
-	if taskStatus != "" {
-		result.Status = normalizeTaskStatus(taskStatus)
 	}
 
 	// Child collector logs often only contain ERROR/pprof lines and miss the
@@ -228,11 +223,6 @@ func AnalyzeDebugRunWithStatus(dir string, taskStatus string) DebugRunAnalysis {
 			logContent = enriched
 			result.setTimesFromLog(logContent)
 			result.setPhasesFromLog(logContent)
-			if taskStatus == "" {
-				result.Status = result.determineStatus(logContent)
-			} else {
-				result.Status = normalizeTaskStatus(taskStatus)
-			}
 		}
 	}
 
@@ -244,7 +234,31 @@ func AnalyzeDebugRunWithStatus(dir string, taskStatus string) DebugRunAnalysis {
 	result.Summary = result.buildSummary(dir, samples)
 	result.Partial = len(result.Errors) > 0
 
+	result.Status = resolveDebugAnalysisStatus(taskStatus, logContent, len(samples))
 	return result
+}
+
+// resolveDebugAnalysisStatus maps the Legion attempt/job status onto the
+// debug analysis badge. Never infer failure from log text.
+func resolveDebugAnalysisStatus(taskStatus, logContent string, sampleCount int) string {
+	if normalized := normalizeTaskStatus(taskStatus); normalized != "" {
+		switch normalized {
+		case "succeeded", "completed", "ok":
+			return "completed"
+		case "failed", "error":
+			return "failed"
+		case "cancelled", "canceled", "timed_out", "lost":
+			return normalized
+		case "running", "claimed", "dispatched", "queued", "created":
+			return "running"
+		default:
+			return normalized
+		}
+	}
+	if sampleCount > 0 || strings.TrimSpace(logContent) != "" {
+		return "running"
+	}
+	return "unknown"
 }
 
 // AnalyzeSample returns detailed analysis for a single pprof sample.
@@ -451,18 +465,9 @@ func enrichLogWithTaskLog(debugDir, logContent string) string {
 }
 
 func (r *DebugRunAnalysis) determineStatus(logContent string) string {
-	lower := strings.ToLower(logContent)
-	if strings.Contains(lower, "code scan done") {
-		return "completed"
-	}
-	if strings.Contains(lower, "code scan failed") || strings.Contains(lower, "panic") {
-		return "failed"
-	}
-	// If log is still being written (file exists but no completion marker)
-	if len(logContent) > 0 {
-		return "running"
-	}
-	return "unknown"
+	// Deprecated: status must come from the Legion task/attempt, not log text.
+	// Kept as a thin wrapper for older call sites/tests.
+	return resolveDebugAnalysisStatus("", logContent, 0)
 }
 
 func (r *DebugRunAnalysis) collectSamples(dir, logContent string) []SampleSummary {

--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -43,24 +43,28 @@ type PhaseAnalysis struct {
 // Detail fields are populated inline so the frontend can expand a row
 // without a second request.
 type SampleSummary struct {
-	Sequence   int        `json:"sequence"`
-	Label      string     `json:"label"` // e.g. "20260805-120030-initial"
-	Timestamp  *time.Time `json:"timestamp,omitempty"`
-	Phase      string     `json:"phase,omitempty"`
-	PhaseSource string    `json:"phase_source,omitempty"` // explicit | boundary_inferred | log_inferred | unknown
-	HasCPU     bool       `json:"has_cpu"`
-	HasHeap    bool       `json:"has_heap"`
-	HasGoroutine bool     `json:"has_goroutine"`
+	Sequence     int        `json:"sequence"`
+	Label        string     `json:"label"` // e.g. "20260805-120030-initial"
+	Timestamp    *time.Time `json:"timestamp,omitempty"`
+	EndedAt      *time.Time `json:"ended_at,omitempty"`
+	DurationMS   int64      `json:"duration_ms,omitempty"`
+	Phase        string     `json:"phase,omitempty"`
+	PhaseSource  string     `json:"phase_source,omitempty"` // explicit | boundary_inferred | log_inferred | unknown
+	HasCPU       bool       `json:"has_cpu"`
+	HasHeap      bool       `json:"has_heap"`
+	HasGoroutine bool       `json:"has_goroutine"`
 	// File paths are internal only, not serialized to JSON
 	CPUFile       string `json:"-"`
 	HeapFile      string `json:"-"`
 	GoroutineFile string `json:"-"`
 	// Inline detail (limited to avoid oversized analysis JSON)
-	CPUTop     []PprofTopFunction `json:"cpu_top,omitempty"`
-	HeapTop    []PprofTopFunction `json:"heap_top,omitempty"`
-	Goroutines int                `json:"goroutines,omitempty"`
-	LogExcerpt string             `json:"log_excerpt,omitempty"`
-	Status     string             `json:"status,omitempty"` // available | partial | error | pending
+	CPUTop         []PprofTopFunction `json:"cpu_top,omitempty"`
+	CPUTopYaklang  []PprofTopFunction `json:"cpu_top_yaklang,omitempty"`
+	HeapTop        []PprofTopFunction `json:"heap_top,omitempty"`
+	HeapTopYaklang []PprofTopFunction `json:"heap_top_yaklang,omitempty"`
+	Goroutines     int                `json:"goroutines,omitempty"`
+	LogExcerpt     string             `json:"log_excerpt,omitempty"`
+	Status         string             `json:"status,omitempty"` // available | partial | error | pending
 }
 
 // SampleDetail is the detailed view of a single 5-minute sample.
@@ -74,12 +78,15 @@ type SampleDetail struct {
 
 // PprofTopAnalysis contains top functions from a pprof profile.
 type PprofTopAnalysis struct {
-	Kind         string             `json:"kind"`
-	TopFunctions []PprofTopFunction  `json:"top_functions,omitempty"`
-	SampleCount  int64              `json:"sample_count"`
-	TotalValue   int64              `json:"total_value"`
-	SampleUnit   string             `json:"sample_unit,omitempty"`
-	ParseError   string             `json:"parse_error,omitempty"`
+	Kind           string            `json:"kind"`
+	TopFunctions   []PprofTopFunction `json:"top_functions,omitempty"`
+	YaklangTop     []PprofTopFunction `json:"yaklang_top,omitempty"`
+	SampleCount    int64             `json:"sample_count"`
+	TotalValue     int64             `json:"total_value"`
+	SampleUnit     string            `json:"sample_unit,omitempty"`
+	ParseError     string            `json:"parse_error,omitempty"`
+	TimeNanos      int64             `json:"time_nanos,omitempty"`
+	DurationNanos  int64             `json:"duration_nanos,omitempty"`
 }
 
 // PprofTopFunction is a single function entry.
@@ -213,11 +220,23 @@ func AnalyzeSample(dir string, label string) (SampleDetail, error) {
 	// Parse CPU profile
 	if cpuFile != "" {
 		detail.CPUProfile = parsePprofFile(cpuFile, "cpu")
+		if detail.CPUProfile != nil {
+			detail.CPUTop = limitTopFunctions(detail.CPUProfile.TopFunctions, 10)
+			detail.CPUTopYaklang = limitTopFunctions(detail.CPUProfile.YaklangTop, 10)
+			ts := parseLabelTimestamp(label)
+			detail.Label = label
+			detail.Timestamp = ts
+			applySampleWindow(&detail.SampleSummary, detail.CPUProfile)
+		}
 	}
 
 	// Parse heap profile
 	if heapFile != "" {
 		detail.HeapProfile = parsePprofFile(heapFile, "heap")
+		if detail.HeapProfile != nil {
+			detail.HeapTop = limitTopFunctions(detail.HeapProfile.TopFunctions, 10)
+			detail.HeapTopYaklang = limitTopFunctions(detail.HeapProfile.YaklangTop, 10)
+		}
 	}
 
 	// Count goroutines from goroutine profile
@@ -454,7 +473,7 @@ func (r *DebugRunAnalysis) collectSamples(cpuDir, memDir, goroutineDir, logConte
 		}
 	}
 
-	// Populate inline details for each sample (limited to top 5 functions)
+	// Populate inline details for each sample (limited top lists for UI)
 	for _, s := range labelMap {
 		s.Status = "available"
 		if s.CPUFile != "" {
@@ -463,6 +482,8 @@ func (r *DebugRunAnalysis) collectSamples(cpuDir, memDir, goroutineDir, logConte
 					s.Status = "partial"
 				}
 				s.CPUTop = limitTopFunctions(p.TopFunctions, 10)
+				s.CPUTopYaklang = limitTopFunctions(p.YaklangTop, 10)
+				applySampleWindow(s, p)
 			}
 		}
 		if s.HeapFile != "" {
@@ -471,6 +492,8 @@ func (r *DebugRunAnalysis) collectSamples(cpuDir, memDir, goroutineDir, logConte
 					s.Status = "partial"
 				}
 				s.HeapTop = limitTopFunctions(p.TopFunctions, 10)
+				s.HeapTopYaklang = limitTopFunctions(p.YaklangTop, 10)
+				// Heap snapshots are instantaneous; only fill window from CPU.
 			}
 		}
 		if s.GoroutineFile != "" {
@@ -581,6 +604,9 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 		return result
 	}
 
+	result.TimeNanos = p.TimeNanos
+	result.DurationNanos = p.DurationNanos
+
 	sampleTypeIdx := 0
 	for i, st := range p.SampleType {
 		if st.Type == "samples" || st.Type == "cpu" || st.Type == "alloc_space" || st.Type == "inuse_space" || st.Type == "alloc_objects" || st.Type == "inuse_objects" {
@@ -589,12 +615,7 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 		}
 	}
 
-	type funcStats struct {
-		name string
-		flat int64
-		cum  int64
-	}
-	funcMap := make(map[string]*funcStats)
+	funcMap := make(map[string]*pprofFuncStats)
 	var totalValue int64
 
 	for _, sample := range p.Sample {
@@ -611,7 +632,7 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 					name := line.Function.Name
 					fs, ok := funcMap[name]
 					if !ok {
-						fs = &funcStats{name: name}
+						fs = &pprofFuncStats{name: name}
 						funcMap[name] = fs
 					}
 					fs.flat += value
@@ -628,7 +649,7 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 						seen[name] = true
 						fs, ok := funcMap[name]
 						if !ok {
-							fs = &funcStats{name: name}
+							fs = &pprofFuncStats{name: name}
 							funcMap[name] = fs
 						}
 						fs.cum += value
@@ -638,7 +659,7 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 		}
 	}
 
-	var stats []*funcStats
+	var stats []*pprofFuncStats
 	for _, fs := range funcMap {
 		stats = append(stats, fs)
 	}
@@ -649,28 +670,71 @@ func buildPprofTopAnalysis(p *profile.Profile, kind string) *PprofTopAnalysis {
 		return stats[i].name < stats[j].name
 	})
 
-	const topN = 20
-	if len(stats) > topN {
-		stats = stats[:topN]
-	}
-
-	for _, fs := range stats {
-		var cumPct, flatPct string
-		if totalValue > 0 {
-			cumPct = fmt.Sprintf("%.2f%%", float64(fs.cum)*100/float64(totalValue))
-			flatPct = fmt.Sprintf("%.2f%%", float64(fs.flat)*100/float64(totalValue))
-		}
-		result.TopFunctions = append(result.TopFunctions, PprofTopFunction{
-			Name: fs.name, CumValue: fs.cum, CumPct: cumPct, FlatValue: fs.flat, FlatPct: flatPct,
-		})
-	}
-
+	result.TopFunctions = pprofTopFromStats(stats, totalValue, 20, nil)
+	result.YaklangTop = pprofTopFromStats(stats, totalValue, 20, isYaklangPprofFunc)
 	result.SampleCount = int64(len(p.Sample))
 	result.TotalValue = totalValue
 	if len(p.SampleType) > sampleTypeIdx {
 		result.SampleUnit = p.SampleType[sampleTypeIdx].Unit
 	}
 	return result
+}
+
+type pprofFuncStats struct {
+	name string
+	flat int64
+	cum  int64
+}
+
+func pprofTopFromStats(
+	stats []*pprofFuncStats,
+	totalValue int64,
+	n int,
+	pred func(string) bool,
+) []PprofTopFunction {
+	out := make([]PprofTopFunction, 0, n)
+	for _, fs := range stats {
+		if pred != nil && !pred(fs.name) {
+			continue
+		}
+		var cumPct, flatPct string
+		if totalValue > 0 {
+			cumPct = fmt.Sprintf("%.2f%%", float64(fs.cum)*100/float64(totalValue))
+			flatPct = fmt.Sprintf("%.2f%%", float64(fs.flat)*100/float64(totalValue))
+		}
+		out = append(out, PprofTopFunction{
+			Name: fs.name, CumValue: fs.cum, CumPct: cumPct, FlatValue: fs.flat, FlatPct: flatPct,
+		})
+		if len(out) >= n {
+			break
+		}
+	}
+	return out
+}
+
+const yaklangPprofPrefix = "github.com/yaklang/yaklang"
+
+func isYaklangPprofFunc(name string) bool {
+	return strings.Contains(name, yaklangPprofPrefix)
+}
+
+// applySampleWindow sets EndedAt / DurationMS from the CPU profile duration.
+func applySampleWindow(s *SampleSummary, p *PprofTopAnalysis) {
+	if s == nil || p == nil || p.DurationNanos <= 0 {
+		return
+	}
+	s.DurationMS = p.DurationNanos / int64(time.Millisecond)
+	var start time.Time
+	if s.Timestamp != nil {
+		start = *s.Timestamp
+	} else if p.TimeNanos > 0 {
+		start = time.Unix(0, p.TimeNanos).UTC()
+		s.Timestamp = &start
+	} else {
+		return
+	}
+	end := start.Add(time.Duration(p.DurationNanos))
+	s.EndedAt = &end
 }
 
 func countGoroutines(path string) int {

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -94,7 +94,7 @@ func writeFakePprof(t *testing.T, path string) {
 
 func TestAnalyzeDebugRun_Complete(t *testing.T) {
 	dir := createTestDebugDir(t)
-	result := AnalyzeDebugRun(dir)
+	result := AnalyzeDebugRunWithStatus(dir, "succeeded")
 
 	assert.Equal(t, "completed", result.Status)
 	require.NotNil(t, result.StartedAt)
@@ -172,8 +172,23 @@ func TestAnalyzeDebugRun_Failed(t *testing.T) {
 	logContent := "2026/08/05 12:00:00 [INFO] start\n2026/08/05 12:01:00 [ERROR] code scan failed: something went wrong\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "log"), []byte(logContent), 0o644))
 
-	result := AnalyzeDebugRun(dir)
+	result := AnalyzeDebugRunWithStatus(dir, "failed")
 	assert.Equal(t, "failed", result.Status)
+}
+
+func TestAnalyzeDebugRun_DoesNotFailOnPanicInRuleComments(t *testing.T) {
+	dir := t.TempDir()
+	logContent := "2026/08/05 12:00:00 [INFO] start\n" +
+		"[DBUG] syntaxflow met statement: // which would otherwise cause the VM to panic or\n" +
+		"[DBUG] syntaxflow met statement: // return a \"BUG: get stack top failed, empty stack\" error.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "log"), []byte(logContent), 0o644))
+
+	result := AnalyzeDebugRunWithStatus(dir, "running")
+	assert.Equal(t, "running", result.Status)
+
+	// Without task status, still must not invent "failed" from the word panic.
+	result = AnalyzeDebugRun(dir)
+	assert.Equal(t, "running", result.Status)
 }
 
 func TestAnalyzeSample_WithPprof(t *testing.T) {

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/pprof/profile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -239,6 +240,45 @@ func TestPprofTopFromStatsYaklang(t *testing.T) {
 	require.Len(t, top, 2)
 	assert.Equal(t, "github.com/yaklang/yaklang/common/yak/ssa.A", top[0].Name)
 	assert.Equal(t, "github.com/yaklang/yaklang/common/yak/ssa.B", top[1].Name)
+}
+
+func TestBuildPprofTopAnalysis_Stacks(t *testing.T) {
+	fRoot := &profile.Function{ID: 1, Name: "main.main"}
+	fMid := &profile.Function{ID: 2, Name: "github.com/yaklang/yaklang/common/yak/ssaapi.Compile"}
+	fLeaf := &profile.Function{ID: 3, Name: "github.com/yaklang/gorm.(*DB).FirstOrCreate"}
+	fOther := &profile.Function{ID: 4, Name: "runtime.systemstack"}
+
+	loc := func(id uint64, fn *profile.Function) *profile.Location {
+		return &profile.Location{ID: id, Line: []profile.Line{{Function: fn}}}
+	}
+	// Leaf at location[0], root at the end — Go pprof convention.
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "cpu", Unit: "nanoseconds"}},
+		Sample: []*profile.Sample{
+			{
+				Location: []*profile.Location{loc(1, fLeaf), loc(2, fMid), loc(3, fRoot)},
+				Value:    []int64{80},
+			},
+			{
+				Location: []*profile.Location{loc(4, fOther), loc(5, fRoot)},
+				Value:    []int64{20},
+			},
+		},
+	}
+
+	result := buildPprofTopAnalysis(p, "cpu")
+	require.Empty(t, result.ParseError)
+	require.NotEmpty(t, result.TopStacks)
+	assert.Equal(t, []string{
+		"main.main",
+		"github.com/yaklang/yaklang/common/yak/ssaapi.Compile",
+		"github.com/yaklang/gorm.(*DB).FirstOrCreate",
+	}, result.TopStacks[0].Frames)
+	assert.Equal(t, int64(80), result.TopStacks[0].Value)
+	assert.Equal(t, "80.00%", result.TopStacks[0].Pct)
+
+	require.NotEmpty(t, result.YaklangStacks)
+	assert.Contains(t, result.YaklangStacks[0].Frames, "github.com/yaklang/yaklang/common/yak/ssaapi.Compile")
 }
 
 func TestParseLabelTimestamp(t *testing.T) {

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -20,6 +20,7 @@ func createTestDebugDir(t *testing.T) string {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "memory-pprof"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "goroutine-pprof"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "db-stats"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "runtime-stats"), 0o755))
 
 	// Write cmd.txt
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd.txt"), []byte("test command"), 0o644))
@@ -64,6 +65,20 @@ func createTestDebugDir(t *testing.T) string {
   "total_count": 3,
   "total_ms": 30
 }`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "runtime-stats", "20260805-120030-initial.runtime.json"), []byte(`{
+  "timestamp": "2026-08-05T12:00:30Z",
+  "num_cpu": 32,
+  "load1": 2.5,
+  "host_cpu_percent": 41.2,
+  "process_cpu_percent": 9.6,
+  "host_mem_total_bytes": 34359738368,
+  "host_mem_used_bytes": 8589934592,
+  "host_mem_available_bytes": 25769803776,
+  "process_rss_bytes": 765460480,
+  "process_heap_alloc_bytes": 512000000,
+  "process_heap_sys_bytes": 600000000,
+  "goroutines": 41
+}`), 0o644))
 
 	return dir
 }
@@ -103,6 +118,11 @@ func TestAnalyzeDebugRun_Complete(t *testing.T) {
 	require.NotNil(t, initial.DBStats)
 	assert.Equal(t, "postgres", initial.DBStats.Dialect)
 	assert.Equal(t, int64(12), initial.DBStats.TotalCount)
+	require.NotNil(t, initial.Runtime)
+	assert.Equal(t, 32, initial.Runtime.NumCPU)
+	assert.InDelta(t, 41.2, initial.Runtime.HostCPUPercent, 0.01)
+	assert.InDelta(t, 9.6, initial.Runtime.ProcessCPUPercent, 0.01)
+	assert.Equal(t, uint64(765460480), initial.Runtime.ProcessRSSBytes)
 	require.NotNil(t, result.Summary.DBStatsTotal)
 	assert.Equal(t, int64(15), result.Summary.DBStatsTotal.TotalCount)
 	assert.Equal(t, int64(150), result.Summary.DBStatsTotal.TotalMs)

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -157,6 +157,33 @@ func TestGenerateDebugZip_PathTraversal(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestIsYaklangPprofFunc(t *testing.T) {
+	assert.True(t, isYaklangPprofFunc("github.com/yaklang/yaklang/common/yak/ssa.Scan"))
+	assert.False(t, isYaklangPprofFunc("runtime.mallocgc"))
+}
+
+func TestApplySampleWindow(t *testing.T) {
+	start := time.Date(2026, 8, 26, 13, 0, 23, 0, time.UTC)
+	s := &SampleSummary{Timestamp: &start}
+	applySampleWindow(s, &PprofTopAnalysis{DurationNanos: int64(60 * time.Second)})
+	require.NotNil(t, s.EndedAt)
+	assert.Equal(t, int64(60_000), s.DurationMS)
+	assert.Equal(t, start.Add(60*time.Second), *s.EndedAt)
+}
+
+func TestPprofTopFromStatsYaklang(t *testing.T) {
+	// Caller must pass cum-desc sorted stats (same as buildPprofTopAnalysis).
+	stats := []*pprofFuncStats{
+		{name: "runtime.mallocgc", cum: 100, flat: 90},
+		{name: "github.com/yaklang/yaklang/common/yak/ssa.A", cum: 50, flat: 25},
+		{name: "github.com/yaklang/yaklang/common/yak/ssa.B", cum: 40, flat: 20},
+	}
+	top := pprofTopFromStats(stats, 190, 10, isYaklangPprofFunc)
+	require.Len(t, top, 2)
+	assert.Equal(t, "github.com/yaklang/yaklang/common/yak/ssa.A", top[0].Name)
+	assert.Equal(t, "github.com/yaklang/yaklang/common/yak/ssa.B", top[1].Name)
+}
+
 func TestParseLabelTimestamp(t *testing.T) {
 	ts := parseLabelTimestamp("20260805-120030-initial")
 	require.NotNil(t, ts)

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -191,3 +191,33 @@ func TestAssignPhase(t *testing.T) {
 	phase, _ = assignPhase(&midScan, phases)
 	assert.Equal(t, "scan", phase)
 }
+
+func TestAnalyzeDebugRun_EnrichesPhasesFromTaskLog(t *testing.T) {
+	nodeRoot := t.TempDir()
+	debugDir := filepath.Join(nodeRoot, "debug-runs", "debug", "job-1_attempt-1")
+	require.NoError(t, os.MkdirAll(filepath.Join(debugDir, "cpu-pprof"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(nodeRoot, "logs"), 0o755))
+
+	// Collector log has compile errors but no SSA phase markers.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(debugDir, "log"),
+		[]byte("[ERRO] 2026-08-26 19:27:12 [ssaLog:ssa_compile_fs:360] parse failed\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(nodeRoot, "logs", "job-1_subtask_attempt-1.log"),
+		[]byte(`[INFO] 2026-08-26 19:26:16 {"id":"ssa-phase","data":"compile","tags":[]}
+[INFO] 2026-08-26 19:26:16 SSA 任务阶段: compile
+`),
+		0o644,
+	))
+	writeFakePprof(t, filepath.Join(debugDir, "cpu-pprof", "20260826-192720-initial.cpu.prof"))
+
+	result := AnalyzeDebugRunWithStatus(debugDir, "running")
+	require.True(t, hasRecognizedDebugPhases(result.Phases), "phases=%+v", result.Phases)
+	assert.Equal(t, "compile", result.Phases[0].Phase)
+	require.NotEmpty(t, result.Samples)
+	assert.Equal(t, "compile", result.Samples[0].Phase)
+	assert.Equal(t, "log_inferred", result.Samples[0].PhaseSource)
+}
+

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -19,6 +19,7 @@ func createTestDebugDir(t *testing.T) string {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cpu-pprof"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "memory-pprof"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "goroutine-pprof"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "db-stats"), 0o755))
 
 	// Write cmd.txt
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd.txt"), []byte("test command"), 0o644))
@@ -46,6 +47,24 @@ func createTestDebugDir(t *testing.T) string {
 	writeFakePprof(t, filepath.Join(dir, "memory-pprof", "20260805-120030-initial.mem.prof"))
 	writeFakePprof(t, filepath.Join(dir, "goroutine-pprof", "20260805-120030-initial.goroutine.prof"))
 
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "db-stats", "20260805-120030-initial.db.json"), []byte(`{
+  "dialect": "postgres",
+  "ops": {
+    "query": {"count": 10, "total_ms": 100, "avg_ms": 10, "min_ms": 1, "max_ms": 40},
+    "create": {"count": 2, "total_ms": 20, "avg_ms": 10}
+  },
+  "total_count": 12,
+  "total_ms": 120
+}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "db-stats", "20260805-121000-121000.db.json"), []byte(`{
+  "dialect": "postgres",
+  "ops": {
+    "query": {"count": 3, "total_ms": 30, "avg_ms": 10}
+  },
+  "total_count": 3,
+  "total_ms": 30
+}`), 0o644))
+
 	return dir
 }
 
@@ -72,6 +91,22 @@ func TestAnalyzeDebugRun_Complete(t *testing.T) {
 	assert.Equal(t, 1, result.Summary.HeapProfileFiles)
 	assert.True(t, result.Summary.CompilePhaseFound)
 	assert.True(t, result.Summary.ScanPhaseFound)
+
+	var initial *SampleSummary
+	for i := range result.Samples {
+		if result.Samples[i].Label == "20260805-120030-initial" {
+			initial = &result.Samples[i]
+			break
+		}
+	}
+	require.NotNil(t, initial)
+	require.NotNil(t, initial.DBStats)
+	assert.Equal(t, "postgres", initial.DBStats.Dialect)
+	assert.Equal(t, int64(12), initial.DBStats.TotalCount)
+	require.NotNil(t, result.Summary.DBStatsTotal)
+	assert.Equal(t, int64(15), result.Summary.DBStatsTotal.TotalCount)
+	assert.Equal(t, int64(150), result.Summary.DBStatsTotal.TotalMs)
+	assert.Equal(t, int64(13), result.Summary.DBStatsTotal.Ops["query"].Count)
 }
 
 func TestAnalyzeDebugRun_MissingDir(t *testing.T) {
@@ -131,6 +166,8 @@ func TestAnalyzeSample_WithPprof(t *testing.T) {
 	if detail.CPUProfile != nil {
 		assert.NotEmpty(t, detail.CPUProfile.TopFunctions)
 	}
+	require.NotNil(t, detail.DBStats)
+	assert.Equal(t, int64(12), detail.DBStats.TotalCount)
 }
 
 func TestAnalyzeSample_MissingLabel(t *testing.T) {
@@ -247,4 +284,3 @@ func TestAnalyzeDebugRun_EnrichesPhasesFromTaskLog(t *testing.T) {
 	assert.Equal(t, "compile", result.Samples[0].Phase)
 	assert.Equal(t, "log_inferred", result.Samples[0].PhaseSource)
 }
-

--- a/scannode/legion_command_consumer.go
+++ b/scannode/legion_command_consumer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -46,6 +47,51 @@ func nakDelayedMessage(delay time.Duration) messageDisposition {
 	return messageDisposition{kind: messageNakDelayed, delay: delay}
 }
 func termMessage() messageDisposition { return messageDisposition{kind: messageTerm} }
+
+// errUnsupportedCommandSubject is returned for legion command subjects this
+// node binary does not implement (e.g. a newer platform than the node). It is
+// handled specially: the message is acked (not nak'd) so JetStream does not
+// redeliver it in a tight loop, and the warning is rate-limited per subject.
+var errUnsupportedCommandSubject = errors.New("unsupported legion command subject")
+
+type unsupportedCommandError struct {
+	subject string
+}
+
+func (e *unsupportedCommandError) Error() string {
+	return fmt.Sprintf("%s: %s", errUnsupportedCommandSubject, e.subject)
+}
+
+func (e *unsupportedCommandError) Unwrap() error { return errUnsupportedCommandSubject }
+
+// unsupportedCommandWarnState rate-limits warnings for unknown command
+// subjects. Without it, a single unsupported subject can flood the node log
+// at thousands of lines per second when the platform keeps delivering it.
+type unsupportedCommandWarnState struct {
+	mu       sync.Mutex
+	lastWarn map[string]time.Time
+}
+
+const unsupportedCommandWarnInterval = 5 * time.Minute
+
+func (s *unsupportedCommandWarnState) warn(subject string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastWarn == nil {
+		s.lastWarn = make(map[string]time.Time)
+	}
+	now := time.Now()
+	if last, ok := s.lastWarn[subject]; ok && now.Sub(last) < unsupportedCommandWarnInterval {
+		return
+	}
+	s.lastWarn[subject] = now
+	log.Warnf(
+		"%s: %s (acked to stop redelivery; further occurrences suppressed for %v)",
+		errUnsupportedCommandSubject,
+		subject,
+		unsupportedCommandWarnInterval,
+	)
+}
 
 type commandConsumer struct {
 	sessionID string
@@ -330,6 +376,14 @@ func (b *legionJobBridge) handleMessageWithDisposition(
 	if errors.As(err, &rejected) {
 		return termMessage(), err
 	}
+	var unsupported *unsupportedCommandError
+	if errors.As(err, &unsupported) {
+		// Ack instead of Nak: Nak causes JetStream to redeliver the message
+		// immediately, and each redelivery logs another error — an unsupported
+		// subject from a newer platform then becomes a multi-GB log flood.
+		b.unsupportedWarn.warn(unsupported.subject)
+		return ackMessage(), nil
+	}
 	return nakMessage(), err
 }
 
@@ -505,7 +559,7 @@ func (b *legionJobBridge) handleMessagePayload(
 	case strings.HasSuffix(message.Subject, "."+legionCommandAIRisksQuery):
 		return b.handleAIRisksQuery(ctx, message.Data)
 	default:
-		return fmt.Errorf("unsupported legion command subject: %s", message.Subject)
+		return &unsupportedCommandError{subject: message.Subject}
 	}
 }
 

--- a/scannode/legion_command_consumer.go
+++ b/scannode/legion_command_consumer.go
@@ -420,6 +420,8 @@ func (b *legionJobBridge) handleMessagePayload(
 		return b.handleHIDSResponseActionExecute(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandSSARuleSyncExport):
 		return b.handleSSARuleSyncExport(ctx, message.Data)
+	case strings.HasSuffix(message.Subject, "."+legionCommandSSADebugQuery):
+		return b.handleSSADebugQuery(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandPluginGroupsList):
 		return b.handlePluginGroupsList(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandPluginStoreSync):

--- a/scannode/legion_command_consumer.go
+++ b/scannode/legion_command_consumer.go
@@ -422,6 +422,8 @@ func (b *legionJobBridge) handleMessagePayload(
 		return b.handleSSARuleSyncExport(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandSSADebugQuery):
 		return b.handleSSADebugQuery(ctx, message.Data)
+	case strings.HasSuffix(message.Subject, "."+legionCommandSSALogTail):
+		return b.handleSSALogTail(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandPluginGroupsList):
 		return b.handlePluginGroupsList(ctx, message.Data)
 	case strings.HasSuffix(message.Subject, "."+legionCommandPluginStoreSync):

--- a/scannode/legion_dispatch_bridge.go
+++ b/scannode/legion_dispatch_bridge.go
@@ -328,6 +328,10 @@ func (b *legionJobBridge) executeDispatch(
 			failureDetail["rule_snapshot_content_sha256"] = preparationErr.Expectation.ContentSHA256
 		}
 	}
+	var scriptFail *scriptFailureError
+	if errors.As(err, &scriptFail) && strings.TrimSpace(scriptFail.Code) != "" {
+		failureCode = strings.TrimSpace(scriptFail.Code)
+	}
 	b.finishDispatch(reservation, task, func(ctx context.Context) error {
 		return b.dispatchReporter().PublishFailed(
 			ctx,

--- a/scannode/legion_job_bridge.go
+++ b/scannode/legion_job_bridge.go
@@ -53,6 +53,10 @@ type legionJobBridge struct {
 	consumer     *commandConsumer
 	shuttingDown atomic.Bool
 
+	// unsupportedWarn rate-limits warnings for legion command subjects this
+	// node binary does not implement (see unsupportedCommandWarnState).
+	unsupportedWarn unsupportedCommandWarnState
+
 	statusMu            sync.Mutex
 	lastStatusSessionID string
 	lastStatusSync      time.Time

--- a/scannode/legion_job_bridge_test.go
+++ b/scannode/legion_job_bridge_test.go
@@ -263,3 +263,32 @@ func validRuleSnapshotRef() *jobv1.RuleSnapshotRef {
 		AssetIds:      []string{"asset-a", "asset-b"},
 	}
 }
+
+func TestHandleUnsupportedCommandAcksInsteadOfNak(t *testing.T) {
+	t.Parallel()
+
+	bridge := &legionJobBridge{agent: &ScanNode{}}
+	message := &nats.Msg{Subject: "legion.command.node.node-a.plugin.store.sync.status.v2"}
+
+	disposition, err := bridge.handleMessageWithDisposition(context.Background(), "session-1", message)
+	if err != nil {
+		t.Fatalf("handle unsupported command: %v", err)
+	}
+	if disposition.kind != messageAck {
+		t.Fatalf("unsupported command must be acked to stop JetStream redelivery, got disposition kind %d", disposition.kind)
+	}
+}
+
+func TestUnsupportedCommandWarnStateRateLimits(t *testing.T) {
+	t.Parallel()
+
+	var state unsupportedCommandWarnState
+	state.warn("legion.command.node.node-a.unknown.subject")
+	// A second occurrence within the interval must not log again; the state
+	// simply drops it. We cannot observe the log, so just ensure no panic and
+	// that repeated warns keep the first timestamp.
+	state.warn("legion.command.node.node-a.unknown.subject")
+	if _, ok := state.lastWarn["legion.command.node.node-a.unknown.subject"]; !ok {
+		t.Fatal("expected rate-limit entry for the warned subject")
+	}
+}

--- a/scannode/legion_job_events.go
+++ b/scannode/legion_job_events.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/node"
+	"github.com/yaklang/yaklang/common/yak/yaklib/codec"
 	jobv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/job/v1"
 	nodev1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/node/v1"
 )
@@ -309,6 +312,10 @@ func (p *jobEventPublisher) PublishFailed(
 	detail map[string]string,
 ) error {
 	now := time.Now().UTC()
+	// Node diagnostics (git output, subprocess stderr) can carry invalid
+	// UTF-8; proto3 string fields reject it, so sanitize at the source.
+	errorMessage = sanitizeUTF8String(errorMessage)
+	detail = sanitizeUTF8Map(detail)
 	raw, err := json.Marshal(detail)
 	if err != nil {
 		return fmt.Errorf("marshal job failure detail: %w", err)
@@ -368,6 +375,14 @@ func (p *jobEventPublisher) publish(
 
 	raw, err := proto.Marshal(message)
 	if err != nil {
+		// proto3 string fields must contain valid UTF-8, but node diagnostics
+		// (git output, subprocess stderr) can carry arbitrary bytes. Sanitize
+		// the whole message and retry so a terminal event is never dropped — a
+		// dropped failure event turns a real failure into a "lost" attempt.
+		sanitizeJobEventUTF8(message)
+		raw, err = proto.Marshal(message)
+	}
+	if err != nil {
 		return fmt.Errorf("marshal job event: %w", err)
 	}
 	msg := nats.NewMsg(subject)
@@ -384,6 +399,64 @@ func (p *jobEventPublisher) publish(
 	}
 	log.Infof("published legion job event: type=%s attempt_id=%s", eventType, ref.AttemptID)
 	return nil
+}
+
+// sanitizeUTF8String replaces invalid UTF-8 bytes in a diagnostic string with
+// \\xNN escapes so it can be stored in a proto3 string field (proto3 requires
+// valid UTF-8) while keeping the raw bytes visible for debugging.
+func sanitizeUTF8String(value string) string {
+	if utf8.ValidString(value) {
+		return value
+	}
+	return codec.UTF8SafeEscape(value)
+}
+
+// sanitizeUTF8Map applies sanitizeUTF8String to every key and value of a
+// diagnostic map.
+func sanitizeUTF8Map(input map[string]string) map[string]string {
+	if len(input) == 0 {
+		return input
+	}
+	output := make(map[string]string, len(input))
+	for key, value := range input {
+		output[sanitizeUTF8String(key)] = sanitizeUTF8String(value)
+	}
+	return output
+}
+
+// sanitizeJobEventUTF8 scrubs invalid UTF-8 from every exported string field
+// of a job event message. Only settable (exported) fields are touched — proto
+// messages carry unexported internal state that must never be written through
+// reflection, which is also why codec.SanitizeUTF8 cannot be used here.
+func sanitizeJobEventUTF8(message proto.Message) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Warnf("[job-event] utf8 sanitize aborted: %v", recovered)
+		}
+	}()
+	var cleanValue func(v reflect.Value)
+	cleanValue = func(v reflect.Value) {
+		switch v.Kind() {
+		case reflect.Ptr, reflect.Interface:
+			if !v.IsNil() {
+				cleanValue(v.Elem())
+			}
+		case reflect.Struct:
+			for i := 0; i < v.NumField(); i++ {
+				field := v.Field(i)
+				if !field.CanSet() {
+					// Unexported proto runtime state: never touch.
+					continue
+				}
+				cleanValue(field)
+			}
+		case reflect.String:
+			if !utf8.ValidString(v.String()) {
+				v.SetString(sanitizeUTF8String(v.String()))
+			}
+		}
+	}
+	cleanValue(reflect.ValueOf(message))
 }
 
 func (p *jobEventPublisher) ensureJetStream(natsURL string) error {

--- a/scannode/legion_job_events_test.go
+++ b/scannode/legion_job_events_test.go
@@ -3,8 +3,10 @@ package scannode
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	jobv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/job/v1"
 	nodev1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/node/v1"
@@ -335,5 +337,73 @@ func eventMetadataFromMessage(message proto.Message) *nodev1.EventMetadata {
 		return value.Metadata
 	default:
 		return nil
+	}
+}
+
+func TestSanitizeUTF8StringEscapesInvalidBytes(t *testing.T) {
+	t.Parallel()
+
+	raw := "clone failed: Get \"https://x/info/refs\": EOF" + string([]byte{0xff, 0xfe, 0x80})
+	cleaned := sanitizeUTF8String(raw)
+	if !utf8.ValidString(cleaned) {
+		t.Fatalf("sanitized string still contains invalid utf-8: %q", cleaned)
+	}
+	if !strings.Contains(cleaned, "clone failed") {
+		t.Fatalf("sanitized string lost content: %q", cleaned)
+	}
+	if !strings.Contains(cleaned, `\xff`) {
+		t.Fatalf("invalid bytes should be escaped for debugging: %q", cleaned)
+	}
+	// Already-valid strings must pass through unchanged.
+	if sanitizeUTF8String("plain message") != "plain message" {
+		t.Fatal("valid string must not be modified")
+	}
+}
+
+func TestSanitizeUTF8MapEscapesKeysAndValues(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]string{
+		"key" + string([]byte{0xff}): "value",
+		"plain":                      "text" + string([]byte{0xfe}),
+	}
+	cleaned := sanitizeUTF8Map(input)
+	if len(cleaned) != 2 {
+		t.Fatalf("unexpected map size: %d", len(cleaned))
+	}
+	for key, value := range cleaned {
+		if !utf8.ValidString(key) || !utf8.ValidString(value) {
+			t.Fatalf("cleaned map still invalid: %q -> %q", key, value)
+		}
+	}
+}
+
+func TestJobFailedWithInvalidUTF8StillMarshals(t *testing.T) {
+	t.Parallel()
+
+	// Regression: a failure event whose message contains invalid UTF-8 (e.g.
+	// git output) must still be publishable — otherwise the terminal event is
+	// dropped and the platform marks the attempt lost.
+	message := &jobv1.JobFailed{
+		ErrorMessage: "SSA Git clone failed: " + string([]byte{0xff, 0xfe}),
+	}
+	if _, err := proto.Marshal(message); err == nil {
+		t.Fatal("precondition failed: invalid utf-8 must fail proto.Marshal")
+	}
+
+	sanitizeJobEventUTF8(message)
+	raw, err := proto.Marshal(message)
+	if err != nil {
+		t.Fatalf("marshal sanitized job failed event: %v", err)
+	}
+	var decoded jobv1.JobFailed
+	if err := proto.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal sanitized event: %v", err)
+	}
+	if !strings.Contains(decoded.GetErrorMessage(), "SSA Git clone failed") {
+		t.Fatalf("error message content lost: %q", decoded.GetErrorMessage())
+	}
+	if !utf8.ValidString(decoded.GetErrorMessage()) {
+		t.Fatalf("error message still invalid after sanitize: %q", decoded.GetErrorMessage())
 	}
 }

--- a/scannode/legion_protocol.go
+++ b/scannode/legion_protocol.go
@@ -15,6 +15,7 @@ const (
 	legionCommandHIDSCurrentStateCollect              = "hids.current_state.collect"
 	legionCommandHIDSFileEvidenceCollect              = "hids.file_evidence.collect"
 	legionCommandSSARuleSyncExport                    = "ssa.rule_sync.export"
+	legionCommandSSADebugQuery                        = "ssa.debug.query"
 	legionCommandPluginGroupsList                     = "plugin.groups.list"
 	legionCommandPluginStoreSync                      = "plugin.store.sync"
 	legionCommandPluginStoreSyncStatusQuery           = "plugin.store.sync.status"

--- a/scannode/legion_protocol.go
+++ b/scannode/legion_protocol.go
@@ -16,6 +16,7 @@ const (
 	legionCommandHIDSFileEvidenceCollect              = "hids.file_evidence.collect"
 	legionCommandSSARuleSyncExport                    = "ssa.rule_sync.export"
 	legionCommandSSADebugQuery                        = "ssa.debug.query"
+	legionCommandSSALogTail                           = "ssa.log.tail"
 	legionCommandPluginGroupsList                     = "plugin.groups.list"
 	legionCommandPluginStoreSync                      = "plugin.store.sync"
 	legionCommandPluginStoreSyncStatusQuery           = "plugin.store.sync.status"

--- a/scannode/legion_reporter_events.go
+++ b/scannode/legion_reporter_events.go
@@ -85,7 +85,22 @@ func (r *ScannerAgentReporter) flushSuccessfulJobProgress() error {
 	if r == nil {
 		return nil
 	}
-	return r.reportJobProgress(1.0)
+	// SSA scripts intentionally stop at ~0.99 and wait for platform risk/artifact
+	// import to publish 1.0. Do not force terminal 100% here or the UI jumps early.
+	if err := r.flushLatestJobProgress(); err != nil {
+		return err
+	}
+	r.progressCheckpoint.mu.Lock()
+	hasObserved := r.progressCheckpoint.hasObserved
+	last := r.progressCheckpoint.lastObservedProcess
+	r.progressCheckpoint.mu.Unlock()
+	if !hasObserved {
+		return r.reportJobProgress(0.99)
+	}
+	if last >= 0.99 {
+		return nil
+	}
+	return r.reportJobProgress(0.99)
 }
 
 func (c *attemptProgressCheckpoint) report(

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -106,21 +106,6 @@ func (s *ScanNode) executeScriptTask(
 	if reporter.ssaCollector != nil {
 		defer reporter.ssaCollector.Cleanup()
 	}
-	ssaDBEnv := extractSSADatabaseEnv(keyValues)
-	ssaDBCleanup := func() {}
-	if s.needIsolateSSARuntimeDB() {
-		ssaOverride := environmentValueFromEntries(ssaDBEnv, consts.ENV_SSA_DATABASE_RAW)
-		isolatedEnv, cleanup := buildSSARuntimeDBEnv(input.RuntimeID, ssaOverride)
-		if environmentValueFromEntries(ssaDBEnv, consts.ENV_SSA_DB_SKIP_MIGRATE) != "" {
-			isolatedEnv = append(isolatedEnv, fmt.Sprintf("%s=1", consts.ENV_SSA_DB_SKIP_MIGRATE))
-		}
-		ssaDBEnv = isolatedEnv
-		ssaDBCleanup = cleanup
-	}
-	defer ssaDBCleanup()
-	if preparedSnapshot != nil {
-		ssaDBEnv = append(ssaDBEnv, "YAKIT_HOME="+preparedSnapshot.taskYakitHome)
-	}
 	result := &ScriptExecutionResult{}
 	if preparedSnapshot != nil {
 		receipt := preparedSnapshot.Receipt
@@ -176,6 +161,22 @@ func (s *ScanNode) executeScriptTask(
 		params = s.buildScriptParams(yakitServer.Addr(), input.RuntimeID, keyValues)
 	}
 
+	ssaDBEnv, sqliteLivePath := resolveSSADatabaseEnv(s, keyValues, debugDir, input.RuntimeID)
+	ssaDBCleanup := func() {}
+	if s.needIsolateSSARuntimeDB() {
+		ssaOverride := environmentValueFromEntries(ssaDBEnv, consts.ENV_SSA_DATABASE_RAW)
+		isolatedEnv, cleanup := buildSSARuntimeDBEnv(input.RuntimeID, ssaOverride)
+		if environmentValueFromEntries(ssaDBEnv, consts.ENV_SSA_DB_SKIP_MIGRATE) != "" {
+			isolatedEnv = append(isolatedEnv, fmt.Sprintf("%s=1", consts.ENV_SSA_DB_SKIP_MIGRATE))
+		}
+		ssaDBEnv = isolatedEnv
+		ssaDBCleanup = cleanup
+	}
+	defer ssaDBCleanup()
+	if preparedSnapshot != nil {
+		ssaDBEnv = append(ssaDBEnv, "YAKIT_HOME="+preparedSnapshot.taskYakitHome)
+	}
+
 	// Register a defer to finalize debug artifacts (analysis + zip) on both
 	// success and failure paths. The pprof collector (started by Scan() inside
 	// the child process) writes its final snapshot during script exit/cleanup.
@@ -187,6 +188,7 @@ func (s *ScanNode) executeScriptTask(
 			if debugFinalized {
 				return
 			}
+			copySQLiteIRIntoDebugDir(debugDir, sqliteLivePath)
 			s.finalizeDebugRun(taskCtx, reporter, debugDir, "unknown")
 		}()
 	}
@@ -200,6 +202,7 @@ func (s *ScanNode) executeScriptTask(
 		// Finalize debug before returning the failure. Cancel / shutdown leaves
 		// taskCtx cancelled; finalize must still upload and write local cache.
 		if debugDir != "" {
+			copySQLiteIRIntoDebugDir(debugDir, sqliteLivePath)
 			s.finalizeDebugRun(taskCtx, reporter, debugDir, debugStatusForScriptError(s, task.AttemptID, err))
 			scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 			debugFinalized = true
@@ -209,6 +212,7 @@ func (s *ScanNode) executeScriptTask(
 	logReporterEventError("final progress checkpoint", reporter.flushSuccessfulJobProgress())
 	if err := s.finalizeSSAArtifactUpload(taskCtx, reporter, result); err != nil {
 		if debugDir != "" {
+			copySQLiteIRIntoDebugDir(debugDir, sqliteLivePath)
 			s.finalizeDebugRun(taskCtx, reporter, debugDir, debugStatusForScriptError(s, task.AttemptID, err))
 			scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 			debugFinalized = true
@@ -218,6 +222,7 @@ func (s *ScanNode) executeScriptTask(
 
 	// Finalize debug artifacts on success path
 	if debugDir != "" {
+		copySQLiteIRIntoDebugDir(debugDir, sqliteLivePath)
 		s.finalizeDebugRun(taskCtx, reporter, debugDir, "succeeded")
 		scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 		debugFinalized = true

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -286,12 +286,97 @@ func (s *ScanNode) handleScriptFailure(
 	// tail — use it directly so the failure_message has actionable content.
 	var scriptErr *scriptExecError
 	if errors.As(err, &scriptErr) {
+		if coded := scriptFailureFromResult(result); coded != nil {
+			return &scriptFailureError{
+				Code:    coded.Code,
+				Message: firstNonEmpty(coded.Message, scriptErr.Error()),
+				Cause:   scriptErr,
+			}
+		}
 		return scriptErr
+	}
+	if coded := scriptFailureFromResult(result); coded != nil {
+		return coded
 	}
 	if detailedError := extractScriptError(result); detailedError != "" {
 		return utils.Errorf("%s", detailedError)
 	}
 	return utils.Errorf("exec yak script failed: %s", err)
+}
+
+type scriptFailureError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *scriptFailureError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return "script execution failed"
+}
+
+func (e *scriptFailureError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+type scriptFailurePayload struct {
+	Code    string
+	Message string
+}
+
+func scriptFailureFromResult(result *ScriptExecutionResult) *scriptFailureError {
+	payload := extractScriptFailurePayload(result)
+	if payload == nil {
+		return nil
+	}
+	return &scriptFailureError{
+		Code:    payload.Code,
+		Message: payload.Message,
+	}
+}
+
+func extractScriptFailurePayload(result *ScriptExecutionResult) *scriptFailurePayload {
+	if result == nil || result.Data == nil {
+		return nil
+	}
+	dataMap, ok := result.Data.(map[string]any)
+	if !ok {
+		return nil
+	}
+	msg, _ := dataMap["error"].(string)
+	msg = strings.TrimSpace(msg)
+	code := ""
+	for _, key := range []string{"error_code", "errorCode", "failure_code"} {
+		if raw, ok := dataMap[key].(string); ok {
+			code = strings.TrimSpace(raw)
+			if code != "" {
+				break
+			}
+		}
+	}
+	if msg == "" && code == "" {
+		return nil
+	}
+	return &scriptFailurePayload{Code: code, Message: msg}
+}
+
+func extractScriptError(result *ScriptExecutionResult) string {
+	payload := extractScriptFailurePayload(result)
+	if payload == nil {
+		return ""
+	}
+	return payload.Message
 }
 
 func (s *ScanNode) cancelReasonForAttempt(attemptID string) string {
@@ -300,22 +385,6 @@ func (s *ScanNode) cancelReasonForAttempt(attemptID string) string {
 		return ""
 	}
 	return task.CancelReason()
-}
-
-func extractScriptError(result *ScriptExecutionResult) string {
-	if result == nil || result.Data == nil {
-		return ""
-	}
-
-	dataMap, ok := result.Data.(map[string]any)
-	if !ok {
-		return ""
-	}
-	errMsg, ok := dataMap["error"].(string)
-	if !ok || errMsg == "" {
-		return ""
-	}
-	return errMsg
 }
 
 func (s *ScanNode) parseScriptParams(jsonParam string) map[string]any {

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/yaklang/yaklang/common/consts"
@@ -192,9 +193,10 @@ func (s *ScanNode) executeScriptTask(
 
 	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID, ssaDBEnv, taskLogWriter); err != nil {
 		logReporterEventError("final progress checkpoint", reporter.flushLatestJobProgress())
-		// Finalize debug before returning the failure
+		// Finalize debug before returning the failure. Cancel / shutdown leaves
+		// taskCtx cancelled; finalize must still upload and write local cache.
 		if debugDir != "" {
-			s.finalizeDebugRun(taskCtx, reporter, debugDir, "failed")
+			s.finalizeDebugRun(taskCtx, reporter, debugDir, debugStatusForScriptError(s, task.AttemptID, err))
 			scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 			debugFinalized = true
 		}
@@ -203,7 +205,7 @@ func (s *ScanNode) executeScriptTask(
 	logReporterEventError("final progress checkpoint", reporter.flushSuccessfulJobProgress())
 	if err := s.finalizeSSAArtifactUpload(taskCtx, reporter, result); err != nil {
 		if debugDir != "" {
-			s.finalizeDebugRun(taskCtx, reporter, debugDir, "failed")
+			s.finalizeDebugRun(taskCtx, reporter, debugDir, debugStatusForScriptError(s, task.AttemptID, err))
 			scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 			debugFinalized = true
 		}
@@ -1225,24 +1227,54 @@ func buildSSAArtifactMetricsPayload(event *SSAArtifactReadyEvent) ([]byte, error
 
 // finalizeDebugRun analyzes the debug run directory, generates a ZIP archive,
 // and publishes both as JobArtifactReady events. Failures are logged but do
-// not affect the scan result. This is called on both success and failure paths.
+// not affect the scan result. This is called on success, failure, cancel, and
+// shutdown paths. Upload uses a detached timeout so a cancelled task context
+// cannot skip persistence.
 func (s *ScanNode) finalizeDebugRun(
 	ctx context.Context,
 	reporter *ScannerAgentReporter,
 	debugDir string,
 	status string,
 ) {
+	uploadCtx, cancel := debugFinalizeContext(ctx)
+	defer cancel()
+
 	// Ensure the debug package contains the actual scan log even when the
 	// child pprof collector did not write its own log file.
 	mergeTaskLogIntoDebugDir(debugDir)
-	s.publishDebugAnalysis(ctx, reporter, debugDir, status)
-	s.publishDebugZip(ctx, reporter, debugDir)
+	s.publishDebugAnalysis(uploadCtx, reporter, debugDir, status)
+	s.publishDebugZip(uploadCtx, reporter, debugDir)
+}
+
+const debugFinalizeTimeout = 45 * time.Second
+
+// debugFinalizeContext returns a timeout context that is not cancelled when
+// the parent task context is cancelled (cancel / shutdown / lease loss paths).
+func debugFinalizeContext(parent context.Context) (context.Context, context.CancelFunc) {
+	base := context.Background()
+	if parent != nil {
+		base = context.WithoutCancel(parent)
+	}
+	return context.WithTimeout(base, debugFinalizeTimeout)
+}
+
+// debugStatusForScriptError maps a script/task error onto the debug analysis
+// status string used in analysis JSON and the console.
+func debugStatusForScriptError(s *ScanNode, attemptID string, err error) string {
+	if s != nil && strings.TrimSpace(s.cancelReasonForAttempt(attemptID)) != "" {
+		return "cancelled"
+	}
+	if err != nil && errors.Is(err, context.Canceled) {
+		return "cancelled"
+	}
+	return "failed"
 }
 
 // publishDebugAnalysis analyzes the debug run directory and publishes the
 // structured result as a JobArtifactReady event with artifact_kind="debug_analysis".
-// The analysis JSON is uploaded to MinIO and the event carries the object key.
-// Failures are logged but do not affect the scan result.
+// The analysis JSON is always written to the local debug dir first so live
+// queries still work after cancel / lost / node restart even when MinIO upload
+// fails. Failures are logged but do not affect the scan result.
 func (s *ScanNode) publishDebugAnalysis(
 	ctx context.Context,
 	reporter *ScannerAgentReporter,
@@ -1255,8 +1287,15 @@ func (s *ScanNode) publishDebugAnalysis(
 		log.Warnf("[debug] marshal analysis failed: %v", err)
 		return
 	}
+	if err := writeCachedDebugAnalysis(debugDir, analysisJSON); err != nil {
+		log.Warnf("[debug] write local analysis cache failed: %v", err)
+	}
 
 	// Upload analysis JSON to MinIO
+	if reporter == nil {
+		log.Warnf("[debug] no reporter available, skipping analysis upload")
+		return
+	}
 	cfg := reporter.ssaUploadCfg
 	if cfg == nil {
 		log.Warnf("[debug] no upload config available, skipping analysis upload")

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -220,12 +220,15 @@ func (s *ScanNode) executeScriptTask(
 		return nil, err
 	}
 
-	// Finalize debug artifacts on success path
+	// Finalize debug AFTER returning success so PublishSucceeded is not blocked
+	// by pprof analysis / zip upload (can take tens of seconds). Blocking here
+	// previously let attempt leases expire → attempt_missing_from_heartbeat
+	// while the scan had already finished and published artifacts.
 	if debugDir != "" {
 		copySQLiteIRIntoDebugDir(debugDir, sqliteLivePath)
-		s.finalizeDebugRun(taskCtx, reporter, debugDir, "succeeded")
 		scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 		debugFinalized = true
+		s.finalizeDebugRunAsync(reporter, debugDir, "succeeded")
 	}
 	return result, nil
 }
@@ -1333,6 +1336,23 @@ func (s *ScanNode) finalizeDebugRun(
 	mergeTaskLogIntoDebugDir(debugDir)
 	s.publishDebugAnalysis(uploadCtx, reporter, debugDir, status)
 	s.publishDebugZip(uploadCtx, reporter, debugDir)
+}
+
+// finalizeDebugRunAsync runs finalizeDebugRun off the success-return path so
+// JobSucceeded can be published before heavy debug analysis finishes.
+func (s *ScanNode) finalizeDebugRunAsync(
+	reporter *ScannerAgentReporter,
+	debugDir string,
+	status string,
+) {
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				log.Errorf("[debug] async finalize panic: %v", recovered)
+			}
+		}()
+		s.finalizeDebugRun(context.Background(), reporter, debugDir, status)
+	}()
 }
 
 const debugFinalizeTimeout = 45 * time.Second

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -191,7 +191,11 @@ func (s *ScanNode) executeScriptTask(
 		}()
 	}
 
-	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID, ssaDBEnv, taskLogWriter); err != nil {
+	// Debug mode: lower yaklog threshold so the task log carries Debug lines the
+	// console can filter (Info/Warn/Error remain available).
+	scriptEnv := scriptEnvWithDebugLogLevel(ssaDBEnv, input.DebugEnabled)
+
+	if err := s.executeScript(taskCtx, scanNodePath, scriptFile, params, input.RuntimeID, scriptEnv, taskLogWriter); err != nil {
 		logReporterEventError("final progress checkpoint", reporter.flushLatestJobProgress())
 		// Finalize debug before returning the failure. Cancel / shutdown leaves
 		// taskCtx cancelled; finalize must still upload and write local cache.
@@ -933,6 +937,17 @@ func replaceEnvironmentValue(env []string, key string, value string) []string {
 		replaced = append(replaced, item)
 	}
 	return append(replaced, prefix+value)
+}
+
+// scriptEnvWithDebugLogLevel copies base env entries and forces LOG_LEVEL=debug
+// when the scan attempt has debug mode enabled, so yaklog Debug lines land in
+// the per-task log the console filters.
+func scriptEnvWithDebugLogLevel(base []string, debugEnabled bool) []string {
+	out := append([]string(nil), base...)
+	if !debugEnabled {
+		return out
+	}
+	return replaceEnvironmentValue(out, "LOG_LEVEL", "debug")
 }
 
 // tailBuffer is a ring buffer that keeps the last N bytes written to it.

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -163,6 +163,9 @@ func (s *ScanNode) executeScriptTask(
 			debugDir = ""
 		} else {
 			log.Infof("[debug] debug directory: %s", debugDir)
+			// Register the directory so ssa.debug.query can serve live pprof/
+			// log data while the task is still running (or after a cancel).
+			scanDebugDirs.register(s.debugBaseDir(), input.TaskID, input.RuntimeID, debugDir)
 		}
 	}
 
@@ -179,6 +182,7 @@ func (s *ScanNode) executeScriptTask(
 	debugFinalized := false
 	if debugDir != "" {
 		defer func() {
+			scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 			if debugFinalized {
 				return
 			}
@@ -191,6 +195,7 @@ func (s *ScanNode) executeScriptTask(
 		// Finalize debug before returning the failure
 		if debugDir != "" {
 			s.finalizeDebugRun(taskCtx, reporter, debugDir, "failed")
+			scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 			debugFinalized = true
 		}
 		return nil, s.handleScriptFailure(err, result, task.AttemptID)
@@ -199,6 +204,7 @@ func (s *ScanNode) executeScriptTask(
 	if err := s.finalizeSSAArtifactUpload(taskCtx, reporter, result); err != nil {
 		if debugDir != "" {
 			s.finalizeDebugRun(taskCtx, reporter, debugDir, "failed")
+			scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 			debugFinalized = true
 		}
 		return nil, err
@@ -207,6 +213,7 @@ func (s *ScanNode) executeScriptTask(
 	// Finalize debug artifacts on success path
 	if debugDir != "" {
 		s.finalizeDebugRun(taskCtx, reporter, debugDir, "succeeded")
+		scanDebugDirs.unregister(input.TaskID, input.RuntimeID)
 		debugFinalized = true
 	}
 	return result, nil

--- a/scannode/script_execution_environment_test.go
+++ b/scannode/script_execution_environment_test.go
@@ -14,3 +14,13 @@ func TestReplaceEnvironmentValueRemovesInheritedDuplicates(t *testing.T) {
 	)
 	require.Equal(t, []string{"KEEP=value", "OWNER=new"}, env)
 }
+
+func TestScriptEnvWithDebugLogLevel(t *testing.T) {
+	base := []string{"FOO=1", "LOG_LEVEL=info"}
+	require.Equal(t, base, scriptEnvWithDebugLogLevel(base, false))
+	require.Equal(
+		t,
+		[]string{"FOO=1", "LOG_LEVEL=debug"},
+		scriptEnvWithDebugLogLevel(base, true),
+	)
+}

--- a/scannode/script_execution_logs.go
+++ b/scannode/script_execution_logs.go
@@ -50,6 +50,10 @@ func (s *ScanNode) createLogHandler(
 			s.handleStatusCardLog(reporter, info)
 		case "ssa-stream":
 			s.handleSSAStreamLog(reporter, info)
+		case "info":
+			// Fallback when StatusCard webhook is dropped under progress flood:
+			// yak scripts also emit a one-line ssa-scan-detail: JSON prefix.
+			s.handleScanDetailInfoFallback(reporter, info)
 		}
 	}
 }
@@ -177,7 +181,8 @@ func (s *ScanNode) handleStatusCardLog(
 	switch card.Id {
 	case "ssa-scan-detail":
 		if reporter != nil {
-			if pubErr := reporter.PublishScanDetail("rule-detail", card.Data); pubErr != nil {
+			stage := scanDetailStage(card.Data)
+			if pubErr := reporter.PublishScanDetail(stage, card.Data); pubErr != nil {
 				log.Warnf("publish scan detail failed: %v", pubErr)
 			}
 		}
@@ -190,6 +195,47 @@ func (s *ScanNode) handleStatusCardLog(
 			reporter.setSSAScanPhase(card.Data)
 		}
 	}
+}
+
+const scanDetailInfoPrefix = "ssa-scan-detail:"
+
+// handleScanDetailInfoFallback publishes scan detail JSON that yak scripts
+// emit via yakit.Info("ssa-scan-detail:{...}") when the StatusCard path is
+// unreliable under HTTP webhook contention.
+func (s *ScanNode) handleScanDetailInfoFallback(
+	reporter *ScannerAgentReporter,
+	info string,
+) {
+	if reporter == nil {
+		return
+	}
+	trimmed := strings.TrimSpace(info)
+	if !strings.HasPrefix(trimmed, scanDetailInfoPrefix) {
+		return
+	}
+	detailJSON := strings.TrimSpace(strings.TrimPrefix(trimmed, scanDetailInfoPrefix))
+	if detailJSON == "" || detailJSON[0] != '{' {
+		return
+	}
+	stage := scanDetailStage(detailJSON)
+	if pubErr := reporter.PublishScanDetail(stage, detailJSON); pubErr != nil {
+		log.Warnf("publish scan detail (info fallback) failed: %v", pubErr)
+	}
+}
+
+// scanDetailStage prefers the phase field inside the detail JSON so early
+// compile scale cards are not mis-labeled as rule-detail.
+func scanDetailStage(detailJSON string) string {
+	var detail struct {
+		Phase string `json:"phase"`
+	}
+	if err := json.Unmarshal([]byte(detailJSON), &detail); err == nil {
+		phase := strings.TrimSpace(detail.Phase)
+		if phase == "compile" || phase == "load-program" || phase == "scan" || phase == "ingest" {
+			return phase
+		}
+	}
+	return "rule-detail"
 }
 
 func (s *ScanNode) handleSSAStreamLog(

--- a/scannode/script_execution_logs_test.go
+++ b/scannode/script_execution_logs_test.go
@@ -1,0 +1,14 @@
+package scannode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanDetailStage(t *testing.T) {
+	assert.Equal(t, "compile", scanDetailStage(`{"phase":"compile","total_files":10}`))
+	assert.Equal(t, "scan", scanDetailStage(`{"phase":"scan","total_rules":3}`))
+	assert.Equal(t, "rule-detail", scanDetailStage(`{"completed_rules":1}`))
+	assert.Equal(t, "rule-detail", scanDetailStage(`not-json`))
+}

--- a/scannode/script_failure_test.go
+++ b/scannode/script_failure_test.go
@@ -1,0 +1,33 @@
+package scannode
+
+import "testing"
+
+func TestScriptFailureFromResultPrefersStructuredCode(t *testing.T) {
+	t.Parallel()
+
+	got := scriptFailureFromResult(&ScriptExecutionResult{
+		Data: map[string]any{
+			"error":      "没有可编译的源码文件",
+			"error_code": "notFoundFileCanCompile",
+		},
+	})
+	if got == nil {
+		t.Fatal("expected structured failure")
+	}
+	if got.Code != "notFoundFileCanCompile" {
+		t.Fatalf("code = %q", got.Code)
+	}
+	if got.Message != "没有可编译的源码文件" {
+		t.Fatalf("message = %q", got.Message)
+	}
+
+	clone := scriptFailureFromResult(&ScriptExecutionResult{
+		Data: map[string]any{
+			"error":      "克隆源码失败: EOF",
+			"error_code": "gitCloneError",
+		},
+	})
+	if clone == nil || clone.Code != "gitCloneError" {
+		t.Fatalf("clone failure = %#v", clone)
+	}
+}

--- a/scannode/ssa_artifact_upload_config.go
+++ b/scannode/ssa_artifact_upload_config.go
@@ -2,10 +2,13 @@ package scannode
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
 )
 
 const scannodeInternalParamPrefix = "_scannode_"
@@ -15,9 +18,13 @@ const scannodeInternalParamPrefix = "_scannode_"
 // injects these into the script input JSON; scannode extracts them and
 // forwards as env vars to the distyak child process.
 const (
-	scannodeSSADatabaseRawParamKey = "_scannode_ssa_database_raw"
-	scannodeSSASkipMigrateParamKey = "_scannode_ssa_skip_migrate"
+	scannodeSSADatabaseRawParamKey     = "_scannode_ssa_database_raw"
+	scannodeSSASkipMigrateParamKey     = "_scannode_ssa_skip_migrate"
+	scannodeSSADatabaseBackendParamKey = "_scannode_ssa_database_backend"
+	scannodeSSASqliteKeyParamKey       = "_scannode_ssa_sqlite_key"
 )
+
+const ssaIRSQLiteDirName = "ssa-ir-sqlite"
 
 // extractSSADatabaseEnv reads the shared SSA IR DB DSN and skip_migrate flag
 // from the scheduler-injected hidden params and returns them as "KEY=VALUE"
@@ -38,6 +45,64 @@ func extractSSADatabaseEnv(params map[string]interface{}) []string {
 		env = append(env, fmt.Sprintf("%s=1", consts.ENV_SSA_DB_SKIP_MIGRATE))
 	}
 	return env
+}
+
+func isSQLiteSSABackend(params map[string]interface{}) bool {
+	b := strings.ToLower(strings.TrimSpace(toString(params[scannodeSSADatabaseBackendParamKey])))
+	return b == "sqlite" || b == "sqlite3"
+}
+
+func scanNodeIRBaseDir(s *ScanNode) string {
+	if s != nil && s.node != nil {
+		if base := strings.TrimSpace(s.node.BaseDir()); base != "" {
+			return base
+		}
+	}
+	return filepath.Join(os.TempDir(), "legion-node")
+}
+
+// resolveSSADatabaseEnv chooses the child SSA_DATABASE_RAW env.
+// Postgres (default): hidden DSN param, same as extractSSADatabaseEnv.
+// SQLite: live file at {nodeBase}/ssa-ir-sqlite/{key}/ssadb.db so compile and
+// scan jobs that share a key reuse the same IR database. debugDir is not the
+// live path; finalize copies the file into the debug zip.
+func resolveSSADatabaseEnv(s *ScanNode, params map[string]interface{}, debugDir, runtimeID string) (env []string, sqlitePath string) {
+	return resolveSSADatabaseEnvWithBase(scanNodeIRBaseDir(s), params, debugDir, runtimeID)
+}
+
+func resolveSSADatabaseEnvWithBase(nodeBase string, params map[string]interface{}, debugDir, runtimeID string) (env []string, sqlitePath string) {
+	if !isSQLiteSSABackend(params) {
+		return extractSSADatabaseEnv(params), ""
+	}
+	key := strings.TrimSpace(toString(params[scannodeSSASqliteKeyParamKey]))
+	if key == "" {
+		key = strings.TrimSpace(runtimeID)
+	}
+	if key == "" {
+		log.Warnf("[ssadb] sqlite backend requested but sqlite key and runtime id are empty; falling back to DSN env")
+		return extractSSADatabaseEnv(params), ""
+	}
+	key = sanitizeLogName(key)
+	nodeBase = strings.TrimSpace(nodeBase)
+	if nodeBase == "" {
+		nodeBase = filepath.Join(os.TempDir(), "legion-node")
+	}
+	sqlitePath = filepath.Join(nodeBase, ssaIRSQLiteDirName, key, "ssadb.db")
+	if err := os.MkdirAll(filepath.Dir(sqlitePath), 0o755); err != nil {
+		log.Warnf("[ssadb] mkdir sqlite IR dir failed: %v", err)
+		return extractSSADatabaseEnv(params), ""
+	}
+	log.Infof("[ssadb] using sqlite IR database: path=%s", sqlitePath)
+	if debugDir != "" {
+		log.Infof("[ssadb] debug zip will include a copy of sqlite IR from %s", sqlitePath)
+	}
+	env = []string{
+		fmt.Sprintf("%s=%s", consts.ENV_SSA_DATABASE_RAW, sqlitePath),
+	}
+	if toBool(params[scannodeSSASkipMigrateParamKey]) {
+		env = append(env, fmt.Sprintf("%s=1", consts.ENV_SSA_DB_SKIP_MIGRATE))
+	}
+	return env, sqlitePath
 }
 
 func extractSSAArtifactUploadConfig(params map[string]interface{}) *SSAArtifactUploadConfig {

--- a/scannode/ssa_artifact_upload_config_test.go
+++ b/scannode/ssa_artifact_upload_config_test.go
@@ -1,6 +1,8 @@
 package scannode
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -116,4 +118,131 @@ func TestExtractSSADatabaseEnv(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestResolveSSADatabaseEnvSQLiteLivePath(t *testing.T) {
+	nodeBase := t.TempDir()
+	debugDir := filepath.Join(t.TempDir(), "debug-run")
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	env, sqlitePath := resolveSSADatabaseEnvWithBase(nodeBase, map[string]interface{}{
+		scannodeSSADatabaseBackendParamKey: "sqlite",
+		scannodeSSASqliteKeyParamKey:       "batch-1",
+		scannodeSSADatabaseRawParamKey:     "postgres://ignored@host/db",
+	}, debugDir, "runtime-x")
+
+	want := filepath.Join(nodeBase, ssaIRSQLiteDirName, "batch-1", "ssadb.db")
+	if sqlitePath != want {
+		t.Fatalf("sqlite path = %q, want %q", sqlitePath, want)
+	}
+	if _, err := os.Stat(filepath.Dir(want)); err != nil {
+		t.Fatalf("expected sqlite parent dir: %v", err)
+	}
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, consts.ENV_SSA_DATABASE_RAW+"="+want) {
+		t.Fatalf("expected SSA_DATABASE_RAW=%s, got %v", want, env)
+	}
+	if strings.Contains(joined, debugDir) {
+		t.Fatalf("live sqlite path must not be under debugDir, got %v", env)
+	}
+	if strings.Contains(joined, consts.ENV_SSA_DB_SKIP_MIGRATE) {
+		t.Fatalf("compile/sqlite without skip_migrate must not set skip, got %v", env)
+	}
+}
+
+func TestResolveSSADatabaseEnvSQLiteHonorsSkipMigrate(t *testing.T) {
+	nodeBase := t.TempDir()
+	env, sqlitePath := resolveSSADatabaseEnvWithBase(nodeBase, map[string]interface{}{
+		scannodeSSADatabaseBackendParamKey: "sqlite",
+		scannodeSSASqliteKeyParamKey:       "k1",
+		scannodeSSASkipMigrateParamKey:     true,
+	}, "", "runtime")
+	want := filepath.Join(nodeBase, ssaIRSQLiteDirName, "k1", "ssadb.db")
+	if sqlitePath != want {
+		t.Fatalf("sqlite path = %q, want %q", sqlitePath, want)
+	}
+	var foundSkip bool
+	for _, e := range env {
+		if strings.Contains(e, consts.ENV_SSA_DB_SKIP_MIGRATE+"=1") {
+			foundSkip = true
+		}
+	}
+	if !foundSkip {
+		t.Fatalf("expected skip_migrate for scan sqlite, got %v", env)
+	}
+}
+
+func TestResolveSSADatabaseEnvSQLiteKeyFallsBackToRuntimeID(t *testing.T) {
+	nodeBase := t.TempDir()
+	_, sqlitePath := resolveSSADatabaseEnvWithBase(nodeBase, map[string]interface{}{
+		scannodeSSADatabaseBackendParamKey: "sqlite",
+	}, "", "att-9")
+	want := filepath.Join(nodeBase, ssaIRSQLiteDirName, "att-9", "ssadb.db")
+	if sqlitePath != want {
+		t.Fatalf("sqlite path = %q, want %q", sqlitePath, want)
+	}
+}
+
+func TestResolveSSADatabaseEnvPostgresUnchanged(t *testing.T) {
+	const dsn = "postgres://legion:legion@127.0.0.1:5436/ssa_ir?sslmode=disable"
+	env, sqlitePath := resolveSSADatabaseEnvWithBase(t.TempDir(), map[string]interface{}{
+		scannodeSSADatabaseRawParamKey: dsn,
+		scannodeSSASkipMigrateParamKey: true,
+	}, "", "runtime")
+	if sqlitePath != "" {
+		t.Fatalf("expected empty sqlite path for postgres, got %q", sqlitePath)
+	}
+	legacy := extractSSADatabaseEnv(map[string]interface{}{
+		scannodeSSADatabaseRawParamKey: dsn,
+		scannodeSSASkipMigrateParamKey: true,
+	})
+	if strings.Join(env, "\n") != strings.Join(legacy, "\n") {
+		t.Fatalf("postgres resolve must match extractSSADatabaseEnv: got %v want %v", env, legacy)
+	}
+}
+
+func TestCopySQLiteIRIntoDebugDir(t *testing.T) {
+	liveDir := t.TempDir()
+	live := filepath.Join(liveDir, "ssadb.db")
+	if err := os.WriteFile(live, []byte("db-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(live+"-wal", []byte("wal-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	debugDir := t.TempDir()
+	copySQLiteIRIntoDebugDir(debugDir, live)
+
+	got, err := os.ReadFile(filepath.Join(debugDir, "ssadb.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "db-bytes" {
+		t.Fatalf("copied db = %q", got)
+	}
+	wal, err := os.ReadFile(filepath.Join(debugDir, "ssadb.db-wal"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(wal) != "wal-bytes" {
+		t.Fatalf("copied wal = %q", wal)
+	}
+}
+
+func TestCopySQLiteIRIntoDebugDirSkipsWhenAlreadyInside(t *testing.T) {
+	debugDir := t.TempDir()
+	live := filepath.Join(debugDir, "ssadb.db")
+	if err := os.WriteFile(live, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	copySQLiteIRIntoDebugDir(debugDir, live)
+	got, err := os.ReadFile(live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("expected no overwrite, got %q", got)
+	}
 }

--- a/scannode/ssa_debug_query.go
+++ b/scannode/ssa_debug_query.go
@@ -1,0 +1,169 @@
+package scannode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/yaklang/yaklang/common/log"
+)
+
+// ssaDebugQueryResultPrefix is the core-NATS subject prefix a node uses to
+// answer ssa.debug.query commands. The full subject is derived from the
+// caller-provided query_id so concurrent queries never collide:
+//
+//	legion.realtime.ssa.debug.result.<query_id>
+const ssaDebugQueryResultPrefix = "legion.realtime.ssa.debug.result"
+
+// ssaDebugQueryPayload is the JSON body of an ssa.debug.query command. The
+// platform sends it to the node that owns (or owned) a scan attempt; the node
+// answers with whatever pprof/log data exists in the attempt's debug
+// directory, regardless of the task state (running, paused, cancel-requested,
+// succeeded, failed, cancelled, ...).
+type ssaDebugQueryPayload struct {
+	QueryID    string `json:"query_id"`
+	JobID      string `json:"job_id"`
+	AttemptID  string `json:"attempt_id"`
+	TaskStatus string `json:"task_status,omitempty"`
+}
+
+// ssaDebugQueryResponse is the JSON body published back to the platform.
+type ssaDebugQueryResponse struct {
+	Found    bool            `json:"found"`
+	Reason   string          `json:"reason,omitempty"`
+	Analysis json.RawMessage `json:"analysis,omitempty"`
+}
+
+// debugDirRegistry tracks the debug directory of every active debug-enabled
+// task so ssa.debug.query can find it no matter which state the run is in.
+// Entries are removed once the run is finalized; the convention-path fallback
+// (<base>/debug/<jobID>_<attemptID>) still answers for directories that are
+// no longer registered (e.g. after a node restart).
+type debugDirRegistry struct {
+	mu      sync.Mutex
+	baseDir string
+	dirs    map[string]string // "<jobID>_<attemptID>" -> debug dir
+}
+
+var scanDebugDirs = &debugDirRegistry{dirs: make(map[string]string)}
+
+func debugDirKey(jobID, attemptID string) string {
+	return sanitizeLogName(jobID) + "_" + sanitizeLogName(attemptID)
+}
+
+func (r *debugDirRegistry) register(baseDir, jobID, attemptID, dir string) {
+	if dir == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if baseDir != "" {
+		r.baseDir = baseDir
+	}
+	r.dirs[debugDirKey(jobID, attemptID)] = dir
+}
+
+func (r *debugDirRegistry) unregister(jobID, attemptID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.dirs, debugDirKey(jobID, attemptID))
+}
+
+func (r *debugDirRegistry) resolve(jobID, attemptID string) string {
+	key := debugDirKey(jobID, attemptID)
+	r.mu.Lock()
+	dir := r.dirs[key]
+	baseDir := r.baseDir
+	r.mu.Unlock()
+	if dir != "" {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	// Fallback: convention path <base>/debug/<jobID>_<attemptID>. Covers runs
+	// whose registry entry was removed by finalization or a node restart.
+	if baseDir == "" {
+		return ""
+	}
+	fallback := filepath.Join(baseDir, "debug", key)
+	if info, err := os.Stat(fallback); err == nil && info.IsDir() {
+		return fallback
+	}
+	return ""
+}
+
+// handleSSADebugQuery analyzes the debug run directory of a scan attempt on
+// demand and returns whatever exists (pprof samples, log, phases, summary).
+// It answers from the local filesystem directly, so it works while the task
+// is still running, when it was cancelled mid-run, and after it finished —
+// as long as the debug directory still exists on this node.
+func (b *legionJobBridge) handleSSADebugQuery(ctx context.Context, raw []byte) error {
+	var payload ssaDebugQueryPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return fmt.Errorf("unmarshal ssa debug query: %w", err)
+	}
+	if strings.TrimSpace(payload.QueryID) == "" {
+		return fmt.Errorf("ssa debug query query_id is required")
+	}
+	if strings.TrimSpace(payload.JobID) == "" || strings.TrimSpace(payload.AttemptID) == "" {
+		return fmt.Errorf("ssa debug query job_id and attempt_id are required")
+	}
+
+	response := ssaDebugQueryResponse{Found: false}
+	dir := scanDebugDirs.resolve(payload.JobID, payload.AttemptID)
+	if dir == "" && b != nil && b.agent != nil {
+		// Registry misses (e.g. node restarted since the run): fall back to
+		// the convention path under the node's current debug base dir.
+		key := debugDirKey(payload.JobID, payload.AttemptID)
+		fallback := filepath.Join(b.agent.debugBaseDir(), "debug", key)
+		if info, err := os.Stat(fallback); err == nil && info.IsDir() {
+			dir = fallback
+		}
+	}
+	if dir == "" {
+		response.Reason = "debug directory not found for this task attempt"
+		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=false (no debug dir)", payload.JobID, payload.AttemptID)
+	} else {
+		analysis := AnalyzeDebugRunWithStatus(dir, payload.TaskStatus)
+		hasContent := len(analysis.Samples) > 0 || analysis.Summary != nil ||
+			analysis.StartedAt != nil || strings.TrimSpace(analysis.Status) != ""
+		if !hasContent && len(analysis.Errors) > 0 {
+			response.Reason = strings.Join(analysis.Errors, "; ")
+		} else {
+			analysisJSON, err := json.Marshal(analysis)
+			if err != nil {
+				return fmt.Errorf("marshal ssa debug analysis: %w", err)
+			}
+			response.Found = true
+			response.Analysis = analysisJSON
+		}
+		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=%v samples=%d dir=%s",
+			payload.JobID, payload.AttemptID, response.Found, len(analysis.Samples), dir)
+	}
+
+	responseRaw, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("marshal ssa debug query response: %w", err)
+	}
+
+	publisher, ok := b.capabilityPublisher.(*capabilityEventPublisher)
+	if !ok || publisher == nil {
+		return fmt.Errorf("capability event publisher is not ready")
+	}
+	publishCtx, cancel := context.WithTimeout(b.agent.node.GetRootContext(), 5*time.Second)
+	defer cancel()
+	subject := ssaDebugQueryResultSubject(payload.QueryID)
+	if err := publisher.PublishRaw(publishCtx, subject, responseRaw); err != nil {
+		return fmt.Errorf("publish ssa debug query response: %w", err)
+	}
+	return nil
+}
+
+func ssaDebugQueryResultSubject(queryID string) string {
+	return ssaDebugQueryResultPrefix + "." + queryID
+}

--- a/scannode/ssa_debug_query.go
+++ b/scannode/ssa_debug_query.go
@@ -128,36 +128,105 @@ func (b *legionJobBridge) handleSSADebugQuery(ctx context.Context, raw []byte) e
 	if dir == "" {
 		response.Reason = "debug directory not found for this task attempt"
 		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=false (no debug dir)", payload.JobID, payload.AttemptID)
-	} else {
-		analysis := AnalyzeDebugRunWithStatus(dir, payload.TaskStatus)
-		hasContent := len(analysis.Samples) > 0 || analysis.Summary != nil ||
-			analysis.StartedAt != nil || strings.TrimSpace(analysis.Status) != ""
-		if !hasContent && len(analysis.Errors) > 0 {
-			response.Reason = strings.Join(analysis.Errors, "; ")
-		} else {
-			analysisJSON, err := json.Marshal(analysis)
-			if err != nil {
-				return fmt.Errorf("marshal ssa debug analysis: %w", err)
-			}
-			response.Found = true
-			response.Analysis = analysisJSON
-		}
-		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=%v samples=%d dir=%s",
-			payload.JobID, payload.AttemptID, response.Found, len(analysis.Samples), dir)
+		return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
 	}
 
+	// Serve the cached analysis when it is newer than every pprof/log input,
+	// so repeated queries do not re-parse large profiles.
+	if cached, ok := readCachedDebugAnalysis(dir); ok {
+		response.Found = true
+		response.Analysis = cached
+		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=true (cached) dir=%s", payload.JobID, payload.AttemptID, dir)
+		return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
+	}
+
+	analysis := AnalyzeDebugRunWithStatus(dir, payload.TaskStatus)
+	hasContent := len(analysis.Samples) > 0 || analysis.Summary != nil ||
+		analysis.StartedAt != nil || strings.TrimSpace(analysis.Status) != ""
+	if !hasContent && len(analysis.Errors) > 0 {
+		response.Reason = strings.Join(analysis.Errors, "; ")
+	} else {
+		analysisJSON, err := json.Marshal(analysis)
+		if err != nil {
+			return fmt.Errorf("marshal ssa debug analysis: %w", err)
+		}
+		if err := writeCachedDebugAnalysis(dir, analysisJSON); err != nil {
+			log.Warnf("[debug] cache analysis json failed: %v", err)
+		}
+		response.Found = true
+		response.Analysis = analysisJSON
+	}
+	log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=%v samples=%d dir=%s",
+		payload.JobID, payload.AttemptID, response.Found, len(analysis.Samples), dir)
+	return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
+}
+
+// debugAnalysisCacheName is the JSON file used to cache a parsed debug run
+// analysis next to the run directory.
+const debugAnalysisCacheName = "analysis.cache.json"
+
+func writeCachedDebugAnalysis(dir string, analysisJSON []byte) error {
+	return os.WriteFile(filepath.Join(dir, debugAnalysisCacheName), analysisJSON, 0o644)
+}
+
+// readCachedDebugAnalysis returns the cached analysis JSON when it is at least
+// as new as every profile/log input file of the debug run.
+func readCachedDebugAnalysis(dir string) (json.RawMessage, bool) {
+	cachePath := filepath.Join(dir, debugAnalysisCacheName)
+	cacheInfo, err := os.Stat(cachePath)
+	if err != nil {
+		return nil, false
+	}
+	newestInput := time.Time{}
+	inputs := []string{"cpu-pprof", "memory-pprof", "goroutine-pprof", "log"}
+	for _, name := range inputs {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			entries, err := os.ReadDir(path)
+			if err != nil {
+				continue
+			}
+			for _, entry := range entries {
+				entryInfo, err := entry.Info()
+				if err != nil {
+					continue
+				}
+				if entryInfo.ModTime().After(newestInput) {
+					newestInput = entryInfo.ModTime()
+				}
+			}
+			continue
+		}
+		if info.ModTime().After(newestInput) {
+			newestInput = info.ModTime()
+		}
+	}
+	if !newestInput.IsZero() && newestInput.After(cacheInfo.ModTime()) {
+		return nil, false
+	}
+	data, err := os.ReadFile(cachePath)
+	if err != nil || len(data) == 0 {
+		return nil, false
+	}
+	return json.RawMessage(data), true
+}
+
+func (b *legionJobBridge) publishDebugQueryResponse(ctx context.Context, queryID string, response ssaDebugQueryResponse) error {
 	responseRaw, err := json.Marshal(response)
 	if err != nil {
 		return fmt.Errorf("marshal ssa debug query response: %w", err)
 	}
-
 	publisher, ok := b.capabilityPublisher.(*capabilityEventPublisher)
 	if !ok || publisher == nil {
 		return fmt.Errorf("capability event publisher is not ready")
 	}
 	publishCtx, cancel := context.WithTimeout(b.agent.node.GetRootContext(), 5*time.Second)
 	defer cancel()
-	subject := ssaDebugQueryResultSubject(payload.QueryID)
+	subject := ssaDebugQueryResultSubject(queryID)
 	if err := publisher.PublishRaw(publishCtx, subject, responseRaw); err != nil {
 		return fmt.Errorf("publish ssa debug query response: %w", err)
 	}

--- a/scannode/ssa_debug_query.go
+++ b/scannode/ssa_debug_query.go
@@ -131,9 +131,13 @@ func (b *legionJobBridge) handleSSADebugQuery(ctx context.Context, raw []byte) e
 		return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
 	}
 
+	// Fold the node task log into debug/log before cache/analysis so live
+	// queries see SSA phase markers (compile/scan) while the run is in progress.
+	mergeTaskLogIntoDebugDir(dir)
+
 	// Serve the cached analysis when it is newer than every pprof/log input,
 	// so repeated queries do not re-parse large profiles.
-	if cached, ok := readCachedDebugAnalysis(dir); ok {
+	if cached, ok := readCachedDebugAnalysis(dir); ok && cachedAnalysisHasPhases(cached) {
 		response.Found = true
 		response.Analysis = cached
 		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=true (cached) dir=%s", payload.JobID, payload.AttemptID, dir)
@@ -213,6 +217,33 @@ func readCachedDebugAnalysis(dir string) (json.RawMessage, bool) {
 		return nil, false
 	}
 	return json.RawMessage(data), true
+}
+
+func cachedAnalysisHasPhases(raw json.RawMessage) bool {
+	var payload struct {
+		Phases []struct {
+			Phase string `json:"phase"`
+		} `json:"phases"`
+		Samples []struct {
+			Phase string `json:"phase"`
+		} `json:"samples"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return false
+	}
+	for _, phase := range payload.Phases {
+		name := strings.ToLower(strings.TrimSpace(phase.Phase))
+		if name != "" && name != "unknown" {
+			return true
+		}
+	}
+	for _, sample := range payload.Samples {
+		name := strings.ToLower(strings.TrimSpace(sample.Phase))
+		if name != "" && name != "unknown" {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *legionJobBridge) publishDebugQueryResponse(ctx context.Context, queryID string, response ssaDebugQueryResponse) error {

--- a/scannode/ssa_debug_query.go
+++ b/scannode/ssa_debug_query.go
@@ -136,10 +136,12 @@ func (b *legionJobBridge) handleSSADebugQuery(ctx context.Context, raw []byte) e
 	mergeTaskLogIntoDebugDir(dir)
 
 	// Serve the cached analysis when it is newer than every pprof/log input,
-	// so repeated queries do not re-parse large profiles.
+	// so repeated queries do not re-parse large profiles. Always overlay the
+	// Legion task status so a stale "failed" badge from log heuristics cannot
+	// stick while the attempt is still running.
 	if cached, ok := readCachedDebugAnalysis(dir); ok && cachedAnalysisHasPhases(cached) {
 		response.Found = true
-		response.Analysis = cached
+		response.Analysis = overlayDebugAnalysisStatus(cached, payload.TaskStatus)
 		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=true (cached) dir=%s", payload.JobID, payload.AttemptID, dir)
 		return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
 	}
@@ -168,6 +170,33 @@ func (b *legionJobBridge) handleSSADebugQuery(ctx context.Context, raw []byte) e
 // debugAnalysisCacheName is the JSON file used to cache a parsed debug run
 // analysis next to the run directory.
 const debugAnalysisCacheName = "analysis.cache.json"
+
+// overlayDebugAnalysisStatus rewrites analysis JSON "status" from the live
+// Legion task status so cached analyses never keep a log-heuristic "failed".
+func overlayDebugAnalysisStatus(analysisJSON json.RawMessage, taskStatus string) json.RawMessage {
+	if len(analysisJSON) == 0 {
+		return analysisJSON
+	}
+	normalized := normalizeTaskStatus(taskStatus)
+	if normalized == "" {
+		return analysisJSON
+	}
+	status := resolveDebugAnalysisStatus(taskStatus, "", 1)
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(analysisJSON, &obj); err != nil {
+		return analysisJSON
+	}
+	encoded, err := json.Marshal(status)
+	if err != nil {
+		return analysisJSON
+	}
+	obj["status"] = encoded
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return analysisJSON
+	}
+	return out
+}
 
 func writeCachedDebugAnalysis(dir string, analysisJSON []byte) error {
 	return os.WriteFile(filepath.Join(dir, debugAnalysisCacheName), analysisJSON, 0o644)

--- a/scannode/ssa_debug_query_cache_test.go
+++ b/scannode/ssa_debug_query_cache_test.go
@@ -1,0 +1,50 @@
+package scannode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReadCachedDebugAnalysisUsesFreshCache(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "log"), []byte("line\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	want := []byte(`{"status":"running","samples":[]}`)
+	if err := writeCachedDebugAnalysis(dir, want); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	got, ok := readCachedDebugAnalysis(dir)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if string(got) != string(want) {
+		t.Fatalf("cached analysis = %s, want %s", got, want)
+	}
+}
+
+func TestReadCachedDebugAnalysisRejectsStaleCache(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, debugAnalysisCacheName)
+	if err := os.WriteFile(cachePath, []byte(`{"status":"old"}`), 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(cachePath, old, old); err != nil {
+		t.Fatalf("chtimes cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "log"), []byte("newer\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if _, ok := readCachedDebugAnalysis(dir); ok {
+		t.Fatal("expected stale cache miss")
+	}
+}

--- a/scannode/ssa_debug_query_test.go
+++ b/scannode/ssa_debug_query_test.go
@@ -1,0 +1,54 @@
+package scannode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDebugDirRegistryRegisterResolveUnregister(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	dir := filepath.Join(base, "debug", "job-a_attempt-b")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir debug dir: %v", err)
+	}
+
+	registry := &debugDirRegistry{dirs: make(map[string]string)}
+	registry.register(base, "job-a", "attempt-b", dir)
+
+	if got := registry.resolve("job-a", "attempt-b"); got != dir {
+		t.Fatalf("resolve registered dir: got %q want %q", got, dir)
+	}
+
+	registry.unregister("job-a", "attempt-b")
+	// After unregister the convention-path fallback must still find the dir.
+	if got := registry.resolve("job-a", "attempt-b"); got != dir {
+		t.Fatalf("resolve fallback dir: got %q want %q", got, dir)
+	}
+
+	if got := registry.resolve("job-a", "missing-attempt"); got != "" {
+		t.Fatalf("resolve unknown attempt: got %q want empty", got)
+	}
+}
+
+func TestDebugDirRegistryIgnoresEmptyRegistration(t *testing.T) {
+	t.Parallel()
+
+	registry := &debugDirRegistry{dirs: make(map[string]string)}
+	registry.register("", "job-a", "attempt-b", "")
+	if got := registry.resolve("job-a", "attempt-b"); got != "" {
+		t.Fatalf("resolve after empty registration: got %q want empty", got)
+	}
+}
+
+func TestDebugDirKeySanitizes(t *testing.T) {
+	t.Parallel()
+
+	// sanitizeLogName replaces path separators, backslashes and NUL bytes
+	// only — spaces are valid in directory names and are preserved.
+	if got := debugDirKey("job/a", "attempt\\b"); got != "job_a_attempt_b" {
+		t.Fatalf("unexpected debug dir key: %q", got)
+	}
+}

--- a/scannode/ssa_log_tail.go
+++ b/scannode/ssa_log_tail.go
@@ -91,6 +91,7 @@ func (b *legionJobBridge) handleSSALogTail(ctx context.Context, raw []byte) erro
 		log.Warnf("[log-tail] job=%s attempt=%s read failed: %v", payload.JobID, payload.AttemptID, err)
 		return b.publishLogTailResponse(ctx, payload.QueryID, response)
 	}
+	response.Found = true
 	response.TotalBytes = totalBytes
 	response.HasMore = hasMore
 	response.Content = content

--- a/scannode/ssa_log_tail.go
+++ b/scannode/ssa_log_tail.go
@@ -34,6 +34,7 @@ type ssaLogTailPayload struct {
 	Offset     int64  `json:"offset"`    // bytes to skip from the end of the file
 	MaxBytes   int64  `json:"max_bytes"` // requested chunk size (clamped by the node)
 	TaskStatus string `json:"task_status,omitempty"`
+	LogKind    string `json:"log_kind,omitempty"` // ""|"task"|"db"
 }
 
 // ssaLogTailResponse is the JSON body published back to the platform.
@@ -78,10 +79,13 @@ func (b *legionJobBridge) handleSSALogTail(ctx context.Context, raw []byte) erro
 	}
 
 	response := ssaLogTailResponse{Offset: payload.Offset}
-	logPath := b.resolveTaskLogPath(payload.JobID, payload.AttemptID)
+	logPath, reason := b.resolveLogTailPath(payload.JobID, payload.AttemptID, payload.LogKind)
 	if logPath == "" {
-		response.Reason = "task log not found for this attempt"
-		log.Infof("[log-tail] answered: job=%s attempt=%s found=false (no log file)", payload.JobID, payload.AttemptID)
+		if reason == "" {
+			reason = "task log not found for this attempt"
+		}
+		response.Reason = reason
+		log.Infof("[log-tail] answered: job=%s attempt=%s kind=%s found=false (%s)", payload.JobID, payload.AttemptID, payload.LogKind, reason)
 		return b.publishLogTailResponse(ctx, payload.QueryID, response)
 	}
 
@@ -136,6 +140,44 @@ func (b *legionJobBridge) resolveTaskLogPath(jobID, attemptID string) string {
 	}
 	dirs = append(dirs, filepath.Join(os.TempDir(), "legion-node-logs"))
 	return resolveTaskLogPathInDirs(dirs, jobID, attemptID)
+}
+
+func (b *legionJobBridge) resolveLogTailPath(jobID, attemptID, logKind string) (string, string) {
+	switch strings.ToLower(strings.TrimSpace(logKind)) {
+	case "", "task":
+		path := b.resolveTaskLogPath(jobID, attemptID)
+		if path == "" {
+			return "", "task log not found for this attempt"
+		}
+		return path, ""
+	case "db":
+		path := b.resolveDBLogPath(jobID, attemptID)
+		if path == "" {
+			return "", "db log not found for this attempt"
+		}
+		return path, ""
+	default:
+		return "", "unsupported log_kind"
+	}
+}
+
+func (b *legionJobBridge) resolveDBLogPath(jobID, attemptID string) string {
+	dir := scanDebugDirs.resolve(jobID, attemptID)
+	if dir == "" && b != nil && b.agent != nil {
+		key := debugDirKey(jobID, attemptID)
+		fallback := filepath.Join(b.agent.debugBaseDir(), "debug", key)
+		if info, err := os.Stat(fallback); err == nil && info.IsDir() {
+			dir = fallback
+		}
+	}
+	if dir == "" {
+		return ""
+	}
+	path := filepath.Join(dir, "db.log")
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
 }
 
 // resolveTaskLogPathWithDirs is the testable core of resolveTaskLogPath.

--- a/scannode/ssa_log_tail.go
+++ b/scannode/ssa_log_tail.go
@@ -1,0 +1,220 @@
+package scannode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/yaklang/yaklang/common/log"
+)
+
+// ssaLogTailResultPrefix is the core-NATS subject prefix a node uses to
+// answer ssa.log.tail commands:
+//
+//	legion.realtime.ssa.log.tail.<query_id>
+const ssaLogTailResultPrefix = "legion.realtime.ssa.log.tail"
+
+// ssaLogTailPayload is the JSON body of an ssa.log.tail command. The platform
+// asks the node for a chunk of a scan task's log file, measured backwards from
+// the end of the file:
+//
+//	offset    = bytes to skip from the end of the file (0 = the very end)
+//	max_bytes = maximum bytes to return for this chunk
+//
+// The frontend starts at offset 0 (the tail) and walks backwards by increasing
+// offset, so a huge log can be inspected without ever shipping it fully.
+type ssaLogTailPayload struct {
+	QueryID    string `json:"query_id"`
+	JobID      string `json:"job_id"`
+	AttemptID  string `json:"attempt_id"`
+	Offset     int64  `json:"offset"`    // bytes to skip from the end of the file
+	MaxBytes   int64  `json:"max_bytes"` // requested chunk size (clamped by the node)
+	TaskStatus string `json:"task_status,omitempty"`
+}
+
+// ssaLogTailResponse is the JSON body published back to the platform.
+type ssaLogTailResponse struct {
+	Found      bool   `json:"found"`
+	Reason     string `json:"reason,omitempty"`
+	TotalBytes int64  `json:"total_bytes"` // full file size at read time
+	Offset     int64  `json:"offset"`      // bytes skipped from the end for THIS chunk
+	HasMore    bool   `json:"has_more"`    // true when older content exists before this chunk
+	Content    string `json:"content,omitempty"`
+}
+
+const (
+	ssaLogTailDefaultMaxBytes = 64 * 1024
+	ssaLogTailMaxBytesLimit   = 1024 * 1024
+)
+
+// handleSSALogTail reads the tail of the per-task log file of a scan attempt.
+// Task logs are written unconditionally for every scan (debug or not) by
+// openTaskLogWriter into <node>/logs/<jobID>_<subtaskID>_<attemptID>.log, so
+// this command works for any task state: running, cancelled or finished.
+func (b *legionJobBridge) handleSSALogTail(ctx context.Context, raw []byte) error {
+	var payload ssaLogTailPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return fmt.Errorf("unmarshal ssa log tail: %w", err)
+	}
+	if strings.TrimSpace(payload.QueryID) == "" {
+		return fmt.Errorf("ssa log tail query_id is required")
+	}
+	if strings.TrimSpace(payload.JobID) == "" || strings.TrimSpace(payload.AttemptID) == "" {
+		return fmt.Errorf("ssa log tail job_id and attempt_id are required")
+	}
+	if payload.Offset < 0 {
+		return fmt.Errorf("ssa log tail offset must be >= 0")
+	}
+	maxBytes := payload.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = ssaLogTailDefaultMaxBytes
+	}
+	if maxBytes > ssaLogTailMaxBytesLimit {
+		maxBytes = ssaLogTailMaxBytesLimit
+	}
+
+	response := ssaLogTailResponse{Offset: payload.Offset}
+	logPath := b.resolveTaskLogPath(payload.JobID, payload.AttemptID)
+	if logPath == "" {
+		response.Reason = "task log not found for this attempt"
+		log.Infof("[log-tail] answered: job=%s attempt=%s found=false (no log file)", payload.JobID, payload.AttemptID)
+		return b.publishLogTailResponse(ctx, payload.QueryID, response)
+	}
+
+	content, totalBytes, start, hasMore, err := tailLogFile(logPath, payload.Offset, maxBytes)
+	if err != nil {
+		response.Reason = fmt.Sprintf("read task log: %v", err)
+		log.Warnf("[log-tail] job=%s attempt=%s read failed: %v", payload.JobID, payload.AttemptID, err)
+		return b.publishLogTailResponse(ctx, payload.QueryID, response)
+	}
+	response.TotalBytes = totalBytes
+	response.HasMore = hasMore
+	response.Content = content
+	response.Offset = totalBytes - start // bytes skipped from the end for this chunk
+
+	log.Infof("[log-tail] answered: job=%s attempt=%s total=%d chunk=%d offset=%d has_more=%v",
+		payload.JobID, payload.AttemptID, totalBytes, len(content), response.Offset, hasMore)
+	return b.publishLogTailResponse(ctx, payload.QueryID, response)
+}
+
+func (b *legionJobBridge) publishLogTailResponse(ctx context.Context, queryID string, response ssaLogTailResponse) error {
+	raw, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("marshal ssa log tail response: %w", err)
+	}
+	publisher, ok := b.capabilityPublisher.(*capabilityEventPublisher)
+	if !ok || publisher == nil {
+		return fmt.Errorf("capability event publisher is not ready")
+	}
+	publishCtx, cancel := context.WithTimeout(b.agent.node.GetRootContext(), 5*time.Second)
+	defer cancel()
+	subject := ssaLogTailResultSubject(queryID)
+	if err := publisher.PublishRaw(publishCtx, subject, raw); err != nil {
+		return fmt.Errorf("publish ssa log tail response: %w", err)
+	}
+	return nil
+}
+
+func ssaLogTailResultSubject(queryID string) string {
+	return ssaLogTailResultPrefix + "." + queryID
+}
+
+// resolveTaskLogPath locates the per-task log file for a job/attempt. File
+// layout: <jobBaseDir>/logs/<JobID>_<SubTaskID>_<AttemptID>.log.
+func (b *legionJobBridge) resolveTaskLogPath(jobID, attemptID string) string {
+	var dirs []string
+	if b != nil && b.agent != nil && b.agent.node != nil {
+		dirs = append(dirs, filepath.Join(b.agent.node.BaseDir(), "logs"))
+	}
+	if env := os.Getenv("SCANNODE_TASK_LOG_DIR"); env != "" {
+		dirs = append(dirs, env)
+	}
+	dirs = append(dirs, filepath.Join(os.TempDir(), "legion-node-logs"))
+	return resolveTaskLogPathInDirs(dirs, jobID, attemptID)
+}
+
+// resolveTaskLogPathWithDirs is the testable core of resolveTaskLogPath.
+func (b *legionJobBridge) resolveTaskLogPathWithDirs(dirs []string, jobID, attemptID string) string {
+	return resolveTaskLogPathInDirs(dirs, jobID, attemptID)
+}
+
+func resolveTaskLogPathInDirs(dirs []string, jobID, attemptID string) string {
+	jobID = sanitizeLogName(jobID)
+	attemptID = sanitizeLogName(attemptID)
+	if jobID == "" || attemptID == "" {
+		return ""
+	}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".log") {
+				continue
+			}
+			if !strings.HasPrefix(name, jobID+"_") {
+				continue
+			}
+			if !strings.HasSuffix(name, "_"+attemptID+".log") {
+				continue
+			}
+			return filepath.Join(dir, name)
+		}
+	}
+	return ""
+}
+
+// tailLogFile reads the last portion of a log file. offset is the number of
+// bytes to skip from the end; the returned chunk is aligned to line boundaries
+// so the frontend can render complete lines. It returns the chunk, the full
+// file size, the byte position of the chunk start, and whether older content
+// exists before the chunk.
+func tailLogFile(path string, offset int64, maxBytes int64) (content string, total int64, start int64, hasMore bool, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, 0, false, err
+	}
+	total = info.Size()
+	if offset >= total {
+		return "", total, total, false, nil
+	}
+	end := total - offset
+	start = end - maxBytes
+	if start < 0 {
+		start = 0
+	}
+	data := make([]byte, end-start)
+	f, err := os.Open(path)
+	if err != nil {
+		return "", total, 0, false, err
+	}
+	defer f.Close()
+	if _, err := f.ReadAt(data, start); err != nil {
+		return "", total, 0, false, err
+	}
+	// Align to line boundaries: skip the partial first line unless the chunk
+	// already starts at the beginning of the file.
+	if start > 0 {
+		if idx := indexByte(data, '\n'); idx >= 0 {
+			start += int64(idx + 1)
+			data = data[idx+1:]
+		}
+	}
+	hasMore = start > 0
+	return string(data), total, start, hasMore, nil
+}
+
+func indexByte(data []byte, b byte) int {
+	for i, c := range data {
+		if c == b {
+			return i
+		}
+	}
+	return -1
+}

--- a/scannode/ssa_log_tail_test.go
+++ b/scannode/ssa_log_tail_test.go
@@ -135,3 +135,32 @@ func TestResolveTaskLogPath(t *testing.T) {
 		t.Fatalf("expected no match for missing attempt: %q", got)
 	}
 }
+
+func TestResolveDBLogPathAndLogKind(t *testing.T) {
+	dir := t.TempDir()
+	dbLog := filepath.Join(dir, "db.log")
+	if err := os.WriteFile(dbLog, []byte("SELECT 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scanDebugDirs.register(filepath.Dir(dir), "job-db", "att-db", dir)
+	t.Cleanup(func() { scanDebugDirs.unregister("job-db", "att-db") })
+
+	bridge := &legionJobBridge{}
+	got := bridge.resolveDBLogPath("job-db", "att-db")
+	if got != dbLog {
+		t.Fatalf("db log path = %q, want %q", got, dbLog)
+	}
+
+	path, reason := bridge.resolveLogTailPath("job-db", "att-db", "db")
+	if path != dbLog || reason != "" {
+		t.Fatalf("log kind db: path=%q reason=%q", path, reason)
+	}
+	path, reason = bridge.resolveLogTailPath("job-db", "att-db", "weird")
+	if path != "" || reason != "unsupported log_kind" {
+		t.Fatalf("unsupported kind: path=%q reason=%q", path, reason)
+	}
+	path, reason = bridge.resolveLogTailPath("missing", "missing", "db")
+	if path != "" || reason != "db log not found for this attempt" {
+		t.Fatalf("missing db log: path=%q reason=%q", path, reason)
+	}
+}

--- a/scannode/ssa_log_tail_test.go
+++ b/scannode/ssa_log_tail_test.go
@@ -1,0 +1,137 @@
+package scannode
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestLog(t *testing.T, dir, jobID, subtaskID, attemptID string, lines []string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	path := filepath.Join(dir, sanitizeLogName(jobID)+"_"+sanitizeLogName(subtaskID)+"_"+sanitizeLogName(attemptID)+".log")
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+	return path
+}
+
+func TestTailLogFileReturnsTailChunkAlignedToLines(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTestLog(t, dir, "job-a", "sub-a", "attempt-b", []string{
+		"line-01",
+		"line-02",
+		"line-03",
+		"line-04",
+		"line-05",
+		"line-06",
+	})
+
+	// Total content is 6 lines of 7 bytes + newline = 48 bytes. A 24-byte
+	// chunk from the end starts exactly at line-04; line alignment therefore
+	// drops line-04's partial boundary and returns the last two full lines.
+	content, total, start, hasMore, err := tailLogFile(path, 0, 24)
+	if err != nil {
+		t.Fatalf("tail log: %v", err)
+	}
+	if total != 48 {
+		t.Fatalf("unexpected total: %d", total)
+	}
+	if content != "line-05\nline-06\n" {
+		t.Fatalf("unexpected tail content: %q", content)
+	}
+	if !hasMore {
+		t.Fatal("expected has_more=true (older lines exist)")
+	}
+	// start must point at line-05: 4 lines * 8 bytes = 32.
+	if start != 32 {
+		t.Fatalf("unexpected chunk start: %d", start)
+	}
+}
+
+func TestTailTaskFileWalksBackwards(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTestLog(t, dir, "job-a", "sub-a", "att-b", []string{
+		"line-01", "line-02", "line-03", "line-04", "line-05", "line-06",
+	})
+
+	// First chunk: last two lines (24-byte window lands on line-05 after
+	// alignment, skipping 16 bytes from the end).
+	first, _, _, hasMore, err := tailLogFile(path, 0, 24)
+	if err != nil {
+		t.Fatalf("tail log: %v", err)
+	}
+	if first != "line-05\nline-06\n" {
+		t.Fatalf("first chunk: %q", first)
+	}
+	if !hasMore {
+		t.Fatal("expected more content before the first chunk")
+	}
+
+	// Second chunk: skip the first chunk's aligned size (16 bytes) from the
+	// end. The window [16,32) holds "line-03\nline-04\n"; line alignment
+	// drops the partial line-03 and returns line-04.
+	second, _, _, hasMore, err := tailLogFile(path, 16, 16)
+	if err != nil {
+		t.Fatalf("tail log: %v", err)
+	}
+	if second != "line-04\n" {
+		t.Fatalf("second chunk: %q", second)
+	}
+	if !hasMore {
+		t.Fatal("expected more content before the second chunk")
+	}
+
+	// Third chunk reaches the beginning of the file.
+	third, _, _, hasMore, err := tailLogFile(path, 32, 24)
+	if err != nil {
+		t.Fatalf("tail log: %v", err)
+	}
+	if third != "line-01\nline-02\n" {
+		t.Fatalf("third chunk: %q", third)
+	}
+	if hasMore {
+		t.Fatal("expected no more content before the third chunk")
+	}
+}
+
+func TestTailLogFileOffsetBeyondEOF(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTestLog(t, dir, "job", "sub", "att", []string{"only-line"})
+	content, total, start, hasMore, err := tailLogFile(path, 4096, 64)
+	if err != nil {
+		t.Fatalf("tail log: %v", err)
+	}
+	if content != "" || total != 10 || start != 10 || hasMore {
+		t.Fatalf("unexpected result: content=%q total=%d start=%d hasMore=%v", content, total, start, hasMore)
+	}
+}
+
+func TestResolveTaskLogPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	jobID := "job-123"
+	attemptID := "attempt-456"
+	writeTestLog(t, dir, jobID, "sub-a", attemptID, []string{"x"})
+	writeTestLog(t, dir, jobID, "sub-b", "attempt-other", []string{"x"})
+
+	bridge := &legionJobBridge{}
+	got := bridge.resolveTaskLogPathWithDirs([]string{dir}, jobID, attemptID)
+	if !strings.HasSuffix(got, jobID+"_sub-a_"+attemptID+".log") {
+		t.Fatalf("unexpected resolved path: %q", got)
+	}
+	if got := bridge.resolveTaskLogPathWithDirs([]string{dir}, jobID, "missing-attempt"); got != "" {
+		t.Fatalf("expected no match for missing attempt: %q", got)
+	}
+}

--- a/scannode/ssa_runtime_db.go
+++ b/scannode/ssa_runtime_db.go
@@ -2,12 +2,14 @@ package scannode
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
 )
 
 const ssaRuntimeDBDirName = "ssa-runtime-db"
@@ -66,4 +68,60 @@ func buildSSARuntimeDBEnv(runtimeID string, ssaDatabaseRawOverride string) (env 
 		}
 	}
 	return env, cleanup
+}
+
+func copySQLiteIRIntoDebugDir(debugDir, livePath string) {
+	debugDir = strings.TrimSpace(debugDir)
+	livePath = strings.TrimSpace(livePath)
+	if debugDir == "" || livePath == "" {
+		return
+	}
+	absLive, err := filepath.Abs(livePath)
+	if err != nil {
+		absLive = livePath
+	}
+	absDebug, err := filepath.Abs(debugDir)
+	if err != nil {
+		absDebug = debugDir
+	}
+	sep := string(os.PathSeparator)
+	if absLive == filepath.Join(absDebug, "ssadb.db") ||
+		strings.HasPrefix(absLive, absDebug+sep) {
+		return
+	}
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		log.Warnf("[ssadb] mkdir debug dir for sqlite copy failed: %v", err)
+		return
+	}
+	dest := filepath.Join(debugDir, "ssadb.db")
+	if err := copyFileIfExists(absLive, dest); err != nil {
+		log.Warnf("[ssadb] copy sqlite IR into debug dir failed: %v", err)
+		return
+	}
+	_ = copyFileIfExists(absLive+"-wal", dest+"-wal")
+	_ = copyFileIfExists(absLive+"-shm", dest+"-shm")
+	log.Infof("[ssadb] copied sqlite IR into debug dir: %s", dest)
+}
+
+func copyFileIfExists(src, dst string) error {
+	if src == "" || dst == "" || src == dst {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }


### PR DESCRIPTION
## Summary
- Keep successful SSA progress at ~99% until Legion finishes risk/artifact import; publish `JobSucceeded` before async debug/pprof finalize so success is not blocked.
- Speed and stabilize compile/import: batch IR upserts, spread deferred-build progress across batches, shallow clone, clone retries, Postgres IR SQL timeouts.
- Add Legion-facing debug surfaces: live `ssa.debug.query`, `ssa.log.tail`, pprof tops / folded stacks, host/task runtime stats, failure_code propagation.

Pairs with Legion PR branch: `fixup/ssa/code-scan-hang`.

## Test plan
- [ ] Run an SSA scan against Legion Scan DEV; progress holds near 99% until import, then succeeds without multi-minute success stall
- [ ] Enable debug mode; confirm live debug analysis / log.tail / pprof tops reach Legion
- [ ] Cancel mid-scan; debug analysis still persists on cancel/failure paths
- [ ] Compile multi-batch project; progress advances across batches instead of jumping near 87% on the first batch


Made with [Cursor](https://cursor.com)