### PR TITLE
feat(aispec): add responses API format support for thinking param bui…

### DIFF
--- a/common/ai/aispec/thinking_extra_body.go
+++ b/common/ai/aispec/thinking_extra_body.go
@@ -193,9 +193,16 @@ func buildQwenParams(ctx ThinkingParamsContext) map[string]any {
 }
 
 // buildKimiParams — Kimi / Moonshot
-// K3: {"reasoning_effort": level}
-// K2.x: {"thinking":{"type":"enabled","keep":"all"}} / {"thinking":{"type":"disabled"}}
+// Responses: {"reasoning":{"effort": level}}
+// Chat Completions K3: {"reasoning_effort": level}
+// Chat Completions K2.x: {"thinking":{"type":"enabled","keep":"all"}} / {"thinking":{"type":"disabled"}}
 func buildKimiParams(ctx ThinkingParamsContext) map[string]any {
+	if ctx.APIType == "responses" {
+		if ctx.Level == "" {
+			return nil
+		}
+		return map[string]any{"reasoning": map[string]any{"effort": ctx.Level}}
+	}
 	if strings.Contains(ctx.Model, "k3") {
 		// K3 用 reasoning_effort
 		if ctx.Level == "" {
@@ -241,12 +248,23 @@ func buildAnthropicParams(ctx ThinkingParamsContext) map[string]any {
 }
 
 // buildFamilyParams — volcengine / chatglm / siliconflow / doubao / glm
-// 通用 thinking.type 开关控制。
+// Responses: {"reasoning":{"effort": level}}
+// Chat Completions: 通用 thinking.type 开关 + reasoning_effort 等级控制。
 func buildFamilyParams(ctx ThinkingParamsContext) map[string]any {
+	if ctx.APIType == "responses" {
+		if ctx.Level == "" || ctx.Level == "none" {
+			return nil
+		}
+		return map[string]any{"reasoning": map[string]any{"effort": ctx.Level}}
+	}
+	// Chat Completions
 	if ctx.Level == "" || ctx.Level == "none" {
 		return map[string]any{"thinking": map[string]any{"type": "disabled"}}
 	}
-	return map[string]any{"thinking": map[string]any{"type": "enabled"}}
+	return map[string]any{
+		"thinking":         map[string]any{"type": "enabled"},
+		"reasoning_effort": ctx.Level,
+	}
 }
 
 // buildMiniMaxParams — MiniMax（稀宇科技直供）
@@ -259,14 +277,25 @@ func buildMiniMaxParams(ctx ThinkingParamsContext) map[string]any {
 }
 
 // buildDefaultParams — 未知 provider 的 fallback
+// Responses: {"reasoning":{"effort": level}}
+// Chat Completions: thinking.type 开关 + reasoning_effort
 func buildDefaultParams(ctx ThinkingParamsContext) map[string]any {
+	if ctx.APIType == "responses" {
+		if ctx.Level == "" || ctx.Level == "none" {
+			return nil
+		}
+		return map[string]any{"reasoning": map[string]any{"effort": ctx.Level}}
+	}
 	if ctx.Level == "none" {
 		return map[string]any{"thinking": map[string]any{"type": "disabled"}}
 	}
 	if ctx.Level == "" {
 		return nil
 	}
-	return map[string]any{"thinking": map[string]any{"type": "enabled"}}
+	return map[string]any{
+		"thinking":         map[string]any{"type": "enabled"},
+		"reasoning_effort": ctx.Level,
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/common/ai/aispec/thinking_extra_body_test.go
+++ b/common/ai/aispec/thinking_extra_body_test.go
@@ -290,6 +290,36 @@ func TestThinkingExtraBodyForProvider_KimiK2Keep(t *testing.T) {
 	assert.Equal(t, "all", inner["keep"])
 }
 
+func TestThinkingExtraBodyForProvider_KimiResponses(t *testing.T) {
+	// K3 Responses: reasoning.effort
+	m := ThinkingExtraBodyForProvider("moonshot", "kimi-k3", "", "", "responses", "high")
+	inner, ok := m["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "high", inner["effort"])
+	_, hasThinking := m["thinking"]
+	assert.False(t, hasThinking, "K3 Responses 不应注入 thinking 开关")
+	_, hasEffort := m["reasoning_effort"]
+	assert.False(t, hasEffort, "Responses 模式不应注入顶层 reasoning_effort")
+
+	// K2.x Responses: reasoning.effort（不使用 thinking.type 开关）
+	m = ThinkingExtraBodyForProvider("moonshot", "kimi-k2.6", "", "", "responses", "medium")
+	inner, ok = m["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "medium", inner["effort"])
+	_, hasThinking = m["thinking"]
+	assert.False(t, hasThinking, "K2 Responses 不应注入 thinking 开关")
+
+	// Kimi Responses none
+	m = ThinkingExtraBodyForProvider("moonshot", "kimi-k3", "", "", "responses", "none")
+	inner, ok = m["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "none", inner["effort"])
+
+	// Kimi Responses auto → 不注入
+	m = ThinkingExtraBodyForProvider("moonshot", "kimi-k3", "", "", "responses", "")
+	assert.Nil(t, m)
+}
+
 // ===========================================================================
 // MiniMax
 // ===========================================================================
@@ -310,6 +340,23 @@ func TestThinkingExtraBodyForProvider_MiniMaxUnderTongyi(t *testing.T) {
 	assert.Equal(t, "adaptive", innerOn["type"])
 }
 
+func TestThinkingExtraBodyForProvider_MiniMaxResponsesStaysUnique(t *testing.T) {
+	// MiniMax 在 Responses 模式下仍使用独特的 thinking.type，而非 reasoning.effort
+	m := ThinkingExtraBodyForProvider("tongyi", "MiniMax/MiniMax-M3", "", "", "responses", "high")
+	inner, ok := m["thinking"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "adaptive", inner["type"])
+	_, hasReasoning := m["reasoning"]
+	assert.False(t, hasReasoning, "MiniMax Responses 不应注入 reasoning.effort")
+
+	m = ThinkingExtraBodyForProvider("tongyi", "MiniMax/MiniMax-M3", "", "", "responses", "none")
+	inner, ok = m["thinking"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "disabled", inner["type"])
+	_, hasReasoning = m["reasoning"]
+	assert.False(t, hasReasoning, "MiniMax Responses none 不应注入 reasoning.effort")
+}
+
 // ===========================================================================
 // 通用 / fallback
 // ===========================================================================
@@ -326,6 +373,31 @@ func TestThinkingExtraBodyForProvider_Default(t *testing.T) {
 	assert.Equal(t, "disabled", inner2["type"])
 }
 
+func TestThinkingExtraBodyForProvider_DefaultResponses(t *testing.T) {
+	// Default Responses: reasoning.effort
+	m := ThinkingExtraBodyForProvider("", "unknown-model-xyz", "https://unknown.example", "", "responses", "high")
+	inner, ok := m["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "high", inner["effort"])
+	_, hasThinking := m["thinking"]
+	assert.False(t, hasThinking, "Default Responses 不应注入 thinking 开关")
+
+	// Default Responses none → 不注入
+	m = ThinkingExtraBodyForProvider("", "unknown-model-xyz", "https://unknown.example", "", "responses", "none")
+	assert.Nil(t, m, "Default Responses none 不应注入任何参数")
+
+	// Default Responses auto → 不注入
+	m = ThinkingExtraBodyForProvider("", "unknown-model-xyz", "https://unknown.example", "", "responses", "")
+	assert.Nil(t, m)
+
+	// Default Chat Completions 仍使用 thinking.type + reasoning_effort
+	m = ThinkingExtraBodyForProvider("", "unknown-model-xyz", "https://unknown.example", "", "chat_completions", "high")
+	inner, ok = m["thinking"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "enabled", inner["type"])
+	assert.Equal(t, "high", m["reasoning_effort"])
+}
+
 func TestThinkingExtraBodyForProvider_TypeBeforeHost(t *testing.T) {
 	// tongyi 厂商名优先：无 dashscope 域名也应走 Qwen 的 enable_thinking
 	m := ThinkingExtraBodyForProvider("tongyi", "foo", "https://proxy.example/v1", "", "", "low")
@@ -338,6 +410,39 @@ func TestThinkingExtraBodyForProvider_VolcengineTypeUsesThinkingMap(t *testing.T
 	inner, ok := m["thinking"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "enabled", inner["type"])
+}
+
+func TestThinkingExtraBodyForProvider_FamilyResponses(t *testing.T) {
+	// volcengine Responses: reasoning.effort
+	m := ThinkingExtraBodyForProvider("volcengine", "doubao-v2", "", "", "responses", "high")
+	inner, ok := m["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "high", inner["effort"])
+	_, hasThinking := m["thinking"]
+	assert.False(t, hasThinking, "Family Responses 不应注入 thinking 开关")
+	_, hasEffort := m["reasoning_effort"]
+	assert.False(t, hasEffort, "Responses 模式不应注入顶层 reasoning_effort")
+
+	// chatglm Responses
+	m = ThinkingExtraBodyForProvider("chatglm", "glm-4", "", "", "responses", "medium")
+	inner, ok = m["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "medium", inner["effort"])
+
+	// siliconflow Responses none
+	m = ThinkingExtraBodyForProvider("siliconflow", "glm-4", "", "", "responses", "none")
+	assert.Nil(t, m, "Family Responses none 不应注入任何参数")
+
+	// Family Responses auto → 不注入
+	m = ThinkingExtraBodyForProvider("volcengine", "doubao-v2", "", "", "responses", "")
+	assert.Nil(t, m)
+
+	// Family Chat Completions 仍使用 thinking.type + reasoning_effort
+	m = ThinkingExtraBodyForProvider("volcengine", "doubao-v2", "", "", "chat_completions", "high")
+	inner, ok = m["thinking"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "enabled", inner["type"])
+	assert.Equal(t, "high", m["reasoning_effort"])
 }
 
 func TestThinkingExtraBodyForProvider_OpenAITypeBeforeModel(t *testing.T) {


### PR DESCRIPTION
…lders

为 buildFamilyParams / buildKimiParams / buildDefaultParams 补充 Responses API 格式（reasoning.effort）支持，MiniMax 保持其独特的 thinking.type 格式不变。 新增对应单元测试覆盖所有 builder 的 responses 路径。