### PR TITLE
fix(ci): embed official license certs in manual build workflows

### DIFF
--- a/.github/workflows/manual-build-target.yml
+++ b/.github/workflows/manual-build-target.yml
@@ -24,8 +24,8 @@ on:
         default: full
       ee:
         type: boolean
-        description: whether to build ee version
-        default: false
+        description: whether to embed official license certs (customer/EE builds)
+        default: true
       sign:
         type: boolean
         description: whether to sign windows executable

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -22,6 +22,8 @@ jobs:
     uses: ./.github/workflows/reuse-build.yml
     with:
       os: ${{ matrix.os }}
-      ee: false
+      # Customer builds must embed the official license certs; without ee=true
+      # the engine ships ephemeral random RSA keys and licenses won't verify.
+      ee: true
       sign: ${{ inputs.sign && contains(matrix.os, 'windows') }}
     secrets: inherit 


### PR DESCRIPTION
ManualBuild hardcoded ee=false and ManualBuildWithTarget defaulted to false, so the Initialize License Machine step in reuse-build.yml never ran and the binaries shipped with ephemeral random RSA keys generated in common/xlic/license.go — customer licenses could not be verified.

- ManualBuild: force ee=true (full-matrix builds are customer builds; shipping a no-cert binary here is never wanted)
- ManualBuildWithTarget: flip ee default to true and clarify the input description, so one-off customer builds embed the official certs by default; uncheck for CE builds if ever needed