### PR TITLE
fix(scannode): bound live debug query cost on long runs

### DIFF
--- a/scannode/debug_run_analyzer.go
+++ b/scannode/debug_run_analyzer.go
@@ -583,17 +583,29 @@ func (r *DebugRunAnalysis) collectSamples(dir, logContent string) []SampleSummar
 		if s.DBStats == nil {
 			s.DBStats = loadSampleDBStats(dir, s.Label)
 		}
-		// Log excerpt limited to 500 chars
-		if s.Label != "" {
-			if logData, err := os.ReadFile(filepath.Join(dir, "log")); err == nil {
-				s.LogExcerpt = extractLogExcerpt(string(logData), s.Label, 500)
-			} else if taskLog := resolveTaskLogByDebugDir(dir); taskLog != "" {
-				if logData, err := os.ReadFile(taskLog); err == nil {
-					s.LogExcerpt = extractLogExcerpt(string(logData), s.Label, 500)
-				}
+	}
+
+	// Convert to a stable slice for excerpt extraction and sorting.
+	summaries := make([]*SampleSummary, 0, len(labelMap))
+	for _, s := range labelMap {
+		summaries = append(summaries, s)
+	}
+
+	// Log excerpts: one shared pass over the log content (which can be
+	// hundreds of MB on long runs). Reading and re-splitting the log per
+	// sample allocated O(samples × log size) and OOM'd nodes on multi-hour
+	// debug runs.
+	excerptSource := logContent
+	if strings.TrimSpace(excerptSource) == "" {
+		if logData, err := os.ReadFile(filepath.Join(dir, "log")); err == nil {
+			excerptSource = string(logData)
+		} else if taskLog := resolveTaskLogByDebugDir(dir); taskLog != "" {
+			if logData, err := os.ReadFile(taskLog); err == nil {
+				excerptSource = string(logData)
 			}
 		}
 	}
+	sampleLogExcerpts(excerptSource, summaries, 500)
 
 	// Convert to sorted slice
 	result := make([]SampleSummary, 0, len(labelMap))
@@ -1243,6 +1255,80 @@ func extractLogExcerpt(logContent string, label string, maxLen int) string {
 	return excerpt
 }
 
+// sampleLogExcerpts extracts a bounded excerpt around each sample's
+// timestamp using a single pass over the log content. Sample labels and log
+// lines are both chronological, so one ascending scan replaces the previous
+// per-sample full read + strings.Split, which allocated O(samples × log size)
+// and OOM'd nodes on multi-hour debug runs.
+func sampleLogExcerpts(logContent string, summaries []*SampleSummary, maxLen int) {
+	if logContent == "" || len(summaries) == 0 || maxLen <= 0 {
+		return
+	}
+	type pendingExcerpt struct {
+		summary *SampleSummary
+		target  string
+	}
+	pending := make([]*pendingExcerpt, 0, len(summaries))
+	headOnly := make([]*SampleSummary, 0)
+	for _, s := range summaries {
+		ts := parseLabelTimestamp(s.Label)
+		if ts == nil || s.Timestamp == nil {
+			headOnly = append(headOnly, s)
+			continue
+		}
+		pending = append(pending, &pendingExcerpt{summary: s, target: ts.Format("2006/01/02 15:04:05")})
+	}
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].summary.Timestamp.Before(*pending[j].summary.Timestamp)
+	})
+
+	// strings.Split shares the underlying bytes, so this is cheap relative to
+	// the content size.
+	lines := strings.Split(logContent, "\n")
+	searchFrom := 0
+	pi := 0
+	for pi < len(pending) {
+		startIdx := -1
+		for i := searchFrom; i < len(lines); i++ {
+			if strings.Contains(lines[i], pending[pi].target) {
+				startIdx = i
+				break
+			}
+		}
+		if startIdx < 0 {
+			// The log ends before this sample's timestamp; remaining samples
+			// are chronologically later and cannot match either.
+			break
+		}
+		start := startIdx - 5
+		if start < 0 {
+			start = 0
+		}
+		end := startIdx + 15
+		if end > len(lines) {
+			end = len(lines)
+		}
+		pending[pi].summary.LogExcerpt = truncateString(strings.Join(lines[start:end], "\n"), maxLen)
+		searchFrom = startIdx + 1
+		pi++
+	}
+	// Samples whose timestamp was not found in the log fall back to the head
+	// of the log (matches the previous extractLogExcerpt behavior).
+	for ; pi < len(pending); pi++ {
+		pending[pi].summary.LogExcerpt = truncateString(logContent, maxLen)
+	}
+	for _, s := range headOnly {
+		s.LogExcerpt = truncateString(logContent, maxLen)
+	}
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
+}
+
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
@@ -1367,10 +1453,22 @@ func resolveNodeTaskLogFallback(firstFile string) string {
 	return ""
 }
 
