### PR TITLE
fix(lowhttp): enforce advertised h2 max frame size

### DIFF
--- a/common/utils/lowhttp/conn_pool.go
+++ b/common/utils/lowhttp/conn_pool.go
@@ -67,6 +67,7 @@ type LowHttpConnPool struct {
 	connSem          chan struct{}
 
 	// H2 连接独立管理：多路复用特性使得单连接承载所有并发 stream，
+	// TODO(httpflow): h2ConnMap has no global cap and is not LRU. Follow-up should bound idle H2 connections.
 	h2Mu         sync.Mutex
 	h2ConnMap    map[string]*persistConn // per-host 缓存单个 H2 persistConn
 	h2Tombstones *tombstoneQueue         // bounded ring-buffer of recent close events (protected by h2Mu)
@@ -714,6 +715,13 @@ func newPersistConn(requestCtx context.Context, key *connectKey, pool *LowHttpCo
 }
 
 func (pc *persistConn) h2Conn() {
+	fr := http2.NewFramer(pc.conn, bufio.NewReader(pc.conn))
+	// Keep the parser limit in sync with SETTINGS_MAX_FRAME_SIZE sent in
+	// preface. NewFramer defaults to the HTTP/2 protocol maximum (16 MiB - 1),
+	// which lets a non-compliant peer pin a multi-megabyte read buffer on every
+	// cached H2 connection.
+	fr.SetMaxReadFrameSize(defaultMaxFrameSize)
+
 	newH2Conn := &http2ClientConn{
 		conn:              pc.conn,
 		ctx:               pc.p.ctx,
@@ -729,7 +737,7 @@ func (pc *persistConn) h2Conn() {
 		headerListMaxSize: defaultHeaderTableSize,
 		connWindowControl: newControl(defaultStreamReceiveWindowSize),
 		maxStreamsCount:   defaultMaxConcurrentStreamSize,
-		fr:                http2.NewFramer(pc.conn, bufio.NewReader(pc.conn)),
+		fr:                fr,
 		frWriteMutex:      new(sync.Mutex),
 		hDec:              hpack.NewDecoder(defaultHeaderTableSize, nil),
 		clientPrefaceOk:   utils.NewAtomicBool(),

--- a/common/utils/lowhttp/conn_pool_test.go
+++ b/common/utils/lowhttp/conn_pool_test.go
@@ -1,0 +1,41 @@
+package lowhttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"testing"
+
+	"golang.org/x/net/http2"
+)
+
+func TestH2FramerRejectsFramesAboveAdvertisedMaxSize(t *testing.T) {
+	localConn, remoteConn := net.Pipe()
+	defer localConn.Close()
+	defer remoteConn.Close()
+
+	pc := &persistConn{
+		conn:     localConn,
+		cacheKey: &connectKey{scheme: H2},
+		p:        NewHttpConnPool(context.Background(), 100, 2),
+	}
+	pc.h2Conn()
+	defer pc.alt.idleTimer.Stop()
+	defer pc.alt.setClose()
+
+	frameHeader := make([]byte, 9)
+	binary.BigEndian.PutUint32(frameHeader[:4], (defaultMaxFrameSize+1)<<8)
+	frameHeader[4] = byte(http2.FrameData)
+	binary.BigEndian.PutUint32(frameHeader[5:], 1)
+	go func() {
+		_, _ = io.Copy(remoteConn, bytes.NewReader(frameHeader))
+	}()
+
+	_, err := pc.alt.fr.ReadFrame()
+	if !errors.Is(err, http2.ErrFrameTooLarge) {
+		t.Fatalf("ReadFrame() error = %v, want %v", err, http2.ErrFrameTooLarge)
+	}
+}


### PR DESCRIPTION
## 背景

Yakit 漏洞扫描时发现内存异常膨胀（heap profile 显示 single HTTP/2 Framer read buffer 导致约 18.9 GiB live 内存）。根因是 HTTP/2 客户端只在 preface 中广告 `SETTINGS_MAX_FRAME_SIZE = 16KiB`，但 `http2.NewFramer` 默认允许收到接近 16MiB 的帧。异常/恶意目标发送超大帧时，`Framer.readBuf` 会分配并长期保留数 MB 的 buffer；连接池按 host 缓存连接后，这个内存被线性放大。

## 修改

- `http2.Framer` 创建后调用 `SetMaxReadFrameSize(defaultMaxFrameSize)`，让 parser 实际上限与已广告的 `SETTINGS_MAX_FRAME_SIZE` 对齐。
- 超过 16KiB 的单帧直接返回 `http2.ErrFrameTooLarge`，不再分配超大 read buffer。
- 新增回归测试，验证 16KiB+1 的 DATA frame 会被拒绝。

## 备注

`h2ConnMap` 当前没有全局连接数上限、也不是 LRU，后续需要考虑单独优化；本次只在代码中标记 TODO。