### PR TITLE
perf(ytoken): optimize token counting

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -1245,7 +1245,7 @@ const UserPresetPromptMaxLength = 4000
 
 func WithUserPresetPrompt(prompt string) ConfigOption {
 	return func(c *Config) error {
-		if MeasureTokens(prompt) > UserPresetPromptMaxLength {
+		if TokenCountExceeds(prompt, UserPresetPromptMaxLength) {
 			prompt = ShrinkByTokens(prompt, UserPresetPromptMaxLength)
 		}
 		c.UserPresetPrompt = prompt

--- a/common/ai/aid/aicommon/contextprovider.go
+++ b/common/ai/aid/aicommon/contextprovider.go
@@ -436,7 +436,7 @@ func KnowledgeBaseSystemFlagContextProvider(flag string, userPrompt ...string) C
 			}
 
 			content := detailBuilder.String()
-			if MeasureTokens(content) > maxInlineKnowledgeBaseTokens {
+			if TokenCountExceeds(content, maxInlineKnowledgeBaseTokens) {
 				filePath := consts.TempAIFileFast("knowledge-bases-*.txt", content)
 				if emitter != nil && filePath != "" {
 					emitter.EmitPinFilename(filePath)
@@ -663,7 +663,7 @@ func (r *ContextProviderManager) executeWithTagStrategy(
 	})
 
 	result := buf.String()
-	if MeasureTokens(result) > r.maxTokens {
+	if TokenCountExceeds(result, r.maxTokens) {
 		shrinkSize := int(float64(r.maxTokens) * 0.8)
 		result = ShrinkTextBlockByTokens(result, shrinkSize)
 		log.Warnf("context provider result exceeded maxTokens (%d), shrunk to %d tokens", r.maxTokens, shrinkSize)

--- a/common/ai/aid/aicommon/evidence_store.go
+++ b/common/ai/aid/aicommon/evidence_store.go
@@ -119,7 +119,7 @@ func (s *EvidenceStore) Render() string {
 func (s *EvidenceStore) ShrinkToTokenBudget(budget int) {
 	for len(s.Items) > 1 {
 		rendered := s.Render()
-		if MeasureTokens(rendered) <= budget {
+		if !TokenCountExceeds(rendered, budget) {
 			return
 		}
 		s.Items = s.Items[1:]

--- a/common/ai/aid/aicommon/session_artifacts.go
+++ b/common/ai/aid/aicommon/session_artifacts.go
@@ -223,7 +223,7 @@ func RenderSessionArtifactGroups(workDir string, groups []SessionArtifactTaskGro
 		sb.WriteString("\n")
 	}
 	result := sb.String()
-	if MeasureTokens(result) > ArtifactsContextMaxTokens {
+	if TokenCountExceeds(result, ArtifactsContextMaxTokens) {
 		result = ShrinkTextBlockByTokens(result, ArtifactsContextMaxTokens)
 	}
 	return result
@@ -482,7 +482,7 @@ func renderSessionArtifactPromptGroups(
 	}
 
 	result := sb.String()
-	if MeasureTokens(result) > ArtifactsContextMaxTokens {
+	if TokenCountExceeds(result, ArtifactsContextMaxTokens) {
 		result = ShrinkTextBlockByTokens(result, ArtifactsContextMaxTokens)
 	}
 	return result

--- a/common/ai/aid/aicommon/session_prompt_state.go
+++ b/common/ai/aid/aicommon/session_prompt_state.go
@@ -217,7 +217,7 @@ func (s *SessionPromptState) GetSessionEvidenceFrozenOpenBlocks(frozenTimeUnix i
 
 	blocks := RenderSessionEvidenceFrozenOpen(s.sessionEvidenceState, store, frozenTimeUnix)
 	rendered := renderSessionEvidencePromptBlocks(blocks, openNonce)
-	for MeasureTokens(joinSessionEvidencePromptBlocks(rendered)) > sessionEvidenceTokenBudget && len(store.Items) > 1 {
+	for len(store.Items) > 1 && TokenCountExceeds(joinSessionEvidencePromptBlocks(rendered), sessionEvidenceTokenBudget) {
 		trimmed := store.Items[0]
 		store.Items = store.Items[1:]
 		pruneSessionEvidenceFrozenItem(s.sessionEvidenceState, trimmed.ID)
@@ -234,7 +234,7 @@ func shrinkEvidenceStoreWithStateToTokenBudget(store *EvidenceStore, state *Sess
 	}
 	for len(store.Items) > 1 {
 		rendered := store.Render()
-		if MeasureTokens(rendered) <= budget {
+		if !TokenCountExceeds(rendered, budget) {
 			return
 		}
 		trimmed := store.Items[0]

--- a/common/ai/aid/aicommon/timeline.go
+++ b/common/ai/aid/aicommon/timeline.go
@@ -1046,18 +1046,25 @@ func (m *Timeline) dumpRecentForPrompt(tokenLimit int, includeLatestModelReplay 
 	result := header + body + footer
 	// Tokenizers can merge differently across concatenation boundaries. Keep a
 	// final guard so the public contract remains a hard upper bound.
-	if MeasureTokens(result) > tokenLimit {
+	if resultTokens := MeasureTokens(result); resultTokens > tokenLimit {
+		originalBody := body
 		bodyBudget := tokenLimit - baseTokens
-		for bodyBudget > 0 && MeasureTokens(result) > tokenLimit {
-			bodyBudget--
-			body = strings.TrimSpace(ShrinkTextBlockByTokens(body, bodyBudget))
+		for bodyBudget > 0 && resultTokens > tokenLimit {
+			// Remove the measured overflow in one step. The previous one-token
+			// decrement re-encoded the complete body once per excess token.
+			bodyBudget -= max(1, resultTokens-tokenLimit)
+			if bodyBudget <= 0 {
+				return ""
+			}
+			body = strings.TrimSpace(ShrinkTextBlockByTokens(originalBody, bodyBudget))
 			if body == "" {
 				return ""
 			}
 			result = header + body + footer
+			resultTokens = MeasureTokens(result)
 		}
 	}
-	if MeasureTokens(result) > tokenLimit {
+	if ytoken.TokenCountExceeds(result, tokenLimit) {
 		return ""
 	}
 	return result

--- a/common/ai/aid/aicommon/timeline_batch_compress.go
+++ b/common/ai/aid/aicommon/timeline_batch_compress.go
@@ -373,7 +373,7 @@ func (m *Timeline) batchCompressOldestWithRecent(toCompress []*TimelineItem, rec
 	}
 
 	// 如果拼接后 head 超预算，触发 head-only 精简
-	if int64(MeasureTokens(finalText)) > outputTokenBudget {
+	if TokenCountExceeds64(finalText, outputTokenBudget) {
 		finalText = m.refineCompressedHeadLocked(finalText, outputTokenBudget, nonceStr)
 	}
 
@@ -826,7 +826,7 @@ func (m *Timeline) refineCompressedHeadLocked(headText string, budget int64, non
 	}
 
 	// 如果 AI 不可用或精简 prompt 构建失败，用规则截断兜底
-	if MeasureTokens(headText) <= int(budget) {
+	if !TokenCountExceeds64(headText, budget) {
 		return headText
 	}
 
@@ -883,7 +883,7 @@ func (m *Timeline) refineCompressedHeadLocked(headText string, budget int64, non
 	}
 
 	// 确保 refined 不超过预算
-	if int64(MeasureTokens(refined)) > budget {
+	if TokenCountExceeds64(refined, budget) {
 		refined = enforceOutputTokenBudget(refined, budget)
 	}
 	return refined

--- a/common/ai/aid/aicommon/token_measure.go
+++ b/common/ai/aid/aicommon/token_measure.go
@@ -1,6 +1,7 @@
 package aicommon
 
 import (
+	"math"
 	"strings"
 
 	"github.com/yaklang/yaklang/common/ai/ytoken"
@@ -115,6 +116,25 @@ func shrinkByTokens(text string, limit int, keepTail bool) string {
 // MeasureTokens returns the token count of text.
 func MeasureTokens(text string) int {
 	return ytoken.CalcTokenCount(text)
+}
+
+// TokenCountExceeds is the allocation-light form for hard budget checks. It
+// stops tokenization as soon as the limit is crossed and skips it entirely
+// when the input byte length already proves the text fits.
+func TokenCountExceeds(text string, tokenLimit int) bool {
+	return ytoken.TokenCountExceeds(text, tokenLimit)
+}
+
+// TokenCountExceeds64 is the int64 budget variant. The range guard keeps the
+// int conversion safe on every architecture supported by Go.
+func TokenCountExceeds64(text string, tokenLimit int64) bool {
+	if tokenLimit < 0 {
+		return true
+	}
+	if tokenLimit > int64(math.MaxInt) {
+		return false
+	}
+	return ytoken.TokenCountExceeds(text, int(tokenLimit))
 }
 
 // ShrinkByTokens truncates text to fit within tokenLimit tokens (head only).

--- a/common/ai/aid/aicommon/toolcall_artifact.go
+++ b/common/ai/aid/aicommon/toolcall_artifact.go
@@ -525,7 +525,7 @@ func normalizeToolResultData(toolResult *aitool.ToolResult, combined, resultText
 	// shrink fields must not bypass it during Timeline rendering.
 	toolResult.ShrinkResult = ""
 	toolResult.ShrinkSimilarResult = ""
-	if ytoken.CalcTokenCount(toolResult.CallExpectations) > toolResultHintReserve/2 {
+	if ytoken.TokenCountExceeds(toolResult.CallExpectations, toolResultHintReserve/2) {
 		toolResult.CallExpectations = ShrinkTextBlockByTokens(toolResult.CallExpectations, toolResultHintReserve/2)
 	}
 	if combined == "" {
@@ -561,11 +561,11 @@ func applyNormalizedData(toolResult *aitool.ToolResult, body, hint string) {
 	}
 
 	// An enormous error cannot be allowed to consume the whole Timeline item.
-	if ytoken.CalcTokenCount(toolResult.Error) > toolResultHintReserve {
+	if ytoken.TokenCountExceeds(toolResult.Error, toolResultHintReserve) {
 		toolResult.Error = ShrinkTextBlockByTokens(toolResult.Error, toolResultHintReserve)
 	}
 	toolResult.Data = shrinkBodyWithStats(body, bodyBudget) + "\n\n" + hint
-	if ytoken.CalcTokenCount(toolResult.Data.(string)) > ToolResultTokenLimit {
+	if ytoken.TokenCountExceeds(toolResult.Data.(string), ToolResultTokenLimit) {
 		toolResult.Data = shrinkBodyWithStats(body, ToolResultTokenLimit-staticTokens) + "\n\n" + hint
 	}
 
@@ -579,18 +579,25 @@ func enforceCanonicalToolResultLimit(toolResult *aitool.ToolResult) {
 	if toolResult == nil {
 		return
 	}
-	if ytoken.CalcTokenCount(toolResult.Error) > toolResultHintReserve {
+	if ytoken.TokenCountExceeds(toolResult.Error, toolResultHintReserve) {
 		toolResult.Error = ShrinkTextBlockByTokens(toolResult.Error, toolResultHintReserve)
 	}
 	// Params remain on ToolResult for audit/checkpoint use, but an exceptionally
 	// large param block is omitted from Timeline rendering to preserve the same
 	// 16K hard ceiling as Data.
-	for attempts := 0; attempts < 8 && ytoken.CalcTokenCount(toolResult.String()) > ToolResultTokenLimit; attempts++ {
+	for attempts := 0; attempts < 8; attempts++ {
 		if !toolResult.OmitParamsInTimeline {
+			if !ytoken.TokenCountExceeds(toolResult.String(), ToolResultTokenLimit) {
+				break
+			}
 			toolResult.OmitParamsInTimeline = true
 			continue
 		}
-		over := ytoken.CalcTokenCount(toolResult.String()) - ToolResultTokenLimit
+		currentTokens := ytoken.CalcTokenCount(toolResult.String())
+		if currentTokens <= ToolResultTokenLimit {
+			break
+		}
+		over := currentTokens - ToolResultTokenLimit
 		data, ok := toolResult.Data.(string)
 		if !ok || data == "" {
 			break
@@ -674,8 +681,7 @@ func (b *toolCallArtifactBundle) finalize(
 
 	hint := toolArtifactHint(b, persistErr)
 	normalizeToolResultData(toolResult, combined, resultText, hint)
-	rawTokens := ytoken.CalcTokenCount(combined) + ytoken.CalcTokenCount(resultText)
-	if persistErr != nil && rawTokens > ToolResultTokenLimit {
+	if persistErr != nil && tokenCountSumExceeds(ToolResultTokenLimit, combined, resultText) {
 		// Artifact persistence is an observation-channel failure after the tool
 		// callback already produced its protocol result. Keep Success unchanged;
 		// the canonical HINT communicates that the oversized observation is not
@@ -733,6 +739,18 @@ func (b *toolCallArtifactBundle) finalize(
 	t.emitter.EmitPinFilename(b.dir)
 	log.Infof("saved tool call artifact bundle to: %s", b.dir)
 	return nil
+}
+
+func tokenCountSumExceeds(limit int, texts ...string) bool {
+	remaining := limit
+	for _, text := range texts {
+		count, exceeded := ytoken.CalcTokenCountUpTo(text, remaining)
+		if exceeded {
+			return true
+		}
+		remaining -= count
+	}
+	return false
 }
 
 func (b *toolCallArtifactBundle) renderReport(tool *aitool.Tool, identifier string, params aitool.InvokeParams, toolResult *aitool.ToolResult, paramGenDuration time.Duration, rawAIParamResponse string) string {
@@ -847,7 +865,7 @@ func migrateLegacyTimelineToolResult(workdir string, toolResult *aitool.ToolResu
 	hint := toolArtifactHint(b, persistErr)
 	normalizeToolResultData(toolResult, combined, resultText, hint)
 	if persistErr != nil {
-		if ytoken.CalcTokenCount(combined)+ytoken.CalcTokenCount(resultText) > ToolResultTokenLimit {
+		if tokenCountSumExceeds(ToolResultTokenLimit, combined, resultText) {
 			normalizeToolResultData(toolResult, combined, resultText, hint)
 		}
 		log.Warnf("failed to migrate legacy Timeline tool result %d: %v", toolResult.ID, persistErr)

--- a/common/ai/aid/aireact/invoke_compress_long_text_with_dest.go
+++ b/common/ai/aid/aireact/invoke_compress_long_text_with_dest.go
@@ -89,7 +89,7 @@ func (r *ReAct) CompressLongTextWithDestination(
 		return "", utils.Error("cannot compress empty text")
 	}
 
-	if int64(ytoken.CalcTokenCount(rawText)) < (targetTokenSize / 2) {
+	if !aicommon.TokenCountExceeds64(rawText, targetTokenSize/2-1) {
 		return rawText, nil
 	}
 

--- a/common/ai/aid/aireact/knowledgebench/bench_compress.go
+++ b/common/ai/aid/aireact/knowledgebench/bench_compress.go
@@ -45,7 +45,7 @@ func BenchCompressLongText(
 	}
 
 	targetTokenSize := opts.TargetTokenSize
-	if int64(ytoken.CalcTokenCount(rawText)) < (targetTokenSize / 2) {
+	if !aicommon.TokenCountExceeds64(rawText, targetTokenSize/2-1) {
 		return rawText, 0, nil
 	}
 

--- a/common/ai/aid/aireact/prompt_loop_materials.go
+++ b/common/ai/aid/aireact/prompt_loop_materials.go
@@ -277,7 +277,7 @@ func boundedLightweightPromptBlock(content string, tokenLimit int, label string)
 	if strings.TrimSpace(content) == "" {
 		return ""
 	}
-	if aicommon.MeasureTokens(content) <= tokenLimit {
+	if !aicommon.TokenCountExceeds(content, tokenLimit) {
 		return content
 	}
 	// These inputs often already contain AITAG wrappers. Cutting through them

--- a/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_fuzztest/init.go
@@ -383,7 +383,7 @@ func searchByKeywords(db *gorm.DB, keywords []string) string {
 
 				results.WriteString(fmt.Sprintf("[%d] %s\n", i+1, entry.KnowledgeTitle))
 				content := entry.KnowledgeDetails
-				if ytoken.CalcTokenCount(content) > 500 {
+				if ytoken.TokenCountExceeds(content, 500) {
 					content = content[:500] + "..."
 				}
 				results.WriteString(content + "\n\n")
@@ -475,7 +475,7 @@ func searchBySemantic(db *gorm.DB, collectionName string, questions []string) st
 			content = result.Document.Content
 		}
 
-		if ytoken.CalcTokenCount(content) > 800 {
+		if ytoken.TokenCountExceeds(content, 800) {
 			content = content[:800] + "\n[... content truncated ...]"
 		}
 

--- a/common/ai/aid/aireact/reactloops/loop_infosec_recon/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_infosec_recon/init.go
@@ -104,7 +104,7 @@ func init() {
 						srcParts = append(srcParts, k+":"+utils.InterfaceToString(bySrc[k]))
 					}
 					reconLog := loop.Get(keyReconLog)
-					if ytoken.CalcTokenCount(reconLog) > 3500 {
+					if ytoken.TokenCountExceeds(reconLog, 3500) {
 						reconLog = reconLog[len(reconLog)-3500:]
 					}
 					pathFailureHint := strings.TrimSpace(loop.Get(keyPathFailureRecoveryHint))

--- a/common/ai/aid/aireact/reactloops/loop_report_generating/action_read_reference.go
+++ b/common/ai/aid/aireact/reactloops/loop_report_generating/action_read_reference.go
@@ -89,7 +89,7 @@ var readReferenceFileAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActL
 
 			// 限制内容大小，避免过大
 			const maxContentTokens = 50 * 1024
-			if ytoken.CalcTokenCount(resultContent) > maxContentTokens {
+			if ytoken.TokenCountExceeds(resultContent, maxContentTokens) {
 				resultContent = resultContent[:maxContentTokens] + "\n\n[... content truncated, file too large ...]"
 				log.Warnf("read_reference_file: content truncated to %d tokens", maxContentTokens)
 			}

--- a/common/ai/aid/aireact/reactloops/loop_report_generating/action_search_knowledge.go
+++ b/common/ai/aid/aireact/reactloops/loop_report_generating/action_search_knowledge.go
@@ -77,7 +77,7 @@ var searchKnowledgeAction = func(r aicommon.AIInvokeRuntime) reactloops.ReActLoo
 
 			// 限制内容大小
 			const maxContentTokens = 30 * 1024
-			if ytoken.CalcTokenCount(resultContent) > maxContentTokens {
+			if ytoken.TokenCountExceeds(resultContent, maxContentTokens) {
 				resultContent = resultContent[:maxContentTokens] + "\n\n[... results truncated ...]"
 				log.Warnf("search_knowledge: results truncated to %d tokens", maxContentTokens)
 			}

--- a/common/ai/aid/aireact/reactloops/perception.go
+++ b/common/ai/aid/aireact/reactloops/perception.go
@@ -184,7 +184,7 @@ func (p *PerceptionState) FormatForContext() string {
 		buf.WriteString(fmt.Sprintf("Keywords: %s\n", strings.Join(p.Keywords, ", ")))
 	}
 	result := buf.String()
-	if aicommon.MeasureTokens(result) > perceptionMaxContextTokens {
+	if aicommon.TokenCountExceeds(result, perceptionMaxContextTokens) {
 		result = aicommon.ShrinkTextBlockByTokens(result, perceptionMaxContextTokens)
 	}
 	return result
@@ -628,7 +628,7 @@ func formatPerceptionKnowledgeContext(query string, knowledgeBases []string, con
 	buf.WriteString(content)
 
 	result := buf.String()
-	if aicommon.MeasureTokens(result) > perceptionKnowledgeMaxContextTokens {
+	if aicommon.TokenCountExceeds(result, perceptionKnowledgeMaxContextTokens) {
 		result = aicommon.ShrinkTextBlockByTokens(result, perceptionKnowledgeMaxContextTokens)
 	}
 	return strings.TrimSpace(result)

--- a/common/ai/ytoken/README.md
+++ b/common/ai/ytoken/README.md
@@ -1,149 +1,106 @@
-# ytoken - Qwen BPE Token Estimator
+# ytoken - high-performance Qwen BPE tokenizer
 
-import "github.com/yaklang/yaklang/common/ai/ytoken"
+`ytoken` is a pure-Go-hot-path token counter and encoder built around the
+embedded Qwen BPE vocabulary. It is intended for prompt budgeting, truncation,
+and local token estimation without a Python or Rust runtime.
 
-## 核心特性
-count := ytoken.CalcTokenCount("你好，世界！")
-- **精确计数**：使用 Qwen 官方 BPE 词表（151,643 mergeable + 208 special = 151,851 tokens），与 Qwen/Qwen2/Qwen3 系列模型完全一致
-- **零外部依赖**：不引入新的 `go.mod` 依赖，仅使用项目已有的 `dlclark/regexp2`
-count := ytoken.CalcOrdinaryTokenCount("普通文本")
-- **延迟初始化**：`sync.Once` 保证首次调用时解压加载词表，后续调用零开销
-
-ids := ytoken.Encode("<|im_start|>user\n你好<|im_end|>")
-
-```go
-text := ytoken.Decode(ids)
-
-// 计算 token 数量（含 special token 处理）
-count := ytoken.CalcTokenCount("你好，世界！")
-
-// 不处理 special token 的计数
-count := ytoken.CalcOrdinaryTokenCount("普通文本")
-
-// 获取 token ID 列表
-ids := ytoken.Encode("<|im_start|>user\n你好<|im_end|>")
-
-// token ID 还原为文本
-text := ytoken.Decode(ids)
-```
+The package preserves the historical ytoken vocabulary and special-token
+surface (`<|endoftext|>`, `<|im_start|>`, `<|im_end|>`, and
+`<|extra_0|>` through `<|extra_204|>`). Model families that define different
+special tokens should use an explicitly versioned tokenizer rather than
+assuming every Qwen generation has an identical special-token map.
 
 ## API
 
-| 函数 | 说明 |
-|------|------|
-| `CalcTokenCount(text string) int` | 计算 token 数，识别 `<\|im_start\|>` 等 special tokens |
-| `CalcOrdinaryTokenCount(text string) int` | 计算 token 数，不处理 special tokens |
-| `Encode(text string) []int` | 编码为 token ID 列表，识别 special tokens |
-| `EncodeOrdinary(text string) []int` | 编码为 token ID 列表，不处理 special tokens |
-| `Decode(tokens []int) string` | 将 token ID 列表解码回文本 |
+```go
+import "github.com/yaklang/yaklang/common/ai/ytoken"
 
-## Token/Bytes 比率参考
+count := ytoken.CalcTokenCount("你好，世界！")
+ordinaryCount := ytoken.CalcOrdinaryTokenCount("ordinary text")
 
-基于真实 Agent prompt 和多种内容类型的实测数据：
+// Exact when exceeded is false. When true, count is an early-exit value
+// greater than the limit, not the complete token count.
+count, exceeded := ytoken.CalcTokenCountUpTo(longPrompt, 16_000)
 
-| 内容类型 | Bytes/Token (B/T) | Runes/Token (R/T) | Tokens/Rune (T/R) | 说明 |
-|----------|-------------------|--------------------|--------------------|------|
-| 英文 | ~4.6 | ~4.5 | ~0.22 | 纯英文 prompt，约 4.5 字符一个 token |
-| 中文 | ~3.9 | ~2.2 | ~0.45 | 纯中文文本，约 2.2 字符一个 token |
-| 中英混合 | ~4.0 | ~3.2 | ~0.31 | Agent 系统 prompt 典型场景 |
-| 代码 | ~3.4 | ~3.4 | ~0.29 | Go/Python/Shell/JSON |
+// Fast hard-limit check. This avoids tokenization entirely when valid UTF-8
+// input bytes already prove the text fits and otherwise stops after crossing.
+if ytoken.TokenCountExceeds(longPrompt, 16_000) {
+	// shrink or reject
+}
 
-### 快速估算公式
-
-当无法调用分词器时，可用以下经验公式近似估算：
-
-```
-tokens ~ runes * T/R
+ids := ytoken.Encode("<|im_start|>user\n你好<|im_end|>")
+text := ytoken.Decode(ids)
 ```
 
-- 纯英文：`tokens ~ len(text) * 0.22`
-- 纯中文：`tokens ~ runeCount * 0.45`
-- 中英混合 prompt：`tokens ~ runeCount * 0.31`
-- 代码：`tokens ~ len(text) * 0.29`
+| Function | Description |
+|---|---|
+| `CalcTokenCount` | Exact count with historical ytoken special tokens |
+| `CalcOrdinaryTokenCount` | Exact count without special-token recognition |
+| `CalcTokenCountUpTo` | Count with an early-exit token limit |
+| `TokenCountExceeds` | Allocation-light hard-limit predicate |
+| `Encode` / `EncodeOrdinary` | Return token IDs |
+| `Decode` | Convert token IDs back to text |
 
-**注意**：这些是粗略估算值，实际使用时应调用 `CalcTokenCount()` 获取精确结果。
+## Implementation
 
-### 实测数据样本
+The tokenizer performs the Qwen-compatible regex pre-split, followed by
+byte-level BPE:
 
-以下为项目真实 prompt 文件的实测结果：
+- A complete regex piece is looked up directly before running BPE.
+- Pieces shorter than 100 bytes use a stack-backed compact boundary array.
+  This retains the cache-friendly `O(m*n)` merge algorithm while bounding `n`.
+- Larger pieces use a minimum heap plus linked byte offsets. Only the two pairs
+  affected by a merge are recomputed, giving `O(n log n)` worst-case time and
+  `O(n)` state instead of repeated whole-piece scans and copies.
+- Counting has a dedicated path and does not construct a token-ID slice.
+- Special tokens are recognized in one bounded scan instead of splitting the
+  input once for each of the 208 token strings.
+- The Qwen regex is implemented as an allocation-free pure-Go scanner for Go's
+  assigned Unicode table. Code points not assigned in that table take the
+  historical PCRE2 compatibility path, preserving category behavior when the
+  bundled PCRE2 has newer Unicode data.
+- The gzip vocabulary is decoded as a stream during one-time initialization,
+  avoiding a second in-memory copy of the decompressed file.
 
-| 文件 | Bytes | Runes | Tokens | B/T | R/T |
-|------|-------|-------|--------|-----|-----|
-| base.txt (Agent 系统 prompt) | 5,995 | 3,939 | 1,423 | 4.21 | 2.77 |
-| verification.txt (任务验证) | 22,936 | 12,928 | 5,869 | 3.91 | 2.20 |
-| tool-params.txt (工具参数) | 7,434 | 7,138 | 1,947 | 3.82 | 3.67 |
-| interval-review.txt (执行监控) | 2,967 | 2,859 | 660 | 4.50 | 4.33 |
-| phase2_scan_instruction.txt (安全审计) | 7,039 | 4,143 | 1,807 | 3.90 | 2.29 |
+No new module dependency is required. The regex pre-tokenizer uses the PCRE2
+implementation already present in the Yaklang module.
 
-## 实现原理
+## Performance
 
-### BPE 编码流程
+Representative count-only benchmarks on Go 1.22.12, darwin/arm64. Benchmarks
+are documentation and are not executed by normal CI tests.
 
-```
-输入文本
-  |
-  v
-[正则预分词] -- 按 Qwen 的 pattern 将文本切分为 chunks
-  |            pattern: (?i:'s|'t|'re|...) | \p{L}+ | \p{N} | ...
-  v
-[Special Token 分割] -- 识别 <|im_start|> <|im_end|> 等并直接映射 ID
-  |
-  v
-[BPE 编码] -- 对每个 chunk:
-  |           1. 拆为单字节序列
-  |           2. 查找 rank 最小的相邻 pair
-  |           3. 合并该 pair
-  |           4. 重复直到无可合并的 pair
-  v
-Token ID 列表
-```
+| Input | Previous implementation | Optimized implementation | Allocations before / after |
+|---|---:|---:|---:|
+| Short English | 13.9-22.6 us | 0.28 us | 361 / 0 |
+| Short Chinese | 180-199 us | 4.45 us | 4,352 / 0 |
+| Medium mixed | 450-457 us | 20.0 us | 12,466 / 0 |
+| About 5 KB Go code | 2.62-2.93 ms | 0.073 ms | about 68,000 / 0 |
+| 8.5 KB real Agent base prompt | about 15.9 ms | 0.70 ms | not recorded / 2 |
 
-### 词表来源
+Results vary by CPU and workload. Run the benchmarks locally when changing the
+merge structure, regex iteration, vocabulary representation, or count path.
 
-- BPE 词表文件 `qwen.tiktoken` 来自 [CharLemAznable/qwen-tokenizer](https://github.com/CharLemAznable/qwen-tokenizer)
-- 原始来源：[Qwen-7B HuggingFace](https://huggingface.co/Qwen/Qwen-7B/resolve/main/qwen.tiktoken)
-- 词表大小：151,643 BPE merges + 208 special tokens
-- Qwen/Qwen1.5/Qwen2/Qwen3 系列共享相同词表
-
-### 存储优化
-
-词表文件使用 gzip 压缩后通过 `go:embed` 内嵌：
-
-| 状态 | 大小 |
-|------|------|
-| 原始 `qwen.tiktoken` | 2.4 MB |
-| gzip -9 压缩 | 1.1 MB |
-| 压缩率 | 54% |
-
-首次调用时通过 `sync.Once` 解压并构建内存索引（map），后续调用直接使用。
-
-## 测试
+## Correctness and tests
 
 ```bash
-# 运行全部测试（含比率分析报告）
-go test -v ./common/ai/ytoken/
-
-# 运行 benchmark
-go test -bench=. -benchmem ./common/ai/ytoken/
+go test ./common/ai/ytoken
+go test -race ./common/ai/ytoken
+go test ./common/ai/ytoken -run '^$' \
+  -bench '^BenchmarkCalcTokenCount_' -benchmem
 ```
 
-测试覆盖：
+The normal test suite includes:
 
-1. **正确性测试** -- 与 CharLemAznable/qwen-tokenizer 的 golden vector 对齐
-2. **编解码往返测试** -- 英文/中文/代码/特殊字符/Unicode/长文本
-3. **幂等性测试** -- 同一文本多次编码结果一致
-4. **Token/Bytes 比率分析** -- 15 种内容类型的详细比率报告
-5. **比率边界验证** -- 确保各类型文本的 B/T 在合理范围内
-6. **真实 prompt 测试** -- 使用 `common/ai/aid/` 中的 Agent prompt 作为测试素材
-7. **Chat 消息开销测试** -- 验证 Qwen chat template 的 overhead 估算精度
-8. **性能 benchmark** -- 短文本/中等文本/长代码的吞吐量基准
+- published Qwen golden vectors;
+- encode/decode round trips for Chinese, English, code, Unicode, whitespace,
+  and special tokens;
+- a deterministic differential corpus comparing the optimized merge engine
+  with ytoken's former reference algorithm, including the large-piece path;
+- legacy special-token splitting compatibility, including invalid and nested
+  markers;
+- bounded-count and invalid UTF-8 behavior;
+- real Agent prompt coverage.
 
-## 文件结构
-
-```
-common/ai/ytoken/
-  qwen.tiktoken.gz      -- gzip 压缩的 BPE 词表 (1.1MB, embed 到二进制)
-  ytoken.go             -- 实现: 词表加载 + BPE 算法 + 公共 API
-  ytoken_test.go        -- 测试: 正确性 + 比率分析 + 稳定性 + benchmark
-  README.md              -- 本文档
-```
+The embedded `qwen.tiktoken.gz` contains 151,643 mergeable tokens. Initialization
+builds the encoder and decoder tables once through `sync.Once`.

--- a/common/ai/ytoken/ytoken.go
+++ b/common/ai/ytoken/ytoken.go
@@ -6,12 +6,12 @@ import (
 	"compress/gzip"
 	_ "embed"
 	"encoding/base64"
-	"fmt"
-	"io"
 	"math"
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 
 	regexp2 "github.com/VillanCh/go-pcre2-lite/regexp2"
 )
@@ -31,9 +31,10 @@ const (
 
 var (
 	initOnce        sync.Once
+	pcreInitOnce    sync.Once
 	mergeableRanks  map[string]int
 	specialTokens   map[string]int
-	specialKeys     []string
+	maxSpecialLen   int
 	decodeSlice     []string
 	compiledPattern *regexp2.Regexp
 )
@@ -46,44 +47,47 @@ func doInit() {
 	initSpecialTokens()
 	initMergeableRanks()
 	initDecodeSlice()
-	compiledPattern = regexp2.MustCompile(bpePattern, 0)
+}
+
+func ensurePCRE() {
+	pcreInitOnce.Do(func() {
+		compiledPattern = regexp2.MustCompile(bpePattern, 0)
+	})
 }
 
 func initSpecialTokens() {
 	specialTokens = make(map[string]int, 208)
-	specialKeys = make([]string, 0, 208)
 	id := specialStartID
 	for _, tok := range []string{endOfText, imStart, imEnd} {
 		specialTokens[tok] = id
-		specialKeys = append(specialKeys, tok)
+		maxSpecialLen = max(maxSpecialLen, len(tok))
 		id++
 	}
 	for i := 0; i < 205; i++ {
-		tok := fmt.Sprintf("<|extra_%d|>", i)
+		tok := "<|extra_" + strconv.Itoa(i) + "|>"
 		specialTokens[tok] = id
-		specialKeys = append(specialKeys, tok)
+		maxSpecialLen = max(maxSpecialLen, len(tok))
 		id++
 	}
 }
 
-func decompressBpeData() []byte {
+func openBpeData() *gzip.Reader {
 	gr, err := gzip.NewReader(bytes.NewReader(qwenBpeDataGz))
 	if err != nil {
 		panic("ytoken: gzip open: " + err.Error())
 	}
-	defer gr.Close()
-	data, err := io.ReadAll(gr)
-	if err != nil {
-		panic("ytoken: gzip decompress: " + err.Error())
-	}
-	return data
+	return gr
 }
 
 func initMergeableRanks() {
-	raw := decompressBpeData()
+	gr := openBpeData()
+	defer gr.Close()
 	mergeableRanks = make(map[string]int, 160000)
-	scanner := bufio.NewScanner(bytes.NewReader(raw))
-	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	scanner := bufio.NewScanner(gr)
+	// The current vocabulary's longest line is well below the initial buffer.
+	// Keep a generous growth limit for future vocabularies without paying a
+	// 1 MiB allocation on every process start.
+	scanner.Buffer(make([]byte, 4<<10), 1<<20)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -122,33 +126,68 @@ func initDecodeSlice() {
 // CalcTokenCount returns the Qwen BPE token count for text.
 // Special tokens (<|im_start|>, <|im_end|>, etc.) are recognized.
 func CalcTokenCount(text string) int {
-	return len(Encode(text))
+	ensureInit()
+	sink := tokenSink{}
+	tokenize(text, &sink, true)
+	return sink.count
 }
 
 // CalcOrdinaryTokenCount returns token count without special token handling.
 func CalcOrdinaryTokenCount(text string) int {
-	return len(EncodeOrdinary(text))
+	ensureInit()
+	sink := tokenSink{}
+	encodeOrdinary(text, &sink)
+	return sink.count
+}
+
+// CalcTokenCountUpTo counts tokens until text is fully processed or the count
+// exceeds limit. The returned count is exact when exceeded is false; otherwise
+// it is an early-exit count greater than limit rather than the total count.
+func CalcTokenCountUpTo(text string, limit int) (count int, exceeded bool) {
+	if limit < 0 {
+		return 0, true
+	}
+	ensureInit()
+	sink := tokenSink{bounded: true, limit: limit}
+	tokenize(text, &sink, true)
+	return sink.count, sink.exceeded
+}
+
+// TokenCountExceeds reports whether text contains more than limit tokens.
+// Since byte-level BPE cannot produce more tokens than input bytes, inputs no
+// longer than a non-negative limit are reported as fitting without invoking
+// the tokenizer.
+func TokenCountExceeds(text string, limit int) bool {
+	if limit < 0 {
+		return true
+	}
+	if len(text) <= limit && utf8.ValidString(text) {
+		return false
+	}
+	_, exceeded := CalcTokenCountUpTo(text, limit)
+	return exceeded
 }
 
 // Encode returns Qwen BPE token IDs, recognizing special tokens.
 func Encode(text string) []int {
 	ensureInit()
-	chunks := splitWithSpecial(text)
-	var tokens []int
-	for _, chunk := range chunks {
-		if id, ok := specialTokens[chunk]; ok {
-			tokens = append(tokens, id)
-		} else {
-			tokens = append(tokens, encodeOrdinary(chunk)...)
-		}
+	sink := tokenSink{collect: true}
+	if len(text) >= 4 {
+		sink.tokens = make([]int, 0, len(text)/4)
 	}
-	return tokens
+	tokenize(text, &sink, true)
+	return sink.tokens
 }
 
 // EncodeOrdinary encodes text without special token processing.
 func EncodeOrdinary(text string) []int {
 	ensureInit()
-	return encodeOrdinary(text)
+	sink := tokenSink{collect: true}
+	if len(text) >= 4 {
+		sink.tokens = make([]int, 0, len(text)/4)
+	}
+	encodeOrdinary(text, &sink)
+	return sink.tokens
 }
 
 // Decode converts token IDs back to text.
@@ -165,141 +204,512 @@ func Decode(tokens []int) string {
 
 // --- internal BPE ---
 
-func encodeOrdinary(text string) []int {
-	var tokens []int
+type tokenSink struct {
+	tokens   []int
+	count    int
+	limit    int
+	collect  bool
+	bounded  bool
+	exceeded bool
+}
+
+func (s *tokenSink) addToken(rank int) bool {
+	if s.collect {
+		s.tokens = append(s.tokens, rank)
+	}
+	return s.addCount(1)
+}
+
+func (s *tokenSink) addCount(count int) bool {
+	s.count += count
+	if s.bounded && s.count > s.limit {
+		s.exceeded = true
+		return false
+	}
+	return true
+}
+
+func encodeOrdinary(text string, sink *tokenSink) bool {
+	if canUsePureGoPreTokenizer(text) {
+		return encodeOrdinaryPureGo(text, sink)
+	}
+	return encodeOrdinaryPCRE(text, sink)
+}
+
+func encodeOrdinaryPCRE(text string, sink *tokenSink) bool {
+	ensurePCRE()
+	mapper := newRuneByteMapper(text)
 	m, err := compiledPattern.FindStringMatch(text)
 	for err == nil && m != nil {
-		tokens = append(tokens, bpeEncodeChunk(m.String())...)
+		piece := mapper.slice(m.Index, m.Index+m.Length, m)
+		if !bpeEncodePiece(piece, sink) {
+			return false
+		}
 		m, err = compiledPattern.FindNextMatch(m)
 	}
-	return tokens
+	return true
 }
 
-type bpeNode struct {
-	data []byte
-	rank int
-}
-
-func bpeEncodeChunk(chunk string) []int {
-	raw := []byte(chunk)
-	nodes := make([]*bpeNode, len(raw))
-	for i, b := range raw {
-		r := math.MaxInt32
-		if v, ok := mergeableRanks[string([]byte{b})]; ok {
-			r = v
-		}
-		nodes[i] = &bpeNode{data: []byte{b}, rank: r}
-	}
-
-	if len(nodes) < 2 {
-		out := make([]int, len(nodes))
-		for i, n := range nodes {
-			out[i] = n.rank
-		}
-		return out
-	}
-
-	for len(nodes) >= 2 {
-		best := lowestRankPair(nodes)
-		if best == nil {
-			break
-		}
-		nodes = applyMerge(nodes, best)
-	}
-
-	out := make([]int, len(nodes))
-	for i, n := range nodes {
-		out[i] = n.rank
-	}
-	return out
-}
-
-func lowestRankPair(nodes []*bpeNode) *bpeNode {
-	seen := make(map[string]struct{}, len(nodes))
-	var best *bpeNode
-	lo := math.MaxInt32
-	for i := 0; i < len(nodes)-1; i++ {
-		merged := joinBytes(nodes[i].data, nodes[i+1].data)
-		key := string(merged)
-		if _, dup := seen[key]; dup {
+func canUsePureGoPreTokenizer(text string) bool {
+	for _, r := range text {
+		if r < utf8.RuneSelf {
 			continue
 		}
-		seen[key] = struct{}{}
-		if r, ok := mergeableRanks[key]; ok && r < lo {
-			lo = r
-			best = &bpeNode{data: merged, rank: r}
+		// Go 1.22 uses Unicode 15.0 while the bundled PCRE2 can know newer
+		// assignments. Fall back for code points unassigned in Go so those rare
+		// inputs retain the historical PCRE category behavior.
+		if !unicode.In(r, unicode.L, unicode.M, unicode.N, unicode.P, unicode.S, unicode.Z, unicode.Cc, unicode.Cf, unicode.Co) {
+			return false
 		}
 	}
-	return best
+	return true
 }
 
-func applyMerge(nodes []*bpeNode, pair *bpeNode) []*bpeNode {
-	pairKey := string(pair.data)
-	out := make([]*bpeNode, 0, len(nodes))
-	i := 0
-	for i < len(nodes) {
-		if i < len(nodes)-1 {
-			merged := joinBytes(nodes[i].data, nodes[i+1].data)
-			if string(merged) == pairKey {
-				out = append(out, &bpeNode{data: merged, rank: pair.rank})
-				i += 2
-				continue
+// runeByteMapper slices the original UTF-8 string using regexp2's rune-based
+// match offsets. This avoids allocating m.String() for every regex piece.
+// Invalid UTF-8 retains regexp2's historical RuneError normalization path.
+type runeByteMapper struct {
+	text      string
+	validUTF8 bool
+	ascii     bool
+	runePos   int
+	bytePos   int
+}
+
+func newRuneByteMapper(text string) runeByteMapper {
+	ascii := true
+	for i := 0; i < len(text); i++ {
+		if text[i] >= utf8.RuneSelf {
+			ascii = false
+			break
+		}
+	}
+	return runeByteMapper{text: text, ascii: ascii, validUTF8: ascii || utf8.ValidString(text)}
+}
+
+func (m *runeByteMapper) byteOffset(runeOffset int) int {
+	for m.runePos < runeOffset {
+		_, size := utf8.DecodeRuneInString(m.text[m.bytePos:])
+		m.bytePos += size
+		m.runePos++
+	}
+	return m.bytePos
+}
+
+func (m *runeByteMapper) slice(startRune, endRune int, match *regexp2.Match) string {
+	if !m.validUTF8 {
+		return match.String()
+	}
+	if m.ascii {
+		return m.text[startRune:endRune]
+	}
+	start := m.byteOffset(startRune)
+	end := m.byteOffset(endRune)
+	return m.text[start:end]
+}
+
+func encodeOrdinaryPureGo(text string, sink *tokenSink) bool {
+	if !utf8.ValidString(text) {
+		// regexp2 historically normalizes each invalid byte through []rune.
+		text = string([]rune(text))
+	}
+	for start := 0; start < len(text); {
+		end := nextPieceEnd(text, start)
+		if end <= start {
+			_, size := utf8.DecodeRuneInString(text[start:])
+			end = start + size
+		}
+		if !bpeEncodePiece(text[start:end], sink) {
+			return false
+		}
+		start = end
+	}
+	return true
+}
+
+// nextPieceEnd implements bpePattern as an anchored, allocation-free scanner.
+// The alternatives intentionally follow the regex order because contractions,
+// leading spaces, and whitespace lookahead depend on that precedence.
+func nextPieceEnd(text string, start int) int {
+	if end := contractionEnd(text, start); end > start {
+		return end
+	}
+
+	// [^\r\n\p{L}\p{N}]?\p{L}+
+	pos := start
+	r, size := utf8.DecodeRuneInString(text[pos:])
+	if r != '\r' && r != '\n' && !unicode.IsLetter(r) && !unicode.IsNumber(r) {
+		next := pos + size
+		if next < len(text) {
+			nextRune, _ := utf8.DecodeRuneInString(text[next:])
+			if unicode.IsLetter(nextRune) {
+				pos = next
+				r = nextRune
 			}
 		}
-		out = append(out, nodes[i])
-		i++
 	}
-	return out
-}
-
-func joinBytes(a, b []byte) []byte {
-	c := make([]byte, len(a)+len(b))
-	copy(c, a)
-	copy(c[len(a):], b)
-	return c
-}
-
-// --- special token splitting ---
-
-func splitWithSpecial(text string) []string {
-	if strings.Contains(text, specialPrefix) && strings.Contains(text, specialSuffix) {
-		return splitByAll(text, specialKeys)
-	}
-	return []string{text}
-}
-
-func splitByAll(text string, seps []string) []string {
-	chunks := []string{text}
-	for _, sep := range seps {
-		var next []string
-		for _, ch := range chunks {
-			next = append(next, splitBySep(ch, sep)...)
+	if unicode.IsLetter(r) {
+		for pos < len(text) {
+			r, size = utf8.DecodeRuneInString(text[pos:])
+			if !unicode.IsLetter(r) {
+				break
+			}
+			pos += size
 		}
-		chunks = next
+		return pos
 	}
-	return chunks
+
+	// \p{N}
+	r, size = utf8.DecodeRuneInString(text[start:])
+	if unicode.IsNumber(r) {
+		return start + size
+	}
+
+	//  ?[^\s\p{L}\p{N}]+[\r\n]*
+	pos = start
+	if text[pos] == ' ' && pos+1 < len(text) {
+		nextRune, _ := utf8.DecodeRuneInString(text[pos+1:])
+		if isSymbolRune(nextRune) {
+			pos++
+		}
+	}
+	if pos < len(text) {
+		r, size = utf8.DecodeRuneInString(text[pos:])
+		if isSymbolRune(r) {
+			for pos < len(text) {
+				r, size = utf8.DecodeRuneInString(text[pos:])
+				if !isSymbolRune(r) {
+					break
+				}
+				pos += size
+			}
+			for pos < len(text) {
+				r, size = utf8.DecodeRuneInString(text[pos:])
+				if r != '\r' && r != '\n' {
+					break
+				}
+				pos += size
+			}
+			return pos
+		}
+	}
+
+	// \s*[\r\n]+ -- greediness makes this end after the last newline in the
+	// current whitespace run, leaving any trailing non-newline space behind.
+	if isWhitespaceAt(text, start) {
+		pos = start
+		lastNewlineEnd := -1
+		lastRuneStart := start
+		runeCount := 0
+		for pos < len(text) {
+			r, size = utf8.DecodeRuneInString(text[pos:])
+			if !unicode.IsSpace(r) {
+				break
+			}
+			lastRuneStart = pos
+			pos += size
+			runeCount++
+			if r == '\r' || r == '\n' {
+				lastNewlineEnd = pos
+			}
+		}
+		if lastNewlineEnd >= 0 {
+			return lastNewlineEnd
+		}
+
+		// \s+(?!\S) consumes the complete final whitespace run. Before a
+		// non-space rune it backtracks one rune so the lookahead sees space.
+		if pos == len(text) {
+			return pos
+		}
+		if runeCount > 1 {
+			return lastRuneStart
+		}
+
+		// Final \s+ alternative.
+		return pos
+	}
+
+	return start
 }
 
-func splitBySep(src, sep string) []string {
-	if !strings.Contains(src, sep) {
-		return []string{src}
+func contractionEnd(text string, start int) int {
+	if start >= len(text) || text[start] != '\'' {
+		return -1
 	}
-	var parts []string
-	from := 0
-	for {
-		rel := strings.Index(src[from:], sep)
+	for _, suffix := range [...]string{"s", "t", "re", "ve", "m", "ll", "d"} {
+		end := start + 1
+		for range suffix {
+			if end >= len(text) {
+				break
+			}
+			_, size := utf8.DecodeRuneInString(text[end:])
+			end += size
+		}
+		if strings.EqualFold(text[start+1:end], suffix) {
+			return end
+		}
+	}
+	return -1
+}
+
+func isSymbolRune(r rune) bool {
+	return !unicode.IsSpace(r) && !unicode.IsLetter(r) && !unicode.IsNumber(r)
+}
+
+func isWhitespaceAt(text string, start int) bool {
+	r, _ := utf8.DecodeRuneInString(text[start:])
+	return unicode.IsSpace(r)
+}
+
+const smallPieceThreshold = 100
+
+type bpePart struct {
+	start int
+	rank  int
+}
+
+func bpeEncodePiece(piece string, sink *tokenSink) bool {
+	if piece == "" {
+		return true
+	}
+	// Every non-empty pre-tokenized piece emits at least one token. Avoid the
+	// merge work when a bounded counter has already consumed its full budget.
+	if sink.bounded && sink.count >= sink.limit {
+		return sink.addCount(1)
+	}
+	if rank, ok := mergeableRanks[piece]; ok {
+		return sink.addToken(rank)
+	}
+	if len(piece) < smallPieceThreshold {
+		return bpeEncodeSmall(piece, sink)
+	}
+	return bpeEncodeLarge(piece, sink)
+}
+
+func bpeEncodeSmall(piece string, sink *tokenSink) bool {
+	var storage [smallPieceThreshold + 1]bpePart
+	parts := storage[:len(piece)+1]
+	minRank, minIndex := math.MaxInt, 0
+	for i := 0; i < len(piece)-1; i++ {
+		rank := pairRank(piece, i, i+2)
+		parts[i] = bpePart{start: i, rank: rank}
+		if rank < minRank {
+			minRank, minIndex = rank, i
+		}
+	}
+	parts[len(piece)-1] = bpePart{start: len(piece) - 1, rank: math.MaxInt}
+	parts[len(piece)] = bpePart{start: len(piece), rank: math.MaxInt}
+
+	getRank := func(i int) int {
+		if i+3 >= len(parts) {
+			return math.MaxInt
+		}
+		return pairRank(piece, parts[i].start, parts[i+3].start)
+	}
+
+	for minRank != math.MaxInt {
+		i := minIndex
+		if i > 0 {
+			parts[i-1].rank = getRank(i - 1)
+		}
+		parts[i].rank = getRank(i)
+		copy(parts[i+1:], parts[i+2:])
+		parts = parts[:len(parts)-1]
+
+		minRank, minIndex = math.MaxInt, 0
+		for i := 0; i < len(parts)-1; i++ {
+			if parts[i].rank < minRank {
+				minRank, minIndex = parts[i].rank, i
+			}
+		}
+	}
+
+	tokenCount := len(parts) - 1
+	if sink.collect {
+		for i := 0; i < tokenCount; i++ {
+			sink.tokens = append(sink.tokens, mergeableRanks[piece[parts[i].start:parts[i+1].start]])
+		}
+	}
+	return sink.addCount(tokenCount)
+}
+
+func pairRank(piece string, start, end int) int {
+	if rank, ok := mergeableRanks[piece[start:end]]; ok {
+		return rank
+	}
+	return math.MaxInt
+}
+
+type bpeMerge struct {
+	rank    int
+	start   int
+	version uint32
+}
+
+type bpeMergeHeap []bpeMerge
+
+func (h bpeMergeHeap) Less(i, j int) bool {
+	if h[i].rank != h[j].rank {
+		return h[i].rank < h[j].rank
+	}
+	return h[i].start < h[j].start
+}
+func (h bpeMergeHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *bpeMergeHeap) push(value bpeMerge) {
+	*h = append(*h, value)
+	for child := len(*h) - 1; child > 0; {
+		parent := (child - 1) / 2
+		if !h.Less(child, parent) {
+			break
+		}
+		h.Swap(child, parent)
+		child = parent
+	}
+}
+
+func (h *bpeMergeHeap) pop() bpeMerge {
+	items := *h
+	result := items[0]
+	last := len(items) - 1
+	if last == 0 {
+		*h = items[:0]
+		return result
+	}
+	items[0] = items[last]
+	items = items[:last]
+	*h = items
+	for parent := 0; ; {
+		left := parent*2 + 1
+		if left >= len(items) {
+			break
+		}
+		child := left
+		right := left + 1
+		if right < len(items) && h.Less(right, left) {
+			child = right
+		}
+		if !h.Less(child, parent) {
+			break
+		}
+		h.Swap(parent, child)
+		parent = child
+	}
+	return result
+}
+
+type bpeLink struct {
+	prev    int
+	next    int
+	version uint32
+	alive   bool
+}
+
+func bpeEncodeLarge(piece string, sink *tokenSink) bool {
+	links := make([]bpeLink, len(piece))
+	merges := make(bpeMergeHeap, 0, len(piece))
+	for i := range links {
+		links[i] = bpeLink{prev: i - 1, next: i + 1, alive: true}
+	}
+	links[len(links)-1].next = -1
+
+	pushPair := func(start int) {
+		links[start].version++
+		right := links[start].next
+		if right < 0 {
+			return
+		}
+		end := links[right].next
+		if end < 0 {
+			end = len(piece)
+		}
+		if rank, ok := mergeableRanks[piece[start:end]]; ok {
+			merges.push(bpeMerge{rank: rank, start: start, version: links[start].version})
+		}
+	}
+
+	for i := 0; i < len(piece)-1; i++ {
+		pushPair(i)
+	}
+	for len(merges) > 0 {
+		candidate := merges.pop()
+		left := candidate.start
+		if !links[left].alive || links[left].version != candidate.version {
+			continue
+		}
+		right := links[left].next
+		if right < 0 || !links[right].alive {
+			continue
+		}
+
+		next := links[right].next
+		links[left].next = next
+		links[right].alive = false
+		links[right].version++
+		if next >= 0 {
+			links[next].prev = left
+		}
+		pushPair(left)
+		if prev := links[left].prev; prev >= 0 {
+			pushPair(prev)
+		}
+	}
+
+	tokenCount := 0
+	for start := 0; start >= 0; start = links[start].next {
+		end := links[start].next
+		if end < 0 {
+			end = len(piece)
+		}
+		if sink.collect {
+			sink.tokens = append(sink.tokens, mergeableRanks[piece[start:end]])
+		}
+		tokenCount++
+		if links[start].next < 0 {
+			break
+		}
+	}
+	return sink.addCount(tokenCount)
+}
+
+// --- special token scanning ---
+
+func tokenize(text string, sink *tokenSink, recognizeSpecial bool) bool {
+	if !recognizeSpecial || !strings.Contains(text, specialPrefix) {
+		return encodeOrdinary(text, sink)
+	}
+
+	ordinaryStart, searchStart := 0, 0
+	for searchStart < len(text) {
+		rel := strings.Index(text[searchStart:], specialPrefix)
 		if rel < 0 {
 			break
 		}
-		pos := from + rel
-		if pos > from {
-			parts = append(parts, src[from:pos])
+		start := searchStart + rel
+		id, end, ok := specialTokenAt(text, start)
+		if !ok {
+			searchStart = start + len(specialPrefix)
+			continue
 		}
-		parts = append(parts, sep)
-		from = pos + len(sep)
+		if start > ordinaryStart && !encodeOrdinary(text[ordinaryStart:start], sink) {
+			return false
+		}
+		if !sink.addToken(id) {
+			return false
+		}
+		ordinaryStart, searchStart = end, end
 	}
-	if from < len(src) {
-		parts = append(parts, src[from:])
+	return ordinaryStart == len(text) || encodeOrdinary(text[ordinaryStart:], sink)
+}
+
+func specialTokenAt(text string, start int) (id int, end int, ok bool) {
+	limit := min(len(text), start+maxSpecialLen)
+	relEnd := strings.Index(text[start:limit], specialSuffix)
+	if relEnd < 0 {
+		return 0, 0, false
 	}
-	return parts
+	end = start + relEnd + len(specialSuffix)
+	id, ok = specialTokens[text[start:end]]
+	return id, end, ok
 }

--- a/common/ai/ytoken/ytoken_test.go
+++ b/common/ai/ytoken/ytoken_test.go
@@ -2,10 +2,13 @@ package ytoken
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -75,6 +78,253 @@ func TestCalcOrdinaryTokenCount(t *testing.T) {
 	if got != 18 {
 		t.Errorf("CalcOrdinaryTokenCount = %d, want 18", got)
 	}
+}
+
+func TestCalcTokenCountUpTo(t *testing.T) {
+	text := "<|im_start|>user\n请分析 this code<|im_end|>"
+	want := CalcTokenCount(text)
+
+	if got, exceeded := CalcTokenCountUpTo(text, want); got != want || exceeded {
+		t.Fatalf("limit at exact count: got=(%d, %v), want=(%d, false)", got, exceeded, want)
+	}
+	if got, exceeded := CalcTokenCountUpTo(text, want-1); got <= want-1 || !exceeded {
+		t.Fatalf("limit below count: got=(%d, %v), want count > %d", got, exceeded, want-1)
+	}
+	if TokenCountExceeds(text, want) {
+		t.Fatalf("TokenCountExceeds returned true at exact count %d", want)
+	}
+	if !TokenCountExceeds(text, want-1) {
+		t.Fatalf("TokenCountExceeds returned false below exact count %d", want)
+	}
+	if TokenCountExceeds("short", len("short")) {
+		t.Fatal("byte-length upper bound rejected a text that cannot exceed the limit")
+	}
+	for _, candidate := range []string{"valid 世界", string([]byte{0xff, 'a', 0xfe})} {
+		exact := CalcTokenCount(candidate)
+		for limit := 0; limit <= exact+1; limit++ {
+			if got, want := TokenCountExceeds(candidate, limit), exact > limit; got != want {
+				t.Fatalf("TokenCountExceeds(%q, %d) = %v, want %v", candidate, limit, got, want)
+			}
+		}
+	}
+}
+
+func TestOptimizedBPEMatchesReference(t *testing.T) {
+	ensureInit()
+	pieces := []string{
+		"a",
+		"hello world",
+		strings.Repeat("a", 256),
+		strings.Repeat("天地玄黄", 40),
+		strings.Repeat(" := function_name(value_123) ", 12),
+	}
+	rng := rand.New(rand.NewSource(0x59544f4b454e))
+	for i := 0; i < 300; i++ {
+		raw := make([]byte, 1+rng.Intn(180))
+		if _, err := rng.Read(raw); err != nil {
+			t.Fatal(err)
+		}
+		pieces = append(pieces, string(raw))
+	}
+
+	for i, piece := range pieces {
+		sink := tokenSink{collect: true}
+		if !bpeEncodePiece(piece, &sink) {
+			t.Fatalf("piece %d unexpectedly stopped", i)
+		}
+		want := referenceBPEEncode(piece)
+		if !reflect.DeepEqual(sink.tokens, want) {
+			t.Fatalf("piece %d mismatch\ngot:  %v\nwant: %v", i, sink.tokens, want)
+		}
+	}
+}
+
+func TestPureGoPreTokenizerMatchesPCRE(t *testing.T) {
+	ensureInit()
+	texts := []string{
+		"hello world",
+		"Hello's I'M we'd they'll I'VE",
+		"你好，世界！１２٣四五",
+		"a  b   c    ",
+		"a\n b\r\n  c\n\n",
+		" \n \n  next",
+		"!@#$%^&*() -- symbols\r\n",
+		"emoji 👨‍👩‍👧‍👦 flags 🇨🇳 combining e\u0301",
+		string([]byte{'a', 0xff, 'b', 0xfe, '\n'}),
+	}
+	alphabet := []rune("abcXYZ' 0129\t\n\r,.-_:/中文界１２٣🙂\u00a0\u0085\u2028\u2029\u0301")
+	rng := rand.New(rand.NewSource(0x505245544f4b454e))
+	for i := 0; i < 500; i++ {
+		var b strings.Builder
+		for j, n := 0, rng.Intn(180); j < n; j++ {
+			b.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		texts = append(texts, b.String())
+	}
+	for i := 0; i < 200; i++ {
+		var b strings.Builder
+		for j := 0; j < 60; j++ {
+			r := rune(rng.Intn(utf8.MaxRune + 1))
+			if r >= 0xd800 && r <= 0xdfff {
+				j--
+				continue
+			}
+			b.WriteRune(r)
+		}
+		texts = append(texts, b.String())
+	}
+
+	unsafeUnicode := 0
+	for i, text := range texts {
+		if !canUsePureGoPreTokenizer(text) {
+			unsafeUnicode++
+			continue
+		}
+		got := pureGoPatternPieces(text)
+		want := pcrePatternPieces(text)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("text %d pre-tokenization mismatch for %q\ngot:  %#v\nwant: %#v", i, text, got, want)
+		}
+	}
+	if unsafeUnicode == 0 {
+		t.Fatal("full-Unicode corpus did not exercise the PCRE compatibility fallback")
+	}
+}
+
+func pureGoPatternPieces(text string) []string {
+	if !utf8.ValidString(text) {
+		text = string([]rune(text))
+	}
+	var pieces []string
+	for start := 0; start < len(text); {
+		end := nextPieceEnd(text, start)
+		if end <= start {
+			_, size := utf8.DecodeRuneInString(text[start:])
+			end = start + size
+		}
+		pieces = append(pieces, text[start:end])
+		start = end
+	}
+	return pieces
+}
+
+func pcrePatternPieces(text string) []string {
+	ensurePCRE()
+	var pieces []string
+	match, err := compiledPattern.FindStringMatch(text)
+	for err == nil && match != nil {
+		pieces = append(pieces, match.String())
+		match, err = compiledPattern.FindNextMatch(match)
+	}
+	return pieces
+}
+
+type referenceBPENode struct {
+	data string
+	rank int
+}
+
+// referenceBPEEncode intentionally retains the former allocation-heavy merge
+// algorithm so the optimized implementation can be checked against its exact
+// token semantics on a bounded deterministic corpus.
+func referenceBPEEncode(piece string) []int {
+	nodes := make([]referenceBPENode, len(piece))
+	for i := 0; i < len(piece); i++ {
+		rank, ok := mergeableRanks[piece[i:i+1]]
+		if !ok {
+			rank = math.MaxInt
+		}
+		nodes[i] = referenceBPENode{data: piece[i : i+1], rank: rank}
+	}
+	for len(nodes) >= 2 {
+		bestRank := math.MaxInt
+		bestPair := ""
+		for i := 0; i < len(nodes)-1; i++ {
+			pair := nodes[i].data + nodes[i+1].data
+			if rank, ok := mergeableRanks[pair]; ok && rank < bestRank {
+				bestRank, bestPair = rank, pair
+			}
+		}
+		if bestRank == math.MaxInt {
+			break
+		}
+
+		out := make([]referenceBPENode, 0, len(nodes))
+		for i := 0; i < len(nodes); {
+			if i+1 < len(nodes) && nodes[i].data+nodes[i+1].data == bestPair {
+				out = append(out, referenceBPENode{data: bestPair, rank: bestRank})
+				i += 2
+				continue
+			}
+			out = append(out, nodes[i])
+			i++
+		}
+		nodes = out
+	}
+
+	result := make([]int, len(nodes))
+	for i := range nodes {
+		result[i] = nodes[i].rank
+	}
+	return result
+}
+
+func TestSpecialScannerMatchesLegacySplitting(t *testing.T) {
+	tests := []string{
+		"plain text",
+		"<|im_start|>user<|im_end|>",
+		"a<|bad<|im_start|>b",
+		"<|extra_1|><|extra_10|><|extra_204|>",
+		"x<|extra_020|>y<|im_end|>z",
+		"missing <|im_start| and trailing <|bad|>",
+	}
+	for _, text := range tests {
+		got := Encode(text)
+		want := referenceEncodeWithLegacySpecialSplit(text)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("special split mismatch for %q\ngot:  %v\nwant: %v", text, got, want)
+		}
+	}
+}
+
+func referenceEncodeWithLegacySpecialSplit(text string) []int {
+	keys := []string{endOfText, imStart, imEnd}
+	for i := 0; i < 205; i++ {
+		keys = append(keys, "<|extra_"+strconv.Itoa(i)+"|>")
+	}
+	chunks := []string{text}
+	for _, sep := range keys {
+		var next []string
+		for _, chunk := range chunks {
+			from := 0
+			for {
+				rel := strings.Index(chunk[from:], sep)
+				if rel < 0 {
+					break
+				}
+				pos := from + rel
+				if pos > from {
+					next = append(next, chunk[from:pos])
+				}
+				next = append(next, sep)
+				from = pos + len(sep)
+			}
+			if from < len(chunk) {
+				next = append(next, chunk[from:])
+			}
+		}
+		chunks = next
+	}
+
+	sink := tokenSink{collect: true}
+	for _, chunk := range chunks {
+		if id, ok := specialTokens[chunk]; ok {
+			sink.addToken(id)
+		} else {
+			encodeOrdinary(chunk, &sink)
+		}
+	}
+	return sink.tokens
 }
 
 func TestEncode_EmptyString(t *testing.T) {
@@ -737,6 +987,21 @@ func BenchmarkCalcTokenCount_LargeCode(b *testing.B) {
 	fmt.Fprintf(w, "received %d bytes", len(body))
 }
 `, 20)
+	ensureInit()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CalcTokenCount(text)
+	}
+}
+
+func BenchmarkCalcTokenCount_RealBasePrompt(b *testing.B) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	data, err := os.ReadFile(filepath.Join(projectRoot, "common/ai/aid/aireact/prompts/base/base.txt"))
+	if err != nil {
+		b.Skipf("base prompt not available: %v", err)
+	}
+	text := string(data)
 	ensureInit()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
## Summary

- replace allocation-heavy count-through-encode with a dedicated count sink and bounded early-exit APIs
- use a pure-Go Qwen pre-tokenizer on the normal Unicode path, with lazy PCRE2 fallback for rare Unicode-version compatibility cases
- use direct vocabulary hits, stack-backed short-piece BPE, and heap/link-based `O(n log n)` large-piece BPE
- scan special tokens and the gzip vocabulary once instead of repeatedly splitting/copying input
- route Agent prompt-budget predicates through early-exit counting and remove several repeated full counts

No new dependency is introduced, token IDs and the historical special-token surface remain unchanged, and normal CI does not run the benchmarks.

## Performance

Go 1.22.12, darwin/arm64, count-only benchmarks after initialization:

| Input | Before | After | Allocations after |
|---|---:|---:|---:|
| Short English | 13.9-22.6 us | 0.29 us | 0 |
| Short Chinese | 180-199 us | 4.6 us | 0 |
| Medium mixed | 450-457 us | about 20.7 us | 0 |
| About 5 KB Go code | 2.62-2.93 ms | about 0.075 ms | 0 |
| 8.5 KB real Agent base prompt | about 15.9 ms | 0.72-0.74 ms | 2 |

## Correctness

The lightweight ytoken suite adds deterministic differential checks against the former BPE merge implementation, pure-Go-vs-PCRE pre-tokenization checks, special-token splitting compatibility, bounded-count edge cases, invalid UTF-8 coverage, and a real Agent prompt benchmark.

## Tests

- `go vet ./common/ai/ytoken`
- `go test ./common/ai/ytoken`
- `go test -race ./common/ai/ytoken`
- `go test ./common/ai/aid/aicommon ./common/ai/aid/aireact/...`
- focused Timeline, 200K-token tool-result, artifact-failure, context-budget, and session-prompt tests
- `go test ./common/ai/ytoken -run '^$' -bench '^BenchmarkCalcTokenCount_' -benchmem -count=3`
