### PR TITLE
refactor(scannode): 加固并精简 SSA 制品上传

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,6 @@ require (
 	github.com/mdlayher/netlink v1.7.2
 	github.com/mfonda/simhash v0.0.0-20151007195837-79f94a1100d6
 	github.com/miekg/dns v1.1.50
-	github.com/minio/minio-go/v7 v7.0.76
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/nats-io/nats.go v1.39.1
@@ -177,13 +176,11 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dop251/base64dec v0.0.0-20231022112746-c6c9f9a96217 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
 	github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -191,7 +188,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
@@ -203,7 +200,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
-	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -211,7 +207,6 @@ require (
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 // indirect
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
-	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/nats-io/nkeys v0.4.9 // indirect
@@ -227,7 +222,6 @@ require (
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.4 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rs/xid v1.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,6 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.13.0 h1:vLn5wlGIh/X78El6r3Jr+30W16Blk0CTcxTYcYPWi5E=
 github.com/go-git/go-git/v5 v5.13.0/go.mod h1:Wjo7/JyVKtQgUNdXYXIepzWfJQkUEIGvkvVkiXRR/zw=
-github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
-github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-ldap/ldap v3.0.3+incompatible h1:HTeSZO8hWMS1Rgb2Ziku6b8a7qRIZZMHjsvuZyatzwk=
 github.com/go-ldap/ldap v3.0.3+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -182,8 +180,6 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
-github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -293,9 +289,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/klauspost/cpuid/v2 v2.2.8 h1:+StwCXwm9PdpiEkPyzBXIy+M9KUb4ODm0Zarf1kS5BM=
-github.com/klauspost/cpuid/v2 v2.2.8/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/knqyf263/go-rpmdb v0.1.0 h1:pOgjtOGtW0B+ibY905hP3ETrYFmLZsHiReKsplcs+to=
 github.com/knqyf263/go-rpmdb v0.1.0/go.mod h1:9LQcoMCMQ9vrF7HcDtXfvqGO4+ddxFQ8+YF/0CVGDww=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
@@ -342,10 +335,6 @@ github.com/mfonda/simhash v0.0.0-20151007195837-79f94a1100d6 h1:bjfMeqxWEJ6IRUvG
 github.com/mfonda/simhash v0.0.0-20151007195837-79f94a1100d6/go.mod h1:WVJJvUw/pIOcwu2O8ZzHEhmigq2jzwRNfJVRMJB7bR8=
 github.com/miekg/dns v1.1.50 h1:DQUfb9uc6smULcREF09Uc+/Gd46YWqJd5DbpPE9xkcA=
 github.com/miekg/dns v1.1.50/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
-github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
-github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
-github.com/minio/minio-go/v7 v7.0.76 h1:9nxHH2XDai61cT/EFhyIw/wW4vJfpPNvl7lSFpRt+Ng=
-github.com/minio/minio-go/v7 v7.0.76/go.mod h1:AVM3IUN6WwKzmwBxVdjzhH8xq+f57JSbbvzqvUzR6eg=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed h1:FI2NIv6fpef6BQl2u3IZX/Cj20tfypRF4yd+uaHOMtI=
@@ -424,8 +413,6 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.0.1-alpha.1/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
-github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca h1:NugYot0LIVPxTvN8n+Kvkn6TrbMyxQiuvKdEwFdR9vI=

--- a/scannode/debug_collector.go
+++ b/scannode/debug_collector.go
@@ -49,7 +49,7 @@ type debugTimingSummary struct {
 	AttemptID  string `json:"attempt_id"`
 	StartedAt  string `json:"started_at"`
 	FinishedAt string `json:"finished_at"`
-	DurationMS int64 `json:"duration_ms"`
+	DurationMS int64  `json:"duration_ms"`
 	Phase      string `json:"phase,omitempty"`
 }
 
@@ -147,13 +147,13 @@ func (dc *DebugCollector) WriteTimingSummary(phase string) error {
 		return nil
 	}
 	summary := debugTimingSummary{
-		TaskID:      dc.taskID,
-		SubTaskID:   dc.subTaskID,
-		AttemptID:   dc.runtimeID,
-		StartedAt:   dc.startedAt.UTC().Format(time.RFC3339Nano),
-		FinishedAt:  dc.finishedAt.UTC().Format(time.RFC3339Nano),
-		DurationMS:  dc.finishedAt.Sub(dc.startedAt).Milliseconds(),
-		Phase:       strings.TrimSpace(phase),
+		TaskID:     dc.taskID,
+		SubTaskID:  dc.subTaskID,
+		AttemptID:  dc.runtimeID,
+		StartedAt:  dc.startedAt.UTC().Format(time.RFC3339Nano),
+		FinishedAt: dc.finishedAt.UTC().Format(time.RFC3339Nano),
+		DurationMS: dc.finishedAt.Sub(dc.startedAt).Milliseconds(),
+		Phase:      strings.TrimSpace(phase),
 	}
 	data, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {
@@ -281,7 +281,7 @@ func (s *ScanNode) uploadDebugArtifacts(
 		}
 
 		provider := s.buildDebugUploadConfigProvider(ctx, reporter, cfg, objKey)
-		if err := uploadDebugArtifactFile(art.FilePath, size, objKey, provider); err != nil {
+		if err := uploadDebugArtifactFile(ctx, art.FilePath, size, objKey, provider); err != nil {
 			log.Warnf("[debug] upload %s failed: %v", art.FileName, err)
 			continue
 		}
@@ -302,18 +302,22 @@ func (s *ScanNode) buildDebugUploadConfigProvider(
 	baseCfg *SSAArtifactUploadConfig,
 	objKey string,
 ) ssaUploadConfigProvider {
-	current := *baseCfg
+	baseProvider := s.buildSSAArtifactUploadConfigProvider(ctx, reporter, baseCfg)
 	return func(force bool) (*SSAArtifactUploadConfig, error) {
-		cp := current
+		cfg, err := baseProvider(force)
+		if err != nil {
+			return nil, err
+		}
+		cp := *cfg
 		cp.ObjectKey = objKey
 		return &cp, nil
 	}
 }
 
-// uploadDebugArtifactFile uploads a file to MinIO with a specific object key.
-func uploadDebugArtifactFile(path string, size int64, objKey string, provider ssaUploadConfigProvider) error {
+// uploadDebugArtifactFile uploads a file with a specific object key.
+func uploadDebugArtifactFile(ctx context.Context, path string, size int64, objKey string, provider ssaUploadConfigProvider) error {
 	tmp := &SSAArtifactCollector{}
-	return tmp.UploadBySTSWithProvider(path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
+	return tmp.UploadBySTSWithProvider(ctx, path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
 		cfg, err := provider(force)
 		if err != nil {
 			return nil, err
@@ -333,14 +337,15 @@ func resolveDebugDir(labels map[string]string) string {
 	}
 	return strings.TrimSpace(labels["debug_dir"])
 }
+
 // computeSHA256FromBytes computes the SHA-256 hash of a byte slice.
 func computeSHA256FromBytes(data []byte) (string, error) {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:]), nil
 }
 
-// uploadDebugArtifactBytes uploads a byte slice to MinIO with a specific object key.
-func uploadDebugArtifactBytes(payload []byte, objKey string, provider ssaUploadConfigProvider) error {
+// uploadDebugArtifactBytes uploads a byte slice with a specific object key.
+func uploadDebugArtifactBytes(ctx context.Context, payload []byte, objKey string, provider ssaUploadConfigProvider) error {
 	tmpFile, err := os.CreateTemp("", "debug-analysis-*.json")
 	if err != nil {
 		return err
@@ -354,5 +359,5 @@ func uploadDebugArtifactBytes(payload []byte, objKey string, provider ssaUploadC
 	if err := tmpFile.Close(); err != nil {
 		return err
 	}
-	return uploadDebugArtifactFile(path, int64(len(payload)), objKey, provider)
+	return uploadDebugArtifactFile(ctx, path, int64(len(payload)), objKey, provider)
 }

--- a/scannode/debug_collector.go
+++ b/scannode/debug_collector.go
@@ -317,7 +317,7 @@ func (s *ScanNode) buildDebugUploadConfigProvider(
 // uploadDebugArtifactFile uploads a file with a specific object key.
 func uploadDebugArtifactFile(ctx context.Context, path string, size int64, objKey string, provider ssaUploadConfigProvider) error {
 	tmp := &SSAArtifactCollector{}
-	return tmp.UploadBySTSWithProvider(ctx, path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
+	return tmp.UploadBySTSWithProviderContext(ctx, path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
 		cfg, err := provider(force)
 		if err != nil {
 			return nil, err

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -103,7 +103,7 @@ func (s *ScanNode) executeScriptTask(
 	}
 	defer cleanupSourcePayload()
 	reporter.ssaUploadCfg = extractSSAArtifactUploadConfig(keyValues)
-	reporter.ssaCollector = NewSSAArtifactCollector(input.TaskID, input.RuntimeID, input.SubTaskID)
+	reporter.ssaCollector = NewSSAArtifactCollectorWithContext(taskCtx, input.TaskID, input.RuntimeID, input.SubTaskID)
 	if reporter.ssaCollector != nil {
 		defer reporter.ssaCollector.Cleanup()
 		if reporter.ssaUploadCfg != nil &&
@@ -1160,6 +1160,31 @@ func classifyUploadError(errMsg string) string {
 	return "put_failed"
 }
 
+func classifySSAUploadError(err error) string {
+	if code := classifyObjectStoreError(err); code != "put_failed" {
+		return code
+	}
+	// Non-object-store errors (ticket fetch, compression, filesystem) retain the
+	// legacy fallback classification. S3 protocol decisions never use strings.
+	return classifyUploadError(err.Error())
+}
+
+func redactSSAUploadErrorMessage(err error, cfg *SSAArtifactUploadConfig) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	if cfg == nil {
+		return message
+	}
+	for _, secret := range []secretValue{cfg.STSAccessKey, cfg.STSSecretKey, cfg.STSSessionToken} {
+		if raw := secret.raw(); raw != "" {
+			message = strings.ReplaceAll(message, raw, "[REDACTED]")
+		}
+	}
+	return message
+}
+
 func (s *ScanNode) finalizeSSAArtifactUpload(
 	ctx context.Context,
 	reporter *ScannerAgentReporter,
@@ -1180,6 +1205,7 @@ func (s *ScanNode) finalizeSSAArtifactUpload(
 
 	provider := s.buildSSAArtifactUploadConfigProvider(ctx, reporter, cfg)
 	build, err := reporter.ssaCollector.FinalizeUploadWithProvider(
+		ctx,
 		normalizeArtifactCodec(cfg.Codec),
 		provider,
 	)
@@ -1248,11 +1274,12 @@ func (s *ScanNode) emitSSAArtifactUploadFailed(
 	if reporter == nil || reporter.ssaCollector == nil || uploadErr == nil {
 		return
 	}
-	errorCode := classifyUploadError(uploadErr.Error())
+	errorCode := classifySSAUploadError(uploadErr)
+	errorMessage := redactSSAUploadErrorMessage(uploadErr, reporter.ssaUploadCfg)
 	metrics := reporter.ssaCollector.snapshotUploadMetrics()
 	failedEvent := reporter.ssaCollector.BuildUploadFailedEvent(
 		errorCode,
-		uploadErr.Error(),
+		errorMessage,
 		metrics.CompressedBytes,
 	)
 	if failedEvent == nil {
@@ -1266,7 +1293,7 @@ func (s *ScanNode) emitSSAArtifactUploadFailed(
 	}
 	log.Infof(
 		"ssa artifact upload failed task=%s error_code=%s error=%s uploaded_bytes=%d",
-		reporter.TaskId, errorCode, uploadErr.Error(), metrics.CompressedBytes,
+		reporter.TaskId, errorCode, errorMessage, metrics.CompressedBytes,
 	)
 }
 
@@ -1487,7 +1514,7 @@ func (s *ScanNode) publishDebugAnalysis(
 	objKey := fmt.Sprintf("debug_analysis/%s/%s/analysis.json", taskID, attemptID)
 
 	provider := s.buildDebugUploadConfigProvider(ctx, reporter, cfg, objKey)
-	if err := uploadDebugArtifactBytes(analysisJSON, objKey, provider); err != nil {
+	if err := uploadDebugArtifactBytes(ctx, analysisJSON, objKey, provider); err != nil {
 		log.Warnf("[debug] upload analysis failed: %v", err)
 		return
 	}
@@ -1530,7 +1557,7 @@ func (s *ScanNode) publishDebugZip(
 
 	provider := s.buildDebugUploadConfigProvider(ctx, reporter, cfg, objKey)
 	zipSize := fileSize(zipPath)
-	if err := uploadDebugArtifactFile(zipPath, zipSize, objKey, provider); err != nil {
+	if err := uploadDebugArtifactFile(ctx, zipPath, zipSize, objKey, provider); err != nil {
 		log.Warnf("[debug] upload zip failed: %v", err)
 		return
 	}

--- a/scannode/script_execution.go
+++ b/scannode/script_execution.go
@@ -1177,7 +1177,7 @@ func redactSSAUploadErrorMessage(err error, cfg *SSAArtifactUploadConfig) string
 	if cfg == nil {
 		return message
 	}
-	for _, secret := range []secretValue{cfg.STSAccessKey, cfg.STSSecretKey, cfg.STSSessionToken} {
+	for _, secret := range []secretValue{cfg.accessKeySecret(), cfg.secretKeySecret(), cfg.sessionTokenSecret()} {
 		if raw := secret.raw(); raw != "" {
 			message = strings.ReplaceAll(message, raw, "[REDACTED]")
 		}
@@ -1204,7 +1204,7 @@ func (s *ScanNode) finalizeSSAArtifactUpload(
 	}
 
 	provider := s.buildSSAArtifactUploadConfigProvider(ctx, reporter, cfg)
-	build, err := reporter.ssaCollector.FinalizeUploadWithProvider(
+	build, err := reporter.ssaCollector.FinalizeUploadWithProviderContext(
 		ctx,
 		normalizeArtifactCodec(cfg.Codec),
 		provider,

--- a/scannode/ssa_artifact_api_compat_test.go
+++ b/scannode/ssa_artifact_api_compat_test.go
@@ -1,0 +1,27 @@
+package scannode_test
+
+import (
+	"testing"
+
+	"github.com/yaklang/yaklang/scannode"
+)
+
+// This compile-time regression guard preserves the exported API that existed
+// before the custom S3 uploader added context-aware internal variants.
+func TestSSAArtifactUploadLegacyAPICompiles(t *testing.T) {
+	accessKey := "dynamic-access-key"
+	secretKey := "dynamic-secret-key"
+	cfg := &scannode.SSAArtifactUploadConfig{
+		STSAccessKey: accessKey,
+		STSSecretKey: secretKey,
+	}
+	collector := &scannode.SSAArtifactCollector{}
+	provider := func(bool) (*scannode.SSAArtifactUploadConfig, error) { return cfg, nil }
+
+	if false {
+		_, _ = collector.FinalizeUploadWithProvider("zstd", provider)
+		_, _ = collector.BuildAndUploadCompressedArtifactWithProvider("zstd", provider)
+		_ = collector.UploadBySTS(cfg, "artifact.zst", 0)
+		_ = collector.UploadBySTSWithProvider("artifact.zst", 0, provider)
+	}
+}

--- a/scannode/ssa_artifact_collector.go
+++ b/scannode/ssa_artifact_collector.go
@@ -1,7 +1,6 @@
 package scannode
 
 import (
-	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -18,8 +17,6 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/zstd"
-	"github.com/minio/minio-go/v7"
-	minioCreds "github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/spec"
 	"github.com/yaklang/yaklang/common/utils"
@@ -34,10 +31,17 @@ type SSAArtifactUploadConfig struct {
 	Bucket   string
 	Region   string
 	UseSSL   bool
+	// TLSVerify defaults to false for compatibility with private ScanNode
+	// deployments that use self-signed certificates. Set it explicitly when
+	// the endpoint must be verified against the system or configured CA pool.
+	TLSVerify        bool
+	TLSCAFile        string
+	AllowHTTP        bool
+	VirtualHostStyle bool
 
-	STSAccessKey    string
-	STSSecretKey    string
-	STSSessionToken string
+	STSAccessKey    secretValue
+	STSSecretKey    secretValue
+	STSSessionToken secretValue
 	STSExpiresAt    int64
 }
 
@@ -100,6 +104,7 @@ type SSAArtifactCollector struct {
 	continuousErr           error
 	continuousBuild         *SSAArtifactBuildResult
 	continuousFlushInterval time.Duration
+	uploadCtx               context.Context
 
 	uploadMetrics ssaUploadMetrics
 }
@@ -107,6 +112,9 @@ type SSAArtifactCollector struct {
 const (
 	defaultSSAMultipartPartSizeBytes = 16 * 1024 * 1024
 	minSSAMultipartPartSizeBytes     = 5 * 1024 * 1024
+	maxSSAMultipartPartSizeBytes     = 128 * 1024 * 1024
+	defaultSSAMultipartConcurrency   = 2
+	maxSSAMultipartConcurrency       = 2
 )
 
 type ssaUploadConfigProvider func(force bool) (*SSAArtifactUploadConfig, error)
@@ -154,6 +162,11 @@ func (c *SSAArtifactCollector) startContinuousUploadIfNeeded() error {
 		codec = "zstd"
 	}
 	provider := c.continuousProvider
+	ctx := c.uploadCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	flushInterval := c.continuousFlushInterval
 	taskID := c.taskID
 	programName := c.programName
 	reportType := c.reportType
@@ -169,7 +182,7 @@ func (c *SSAArtifactCollector) startContinuousUploadIfNeeded() error {
 	c.mu.Unlock()
 
 	go func() {
-		build, err := runContinuousSegmentedUpload(codec, c.continuousFlushInterval, provider, taskID, programName, reportType, input, func(uploadMs int64) {
+		build, err := runContinuousSegmentedUpload(ctx, codec, flushInterval, provider, taskID, programName, reportType, input, func(uploadMs int64) {
 			c.recordUploadMs(uploadMs)
 			c.recordSegment()
 		})
@@ -209,6 +222,8 @@ func (c *SSAArtifactCollector) enqueueContinuousPayload(payload []byte) error {
 	select {
 	case input <- payload:
 		return nil
+	case <-c.uploadContext().Done():
+		return c.uploadContext().Err()
 	case <-done:
 		c.mu.Lock()
 		defer c.mu.Unlock()
@@ -219,12 +234,27 @@ func (c *SSAArtifactCollector) enqueueContinuousPayload(payload []byte) error {
 	}
 }
 
+func (c *SSAArtifactCollector) uploadContext() context.Context {
+	if c == nil || c.uploadCtx == nil {
+		return context.Background()
+	}
+	return c.uploadCtx
+}
+
 func NewSSAArtifactCollector(taskID, runtimeID, subTaskID string) *SSAArtifactCollector {
+	return NewSSAArtifactCollectorWithContext(context.Background(), taskID, runtimeID, subTaskID)
+}
+
+func NewSSAArtifactCollectorWithContext(ctx context.Context, taskID, runtimeID, subTaskID string) *SSAArtifactCollector {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	c := &SSAArtifactCollector{
 		taskID:    taskID,
 		runtimeID: runtimeID,
 		subTaskID: subTaskID,
 		startedAt: time.Now(),
+		uploadCtx: ctx,
 	}
 	if err := c.initSpoolLocked(); err != nil {
 		c.initErr = err
@@ -392,9 +422,12 @@ func (c *SSAArtifactCollector) HasData() bool {
 	return c.hasData
 }
 
-func (c *SSAArtifactCollector) FinalizeUploadWithProvider(codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
+func (c *SSAArtifactCollector) FinalizeUploadWithProvider(ctx context.Context, codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
 	if c == nil {
 		return nil, utils.Errorf("collector is nil")
+	}
+	if ctx == nil {
+		ctx = c.uploadContext()
 	}
 	c.mu.Lock()
 	hasData := c.hasData
@@ -446,11 +479,15 @@ func (c *SSAArtifactCollector) FinalizeUploadWithProvider(codec string, provider
 			_ = c.partsFile.Sync()
 		}
 		c.mu.Unlock()
-		return c.BuildAndUploadCompressedArtifactWithProvider(codec, provider)
+		return c.BuildAndUploadCompressedArtifactWithProvider(ctx, codec, provider)
 	}
 
 	if continuousEnabled && started && done != nil {
-		<-done
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 		c.mu.Lock()
 		err := c.continuousErr
 		base := c.continuousBuild
@@ -485,7 +522,7 @@ func (c *SSAArtifactCollector) FinalizeUploadWithProvider(codec string, provider
 		return result, nil
 	}
 
-	return c.BuildAndUploadCompressedArtifactWithProvider(codec, provider)
+	return c.BuildAndUploadCompressedArtifactWithProvider(ctx, codec, provider)
 }
 
 const (
@@ -517,7 +554,10 @@ func readSSASegmentFlushInterval() time.Duration {
 	return time.Duration(sec) * time.Second
 }
 
-func runContinuousSegmentedUpload(codec string, customFlushInterval time.Duration, provider ssaUploadConfigProvider, taskID string, programName string, reportType string, input <-chan []byte, onSegment func(uploadMs int64)) (*SSAArtifactBuildResult, error) {
+func runContinuousSegmentedUpload(ctx context.Context, codec string, customFlushInterval time.Duration, provider ssaUploadConfigProvider, taskID string, programName string, reportType string, input <-chan []byte, onSegment func(uploadMs int64)) (*SSAArtifactBuildResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if provider == nil {
 		return nil, utils.Errorf("empty upload config provider")
 	}
@@ -525,9 +565,14 @@ func runContinuousSegmentedUpload(codec string, customFlushInterval time.Duratio
 	if err != nil {
 		return nil, err
 	}
-	if err := validateSSAUploadConfig(baseCfg); err != nil {
+	if _, err := validateSSAUploadConfig(baseCfg); err != nil {
 		return nil, err
 	}
+	session, err := newSSAObjectStoreUploadSession(provider, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
 	segmentPrefix, manifestKey := deriveSSAContinuousObjectKeys(strings.TrimSpace(baseCfg.ObjectKey))
 	segmentMaxBytes := readSSASegmentMaxBytes()
 	if segmentMaxBytes <= 0 {
@@ -593,7 +638,7 @@ func runContinuousSegmentedUpload(codec string, customFlushInterval time.Duratio
 		}
 		segmentKey := ppath.Join(segmentPrefix, fmt.Sprintf("segment-%06d.ndjson.%s", seq, codecExt(uploadCodec)))
 		uploadStart := time.Now()
-		if err := uploadSSAArtifactFileWithObjectKey(compPath, compressedSize, segmentKey, provider); err != nil {
+		if _, err := session.uploadFile(ctx, compPath, compressedSize, segmentKey); err != nil {
 			return err
 		}
 		uploadMS := time.Since(uploadStart).Milliseconds()
@@ -628,6 +673,8 @@ func runContinuousSegmentedUpload(codec string, customFlushInterval time.Duratio
 loop:
 	for {
 		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case chunk, ok := <-input:
 			if !ok {
 				if err := flushSegment(); err != nil {
@@ -684,7 +731,7 @@ loop:
 	if err != nil {
 		return nil, err
 	}
-	if err := uploadSSAArtifactBytesWithObjectKey(manifestRaw, manifestKey, provider); err != nil {
+	if _, err := session.uploadBytes(ctx, manifestRaw, manifestKey); err != nil {
 		return nil, err
 	}
 	log.Infof("ssa artifact manifest uploaded task=%s key=%s segments=%d total_raw=%d total_compressed=%d",
@@ -767,9 +814,9 @@ func compressSSAArtifactFile(rawPath, compressedPath, codec string) (int64, stri
 	return st.Size(), hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
-func uploadSSAArtifactFileWithObjectKey(path string, size int64, objectKey string, provider ssaUploadConfigProvider) error {
+func uploadSSAArtifactFileWithObjectKey(ctx context.Context, path string, size int64, objectKey string, provider ssaUploadConfigProvider) error {
 	tmp := &SSAArtifactCollector{}
-	return tmp.UploadBySTSWithProvider(path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
+	return tmp.UploadBySTSWithProvider(ctx, path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
 		cfg, err := provider(force)
 		if err != nil {
 			return nil, err
@@ -780,7 +827,7 @@ func uploadSSAArtifactFileWithObjectKey(path string, size int64, objectKey strin
 	})
 }
 
-func uploadSSAArtifactBytesWithObjectKey(payload []byte, objectKey string, provider ssaUploadConfigProvider) error {
+func uploadSSAArtifactBytesWithObjectKey(ctx context.Context, payload []byte, objectKey string, provider ssaUploadConfigProvider) error {
 	tmpFile, err := os.CreateTemp("", "ssa-manifest-*.json")
 	if err != nil {
 		return err
@@ -794,7 +841,7 @@ func uploadSSAArtifactBytesWithObjectKey(payload []byte, objectKey string, provi
 	if err := tmpFile.Close(); err != nil {
 		return err
 	}
-	return uploadSSAArtifactFileWithObjectKey(path, int64(len(payload)), objectKey, provider)
+	return uploadSSAArtifactFileWithObjectKey(ctx, path, int64(len(payload)), objectKey, provider)
 }
 
 func (c *SSAArtifactCollector) BuildCompressedArtifact(codec string) (*SSAArtifactBuildResult, error) {
@@ -901,9 +948,12 @@ func (c *SSAArtifactCollector) BuildCompressedArtifact(codec string) (*SSAArtifa
 	}, nil
 }
 
-func (c *SSAArtifactCollector) BuildAndUploadCompressedArtifactWithProvider(codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
+func (c *SSAArtifactCollector) BuildAndUploadCompressedArtifactWithProvider(ctx context.Context, codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
 	if provider == nil {
 		return nil, utils.Errorf("empty upload config provider")
+	}
+	if ctx == nil {
+		ctx = c.uploadContext()
 	}
 	c.mu.Lock()
 	if c.initErr != nil {
@@ -946,211 +996,84 @@ func (c *SSAArtifactCollector) BuildAndUploadCompressedArtifactWithProvider(code
 		_ = in.Close()
 		return nil, err
 	}
-	if err := validateSSAUploadConfig(cfg); err != nil {
+	if _, err := validateSSAUploadConfig(cfg); err != nil {
 		_ = in.Close()
 		return nil, err
 	}
-	baseBucket := strings.TrimSpace(cfg.Bucket)
-	baseObjectKey := strings.TrimSpace(cfg.ObjectKey)
-	uploadOpts := minio.PutObjectOptions{ContentType: "application/octet-stream"}
-	partSize := readSSAMultipartPartSize()
+	objectKey := strings.TrimSpace(cfg.ObjectKey)
 	actualCodec := normalizeArtifactCodec(codec)
-
-	var (
-		uploadID string
-		core     *minio.Core
-	)
-	for attempt := 0; attempt < 2; attempt++ {
-		curCfg, e := provider(attempt == 1)
-		if e != nil {
-			_ = in.Close()
-			return nil, e
-		}
-		if strings.TrimSpace(curCfg.Bucket) != baseBucket || strings.TrimSpace(curCfg.ObjectKey) != baseObjectKey {
-			_ = in.Close()
-			return nil, utils.Errorf("upload target changed during sts refresh")
-		}
-		client, e := buildSSAUploadClient(curCfg)
-		if e != nil {
-			_ = in.Close()
-			return nil, e
-		}
-		tmpCore := &minio.Core{Client: client}
-		uid, e := tmpCore.NewMultipartUpload(context.Background(), baseBucket, baseObjectKey, uploadOpts)
-		if e == nil {
-			core = tmpCore
-			uploadID = uid
-			break
-		}
-		if !isSSACredentialError(e) || attempt > 0 {
-			_ = in.Close()
-			return nil, e
-		}
-	}
-	if uploadID == "" || core == nil {
+	session, err := newSSAObjectStoreUploadSession(provider, c.recordRetry)
+	if err != nil {
 		_ = in.Close()
-		return nil, utils.Errorf("new multipart upload failed")
+		return nil, err
 	}
-	abort := true
-	defer func() {
-		if abort {
-			_ = core.AbortMultipartUpload(context.Background(), baseBucket, baseObjectKey, uploadID)
-		}
-	}()
+	defer session.Close()
 
-	pr, pw := io.Pipe()
+	pipeReader, pipeWriter := io.Pipe()
 	compressErrCh := make(chan error, 1)
 	go func() {
-		defer close(compressErrCh)
-		defer func() {
-			_ = in.Close()
-		}()
+		defer in.Close()
 		var copyErr error
 		switch actualCodec {
 		case "zstd":
-			zw, err := zstd.NewWriter(pw, zstd.WithEncoderLevel(zstd.SpeedDefault))
-			if err != nil {
-				_ = pw.CloseWithError(err)
-				compressErrCh <- err
+			writer, writerErr := zstd.NewWriter(pipeWriter, zstd.WithEncoderLevel(zstd.SpeedDefault))
+			if writerErr != nil {
+				_ = pipeWriter.CloseWithError(writerErr)
+				compressErrCh <- writerErr
 				return
 			}
-			_, copyErr = io.Copy(zw, in)
-			if closeErr := zw.Close(); copyErr == nil {
+			_, copyErr = io.Copy(writer, in)
+			if closeErr := writer.Close(); copyErr == nil {
 				copyErr = closeErr
 			}
 		case "gzip":
-			gw := gzip.NewWriter(pw)
-			_, copyErr = io.Copy(gw, in)
-			if closeErr := gw.Close(); copyErr == nil {
+			writer := gzip.NewWriter(pipeWriter)
+			_, copyErr = io.Copy(writer, in)
+			if closeErr := writer.Close(); copyErr == nil {
 				copyErr = closeErr
 			}
 		case "identity":
-			_, copyErr = io.Copy(pw, in)
+			_, copyErr = io.Copy(pipeWriter, in)
 		default:
 			copyErr = utils.Errorf("unsupported artifact codec: %s", actualCodec)
 		}
 		if copyErr != nil {
-			_ = pw.CloseWithError(copyErr)
-			compressErrCh <- copyErr
-			return
+			_ = pipeWriter.CloseWithError(copyErr)
+		} else {
+			_ = pipeWriter.Close()
 		}
-		compressErrCh <- nil
-		_ = pw.Close()
+		compressErrCh <- copyErr
 	}()
 
-	defer pr.Close()
-	buf := make([]byte, partSize)
-	partNo := 1
-	var (
-		completeParts    []minio.CompletePart
-		compressedSize   int64
-		compressedHasher = sha256.New()
-	)
-
-	for {
-		n, readErr := io.ReadFull(pr, buf)
-		if n > 0 {
-			chunk := buf[:n]
-			_, _ = compressedHasher.Write(chunk)
-			compressedSize += int64(n)
-
-			var part minio.ObjectPart
-			var partErr error
-			for attempt := 0; attempt < 2; attempt++ {
-				curCfg, e := provider(attempt == 1)
-				if e != nil {
-					return nil, e
-				}
-				if strings.TrimSpace(curCfg.Bucket) != baseBucket || strings.TrimSpace(curCfg.ObjectKey) != baseObjectKey {
-					return nil, utils.Errorf("upload target changed during sts refresh")
-				}
-				client, e := buildSSAUploadClient(curCfg)
-				if e != nil {
-					return nil, e
-				}
-				core = &minio.Core{Client: client}
-				part, partErr = core.PutObjectPart(
-					context.Background(),
-					baseBucket,
-					baseObjectKey,
-					uploadID,
-					partNo,
-					bytes.NewReader(chunk),
-					int64(n),
-					minio.PutObjectPartOptions{},
-				)
-				if partErr == nil {
-					break
-				}
-				if !isSSACredentialError(partErr) || attempt > 0 {
-					return nil, partErr
-				}
-			}
-			completeParts = append(completeParts, minio.CompletePart{
-				PartNumber:     part.PartNumber,
-				ETag:           part.ETag,
-				ChecksumCRC32:  part.ChecksumCRC32,
-				ChecksumCRC32C: part.ChecksumCRC32C,
-				ChecksumSHA1:   part.ChecksumSHA1,
-				ChecksumSHA256: part.ChecksumSHA256,
-			})
-			partNo++
-		}
-
-		if readErr == io.EOF {
-			break
-		}
-		if readErr == io.ErrUnexpectedEOF {
-			break
-		}
-		if readErr != nil {
-			return nil, readErr
-		}
+	uploadStart := time.Now()
+	stats, uploadErr := session.upload(ctx, pipeReader, -1, objectKey)
+	_ = pipeReader.CloseWithError(uploadErr)
+	compressErr := <-compressErrCh
+	uploadMS := time.Since(uploadStart).Milliseconds()
+	c.recordUploadMs(uploadMS)
+	if uploadErr != nil {
+		return nil, uploadErr
 	}
-	if compressErr := <-compressErrCh; compressErr != nil {
+	if compressErr != nil {
 		return nil, compressErr
 	}
+	log.Infof("ssa artifact stream uploaded task=%s key=%s raw=%d stored=%d sha256=%s parts=%d request_id=%s duration_ms=%d",
+		c.taskID, objectKey, uncompressedSize, stats.Bytes, stats.SHA256, stats.Parts, stats.RequestID, uploadMS)
 
-	if len(completeParts) == 0 {
-		return nil, utils.Errorf("no multipart parts uploaded")
-	}
-
-	for attempt := 0; attempt < 2; attempt++ {
-		curCfg, e := provider(attempt == 1)
-		if e != nil {
-			return nil, e
-		}
-		if strings.TrimSpace(curCfg.Bucket) != baseBucket || strings.TrimSpace(curCfg.ObjectKey) != baseObjectKey {
-			return nil, utils.Errorf("upload target changed during sts refresh")
-		}
-		client, e := buildSSAUploadClient(curCfg)
-		if e != nil {
-			return nil, e
-		}
-		core = &minio.Core{Client: client}
-		_, err = core.CompleteMultipartUpload(context.Background(), baseBucket, baseObjectKey, uploadID, completeParts, uploadOpts)
-		if err == nil {
-			abort = false
-			return &SSAArtifactBuildResult{
-				ObjectKey:        baseObjectKey,
-				Codec:            actualCodec,
-				ArtifactPath:     "",
-				ArtifactFormat:   spec.SSAArtifactFormatPartsNDJSONV1,
-				UncompressedSize: uncompressedSize,
-				CompressedSize:   compressedSize,
-				SHA256:           hex.EncodeToString(compressedHasher.Sum(nil)),
-				ProgramName:      programName,
-				ReportType:       reportType,
-				RiskCount:        riskCount,
-				FileCount:        fileCount,
-				FlowCount:        flowCount,
-			}, nil
-		}
-		if !isSSACredentialError(err) || attempt > 0 {
-			return nil, err
-		}
-	}
-	return nil, utils.Errorf("complete multipart upload failed")
+	return &SSAArtifactBuildResult{
+		ObjectKey:        objectKey,
+		Codec:            actualCodec,
+		ArtifactPath:     "",
+		ArtifactFormat:   spec.SSAArtifactFormatPartsNDJSONV1,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   stats.Bytes,
+		SHA256:           stats.SHA256,
+		ProgramName:      programName,
+		ReportType:       reportType,
+		RiskCount:        riskCount,
+		FileCount:        fileCount,
+		FlowCount:        flowCount,
+	}, nil
 }
 
 func readSSAMultipartPartSize() int64 {
@@ -1162,270 +1085,69 @@ func readSSAMultipartPartSize() int64 {
 	if err != nil || mb <= 0 {
 		return defaultSSAMultipartPartSizeBytes
 	}
-	size := mb * 1024 * 1024
-	if size < minSSAMultipartPartSizeBytes {
+	if mb >= maxSSAMultipartPartSizeBytes/(1024*1024) {
+		return maxSSAMultipartPartSizeBytes
+	}
+	if mb <= minSSAMultipartPartSizeBytes/(1024*1024) {
 		return minSSAMultipartPartSizeBytes
 	}
+	size := mb * 1024 * 1024
 	return size
 }
 
-func isSSACredentialError(err error) bool {
-	if err == nil {
-		return false
+func readSSAMultipartConcurrency() int {
+	raw := strings.TrimSpace(os.Getenv("SCANNODE_SSA_MULTIPART_CONCURRENCY"))
+	if raw == "" {
+		return defaultSSAMultipartConcurrency
 	}
-	msg := strings.ToLower(strings.TrimSpace(err.Error()))
-	if msg == "" {
-		return false
+	concurrency, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultSSAMultipartConcurrency
 	}
-	keys := []string{
-		"expiredtoken",
-		"token expired",
-		"signaturedoesnotmatch",
-		"invalidtoken",
-		"accessdenied",
-		"sts credentials expired",
+	if concurrency < 1 {
+		return 1
 	}
-	for _, key := range keys {
-		if strings.Contains(msg, key) {
-			return true
-		}
+	if concurrency > maxSSAMultipartConcurrency {
+		return maxSSAMultipartConcurrency
 	}
-	return false
+	return concurrency
 }
 
-func validateSSAUploadConfig(cfg *SSAArtifactUploadConfig) error {
-	if cfg == nil {
-		return utils.Errorf("empty upload config")
-	}
-	endpoint := strings.TrimSpace(cfg.Endpoint)
-	bucket := strings.TrimSpace(cfg.Bucket)
-	objectKey := strings.TrimSpace(cfg.ObjectKey)
-	if endpoint == "" || bucket == "" || objectKey == "" {
-		return utils.Errorf("upload config missing endpoint/bucket/object_key")
-	}
-	accessKey := strings.TrimSpace(cfg.STSAccessKey)
-	secretKey := strings.TrimSpace(cfg.STSSecretKey)
-	if accessKey == "" || secretKey == "" {
-		return utils.Errorf("sts credentials missing")
-	}
-	return nil
-}
-
-func buildSSAUploadClient(cfg *SSAArtifactUploadConfig) (*minio.Client, error) {
-	if err := validateSSAUploadConfig(cfg); err != nil {
-		return nil, err
-	}
-	return minio.New(strings.TrimSpace(cfg.Endpoint), &minio.Options{
-		Creds:  minioCreds.NewStaticV4(strings.TrimSpace(cfg.STSAccessKey), strings.TrimSpace(cfg.STSSecretKey), strings.TrimSpace(cfg.STSSessionToken)),
-		Secure: cfg.UseSSL,
-		Region: strings.TrimSpace(cfg.Region),
-	})
-}
-
-func (c *SSAArtifactCollector) UploadBySTS(cfg *SSAArtifactUploadConfig, artifactPath string, size int64) error {
-	return c.UploadBySTSWithProvider(artifactPath, size, func(force bool) (*SSAArtifactUploadConfig, error) {
+func (c *SSAArtifactCollector) UploadBySTS(ctx context.Context, cfg *SSAArtifactUploadConfig, artifactPath string, size int64) error {
+	return c.UploadBySTSWithProvider(ctx, artifactPath, size, func(force bool) (*SSAArtifactUploadConfig, error) {
 		_ = force
 		return cfg, nil
 	})
 }
 
-func (c *SSAArtifactCollector) UploadBySTSWithProvider(artifactPath string, size int64, provider ssaUploadConfigProvider) error {
-	if provider == nil {
-		return utils.Errorf("empty upload config provider")
+func (c *SSAArtifactCollector) UploadBySTSWithProvider(ctx context.Context, artifactPath string, size int64, provider ssaUploadConfigProvider) error {
+	if ctx == nil {
+		ctx = c.uploadContext()
 	}
 	cfg, err := provider(false)
 	if err != nil {
 		return err
 	}
-	if err := validateSSAUploadConfig(cfg); err != nil {
+	if _, err := validateSSAUploadConfig(cfg); err != nil {
 		return err
 	}
-	f, err := os.Open(artifactPath)
+	session, err := newSSAObjectStoreUploadSession(provider, c.recordRetry)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer session.Close()
 
-	if size <= 0 {
-		if st, err := f.Stat(); err == nil {
-			size = st.Size()
-		}
+	uploadStart := time.Now()
+	stats, err := session.uploadFile(ctx, artifactPath, size, strings.TrimSpace(cfg.ObjectKey))
+	uploadMS := time.Since(uploadStart).Milliseconds()
+	c.recordUploadMs(uploadMS)
+	if err != nil {
+		log.Warnf("upload_attempt_failed task=%s key=%s duration_ms=%d error=%q", c.taskID, cfg.ObjectKey, uploadMS, err.Error())
+		return err
 	}
-
-	if size <= 0 {
-		return utils.Errorf("artifact size invalid")
-	}
-	partSize := readSSAMultipartPartSize()
-	if size <= partSize {
-		for attempt := 0; attempt < 2; attempt++ {
-			if attempt > 0 {
-				c.recordRetry()
-			}
-			uploadStart := time.Now()
-			cfg, err := provider(attempt == 1)
-			if err != nil {
-				return err
-			}
-			client, err := buildSSAUploadClient(cfg)
-			if err != nil {
-				return err
-			}
-			if _, err := f.Seek(0, io.SeekStart); err != nil {
-				return err
-			}
-			info, err := client.PutObject(context.Background(),
-				strings.TrimSpace(cfg.Bucket),
-				strings.TrimSpace(cfg.ObjectKey),
-				f,
-				size,
-				minio.PutObjectOptions{ContentType: "application/octet-stream"})
-			uploadMs := time.Since(uploadStart).Milliseconds()
-			c.recordUploadMs(uploadMs)
-			if err == nil {
-				log.Infof("upload_attempt task=%s attempt=%d key=%s duration_ms=%d", c.taskID, attempt, cfg.ObjectKey, uploadMs)
-				if info.Size > 0 && info.Size != size {
-					return utils.Errorf("uploaded size mismatch expect=%d got=%d", size, info.Size)
-				}
-				return nil
-			}
-			log.Warnf("upload_attempt_failed task=%s attempt=%d key=%s duration_ms=%d error=%q", c.taskID, attempt, cfg.ObjectKey, uploadMs, err.Error())
-			if !isSSACredentialError(err) || attempt > 0 {
-				return err
-			}
-		}
-		return utils.Errorf("upload failed")
-	}
-
-	baseBucket := strings.TrimSpace(cfg.Bucket)
-	baseObjectKey := strings.TrimSpace(cfg.ObjectKey)
-	uploadOpts := minio.PutObjectOptions{ContentType: "application/octet-stream"}
-	var (
-		uploadID string
-		core     *minio.Core
-	)
-	for attempt := 0; attempt < 2; attempt++ {
-		curCfg, e := provider(attempt == 1)
-		if e != nil {
-			return e
-		}
-		if strings.TrimSpace(curCfg.Bucket) != baseBucket || strings.TrimSpace(curCfg.ObjectKey) != baseObjectKey {
-			return utils.Errorf("upload target changed during sts refresh")
-		}
-		client, e := buildSSAUploadClient(curCfg)
-		if e != nil {
-			return e
-		}
-		tmpCore := &minio.Core{Client: client}
-		uid, e := tmpCore.NewMultipartUpload(context.Background(), baseBucket, baseObjectKey, uploadOpts)
-		if e == nil {
-			core = tmpCore
-			uploadID = uid
-			break
-		}
-		if !isSSACredentialError(e) || attempt > 0 {
-			return e
-		}
-	}
-	if uploadID == "" || core == nil {
-		return utils.Errorf("new multipart upload failed")
-	}
-	abort := true
-	defer func() {
-		if abort {
-			_ = core.AbortMultipartUpload(context.Background(), baseBucket, baseObjectKey, uploadID)
-		}
-	}()
-
-	buf := make([]byte, partSize)
-	partNo := 1
-	var completeParts []minio.CompletePart
-	for {
-		n, readErr := io.ReadFull(f, buf)
-		if readErr == io.EOF {
-			break
-		}
-		if readErr != nil && readErr != io.ErrUnexpectedEOF {
-			return readErr
-		}
-		if n <= 0 {
-			if readErr == io.ErrUnexpectedEOF {
-				break
-			}
-			continue
-		}
-
-		var part minio.ObjectPart
-		var partErr error
-		for attempt := 0; attempt < 2; attempt++ {
-			curCfg, e := provider(attempt == 1)
-			if e != nil {
-				return e
-			}
-			if strings.TrimSpace(curCfg.Bucket) != baseBucket || strings.TrimSpace(curCfg.ObjectKey) != baseObjectKey {
-				return utils.Errorf("upload target changed during sts refresh")
-			}
-			client, e := buildSSAUploadClient(curCfg)
-			if e != nil {
-				return e
-			}
-			core = &minio.Core{Client: client}
-			part, partErr = core.PutObjectPart(
-				context.Background(),
-				baseBucket,
-				baseObjectKey,
-				uploadID,
-				partNo,
-				bytes.NewReader(buf[:n]),
-				int64(n),
-				minio.PutObjectPartOptions{},
-			)
-			if partErr == nil {
-				break
-			}
-			if !isSSACredentialError(partErr) || attempt > 0 {
-				return partErr
-			}
-		}
-		completeParts = append(completeParts, minio.CompletePart{
-			PartNumber:     part.PartNumber,
-			ETag:           part.ETag,
-			ChecksumCRC32:  part.ChecksumCRC32,
-			ChecksumCRC32C: part.ChecksumCRC32C,
-			ChecksumSHA1:   part.ChecksumSHA1,
-			ChecksumSHA256: part.ChecksumSHA256,
-		})
-		partNo++
-		if readErr == io.ErrUnexpectedEOF {
-			break
-		}
-	}
-	if len(completeParts) == 0 {
-		return utils.Errorf("no multipart parts uploaded")
-	}
-
-	for attempt := 0; attempt < 2; attempt++ {
-		curCfg, e := provider(attempt == 1)
-		if e != nil {
-			return e
-		}
-		if strings.TrimSpace(curCfg.Bucket) != baseBucket || strings.TrimSpace(curCfg.ObjectKey) != baseObjectKey {
-			return utils.Errorf("upload target changed during sts refresh")
-		}
-		client, e := buildSSAUploadClient(curCfg)
-		if e != nil {
-			return e
-		}
-		core = &minio.Core{Client: client}
-		_, err = core.CompleteMultipartUpload(context.Background(), baseBucket, baseObjectKey, uploadID, completeParts, uploadOpts)
-		if err == nil {
-			abort = false
-			return nil
-		}
-		if !isSSACredentialError(err) || attempt > 0 {
-			return err
-		}
-	}
-	return utils.Errorf("complete multipart upload failed")
+	log.Infof("upload_attempt task=%s key=%s bytes=%d sha256=%s parts=%d request_id=%s duration_ms=%d",
+		c.taskID, cfg.ObjectKey, stats.Bytes, stats.SHA256, stats.Parts, stats.RequestID, uploadMS)
+	return nil
 }
 
 func (c *SSAArtifactCollector) BuildReadyEvent(result *SSAArtifactBuildResult, totalLines int64, riskCountHint int64) *spec.SSAArtifactReadyEvent {

--- a/scannode/ssa_artifact_collector.go
+++ b/scannode/ssa_artifact_collector.go
@@ -31,19 +31,61 @@ type SSAArtifactUploadConfig struct {
 	Bucket   string
 	Region   string
 	UseSSL   bool
-	// TLSVerify defaults to false for compatibility with private ScanNode
-	// deployments that use self-signed certificates. Set it explicitly when
-	// the endpoint must be verified against the system or configured CA pool.
+	// TLSVerify is retained for input compatibility. Object-store TLS is
+	// verified by default; use AllowInsecureTLS only for an explicitly trusted
+	// development endpoint, or configure TLSCAFile for a private CA.
 	TLSVerify        bool
+	AllowInsecureTLS bool
 	TLSCAFile        string
 	AllowHTTP        bool
 	VirtualHostStyle bool
 
-	STSAccessKey    secretValue
-	STSSecretKey    secretValue
-	STSSessionToken secretValue
+	// These exported string fields preserve the pre-existing Go API for callers
+	// that build or inspect configs with dynamic strings. String, GoString, and
+	// JSON formatting on the containing config redact them; request signing
+	// converts them to the internal redacting value.
+	STSAccessKey    string `json:"-"`
+	STSSecretKey    string `json:"-"`
+	STSSessionToken string `json:"-"`
 	STSExpiresAt    int64
 }
+
+func (cfg *SSAArtifactUploadConfig) accessKeySecret() secretValue {
+	if cfg == nil {
+		return ""
+	}
+	return newSecretValue(cfg.STSAccessKey)
+}
+
+func (cfg *SSAArtifactUploadConfig) secretKeySecret() secretValue {
+	if cfg == nil {
+		return ""
+	}
+	return newSecretValue(cfg.STSSecretKey)
+}
+
+func (cfg *SSAArtifactUploadConfig) sessionTokenSecret() secretValue {
+	if cfg == nil {
+		return ""
+	}
+	return newSecretValue(cfg.STSSessionToken)
+}
+
+func (cfg *SSAArtifactUploadConfig) setSTSCredentials(accessKey, secretKey, sessionToken string) {
+	if cfg == nil {
+		return
+	}
+	cfg.STSAccessKey = accessKey
+	cfg.STSSecretKey = secretKey
+	cfg.STSSessionToken = sessionToken
+}
+
+func (cfg SSAArtifactUploadConfig) String() string {
+	return fmt.Sprintf("SSAArtifactUploadConfig{ObjectKey:%q Codec:%q Endpoint:%q Bucket:%q Region:%q UseSSL:%t TLSVerify:%t AllowInsecureTLS:%t TLSCAFile:%q AllowHTTP:%t VirtualHostStyle:%t STSAccessKey:[REDACTED] STSSecretKey:[REDACTED] STSSessionToken:[REDACTED] STSExpiresAt:%d}",
+		cfg.ObjectKey, cfg.Codec, cfg.Endpoint, cfg.Bucket, cfg.Region, cfg.UseSSL, cfg.TLSVerify, cfg.AllowInsecureTLS, cfg.TLSCAFile, cfg.AllowHTTP, cfg.VirtualHostStyle, cfg.STSExpiresAt)
+}
+
+func (cfg SSAArtifactUploadConfig) GoString() string { return cfg.String() }
 
 // ssaUploadMetrics accumulates upload-phase observability data across the
 // collector's lifetime. All fields are accessed under the collector's mutex.
@@ -422,7 +464,11 @@ func (c *SSAArtifactCollector) HasData() bool {
 	return c.hasData
 }
 
-func (c *SSAArtifactCollector) FinalizeUploadWithProvider(ctx context.Context, codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
+func (c *SSAArtifactCollector) FinalizeUploadWithProvider(codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
+	return c.FinalizeUploadWithProviderContext(context.Background(), codec, provider)
+}
+
+func (c *SSAArtifactCollector) FinalizeUploadWithProviderContext(ctx context.Context, codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
 	if c == nil {
 		return nil, utils.Errorf("collector is nil")
 	}
@@ -479,7 +525,7 @@ func (c *SSAArtifactCollector) FinalizeUploadWithProvider(ctx context.Context, c
 			_ = c.partsFile.Sync()
 		}
 		c.mu.Unlock()
-		return c.BuildAndUploadCompressedArtifactWithProvider(ctx, codec, provider)
+		return c.BuildAndUploadCompressedArtifactWithProviderContext(ctx, codec, provider)
 	}
 
 	if continuousEnabled && started && done != nil {
@@ -522,7 +568,7 @@ func (c *SSAArtifactCollector) FinalizeUploadWithProvider(ctx context.Context, c
 		return result, nil
 	}
 
-	return c.BuildAndUploadCompressedArtifactWithProvider(ctx, codec, provider)
+	return c.BuildAndUploadCompressedArtifactWithProviderContext(ctx, codec, provider)
 }
 
 const (
@@ -816,7 +862,7 @@ func compressSSAArtifactFile(rawPath, compressedPath, codec string) (int64, stri
 
 func uploadSSAArtifactFileWithObjectKey(ctx context.Context, path string, size int64, objectKey string, provider ssaUploadConfigProvider) error {
 	tmp := &SSAArtifactCollector{}
-	return tmp.UploadBySTSWithProvider(ctx, path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
+	return tmp.UploadBySTSWithProviderContext(ctx, path, size, func(force bool) (*SSAArtifactUploadConfig, error) {
 		cfg, err := provider(force)
 		if err != nil {
 			return nil, err
@@ -948,7 +994,11 @@ func (c *SSAArtifactCollector) BuildCompressedArtifact(codec string) (*SSAArtifa
 	}, nil
 }
 
-func (c *SSAArtifactCollector) BuildAndUploadCompressedArtifactWithProvider(ctx context.Context, codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
+func (c *SSAArtifactCollector) BuildAndUploadCompressedArtifactWithProvider(codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
+	return c.BuildAndUploadCompressedArtifactWithProviderContext(context.Background(), codec, provider)
+}
+
+func (c *SSAArtifactCollector) BuildAndUploadCompressedArtifactWithProviderContext(ctx context.Context, codec string, provider ssaUploadConfigProvider) (*SSAArtifactBuildResult, error) {
 	if provider == nil {
 		return nil, utils.Errorf("empty upload config provider")
 	}
@@ -1113,14 +1163,25 @@ func readSSAMultipartConcurrency() int {
 	return concurrency
 }
 
-func (c *SSAArtifactCollector) UploadBySTS(ctx context.Context, cfg *SSAArtifactUploadConfig, artifactPath string, size int64) error {
-	return c.UploadBySTSWithProvider(ctx, artifactPath, size, func(force bool) (*SSAArtifactUploadConfig, error) {
+func (c *SSAArtifactCollector) UploadBySTS(cfg *SSAArtifactUploadConfig, artifactPath string, size int64) error {
+	return c.UploadBySTSContext(context.Background(), cfg, artifactPath, size)
+}
+
+func (c *SSAArtifactCollector) UploadBySTSContext(ctx context.Context, cfg *SSAArtifactUploadConfig, artifactPath string, size int64) error {
+	return c.UploadBySTSWithProviderContext(ctx, artifactPath, size, func(force bool) (*SSAArtifactUploadConfig, error) {
 		_ = force
 		return cfg, nil
 	})
 }
 
-func (c *SSAArtifactCollector) UploadBySTSWithProvider(ctx context.Context, artifactPath string, size int64, provider ssaUploadConfigProvider) error {
+func (c *SSAArtifactCollector) UploadBySTSWithProvider(artifactPath string, size int64, provider ssaUploadConfigProvider) error {
+	return c.UploadBySTSWithProviderContext(context.Background(), artifactPath, size, provider)
+}
+
+func (c *SSAArtifactCollector) UploadBySTSWithProviderContext(ctx context.Context, artifactPath string, size int64, provider ssaUploadConfigProvider) error {
+	if provider == nil {
+		return utils.Errorf("empty upload config provider")
+	}
 	if ctx == nil {
 		ctx = c.uploadContext()
 	}

--- a/scannode/ssa_artifact_ticket_client.go
+++ b/scannode/ssa_artifact_ticket_client.go
@@ -31,6 +31,8 @@ type ssaArtifactTicketResponse struct {
 	Endpoint         string      `json:"endpoint"`
 	UseSSL           bool        `json:"use_ssl"`
 	TLSVerify        bool        `json:"tls_verify"`
+	AllowInsecureTLS bool        `json:"allow_insecure_tls"`
+	TLSCAFile        string      `json:"tls_ca_file"`
 	AllowHTTP        bool        `json:"allow_http"`
 	VirtualHostStyle bool        `json:"virtual_host_style"`
 	STSAccessKey     secretValue `json:"sts_access_key"`
@@ -121,36 +123,42 @@ func (s *ScanNode) fetchSSAArtifactUploadTicket(ctx context.Context, taskID, obj
 			}
 		}
 	}
+	ticketEndpoint := strings.TrimSpace(ticket.Endpoint)
+	legacySchemeLessHTTP := ticketEndpoint != "" && !ticket.UseSSL && !strings.Contains(ticketEndpoint, "://")
 	cfg = &SSAArtifactUploadConfig{
 		ObjectKey:        strings.TrimSpace(ticket.ObjectKey),
 		Codec:            strings.TrimSpace(ticket.Codec),
-		Endpoint:         strings.TrimSpace(ticket.Endpoint),
+		Endpoint:         ticketEndpoint,
 		Bucket:           strings.TrimSpace(ticket.Bucket),
 		Region:           strings.TrimSpace(ticket.Region),
 		UseSSL:           ticket.UseSSL,
 		TLSVerify:        ticket.TLSVerify,
-		AllowHTTP:        ticket.AllowHTTP || ssaExplicitHTTPAllowed(),
+		AllowInsecureTLS: ticket.AllowInsecureTLS,
+		TLSCAFile:        strings.TrimSpace(ticket.TLSCAFile),
+		AllowHTTP:        ticket.AllowHTTP || legacySchemeLessHTTP || ssaExplicitHTTPAllowed(),
 		VirtualHostStyle: ticket.VirtualHostStyle,
-		STSAccessKey:     newSecretValue(ticket.STSAccessKey.raw()),
-		STSSecretKey:     newSecretValue(ticket.STSSecretKey.raw()),
-		STSSessionToken:  newSecretValue(ticket.STSSessionToken.raw()),
 		STSExpiresAt:     ticket.STSExpiresAt,
 	}
+	cfg.setSTSCredentials(ticket.STSAccessKey.raw(), ticket.STSSecretKey.raw(), ticket.STSSessionToken.raw())
 	if cfg.Codec == "" {
 		cfg.Codec = "zstd"
 	}
 	if cfg.ObjectKey == "" {
 		cfg.ObjectKey = strings.TrimSpace(objectKey)
 	}
-	if cfg.STSAccessKey.raw() == "" || cfg.STSSecretKey.raw() == "" {
+	if cfg.accessKeySecret().raw() == "" || cfg.secretKeySecret().raw() == "" {
 		return nil, utils.Errorf("invalid upload ticket: missing sts credentials")
 	}
 	return cfg, nil
 }
 
 func newSSATicketHTTPClient() (*http.Client, error) {
-	verifyTLS := strings.EqualFold(strings.TrimSpace(os.Getenv("SCANNODE_SSA_TICKET_TLS_VERIFY")), "true")
-	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: !verifyTLS}
+	allowInsecureTLS := false
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SCANNODE_SSA_TICKET_ALLOW_INSECURE_TLS"))) {
+	case "1", "true", "yes", "on":
+		allowInsecureTLS = true
+	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: allowInsecureTLS}
 	caFile := strings.TrimSpace(os.Getenv("SCANNODE_SSA_TICKET_TLS_CA_FILE"))
 	if caFile == "" {
 		caFile = strings.TrimSpace(os.Getenv("SCANNODE_SSA_TLS_CA_FILE"))

--- a/scannode/ssa_artifact_ticket_client.go
+++ b/scannode/ssa_artifact_ticket_client.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -20,17 +23,20 @@ type ssaArtifactTicketRequest struct {
 }
 
 type ssaArtifactTicketResponse struct {
-	TaskID          string `json:"task_id"`
-	ObjectKey       string `json:"object_key"`
-	Codec           string `json:"codec"`
-	Bucket          string `json:"bucket"`
-	Region          string `json:"region"`
-	Endpoint        string `json:"endpoint"`
-	UseSSL          bool   `json:"use_ssl"`
-	STSAccessKey    string `json:"sts_access_key"`
-	STSSecretKey    string `json:"sts_secret_key"`
-	STSSessionToken string `json:"sts_session_token"`
-	STSExpiresAt    int64  `json:"sts_expires_at"`
+	TaskID           string      `json:"task_id"`
+	ObjectKey        string      `json:"object_key"`
+	Codec            string      `json:"codec"`
+	Bucket           string      `json:"bucket"`
+	Region           string      `json:"region"`
+	Endpoint         string      `json:"endpoint"`
+	UseSSL           bool        `json:"use_ssl"`
+	TLSVerify        bool        `json:"tls_verify"`
+	AllowHTTP        bool        `json:"allow_http"`
+	VirtualHostStyle bool        `json:"virtual_host_style"`
+	STSAccessKey     secretValue `json:"sts_access_key"`
+	STSSecretKey     secretValue `json:"sts_secret_key"`
+	STSSessionToken  secretValue `json:"sts_session_token"`
+	STSExpiresAt     int64       `json:"sts_expires_at"`
 }
 
 func (s *ScanNode) fetchSSAArtifactUploadTicket(ctx context.Context, taskID, objectKey string) (cfg *SSAArtifactUploadConfig, err error) {
@@ -55,6 +61,13 @@ func (s *ScanNode) fetchSSAArtifactUploadTicket(ctx context.Context, taskID, obj
 	if baseURL == "" {
 		return nil, utils.Errorf("server http url unavailable")
 	}
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil || parsedBaseURL.Host == "" || (parsedBaseURL.Scheme != "https" && parsedBaseURL.Scheme != "http") || parsedBaseURL.User != nil {
+		return nil, utils.Errorf("invalid server URL")
+	}
+	if parsedBaseURL.Scheme == "http" && !ssaExplicitHTTPAllowed() {
+		return nil, utils.Errorf("plaintext ticket endpoint requires SCANNODE_SSA_ALLOW_HTTP=1")
+	}
 	token := strings.TrimSpace(s.node.GetToken())
 	if token == "" {
 		return nil, utils.Errorf("node token unavailable")
@@ -74,12 +87,11 @@ func (s *ScanNode) fetchSSAArtifactUploadTicket(ctx context.Context, taskID, obj
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Timeout: 20 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
+	client, err := newSSATicketHTTPClient()
+	if err != nil {
+		return nil, err
 	}
+	defer client.CloseIdleConnections()
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, err
@@ -87,8 +99,8 @@ func (s *ScanNode) fetchSSAArtifactUploadTicket(ctx context.Context, taskID, obj
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, utils.Errorf("fetch upload ticket failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return nil, utils.Errorf("fetch upload ticket failed: status=%d request_id=%s", resp.StatusCode, strings.TrimSpace(resp.Header.Get("x-request-id")))
 	}
 	rawBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
@@ -110,16 +122,19 @@ func (s *ScanNode) fetchSSAArtifactUploadTicket(ctx context.Context, taskID, obj
 		}
 	}
 	cfg = &SSAArtifactUploadConfig{
-		ObjectKey:       strings.TrimSpace(ticket.ObjectKey),
-		Codec:           strings.TrimSpace(ticket.Codec),
-		Endpoint:        strings.TrimSpace(ticket.Endpoint),
-		Bucket:          strings.TrimSpace(ticket.Bucket),
-		Region:          strings.TrimSpace(ticket.Region),
-		UseSSL:          ticket.UseSSL,
-		STSAccessKey:    strings.TrimSpace(ticket.STSAccessKey),
-		STSSecretKey:    strings.TrimSpace(ticket.STSSecretKey),
-		STSSessionToken: strings.TrimSpace(ticket.STSSessionToken),
-		STSExpiresAt:    ticket.STSExpiresAt,
+		ObjectKey:        strings.TrimSpace(ticket.ObjectKey),
+		Codec:            strings.TrimSpace(ticket.Codec),
+		Endpoint:         strings.TrimSpace(ticket.Endpoint),
+		Bucket:           strings.TrimSpace(ticket.Bucket),
+		Region:           strings.TrimSpace(ticket.Region),
+		UseSSL:           ticket.UseSSL,
+		TLSVerify:        ticket.TLSVerify,
+		AllowHTTP:        ticket.AllowHTTP || ssaExplicitHTTPAllowed(),
+		VirtualHostStyle: ticket.VirtualHostStyle,
+		STSAccessKey:     newSecretValue(ticket.STSAccessKey.raw()),
+		STSSecretKey:     newSecretValue(ticket.STSSecretKey.raw()),
+		STSSessionToken:  newSecretValue(ticket.STSSessionToken.raw()),
+		STSExpiresAt:     ticket.STSExpiresAt,
 	}
 	if cfg.Codec == "" {
 		cfg.Codec = "zstd"
@@ -127,10 +142,45 @@ func (s *ScanNode) fetchSSAArtifactUploadTicket(ctx context.Context, taskID, obj
 	if cfg.ObjectKey == "" {
 		cfg.ObjectKey = strings.TrimSpace(objectKey)
 	}
-	if cfg.STSAccessKey == "" || cfg.STSSecretKey == "" {
+	if cfg.STSAccessKey.raw() == "" || cfg.STSSecretKey.raw() == "" {
 		return nil, utils.Errorf("invalid upload ticket: missing sts credentials")
 	}
 	return cfg, nil
+}
+
+func newSSATicketHTTPClient() (*http.Client, error) {
+	verifyTLS := strings.EqualFold(strings.TrimSpace(os.Getenv("SCANNODE_SSA_TICKET_TLS_VERIFY")), "true")
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: !verifyTLS}
+	caFile := strings.TrimSpace(os.Getenv("SCANNODE_SSA_TICKET_TLS_CA_FILE"))
+	if caFile == "" {
+		caFile = strings.TrimSpace(os.Getenv("SCANNODE_SSA_TLS_CA_FILE"))
+	}
+	if caFile != "" {
+		pemBytes, err := readSSACertificateFile(caFile)
+		if err != nil {
+			return nil, utils.Errorf("read ticket CA file: %v", err)
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(pemBytes) {
+			return nil, utils.Errorf("ticket CA file contains no certificates")
+		}
+		tlsConfig.RootCAs = pool
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	return &http.Client{Timeout: 20 * time.Second, Transport: transport}, nil
+}
+
+func ssaExplicitHTTPAllowed() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SCANNODE_SSA_ALLOW_HTTP"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *ScanNode) resolvePlatformAPIBaseURL() string {

--- a/scannode/ssa_artifact_upload_config.go
+++ b/scannode/ssa_artifact_upload_config.go
@@ -109,23 +109,32 @@ func extractSSAArtifactUploadConfig(params map[string]interface{}) *SSAArtifactU
 	if len(params) == 0 {
 		return nil
 	}
+	endpoint := strings.TrimSpace(toString(params["_scannode_ssa_endpoint"]))
+	useSSL := toBool(params["_scannode_ssa_use_ssl"])
+	// Legion historically sends a scheme-less endpoint together with
+	// use_ssl=false. Preserve that trusted scheduler contract while continuing
+	// to reject an arbitrary explicit http:// endpoint unless it is allowed.
+	legacySchemeLessHTTP := endpoint != "" && !useSSL && !strings.Contains(endpoint, "://")
 	cfg := &SSAArtifactUploadConfig{
 		ObjectKey:        strings.TrimSpace(toString(params["_scannode_ssa_object_key"])),
 		Codec:            strings.TrimSpace(toString(params["_scannode_ssa_codec"])),
-		Endpoint:         strings.TrimSpace(toString(params["_scannode_ssa_endpoint"])),
+		Endpoint:         endpoint,
 		Bucket:           strings.TrimSpace(toString(params["_scannode_ssa_bucket"])),
 		Region:           strings.TrimSpace(toString(params["_scannode_ssa_region"])),
-		UseSSL:           toBool(params["_scannode_ssa_use_ssl"]),
+		UseSSL:           useSSL,
 		TLSVerify:        toBool(params["_scannode_ssa_tls_verify"]),
+		AllowInsecureTLS: toBool(params["_scannode_ssa_allow_insecure_tls"]),
 		TLSCAFile:        strings.TrimSpace(toString(params["_scannode_ssa_tls_ca_file"])),
-		AllowHTTP:        toBool(params["_scannode_ssa_allow_http"]),
+		AllowHTTP:        toBool(params["_scannode_ssa_allow_http"]) || legacySchemeLessHTTP,
 		VirtualHostStyle: toBool(params["_scannode_ssa_virtual_host_style"]),
 
-		STSAccessKey:    newSecretValue(toString(params["_scannode_ssa_sts_access_key"])),
-		STSSecretKey:    newSecretValue(toString(params["_scannode_ssa_sts_secret_key"])),
-		STSSessionToken: newSecretValue(toString(params["_scannode_ssa_sts_session_token"])),
-		STSExpiresAt:    toInt64(params["_scannode_ssa_sts_expires_at"]),
+		STSExpiresAt: toInt64(params["_scannode_ssa_sts_expires_at"]),
 	}
+	cfg.setSTSCredentials(
+		toString(params["_scannode_ssa_sts_access_key"]),
+		toString(params["_scannode_ssa_sts_secret_key"]),
+		toString(params["_scannode_ssa_sts_session_token"]),
+	)
 	if cfg.Codec == "" {
 		cfg.Codec = "zstd"
 	}
@@ -139,7 +148,7 @@ func (cfg *SSAArtifactUploadConfig) NeedSTSRefresh(renewBeforeSec int64) bool {
 	if cfg == nil {
 		return true
 	}
-	if cfg.STSAccessKey.raw() == "" || cfg.STSSecretKey.raw() == "" {
+	if cfg.accessKeySecret().raw() == "" || cfg.secretKeySecret().raw() == "" {
 		return true
 	}
 	if renewBeforeSec <= 0 {

--- a/scannode/ssa_artifact_upload_config.go
+++ b/scannode/ssa_artifact_upload_config.go
@@ -110,16 +110,20 @@ func extractSSAArtifactUploadConfig(params map[string]interface{}) *SSAArtifactU
 		return nil
 	}
 	cfg := &SSAArtifactUploadConfig{
-		ObjectKey: strings.TrimSpace(toString(params["_scannode_ssa_object_key"])),
-		Codec:     strings.TrimSpace(toString(params["_scannode_ssa_codec"])),
-		Endpoint:  strings.TrimSpace(toString(params["_scannode_ssa_endpoint"])),
-		Bucket:    strings.TrimSpace(toString(params["_scannode_ssa_bucket"])),
-		Region:    strings.TrimSpace(toString(params["_scannode_ssa_region"])),
-		UseSSL:    toBool(params["_scannode_ssa_use_ssl"]),
+		ObjectKey:        strings.TrimSpace(toString(params["_scannode_ssa_object_key"])),
+		Codec:            strings.TrimSpace(toString(params["_scannode_ssa_codec"])),
+		Endpoint:         strings.TrimSpace(toString(params["_scannode_ssa_endpoint"])),
+		Bucket:           strings.TrimSpace(toString(params["_scannode_ssa_bucket"])),
+		Region:           strings.TrimSpace(toString(params["_scannode_ssa_region"])),
+		UseSSL:           toBool(params["_scannode_ssa_use_ssl"]),
+		TLSVerify:        toBool(params["_scannode_ssa_tls_verify"]),
+		TLSCAFile:        strings.TrimSpace(toString(params["_scannode_ssa_tls_ca_file"])),
+		AllowHTTP:        toBool(params["_scannode_ssa_allow_http"]),
+		VirtualHostStyle: toBool(params["_scannode_ssa_virtual_host_style"]),
 
-		STSAccessKey:    strings.TrimSpace(toString(params["_scannode_ssa_sts_access_key"])),
-		STSSecretKey:    strings.TrimSpace(toString(params["_scannode_ssa_sts_secret_key"])),
-		STSSessionToken: strings.TrimSpace(toString(params["_scannode_ssa_sts_session_token"])),
+		STSAccessKey:    newSecretValue(toString(params["_scannode_ssa_sts_access_key"])),
+		STSSecretKey:    newSecretValue(toString(params["_scannode_ssa_sts_secret_key"])),
+		STSSessionToken: newSecretValue(toString(params["_scannode_ssa_sts_session_token"])),
 		STSExpiresAt:    toInt64(params["_scannode_ssa_sts_expires_at"]),
 	}
 	if cfg.Codec == "" {
@@ -135,7 +139,7 @@ func (cfg *SSAArtifactUploadConfig) NeedSTSRefresh(renewBeforeSec int64) bool {
 	if cfg == nil {
 		return true
 	}
-	if strings.TrimSpace(cfg.STSAccessKey) == "" || strings.TrimSpace(cfg.STSSecretKey) == "" {
+	if cfg.STSAccessKey.raw() == "" || cfg.STSSecretKey.raw() == "" {
 		return true
 	}
 	if renewBeforeSec <= 0 {

--- a/scannode/ssa_artifact_upload_config_test.go
+++ b/scannode/ssa_artifact_upload_config_test.go
@@ -32,6 +32,46 @@ func TestExtractSSAArtifactUploadConfigSTS(t *testing.T) {
 	if cfg.STSAccessKey == "" || cfg.STSSecretKey == "" {
 		t.Fatalf("sts creds should be parsed: %+v", cfg)
 	}
+	if !cfg.AllowHTTP {
+		t.Fatal("legacy scheme-less HTTP endpoint should preserve the Legion scheduler contract")
+	}
+	if _, err := validateSSAUploadConfig(cfg); err != nil {
+		t.Fatalf("legacy Legion HTTP config must validate: %v", err)
+	}
+}
+
+func TestExtractSSAArtifactUploadConfig_ExplicitHTTPStillRequiresAllowance(t *testing.T) {
+	cfg := extractSSAArtifactUploadConfig(map[string]interface{}{
+		"_scannode_ssa_object_key":     "ssa/tasks/t1/result.ndjson.zst",
+		"_scannode_ssa_endpoint":       "http://127.0.0.1:9000",
+		"_scannode_ssa_bucket":         "irify-ssa",
+		"_scannode_ssa_use_ssl":        false,
+		"_scannode_ssa_sts_access_key": "ak",
+		"_scannode_ssa_sts_secret_key": "sk",
+	})
+	if cfg == nil {
+		t.Fatal("expected non-nil cfg")
+	}
+	if cfg.AllowHTTP {
+		t.Fatal("an explicit plaintext URL must not be trusted without allow_http")
+	}
+	if _, err := validateSSAUploadConfig(cfg); err == nil {
+		t.Fatal("an explicit plaintext URL must fail validation without allow_http")
+	}
+
+	cfg = extractSSAArtifactUploadConfig(map[string]interface{}{
+		"_scannode_ssa_object_key":         "ssa/tasks/t1/result.ndjson.zst",
+		"_scannode_ssa_endpoint":           "http://127.0.0.1:9000",
+		"_scannode_ssa_bucket":             "irify-ssa",
+		"_scannode_ssa_use_ssl":            false,
+		"_scannode_ssa_allow_http":         true,
+		"_scannode_ssa_allow_insecure_tls": true,
+		"_scannode_ssa_sts_access_key":     "ak",
+		"_scannode_ssa_sts_secret_key":     "sk",
+	})
+	if cfg == nil || !cfg.AllowHTTP || !cfg.AllowInsecureTLS {
+		t.Fatalf("explicit transport allowances were not parsed: %+v", cfg)
+	}
 }
 
 func TestExtractSSAArtifactUploadConfigNoSTS(t *testing.T) {

--- a/scannode/ssa_object_store.go
+++ b/scannode/ssa_object_store.go
@@ -280,9 +280,9 @@ func credentialsFromSSAConfig(cfg *SSAArtifactUploadConfig) objectStoreCredentia
 		return objectStoreCredentials{}
 	}
 	return objectStoreCredentials{
-		AccessKey:    cfg.STSAccessKey,
-		SecretKey:    cfg.STSSecretKey,
-		SessionToken: cfg.STSSessionToken,
+		AccessKey:    cfg.accessKeySecret(),
+		SecretKey:    cfg.secretKeySecret(),
+		SessionToken: cfg.sessionTokenSecret(),
 	}
 }
 
@@ -301,7 +301,7 @@ func (c *s3ObjectStoreClient) currentCredentials() objectStoreCredentials {
 func buildSSAObjectStoreTLSConfig(cfg *SSAArtifactUploadConfig) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: cfg == nil || !cfg.TLSVerify,
+		InsecureSkipVerify: cfg != nil && cfg.AllowInsecureTLS,
 	}
 	caFile := ""
 	if cfg != nil {
@@ -336,7 +336,10 @@ func (c *s3ObjectStoreClient) Put(ctx context.Context, req PutRequest) (ObjectSt
 }
 
 func (c *s3ObjectStoreClient) CreateMultipart(ctx context.Context, req CreateRequest) (string, ObjectStoreResult, error) {
-	result, body, err := c.executeXML(ctx, "create_multipart", http.MethodPost, req.Bucket, req.ObjectKey, []queryValue{{Key: "uploads"}}, req.ContentType, emptySHA256Hex, nil, 0)
+	// CreateMultipartUpload is not idempotent: if the service creates an upload
+	// but its response is lost, retrying creates an orphan upload ID that the
+	// caller can never abort. Leave any retry decision to a higher-level flow.
+	result, body, err := c.executeXMLWithRetryLimit(ctx, "create_multipart", http.MethodPost, req.Bucket, req.ObjectKey, []queryValue{{Key: "uploads"}}, req.ContentType, emptySHA256Hex, nil, 0, 1)
 	if err != nil {
 		return "", result, err
 	}
@@ -410,11 +413,16 @@ func (c *s3ObjectStoreClient) CompleteMultipart(ctx context.Context, req Complet
 			return result, embeddedErr
 		}
 		var response struct {
-			ETag string `xml:"ETag"`
+			XMLName xml.Name `xml:"CompleteMultipartUploadResult"`
+			ETag    string   `xml:"ETag"`
 		}
-		if xml.Unmarshal(responseBody, &response) == nil && response.ETag != "" {
-			result.ETag = unquoteETag(response.ETag)
+		if unmarshalErr := xml.Unmarshal(responseBody, &response); unmarshalErr != nil || strings.TrimSpace(response.ETag) == "" {
+			return result, &ObjectStoreError{
+				Operation: "complete_multipart", Code: "InvalidResponse", Message: "invalid completion response",
+				StatusCode: http.StatusOK, RequestID: result.RequestID, Cause: unmarshalErr,
+			}
 		}
+		result.ETag = unquoteETag(response.ETag)
 		return result, nil
 	}
 	return ObjectStoreResult{}, &ObjectStoreError{Operation: "complete_multipart", Code: "RetryLimitExceeded"}
@@ -459,6 +467,10 @@ func (c *s3ObjectStoreClient) execute(ctx context.Context, operation, method, bu
 }
 
 func (c *s3ObjectStoreClient) executeXML(ctx context.Context, operation, method, bucket, objectKey string, query []queryValue, contentType, payloadHash string, body io.ReadSeeker, size int64) (ObjectStoreResult, []byte, error) {
+	return c.executeXMLWithRetryLimit(ctx, operation, method, bucket, objectKey, query, contentType, payloadHash, body, size, c.retryLimit)
+}
+
+func (c *s3ObjectStoreClient) executeXMLWithRetryLimit(ctx context.Context, operation, method, bucket, objectKey string, query []queryValue, contentType, payloadHash string, body io.ReadSeeker, size int64, retryLimit int) (ObjectStoreResult, []byte, error) {
 	if c == nil || c.httpClient == nil || c.endpoint == nil {
 		return ObjectStoreResult{}, nil, &ObjectStoreError{Operation: operation, Code: "ClientUnavailable"}
 	}
@@ -480,7 +492,7 @@ func (c *s3ObjectStoreClient) executeXML(ctx context.Context, operation, method,
 			return ObjectStoreResult{}, nil, &ObjectStoreError{Operation: operation, Code: "InvalidArgument", Message: "request body must be seekable", Cause: err}
 		}
 	}
-	limit := c.retryLimit
+	limit := retryLimit
 	if limit < 1 {
 		limit = 1
 	}
@@ -819,7 +831,7 @@ func validateSSAUploadConfig(cfg *SSAArtifactUploadConfig) (*url.URL, error) {
 			return nil, fmt.Errorf("invalid object store region")
 		}
 	}
-	if cfg.STSAccessKey.raw() == "" || cfg.STSSecretKey.raw() == "" {
+	if cfg.accessKeySecret().raw() == "" || cfg.secretKeySecret().raw() == "" {
 		return nil, fmt.Errorf("STS credentials missing")
 	}
 	endpointRaw := strings.TrimSpace(cfg.Endpoint)

--- a/scannode/ssa_object_store.go
+++ b/scannode/ssa_object_store.go
@@ -1,0 +1,902 @@
+package scannode
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	defaultSSAObjectStoreRequestTimeout  = 5 * time.Minute
+	defaultSSAObjectStoreFinalizeTimeout = 30 * time.Second
+	defaultSSAObjectStoreRetryLimit      = 3
+	maxSSAObjectStoreErrorBodyBytes      = 64 * 1024
+	maxSSACertificateFileBytes           = 1024 * 1024
+	maxSSAMultipartParts                 = 10000
+)
+
+// secretValue deliberately redacts itself from every normal formatting and
+// JSON path. raw is only used at the HTTP signing boundary.
+type secretValue string
+
+func newSecretValue(value string) secretValue { return secretValue(strings.TrimSpace(value)) }
+func (s secretValue) raw() string             { return string(s) }
+func (s secretValue) String() string          { return "[REDACTED]" }
+func (s secretValue) GoString() string        { return "[REDACTED]" }
+func (s secretValue) MarshalText() ([]byte, error) {
+	return []byte("[REDACTED]"), nil
+}
+func (s secretValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal("[REDACTED]")
+}
+func (s *secretValue) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return fmt.Errorf("nil secret destination")
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*s = newSecretValue(value)
+	return nil
+}
+
+type objectStoreCredentials struct {
+	AccessKey    secretValue
+	SecretKey    secretValue
+	SessionToken secretValue
+}
+
+type PutRequest struct {
+	Bucket        string
+	ObjectKey     string
+	Body          io.ReadSeeker
+	Size          int64
+	ContentType   string
+	PayloadSHA256 string
+}
+
+type CreateRequest struct {
+	Bucket      string
+	ObjectKey   string
+	ContentType string
+}
+
+type PartRequest struct {
+	Bucket        string
+	ObjectKey     string
+	UploadID      string
+	PartNumber    int
+	Body          io.ReadSeeker
+	Size          int64
+	PayloadSHA256 string
+}
+
+type CompletePart struct {
+	PartNumber int
+	ETag       string
+}
+
+type CompleteRequest struct {
+	Bucket    string
+	ObjectKey string
+	UploadID  string
+	Parts     []CompletePart
+}
+
+type AbortRequest struct {
+	Bucket    string
+	ObjectKey string
+	UploadID  string
+}
+
+type ObjectStoreResult struct {
+	ETag      string
+	VersionID string
+	RequestID string
+}
+
+// ObjectStoreUploader is the complete object-storage surface required by the
+// ScanNode artifact pipeline. It intentionally excludes discovery, listing,
+// downloads, and bucket administration.
+type ObjectStoreUploader interface {
+	Put(context.Context, PutRequest) (ObjectStoreResult, error)
+	CreateMultipart(context.Context, CreateRequest) (string, ObjectStoreResult, error)
+	UploadPart(context.Context, PartRequest) (string, ObjectStoreResult, error)
+	CompleteMultipart(context.Context, CompleteRequest) (ObjectStoreResult, error)
+	AbortMultipart(context.Context, AbortRequest) error
+}
+
+type ObjectStoreError struct {
+	Operation  string
+	Code       string
+	Message    string
+	StatusCode int
+	RequestID  string
+	Retryable  bool
+	Cause      error
+}
+
+func (e *ObjectStoreError) Error() string {
+	if e == nil {
+		return "object store error"
+	}
+	parts := []string{"object store " + strings.TrimSpace(e.Operation) + " failed"}
+	if e.Code != "" {
+		parts = append(parts, "code="+e.Code)
+	}
+	if e.StatusCode != 0 {
+		parts = append(parts, "status="+strconv.Itoa(e.StatusCode))
+	}
+	if e.RequestID != "" {
+		parts = append(parts, "request_id="+e.RequestID)
+	}
+	if e.Message != "" {
+		parts = append(parts, "message="+sanitizeObjectStoreMessage(e.Message))
+	} else if e.Cause != nil {
+		parts = append(parts, "cause="+sanitizeObjectStoreMessage(e.Cause.Error()))
+	}
+	return strings.Join(parts, " ")
+}
+
+func (e *ObjectStoreError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func sanitizeObjectStoreMessage(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	if len(value) > 512 {
+		value = value[:512]
+	}
+	return value
+}
+
+func isObjectStoreCredentialExpired(err error) bool {
+	var storeErr *ObjectStoreError
+	if !errors.As(err, &storeErr) {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(storeErr.Code)) {
+	case "expiredtoken", "invalidtoken", "invalidsecuritytoken", "tokenrefreshrequired":
+		return true
+	default:
+		return false
+	}
+}
+
+func classifyObjectStoreError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return "upload_canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "upload_timeout"
+	}
+	var storeErr *ObjectStoreError
+	if !errors.As(err, &storeErr) {
+		return "put_failed"
+	}
+	if isObjectStoreCredentialExpired(storeErr) {
+		return "sts_expired"
+	}
+	switch strings.ToLower(strings.TrimSpace(storeErr.Code)) {
+	case "accessdenied", "allaccessdisabled":
+		return "permission_denied"
+	case "signaturedoesnotmatch", "authorizationheadermalformed", "invalidaccesskeyid":
+		return "signature_invalid"
+	case "nosuchbucket":
+		return "bucket_not_found"
+	case "invalidbucketname", "invalidargument", "invalidrequest", "keytoolongerror":
+		return "invalid_upload_target"
+	}
+	switch storeErr.Operation {
+	case "create_multipart", "upload_part", "complete_multipart", "abort_multipart":
+		return "multipart_failed"
+	default:
+		return "put_failed"
+	}
+}
+
+type s3ObjectStoreClient struct {
+	endpoint         *url.URL
+	region           string
+	virtualHostStyle bool
+	httpClient       *http.Client
+	transport        *http.Transport
+	now              func() time.Time
+	retryLimit       int
+	onRetry          func()
+
+	credentialsMu sync.RWMutex
+	credentials   objectStoreCredentials
+}
+
+func newS3ObjectStoreClient(cfg *SSAArtifactUploadConfig) (*s3ObjectStoreClient, error) {
+	endpoint, err := validateSSAUploadConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig, err := buildSSAObjectStoreTLSConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	transport.MaxIdleConns = 32
+	transport.MaxIdleConnsPerHost = 8
+	transport.IdleConnTimeout = 90 * time.Second
+	client := &s3ObjectStoreClient{
+		endpoint:         endpoint,
+		region:           normalizedSSARegion(cfg.Region),
+		virtualHostStyle: cfg.VirtualHostStyle,
+		httpClient: &http.Client{
+			Transport: transport,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		transport:  transport,
+		now:        time.Now,
+		retryLimit: defaultSSAObjectStoreRetryLimit,
+	}
+	client.setCredentials(credentialsFromSSAConfig(cfg))
+	return client, nil
+}
+
+func (c *s3ObjectStoreClient) Close() {
+	if c != nil && c.transport != nil {
+		c.transport.CloseIdleConnections()
+	}
+}
+
+func credentialsFromSSAConfig(cfg *SSAArtifactUploadConfig) objectStoreCredentials {
+	if cfg == nil {
+		return objectStoreCredentials{}
+	}
+	return objectStoreCredentials{
+		AccessKey:    cfg.STSAccessKey,
+		SecretKey:    cfg.STSSecretKey,
+		SessionToken: cfg.STSSessionToken,
+	}
+}
+
+func (c *s3ObjectStoreClient) setCredentials(credentials objectStoreCredentials) {
+	c.credentialsMu.Lock()
+	c.credentials = credentials
+	c.credentialsMu.Unlock()
+}
+
+func (c *s3ObjectStoreClient) currentCredentials() objectStoreCredentials {
+	c.credentialsMu.RLock()
+	defer c.credentialsMu.RUnlock()
+	return c.credentials
+}
+
+func buildSSAObjectStoreTLSConfig(cfg *SSAArtifactUploadConfig) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: cfg == nil || !cfg.TLSVerify,
+	}
+	caFile := ""
+	if cfg != nil {
+		caFile = strings.TrimSpace(cfg.TLSCAFile)
+	}
+	if caFile == "" {
+		caFile = strings.TrimSpace(os.Getenv("SCANNODE_SSA_TLS_CA_FILE"))
+	}
+	if caFile == "" {
+		return tlsConfig, nil
+	}
+	pemBytes, err := readSSACertificateFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read object store CA file: %w", err)
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf("object store CA file contains no certificates")
+	}
+	tlsConfig.RootCAs = pool
+	return tlsConfig, nil
+}
+
+func (c *s3ObjectStoreClient) Put(ctx context.Context, req PutRequest) (ObjectStoreResult, error) {
+	if req.Body == nil || req.Size < 0 {
+		return ObjectStoreResult{}, &ObjectStoreError{Operation: "put", Code: "InvalidArgument", Message: "body and non-negative size required"}
+	}
+	return c.execute(ctx, "put", http.MethodPut, req.Bucket, req.ObjectKey, nil, req.ContentType, req.PayloadSHA256, req.Body, req.Size)
+}
+
+func (c *s3ObjectStoreClient) CreateMultipart(ctx context.Context, req CreateRequest) (string, ObjectStoreResult, error) {
+	result, body, err := c.executeXML(ctx, "create_multipart", http.MethodPost, req.Bucket, req.ObjectKey, []queryValue{{Key: "uploads"}}, req.ContentType, emptySHA256Hex, nil, 0)
+	if err != nil {
+		return "", result, err
+	}
+	var response struct {
+		UploadID string `xml:"UploadId"`
+	}
+	if err := xml.Unmarshal(body, &response); err != nil || strings.TrimSpace(response.UploadID) == "" {
+		return "", result, &ObjectStoreError{Operation: "create_multipart", Code: "InvalidResponse", Message: "missing upload id", Cause: err}
+	}
+	return strings.TrimSpace(response.UploadID), result, nil
+}
+
+func (c *s3ObjectStoreClient) UploadPart(ctx context.Context, req PartRequest) (string, ObjectStoreResult, error) {
+	if req.PartNumber < 1 || req.PartNumber > maxSSAMultipartParts || strings.TrimSpace(req.UploadID) == "" {
+		return "", ObjectStoreResult{}, &ObjectStoreError{Operation: "upload_part", Code: "InvalidArgument", Message: "invalid part number or upload id"}
+	}
+	query := []queryValue{{Key: "partNumber", Value: strconv.Itoa(req.PartNumber)}, {Key: "uploadId", Value: req.UploadID}}
+	result, err := c.execute(ctx, "upload_part", http.MethodPut, req.Bucket, req.ObjectKey, query, "application/octet-stream", req.PayloadSHA256, req.Body, req.Size)
+	if err != nil {
+		return "", result, err
+	}
+	if strings.TrimSpace(result.ETag) == "" {
+		return "", result, &ObjectStoreError{Operation: "upload_part", Code: "InvalidResponse", Message: "missing ETag", RequestID: result.RequestID}
+	}
+	return result.ETag, result, nil
+}
+
+func (c *s3ObjectStoreClient) CompleteMultipart(ctx context.Context, req CompleteRequest) (ObjectStoreResult, error) {
+	if strings.TrimSpace(req.UploadID) == "" || len(req.Parts) == 0 || len(req.Parts) > maxSSAMultipartParts {
+		return ObjectStoreResult{}, &ObjectStoreError{Operation: "complete_multipart", Code: "InvalidArgument", Message: "upload id and parts required"}
+	}
+	type completedPartXML struct {
+		PartNumber int    `xml:"PartNumber"`
+		ETag       string `xml:"ETag"`
+	}
+	type completeUploadXML struct {
+		XMLName xml.Name           `xml:"CompleteMultipartUpload"`
+		Parts   []completedPartXML `xml:"Part"`
+	}
+	payload := completeUploadXML{Parts: make([]completedPartXML, 0, len(req.Parts))}
+	for index, part := range req.Parts {
+		if part.PartNumber != index+1 || strings.TrimSpace(part.ETag) == "" {
+			return ObjectStoreResult{}, &ObjectStoreError{Operation: "complete_multipart", Code: "InvalidPart", Message: "parts must be ordered, contiguous, and include ETags"}
+		}
+		payload.Parts = append(payload.Parts, completedPartXML{PartNumber: part.PartNumber, ETag: quoteETag(part.ETag)})
+	}
+	body, err := xml.Marshal(payload)
+	if err != nil {
+		return ObjectStoreResult{}, err
+	}
+	payloadHash := sha256Hex(body)
+	limit := c.retryLimit
+	if limit < 1 {
+		limit = 1
+	}
+	for attempt := 0; attempt < limit; attempt++ {
+		result, responseBody, executeErr := c.executeXML(ctx, "complete_multipart", http.MethodPost, req.Bucket, req.ObjectKey, []queryValue{{Key: "uploadId", Value: req.UploadID}}, "application/xml", payloadHash, bytes.NewReader(body), int64(len(body)))
+		if executeErr != nil {
+			return result, executeErr
+		}
+		if embeddedErr := parseS3EmbeddedCompleteError(responseBody); embeddedErr != nil {
+			if attempt+1 < limit && shouldRetryObjectStoreError(embeddedErr) {
+				if c.onRetry != nil {
+					c.onRetry()
+				}
+				if waitErr := waitSSAObjectStoreRetry(ctx, attempt); waitErr != nil {
+					return result, waitErr
+				}
+				continue
+			}
+			return result, embeddedErr
+		}
+		var response struct {
+			ETag string `xml:"ETag"`
+		}
+		if xml.Unmarshal(responseBody, &response) == nil && response.ETag != "" {
+			result.ETag = unquoteETag(response.ETag)
+		}
+		return result, nil
+	}
+	return ObjectStoreResult{}, &ObjectStoreError{Operation: "complete_multipart", Code: "RetryLimitExceeded"}
+}
+
+func parseS3EmbeddedCompleteError(body []byte) error {
+	parsed := struct {
+		XMLName   xml.Name
+		Code      string `xml:"Code"`
+		Message   string `xml:"Message"`
+		RequestID string `xml:"RequestId"`
+	}{}
+	if err := xml.Unmarshal(body, &parsed); err != nil || !strings.EqualFold(parsed.XMLName.Local, "Error") {
+		return nil
+	}
+	code := strings.TrimSpace(parsed.Code)
+	if code == "" {
+		code = "InvalidResponse"
+	}
+	return &ObjectStoreError{
+		Operation: "complete_multipart", Code: code, Message: parsed.Message,
+		StatusCode: http.StatusOK, RequestID: strings.TrimSpace(parsed.RequestID), Retryable: isRetryableS3Response(http.StatusOK, code),
+	}
+}
+
+func (c *s3ObjectStoreClient) AbortMultipart(ctx context.Context, req AbortRequest) error {
+	if strings.TrimSpace(req.UploadID) == "" {
+		return &ObjectStoreError{Operation: "abort_multipart", Code: "InvalidArgument", Message: "upload id required"}
+	}
+	_, err := c.execute(ctx, "abort_multipart", http.MethodDelete, req.Bucket, req.ObjectKey, []queryValue{{Key: "uploadId", Value: req.UploadID}}, "", emptySHA256Hex, nil, 0)
+	return err
+}
+
+type queryValue struct {
+	Key   string
+	Value string
+}
+
+func (c *s3ObjectStoreClient) execute(ctx context.Context, operation, method, bucket, objectKey string, query []queryValue, contentType, payloadHash string, body io.ReadSeeker, size int64) (ObjectStoreResult, error) {
+	result, _, err := c.executeXML(ctx, operation, method, bucket, objectKey, query, contentType, payloadHash, body, size)
+	return result, err
+}
+
+func (c *s3ObjectStoreClient) executeXML(ctx context.Context, operation, method, bucket, objectKey string, query []queryValue, contentType, payloadHash string, body io.ReadSeeker, size int64) (ObjectStoreResult, []byte, error) {
+	if c == nil || c.httpClient == nil || c.endpoint == nil {
+		return ObjectStoreResult{}, nil, &ObjectStoreError{Operation: operation, Code: "ClientUnavailable"}
+	}
+	if err := validateSSABucket(bucket); err != nil {
+		return ObjectStoreResult{}, nil, &ObjectStoreError{Operation: operation, Code: "InvalidBucketName", Message: err.Error()}
+	}
+	if err := validateSSAObjectKey(objectKey); err != nil {
+		return ObjectStoreResult{}, nil, &ObjectStoreError{Operation: operation, Code: "InvalidArgument", Message: err.Error()}
+	}
+	if payloadHash == "" {
+		return ObjectStoreResult{}, nil, &ObjectStoreError{Operation: operation, Code: "InvalidArgument", Message: "payload SHA-256 required"}
+	}
+
+	startOffset := int64(0)
+	if body != nil {
+		var err error
+		startOffset, err = body.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return ObjectStoreResult{}, nil, &ObjectStoreError{Operation: operation, Code: "InvalidArgument", Message: "request body must be seekable", Cause: err}
+		}
+	}
+	limit := c.retryLimit
+	if limit < 1 {
+		limit = 1
+	}
+	var lastErr error
+	for attempt := 0; attempt < limit; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return ObjectStoreResult{}, nil, err
+		}
+		if body != nil {
+			if _, err := body.Seek(startOffset, io.SeekStart); err != nil {
+				return ObjectStoreResult{}, nil, err
+			}
+		}
+		requestURL := c.objectURL(bucket, objectKey, query)
+		var requestBody io.Reader
+		if body != nil {
+			requestBody = io.LimitReader(body, size)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, requestURL.String(), requestBody)
+		if err != nil {
+			return ObjectStoreResult{}, nil, err
+		}
+		if body != nil {
+			req.ContentLength = size
+		}
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		credentials := c.currentCredentials()
+		if err := signS3Request(req, credentials, c.region, payloadHash, c.now().UTC()); err != nil {
+			return ObjectStoreResult{}, nil, err
+		}
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = classifyS3TransportError(operation, err)
+			if attempt+1 < limit && shouldRetryObjectStoreError(lastErr) {
+				if c.onRetry != nil {
+					c.onRetry()
+				}
+				if err := waitSSAObjectStoreRetry(ctx, attempt); err != nil {
+					return ObjectStoreResult{}, nil, err
+				}
+				continue
+			}
+			return ObjectStoreResult{}, nil, lastErr
+		}
+		responseBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxSSAObjectStoreErrorBodyBytes+1))
+		_ = resp.Body.Close()
+		result := ObjectStoreResult{
+			ETag:      unquoteETag(resp.Header.Get("ETag")),
+			VersionID: strings.TrimSpace(resp.Header.Get("x-amz-version-id")),
+			RequestID: firstNonEmptyS3(resp.Header.Get("x-amz-request-id"), resp.Header.Get("x-minio-deployment-id")),
+		}
+		if readErr != nil {
+			lastErr = &ObjectStoreError{Operation: operation, Code: "ResponseReadError", RequestID: result.RequestID, Retryable: true, Cause: readErr}
+		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastErr = redactObjectStoreCredentials(parseS3Error(operation, resp.StatusCode, resp.Header, responseBody), credentials)
+		} else {
+			return result, responseBody, nil
+		}
+		if attempt+1 < limit && shouldRetryObjectStoreError(lastErr) {
+			if c.onRetry != nil {
+				c.onRetry()
+			}
+			if err := waitSSAObjectStoreRetry(ctx, attempt); err != nil {
+				return ObjectStoreResult{}, nil, err
+			}
+			continue
+		}
+		return result, nil, lastErr
+	}
+	return ObjectStoreResult{}, nil, lastErr
+}
+
+func redactObjectStoreCredentials(err error, credentials objectStoreCredentials) error {
+	var storeErr *ObjectStoreError
+	if err == nil || !errors.As(err, &storeErr) {
+		return err
+	}
+	for _, secret := range []secretValue{credentials.AccessKey, credentials.SecretKey, credentials.SessionToken} {
+		if raw := secret.raw(); raw != "" {
+			storeErr.Message = strings.ReplaceAll(storeErr.Message, raw, "[REDACTED]")
+		}
+	}
+	return err
+}
+
+func (c *s3ObjectStoreClient) objectURL(bucket, objectKey string, query []queryValue) *url.URL {
+	result := *c.endpoint
+	basePath := strings.TrimSuffix(result.Path, "/")
+	if c.virtualHostStyle {
+		result.Host = bucket + "." + result.Host
+		result.Path = basePath + "/" + objectKey
+	} else {
+		result.Path = basePath + "/" + bucket + "/" + objectKey
+	}
+	result.RawPath = awsURIEncode(result.Path, false)
+	result.RawQuery = canonicalS3Query(query)
+	return &result
+}
+
+func signS3Request(req *http.Request, credentials objectStoreCredentials, region, payloadHash string, now time.Time) error {
+	if req == nil || req.URL == nil {
+		return &ObjectStoreError{Operation: "sign", Code: "InvalidArgument", Message: "request URL required"}
+	}
+	accessKey := credentials.AccessKey.raw()
+	secretKey := credentials.SecretKey.raw()
+	if strings.TrimSpace(accessKey) == "" || strings.TrimSpace(secretKey) == "" {
+		return &ObjectStoreError{Operation: "sign", Code: "CredentialsMissing"}
+	}
+	region = normalizedSSARegion(region)
+	payloadHash = strings.ToLower(strings.TrimSpace(payloadHash))
+	if len(payloadHash) != sha256.Size*2 {
+		return &ObjectStoreError{Operation: "sign", Code: "InvalidArgument", Message: "invalid payload SHA-256"}
+	}
+	now = now.UTC()
+	amzDate := now.Format("20060102T150405Z")
+	shortDate := now.Format("20060102")
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", payloadHash)
+	if token := credentials.SessionToken.raw(); token != "" {
+		req.Header.Set("x-amz-security-token", token)
+	}
+	canonicalHeaders, signedHeaders := canonicalS3Headers(req)
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		awsURIEncode(req.URL.Path, false),
+		canonicalizeRawQuery(req.URL.Query()),
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+	scope := shortDate + "/" + region + "/s3/aws4_request"
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + scope + "\n" + sha256Hex([]byte(canonicalRequest))
+	kDate := hmacSHA256([]byte("AWS4"+secretKey), shortDate)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, "s3")
+	kSigning := hmacSHA256(kService, "aws4_request")
+	signature := hex.EncodeToString(hmacSHA256(kSigning, stringToSign))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+accessKey+"/"+scope+",SignedHeaders="+signedHeaders+",Signature="+signature)
+	return nil
+}
+
+func canonicalS3Headers(req *http.Request) (string, string) {
+	headers := make(map[string][]string, len(req.Header)+1)
+	headers["host"] = []string{req.URL.Host}
+	for name, values := range req.Header {
+		lowerName := strings.ToLower(strings.TrimSpace(name))
+		switch lowerName {
+		case "authorization", "content-length", "expect", "transfer-encoding", "user-agent", "x-amzn-trace-id":
+			continue
+		}
+		for _, value := range values {
+			headers[lowerName] = append(headers[lowerName], collapseHTTPSpaces(value))
+		}
+	}
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var canonical strings.Builder
+	for _, name := range names {
+		canonical.WriteString(name)
+		canonical.WriteByte(':')
+		canonical.WriteString(strings.Join(headers[name], ","))
+		canonical.WriteByte('\n')
+	}
+	return canonical.String(), strings.Join(names, ";")
+}
+
+func collapseHTTPSpaces(value string) string { return strings.Join(strings.Fields(value), " ") }
+
+func awsURIEncode(value string, encodeSlash bool) string {
+	const hexUpper = "0123456789ABCDEF"
+	var encoded strings.Builder
+	for index := 0; index < len(value); index++ {
+		ch := value[index]
+		if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch == '.' || ch == '~' || (ch == '/' && !encodeSlash) {
+			encoded.WriteByte(ch)
+			continue
+		}
+		encoded.WriteByte('%')
+		encoded.WriteByte(hexUpper[ch>>4])
+		encoded.WriteByte(hexUpper[ch&0x0f])
+	}
+	return encoded.String()
+}
+
+func canonicalS3Query(values []queryValue) string {
+	sorted := append([]queryValue(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool {
+		leftKey, rightKey := awsURIEncode(sorted[i].Key, true), awsURIEncode(sorted[j].Key, true)
+		if leftKey == rightKey {
+			return awsURIEncode(sorted[i].Value, true) < awsURIEncode(sorted[j].Value, true)
+		}
+		return leftKey < rightKey
+	})
+	parts := make([]string, 0, len(sorted))
+	for _, item := range sorted {
+		parts = append(parts, awsURIEncode(item.Key, true)+"="+awsURIEncode(item.Value, true))
+	}
+	return strings.Join(parts, "&")
+}
+
+func canonicalizeRawQuery(values url.Values) string {
+	items := make([]queryValue, 0)
+	for key, list := range values {
+		if len(list) == 0 {
+			items = append(items, queryValue{Key: key})
+			continue
+		}
+		for _, value := range list {
+			items = append(items, queryValue{Key: key, Value: value})
+		}
+	}
+	return canonicalS3Query(items)
+}
+
+func hmacSHA256(key []byte, value string) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(value))
+	return mac.Sum(nil)
+}
+
+func sha256Hex(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
+}
+
+const emptySHA256Hex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func parseS3Error(operation string, statusCode int, headers http.Header, body []byte) error {
+	parsed := struct {
+		Code      string `xml:"Code"`
+		Message   string `xml:"Message"`
+		RequestID string `xml:"RequestId"`
+	}{}
+	_ = xml.Unmarshal(body, &parsed)
+	requestID := firstNonEmptyS3(parsed.RequestID, headers.Get("x-amz-request-id"), headers.Get("x-minio-deployment-id"))
+	code := strings.TrimSpace(parsed.Code)
+	if code == "" {
+		code = http.StatusText(statusCode)
+	}
+	return &ObjectStoreError{
+		Operation:  operation,
+		Code:       code,
+		Message:    parsed.Message,
+		StatusCode: statusCode,
+		RequestID:  strings.TrimSpace(requestID),
+		Retryable:  isRetryableS3Response(statusCode, code),
+	}
+}
+
+func classifyS3TransportError(operation string, err error) error {
+	retryable := false
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		retryable = netErr.Timeout() || netErr.Temporary()
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		retryable = true
+	}
+	return &ObjectStoreError{Operation: operation, Code: "NetworkError", Retryable: retryable, Cause: err}
+}
+
+func shouldRetryObjectStoreError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var storeErr *ObjectStoreError
+	return errors.As(err, &storeErr) && storeErr.Retryable
+}
+
+func isRetryableS3Response(statusCode int, code string) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(code)) {
+	case "internalerror", "requesttimeout", "requesttimeoutexception", "serviceunavailable", "slowdown":
+		return true
+	default:
+		return false
+	}
+}
+
+func waitSSAObjectStoreRetry(ctx context.Context, attempt int) error {
+	delay := time.Duration(100*(1<<min(attempt, 4))) * time.Millisecond
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func quoteETag(value string) string   { return `"` + unquoteETag(value) + `"` }
+func unquoteETag(value string) string { return strings.Trim(strings.TrimSpace(value), `"`) }
+
+func firstNonEmptyS3(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizedSSARegion(region string) string {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return "us-east-1"
+	}
+	return region
+}
+
+func validateSSAUploadConfig(cfg *SSAArtifactUploadConfig) (*url.URL, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("empty upload config")
+	}
+	if err := validateSSABucket(cfg.Bucket); err != nil {
+		return nil, err
+	}
+	if err := validateSSAObjectKey(cfg.ObjectKey); err != nil {
+		return nil, err
+	}
+	region := normalizedSSARegion(cfg.Region)
+	if len(region) > 64 {
+		return nil, fmt.Errorf("invalid object store region")
+	}
+	for _, ch := range region {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-') {
+			return nil, fmt.Errorf("invalid object store region")
+		}
+	}
+	if cfg.STSAccessKey.raw() == "" || cfg.STSSecretKey.raw() == "" {
+		return nil, fmt.Errorf("STS credentials missing")
+	}
+	endpointRaw := strings.TrimSpace(cfg.Endpoint)
+	if endpointRaw == "" {
+		return nil, fmt.Errorf("object store endpoint missing")
+	}
+	if !strings.Contains(endpointRaw, "://") {
+		scheme := "http"
+		if cfg.UseSSL {
+			scheme = "https"
+		}
+		endpointRaw = scheme + "://" + endpointRaw
+	}
+	endpoint, err := url.Parse(endpointRaw)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return nil, fmt.Errorf("invalid object store endpoint")
+	}
+	if endpoint.Scheme != "https" && endpoint.Scheme != "http" {
+		return nil, fmt.Errorf("object store endpoint scheme must be HTTP or HTTPS")
+	}
+	if endpoint.Scheme == "http" && !cfg.AllowHTTP && !ssaExplicitHTTPAllowed() {
+		return nil, fmt.Errorf("plaintext object store endpoint requires explicit development allowance")
+	}
+	if cfg.UseSSL && endpoint.Scheme != "https" {
+		return nil, fmt.Errorf("object store endpoint TLS mode mismatch")
+	}
+	endpoint.Path = strings.TrimSuffix(endpoint.Path, "/")
+	endpoint.RawPath = ""
+	return endpoint, nil
+}
+
+func readSSACertificateFile(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	contents, err := io.ReadAll(io.LimitReader(file, maxSSACertificateFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(contents) > maxSSACertificateFileBytes {
+		return nil, fmt.Errorf("certificate file exceeds %d bytes", maxSSACertificateFileBytes)
+	}
+	return contents, nil
+}
+
+func validateSSABucket(bucket string) error {
+	bucket = strings.TrimSpace(bucket)
+	if len(bucket) < 3 || len(bucket) > 63 {
+		return fmt.Errorf("invalid object store bucket length")
+	}
+	if bucket[0] == '-' || bucket[len(bucket)-1] == '-' || bucket[0] == '.' || bucket[len(bucket)-1] == '.' || strings.Contains(bucket, "..") {
+		return fmt.Errorf("invalid object store bucket")
+	}
+	for _, ch := range bucket {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '.') {
+			return fmt.Errorf("invalid object store bucket")
+		}
+	}
+	if net.ParseIP(bucket) != nil {
+		return fmt.Errorf("object store bucket cannot be an IP address")
+	}
+	return nil
+}
+
+func validateSSAObjectKey(objectKey string) error {
+	if objectKey == "" || strings.TrimSpace(objectKey) == "" || len(objectKey) > 1024 || !utf8.ValidString(objectKey) {
+		return fmt.Errorf("invalid object store object key")
+	}
+	if strings.HasPrefix(objectKey, "/") || strings.ContainsRune(objectKey, '\x00') {
+		return fmt.Errorf("invalid object store object key")
+	}
+	for _, ch := range objectKey {
+		if ch < 0x20 || ch == 0x7f {
+			return fmt.Errorf("invalid object store object key")
+		}
+	}
+	return nil
+}

--- a/scannode/ssa_object_store_benchmark.md
+++ b/scannode/ssa_object_store_benchmark.md
@@ -1,0 +1,73 @@
+# ScanNode SSA object-store replacement report
+
+Date: 2026-09-01
+
+## Environment
+
+- Host: Apple M1 Max, 64 GiB RAM, Darwin 23.1.0 arm64
+- Go: go1.22.12 darwin/arm64
+- Server: MinIO RELEASE.2025-09-07T16-13-09Z, darwin/arm64
+- MinIO binary SHA-256: `7c3b3039b76e55a1b80935848ed83998d5e8d317374f87851f46a019ff5c0aa4`
+- Client and server ran on the same host over `127.0.0.1`
+- Payload: one 64 MiB file, 16 MiB multipart size
+- Samples: 10 independent one-iteration benchmark runs for each implementation
+
+The baseline and replacement were built from the same repository revision. The
+baseline used `minio-go/v7`; the replacement used the standard-library S3
+client with multipart concurrency 2. P95 below uses the nearest-rank method;
+with 10 samples it is the slowest observed sample.
+
+## Results
+
+| Metric | `minio-go/v7` baseline | Standard-library client | Change |
+| --- | ---: | ---: | ---: |
+| Median upload time | 203.1 ms | 163.1 ms | -19.7% |
+| P95 upload time | 222.9 ms | 191.0 ms | -14.3% |
+| Median throughput | 330.5 MB/s | 411.4 MB/s | +24.5% |
+| Allocations per upload | about 51,245 | about 1,638 | -96.8% |
+| `yak` binary (`go build -trimpath`) | 303,612,914 bytes | 301,800,562 bytes | -1,812,352 bytes (-1.73 MiB) |
+
+Raw elapsed-time samples in nanoseconds:
+
+- Baseline: `186773792, 184285166, 205682625, 222888250, 215296084, 195676500, 203400250, 208298500, 187629166, 202733792`
+- Replacement: `159929000, 135358208, 170638125, 160434708, 191023792, 177717083, 168708000, 165789083, 151967375, 159623292`
+
+The replacement intentionally keeps two reusable payload buffers to overlap
+part uploads. Its bounded multipart payload memory is:
+
+`part_size * concurrency`
+
+That is 32 MiB by default (`16 MiB * 2`) and at most 256 MiB (`128 MiB * 2`).
+It does not grow with object size.
+
+## Dependency and interoperability checks
+
+- `go list -deps ./common/yak/cmd` and `go version -m yak` contain neither
+  `github.com/minio/minio-go/v7` nor `github.com/goccy/go-json` after the
+  replacement.
+- The old binary included `minio-go/v7`, `goccy/go-json`, `md5-simd`,
+  `go-ini/ini`, and `rs/xid`; the new binary includes none of them.
+- The real MinIO test covered small Put, a 5 MiB boundary object, a
+  16 MiB multipart object, Unicode/space/special-character keys, read-back
+  verification, and explicit multipart Abort followed by a list assertion that
+  the Upload ID no longer exists.
+- SigV4 is checked against AWS's published S3 signing example.
+- Live AWS S3 and Ceph RGW tests require external credentials/services and
+  were not run in this environment. The opt-in integration test accepts an
+  existing bucket for those runs and does not create one when a bucket is
+  explicitly supplied.
+
+## Commands
+
+```sh
+go test ./scannode -run 'Test(SignS3|AWSURI|SecretValue|ValidateSSAUploadConfig|SSATLS|S3ObjectStore|ObjectStoreSession|ClassifyObjectStore)' -count=1
+go test -race ./scannode -run 'Test(SignS3|AWSURI|SecretValue|ValidateSSAUploadConfig|SSATLS|S3ObjectStore|ObjectStoreSession|ClassifyObjectStore)' -count=1
+go vet ./scannode
+go list -deps ./common/yak/cmd
+go build -trimpath -o /tmp/yak ./common/yak/cmd
+go version -m /tmp/yak
+```
+
+Real-service checks use the `SCANNODE_S3_INTEGRATION_*` environment variables
+defined in `ssa_object_store_integration_test.go`; credentials are deliberately
+omitted from this report.

--- a/scannode/ssa_object_store_integration_test.go
+++ b/scannode/ssa_object_store_integration_test.go
@@ -39,9 +39,9 @@ func TestS3ObjectStoreIntegration(t *testing.T) {
 		AllowHTTP:        strings.HasPrefix(endpoint, "http://"),
 		TLSVerify:        strings.EqualFold(os.Getenv("SCANNODE_S3_INTEGRATION_TLS_VERIFY"), "true"),
 		VirtualHostStyle: strings.EqualFold(os.Getenv("SCANNODE_S3_INTEGRATION_VIRTUAL_HOST"), "true"),
-		STSAccessKey:     newSecretValue(accessKey),
-		STSSecretKey:     newSecretValue(secretKey),
-		STSSessionToken:  newSecretValue(os.Getenv("SCANNODE_S3_INTEGRATION_SESSION_TOKEN")),
+		STSAccessKey:     accessKey,
+		STSSecretKey:     secretKey,
+		STSSessionToken:  os.Getenv("SCANNODE_S3_INTEGRATION_SESSION_TOKEN"),
 	}
 	client, err := newS3ObjectStoreClient(cfg)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func BenchmarkS3ObjectStoreIntegration64MiB(b *testing.B) {
 	cfg := &SSAArtifactUploadConfig{
 		Endpoint: endpoint, Bucket: fmt.Sprintf("scannode-s3-bench-%d", time.Now().UnixNano()), ObjectKey: "benchmark/payload.bin",
 		Region: normalizedSSARegion(os.Getenv("SCANNODE_S3_INTEGRATION_REGION")), UseSSL: strings.HasPrefix(endpoint, "https://"), AllowHTTP: strings.HasPrefix(endpoint, "http://"),
-		STSAccessKey: newSecretValue(accessKey), STSSecretKey: newSecretValue(secretKey), STSSessionToken: newSecretValue(os.Getenv("SCANNODE_S3_INTEGRATION_SESSION_TOKEN")),
+		STSAccessKey: accessKey, STSSecretKey: secretKey, STSSessionToken: os.Getenv("SCANNODE_S3_INTEGRATION_SESSION_TOKEN"),
 	}
 	client, err := newS3ObjectStoreClient(cfg)
 	require.NoError(b, err)

--- a/scannode/ssa_object_store_integration_test.go
+++ b/scannode/ssa_object_store_integration_test.go
@@ -1,0 +1,215 @@
+package scannode
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestS3ObjectStoreIntegration exercises the same client against a real
+// MinIO, AWS S3, or compatible endpoint. It is opt-in so ordinary unit tests
+// never need external credentials or mutate a remote bucket.
+func TestS3ObjectStoreIntegration(t *testing.T) {
+	endpoint := strings.TrimSpace(os.Getenv("SCANNODE_S3_INTEGRATION_ENDPOINT"))
+	accessKey := strings.TrimSpace(os.Getenv("SCANNODE_S3_INTEGRATION_ACCESS_KEY"))
+	secretKey := strings.TrimSpace(os.Getenv("SCANNODE_S3_INTEGRATION_SECRET_KEY"))
+	if endpoint == "" || accessKey == "" || secretKey == "" {
+		t.Skip("set SCANNODE_S3_INTEGRATION_ENDPOINT and integration credentials")
+	}
+	bucket := strings.TrimSpace(os.Getenv("SCANNODE_S3_INTEGRATION_BUCKET"))
+	createBucket := bucket == ""
+	if bucket == "" {
+		bucket = fmt.Sprintf("scannode-s3-test-%d", time.Now().UnixNano())
+	}
+	cfg := &SSAArtifactUploadConfig{
+		Endpoint:         endpoint,
+		Bucket:           bucket,
+		ObjectKey:        "integration/probe.bin",
+		Region:           normalizedSSARegion(os.Getenv("SCANNODE_S3_INTEGRATION_REGION")),
+		UseSSL:           strings.HasPrefix(endpoint, "https://"),
+		AllowHTTP:        strings.HasPrefix(endpoint, "http://"),
+		TLSVerify:        strings.EqualFold(os.Getenv("SCANNODE_S3_INTEGRATION_TLS_VERIFY"), "true"),
+		VirtualHostStyle: strings.EqualFold(os.Getenv("SCANNODE_S3_INTEGRATION_VIRTUAL_HOST"), "true"),
+		STSAccessKey:     newSecretValue(accessKey),
+		STSSecretKey:     newSecretValue(secretKey),
+		STSSessionToken:  newSecretValue(os.Getenv("SCANNODE_S3_INTEGRATION_SESSION_TOKEN")),
+	}
+	client, err := newS3ObjectStoreClient(cfg)
+	require.NoError(t, err)
+	defer client.Close()
+	if createBucket {
+		require.NoError(t, createS3IntegrationBucket(context.Background(), client, bucket))
+	}
+
+	provider := func(bool) (*SSAArtifactUploadConfig, error) { cp := *cfg; return &cp, nil }
+	session, err := newSSAObjectStoreUploadSession(provider, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	t.Setenv("SCANNODE_SSA_MULTIPART_PART_SIZE_MB", "16")
+	tests := []struct {
+		name    string
+		key     string
+		payload []byte
+	}{
+		{name: "small special key", key: "integration/中文 name + %.txt", payload: []byte("small payload")},
+		{name: "five MiB boundary", key: "integration/five-mib.bin", payload: bytes.Repeat([]byte("5"), 5*1024*1024)},
+		{name: "multipart", key: "integration/multipart.bin", payload: bytes.Repeat([]byte("m"), 16*1024*1024+257)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			stats, err := session.uploadBytes(ctx, tc.payload, tc.key)
+			require.NoError(t, err)
+			require.EqualValues(t, len(tc.payload), stats.Bytes)
+			downloaded, err := getS3IntegrationObject(ctx, client, bucket, tc.key)
+			require.NoError(t, err)
+			require.Equal(t, tc.payload, downloaded)
+		})
+	}
+
+	uploadID, _, err := client.CreateMultipart(context.Background(), CreateRequest{Bucket: bucket, ObjectKey: "integration/abort.bin", ContentType: "application/octet-stream"})
+	require.NoError(t, err)
+	require.NoError(t, client.AbortMultipart(context.Background(), AbortRequest{Bucket: bucket, ObjectKey: "integration/abort.bin", UploadID: uploadID}))
+	remainingUploadIDs, err := listS3IntegrationMultipartUploads(context.Background(), client, bucket)
+	require.NoError(t, err)
+	require.NotContains(t, remainingUploadIDs, uploadID)
+}
+
+func BenchmarkS3ObjectStoreIntegration64MiB(b *testing.B) {
+	endpoint := strings.TrimSpace(os.Getenv("SCANNODE_S3_INTEGRATION_ENDPOINT"))
+	accessKey := strings.TrimSpace(os.Getenv("SCANNODE_S3_INTEGRATION_ACCESS_KEY"))
+	secretKey := strings.TrimSpace(os.Getenv("SCANNODE_S3_INTEGRATION_SECRET_KEY"))
+	if endpoint == "" || accessKey == "" || secretKey == "" {
+		b.Skip("set SCANNODE S3 integration endpoint and credentials")
+	}
+	cfg := &SSAArtifactUploadConfig{
+		Endpoint: endpoint, Bucket: fmt.Sprintf("scannode-s3-bench-%d", time.Now().UnixNano()), ObjectKey: "benchmark/payload.bin",
+		Region: normalizedSSARegion(os.Getenv("SCANNODE_S3_INTEGRATION_REGION")), UseSSL: strings.HasPrefix(endpoint, "https://"), AllowHTTP: strings.HasPrefix(endpoint, "http://"),
+		STSAccessKey: newSecretValue(accessKey), STSSecretKey: newSecretValue(secretKey), STSSessionToken: newSecretValue(os.Getenv("SCANNODE_S3_INTEGRATION_SESSION_TOKEN")),
+	}
+	client, err := newS3ObjectStoreClient(cfg)
+	require.NoError(b, err)
+	defer client.Close()
+	require.NoError(b, createS3IntegrationBucket(context.Background(), client, cfg.Bucket))
+	session, err := newSSAObjectStoreUploadSession(func(bool) (*SSAArtifactUploadConfig, error) { cp := *cfg; return &cp, nil }, nil)
+	require.NoError(b, err)
+	defer session.Close()
+	b.Setenv("SCANNODE_SSA_MULTIPART_PART_SIZE_MB", "16")
+	payload := bytes.Repeat([]byte("b"), 64*1024*1024)
+	file, err := os.CreateTemp("", "s3-client-benchmark-*.bin")
+	require.NoError(b, err)
+	path := file.Name()
+	defer os.Remove(path)
+	_, err = file.Write(payload)
+	require.NoError(b, err)
+	require.NoError(b, file.Close())
+	payload = nil
+	b.SetBytes(64 * 1024 * 1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		cfg.ObjectKey = fmt.Sprintf("benchmark/payload-%06d.bin", index)
+		_, err := session.uploadFile(context.Background(), path, 64*1024*1024, cfg.ObjectKey)
+		require.NoError(b, err)
+	}
+}
+
+func createS3IntegrationBucket(ctx context.Context, client *s3ObjectStoreClient, bucket string) error {
+	requestURL := *client.endpoint
+	requestURL.Path = strings.TrimSuffix(requestURL.Path, "/") + "/" + bucket
+	requestURL.RawPath = awsURIEncode(requestURL.Path, false)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	if err := signS3Request(req, client.currentCredentials(), client.region, emptySHA256Hex, client.now()); err != nil {
+		return err
+	}
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxSSAObjectStoreErrorBodyBytes))
+	if (resp.StatusCode >= 200 && resp.StatusCode < 300) || resp.StatusCode == http.StatusConflict {
+		return nil
+	}
+	return parseS3Error("create_bucket", resp.StatusCode, resp.Header, body)
+}
+
+func getS3IntegrationObject(ctx context.Context, client *s3ObjectStoreClient, bucket, objectKey string) ([]byte, error) {
+	requestURL := client.objectURL(bucket, objectKey, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := signS3Request(req, client.currentCredentials(), client.region, emptySHA256Hex, client.now()); err != nil {
+		return nil, err
+	}
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxSSAObjectStoreErrorBodyBytes))
+		return nil, parseS3Error("get", resp.StatusCode, resp.Header, body)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func listS3IntegrationMultipartUploads(ctx context.Context, client *s3ObjectStoreClient, bucket string) ([]string, error) {
+	requestURL := *client.endpoint
+	basePath := strings.TrimSuffix(requestURL.Path, "/")
+	if client.virtualHostStyle {
+		requestURL.Host = bucket + "." + requestURL.Host
+		requestURL.Path = basePath + "/"
+	} else {
+		requestURL.Path = basePath + "/" + bucket
+	}
+	requestURL.RawPath = awsURIEncode(requestURL.Path, false)
+	requestURL.RawQuery = canonicalS3Query([]queryValue{{Key: "uploads"}})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := signS3Request(req, client.currentCredentials(), client.region, emptySHA256Hex, client.now()); err != nil {
+		return nil, err
+	}
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSSAObjectStoreErrorBodyBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, parseS3Error("list_multipart_uploads", resp.StatusCode, resp.Header, body)
+	}
+	var response struct {
+		Uploads []struct {
+			UploadID string `xml:"UploadId"`
+		} `xml:"Upload"`
+	}
+	if err := xml.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(response.Uploads))
+	for _, upload := range response.Uploads {
+		ids = append(ids, strings.TrimSpace(upload.UploadID))
+	}
+	return ids, nil
+}

--- a/scannode/ssa_object_store_test.go
+++ b/scannode/ssa_object_store_test.go
@@ -1,0 +1,409 @@
+package scannode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignS3Request_AWSOfficialGetObjectVector(t *testing.T) {
+	// AWS S3's published SigV4 example:
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+	req, err := http.NewRequest(http.MethodGet, "https://examplebucket.s3.amazonaws.com/test.txt", nil)
+	require.NoError(t, err)
+	req.Header.Set("Range", "bytes=0-9")
+	err = signS3Request(req, objectStoreCredentials{
+		AccessKey: newSecretValue("AKIAIOSFODNN7EXAMPLE"),
+		SecretKey: newSecretValue("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+	}, "us-east-1", emptySHA256Hex, time.Date(2013, 5, 24, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Equal(t,
+		"AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,"+
+			"SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,"+
+			"Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+		req.Header.Get("Authorization"),
+	)
+}
+
+func TestAWSURIEncode_ObjectNames(t *testing.T) {
+	require.Equal(t, "/bucket/%E4%B8%AD%E6%96%87%20name/%24file%2B%25.txt", awsURIEncode("/bucket/中文 name/$file+%.txt", false))
+	require.Equal(t, "uploadId=a%2Fb%2Bc%3D&x=%E4%B8%AD%E6%96%87%20value", canonicalS3Query([]queryValue{
+		{Key: "x", Value: "中文 value"},
+		{Key: "uploadId", Value: "a/b+c="},
+	}))
+	endpoint, err := url.Parse("https://objects.example.test/base")
+	require.NoError(t, err)
+	client := &s3ObjectStoreClient{endpoint: endpoint, virtualHostStyle: true}
+	objectURL := client.objectURL("test-bucket", "中文 name/$file+%.txt", nil)
+	require.Equal(t, "test-bucket.objects.example.test", objectURL.Host)
+	require.Equal(t, "/base/%E4%B8%AD%E6%96%87%20name/%24file%2B%25.txt", objectURL.EscapedPath())
+}
+
+func TestSecretValueRedactsFormattingAndJSON(t *testing.T) {
+	const accessKey = "ACCESS_SHOULD_NOT_LEAK"
+	const secretKey = "SECRET_SHOULD_NOT_LEAK"
+	const token = "TOKEN_SHOULD_NOT_LEAK"
+	cfg := &SSAArtifactUploadConfig{
+		STSAccessKey: newSecretValue(accessKey), STSSecretKey: newSecretValue(secretKey), STSSessionToken: newSecretValue(token),
+	}
+	formatted := fmt.Sprintf("%+v %#v %s", cfg, cfg, cfg.STSSecretKey)
+	encoded, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	for _, value := range []string{accessKey, secretKey, token} {
+		require.NotContains(t, formatted, value)
+		require.NotContains(t, string(encoded), value)
+	}
+	require.Contains(t, formatted, "[REDACTED]")
+}
+
+func TestValidateSSAUploadConfig_RequiresExplicitHTTPAndBoundsPartSize(t *testing.T) {
+	t.Setenv("SCANNODE_SSA_ALLOW_HTTP", "")
+	cfg := testSSAUploadConfig("http://127.0.0.1:9000")
+	cfg.AllowHTTP = false
+	_, err := validateSSAUploadConfig(cfg)
+	require.ErrorContains(t, err, "explicit development allowance")
+
+	cfg.AllowHTTP = true
+	_, err = validateSSAUploadConfig(cfg)
+	require.NoError(t, err)
+
+	t.Setenv("SCANNODE_SSA_MULTIPART_PART_SIZE_MB", "9999")
+	require.EqualValues(t, maxSSAMultipartPartSizeBytes, readSSAMultipartPartSize())
+	t.Setenv("SCANNODE_SSA_MULTIPART_PART_SIZE_MB", "1")
+	require.EqualValues(t, minSSAMultipartPartSizeBytes, readSSAMultipartPartSize())
+	t.Setenv("SCANNODE_SSA_MULTIPART_CONCURRENCY", "99")
+	require.Equal(t, maxSSAMultipartConcurrency, readSSAMultipartConcurrency())
+	t.Setenv("SCANNODE_SSA_MULTIPART_CONCURRENCY", "0")
+	require.Equal(t, 1, readSSAMultipartConcurrency())
+}
+
+func TestSSATLS_DefaultSkipVerifyAndExplicitPrivateCA(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	t.Setenv("SCANNODE_SSA_TICKET_TLS_VERIFY", "")
+	t.Setenv("SCANNODE_SSA_TICKET_TLS_CA_FILE", "")
+	client, err := newSSATicketHTTPClient()
+	require.NoError(t, err)
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	client.CloseIdleConnections()
+
+	t.Setenv("SCANNODE_SSA_TICKET_TLS_VERIFY", "true")
+	client, err = newSSATicketHTTPClient()
+	require.NoError(t, err)
+	_, err = client.Get(server.URL)
+	require.Error(t, err)
+	client.CloseIdleConnections()
+
+	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.TLS.Certificates[0].Certificate[0]})
+	caPath := t.TempDir() + "/private-ca.pem"
+	require.NoError(t, os.WriteFile(caPath, certificatePEM, 0o600))
+	t.Setenv("SCANNODE_SSA_TICKET_TLS_CA_FILE", caPath)
+	client, err = newSSATicketHTTPClient()
+	require.NoError(t, err)
+	resp, err = client.Get(server.URL)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	client.CloseIdleConnections()
+
+	// Object-store TLS follows the same compatibility default requested for
+	// private ScanNode deployments, while still allowing strict verification.
+	t.Setenv("SCANNODE_SSA_TLS_CA_FILE", "")
+	cfg := testSSAUploadConfig(server.URL)
+	store, err := newS3ObjectStoreClient(cfg)
+	require.NoError(t, err)
+	_, err = store.Put(context.Background(), PutRequest{
+		Bucket: cfg.Bucket, ObjectKey: cfg.ObjectKey, Body: bytes.NewReader([]byte("tls")), Size: 3, PayloadSHA256: sha256Hex([]byte("tls")),
+	})
+	require.NoError(t, err)
+	store.Close()
+
+	cfg.TLSVerify = true
+	store, err = newS3ObjectStoreClient(cfg)
+	require.NoError(t, err)
+	_, err = store.Put(context.Background(), PutRequest{
+		Bucket: cfg.Bucket, ObjectKey: cfg.ObjectKey, Body: bytes.NewReader([]byte("tls")), Size: 3, PayloadSHA256: sha256Hex([]byte("tls")),
+	})
+	require.Error(t, err)
+	store.Close()
+
+	cfg.TLSCAFile = caPath
+	store, err = newS3ObjectStoreClient(cfg)
+	require.NoError(t, err)
+	_, err = store.Put(context.Background(), PutRequest{
+		Bucket: cfg.Bucket, ObjectKey: cfg.ObjectKey, Body: bytes.NewReader([]byte("tls")), Size: 3, PayloadSHA256: sha256Hex([]byte("tls")),
+	})
+	require.NoError(t, err)
+	store.Close()
+}
+
+func TestS3ObjectStore_PutMultipartRetryAndEncoding(t *testing.T) {
+	var mu sync.Mutex
+	requests := make([]string, 0, 8)
+	parts := make(map[int][]byte)
+	var retryCount atomic.Int32
+	var completeAttempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.EscapedPath()+"?"+r.URL.RawQuery)
+		mu.Unlock()
+		require.Contains(t, r.Header.Get("Authorization"), "Credential=test-access/")
+		require.Equal(t, "test-token", r.Header.Get("x-amz-security-token"))
+		require.NotEmpty(t, r.Header.Get("x-amz-content-sha256"))
+
+		switch {
+		case r.Method == http.MethodPut && r.URL.Query().Get("uploadId") == "upload-1":
+			partNumber := r.URL.Query().Get("partNumber")
+			if partNumber == "1" && retryCount.Add(1) == 1 {
+				w.Header().Set("Content-Type", "application/xml")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = io.WriteString(w, `<Error><Code>SlowDown</Code><Message>retry later</Message></Error>`)
+				return
+			}
+			var number int
+			_, _ = fmt.Sscanf(partNumber, "%d", &number)
+			parts[number] = append([]byte(nil), body...)
+			w.Header().Set("ETag", fmt.Sprintf(`"part-%d"`, number))
+			w.Header().Set("x-amz-request-id", fmt.Sprintf("part-request-%d", number))
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && hasRawQueryKey(r.URL.RawQuery, "uploads"):
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = io.WriteString(w, `<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>`)
+		case r.Method == http.MethodPost && r.URL.Query().Get("uploadId") == "upload-1":
+			if completeAttempts.Add(1) == 1 {
+				// S3 may report completion errors inside a 200 response after the
+				// whitespace keepalive. This must remain a failure/retry path.
+				_, _ = io.WriteString(w, `<?xml version="1.0"?><Error><Code>SlowDown</Code><Message>retry completion</Message></Error>`)
+				return
+			}
+			var complete struct {
+				Parts []struct {
+					PartNumber int    `xml:"PartNumber"`
+					ETag       string `xml:"ETag"`
+				} `xml:"Part"`
+			}
+			require.NoError(t, xml.Unmarshal(body, &complete))
+			require.Len(t, complete.Parts, 2)
+			w.Header().Set("x-amz-request-id", "complete-request")
+			_, _ = io.WriteString(w, `<CompleteMultipartUploadResult><ETag>"complete-etag"</ETag></CompleteMultipartUploadResult>`)
+		case r.Method == http.MethodPut:
+			require.Equal(t, []byte("small payload"), body)
+			w.Header().Set("ETag", `"small-etag"`)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	cfg := testSSAUploadConfig(server.URL)
+	provider := func(bool) (*SSAArtifactUploadConfig, error) { cp := *cfg; return &cp, nil }
+	session, err := newSSAObjectStoreUploadSession(provider, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	smallStats, err := session.uploadBytes(context.Background(), []byte("small payload"), "path/中文 name+$%.txt")
+	require.NoError(t, err)
+	require.Equal(t, "small-etag", smallStats.ETag)
+
+	t.Setenv("SCANNODE_SSA_MULTIPART_PART_SIZE_MB", "5")
+	payload := bytes.Repeat([]byte("x"), 5*1024*1024+17)
+	largeStats, err := session.upload(context.Background(), bytes.NewReader(payload), int64(len(payload)), "large/object.bin")
+	require.NoError(t, err)
+	require.EqualValues(t, len(payload), largeStats.Bytes)
+	require.Equal(t, 2, largeStats.Parts)
+	require.Equal(t, "complete-request", largeStats.RequestID)
+	require.Equal(t, payload, append(parts[1], parts[2]...))
+	require.EqualValues(t, 2, retryCount.Load())
+	require.EqualValues(t, 2, completeAttempts.Load())
+
+	mu.Lock()
+	joined := strings.Join(requests, "\n")
+	mu.Unlock()
+	require.Contains(t, joined, "/test-bucket/path/%E4%B8%AD%E6%96%87%20name%2B%24%25.txt")
+}
+
+func TestObjectStoreSession_RefreshesOnlyExpiredCredentials(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          string
+		wantRefreshes int32
+		wantError     bool
+	}{
+		{name: "expired", code: "ExpiredToken", wantRefreshes: 1},
+		{name: "denied", code: "AccessDenied", wantRefreshes: 0, wantError: true},
+		{name: "bad signature", code: "SignatureDoesNotMatch", wantRefreshes: 0, wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				call := calls.Add(1)
+				if tc.code != "" && call == 1 {
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = io.WriteString(w, `<Error><Code>`+tc.code+`</Code><Message>rejected test-access test-secret test-token</Message></Error>`)
+					return
+				}
+				if tc.code == "ExpiredToken" {
+					require.Contains(t, r.Header.Get("Authorization"), "Credential=fresh-access/")
+				}
+				w.Header().Set("ETag", `"ok"`)
+			}))
+			defer server.Close()
+
+			cfg := testSSAUploadConfig(server.URL)
+			var refreshes atomic.Int32
+			provider := func(force bool) (*SSAArtifactUploadConfig, error) {
+				cp := *cfg
+				if force {
+					refreshes.Add(1)
+					cp.STSAccessKey = newSecretValue("fresh-access")
+				}
+				return &cp, nil
+			}
+			session, err := newSSAObjectStoreUploadSession(provider, nil)
+			require.NoError(t, err)
+			defer session.Close()
+			_, err = session.uploadBytes(context.Background(), []byte("payload"), "object.bin")
+			if tc.wantError {
+				require.Error(t, err)
+				require.NotContains(t, err.Error(), "test-access")
+				require.NotContains(t, err.Error(), "test-secret")
+				require.NotContains(t, err.Error(), "test-token")
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantRefreshes, refreshes.Load())
+		})
+	}
+}
+
+func TestObjectStoreSession_CancelAbortsMultipart(t *testing.T) {
+	t.Setenv("SCANNODE_SSA_MULTIPART_PART_SIZE_MB", "5")
+	partStarted := make(chan struct{})
+	aborted := make(chan struct{})
+	var partOnce, abortOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && hasRawQueryKey(r.URL.RawQuery, "uploads"):
+			_, _ = io.WriteString(w, `<InitiateMultipartUploadResult><UploadId>cancel-upload</UploadId></InitiateMultipartUploadResult>`)
+		case r.Method == http.MethodPut && r.URL.Query().Get("uploadId") == "cancel-upload":
+			_, _ = io.Copy(io.Discard, r.Body)
+			partOnce.Do(func() { close(partStarted) })
+			<-r.Context().Done()
+		case r.Method == http.MethodDelete && r.URL.Query().Get("uploadId") == "cancel-upload":
+			abortOnce.Do(func() { close(aborted) })
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	cfg := testSSAUploadConfig(server.URL)
+	session, err := newSSAObjectStoreUploadSession(func(bool) (*SSAArtifactUploadConfig, error) { cp := *cfg; return &cp, nil }, nil)
+	require.NoError(t, err)
+	defer session.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	pipeReader, pipeWriter := io.Pipe()
+	defer pipeWriter.Close()
+	errCh := make(chan error, 1)
+	go func() {
+		_, uploadErr := session.upload(ctx, pipeReader, -1, "cancel.bin")
+		errCh <- uploadErr
+	}()
+	go func() {
+		_, _ = pipeWriter.Write(bytes.Repeat([]byte("x"), 5*1024*1024))
+	}()
+	select {
+	case <-partStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("multipart part did not start")
+	}
+	cancel()
+	require.ErrorIs(t, <-errCh, context.Canceled)
+	select {
+	case <-aborted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled multipart upload was not aborted")
+	}
+}
+
+func TestObjectStoreSession_CompleteFailureAbortsMultipart(t *testing.T) {
+	t.Setenv("SCANNODE_SSA_MULTIPART_PART_SIZE_MB", "5")
+	aborted := make(chan struct{})
+	var abortOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && hasRawQueryKey(r.URL.RawQuery, "uploads"):
+			_, _ = io.WriteString(w, `<InitiateMultipartUploadResult><UploadId>complete-failure</UploadId></InitiateMultipartUploadResult>`)
+		case r.Method == http.MethodPut && r.URL.Query().Get("uploadId") == "complete-failure":
+			w.Header().Set("ETag", `"part"`)
+		case r.Method == http.MethodPost && r.URL.Query().Get("uploadId") == "complete-failure":
+			_, _ = io.WriteString(w, `<Error><Code>AccessDenied</Code><Message>completion denied</Message></Error>`)
+		case r.Method == http.MethodDelete && r.URL.Query().Get("uploadId") == "complete-failure":
+			abortOnce.Do(func() { close(aborted) })
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	cfg := testSSAUploadConfig(server.URL)
+	session, err := newSSAObjectStoreUploadSession(func(bool) (*SSAArtifactUploadConfig, error) { cp := *cfg; return &cp, nil }, nil)
+	require.NoError(t, err)
+	defer session.Close()
+	_, err = session.uploadBytes(context.Background(), bytes.Repeat([]byte("x"), 5*1024*1024+1), "complete-failure.bin")
+	require.Error(t, err)
+	require.Equal(t, "permission_denied", classifyObjectStoreError(err))
+	select {
+	case <-aborted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("failed completion was not aborted")
+	}
+}
+
+func TestClassifyObjectStoreErrorStructured(t *testing.T) {
+	require.Equal(t, "sts_expired", classifyObjectStoreError(&ObjectStoreError{Operation: "put", Code: "ExpiredToken"}))
+	require.Equal(t, "permission_denied", classifyObjectStoreError(&ObjectStoreError{Operation: "put", Code: "AccessDenied"}))
+	require.Equal(t, "signature_invalid", classifyObjectStoreError(&ObjectStoreError{Operation: "put", Code: "SignatureDoesNotMatch"}))
+	require.Equal(t, "upload_canceled", classifyObjectStoreError(context.Canceled))
+}
+
+func testSSAUploadConfig(endpoint string) *SSAArtifactUploadConfig {
+	return &SSAArtifactUploadConfig{
+		Endpoint: endpoint, Bucket: "test-bucket", ObjectKey: "object.bin", Region: "us-east-1",
+		UseSSL: strings.HasPrefix(endpoint, "https://"), AllowHTTP: strings.HasPrefix(endpoint, "http://"),
+		STSAccessKey: newSecretValue("test-access"), STSSecretKey: newSecretValue("test-secret"), STSSessionToken: newSecretValue("test-token"),
+	}
+}
+
+func hasRawQueryKey(rawQuery, key string) bool {
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return false
+	}
+	_, ok := values[key]
+	return ok
+}

--- a/scannode/ssa_object_store_test.go
+++ b/scannode/ssa_object_store_test.go
@@ -59,9 +59,9 @@ func TestSecretValueRedactsFormattingAndJSON(t *testing.T) {
 	const secretKey = "SECRET_SHOULD_NOT_LEAK"
 	const token = "TOKEN_SHOULD_NOT_LEAK"
 	cfg := &SSAArtifactUploadConfig{
-		STSAccessKey: newSecretValue(accessKey), STSSecretKey: newSecretValue(secretKey), STSSessionToken: newSecretValue(token),
+		STSAccessKey: accessKey, STSSecretKey: secretKey, STSSessionToken: token,
 	}
-	formatted := fmt.Sprintf("%+v %#v %s", cfg, cfg, cfg.STSSecretKey)
+	formatted := fmt.Sprintf("%+v %#v", cfg, cfg)
 	encoded, err := json.Marshal(cfg)
 	require.NoError(t, err)
 	for _, value := range []string{accessKey, secretKey, token} {
@@ -92,32 +92,34 @@ func TestValidateSSAUploadConfig_RequiresExplicitHTTPAndBoundsPartSize(t *testin
 	require.Equal(t, 1, readSSAMultipartConcurrency())
 }
 
-func TestSSATLS_DefaultSkipVerifyAndExplicitPrivateCA(t *testing.T) {
+func TestSSATLS_ObjectStoreStrictByDefaultAndExplicitPrivateCA(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
 	t.Setenv("SCANNODE_SSA_TICKET_TLS_VERIFY", "")
+	t.Setenv("SCANNODE_SSA_TICKET_ALLOW_INSECURE_TLS", "")
 	t.Setenv("SCANNODE_SSA_TICKET_TLS_CA_FILE", "")
 	client, err := newSSATicketHTTPClient()
+	require.NoError(t, err)
+	_, err = client.Get(server.URL)
+	require.Error(t, err)
+	client.CloseIdleConnections()
+
+	t.Setenv("SCANNODE_SSA_TICKET_ALLOW_INSECURE_TLS", "true")
+	client, err = newSSATicketHTTPClient()
 	require.NoError(t, err)
 	resp, err := client.Get(server.URL)
 	require.NoError(t, err)
 	_ = resp.Body.Close()
 	client.CloseIdleConnections()
 
-	t.Setenv("SCANNODE_SSA_TICKET_TLS_VERIFY", "true")
-	client, err = newSSATicketHTTPClient()
-	require.NoError(t, err)
-	_, err = client.Get(server.URL)
-	require.Error(t, err)
-	client.CloseIdleConnections()
-
 	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.TLS.Certificates[0].Certificate[0]})
 	caPath := t.TempDir() + "/private-ca.pem"
 	require.NoError(t, os.WriteFile(caPath, certificatePEM, 0o600))
 	t.Setenv("SCANNODE_SSA_TICKET_TLS_CA_FILE", caPath)
+	t.Setenv("SCANNODE_SSA_TICKET_ALLOW_INSECURE_TLS", "")
 	client, err = newSSATicketHTTPClient()
 	require.NoError(t, err)
 	resp, err = client.Get(server.URL)
@@ -125,8 +127,8 @@ func TestSSATLS_DefaultSkipVerifyAndExplicitPrivateCA(t *testing.T) {
 	_ = resp.Body.Close()
 	client.CloseIdleConnections()
 
-	// Object-store TLS follows the same compatibility default requested for
-	// private ScanNode deployments, while still allowing strict verification.
+	// Object-store TLS preserves the old minio-go security property: certificates
+	// are verified by default, including when TLSVerify is left at its zero value.
 	t.Setenv("SCANNODE_SSA_TLS_CA_FILE", "")
 	cfg := testSSAUploadConfig(server.URL)
 	store, err := newS3ObjectStoreClient(cfg)
@@ -134,18 +136,19 @@ func TestSSATLS_DefaultSkipVerifyAndExplicitPrivateCA(t *testing.T) {
 	_, err = store.Put(context.Background(), PutRequest{
 		Bucket: cfg.Bucket, ObjectKey: cfg.ObjectKey, Body: bytes.NewReader([]byte("tls")), Size: 3, PayloadSHA256: sha256Hex([]byte("tls")),
 	})
-	require.NoError(t, err)
+	require.Error(t, err)
 	store.Close()
 
-	cfg.TLSVerify = true
+	cfg.AllowInsecureTLS = true
 	store, err = newS3ObjectStoreClient(cfg)
 	require.NoError(t, err)
 	_, err = store.Put(context.Background(), PutRequest{
 		Bucket: cfg.Bucket, ObjectKey: cfg.ObjectKey, Body: bytes.NewReader([]byte("tls")), Size: 3, PayloadSHA256: sha256Hex([]byte("tls")),
 	})
-	require.Error(t, err)
+	require.NoError(t, err)
 	store.Close()
 
+	cfg.AllowInsecureTLS = false
 	cfg.TLSCAFile = caPath
 	store, err = newS3ObjectStoreClient(cfg)
 	require.NoError(t, err)
@@ -154,6 +157,61 @@ func TestSSATLS_DefaultSkipVerifyAndExplicitPrivateCA(t *testing.T) {
 	})
 	require.NoError(t, err)
 	store.Close()
+}
+
+func TestS3ObjectStore_CreateMultipartDoesNotRetryAmbiguousFailure(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `<Error><Code>SlowDown</Code></Error>`)
+	}))
+	defer server.Close()
+
+	store, err := newS3ObjectStoreClient(testSSAUploadConfig(server.URL))
+	require.NoError(t, err)
+	store.retryLimit = 3
+	defer store.Close()
+
+	_, _, err = store.CreateMultipart(context.Background(), CreateRequest{
+		Bucket: "test-bucket", ObjectKey: "object.bin", ContentType: "application/octet-stream",
+	})
+	require.Error(t, err)
+	require.EqualValues(t, 1, requests.Load())
+}
+
+func TestS3ObjectStore_CompleteMultipartRejectsInvalidSuccessBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty"},
+		{name: "malformed", body: `<CompleteMultipartUploadResult>`},
+		{name: "wrong root", body: `<html><ETag>unexpected</ETag></html>`},
+		{name: "missing etag", body: `<CompleteMultipartUploadResult></CompleteMultipartUploadResult>`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("x-amz-request-id", "complete-invalid")
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer server.Close()
+
+			store, err := newS3ObjectStoreClient(testSSAUploadConfig(server.URL))
+			require.NoError(t, err)
+			defer store.Close()
+			_, err = store.CompleteMultipart(context.Background(), CompleteRequest{
+				Bucket: "test-bucket", ObjectKey: "object.bin", UploadID: "upload-1",
+				Parts: []CompletePart{{PartNumber: 1, ETag: "part-1"}},
+			})
+			require.Error(t, err)
+			var storeErr *ObjectStoreError
+			require.ErrorAs(t, err, &storeErr)
+			require.Equal(t, "InvalidResponse", storeErr.Code)
+			require.Equal(t, "complete-invalid", storeErr.RequestID)
+		})
+	}
 }
 
 func TestS3ObjectStore_PutMultipartRetryAndEncoding(t *testing.T) {
@@ -277,7 +335,7 @@ func TestObjectStoreSession_RefreshesOnlyExpiredCredentials(t *testing.T) {
 				cp := *cfg
 				if force {
 					refreshes.Add(1)
-					cp.STSAccessKey = newSecretValue("fresh-access")
+					cp.STSAccessKey = "fresh-access"
 				}
 				return &cp, nil
 			}
@@ -395,7 +453,7 @@ func testSSAUploadConfig(endpoint string) *SSAArtifactUploadConfig {
 	return &SSAArtifactUploadConfig{
 		Endpoint: endpoint, Bucket: "test-bucket", ObjectKey: "object.bin", Region: "us-east-1",
 		UseSSL: strings.HasPrefix(endpoint, "https://"), AllowHTTP: strings.HasPrefix(endpoint, "http://"),
-		STSAccessKey: newSecretValue("test-access"), STSSecretKey: newSecretValue("test-secret"), STSSessionToken: newSecretValue("test-token"),
+		STSAccessKey: "test-access", STSSecretKey: "test-secret", STSSessionToken: "test-token",
 	}
 }
 

--- a/scannode/ssa_object_store_upload.go
+++ b/scannode/ssa_object_store_upload.go
@@ -1,0 +1,421 @@
+package scannode
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ssaObjectStoreUploadStats struct {
+	Bytes     int64
+	SHA256    string
+	ETag      string
+	RequestID string
+	Parts     int
+}
+
+// ssaObjectStoreUploadSession owns exactly one S3 client and transport for an
+// artifact task. Credential refresh updates only the signer state, preserving
+// the transport and its connection pool.
+type ssaObjectStoreUploadSession struct {
+	provider          ssaUploadConfigProvider
+	uploader          ObjectStoreUploader
+	updateCredentials func(objectStoreCredentials)
+	closeUploader     func()
+
+	endpoint         string
+	bucket           string
+	region           string
+	virtualHostStyle bool
+	onRetry          func()
+	credentialMu     sync.Mutex
+	credentialGen    uint64
+}
+
+func newSSAObjectStoreUploadSession(provider ssaUploadConfigProvider, onRetry func()) (*ssaObjectStoreUploadSession, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("empty upload config provider")
+	}
+	cfg, err := provider(false)
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := validateSSAUploadConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	client, err := newS3ObjectStoreClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	client.onRetry = onRetry
+	return &ssaObjectStoreUploadSession{
+		provider:          provider,
+		uploader:          client,
+		updateCredentials: client.setCredentials,
+		closeUploader:     client.Close,
+		endpoint:          endpoint.String(),
+		bucket:            strings.TrimSpace(cfg.Bucket),
+		region:            normalizedSSARegion(cfg.Region),
+		virtualHostStyle:  cfg.VirtualHostStyle,
+		onRetry:           onRetry,
+	}, nil
+}
+
+func (s *ssaObjectStoreUploadSession) Close() {
+	if s != nil && s.closeUploader != nil {
+		s.closeUploader()
+	}
+}
+
+func (s *ssaObjectStoreUploadSession) refreshCredentials(force bool) error {
+	if s == nil || s.provider == nil || s.uploader == nil || s.updateCredentials == nil {
+		return fmt.Errorf("object store upload session unavailable")
+	}
+	cfg, err := s.provider(force)
+	if err != nil {
+		return err
+	}
+	endpoint, err := validateSSAUploadConfig(cfg)
+	if err != nil {
+		return err
+	}
+	if endpoint.String() != s.endpoint || strings.TrimSpace(cfg.Bucket) != s.bucket || normalizedSSARegion(cfg.Region) != s.region || cfg.VirtualHostStyle != s.virtualHostStyle {
+		return fmt.Errorf("upload target changed during STS refresh")
+	}
+	s.updateCredentials(credentialsFromSSAConfig(cfg))
+	return nil
+}
+
+func (s *ssaObjectStoreUploadSession) withCredentialRefresh(operation func() error) error {
+	s.credentialMu.Lock()
+	if err := s.refreshCredentials(false); err != nil {
+		s.credentialMu.Unlock()
+		return err
+	}
+	generation := s.credentialGen
+	s.credentialMu.Unlock()
+	err := operation()
+	if !isObjectStoreCredentialExpired(err) {
+		return err
+	}
+	if s.onRetry != nil {
+		s.onRetry()
+	}
+	s.credentialMu.Lock()
+	if generation == s.credentialGen {
+		if refreshErr := s.refreshCredentials(true); refreshErr != nil {
+			s.credentialMu.Unlock()
+			return errors.Join(err, refreshErr)
+		}
+		s.credentialGen++
+	}
+	s.credentialMu.Unlock()
+	return operation()
+}
+
+func (s *ssaObjectStoreUploadSession) uploadFile(ctx context.Context, path string, size int64, objectKey string) (ssaObjectStoreUploadStats, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return ssaObjectStoreUploadStats{}, err
+	}
+	defer file.Close()
+	if size < 0 {
+		return ssaObjectStoreUploadStats{}, fmt.Errorf("artifact size cannot be negative")
+	}
+	if size == 0 {
+		stat, statErr := file.Stat()
+		if statErr != nil {
+			return ssaObjectStoreUploadStats{}, statErr
+		}
+		size = stat.Size()
+	}
+	return s.upload(ctx, file, size, objectKey)
+}
+
+func (s *ssaObjectStoreUploadSession) uploadBytes(ctx context.Context, payload []byte, objectKey string) (ssaObjectStoreUploadStats, error) {
+	return s.upload(ctx, bytes.NewReader(payload), int64(len(payload)), objectKey)
+}
+
+func (s *ssaObjectStoreUploadSession) upload(ctx context.Context, body io.Reader, size int64, objectKey string) (stats ssaObjectStoreUploadStats, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.uploader == nil {
+		return stats, fmt.Errorf("object store upload session unavailable")
+	}
+	if err := validateSSAObjectKey(objectKey); err != nil {
+		return stats, err
+	}
+	partSize := readSSAMultipartPartSize()
+	if size >= 0 {
+		partCount := (size + partSize - 1) / partSize
+		if partCount > maxSSAMultipartParts {
+			return stats, fmt.Errorf("artifact requires %d parts; maximum is %d", partCount, maxSSAMultipartParts)
+		}
+	}
+	if seeker, ok := body.(io.ReadSeeker); ok && size <= partSize && size >= 0 {
+		payloadHash, hashErr := hashSSAUploadBody(seeker, size)
+		if hashErr != nil {
+			return stats, hashErr
+		}
+		bodyStart, seekErr := seeker.Seek(0, io.SeekCurrent)
+		if seekErr != nil {
+			return stats, seekErr
+		}
+		var result ObjectStoreResult
+		err = s.withCredentialRefresh(func() error {
+			if _, err := seeker.Seek(bodyStart, io.SeekStart); err != nil {
+				return err
+			}
+			requestCtx, cancel := context.WithTimeout(ctx, readSSAObjectStoreRequestTimeout())
+			defer cancel()
+			var putErr error
+			result, putErr = s.uploader.Put(requestCtx, PutRequest{
+				Bucket:        s.bucket,
+				ObjectKey:     objectKey,
+				Body:          seeker,
+				Size:          size,
+				ContentType:   "application/octet-stream",
+				PayloadSHA256: payloadHash,
+			})
+			return putErr
+		})
+		if err != nil {
+			return stats, err
+		}
+		return ssaObjectStoreUploadStats{Bytes: size, SHA256: payloadHash, ETag: result.ETag, RequestID: result.RequestID}, nil
+	}
+
+	var uploadID string
+	var createResult ObjectStoreResult
+	err = s.withCredentialRefresh(func() error {
+		requestCtx, cancel := context.WithTimeout(ctx, readSSAObjectStoreRequestTimeout())
+		defer cancel()
+		var createErr error
+		uploadID, createResult, createErr = s.uploader.CreateMultipart(requestCtx, CreateRequest{
+			Bucket:      s.bucket,
+			ObjectKey:   objectKey,
+			ContentType: "application/octet-stream",
+		})
+		return createErr
+	})
+	if err != nil {
+		return stats, err
+	}
+	abortNeeded := true
+	defer func() {
+		if !abortNeeded {
+			return
+		}
+		cleanupBase := context.WithoutCancel(ctx)
+		cleanupCtx, cancel := context.WithTimeout(cleanupBase, readSSAObjectStoreFinalizeTimeout())
+		defer cancel()
+		abortErr := s.uploader.AbortMultipart(cleanupCtx, AbortRequest{Bucket: s.bucket, ObjectKey: objectKey, UploadID: uploadID})
+		if abortErr != nil {
+			err = errors.Join(err, fmt.Errorf("abort incomplete multipart upload: %w", abortErr))
+		}
+	}()
+
+	// Multipart payload buffers are the dominant bounded allocation. The exact
+	// upper bound is part_size * concurrency (default 16 MiB * 2 = 32 MiB;
+	// configurable maximum 128 MiB * 2 = 256 MiB).
+	concurrency := readSSAMultipartConcurrency()
+	type multipartUploadJob struct {
+		partNumber int
+		buffer     []byte
+		size       int
+		sha256     string
+	}
+	uploadCtx, cancelUploads := context.WithCancel(ctx)
+	defer cancelUploads()
+	if closer, ok := body.(io.Closer); ok {
+		stopReadCancel := make(chan struct{})
+		defer close(stopReadCancel)
+		go func() {
+			select {
+			case <-uploadCtx.Done():
+				_ = closer.Close()
+			case <-stopReadCancel:
+			}
+		}()
+	}
+	jobs := make(chan multipartUploadJob, concurrency)
+	buffers := make(chan []byte, concurrency)
+	for index := 0; index < concurrency; index++ {
+		buffers <- make([]byte, partSize)
+	}
+	parts := make([]CompletePart, maxSSAMultipartParts)
+	var workerWG sync.WaitGroup
+	var resultMu sync.Mutex
+	var firstPartErr error
+	var partErrOnce sync.Once
+	workerWG.Add(concurrency)
+	for worker := 0; worker < concurrency; worker++ {
+		go func() {
+			defer workerWG.Done()
+			for job := range jobs {
+				if uploadCtx.Err() == nil {
+					var etag string
+					var partResult ObjectStoreResult
+					partErr := s.withCredentialRefresh(func() error {
+						requestCtx, cancel := context.WithTimeout(uploadCtx, readSSAObjectStoreRequestTimeout())
+						defer cancel()
+						var uploadErr error
+						etag, partResult, uploadErr = s.uploader.UploadPart(requestCtx, PartRequest{
+							Bucket:        s.bucket,
+							ObjectKey:     objectKey,
+							UploadID:      uploadID,
+							PartNumber:    job.partNumber,
+							Body:          bytes.NewReader(job.buffer[:job.size]),
+							Size:          int64(job.size),
+							PayloadSHA256: job.sha256,
+						})
+						return uploadErr
+					})
+					if partErr != nil {
+						partErrOnce.Do(func() {
+							firstPartErr = partErr
+							cancelUploads()
+						})
+					} else {
+						parts[job.partNumber-1] = CompletePart{PartNumber: job.partNumber, ETag: etag}
+						resultMu.Lock()
+						stats.ETag = etag
+						stats.RequestID = firstNonEmptyS3(partResult.RequestID, stats.RequestID, createResult.RequestID)
+						resultMu.Unlock()
+					}
+				}
+				buffers <- job.buffer
+			}
+		}()
+	}
+
+	hasher := sha256.New()
+	partCount := 0
+	var readFailure error
+readParts:
+	for partNumber := 1; ; partNumber++ {
+		if partNumber > maxSSAMultipartParts {
+			readFailure = fmt.Errorf("multipart upload exceeds %d parts", maxSSAMultipartParts)
+			break
+		}
+		var buffer []byte
+		select {
+		case buffer = <-buffers:
+		case <-uploadCtx.Done():
+			readFailure = uploadCtx.Err()
+			break readParts
+		}
+		n, readErr := io.ReadFull(body, buffer)
+		if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
+			buffers <- buffer
+			readFailure = readErr
+			cancelUploads()
+			break
+		}
+		if n > 0 {
+			chunk := buffer[:n]
+			_, _ = hasher.Write(chunk)
+			stats.Bytes += int64(n)
+			job := multipartUploadJob{partNumber: partNumber, buffer: buffer, size: n, sha256: sha256Hex(chunk)}
+			select {
+			case jobs <- job:
+				partCount++
+			case <-uploadCtx.Done():
+				buffers <- buffer
+				readFailure = uploadCtx.Err()
+				break readParts
+			}
+		} else {
+			buffers <- buffer
+		}
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
+			break
+		}
+	}
+	close(jobs)
+	workerWG.Wait()
+	if firstPartErr != nil {
+		return stats, firstPartErr
+	}
+	if readFailure != nil {
+		return stats, readFailure
+	}
+	if partCount == 0 {
+		return stats, fmt.Errorf("no multipart parts uploaded")
+	}
+	parts = parts[:partCount]
+	for index, part := range parts {
+		if part.PartNumber != index+1 || strings.TrimSpace(part.ETag) == "" {
+			return stats, fmt.Errorf("multipart part %d did not complete", index+1)
+		}
+	}
+	stats.Parts = partCount
+	stats.SHA256 = hex.EncodeToString(hasher.Sum(nil))
+	var completeResult ObjectStoreResult
+	err = s.withCredentialRefresh(func() error {
+		requestCtx, cancel := context.WithTimeout(ctx, readSSAObjectStoreFinalizeTimeout())
+		defer cancel()
+		var completeErr error
+		completeResult, completeErr = s.uploader.CompleteMultipart(requestCtx, CompleteRequest{
+			Bucket: s.bucket, ObjectKey: objectKey, UploadID: uploadID, Parts: parts,
+		})
+		return completeErr
+	})
+	if err != nil {
+		return stats, err
+	}
+	abortNeeded = false
+	stats.ETag = firstNonEmptyS3(completeResult.ETag, stats.ETag)
+	stats.RequestID = firstNonEmptyS3(completeResult.RequestID, stats.RequestID, createResult.RequestID)
+	return stats, nil
+}
+
+func hashSSAUploadBody(body io.ReadSeeker, size int64) (string, error) {
+	start, err := body.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return "", err
+	}
+	hasher := sha256.New()
+	written, copyErr := io.CopyN(hasher, body, size)
+	_, seekErr := body.Seek(start, io.SeekStart)
+	if copyErr != nil && !errors.Is(copyErr, io.EOF) {
+		return "", copyErr
+	}
+	if written != size {
+		return "", fmt.Errorf("upload body size mismatch: expected=%d actual=%d", size, written)
+	}
+	if seekErr != nil {
+		return "", seekErr
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func readSSAObjectStoreRequestTimeout() time.Duration {
+	return readPositiveDurationSeconds("SCANNODE_SSA_UPLOAD_TIMEOUT_SEC", defaultSSAObjectStoreRequestTimeout, 24*time.Hour)
+}
+
+func readSSAObjectStoreFinalizeTimeout() time.Duration {
+	return readPositiveDurationSeconds("SCANNODE_SSA_FINALIZE_TIMEOUT_SEC", defaultSSAObjectStoreFinalizeTimeout, 10*time.Minute)
+}
+
+func readPositiveDurationSeconds(name string, fallback, maximum time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	seconds, err := time.ParseDuration(raw + "s")
+	if err != nil || seconds <= 0 || seconds > maximum {
+		return fallback
+	}
+	return seconds
+}


### PR DESCRIPTION
## 目标

将 ScanNode SSA 制品上传从完整 `minio-go/v7` 解耦为只覆盖当前业务能力的轻量 S3 实现，并补齐取消、超时、凭证脱敏、配置边界、结构化错误和 Multipart 清理，同时保持 Legion 当前 HTTP MinIO 契约与既有 Go 调用兼容。

## 改动摘要

### 依赖与架构

- 新增内部 `ObjectStoreUploader`，统一普通 Put、流式 Multipart、连续分段和 Manifest 上传。
- 使用 Go 标准库实现最小 S3 客户端与 AWS Signature V4，不引入 AWS SDK。
- 每个上传任务复用客户端、`http.Transport` 和连接池；STS 刷新只替换签名凭证。
- 移除 `minio-go/v7` 及其不再需要的间接依赖。

### 兼容、安全与可靠性

- 保留历史无 scheme endpoint + `use_ssl=false` 的 Legion HTTP MinIO 契约；显式 `http://` endpoint 仍必须通过 `AllowHTTP`、任务参数或受控环境配置启用。
- 对象存储和 Ticket HTTPS 默认严格校验证书；私有 CA 通过 `TLSCAFile` 配置，仅受信开发环境可显式设置 `AllowInsecureTLS`。
- 保留既有导出字段类型与公开方法签名，并增加 Context 版本；外部调用编译测试覆盖旧 API。
- Node Token 与 STS 凭证在 `String`、`GoString` 和 JSON 中脱敏。
- Put、分片、完成和终止均传递任务 `context.Context`；失败或取消统一执行带独立超时的 Abort。
- `CompleteMultipart` 必须返回合法结果根节点及非空 ETag；创建 Multipart 不重试语义不明确的请求，避免遗留孤儿 UploadID。
- 最新 `main` 的连续制品 flush interval、部分制品保留和锁内指标更新行为已在 rebase 中保留。

### 错误与资源边界

- 解析 S3 XML 错误，区分凭证过期、权限拒绝、签名错误和临时服务错误。
- 仅重试临时网络错误、429、500/502/503/504 和明确的临时 S3 错误。
- 只有结构化凭证过期错误触发一次 STS 刷新。
- 分片限制为 5–128 MiB、最多 10,000 片、并发 1–2；内存上限不随对象大小增长。

## 主要文件

- `scannode/ssa_object_store.go`
- `scannode/ssa_object_store_upload.go`
- `scannode/ssa_artifact_collector.go`
- `scannode/ssa_artifact_ticket_client.go`
- `scannode/ssa_artifact_upload_config.go`
- 对应单元、兼容性和真实服务互操作测试

Legion 侧配套契约见 VillanCh/legion#437，由调度端明确下发 HTTP 允许标记。

## 验证方式

最新 `origin/main` rebase 后：

- `go test ./scannode -count=1`：通过。
- MinIO、collector、TLS、Multipart 和旧 API 相关 `go test -race`：通过。
- `go vet ./scannode`：通过。
- `git diff --check` 与两提交 `range-diff`：通过；安全修复提交语义未变化。

真实 MinIO 互操作覆盖：小对象、特殊对象键、5 MiB 边界、16 MiB Multipart、读回校验与 Abort，无残留上传。

真实 SSA 链路使用 61 个 Java 文件、10,840 行源码：编译成功，`ssa_result_v1` 制品经 HTTP MinIO 上传后可按精确对象键读取，Legion 导入状态为 `imported`。

后续 338 条规则扫描在 8291/10000 因 `native call not found: constSelectedPhi` 失败。该调用在当前源码中无实现，且不属于本 PR 的对象存储改动，因此本 PR 只声明 SSA 制品回传链路通过，不将整条规则扫描标记为 T2 通过。

## 性能基准

原 PR 在相同主机、同一 MinIO、64 MiB 文件、16 MiB 分片、各 10 次采样下：中位上传耗时降低约 19.7%，中位吞吐提高约 24.5%，每次上传分配次数降低约 96.8%。完整环境与命令见 `scannode/ssa_object_store_benchmark.md`。
