### PR TITLE
feat(ssa): 导出由 YAML 定义的标准规则组分类契约

### DIFF
--- a/common/syntaxflow/sfdb/rule_export.go
+++ b/common/syntaxflow/sfdb/rule_export.go
@@ -6,12 +6,13 @@ import (
 	"io"
 	"os"
 
-	"github.com/yaklang/gorm"
 	"github.com/samber/lo"
 	"github.com/tidwall/sjson"
+	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/bizhelper"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
 )
 
 // =============================================================================
@@ -103,6 +104,7 @@ func ExportRulesToZip(ctx context.Context, db *gorm.DB, targetPath string, opts 
 			"group_names": groupNames,
 		}
 	})
+	metadata["rule_group_taxonomy"] = ssaconfig.GetRuleGroupTaxonomy()
 
 	// 获取规则数量
 	var ruleCount int

--- a/common/syntaxflow/sfdb/rule_export_taxonomy_test.go
+++ b/common/syntaxflow/sfdb/rule_export_taxonomy_test.go
@@ -26,9 +26,13 @@ func TestRuleExportEmbedsTaxonomyAndRemainsImportCompatible(t *testing.T) {
 		Content:  `desc(title: "taxonomy") alert $result`,
 	}
 	require.NoError(t, db.Create(rule).Error)
-	group := &schema.SyntaxFlowGroup{GroupName: "java"}
-	require.NoError(t, db.Create(group).Error)
-	require.NoError(t, db.Model(rule).Association("Groups").Append(group).Error)
+	standardGroups := append(ssaconfig.GetAllSupportedLanguages(), ssaconfig.General.String(), "go", "javascript")
+	rawGroups := append(append([]string(nil), standardGroups...), "user-defined-group")
+	for _, name := range rawGroups {
+		group := &schema.SyntaxFlowGroup{GroupName: name}
+		require.NoError(t, db.Create(group).Error)
+		require.NoError(t, db.Model(rule).Association("Groups").Append(group).Error)
+	}
 
 	archive, result, err := ExportRulesToBytes(context.Background(), db)
 	require.NoError(t, err)
