### PR TITLE
feat(ssa): 按扫描批次输出完整源码规模统计

### DIFF
--- a/common/spec/ssa_artifact.go
+++ b/common/spec/ssa_artifact.go
@@ -41,12 +41,13 @@ type SSAArtifactManifestV1 struct {
 // artifact to object storage. Server should consume this as a control-plane
 // notification and run async import from object storage.
 type SSAArtifactReadyEvent struct {
-	ObjectKey        string `json:"object_key"`
-	Codec            string `json:"codec"` // "zstd" | "gzip" | "identity"
-	ArtifactFormat   string `json:"artifact_format,omitempty"`
-	CompressedSize   int64  `json:"compressed_size"`
-	UncompressedSize int64  `json:"uncompressed_size"`
-	SHA256           string `json:"sha256"`
+	SourceStatistics json.RawMessage `json:"source_statistics,omitempty"`
+	ObjectKey        string          `json:"object_key"`
+	Codec            string          `json:"codec"` // "zstd" | "gzip" | "identity"
+	ArtifactFormat   string          `json:"artifact_format,omitempty"`
+	CompressedSize   int64           `json:"compressed_size"`
+	UncompressedSize int64           `json:"uncompressed_size"`
+	SHA256           string          `json:"sha256"`
 
 	ProgramName string `json:"program_name,omitempty"`
 	ReportType  string `json:"report_type,omitempty"`

--- a/common/syntaxflow/sfdb/rule_group_unique_test.go
+++ b/common/syntaxflow/sfdb/rule_group_unique_test.go
@@ -13,6 +13,10 @@ import (
 func TestCreateGroupConcurrentSameNameIsIdempotent(t *testing.T) {
 	db, err := utils.CreateTempTestDatabaseInMemory()
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	// Match production SQLite's single-writer pool while keeping callers concurrent.
+	db.DB().SetMaxOpenConns(1)
+	db.DB().SetMaxIdleConns(1)
 	require.NoError(t, db.AutoMigrate(&schema.SyntaxFlowGroup{}, &schema.SyntaxFlowRule{}).Error)
 
 	name := "concurrent-" + uuid.NewString()

--- a/common/yak/ssaapi/source_statistics.go
+++ b/common/yak/ssaapi/source_statistics.go
@@ -1,0 +1,117 @@
+package ssaapi
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SourceStatistics describes saved sources, not risk attachments or a repository.
+// Physical lines follow MemEditor: LF count + 1, including empty final lines.
+type SourceStatistics struct {
+	SchemaVersion     string `json:"schema_version"`
+	Scope             string `json:"scope"`
+	LineCountKind     string `json:"line_count_kind"`
+	AnalyzedFileCount int64  `json:"analyzed_file_count"`
+	AnalyzedLineCount int64  `json:"analyzed_line_count"`
+}
+
+// GetSourceStatistics fails closed when any visible source cannot be read.
+// It never uses the cumulatively updated Program.LineCount.
+func (p *Program) GetSourceStatistics() (*SourceStatistics, error) {
+	if p == nil || p.Program == nil || p.Program.FileList == nil {
+		return nil, fmt.Errorf("source statistics: missing program")
+	}
+	if overlay := p.GetOverlay(); overlay != nil && overlay.IsTopLayerProgram(p) {
+		return overlay.GetSourceStatistics()
+	}
+	if p.IsIncrementalCompile() && !p.IsBaseProgram() {
+		return nil, fmt.Errorf("source statistics: incremental view is unavailable")
+	}
+	lines := make(map[string]int64)
+	for _, files := range []map[string]string{p.Program.FileList, p.Program.ExtraFile} {
+		for path, hash := range files {
+			pathKey := normalizeOverlayFilePath(path, p.GetProgramName())
+			if pathKey == "" {
+				return nil, fmt.Errorf("source statistics: invalid source path")
+			}
+			if _, exists := lines[pathKey]; exists {
+				continue
+			}
+			editor, err := p.getEditor(path, hash)
+			if err != nil || editor == nil {
+				return nil, fmt.Errorf("source statistics: incomplete saved sources")
+			}
+			lines[pathKey] = int64(editor.GetLineCount())
+		}
+	}
+	return sourceStatisticsFromLines(lines), nil
+}
+
+// GetSourceStatistics follows the same effective file ownership as aggregateFileSystems,
+// but a failed read is an error instead of silently reducing the count.
+func (p *ProgramOverLay) GetSourceStatistics() (*SourceStatistics, error) {
+	if p == nil || p.Base == nil || p.Base.Program == nil || p.Base.Program.FileList == nil || len(p.Diff) == 0 {
+		return nil, fmt.Errorf("source statistics: incomplete overlay")
+	}
+	lines := make(map[string]int64)
+	for _, layer := range p.Diff {
+		if layer == nil || layer.Program == nil || layer.Program.Program == nil {
+			return nil, fmt.Errorf("source statistics: missing overlay layer")
+		}
+		for _, filePath := range layer.File {
+			path := ensureOverlayPathSlash(filePath)
+			content, ok := readStatisticsSource(layer.Program, path)
+			if path == "" || !ok {
+				return nil, fmt.Errorf("source statistics: incomplete overlay sources")
+			}
+			lines[path] = int64(strings.Count(content, "\n")) + 1
+		}
+	}
+	excluded := overlayPathSet(p.ExcludeFile)
+	for _, files := range []map[string]string{p.Base.Program.FileList, p.Base.Program.ExtraFile} {
+		for filePath, hash := range files {
+			path := normalizeOverlayFilePath(filePath, p.Base.GetProgramName())
+			if path == "" {
+				return nil, fmt.Errorf("source statistics: invalid source path")
+			}
+			if _, skip := excluded[path]; skip {
+				continue
+			}
+			if _, owned := lines[path]; owned {
+				continue
+			}
+			editor, err := p.Base.getEditor(filePath, hash)
+			if err != nil || editor == nil {
+				return nil, fmt.Errorf("source statistics: incomplete base sources")
+			}
+			lines[path] = int64(editor.GetLineCount())
+		}
+	}
+	return sourceStatisticsFromLines(lines), nil
+}
+
+func sourceStatisticsFromLines(lines map[string]int64) *SourceStatistics {
+	stats := &SourceStatistics{SchemaVersion: "ssa-source-statistics.v1", Scope: "compiled_sources", LineCountKind: "physical", AnalyzedFileCount: int64(len(lines))}
+	for _, count := range lines {
+		stats.AnalyzedLineCount += count
+	}
+	return stats
+}
+
+// ExtraFile keeps source-mode sidecars such as YAML/properties. They belong to
+// the same saved-source scope as FileList and must survive overlay counting.
+func readStatisticsSource(p *Program, path string) (string, bool) {
+	if content, ok := readProgramFileContent(p, path); ok {
+		return content, true
+	}
+	for filePath, hash := range p.Program.ExtraFile {
+		if normalizeOverlayFilePath(filePath, p.GetProgramName()) != path {
+			continue
+		}
+		editor, err := p.getEditor(filePath, hash)
+		if err == nil && editor != nil {
+			return editor.GetSourceCode(), true
+		}
+	}
+	return "", false
+}

--- a/common/yak/ssaapi/source_statistics_test.go
+++ b/common/yak/ssaapi/source_statistics_test.go
@@ -1,0 +1,65 @@
+package ssaapi_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils/memedit"
+	"github.com/yaklang/yaklang/common/yak/ssa"
+	"github.com/yaklang/yaklang/common/yak/ssaapi"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/test/ssatest"
+)
+
+func TestSourceStatisticsDistinctSourcesAndMissingEvidence(t *testing.T) {
+	p := ssaapi.NewTmpProgram("statistics")
+	p.Program.Cache = ssa.NewDBCache(nil, p.Program, ssa.ProgramCacheMemory, 2)
+	t.Cleanup(p.Program.Cache.CloseWithoutSave)
+	p.Program.ExtraFile = map[string]string{}
+	for path, content := range map[string]string{"main.yak": "// comment\r\n\r\na=1\n", "empty.yak": ""} {
+		editor := memedit.NewMemEditor(content)
+		p.Program.SetEditor(path, editor)
+		p.Program.FileList[path] = "hash-" + path
+		p.Program.ExtraFile[path] = "hash-" + path
+	}
+	p.Program.LineCount = 999 // cumulative legacy metadata must not be used.
+	stats, err := p.GetSourceStatistics()
+	require.NoError(t, err)
+	require.EqualValues(t, 2, stats.AnalyzedFileCount)
+	require.EqualValues(t, 5, stats.AnalyzedLineCount)
+	p.Program.FileList["missing.yak"] = "missing"
+	stats, err = p.GetSourceStatistics()
+	require.Error(t, err)
+	require.Nil(t, stats)
+	stats, err = ssaapi.NewTmpProgram("empty").GetSourceStatistics()
+	require.NoError(t, err)
+	require.Zero(t, stats.AnalyzedFileCount)
+	require.Zero(t, stats.AnalyzedLineCount)
+	p.Program.FileList = nil
+	stats, err = p.GetSourceStatistics()
+	require.Error(t, err, "missing source registry is not an empty source snapshot")
+	require.Nil(t, stats)
+}
+
+func TestSourceStatisticsOverlayAndDatabaseReload(t *testing.T) {
+	base := "public class A { public int value() { return 1; } }\n"
+	changed := "// changed\npublic class A { public int value() { return 2; } }\n"
+	keep := "public class Keep {}"
+	added := "public class Added {}\n"
+	ssatest.CheckIncrementalProgram(t,
+		ssatest.IncrementalStep{Files: map[string]string{"A.java": base, "Keep.java": keep, "Delete.java": "public class Delete {}", "config.yml": "setting: true\n"}},
+		ssatest.IncrementalStep{
+			Files: map[string]string{"A.java": changed, "Added.java": added, "Delete.java": ""},
+			Check: func(overlay *ssaapi.ProgramOverLay, _ ssatest.IncrementalCheckStage) {
+				baseStats, err := overlay.Base.GetSourceStatistics()
+				require.NoError(t, err)
+				require.EqualValues(t, 4, baseStats.AnalyzedFileCount)
+				require.EqualValues(t, 6, baseStats.AnalyzedLineCount, "a cached base must keep its original source snapshot")
+				stats, err := overlay.GetSourceStatistics()
+				require.NoError(t, err)
+				require.EqualValues(t, 4, stats.AnalyzedFileCount)
+				require.EqualValues(t, strings.Count(changed, "\n")+strings.Count(keep, "\n")+strings.Count(added, "\n")+5, stats.AnalyzedLineCount)
+			},
+		},
+	)
+}

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -1160,6 +1160,7 @@ func (s *ScanNode) finalizeSSAArtifactUpload(
 	if event == nil {
 		return nil
 	}
+	event.SourceStatistics = meta.SourceStatistics
 	if err := reporter.PublishSSAArtifactReady(event); err != nil {
 		return err
 	}
@@ -1273,9 +1274,10 @@ func (s *ScanNode) buildSSAArtifactUploadConfigProvider(
 }
 
 type ssaResultMeta struct {
-	ProgramName string
-	TotalLines  int64
-	RiskCount   int64
+	SourceStatistics json.RawMessage
+	ProgramName      string
+	TotalLines       int64
+	RiskCount        int64
 }
 
 func parseSSAResultMeta(result *ScriptExecutionResult) ssaResultMeta {
@@ -1289,6 +1291,9 @@ func parseSSAResultMeta(result *ScriptExecutionResult) ssaResultMeta {
 		return meta
 	}
 
+	if statistics := dataMap["source_statistics"]; statistics != nil {
+		meta.SourceStatistics, _ = json.Marshal(statistics)
+	}
 	meta.ProgramName = strings.TrimSpace(utils.InterfaceToString(
 		utils.MapGetFirstRaw(dataMap, "program_name", "programName", "ProgramName"),
 	))
@@ -1311,6 +1316,9 @@ func buildSSAArtifactMetricsPayload(event *SSAArtifactReadyEvent) ([]byte, error
 		_ = json.Unmarshal(event.Metrics, &merged)
 	}
 	// Add risk/file/flow counts
+	if len(event.SourceStatistics) > 0 && json.Valid(event.SourceStatistics) {
+		merged["source_statistics"] = event.SourceStatistics
+	}
 	merged["risk_count"] = event.RiskCount
 	merged["file_count"] = event.FileCount
 	merged["dataflow_count"] = event.FlowCount

--- a/scannode/ssa_source_statistics_test.go
+++ b/scannode/ssa_source_statistics_test.go
@@ -1,0 +1,26 @@
+package scannode
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceStatisticsMetricsWithZeroRisks(t *testing.T) {
+	stats := map[string]any{"schema_version": "ssa-source-statistics.v1", "scope": "compiled_sources", "line_count_kind": "physical", "analyzed_file_count": 3, "analyzed_line_count": 12}
+	meta := parseSSAResultMeta(&ScriptExecutionResult{Data: map[string]any{"program_name": "zero-risks", "risk_count": 0, "source_statistics": stats}})
+	metrics, err := buildSSAArtifactMetricsPayload(&SSAArtifactReadyEvent{SourceStatistics: meta.SourceStatistics, Metrics: json.RawMessage(`{"upload_ms":7}`)})
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(metrics, &payload))
+	require.EqualValues(t, 0, payload["risk_count"])
+	require.EqualValues(t, 0, payload["file_count"], "risk-file count is independent")
+	require.EqualValues(t, 3, payload["source_statistics"].(map[string]any)["analyzed_file_count"])
+	require.EqualValues(t, 7, payload["upload_ms"])
+	legacy := parseSSAResultMeta(&ScriptExecutionResult{Data: map[string]any{"total_lines": 12}})
+	require.Empty(t, legacy.SourceStatistics)
+	metrics, err = buildSSAArtifactMetricsPayload(&SSAArtifactReadyEvent{})
+	require.NoError(t, err)
+	require.NotContains(t, string(metrics), "source_statistics")
+}


### PR DESCRIPTION
## 改动摘要

Legion 项目详情需要展示每个扫描批次实际分析的源码规模。现有程序累计行数在增量编译时可能重复计算基线，按漏洞关联文件统计又会漏掉未产生漏洞的文件，因此新增独立、可选的源码统计结果。

- 从编译保存的源码集合按归一化路径去重，统计文件数及物理行数，支持程序落库后的重新加载。
- 增量程序按最终可见文件集合统计，保留修改覆盖与删除语义，不累加基线和差量的行数。
- 物理行数包含注释、空行及保存的配置文件；统计范围为编译保存的源码，不代表整个 Git 仓库。
- 任一必要源码读取失败时不提供统计，避免把不完整数据或未知状态呈现为零。
- 将脚本返回的可选 `source_statistics` 透传到扫描产物指标；零漏洞扫描同样保留统计。新增版本为 `ssa-source-statistics.v1`，范围为 `compiled_sources`，行数口径为 `physical`。

## 关键文件

- `common/yak/ssaapi/source_statistics.go`：源码集合统计及完整性检查。
- `common/spec/ssa_artifact.go`：可选统计字段。
- `scannode/script_execution.go`：脚本结果到产物指标的传递。
- `common/yak/ssaapi/source_statistics_test.go`、`scannode/ssa_source_statistics_test.go`：普通程序、数据库重载、增量覆盖/删除、缺失证据及零漏洞回归。

## 配套与兼容

- 消费端及页面：VillanCh/legion#426。两个仓库仅通过产物合同交互，不引入直接代码依赖。
- 字段为可选；旧节点或无法获得完整统计时继续正常扫描，由消费端显示“未统计”。
- 不新增 Git 服务商接口请求，不修改既有漏洞处置或扫描任务调度语义。

## 验证方式

- T1：SSA API 与 Scan Node 中 `TestSourceStatistics*` 聚焦测试已通过；覆盖去重、物理行数、增量最终文件集合、数据库重载、缺失源码及零漏洞指标。提交范围的 `git diff --check` 通过。
- T2（rebase 前原始验证）：`cedb34e3fd0416b1437943960e8a1a60b6475fa5` 配合 Legion `5e3b39379c23a432c7cdd8d33923c5515ebdf67a`，同项目、同一单规则快照完成两次真实 ZIP 编译扫描。第一批 2 个 XXE 风险、4 文件 / 33 行；第二批 0 风险、4 文件 / 13 行；历史首批统计保持不变。
- 原始产物、API 与项目详情展示已核对；带条件进入审计/任务后返回、移动端展示通过。任务专属运行资源已清理，共享基础设施保留。
- Git 服务商连接、部署和版本发布不在本次验收范围内。保持 Draft，不执行合并或发布。


## 本次 CI 修复与 rebase

- 已 rebase 到 `main` 的 `69db2365c6beb1b25b72816df19e77d91d7b49e8`；源码统计功能补丁经 `range-diff` 确认不变。当前提交 `e5dbb234c0ababc5b3adaaa9817a74040d35ab15`。
- 原 CI 唯一失败用例为既有 `TestCreateGroupConcurrentSameNameIsIdempotent`：shared-cache SQLite fixture 的不限连接池导致表锁。生产代码使用单写连接池。仅为该测试设置相同连接池并清理数据库，保留 16 个并发调用及全部唯一性断言，不修改生产规则组逻辑。
- 本地原用例重复运行复现失败；修复后 `GOMAXPROCS=4 go test -p 2 ./common/syntaxflow/sfdb -run '^TestCreateGroupConcurrentSameNameIsIdempotent$' -count=100` 通过。源码统计定向测试（SSA API、Scan Node）和整个 `sfdb` 包回归均通过；测试使用任务隔离的 `YAKIT_HOME`/Go cache，修复后 CI 已完成：[Essential Tests](https://github.com/yaklang/yaklang/actions/runs/33364898259) 与 [Diff-Code-Check](https://github.com/yaklang/yaklang/actions/runs/33364898316) 均为 success，`Essential Tests Gate` 通过，原失败的 SSA / SFDB 检查通过。`Test ScanNode Focused` 按工作流规则跳过，本地 Scan Node T1 单独通过，不将跳过计为测试通过。
- 以上 T2 记录仍绑定原始验证 SHA；rebase 不改写历史验收证据。保持 Draft，不合并或发布。
