### PR TITLE
fix: ReAct 任务执行失败文案改为任务执行中断

### DIFF
--- a/common/schema/ai_node_id_i18n.go
+++ b/common/schema/ai_node_id_i18n.go
@@ -1017,8 +1017,8 @@ var nodeIdMapper = map[string]*I18n{
 		En: "plan and execute failed",
 	},
 	"re_act_fail": {
-		Zh: "ReAct 任务执行失败",
-		En: "ReAct Task Execution Failed",
+		Zh: "ReAct 任务执行中断",
+		En: "ReAct Task Execution Interrupted",
 	},
 	"re_act_success": {
 		Zh: "ReAct 任务执行成功",


### PR DESCRIPTION
## 修改内容

将 `common/schema/ai_node_id_i18n.go` 中 `re_act_fail` 的文案从「ReAct 任务执行失败」改为「ReAct 任务执行中断」。

| 字段 | 修改前 | 修改后 |
|------|--------|--------|
| Zh | ReAct 任务执行失败 | ReAct 任务执行中断 |
| En | ReAct Task Execution Failed | ReAct Task Execution Interrupted |