@@ -37,13 +41,18 @@ func TestRuleExportEmbedsTaxonomyAndRemainsImportCompatible(t *testing.T) {
 	metadata := readRuleExportMetadata(t, archive)
 	require.Equal(t, ssaconfig.RuleGroupTaxonomySchemaVersion, metadata.RuleGroupTaxonomy.SchemaVersion)
 	require.NotEmpty(t, metadata.RuleGroupTaxonomy.Categories)
-	taxonomyGroupCount := 0
+	taxonomyNames := make(map[string]bool)
 	for _, category := range metadata.RuleGroupTaxonomy.Categories {
-		taxonomyGroupCount += len(category.Groups)
+		for _, group := range category.Groups {
+			taxonomyNames[group.Name] = true
+		}
 	}
-	require.Equal(t, 36, taxonomyGroupCount)
+	for _, name := range standardGroups {
+		require.True(t, taxonomyNames[name], "exported raw group %q must have exact taxonomy metadata", name)
+	}
+	require.False(t, taxonomyNames["user-defined-group"], "custom groups must not become standard taxonomy")
 	require.Equal(t, "taxonomy-rule-id", metadata.Relationship[0].RuleID)
-	require.Equal(t, []string{"java"}, metadata.Relationship[0].GroupNames)
+	require.ElementsMatch(t, rawGroups, metadata.Relationship[0].GroupNames)
 
 	importDB, err := utils.CreateTempTestDatabaseInMemory()
 	require.NoError(t, err)
@@ -54,8 +63,11 @@ func TestRuleExportEmbedsTaxonomyAndRemainsImportCompatible(t *testing.T) {
 
 	var imported schema.SyntaxFlowRule
 	require.NoError(t, importDB.Preload("Groups").Where("rule_id = ?", rule.RuleId).First(&imported).Error)
-	require.Len(t, imported.Groups, 1)
-	require.Equal(t, "java", imported.Groups[0].GroupName)
+	var importedGroupNames []string
+	for _, group := range imported.Groups {
+		importedGroupNames = append(importedGroupNames, group.GroupName)
+	}
+	require.ElementsMatch(t, rawGroups, importedGroupNames)
 }
 
 type ruleExportMetadata struct {

--- a/common/syntaxflow/sfdb/rule_export_taxonomy_test.go
+++ b/common/syntaxflow/sfdb/rule_export_taxonomy_test.go
@@ -1,0 +1,88 @@
+package sfdb
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+func TestRuleExportEmbedsTaxonomyAndRemainsImportCompatible(t *testing.T) {
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.SyntaxFlowGroup{}, &schema.SyntaxFlowRule{}).Error)
+
+	rule := &schema.SyntaxFlowRule{
+		RuleId:   "taxonomy-rule-id",
+		RuleName: "taxonomy-rule",
+		Content:  `desc(title: "taxonomy") alert $result`,
+	}
+	require.NoError(t, db.Create(rule).Error)
+	group := &schema.SyntaxFlowGroup{GroupName: "java"}
+	require.NoError(t, db.Create(group).Error)
+	require.NoError(t, db.Model(rule).Association("Groups").Append(group).Error)
+
+	archive, result, err := ExportRulesToBytes(context.Background(), db)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Count)
+
+	metadata := readRuleExportMetadata(t, archive)
+	require.Equal(t, ssaconfig.RuleGroupTaxonomySchemaVersion, metadata.RuleGroupTaxonomy.SchemaVersion)
+	require.NotEmpty(t, metadata.RuleGroupTaxonomy.Categories)
+	taxonomyGroupCount := 0
+	for _, category := range metadata.RuleGroupTaxonomy.Categories {
+		taxonomyGroupCount += len(category.Groups)
+	}
+	require.Equal(t, 36, taxonomyGroupCount)
+	require.Equal(t, "taxonomy-rule-id", metadata.Relationship[0].RuleID)
+	require.Equal(t, []string{"java"}, metadata.Relationship[0].GroupNames)
+
+	importDB, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	require.NoError(t, importDB.AutoMigrate(&schema.SyntaxFlowGroup{}, &schema.SyntaxFlowRule{}).Error)
+	importedMetadata, err := ImportRulesFromBytes(context.Background(), importDB, archive)
+	require.NoError(t, err)
+	require.Contains(t, importedMetadata, "rule_group_taxonomy")
+
+	var imported schema.SyntaxFlowRule
+	require.NoError(t, importDB.Preload("Groups").Where("rule_id = ?", rule.RuleId).First(&imported).Error)
+	require.Len(t, imported.Groups, 1)
+	require.Equal(t, "java", imported.Groups[0].GroupName)
+}
+
+type ruleExportMetadata struct {
+	RuleGroupTaxonomy ssaconfig.RuleGroupTaxonomy `json:"rule_group_taxonomy"`
+	Relationship      []struct {
+		RuleID     string   `json:"rule_id"`
+		GroupNames []string `json:"group_names"`
+	} `json:"relationship"`
+}
+
+func readRuleExportMetadata(t *testing.T, data []byte) ruleExportMetadata {
+	t.Helper()
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	for _, file := range reader.File {
+		if filepath.Base(file.Name) != "meta.json" {
+			continue
+		}
+		stream, err := file.Open()
+		require.NoError(t, err)
+		payload, err := io.ReadAll(stream)
+		require.NoError(t, err)
+		require.NoError(t, stream.Close())
+		var metadata ruleExportMetadata
+		require.NoError(t, json.Unmarshal(payload, &metadata))
+		return metadata
+	}
+	t.Fatal("meta.json not found")
+	return ruleExportMetadata{}
+}

--- a/common/yak/ssaapi/ssaconfig/scan_policies.yaml
+++ b/common/yak/ssaapi/ssaconfig/scan_policies.yaml
@@ -3,7 +3,7 @@
 
 version: "1.0"
 rule_group_taxonomy_version: "1.0"
