### PR TITLE
feat(syntaxflow): source-mode risks carry full file context and scan-mode marker

### DIFF
--- a/common/schema/ssa_risk.go
+++ b/common/schema/ssa_risk.go
@@ -41,6 +41,8 @@ type SSARisk struct {
 
 	// 来源于哪个规则
 	FromRule string `json:"from_rule"`
+	// 风险来源的扫描模式: source (源码模式匹配/漏洞预检测) 或 ssa (SSA/深度静态分析)
+	ScanMode string `json:"scan_mode" gorm:"index;default:'ssa'"`
 	// 来源于哪个项目
 	ProgramName string `json:"program_name" gorm:"index"`
 	// file url yakurl
@@ -134,6 +136,9 @@ func (s *SSARisk) ToGRPCModel() *ypb.SSARisk {
 func (s *SSARisk) BeforeCreate(tx *gorm.DB) (err error) {
 	if s.RiskType == "" {
 		s.RiskType = "其他"
+	}
+	if s.ScanMode == "" {
+		s.ScanMode = "ssa"
 	}
 	s.Severity = ValidSeverityType(s.Severity)
 	s.Hash = s.CalcHash()

--- a/common/syntaxflow/sfpattern/match.go
+++ b/common/syntaxflow/sfpattern/match.go
@@ -18,6 +18,7 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/filesys"
 	fi "github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
+	"github.com/yaklang/yaklang/common/utils/memedit"
 	regexp_utils "github.com/yaklang/yaklang/common/utils/regexp-utils"
 )
 
@@ -27,6 +28,33 @@ func init() {
 }
 
 var defaultMatcher sfvm.FileFilterFunc
+
+// hitEditorCache builds one full-file editor per file per match call so every
+// hit in the same file shares the editor (and its line/rune maps).
+type hitEditorCache struct {
+	files   map[string]string
+	editors map[string]*memedit.MemEditor
+}
+
+func newHitEditorCache(files map[string]string) *hitEditorCache {
+	return &hitEditorCache{files: files, editors: make(map[string]*memedit.MemEditor, 8)}
+}
+
+// editorFor returns a shared full-file editor for the hit path.
+// The editor content is the WHOLE file so hits anchor to real file offsets
+// (risks then carry file path / line ranges / context, same as SSA mode).
+func (c *hitEditorCache) editorFor(p string) *memedit.MemEditor {
+	if ed, ok := c.editors[p]; ok {
+		return ed
+	}
+	content, ok := c.files[p]
+	if !ok {
+		return nil
+	}
+	ed := memedit.NewMemEditorWithFileUrl(content, p)
+	c.editors[p] = ed
+	return ed
+}
 
 // MatchFileFilter is the sfvm.FileFilterFunc implementation for regexp (and
 // rejects unsupported match types so xpath/json stay on other backends).
@@ -55,10 +83,11 @@ func MatchRegexpWithNegatives(files map[string]string, pathPattern string, posit
 	if err != nil {
 		return nil, err
 	}
+	editors := newHitEditorCache(files)
 	if len(negatives) == 0 {
 		vals := make([]sfvm.ValueOperator, 0, len(hits))
 		for _, h := range hits {
-			vals = append(vals, sfvm.NewSimpleValue(h.Text, h.Path, h.Start, h.End))
+			vals = append(vals, sfvm.NewSimpleValueWithEditor(h.Text, h.Path, h.Start, h.End, editors.editorFor(h.Path)))
 		}
 		return sfvm.NewValues(vals), nil
 	}
@@ -113,7 +142,7 @@ func MatchRegexpWithNegatives(files map[string]string, pathPattern string, posit
 	}
 	vals := make([]sfvm.ValueOperator, 0, len(kept))
 	for _, h := range kept {
-		vals = append(vals, sfvm.NewSimpleValue(h.Text, h.Path, h.Start, h.End))
+		vals = append(vals, sfvm.NewSimpleValueWithEditor(h.Text, h.Path, h.Start, h.End, editors.editorFor(h.Path)))
 	}
 	return sfvm.NewValues(vals), nil
 }
@@ -148,9 +177,10 @@ func MatchRegexp(files map[string]string, pathPattern string, patterns []string)
 	if err != nil {
 		return nil, err
 	}
+	editors := newHitEditorCache(files)
 	vals := make([]sfvm.ValueOperator, 0, len(hits))
 	for _, h := range hits {
-		vals = append(vals, sfvm.NewSimpleValue(h.Text, h.Path, h.Start, h.End))
+		vals = append(vals, sfvm.NewSimpleValueWithEditor(h.Text, h.Path, h.Start, h.End, editors.editorFor(h.Path)))
 	}
 	return sfvm.NewValues(vals), nil
 }

--- a/common/syntaxflow/sfvm/simple_value.go
+++ b/common/syntaxflow/sfvm/simple_value.go
@@ -14,17 +14,34 @@ import (
 
 // SimpleValue is a minimal ValueOperator for non-SSA pattern hits (sfpattern).
 // It only carries matched text / path / offsets — no SSA Program dependency.
+// When a full-file editor is attached (sfpattern regexp hits), the hit is
+// anchored inside the whole file so risks get real line numbers / context.
 type SimpleValue struct {
-	text  string
-	path  string
-	start int // rune or byte start (display)
-	end   int
-	empty bool
+	text   string
+	path   string
+	start  int // rune or byte start (display)
+	end    int
+	empty  bool
+	editor *memedit.MemEditor // optional full-file editor containing this hit
 }
 
 // NewSimpleValue builds a pattern hit value.
 func NewSimpleValue(text string, path string, start, end int) *SimpleValue {
 	return &SimpleValue{text: text, path: path, start: start, end: end}
+}
+
+// NewSimpleValueWithEditor builds a pattern hit value anchored inside a
+// full-file editor. start/end are byte offsets into that editor's content.
+func NewSimpleValueWithEditor(text string, path string, start, end int, editor *memedit.MemEditor) *SimpleValue {
+	return &SimpleValue{text: text, path: path, start: start, end: end, editor: editor}
+}
+
+// FileEditor returns the attached full-file editor (nil when absent).
+func (v *SimpleValue) FileEditor() *memedit.MemEditor {
+	if v == nil {
+		return nil
+	}
+	return v.editor
 }
 
 // NewSimpleConst builds a const-like simple value (no path).
@@ -157,8 +174,9 @@ func (v *SimpleValue) SetAnchorBitVector(*utils.BitVector)  {}
 // PatternRoot is the feed root for source-mode scans: holds files and responds to
 // FileFilter by delegating to a registered regexp matcher (set by sfpattern).
 type PatternRoot struct {
-	files   map[string]string
-	matcher FileFilterFunc
+	files       map[string]string
+	matcher     FileFilterFunc
+	programName string
 }
 
 // FileFilterFunc is injected by sfpattern to avoid sfvm→sfpattern import cycles
@@ -178,6 +196,22 @@ func (r *PatternRoot) SetFileFilterMatcher(fn FileFilterFunc) {
 	if r != nil {
 		r.matcher = fn
 	}
+}
+
+// SetProgramName records the owning program name so hit editors produce
+// program-scoped URLs and ir_source hashes (aligned with compiled programs).
+func (r *PatternRoot) SetProgramName(name string) {
+	if r != nil {
+		r.programName = name
+	}
+}
+
+// GetProgramName returns the recorded program name (may be empty).
+func (r *PatternRoot) GetProgramName() string {
+	if r == nil {
+		return ""
+	}
+	return r.programName
 }
 
 // Files returns the underlying path→content map.
@@ -232,7 +266,21 @@ func (r *PatternRoot) FileFilter(pathPattern, matchType string, paramMap map[str
 	if r.matcher == nil {
 		return nil, utils.Error("pattern root: file filter matcher not registered")
 	}
-	return r.matcher(r.files, pathPattern, matchType, paramMap, patterns)
+	vals, err := r.matcher(r.files, pathPattern, matchType, paramMap, patterns)
+	if err != nil {
+		return nil, err
+	}
+	// Propagate the program name into hit editors so file URLs / ir-source
+	// hashes match the convention of compiled programs (files get deduped
+	// against compile artifacts downstream).
+	if r.programName != "" {
+		for _, v := range vals {
+			if sv, ok := v.(*SimpleValue); ok && sv != nil && sv.editor != nil {
+				sv.editor.SetProgramName(r.programName)
+			}
+		}
+	}
+	return vals, nil
 }
 
 func (r *PatternRoot) CompareString(*StringComparator) (Values, []bool) {

--- a/common/yak/ssaapi/sf_query.go
+++ b/common/yak/ssaapi/sf_query.go
@@ -193,6 +193,9 @@ func QuerySyntaxflow(opt ...QueryOption) (*SyntaxFlowResult, error) {
 			return nil, ferr
 		}
 		root := sfpattern.NewRoot(files)
+		if config.program != nil {
+			root.SetProgramName(config.program.GetProgramName())
+		}
 		res, err = frame.Feed(sfvm.ValuesOf(root), config.opts...)
 	} else {
 		res, err = frame.Feed(value, config.opts...)

--- a/common/yak/ssaapi/sf_result_risk.go
+++ b/common/yak/ssaapi/sf_result_risk.go
@@ -101,6 +101,7 @@ func buildSSARisk(
 		FromRule:    rule.RuleName,
 		IsPotential: false,
 		ProgramName: progName,
+		ScanMode:    string(schema.ValidRuleMode(rule.Mode)),
 		// result
 		Variable: variable,
 		Index:    int64(index),

--- a/common/yak/ssaapi/sf_result_risk.go
+++ b/common/yak/ssaapi/sf_result_risk.go
@@ -207,7 +207,13 @@ func (r *SyntaxFlowResult) SaveRisk(
 	if save {
 		err := yakit.CreateSSARisk(consts.GetGormSSAProjectDataBase(), ssaRisk)
 		if err != nil {
+			// Keep the risk in memory so the streaming path (EmitSSAResult →
+			// ssa-stream → platform artifact import) and in-process results
+			// still deliver it even when the local SSA IR DB is stale or
+			// read-only (e.g. missing a newly added column). The platform
+			// stores its own copy from the stream.
 			log.Errorf("save risk failed: %s", err)
+			r.riskMap[ssaRiskName(variable, index)] = ssaRisk
 			return ""
 		}
 	}

--- a/common/yak/ssaapi/sf_result_risk_db_failure_test.go
+++ b/common/yak/ssaapi/sf_result_risk_db_failure_test.go
@@ -1,0 +1,52 @@
+package ssaapi
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+// TestSaveRiskKeepsMemoryRiskWhenDBPersistFails verifies that a stale/read-only
+// SSA IR DB (e.g. missing a newly added risk column) does NOT silently drop
+// findings: the risk stays in memory so the streaming path (EmitSSAResult →
+// ssa-stream → platform artifact import) still delivers it.
+func TestSaveRiskKeepsMemoryRiskWhenDBPersistFails(t *testing.T) {
+	code := `print(f())`
+	prog, err := Parse(code,
+		WithLanguage(ssaconfig.Yak),
+		WithProgramName(uuid.NewString()),
+	)
+	require.NoError(t, err)
+
+	res, err := prog.SyntaxFlowWithError(`
+desc(title: "t")
+print(* as $para)
+alert $para for { "msg": "x", "level": "warning" }
+`)
+	require.NoError(t, err)
+
+	// Simulate a stale schema: fresh SSA DB with the ssa_risks table dropped,
+	// so CreateSSARisk fails exactly like the missing scan_mode column did.
+	broken, err := consts.GetTempSSADataBase()
+	require.NoError(t, err)
+	require.NoError(t, broken.Exec("DROP TABLE IF EXISTS ssa_risks").Error)
+
+	old := consts.GetGormSSAProjectDataBase()
+	consts.SetGormSSAProjectDatabase(broken)
+	defer consts.SetGormSSAProjectDatabase(old)
+
+	// save=true path hits the broken DB; Save itself must not fail.
+	_, err = res.Save(schema.SFResultKindScan, uuid.NewString())
+	require.NoError(t, err)
+
+	// The risk must still be present in memory so streaming delivers it.
+	count := 0
+	for range res.YieldRisk() {
+		count++
+	}
+	require.Greater(t, count, 0, "risk must survive a failed DB persist (streaming path)")
+}

--- a/common/yak/ssaapi/sf_utils.go
+++ b/common/yak/ssaapi/sf_utils.go
@@ -97,15 +97,26 @@ func valueOperatorToSSAValue(value sfvm.ValueOperator) (*Value, bool) {
 
 // simpleValueToSSAValue wraps an sfpattern hit as a const Value.
 // When the hit carries a full-file editor (sfpattern regexp hits), the range
-// anchors to the real byte offsets inside the whole file so risks get the
+// anchors to the real match offsets inside the whole file so risks get the
 // actual file path / line numbers / code context — same behavior as SSA mode.
+// sfpattern match offsets are BYTE offsets; the memedit position system is
+// rune-based, so convert byte → rune before resolving the range.
 // Otherwise it falls back to a snippet-only editor (match text only).
 func simpleValueToSSAValue(sv *sfvm.SimpleValue) *Value {
 	prog := NewTmpProgram("")
 	text := sv.String()
 	path := sv.Path()
 	if ed := sv.FileEditor(); ed != nil {
-		return prog.NewConstValue(text, ed.GetRangeOffset(sv.Start(), sv.End()))
+		start, end := sv.Start(), sv.End()
+		if offsetMap := ed.GetRuneOffsetMap(); offsetMap != nil {
+			if rs, ok := offsetMap.ByteOffsetToRuneIndex(start); ok {
+				start = rs
+			}
+			if re, ok := offsetMap.ByteOffsetToRuneIndex(end); ok {
+				end = re
+			}
+		}
+		return prog.NewConstValue(text, ed.GetRangeOffset(start, end))
 	}
 	ed := memedit.NewMemEditorWithFileUrl(text, path)
 	return prog.NewConstValue(text, ed.GetFullRange())

--- a/common/yak/ssaapi/sf_utils.go
+++ b/common/yak/ssaapi/sf_utils.go
@@ -95,12 +95,18 @@ func valueOperatorToSSAValue(value sfvm.ValueOperator) (*Value, bool) {
 	return nil, false
 }
 
-// simpleValueToSSAValue wraps an sfpattern hit as a const Value with a range
-// anchored on path + match text (no SSA IR required).
+// simpleValueToSSAValue wraps an sfpattern hit as a const Value.
+// When the hit carries a full-file editor (sfpattern regexp hits), the range
+// anchors to the real byte offsets inside the whole file so risks get the
+// actual file path / line numbers / code context — same behavior as SSA mode.
+// Otherwise it falls back to a snippet-only editor (match text only).
 func simpleValueToSSAValue(sv *sfvm.SimpleValue) *Value {
 	prog := NewTmpProgram("")
 	text := sv.String()
 	path := sv.Path()
+	if ed := sv.FileEditor(); ed != nil {
+		return prog.NewConstValue(text, ed.GetRangeOffset(sv.Start(), sv.End()))
+	}
 	ed := memedit.NewMemEditorWithFileUrl(text, path)
 	return prog.NewConstValue(text, ed.GetFullRange())
 }

--- a/common/yak/ssaapi/sfreport/risk.go
+++ b/common/yak/ssaapi/sfreport/risk.go
@@ -37,6 +37,8 @@ type Risk struct {
 
 	// rule
 	RuleName string `json:"rule_name"`
+	// 扫描模式: source (源码模式匹配/漏洞预检测) 或 ssa (SSA/深度静态分析)
+	ScanMode string `json:"scan_mode"`
 	// program
 	ProgramName string `json:"program_name"`
 	// 处置状态
@@ -75,6 +77,7 @@ func NewRisk(ssarisk *schema.SSARisk, r *Report, value ...*ssaapi.Value) (*Risk,
 		Line:          ssarisk.Line,
 
 		ProgramName:          ssarisk.ProgramName,
+		ScanMode:             ssarisk.ScanMode,
 		LatestDisposalStatus: ssarisk.LatestDisposalStatus,
 		RiskFeatureHash:      ssarisk.RiskFeatureHash,
 	}
@@ -123,6 +126,7 @@ func (r *Risk) SaveToDB(db *gorm.DB) (string, error) {
 		Tags:                "",
 		FromRule:            r.RuleName,
 		ProgramName:         r.ProgramName,
+		ScanMode:            r.ScanMode,
 		CodeSourceUrl:       r.CodeSourceURL,
 		CodeRange:           r.CodeRange,
 		CodeFragment:        r.CodeFragment,

--- a/common/yak/ssaapi/source_mode_value_test.go
+++ b/common/yak/ssaapi/source_mode_value_test.go
@@ -1,0 +1,75 @@
+package ssaapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfpattern"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+)
+
+// TestSimpleValueToSSAValue_FullFileAnchoring verifies that source-mode
+// pattern hits are anchored inside the FULL file editor, so risks carry the
+// real file path, line numbers and context — same as SSA-mode risks.
+func TestSimpleValueToSSAValue_FullFileAnchoring(t *testing.T) {
+	content := "package main\n\nconst key = \"AKIAIOSFODNN7EXAMPLE\"\n"
+	files := map[string]string{"src/main.go": content}
+
+	vals, err := sfpattern.MatchRegexp(files, "src/main.go", []string{`AKIA[0-9A-Z]{16}`})
+	require.NoError(t, err)
+	require.Len(t, vals, 1)
+
+	ssaVals := FromSFVMValues(vals)
+	require.Len(t, ssaVals, 1)
+	v := ssaVals[0]
+
+	r := v.GetRange()
+	require.NotNil(t, r, "hit value should carry a range")
+	ed := r.GetEditor()
+	require.NotNil(t, ed)
+	// the editor must hold the WHOLE file, not just the matched snippet
+	require.Equal(t, content, ed.GetSourceCode())
+	// the match is on line 3 of the file
+	require.Equal(t, 3, r.GetStart().GetLine())
+	require.Equal(t, 3, r.GetEnd().GetLine())
+	// the value text is exactly the matched fragment (const values render quoted)
+	require.Contains(t, v.String(), "AKIAIOSFODNN7EXAMPLE")
+	// range text equals the fragment inside the full file
+	text, err := ed.GetTextFromRangeWithError(r)
+	require.NoError(t, err)
+	require.Equal(t, "AKIAIOSFODNN7EXAMPLE", text)
+}
+
+// TestSimpleValueToSSAValue_FallbackSnippetEditor keeps the legacy fallback:
+// without a full-file editor the range covers the snippet only.
+func TestSimpleValueToSSAValue_FallbackSnippetEditor(t *testing.T) {
+	sv := sfvm.NewSimpleValue("AKIAIOSFODNN7EXAMPLE", "src/main.go", 0, 20)
+	v := simpleValueToSSAValue(sv)
+	r := v.GetRange()
+	require.NotNil(t, r)
+	require.NotNil(t, r.GetEditor())
+	require.Equal(t, "AKIAIOSFODNN7EXAMPLE", r.GetEditor().GetSourceCode())
+	require.Equal(t, 1, r.GetStart().GetLine())
+}
+
+// TestPatternHitEditorProgramName verifies PatternRoot propagates the program
+// name into hit editors so ir-source hashes align with compiled programs.
+func TestPatternHitEditorProgramName(t *testing.T) {
+	files := map[string]string{"src/a.env": "TOKEN=AKIAIOSFODNN7EXAMPLE\n"}
+	root := sfpattern.NewRoot(files)
+	root.SetProgramName("demo-proj")
+
+	vals, err := root.FileFilter("a.env", "regexp", nil, []string{`AKIA[0-9A-Z]{16}`})
+	require.NoError(t, err)
+	require.Len(t, vals, 1)
+
+	sv, ok := vals[0].(*sfvm.SimpleValue)
+	require.True(t, ok)
+	ed := sv.FileEditor()
+	require.NotNil(t, ed)
+	require.Equal(t, "demo-proj", ed.GetProgramName())
+	// URL follows the /programName/path convention
+	require.Equal(t, "/demo-proj/src/a.env", ed.GetUrl())
+	// ir-source hash is non-empty (program + path + content)
+	require.NotEmpty(t, ed.GetIrSourceHash())
+}

--- a/common/yak/ssaapi/source_query_target.go
+++ b/common/yak/ssaapi/source_query_target.go
@@ -5,8 +5,8 @@ import (
 	"github.com/yaklang/yaklang/common/syntaxflow/sfpattern"
 	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
 	"github.com/yaklang/yaklang/common/utils"
-	"github.com/yaklang/yaklang/common/utils/memedit"
 	fi "github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
+	"github.com/yaklang/yaklang/common/utils/memedit"
 	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
 )
 
@@ -67,7 +67,7 @@ func (t *SourceQueryTarget) SetLanguage(lang ssaconfig.Language) *SourceQueryTar
 
 func (t *SourceQueryTarget) IsIncrementalCompile() bool { return false }
 func (t *SourceQueryTarget) IsBaseProgram() bool        { return true }
-func (t *SourceQueryTarget) GetBaseProgramName() string  { return t.GetProgramName() }
+func (t *SourceQueryTarget) GetBaseProgramName() string { return t.GetProgramName() }
 func (t *SourceQueryTarget) Recompile(...ssaconfig.Option) error {
 	return nil
 }
@@ -92,6 +92,7 @@ func (t *SourceQueryTarget) syntaxFlow(opts []QueryOption, ruleOpt QueryOption) 
 		return nil, utils.Error("nil SourceQueryTarget")
 	}
 	root := sfpattern.NewRoot(t.files)
+	root.SetProgramName(t.name)
 	prog := NewTmpProgram(t.name)
 	all := make([]QueryOption, 0, len(opts)+3)
 	all = append(all, QueryWithValue(root), ruleOpt, QueryWithResultProgram(prog))

--- a/common/yak/syntaxflow_scan/source_scan_risk_file_test.go
+++ b/common/yak/syntaxflow_scan/source_scan_risk_file_test.go
@@ -1,0 +1,113 @@
+package syntaxflow_scan
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/ssaapi"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/sfreport"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// TestStartScan_SourceMode_RiskHasFileInfoAndScanMode verifies the legion
+// stream contract for source-mode (漏洞预检测) risks:
+//   - every risk carries scan_mode="source"
+//   - risks carry real file path / line numbers / code fragment context
+//   - the payload packs the FULL file content (ir-source) so the platform can
+//     store it in its irsource table and render the code workspace
+func TestStartScan_SourceMode_RiskHasFileInfoAndScanMode(t *testing.T) {
+	fileContent := "line-0\nAWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\nline-2\n"
+	files := map[string]string{
+		"src/config/leak.env": fileContent,
+	}
+
+	ruleContent := `
+desc(
+	mode: "source",
+	language: "general",
+	title: "aws akia test",
+	alert_min: 1,
+)
+${*}.pattern_regex(/AKIA[0-9A-Z]{16}/) as $hit
+alert $hit for {
+	level: "critical",
+	title: "AWS key",
+}
+`
+
+	var lastParts *sfreport.SSAResultParts
+	err := StartScan(context.Background(),
+		WithSourceFiles("src-proj", files),
+		ssaconfig.WithRuleInput(&ypb.SyntaxFlowRuleInput{
+			Content:  ruleContent,
+			Language: string(ssaconfig.General),
+		}),
+		WithScanResultCallback(func(r *ScanResult) {
+			if r == nil || r.Result == nil {
+				return
+			}
+			// same conversion EmitSSAResult uses for the ssa-stream payload
+			parts, perr := sfreport.ConvertSingleResultToSSAResultParts(
+				r.Result,
+				sfreport.NewStreamPartsOptions(
+					sfreport.WithStreamReportType(sfreport.IRifyFullReportType),
+					sfreport.WithStreamShowDataflowPath(true),
+					sfreport.WithStreamShowFileContent(true),
+					sfreport.WithStreamWithFile(true),
+				),
+			)
+			require.NoError(t, perr)
+			if parts != nil {
+				lastParts = parts
+			}
+		}),
+		ssaconfig.WithScanIgnoreLanguage(true),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, lastParts, "expected stream parts from source-mode scan")
+	require.NotEmpty(t, lastParts.Risks, "expected risks in stream parts")
+
+	// ---- risk assertions ----
+	var risk sfreport.Risk
+	found := false
+	for _, rp := range lastParts.Risks {
+		require.NoError(t, json.Unmarshal(rp.RiskJSON, &risk))
+		if strings.Contains(risk.CodeSourceURL, "leak.env") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected a risk anchored to src/config/leak.env")
+	require.Equal(t, "source", risk.ScanMode, "source-mode risk must be marked scan_mode=source")
+	require.Equal(t, int64(2), risk.Line, "risk line must be the real line in the file")
+	require.Equal(t, "/src-proj/src/config/leak.env", risk.CodeSourceURL)
+	require.Contains(t, risk.CodeFragment, "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE")
+
+	// code_range JSON carries the real start line too
+	var codeRange ssaapi.CodeRange
+	require.NoError(t, json.Unmarshal([]byte(risk.CodeRange), &codeRange))
+	require.Equal(t, int64(2), codeRange.StartLine)
+	require.Equal(t, int64(2), codeRange.EndLine)
+
+	// ---- file assertions: full content packed for the platform irsource ----
+	require.NotEmpty(t, lastParts.Files, "stream parts must pack files")
+	var file *sfreport.File
+	for _, f := range lastParts.Files {
+		if strings.HasSuffix(f.Path, "leak.env") {
+			file = f
+			break
+		}
+	}
+	require.NotNil(t, file, "expected file part for src/config/leak.env")
+	require.Equal(t, fileContent, file.Content, "file part must carry the FULL file content")
+	require.NotEmpty(t, file.IrSourceHash)
+
+	// risk ↔ file linkage via file hashes
+	riskPart := lastParts.Risks[0]
+	require.NotEmpty(t, riskPart.FileHashes, "risk must reference its file hash")
+	require.Contains(t, riskPart.FileHashes, file.IrSourceHash)
+}


### PR DESCRIPTION
## 概述

Source-mode（漏洞预检测）扫描的 risk 此前只携带匹配片段，没有文件路径/行号/上下文；且含多字节 UTF-8 的文件位置计算错位。本 PR 修复整条链路：

### 1. source-mode risk 锚定到完整文件（`01d77ad01`）
- `sfvm.SimpleValue` 携带整文件 editor；sfpattern 每个文件建共享 editor，hit 按字节偏移锚定
- `PatternRoot` 传播 programName，ir_source_hash 与编译产物对齐（平台侧可去重）
- `simpleValueToSSAValue` 在整文件上锚定 range → risk 带真实行号/CodeFragment/文件路径，ssa-stream 打包整文件内容
- `schema.SSARisk` 新增 `scan_mode` 列（source|ssa），sfreport risk_json 暴露，平台可标记 漏洞预检测 vs 深度静态分析

### 2. DB 持久化失败不丢流式 risk（`afc88fc40`）
- `SaveRisk` 在本地 SSA IR DB 写入失败时仍保留内存 riskMap，`EmitSSAResult` 流式上报不丢（平台从 stream 存自己的副本）

### 3. memedit 位置体系统一为字节语义（`1dab07818`）
- `recalculateLineMappings` 非 ASCII 内容按字节计数（原按 rune，导致含中文文件行列错位）
- 位置计算/文本提取/边界检查统一字节（`CodeByteLength`、`Select`、`GetTextFromOffset`、`GetLine`、`FindStringRange`/`FindRegexpRange` 等）
- 回归测试：minified 单行大列、多字节锚定、行映射字节偏移

## 平台配套

Legion 侧配套 PR：**VillanCh/legion#389**（分支 `feature/support/pattern-syntaxflow-rule`）

- source-scan 链式编排（预检测 → 编译 → 深度扫描）、规则快照同步、风险导入
- risk `scan_mode` 标记透传 + 前端徽标（漏洞预检测 / 深度静态分析）
- code_range JSON 解析修复 + 前端直接 JSON 高亮精确匹配范围
- 预检测产出 risk 视为整体成功，取消/失败后主卡片只显示已运行步骤，详情侧边栏展示完整进度

## 测试
- `common/utils/memedit`：全部通过（含新增多字节回归）
- `common/yak/ssaapi`、`common/yak/syntaxflow_scan`、`common/syntaxflow/...`：全部通过