+// taskLogMergeMarkerName tracks how much of the node task log has already
+// been folded into debugDir/log so repeated merges (live queries, finalize,
+// shutdown) append only new bytes instead of re-appending the whole log.
+const taskLogMergeMarkerName = "task.log.merge.json"
+
+type taskLogMergeState struct {
+	Offset int64 `json:"offset"`
+}
+
 // mergeTaskLogIntoDebugDir copies the node-side per-task log into
-// debugDir/log when that file is empty or absent, so the debug zip and
-// analysis contain the scan stdout/stderr even if the child profiler did
-// not redirect logs.
+// debugDir/log, appending incrementally, so the debug zip and analysis
+// contain the scan stdout/stderr even if the child profiler did not redirect
+// logs. The previous implementation re-read and re-appended the FULL task
+// log on every call: a console polling ssa.debug.query every few seconds
+// made debug/log grow without bound and kept the analysis cache
+// permanently stale.
 func mergeTaskLogIntoDebugDir(debugDir string) {
 	if debugDir == "" {
 		return
@@ -1379,19 +1477,61 @@ func mergeTaskLogIntoDebugDir(debugDir string) {
 	if taskLog == "" {
 		return
 	}
-	data, err := os.ReadFile(taskLog)
-	if err != nil || len(data) == 0 {
+	info, err := os.Stat(taskLog)
+	if err != nil || info.Size() <= 0 {
 		return
 	}
+	offset := int64(0)
+	if raw, err := os.ReadFile(filepath.Join(debugDir, taskLogMergeMarkerName)); err == nil {
+		var state taskLogMergeState
+		if json.Unmarshal(raw, &state) == nil && state.Offset > 0 {
+			offset = state.Offset
+		}
+	}
+	if offset > info.Size() {
+		// Task log was truncated or recreated since the last merge; start over.
+		offset = 0
+	}
+	if offset == info.Size() {
+		return // nothing new to fold in
+	}
+
+	file, err := os.Open(taskLog)
+	if err != nil {
+		return
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		file.Close()
+		return
+	}
+	newData, err := io.ReadAll(file)
+	file.Close()
+	if err != nil || len(newData) == 0 {
+		return
+	}
+
 	debugLog := filepath.Join(debugDir, "log")
-	if existing, err := os.ReadFile(debugLog); err == nil && len(existing) > 0 {
-		// Keep child collector content and append task log after a separator.
-		out := append(append(existing, '\n'), []byte("--- node task log ---\n")...)
-		out = append(out, data...)
-		_ = os.WriteFile(debugLog, out, 0o644)
+	out, err := os.OpenFile(debugLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
 		return
 	}
-	_ = os.WriteFile(debugLog, data, 0o644)
+	if offset == 0 {
+		if existing, err := out.Stat(); err == nil && existing.Size() > 0 {
+			// Keep child collector content and separate the task log.
+			if _, err := out.Write([]byte("\n--- node task log ---\n")); err != nil {
+				out.Close()
+				return
+			}
+		}
+	}
+	if _, err := out.Write(newData); err != nil {
+		out.Close()
+		return
+	}
+	out.Close()
+	if raw, err := json.Marshal(taskLogMergeState{Offset: info.Size()}); err == nil {
+		_ = os.WriteFile(filepath.Join(debugDir, taskLogMergeMarkerName), raw, 0o644)
+	}
 }
 
 // resolveTaskLogByDebugDir derives the node task log path from a debug run

--- a/scannode/debug_run_analyzer_test.go
+++ b/scannode/debug_run_analyzer_test.go
@@ -359,3 +359,80 @@ func TestAnalyzeDebugRun_EnrichesPhasesFromTaskLog(t *testing.T) {
 	assert.Equal(t, "compile", result.Samples[0].Phase)
 	assert.Equal(t, "log_inferred", result.Samples[0].PhaseSource)
 }
+
+func TestSampleLogExcerpts_SinglePass(t *testing.T) {
+	logContent := "2026/08/05 12:00:00 boot\n" +
+		"2026/08/05 12:00:29 warmup\n" +
+		"2026/08/05 12:00:30 sample-one context\n" +
+		"2026/08/05 12:05:00 middle\n" +
+		"2026/08/05 12:10:00 sample-two context\n" +
+		"2026/08/05 12:11:00 tail\n"
+
+	mk := func(label string) *SampleSummary {
+		return &SampleSummary{Label: label, Timestamp: parseLabelTimestamp(label)}
+	}
+	summaries := []*SampleSummary{
+		mk("20260805-121000-121000"), // 12:10:00
+		mk("20260805-120030-initial"), // 12:00:30 (deliberately out of order)
+		mk("not-a-timestamp"),         // unparseable → head fallback
+		mk("20260805-235900-late"),    // not in log → head fallback
+	}
+
+	sampleLogExcerpts(logContent, summaries, 500)
+
+	// Newest label first: the two-pointer scan must not let the later label
+	// steal the earlier one's match.
+	assert.Contains(t, summaries[1].LogExcerpt, "sample-one context")
+	assert.Contains(t, summaries[0].LogExcerpt, "sample-two context")
+	for _, s := range summaries {
+		assert.LessOrEqual(t, len(s.LogExcerpt), 500)
+		assert.NotEmpty(t, s.LogExcerpt)
+	}
+}
+
+func TestMergeTaskLogIntoDebugDir_IncrementalIdempotent(t *testing.T) {
+	root := t.TempDir()
+	debugDir := filepath.Join(root, "debug-runs", "debug", "task-abc_1234")
+	require.NoError(t, os.MkdirAll(debugDir, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "logs"), 0o755))
+
+	taskLog := filepath.Join(root, "logs", "task-abc_1234.log")
+	require.NoError(t, os.WriteFile(taskLog, []byte("line1\nline2\n"), 0o644))
+
+	// 1) first merge seeds the log with the task log
+	mergeTaskLogIntoDebugDir(debugDir)
+	first, err := os.ReadFile(filepath.Join(debugDir, "log"))
+	require.NoError(t, err)
+	assert.Equal(t, "line1\nline2\n", string(first))
+
+	// 2) merge again with no new task-log bytes: no change, no duplication
+	mergeTaskLogIntoDebugDir(debugDir)
+	same, err := os.ReadFile(filepath.Join(debugDir, "log"))
+	require.NoError(t, err)
+	assert.Equal(t, "line1\nline2\n", string(same))
+
+	// 3) task log grows: merge appends only the new tail
+	require.NoError(t, os.WriteFile(taskLog, []byte("line1\nline2\nline3\n"), 0o644))
+	mergeTaskLogIntoDebugDir(debugDir)
+	grown, err := os.ReadFile(filepath.Join(debugDir, "log"))
+	require.NoError(t, err)
+	assert.Equal(t, "line1\nline2\nline3\n", string(grown))
+
+	// 4) existing collector content gets the separator on the first merge
+	root2 := t.TempDir()
+	debugDir2 := filepath.Join(root2, "debug-runs", "debug", "task-def_5678")
+	require.NoError(t, os.MkdirAll(debugDir2, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root2, "logs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(debugDir2, "log"), []byte("collector out\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root2, "logs", "task-def_5678.log"), []byte("task log\n"), 0o644))
+	mergeTaskLogIntoDebugDir(debugDir2)
+	merged, err := os.ReadFile(filepath.Join(debugDir2, "log"))
+	require.NoError(t, err)
+	assert.Equal(t, "collector out\n\n--- node task log ---\ntask log\n", string(merged))
+
+	// 5) repeated finalize merges must not re-append the task log
+	mergeTaskLogIntoDebugDir(debugDir2)
+	mergedAgain, err := os.ReadFile(filepath.Join(debugDir2, "log"))
+	require.NoError(t, err)
+	assert.Equal(t, "collector out\n\n--- node task log ---\ntask log\n", string(mergedAgain))
+}

--- a/scannode/ssa_debug_query.go
+++ b/scannode/ssa_debug_query.go
@@ -131,21 +131,50 @@ func (b *legionJobBridge) handleSSADebugQuery(ctx context.Context, raw []byte) e
 		return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
 	}
 
-	// Fold the node task log into debug/log before cache/analysis so live
-	// queries see SSA phase markers (compile/scan) while the run is in progress.
-	mergeTaskLogIntoDebugDir(dir)
+	// NOTE: the live path deliberately does not fold the task log into
+	// debug/log on every query any more. The analysis folds it in memory when
+	// phase detection needs it (enrichLogWithTaskLog), and finalizeDebugRun
+	// keeps merging incrementally for the zip. Merging per query made
+	// debug/log grow without bound and kept the analysis cache stale forever.
 
-	// Serve the cached analysis when it is newer than every pprof/log input,
-	// so repeated queries do not re-parse large profiles. Always overlay the
+	// Serve the cached analysis when it is newer than every pprof input, so
+	// repeated queries do not re-parse large profiles. Always overlay the
 	// Legion task status so a stale "failed" badge from log heuristics cannot
 	// stick while the attempt is still running.
 	if cached, ok := readCachedDebugAnalysis(dir); ok && cachedAnalysisHasPhases(cached) {
 		response.Found = true
-		response.Analysis = overlayDebugAnalysisStatus(cached, payload.TaskStatus)
+		response.Analysis = capLiveDebugAnalysis(overlayDebugAnalysisStatus(cached, payload.TaskStatus), debugLiveResponseMaxBytes)
 		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=true (cached) dir=%s", payload.JobID, payload.AttemptID, dir)
 		return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
 	}
 
+	// A full analysis parses every pprof snapshot and can take minutes on
+	// long runs. Debounce + single-flight keep repeated console polls from
+	// piling up concurrent analyses, which OOM'd a node during an 18-hour
+	// debug run: after the first full pass, later polls are served from the
+	// (possibly slightly stale) cache until the cooldown elapses.
+	if last, ok := debugLiveAnalyzeFinished.Load(dir); ok {
+		if finished, _ := last.(time.Time); time.Since(finished) < debugLiveAnalysisMinInterval {
+			if stale, ok := readCachedDebugAnalysisAny(dir); ok {
+				response.Found = true
+				response.Analysis = capLiveDebugAnalysis(overlayDebugAnalysisStatus(stale, payload.TaskStatus), debugLiveResponseMaxBytes)
+			} else {
+				response.Reason = "debug analysis in progress"
+			}
+			return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
+		}
+	}
+
+	debugLiveAnalyzeMu.Lock()
+	// Double-check: a query that waited on the lock can serve the cache the
+	// winner just refreshed instead of analyzing again.
+	if cached, ok := readCachedDebugAnalysis(dir); ok && cachedAnalysisHasPhases(cached) {
+		debugLiveAnalyzeMu.Unlock()
+		response.Found = true
+		response.Analysis = capLiveDebugAnalysis(overlayDebugAnalysisStatus(cached, payload.TaskStatus), debugLiveResponseMaxBytes)
+		log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=true (cached after wait) dir=%s", payload.JobID, payload.AttemptID, dir)
+		return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
+	}
 	analysis := AnalyzeDebugRunWithStatus(dir, payload.TaskStatus)
 	hasContent := len(analysis.Samples) > 0 || analysis.Summary != nil ||
 		analysis.StartedAt != nil || strings.TrimSpace(analysis.Status) != ""
@@ -154,14 +183,17 @@ func (b *legionJobBridge) handleSSADebugQuery(ctx context.Context, raw []byte) e
 	} else {
 		analysisJSON, err := json.Marshal(analysis)
 		if err != nil {
+			debugLiveAnalyzeMu.Unlock()
 			return fmt.Errorf("marshal ssa debug analysis: %w", err)
 		}
 		if err := writeCachedDebugAnalysis(dir, analysisJSON); err != nil {
 			log.Warnf("[debug] cache analysis json failed: %v", err)
 		}
 		response.Found = true
-		response.Analysis = analysisJSON
+		response.Analysis = capLiveDebugAnalysis(analysisJSON, debugLiveResponseMaxBytes)
 	}