-updated_at: "2026-08-29"
+updated_at: "2026-08-30"
 
 # 策略列表
 policies:
@@ -147,6 +147,23 @@ custom_rule_groups:
         - name: "c"
           display_name: "C"
           canonical_name: "c"
+        # Exact engine language names; retain the policy aliases above.
+        # Appending keeps existing display order and policy selection intact.
+        - name: "golang"
+          display_name: "Golang"
+          canonical_name: "go"
+        - name: "js"
+          display_name: "JavaScript"
+          canonical_name: "javascript"
+        - name: "general"
+          display_name: "通用规则"
+          canonical_name: "general"
+        - name: "yak"
+          display_name: "Yak"
+          canonical_name: "yak"
+        - name: "ts"
+          display_name: "TypeScript"
+          canonical_name: "typescript"
 
     - id: "language-library"
       category: "语言库"

--- a/common/yak/ssaapi/ssaconfig/scan_policies.yaml
+++ b/common/yak/ssaapi/ssaconfig/scan_policies.yaml
@@ -2,7 +2,8 @@
 # 定义预设策略及其对应的规则组映射关系
 
 version: "1.0"
-updated_at: "2026-02-02"
+rule_group_taxonomy_version: "1.0"
+updated_at: "2026-08-29"
 
 # 策略列表
 policies:
@@ -88,12 +89,13 @@ categories:
     name: "自定义"
     policies: ["custom"]
 
-# 自定义规则组分类（用于自定义策略的规则选择器）
-# 前端通过 API 获取此配置动态渲染规则组选择器
+# 标准规则组 taxonomy，同时为自定义策略选择器提供分类数据。
+# 规则导出会把这里的稳定 ID、展示名和 canonical name 写入 meta.json。
 custom_rule_groups:
   # 合规规则（基于行业标准）
   compliance_rules:
-    - category: "OWASP Top 10 (2021)"
+    - id: "owasp"
+      category: "OWASP Top 10 (2021)"
       groups:
         - name: "OWASP 2021 A01:Broken Access Control"
           display_name: "A01: 失效的访问控制"
@@ -116,29 +118,57 @@ custom_rule_groups:
         - name: "OWASP 2021 A10:Server-Side Request Forgery"
           display_name: "A10: 服务器端请求伪造"
     
-    - category: "CWE"
+    - id: "cwe"
+      category: "CWE"
       groups:
         - name: "CWE Top 25 (2023)"
           display_name: "CWE Top 25 (2023)"
   
   # 技术栈规则（语言、框架、组件）
   tech_stack_rules:
-    - category: "语言"
+    - id: "language"
+      category: "语言"
       groups:
         - name: "java"
           display_name: "Java"
+          canonical_name: "java"
         - name: "go"
           display_name: "Golang"
+          canonical_name: "go"
         - name: "php"
           display_name: "PHP"
+          canonical_name: "php"
         - name: "javascript"
           display_name: "JavaScript"
+          canonical_name: "javascript"
         - name: "python"
           display_name: "Python"
+          canonical_name: "python"
         - name: "c"
           display_name: "C"
+          canonical_name: "c"
+
+    - id: "language-library"
+      category: "语言库"
+      groups:
+        - name: "Language Library - Golang"
+          display_name: "Golang"
+          canonical_name: "go"
+        - name: "Language Library - Java"
+          display_name: "Java"
+          canonical_name: "java"
+        - name: "Language Library - PHP"
+          display_name: "PHP"
+          canonical_name: "php"
+        - name: "Language Library - Python"
+          display_name: "Python"
+          canonical_name: "python"
+        - name: "Language Library - JavaScript"
+          display_name: "JavaScript"
+          canonical_name: "javascript"
     
-    - category: "框架/组件"
+    - id: "framework"
+      category: "框架/组件"
       groups:
         - name: "Framework - Spring"
           display_name: "Spring"
@@ -147,14 +177,22 @@ custom_rule_groups:
         - name: "Framework - ThinkPHP"
           display_name: "ThinkPHP"
     
-    - category: "组件扫描"
+    - id: "sca"
+      category: "组件扫描"
       groups:
         - name: "SCA - Dependency Check"
           display_name: "依赖组件检查"
+
+    - id: "code-quality"
+      category: "代码质量"
+      groups:
+        - name: "Code Style"
+          display_name: "代码规范"
   
   # 特殊规则（严重性、用途等）
   special_rules:
-    - category: "严重性"
+    - id: "severity"
+      category: "严重性"
       groups:
         - name: "critical"
           display_name: "严重"
@@ -164,8 +202,11 @@ custom_rule_groups:
           display_name: "中危"
         - name: "low"
           display_name: "低危"
+        - name: "info"
+          display_name: "信息"
     
-    - category: "检测目的"
+    - id: "purpose"
+      category: "检测目的"
       groups:
         - name: "audit"
           display_name: "审计"

--- a/common/yak/ssaapi/ssaconfig/scan_policy.go
+++ b/common/yak/ssaapi/ssaconfig/scan_policy.go
@@ -27,10 +27,11 @@ type PolicyDefinition struct {
 
 // ScanPoliciesConfig 策略配置文件结构
 type ScanPoliciesConfig struct {
-	Version          string                      `yaml:"version"`
-	Policies         map[string]PolicyDefinition `yaml:"policies"`
-	Categories       []PolicyCategory            `yaml:"categories"`
-	CustomRuleGroups CustomRuleGroupsConfig      `yaml:"custom_rule_groups"`
+	Version                  string                      `yaml:"version"`
+	RuleGroupTaxonomyVersion string                      `yaml:"rule_group_taxonomy_version"`
+	Policies                 map[string]PolicyDefinition `yaml:"policies"`
+	Categories               []PolicyCategory            `yaml:"categories"`
+	CustomRuleGroups         CustomRuleGroupsConfig      `yaml:"custom_rule_groups"`
 }
 
 // PolicyCategory 策略分类
@@ -49,19 +50,46 @@ type CustomRuleGroupsConfig struct {
 
 // RuleGroupCategory 规则组分类
 type RuleGroupCategory struct {
+	ID       string      `yaml:"id" json:"id"`
 	Category string      `yaml:"category" json:"category"`
 	Groups   []RuleGroup `yaml:"groups" json:"groups"`
 }
 
 // RuleGroup 规则组
 type RuleGroup struct {
-	Name        string `yaml:"name" json:"name"`
-	DisplayName string `yaml:"display_name" json:"display_name"`
+	Name          string `yaml:"name" json:"name"`
+	DisplayName   string `yaml:"display_name" json:"display_name"`
+	CanonicalName string `yaml:"canonical_name,omitempty" json:"canonical_name,omitempty"`
+}
+
+const RuleGroupTaxonomySchemaVersion = "yaklang_rule_group_taxonomy.v1"
+
+// RuleGroupTaxonomy is the versioned, transport-safe taxonomy embedded in
+// exported SyntaxFlow rule archives. Its definitions come only from
+// scan_policies.yaml; consumers must not infer categories from group names.
+type RuleGroupTaxonomy struct {
+	SchemaVersion string                      `json:"schema_version"`
+	Version       string                      `json:"version"`
+	Categories    []RuleGroupTaxonomyCategory `json:"categories"`
+}
+
+type RuleGroupTaxonomyCategory struct {
+	ID          string                  `json:"id"`
+	DisplayName string                  `json:"display_name"`
+	Order       int                     `json:"order"`
+	Groups      []RuleGroupTaxonomyItem `json:"groups"`
+}
+
+type RuleGroupTaxonomyItem struct {
+	Name          string `json:"name"`
+	DisplayName   string `json:"display_name"`
+	CanonicalName string `json:"canonical_name,omitempty"`
+	Order         int    `json:"order"`
 }
 
 // ScanPolicyConfig 扫描策略配置
 type ScanPolicyConfig struct {
-	PolicyType  string            `json:"policy_type"`  // 策略类型: owasp-web, critical-high, fullstack, custom
+	PolicyType  string             `json:"policy_type"`  // 策略类型: owasp-web, critical-high, fullstack, custom
 	CustomRules *CustomRulesConfig `json:"custom_rules"` // 自定义规则组（当 PolicyType 为 custom 时使用）
 }
 
@@ -109,39 +137,54 @@ func GetScanPoliciesConfig() *ScanPoliciesConfig {
 
 // GetAllStandardGroupNames 获取所有标准规则组名称
 func GetAllStandardGroupNames() []string {
+	taxonomy := GetRuleGroupTaxonomy()
+	groupNames := make([]string, 0)
+	for _, category := range taxonomy.Categories {
+		for _, group := range category.Groups {
+			groupNames = append(groupNames, group.Name)
+		}
+	}
+	return groupNames
+}
+
+// GetRuleGroupTaxonomy returns a detached taxonomy value so callers cannot
+// mutate the cached scan-policy configuration.
+func GetRuleGroupTaxonomy() RuleGroupTaxonomy {
 	config := GetScanPoliciesConfig()
 	if config == nil {
-		return nil
+		return RuleGroupTaxonomy{}
 	}
-	
-	var groupNames []string
-	
-	// 从 custom_rule_groups 中提取所有组名
-	if config.CustomRuleGroups.ComplianceRules != nil {
-		for _, category := range config.CustomRuleGroups.ComplianceRules {
-			for _, group := range category.Groups {
-				groupNames = append(groupNames, group.Name)
+
+	taxonomy := RuleGroupTaxonomy{
+		SchemaVersion: RuleGroupTaxonomySchemaVersion,
+		Version:       config.RuleGroupTaxonomyVersion,
+	}
+	categoryOrder := 1
+	appendCategories := func(categories []RuleGroupCategory) {
+		for _, category := range categories {
+			items := make([]RuleGroupTaxonomyItem, 0, len(category.Groups))
+			for groupOrder, group := range category.Groups {
+				items = append(items, RuleGroupTaxonomyItem{
+					Name:          group.Name,
+					DisplayName:   group.DisplayName,
+					CanonicalName: group.CanonicalName,
+					Order:         groupOrder + 1,
+				})
 			}
+			taxonomy.Categories = append(taxonomy.Categories, RuleGroupTaxonomyCategory{
+				ID:          category.ID,
+				DisplayName: category.Category,
+				Order:       categoryOrder,
+				Groups:      items,
+			})
+			categoryOrder++
 		}
 	}
-	
-	if config.CustomRuleGroups.TechStackRules != nil {
-		for _, category := range config.CustomRuleGroups.TechStackRules {
-			for _, group := range category.Groups {
-				groupNames = append(groupNames, group.Name)
-			}
-		}
-	}
-	
-	if config.CustomRuleGroups.SpecialRules != nil {
-		for _, category := range config.CustomRuleGroups.SpecialRules {
-			for _, group := range category.Groups {
-				groupNames = append(groupNames, group.Name)
-			}
-		}
-	}
-	
-	return groupNames
+
+	appendCategories(config.CustomRuleGroups.ComplianceRules)
+	appendCategories(config.CustomRuleGroups.TechStackRules)
+	appendCategories(config.CustomRuleGroups.SpecialRules)
+	return taxonomy
 }
 
 var (

--- a/common/yak/ssaapi/ssaconfig/scan_policy_test.go
+++ b/common/yak/ssaapi/ssaconfig/scan_policy_test.go
@@ -29,7 +29,17 @@ func TestRuleGroupTaxonomyIsVersionedAndComplete(t *testing.T) {
 		}
 	}
 
-	require.Len(t, groups, 36)
+	// A matching count does not prove coverage: the exported raw names come
+	// from engine language values, not policy aliases such as go/javascript.
+	for _, language := range append(GetAllSupportedLanguages(), General.String()) {
+		require.Contains(t, groups, language, "engine language group must have exact taxonomy metadata")
+	}
+	for rawName, canonical := range map[string]string{
+		"go": "go", "golang": "go", "javascript": "javascript", "js": "javascript",
+		"general": "general", "yak": "yak", "ts": "typescript",
+	} {
+		require.Equal(t, canonical, groups[rawName].CanonicalName, "raw group %q", rawName)
+	}
 	require.Equal(t, "java", groups["Language Library - Java"].CanonicalName)
 	require.Equal(t, 3, categories["language"].Order)
 	require.Equal(t, 1, groups["java"].Order)
@@ -41,6 +51,13 @@ func TestRuleGroupTaxonomyIsVersionedAndComplete(t *testing.T) {
 			require.Contains(t, groups, groupName, "policy %q references a non-standard group", policyName)
 		}
 	}
+}
+
+func TestTaxonomyDoesNotChangeExistingPolicyGroupSelection(t *testing.T) {
+	require.Equal(t, []string{
+		"critical", "high", "middle", "java", "go", "php", "javascript", "python",
+		"Framework - Spring", "Framework - Apache Shiro", "Framework - ThinkPHP", "SCA - Dependency Check",
+	}, (&ScanPolicyConfig{PolicyType: PolicyTypeFullStack}).MapToGroups())
 }
 
 func mapKeys[K comparable, V any](values map[K]V) []K {

--- a/common/yak/ssaapi/ssaconfig/scan_policy_test.go
+++ b/common/yak/ssaapi/ssaconfig/scan_policy_test.go
@@ -6,6 +6,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRuleGroupTaxonomyIsVersionedAndComplete(t *testing.T) {
+	taxonomy := GetRuleGroupTaxonomy()
+	require.Equal(t, RuleGroupTaxonomySchemaVersion, taxonomy.SchemaVersion)
+	require.Equal(t, "1.0", taxonomy.Version)
+	require.NotEmpty(t, taxonomy.Categories)
+
+	groups := make(map[string]RuleGroupTaxonomyItem)
+	categories := make(map[string]RuleGroupTaxonomyCategory)
+	for _, category := range taxonomy.Categories {
+		require.NotEmpty(t, category.ID)
+		require.NotEmpty(t, category.DisplayName)
+		_, duplicateCategory := categories[category.ID]
+		require.False(t, duplicateCategory, "duplicate taxonomy category %q", category.ID)
+		categories[category.ID] = category
+		for _, group := range category.Groups {
+			require.NotEmpty(t, group.Name)
+			require.NotEmpty(t, group.DisplayName)
+			_, duplicateGroup := groups[group.Name]
+			require.False(t, duplicateGroup, "duplicate taxonomy group %q", group.Name)
+			groups[group.Name] = group
+		}
+	}
+
+	require.Len(t, groups, 36)
+	require.Equal(t, "java", groups["Language Library - Java"].CanonicalName)
+	require.Equal(t, 3, categories["language"].Order)
+	require.Equal(t, 1, groups["java"].Order)
+	require.Equal(t, "信息", groups["info"].DisplayName)
+	require.Contains(t, categories, "code-quality")
+	require.ElementsMatch(t, GetAllStandardGroupNames(), mapKeys(groups))
+	for policyName, policy := range GetScanPoliciesConfig().Policies {
+		for _, groupName := range policy.RuleGroups {
+			require.Contains(t, groups, groupName, "policy %q references a non-standard group", policyName)
+		}
+	}
+}
+
+func mapKeys[K comparable, V any](values map[K]V) []K {
+	keys := make([]K, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 func TestGetScanPolicy(t *testing.T) {
 	cfg, err := New(ModeAll)
 	require.NoError(t, err)


### PR DESCRIPTION
## 改动摘要

将 `scan_policies.yaml` 作为标准规则组分类的唯一数据源，向 SyntaxFlow 规则 ZIP 的 `meta.json` 增加独立版本化的 `rule_group_taxonomy`，让消费端使用生产端的分类定义，避免按组名猜测而将标准组误归到“自定义分组”。

## 改动文件

- `common/yak/ssaapi/ssaconfig/scan_policies.yaml`：声明稳定分类 ID、展示名、顺序和语言 canonical key；显式覆盖实际引擎语言名 `golang/js/general/yak/ts`，同时保留旧 `go/javascript` 和无当前成员的标准定义
- `common/yak/ssaapi/ssaconfig/scan_policy.go`：从现有 YAML 派生可传输的 taxonomy，schema 为 `yaklang_rule_group_taxonomy.v1`
- `common/syntaxflow/sfdb/rule_export.go`：将 taxonomy 作为加法元数据写入导出 ZIP
- 对应测试：逐项核对引擎语言枚举、唯一性、原扫描策略数组，以及实际 ZIP 的标准/旧别名/自定义分组导出与导入回灌；不再以固定分类数量代替名称覆盖检查

## 兼容边界

- 不升级 ZIP 容器格式，不修改现有 `relationship[].group_names`
- 不重命名规则组，不改变规则内容、成员关系或扫描选规则语义
- 旧导入器仍读取原关系元数据；新 taxonomy 可由忽略未知字段的消费者安全跳过
- 分类元数据不进入 Legion 规则快照执行条目及其摘要

配套消费端：[Legion PR #413](https://github.com/VillanCh/legion/pull/413)。该 PR 支持持久化/API/Console 分类，并保留旧 ZIP 和未知 taxonomy schema 的回退路径。

## 验证方式

- `go test ./common/yak/ssaapi/ssaconfig ./common/syntaxflow/sfdb -count=1`：通过（使用隔离的 YAKIT_HOME）
- `go test ./scannode -run '^TestInspectExportedRuleArchiveCountsRulesGroupsAndRiskTypes$' -count=1`：通过
- `git diff --check`：通过
- 在 `df065e886` 上的一次真实同步暴露覆盖缺口：原始组36个，实际有定义的只有33个；`general/golang/js` 没有精确名称定义。另有浏览器/分发读取 harness 缺口，该轮不声明 T2。
- `2e39f5a0c` 已补齐实际名称并保留旧别名，回归先 RED 后 GREEN。

## T2 结果

固定 Yaklang `2e39f5a0c` + Legion `ac6afdd70` 的 5 项验收全部通过（Legion 产品代码同 `07b95a054`，最终提交仅补充说明）：

- 精确源码健康门通过，下载通道对象与所选节点二进制 SHA-256、大小一致
- 真实 Console 仅点击一次开始同步，HTTP 202；最终 imported，674 条规则 / 36 个原始组 / 120 个风险类型，并设为活动快照
- 同步前缺 `general/golang/js` 三个定义，同步后 36/36 原始组都有有效分类；数据库回读一致
- 页面仅一个 Java 节点，Go/JavaScript 原始别名合并，通用规则、审计、信息、代码规范均在正确分类，无当前标准组落入自定义分组
- 同一浏览器会话的三个 Java 原始查询返回 165/163/163 个唯一资产；快照仍为 674 条、36 组，无分类字段进入执行条目，快照内容摘要保持不变
- 具名浏览器与任务栈已清理；任务持久数据按规范保留，未修改其他栈；未执行目标扫描或部署

早期页面缓存等待和选择器错误只属于测试脚本问题，最终由成功的真实 UI 操作、同浏览器会话只读查询、数据库与截图证据覆盖，没有重复提交同步。

本地 T1/T2 与 CI 分开记录：提交 `2e39f5a0c` 的完整 Essential Tests 运行 `33288907679` 中，已运行检查全部通过，Essential Tests Gate 通过，1 项 Test ScanNode Focused 被 CI 跳过（对应本地聚焦测试已通过）；旧提交的 AI Memory 两项失败未在该运行对应 job 中重现。Legion 关联分支已获准以精确 force-with-lease 更新，发布前 rebase 影响与追加 T1 详见 PR #413；原 T2 报告仍绑定上述精确源码，不冒充在新的 Legion SHA 上重新运行 T2。

本次更新未修改 PR 的评审状态，未执行合并、tag 或发版。