+	debugLiveAnalyzeFinished.Store(dir, time.Now())
+	debugLiveAnalyzeMu.Unlock()
 	log.Infof("[debug] ssa.debug.query answered: job=%s attempt=%s found=%v samples=%d dir=%s",
 		payload.JobID, payload.AttemptID, response.Found, len(analysis.Samples), dir)
 	return b.publishDebugQueryResponse(ctx, payload.QueryID, response)
@@ -203,7 +235,7 @@ func writeCachedDebugAnalysis(dir string, analysisJSON []byte) error {
 }
 
 // readCachedDebugAnalysis returns the cached analysis JSON when it is at least
-// as new as every profile/log input file of the debug run.
+// as new as every profile input file of the debug run.
 func readCachedDebugAnalysis(dir string) (json.RawMessage, bool) {
 	cachePath := filepath.Join(dir, debugAnalysisCacheName)
 	cacheInfo, err := os.Stat(cachePath)
@@ -211,7 +243,12 @@ func readCachedDebugAnalysis(dir string) (json.RawMessage, bool) {
 		return nil, false
 	}
 	newestInput := time.Time{}
-	inputs := []string{"cpu-pprof", "memory-pprof", "goroutine-pprof", "log"}
+	// "log" is intentionally NOT an invalidation input: the engine keeps
+	// appending to the log for the whole run, which used to invalidate the
+	// cache on every query and forced a full re-parse of every profile per
+	// poll. New pprof snapshots (the meaningful new inputs) still invalidate
+	// it, and phase/status are refreshed via the task-status overlay.
+	inputs := []string{"cpu-pprof", "memory-pprof", "goroutine-pprof"}
 	for _, name := range inputs {
 		path := filepath.Join(dir, name)
 		info, err := os.Stat(path)
@@ -248,6 +285,17 @@ func readCachedDebugAnalysis(dir string) (json.RawMessage, bool) {
 	return json.RawMessage(data), true
 }
 
+// readCachedDebugAnalysisAny reads the cached analysis regardless of input
+// freshness. Used as the fallback while a fresh analysis is debounced or
+// still running in another query.
+func readCachedDebugAnalysisAny(dir string) (json.RawMessage, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, debugAnalysisCacheName))
+	if err != nil || len(data) == 0 {
+		return nil, false
+	}
+	return json.RawMessage(data), true
+}
+
 func cachedAnalysisHasPhases(raw json.RawMessage) bool {
 	var payload struct {
 		Phases []struct {
@@ -273,6 +321,97 @@ func cachedAnalysisHasPhases(raw json.RawMessage) bool {
 		}
 	}
 	return false
+}
+
+const (
+	// debugLiveAnalysisMinInterval debounces full debug-directory analyses:
+	// new pprof snapshots land every ~5 minutes, so re-analyzing more often
+	// than this only burns CPU/memory on identical inputs.
+	debugLiveAnalysisMinInterval = 45 * time.Second
+)
+
+var (
+	// debugLiveAnalyzeMu serializes full debug-directory analyses node-wide.
+	debugLiveAnalyzeMu sync.Mutex
+	// debugLiveAnalyzeFinished tracks when the last full analysis finished,
+	// keyed by debug dir, so repeated queries are served from cache.
+	debugLiveAnalyzeFinished sync.Map
+)
+
+const (
+	// debugLiveResponseMaxBytes keeps the ssa.debug.query reply under the
+	// NATS max payload (~1MB). Long runs produce hundreds of samples with
+	// inline top lists and folded stacks (~30KB per sample); the full
+	// analysis stays in analysis.cache.json and is uploaded as an artifact
+	// at finalize.
+	debugLiveResponseMaxBytes = 900 * 1024
+
+	// liveAnalysisDetailedSamples keeps this many of the newest samples with
+	// their full inline details; older samples are reduced to light rows
+	// (and dropped entirely if the reply still does not fit).
+	liveAnalysisDetailedSamples = 24
+)
+
+// liveAnalysisHeavySampleFields are the per-sample inline fields that
+// dominate the analysis JSON size (folded stacks are ~2/3 of a sample).
+var liveAnalysisHeavySampleFields = []string{
+	"cpu_stacks", "cpu_stacks_yaklang", "heap_stacks", "heap_stacks_yaklang",
+	"cpu_top", "cpu_top_yaklang", "heap_top", "heap_top_yaklang",
+}
+
+// capLiveDebugAnalysis shrinks an analysis JSON to fit the live-query reply
+// budget without touching the on-disk cache. A 200+ sample run serializes to
+// several MB, which NATS drops (>1MB max payload), so the console never saw
+// more than the earliest samples. The full analysis remains available in
+// analysis.cache.json and in the finalized debug artifacts.
+func capLiveDebugAnalysis(raw json.RawMessage, maxBytes int) json.RawMessage {
+	if len(raw) <= maxBytes {
+		return raw
+	}
+	var payload struct {
+		Status     string           `json:"status,omitempty"`
+		StartedAt  *string          `json:"started_at,omitempty"`
+		FinishedAt *string          `json:"finished_at,omitempty"`
+		Duration   string           `json:"duration,omitempty"`
+		Phases     json.RawMessage  `json:"phases,omitempty"`
+		Samples    []map[string]any `json:"samples,omitempty"`
+		Summary    json.RawMessage  `json:"summary,omitempty"`
+		Errors     []string         `json:"errors,omitempty"`
+		Partial    bool             `json:"partial,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return raw
+	}
+	marshal := func() []byte {
+		out, err := json.Marshal(payload)
+		if err != nil {
+			return nil
+		}
+		return out
+	}
+	// 1) Keep the newest samples detailed; strip heavy inline fields from
+	// older ones so the sample list itself survives.
+	if n := len(payload.Samples); n > liveAnalysisDetailedSamples {
+		for i := 0; i < n-liveAnalysisDetailedSamples; i++ {
+			for _, field := range liveAnalysisHeavySampleFields {
+				delete(payload.Samples[i], field)
+			}
+		}
+	}
+	if out := marshal(); out != nil && len(out) <= maxBytes {
+		return out
+	}
+	// 2) Drop the oldest sample rows until it fits (keep at least one).
+	for len(payload.Samples) > 1 {
+		payload.Samples = payload.Samples[1:]
+		if out := marshal(); out != nil && len(out) <= maxBytes {
+			return out
+		}
+	}
+	if out := marshal(); out != nil {
+		return out
+	}
+	return raw
 }
 
 func (b *legionJobBridge) publishDebugQueryResponse(ctx context.Context, queryID string, response ssaDebugQueryResponse) error {

--- a/scannode/ssa_debug_query_cache_test.go
+++ b/scannode/ssa_debug_query_cache_test.go
@@ -1,10 +1,16 @@
 package scannode
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadCachedDebugAnalysisUsesFreshCache(t *testing.T) {
@@ -28,10 +34,14 @@ func TestReadCachedDebugAnalysisUsesFreshCache(t *testing.T) {
 	}
 }
 
-func TestReadCachedDebugAnalysisRejectsStaleCache(t *testing.T) {
+func TestReadCachedDebugAnalysisRejectsStaleCacheOnNewProfile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	profiles := filepath.Join(dir, "cpu-pprof")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
 	cachePath := filepath.Join(dir, debugAnalysisCacheName)
 	if err := os.WriteFile(cachePath, []byte(`{"status":"old"}`), 0o644); err != nil {
 		t.Fatalf("write cache: %v", err)
@@ -40,11 +50,123 @@ func TestReadCachedDebugAnalysisRejectsStaleCache(t *testing.T) {
 	if err := os.Chtimes(cachePath, old, old); err != nil {
 		t.Fatalf("chtimes cache: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "log"), []byte("newer\n"), 0o644); err != nil {
-		t.Fatalf("write log: %v", err)
+	if err := os.WriteFile(filepath.Join(profiles, "20260101-120000-x.cpu.prof"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
 	}
 
 	if _, ok := readCachedDebugAnalysis(dir); ok {
-		t.Fatal("expected stale cache miss")
+		t.Fatal("expected stale cache miss when a newer profile exists")
 	}
+}
+
+// The engine keeps appending to debug/log for the whole run; the log must
+// NOT invalidate the analysis cache, otherwise every console poll forces a
+// full re-parse of every profile (which OOM'd nodes on long debug runs).
+func TestReadCachedDebugAnalysisIgnoresLogGrowth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	profiles := filepath.Join(dir, "cpu-pprof")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	profile := filepath.Join(profiles, "20260101-120000-x.cpu.prof")
+	if err := os.WriteFile(profile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(profile, old, old); err != nil {
+		t.Fatalf("chtimes profile: %v", err)
+	}
+	want := []byte(`{"status":"running","samples":[]}`)
+	if err := writeCachedDebugAnalysis(dir, want); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "log"), []byte("newer log line\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	got, ok := readCachedDebugAnalysis(dir)
+	if !ok {
+		t.Fatal("expected cache hit even though the log is newer")
+	}
+	if string(got) != string(want) {
+		t.Fatalf("cached analysis = %s, want %s", got, want)
+	}
+}
+
+// capTestSample builds one analysis sample whose inline stack payload weighs
+// about stackKB kilobytes.
+func capTestSample(sequence int, stackKB int) map[string]any {
+	frame := strings.Repeat("F", stackKB*1024)
+	return map[string]any{
+		"sequence":   sequence,
+		"label":      fmt.Sprintf("20260101-12%02d00-x", sequence%60),
+		"phase":      "scan",
+		"runtime":    map[string]any{"goroutines": 42},
+		"cpu_stacks": []map[string]any{{"frames": []string{frame}, "value": 1}},
+		"cpu_top":    []map[string]any{{"name": "pkg.fn", "cum_value": 1}},
+	}
+}
+
+func TestCapLiveDebugAnalysisStripsOldSamples(t *testing.T) {
+	samples := make([]map[string]any, 0, 40)
+	for i := 0; i < 40; i++ {
+		samples = append(samples, capTestSample(i, 25)) // 40 × ~25KB > 900KB
+	}
+	raw, err := json.Marshal(map[string]any{
+		"status":  "running",
+		"phases":  []map[string]any{{"phase": "scan", "status": "running"}},
+		"samples": samples,
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 900*1024)
+
+	capped := capLiveDebugAnalysis(raw, 900*1024)
+	assert.LessOrEqual(t, len(capped), 900*1024)
+
+	var payload struct {
+		Status  string           `json:"status"`
+		Samples []map[string]any `json:"samples"`
+	}
+	require.NoError(t, json.Unmarshal(capped, &payload))
+	assert.Equal(t, "running", payload.Status)
+	// The sample LIST survives; only the heavy inline details are trimmed.
+	assert.Len(t, payload.Samples, 40)
+	// Newest samples keep their stacks, the oldest lose them.
+	assert.NotEmpty(t, payload.Samples[len(payload.Samples)-1]["cpu_stacks"])
+	assert.Empty(t, payload.Samples[0]["cpu_stacks"])
+	assert.NotEmpty(t, payload.Samples[0]["label"])
+}
+
+func TestCapLiveDebugAnalysisDropsRowsWhenStillTooBig(t *testing.T) {
+	// One sample with a giant non-strippable field: the only way under the
+	// budget is dropping rows down to the last one (best effort).
+	samples := make([]map[string]any, 0, 30)
+	for i := 0; i < 30; i++ {
+		samples = append(samples, map[string]any{
+			"sequence": i,
+			"label":    fmt.Sprintf("20260101-1200%02d-x", i),
+		})
+	}
+	raw, err := json.Marshal(map[string]any{
+		"status": "running",
+		"phases": []map[string]any{{"phase": strings.Repeat("P", 2*1024*1024)}},
+		"samples": samples,
+	})
+	require.NoError(t, err)
+
+	capped := capLiveDebugAnalysis(raw, 900*1024)
+	var payload struct {
+		Samples []map[string]any `json:"samples"`
+	}
+	require.NoError(t, json.Unmarshal(capped, &payload))
+	assert.Less(t, len(payload.Samples), 30, "oldest sample rows must be dropped")
+	assert.NotEmpty(t, payload.Samples, "at least one sample row must survive")
+}
+
+func TestCapLiveDebugAnalysisKeepsSmallPayloadUntouched(t *testing.T) {
+	raw := json.RawMessage(`{"status":"running","samples":[{"sequence":1,"label":"a"}]}`)
+	capped := capLiveDebugAnalysis(raw, 900*1024)
+	assert.Equal(t, string(raw), string(capped))
 }


### PR DESCRIPTION
## 问题

长时 debug 扫描（实测 18 小时）期间，控制台的 `ssa.debug.query` 轮询触发三重放大：

1. `collectSamples` 对**每个采样**都全量读入并 `strings.Split` 任务日志（实测 332MB）——217 个采样 ≈ 每次 ~72GB 瞬时分配
2. `mergeTaskLogIntoDebugDir` 每次查询把**整个任务日志**重新 append 进 `debug/log`——文件无限膨胀，且 log mtime 永远最新导致分析缓存永久失效
3. 分析 JSON（217 采样 ≈ 6MB）超出 NATS ~1MB max payload，发布永远失败——控制台只能显示最早一次成功的响应（只有 1 个采样）

节点进程（容器内、宿主 ps 不可见）被并发分析打到 OOM，连带 attempt heartbeat 停止。

## 修复

- `collectSamples`：日志摘要改为单次读入 + 单遍两指针扫描（样本与日志行均时间有序）
- `mergeTaskLogIntoDebugDir`：按 offset marker 增量 append，幂等，不再无限膨胀
- `ssa.debug.query`：去掉每查询的文件合并（分析路径已在内存中 enrich）；分析缓存失效不再看 log；45s 防抖 + 单飞行串行化全量分析
- live 响应裁剪 ≤900KB：最新 24 个采样保留完整 tops/stacks，更老样本降为轻量行；完整分析保留在 `analysis.cache.json` 与 finalize artifacts

## 关联（互相引用）

平台侧配套修复（live 查询 15s 冷却限流 + 前端 terminal 停止轮询）：VillanCh/legion#409

## 测试

- `go test ./scannode/` 全套通过
- 新增回归：`TestSampleLogExcerpts_SinglePass`、`TestMergeTaskLogIntoDebugDir_IncrementalIdempotent`、`TestCapLiveDebugAnalysis{StripsOldSamples,DropsRowsWhenStillTooBig,KeepsSmallPayloadUntouched}`、`TestReadCachedDebugAnalysisIgnoresLogGrowth`