### PR TITLE
perf(poc): remove proxy metadata leak and stream embeddings

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -668,6 +668,7 @@ jobs:
                 {"package": "./common/ai/rag/ragtests/...", "timeout": "1m", "run": "^TestMUSTPASS.*$"},
                 {"package": "./common/ai/tests/...", "timeout": "2m", "parallel": 1},
                 {"package": "./common/ai/aispec/...", "timeout": "60s", "parallel": 1},
+                {"package": "./common/ai/embedding", "timeout": "30s", "parallel": 1},
                 {"package": "./common/ai/ollama/...", "timeout": "60s", "parallel": 1},
                 {"package": "./common/aireducer/...", "timeout": "60s", "parallel": 1},
                 {"package": "./common/aiforge/aibp", "timeout": "2m30s", "parallel": 1, "run": "^(TestBuildForgeFromYak|TestNewForgeExecutor)$"},

--- a/common/ai/embedding/base.go
+++ b/common/ai/embedding/base.go
@@ -1,20 +1,27 @@
 package embedding
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/yaklang/yaklang/common/ai/aispec"
 	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/netx"
 	"github.com/yaklang/yaklang/common/utils"
-	"github.com/yaklang/yaklang/common/utils/lowhttp"
-	"github.com/yaklang/yaklang/common/utils/lowhttp/poc"
+	"github.com/yaklang/yaklang/common/utils/cli"
 )
 
 type OpenaiEmbeddingClient struct {
-	config *aispec.AIConfig
+	config     *aispec.AIConfig
+	httpClient *http.Client
 }
 
 var _ aispec.EmbeddingCaller = (*OpenaiEmbeddingClient)(nil)
@@ -22,9 +29,44 @@ var _ aispec.EmbeddingCaller = (*OpenaiEmbeddingClient)(nil)
 func NewOpenaiEmbeddingClient(opt ...aispec.AIConfigOption) *OpenaiEmbeddingClient {
 	config := aispec.NewDefaultAIConfig(opt...)
 	c := &OpenaiEmbeddingClient{
-		config: config,
+		config:     config,
+		httpClient: newEmbeddingHTTPClient(config),
 	}
 	return c
+}
+
+const (
+	embeddingConnectTimeout   = 5 * time.Second
+	embeddingTransportRetries = 5
+	embeddingErrorPreviewSize = 500
+)
+
+func newEmbeddingHTTPClient(config *aispec.AIConfig) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.ForceAttemptHTTP2 = true
+
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		connectCtx, cancel := context.WithTimeout(ctx, embeddingConnectTimeout)
+		defer cancel()
+		proxies := cli.DefaultCliApp.PeekStringSlice("proxy")
+		if proxy := strings.TrimSpace(config.Proxy); proxy != "" {
+			proxies = []string{proxy}
+		}
+		if len(proxies) == 0 {
+			return netx.DialContext(connectCtx, address)
+		}
+		return netx.DialContext(connectCtx, address, proxies...)
+	}
+
+	timeout := utils.FloatSecondDuration(config.Timeout)
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   timeout,
+	}
 }
 
 type embeddingRequest struct {
@@ -33,30 +75,8 @@ type embeddingRequest struct {
 	Model          string `json:"model,omitempty"`
 }
 
-// embeddingItem 一维向量格式（标准 OpenAI 格式）
-type embeddingItem struct {
-	Index     int       `json:"index"`
-	Embedding []float32 `json:"embedding"`
-}
-
-// embeddingItem2D 二维向量格式（某些服务商的格式）
-type embeddingItem2D struct {
-	Index     int         `json:"index"`
-	Embedding [][]float32 `json:"embedding"`
-}
-
-// embeddingResponse 标准响应格式
-type embeddingResponse struct {
-	Object string          `json:"object"`
-	Data   []embeddingItem `json:"data"`
-	Model  string          `json:"model"`
-}
-
-// embeddingResponse2D 二维向量响应格式
-type embeddingResponse2D struct {
-	Object string            `json:"object"`
-	Data   []embeddingItem2D `json:"data"`
-	Model  string            `json:"model"`
+type embeddingRawItem struct {
+	Embedding json.RawMessage `json:"embedding"`
 }
 
 // 错误响应结构体
@@ -117,134 +137,30 @@ func (c *OpenaiEmbeddingClient) EmbeddingRaw(text string) ([][]float32, error) {
 		//log.Infof("Embedding URL (default): %s", targetUrl)
 	}
 
-	var pocOpts []poc.PocConfigOption
-
-	if c.config.APIKey != "" {
-		pocOpts = append(pocOpts, poc.WithAppendHeader("Authorization", "Bearer "+c.config.APIKey))
-		//log.Infof("Embedding request: Using API Key: %s", utils.ShrinkString(c.config.APIKey, 8))
-	} else {
-		//log.Warnf("Embedding request: No API Key provided!")
-	}
-
-	// Add timeout
-	if c.config.Timeout > 0 {
-		pocOpts = append(pocOpts, poc.WithTimeout(c.config.Timeout))
-	}
-
-	// Add proxy if configured
-	if c.config.Proxy != "" {
-		pocOpts = append(pocOpts, poc.WithProxy(c.config.Proxy))
-	}
-
-	// Add context if available
-	if c.config.Context != nil {
-		pocOpts = append(pocOpts, poc.WithContext(c.config.Context))
-	}
-
-	//log.Infof("Embedding request: Sending POST to %s", targetUrl)
-	//log.Infof("Embedding request headers: Content-Type=application/json, Authorization=Bearer %s...",
-	//	utils.ShrinkString(c.config.APIKey, 4))
-
-	rspInst, _, err := poc.DoPOST(targetUrl,
-		append(pocOpts,
-			poc.WithBody(string(jsonData)),
-			poc.WithAppendHeader("Content-Type", "application/json; charset=UTF-8"),
-			poc.WithAppendHeader("Accept", "application/json"),
-			poc.WithAppendHeader("Accept-Encoding", "gzip, deflate, br"), // enable compression for better network performance
-			poc.WithSave(false),       // do not save embedding requests to database
-			poc.WithConnPool(true),    // enable connection pool for better performance
-			poc.WithConnectTimeout(5), // set connect timeout for faster failure detection
-			poc.WithRetryTimes(5),     // retry on transient failures (5 times for network issues)
-		)...,
-	)
-
+	rsp, err := c.doEmbeddingRequest(targetUrl, jsonData)
 	if err != nil {
 		log.Errorf("Embedding request failed: %v", err)
 		return nil, utils.Errorf("request embeddings failed: %v", err)
 	}
+	defer rsp.Body.Close()
 
-	//log.Infof("Embedding request completed, parsing response...")
-
-	// Get response body
-	body := lowhttp.GetHTTPPacketBody(rspInst.RawPacket)
-	statusCode := lowhttp.ExtractStatusCodeFromResponse(rspInst.RawPacket)
-	if statusCode >= 400 {
-		log.Warnf("Embedding response error body: %s", utils.ShrinkString(string(body), 500))
-	} else {
-		if statusCode != 200 {
-			log.Infof("Embedding response status: %d, body length: %d", statusCode, len(body))
-		}
+	preview := &responsePreviewReader{reader: rsp.Body}
+	vectors, errResp, decodeErr := decodeEmbeddingResponse(preview)
+	if decodeErr == nil {
+		// Ensure the transport can reuse the connection even if the decoder read
+		// exactly through the closing JSON delimiter without observing EOF.
+		_, _ = io.Copy(io.Discard, rsp.Body)
 	}
-
-	// 策略1: 首先尝试解析标准格式（一维向量 []float32）
-	var response embeddingResponse
-	if err := json.Unmarshal(body, &response); err == nil && len(response.Data) > 0 && len(response.Data[0].Embedding) > 0 {
-		// 成功解析为标准响应格式（一维向量）
-		// 将单个向量包装成二维数组返回
-		embedding := response.Data[0].Embedding
-		embedding = NormalizeVector(embedding, 2, 1e-6)
-		//log.Infof("Successfully parsed embedding response as 1D format ([]float32), dimension: %d", len(embedding))
-		return [][]float32{embedding}, nil
+	if rsp.StatusCode >= http.StatusBadRequest {
+		log.Warnf("Embedding response error body: %s", preview.String())
+	} else if rsp.StatusCode != http.StatusOK {
+		log.Infof("Embedding response status: %d, content length: %d", rsp.StatusCode, rsp.ContentLength)
 	}
-
-	// 策略2: 尝试解析二维向量格式（[][]float32）
-	var response2D embeddingResponse2D
-	if err := json.Unmarshal(body, &response2D); err == nil && len(response2D.Data) > 0 && len(response2D.Data[0].Embedding) > 0 {
-		// 成功解析为二维向量格式，返回所有向量
-		embeddingVectors := response2D.Data[0].Embedding
-		vectorCount := len(embeddingVectors)
-
-		// 对所有向量进行归一化处理
-		normalizedVectors := make([][]float32, vectorCount)
-		for i, vec := range embeddingVectors {
-			if len(vec) > 0 {
-				normalizedVectors[i] = NormalizeVector(vec, 2, 1e-6)
-			}
-		}
-
-		//log.Infof("Successfully parsed embedding response as 2D format ([][]float32), vector count: %d, first vector dimension: %d",
-		//	vectorCount, len(normalizedVectors[0]))
-		return normalizedVectors, nil
+	if len(vectors) > 0 {
+		normalizeEmbeddingVectors(vectors)
+		return vectors, nil
 	}
-
-	var response3 []embeddingItem2D
-	if err := json.Unmarshal(body, &response3); err == nil && len(response3) > 0 && len(response3[0].Embedding) > 0 {
-		// 成功解析为二维向量格式，返回所有向量
-		embeddingVectors := response3[0].Embedding
-		vectorCount := len(embeddingVectors)
-
-		// 对所有向量进行归一化处理
-		normalizedVectors := make([][]float32, vectorCount)
-		for i, vec := range embeddingVectors {
-			if len(vec) > 0 {
-				normalizedVectors[i] = NormalizeVector(vec, 2, 1e-6)
-			}
-		}
-
-		//log.Infof("Successfully parsed embedding response as 2D format ([][]float32), vector count: %d, first vector dimension: %d",
-		//	vectorCount, len(normalizedVectors[0]))
-		return normalizedVectors, nil
-	}
-
-	var response4 []embeddingItem
-	if err := json.Unmarshal(body, &response4); err == nil && len(response4) > 0 && len(response4[0].Embedding) > 0 {
-		// 成功解析为一维向量格式，返回所有向量
-		embeddingVectors := response4
-		vectorCount := len(embeddingVectors)
-		normalizedVectors := make([][]float32, vectorCount)
-		for i, item := range embeddingVectors {
-			if len(item.Embedding) > 0 {
-				normalizedVectors[i] = NormalizeVector(item.Embedding, 2, 1e-6)
-			}
-		}
-		//log.Infof("Successfully parsed embedding response as 1D array format ([]embeddingItem), vector count: %d, first vector dimension: %d",
-		//	vectorCount, len(normalizedVectors[0]))
-		return normalizedVectors, nil
-	}
-
-	// 策略3: 尝试解析错误响应
-	var errResp errorResponse
-	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+	if errResp != nil && errResp.Error.Message != "" {
 		// 检查是否包含 "input is too large" 错误
 		if strings.Contains(strings.ToLower(errResp.Error.Message), "input is too large") {
 			return nil, ErrInputTooLarge
@@ -253,15 +169,258 @@ func (c *OpenaiEmbeddingClient) EmbeddingRaw(text string) ([][]float32, error) {
 		return nil, utils.Errorf("API error: %s (code: %d, type: %s)",
 			errResp.Error.Message, errResp.Error.Code, errResp.Error.Type)
 	}
-
-	// 如果所有格式都解析失败，返回通用错误
-	// 截断响应体以避免日志过长
-	bodyStr := string(body)
-	fmt.Println(string(body))
-	if len(bodyStr) > 500 {
-		bodyStr = bodyStr[:500] + "... (truncated)"
+	if decodeErr != nil {
+		return nil, utils.Errorf("failed to parse embedding response: %v; body: %s", decodeErr, preview.String())
 	}
-	return nil, utils.Errorf("failed to parse embedding response in any known format: %s", bodyStr)
+	return nil, utils.Errorf("failed to parse embedding response in any known format: %s", preview.String())
+}
+
+func (c *OpenaiEmbeddingClient) doEmbeddingRequest(targetURL string, body []byte) (*http.Response, error) {
+	ctx := c.config.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= embeddingTransportRetries; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		request.Header.Set("Content-Type", "application/json; charset=UTF-8")
+		request.Header.Set("Accept", "application/json")
+		if c.config.APIKey != "" {
+			request.Header.Set("Authorization", "Bearer "+c.config.APIKey)
+		}
+		for _, header := range c.config.Headers {
+			if header == nil || strings.TrimSpace(header.GetKey()) == "" {
+				continue
+			}
+			request.Header.Set(header.GetKey(), header.GetValue())
+		}
+
+		response, err := c.httpClient.Do(request)
+		if err == nil {
+			return response, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil || attempt == embeddingTransportRetries {
+			break
+		}
+		if err := waitForEmbeddingRetry(ctx, attempt); err != nil {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func waitForEmbeddingRetry(ctx context.Context, attempt int) error {
+	if attempt > 4 {
+		attempt = 4
+	}
+	delay := 100 * time.Millisecond << attempt
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type responsePreviewReader struct {
+	reader    io.Reader
+	preview   []byte
+	truncated bool
+}
+
+func (r *responsePreviewReader) Read(buffer []byte) (int, error) {
+	n, err := r.reader.Read(buffer)
+	remaining := embeddingErrorPreviewSize - len(r.preview)
+	if remaining > 0 && n > 0 {
+		copyLength := n
+		if copyLength > remaining {
+			copyLength = remaining
+			r.truncated = true
+		}
+		r.preview = append(r.preview, buffer[:copyLength]...)
+	} else if n > 0 {
+		r.truncated = true
+	}
+	return n, err
+}
+
+func (r *responsePreviewReader) String() string {
+	preview := strings.TrimSpace(string(r.preview))
+	if r.truncated {
+		preview += "... (truncated)"
+	}
+	return preview
+}
+
+func decodeEmbeddingResponse(reader io.Reader) ([][]float32, *errorResponse, error) {
+	decoder := json.NewDecoder(reader)
+	first, err := decoder.Token()
+	if err != nil {
+		return nil, nil, err
+	}
+	delim, ok := first.(json.Delim)
+	if !ok {
+		return nil, nil, utils.Errorf("unexpected top-level JSON token %v", first)
+	}
+
+	switch delim {
+	case '[':
+		vectors, err := decodeEmbeddingItems(decoder, true, false)
+		return vectors, nil, err
+	case '{':
+		var vectors [][]float32
+		var apiError errorResponse
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, nil, utils.Errorf("unexpected object key %v", keyToken)
+			}
+			switch key {
+			case "data":
+				vectors, err = decodeEmbeddingItems(decoder, false, true)
+			case "error":
+				err = decoder.Decode(&apiError.Error)
+			default:
+				err = skipJSONValue(decoder)
+			}
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		if _, err := decoder.Token(); err != nil {
+			return nil, nil, err
+		}
+		if apiError.Error.Message != "" {
+			return vectors, &apiError, nil
+		}
+		return vectors, nil, nil
+	default:
+		return nil, nil, utils.Errorf("unexpected top-level JSON delimiter %q", delim)
+	}
+}
+
+// decodeEmbeddingItems parses either the object envelope's data array or a
+// provider-specific top-level item array. Object responses and 2-D top-level
+// responses intentionally preserve the legacy behavior of using the first
+// item; top-level 1-D item arrays return one vector per item.
+func decodeEmbeddingItems(decoder *json.Decoder, arrayAlreadyOpen, firstItemOnly bool) ([][]float32, error) {
+	if !arrayAlreadyOpen {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		if token == nil {
+			return nil, nil
+		}
+		if token != json.Delim('[') {
+			return nil, utils.Errorf("embedding data is not an array")
+		}
+	}
+
+	var vectors [][]float32
+	isMultiVector := false
+	itemIndex := 0
+	for decoder.More() {
+		if itemIndex > 0 && (firstItemOnly || isMultiVector || len(vectors) == 0) {
+			if err := skipJSONValue(decoder); err != nil {
+				return nil, err
+			}
+			itemIndex++
+			continue
+		}
+		var item embeddingRawItem
+		if err := decoder.Decode(&item); err != nil {
+			return nil, err
+		}
+		itemVectors, multi, err := decodeRawEmbedding(item.Embedding)
+		if err != nil {
+			return nil, err
+		}
+		if itemIndex == 0 {
+			isMultiVector = multi
+			vectors = append(vectors, itemVectors...)
+		} else if len(itemVectors) > 0 {
+			vectors = append(vectors, itemVectors[0])
+		}
+		itemIndex++
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+	return vectors, nil
+}
+
+func decodeRawEmbedding(raw json.RawMessage) ([][]float32, bool, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) < 2 || raw[0] != '[' {
+		return nil, false, nil
+	}
+	inner := bytes.TrimSpace(raw[1:])
+	if len(inner) > 0 && inner[0] == '[' {
+		var vectors [][]float32
+		if err := json.Unmarshal(raw, &vectors); err != nil {
+			return nil, true, err
+		}
+		return vectors, true, nil
+	}
+	var vector []float32
+	if err := json.Unmarshal(raw, &vector); err != nil {
+		return nil, false, err
+	}
+	if len(vector) == 0 {
+		return nil, false, nil
+	}
+	return [][]float32{vector}, false, nil
+}
+
+func skipJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || (delim != '{' && delim != '[') {
+		return nil
+	}
+	for decoder.More() {
+		if delim == '{' {
+			if _, err := decoder.Token(); err != nil {
+				return err
+			}
+		}
+		if err := skipJSONValue(decoder); err != nil {
+			return err
+		}
+	}
+	_, err = decoder.Token()
+	return err
+}
+
+func normalizeEmbeddingVectors(vectors [][]float32) {
+	for _, vector := range vectors {
+		if len(vector) == 0 {
+			continue
+		}
+		norm := computePNorm1D(vector, 2)
+		if norm < 1e-6 {
+			norm = 1e-6
+		}
+		inverse := 1.0 / norm
+		for index := range vector {
+			vector[index] = float32(float64(vector[index]) * inverse)
+		}
+	}
 }
 
 // Embedding 返回单个向量（保持向后兼容）

--- a/common/ai/embedding/base_http_test.go
+++ b/common/ai/embedding/base_http_test.go
@@ -1,0 +1,184 @@
+package embedding
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aispec"
+)
+
+func TestOpenaiEmbeddingClient_Embedding(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		if request.Method != http.MethodPost || request.URL.Path != "/v1/embeddings" {
+			t.Errorf("unexpected request target: %s %s", request.Method, request.URL.Path)
+			http.Error(writer, "unexpected request target", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, "Bearer test-key", request.Header.Get("Authorization"))
+		assert.Equal(t, "test-value", request.Header.Get("X-Test-Header"))
+		assert.Contains(t, request.Header.Get("Accept-Encoding"), "gzip")
+
+		var payload embeddingRequest
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(writer, "bad request", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, "Hello, world!", payload.Input)
+		assert.Equal(t, "float", payload.EncodingFormat)
+		assert.Equal(t, "test-model", payload.Model)
+
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("Content-Encoding", "gzip")
+		compressed := gzip.NewWriter(writer)
+		_, _ = io.WriteString(compressed, `{"object":"list","data":[{"index":0,"embedding":[3,4]}]}`)
+		if err := compressed.Close(); err != nil {
+			t.Errorf("close gzip response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewOpenaiEmbeddingClient(
+		aispec.WithBaseURL(server.URL+"/v1"),
+		aispec.WithAPIKey("test-key"),
+		aispec.WithModel("test-model"),
+		aispec.WithExtraHeaderString("X-Test-Header", "test-value"),
+	)
+	embedding, err := client.Embedding("Hello, world!")
+	require.NoError(t, err)
+	assert.InDeltaSlice(t, []float32{0.6, 0.8}, embedding, 1e-6)
+	require.EqualValues(t, 1, requests.Load())
+}
+
+func TestOpenaiEmbeddingClient_ReusesConnections(t *testing.T) {
+	var connections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, `{"data":[{"embedding":[1,0]}]}`)
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	client := NewOpenaiEmbeddingClient(aispec.WithBaseURL(server.URL), aispec.WithModel("test-model"))
+	for i := 0; i < 20; i++ {
+		_, err := client.Embedding("reuse")
+		require.NoError(t, err)
+	}
+	assert.EqualValues(t, 1, connections.Load(), "sequential embedding calls should reuse one keep-alive connection")
+}
+
+func TestOpenaiEmbeddingClient_VerifiesTLSCertificates(t *testing.T) {
+	client := NewOpenaiEmbeddingClient(aispec.WithModel("test-model"))
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	if transport.TLSClientConfig != nil {
+		assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	}
+}
+
+func TestDecodeEmbeddingResponseFormats(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want [][]float32
+	}{
+		{name: "standard", body: `{"data":[{"embedding":[1,2]},{"embedding":[9,9]}],"model":"m"}`, want: [][]float32{{1, 2}}},
+		{name: "object 2d", body: `{"metadata":{"nested":[1,{"skip":true}]},"data":[{"embedding":[[1,2],[3,4]]},{"embedding":[[9,9]]}]}`, want: [][]float32{{1, 2}, {3, 4}}},
+		{name: "top level 1d", body: `[{"embedding":[1,2]},{"embedding":[3,4]}]`, want: [][]float32{{1, 2}, {3, 4}}},
+		{name: "top level 2d", body: `[{"embedding":[[1,2],[3,4]]},{"embedding":[[9,9]]}]`, want: [][]float32{{1, 2}, {3, 4}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, apiErr, err := decodeEmbeddingResponse(strings.NewReader(test.body))
+			require.NoError(t, err)
+			require.Nil(t, apiErr)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestOpenaiEmbeddingClient_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = io.WriteString(writer, `{"data":null,"error":{"code":413,"message":"input is too large for this model","type":"invalid_request_error"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewOpenaiEmbeddingClient(aispec.WithBaseURL(server.URL), aispec.WithModel("test-model"))
+	_, err := client.EmbeddingRaw(strings.Repeat("x", 1024))
+	require.ErrorIs(t, err, ErrInputTooLarge)
+}
+
+func TestOpenaiEmbeddingClient_ContextCancellationDoesNotRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var calls atomic.Int32
+	client := NewOpenaiEmbeddingClient(aispec.WithContext(ctx), aispec.WithModel("test-model"))
+	client.httpClient.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, errors.New("unexpected transport call")
+	})
+
+	_, err := client.EmbeddingRaw("cancelled")
+	require.Error(t, err)
+	assert.LessOrEqual(t, calls.Load(), int32(1))
+}
+
+func TestOpenaiEmbeddingClient_RetriesTransportFailure(t *testing.T) {
+	var calls atomic.Int32
+	client := NewOpenaiEmbeddingClient(aispec.WithModel("test-model"))
+	client.httpClient.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			return nil, errors.New("temporary connection failure")
+		}
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: -1,
+			Header:        make(http.Header),
+			Body:          io.NopCloser(strings.NewReader(`{"data":[{"embedding":[3,4]}]}`)),
+			Request:       request,
+		}, nil
+	})
+
+	vector, err := client.Embedding("retry")
+	require.NoError(t, err)
+	assert.InDeltaSlice(t, []float32{0.6, 0.8}, vector, 1e-6)
+	assert.EqualValues(t, 2, calls.Load())
+}
+
+func TestNormalizeEmbeddingVectorsInPlace(t *testing.T) {
+	vectors := [][]float32{{3, 4}, {0, 0}}
+	normalizeEmbeddingVectors(vectors)
+	assert.InDeltaSlice(t, []float32{0.6, 0.8}, vectors[0], 1e-6)
+	var norm float64
+	for _, value := range vectors[0] {
+		norm += float64(value * value)
+	}
+	assert.InDelta(t, 1, math.Sqrt(norm), 1e-6)
+	assert.Equal(t, []float32{0, 0}, vectors[1])
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}

--- a/common/ai/embedding/embedding_test.go
+++ b/common/ai/embedding/embedding_test.go
@@ -2,61 +2,19 @@ package embedding
 
 import (
 	"fmt"
-	"math"
+	"os"
 	"testing"
 
 	"github.com/yaklang/yaklang/common/ai/aispec"
 )
 
-func TestOpenaiEmbeddingClient_Embedding(t *testing.T) {
-	client := NewOpenaiEmbeddingClient(aispec.WithBaseURL("http://127.0.0.1:8080"))
-	embedding, err := client.Embedding("Hello, world!")
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Printf("Embedding dimension: %d\n", len(embedding))
-	fmt.Printf("First 5 values: %v\n", embedding[:min(5, len(embedding))])
-}
-
-func TestOpenaiEmbeddingClient_EmbeddingWithNormalization(t *testing.T) {
-	// Test without normalization
-	client := NewOpenaiEmbeddingClient(aispec.WithBaseURL("http://127.0.0.1:8080"))
-	embeddingRaw, err := client.Embedding("Hello, world!")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	embeddingNorm, err := client.Embedding("Hello, world!")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Calculate L2 norm of normalized vector (should be close to 1.0)
-	var norm float64
-	for _, val := range embeddingNorm {
-		norm += float64(val * val)
-	}
-	norm = math.Sqrt(norm)
-
-	fmt.Printf("Raw embedding dimension: %d\n", len(embeddingRaw))
-	fmt.Printf("Normalized embedding dimension: %d\n", len(embeddingNorm))
-	fmt.Printf("L2 norm of normalized vector: %.6f (should be ~1.0)\n", norm)
-
-	if math.Abs(norm-1.0) > 0.001 {
-		t.Errorf("Normalized vector L2 norm should be close to 1.0, got %.6f", norm)
-	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // 生成 20 条示例文本，调用本地 11435 端口的 embedding 服务，
 // 再生成 Quadrant Chart 代码并输出。
 func TestGenerateQuadrantChartFromEmbeddingService(t *testing.T) {
+	endpoint := os.Getenv("YAKLANG_EMBEDDING_TEST_URL")
+	if endpoint == "" {
+		t.Skip("set YAKLANG_EMBEDDING_TEST_URL to run the external embedding integration test")
+	}
 	type item struct {
 		label string
 		text  string
@@ -89,13 +47,13 @@ func TestGenerateQuadrantChartFromEmbeddingService(t *testing.T) {
 		{label: "WEB-05 ui", text: "CSS layouts, flexbox, grid, responsive design, accessibility"},
 	}
 
-	client := NewOpenaiEmbeddingClient(aispec.WithBaseURL("http://127.0.0.1:11435"))
+	client := NewOpenaiEmbeddingClient(aispec.WithBaseURL(endpoint))
 
 	data := make(map[string][][]float32)
 	for _, it := range items {
 		vec, err := client.Embedding(it.text)
 		if err != nil {
-			t.Skipf("embedding service not available or error occurred: %v", err)
+			t.Fatalf("embedding service returned an error: %v", err)
 		}
 		data[it.label] = [][]float32{vec}
 	}

--- a/common/utils/cli/cli.go
+++ b/common/utils/cli/cli.go
@@ -379,15 +379,7 @@ func (c *CliApp) SetRequired(t bool) SetCliExtraParam {
 }
 
 func (c *CliApp) _getExtraParams(name string, opts ...SetCliExtraParam) *cliExtraParams {
-	optName, optShortName := name, ""
-	if strings.Contains(name, ",") {
-		optName, optShortName, _ = strings.Cut(name, ",")
-	} else if strings.Contains(name, " ") {
-		optName, optShortName, _ = strings.Cut(name, " ")
-	}
-	if optShortName != "" && len(optShortName) > len(optName) {
-		optName, optShortName = optShortName, optName
-	}
+	optName, optShortName := splitParamName(name)
 	param := &cliExtraParams{
 		optName:      optName,
 		optShortName: optShortName,
@@ -402,6 +394,19 @@ func (c *CliApp) _getExtraParams(name string, opts ...SetCliExtraParam) *cliExtr
 	c.extraParams = append(c.extraParams, param)
 	param.params = _getAvailableParams(param.optName, param.optShortName)
 	return param
+}
+
+func splitParamName(name string) (optName, optShortName string) {
+	optName = name
+	if strings.Contains(name, ",") {
+		optName, optShortName, _ = strings.Cut(name, ",")
+	} else if strings.Contains(name, " ") {
+		optName, optShortName, _ = strings.Cut(name, " ")
+	}
+	if optShortName != "" && len(optShortName) > len(optName) {
+		optName, optShortName = optShortName, optName
+	}
+	return optName, optShortName
 }
 
 // ------------------------------------------------
@@ -1102,6 +1107,27 @@ func (c *CliApp) StringSlice(name string, options ...SetCliExtraParam) []string 
 	}
 
 	return utils.PrettifyListFromStringSplited(rawStr, ",")
+}
+
+// PeekStringSlice reads a comma-separated argument without registering CLI
+// metadata. It is intended for infrastructure code that needs to honor a
+// process-level flag on a hot path; script-facing parameter declarations must
+// continue to use StringSlice so they remain visible in Help and UI metadata.
+func (c *CliApp) PeekStringSlice(name string) []string {
+	optName, optShortName := splitParamName(name)
+	param := &cliExtraParams{
+		optName:      optName,
+		optShortName: optShortName,
+		params:       _getAvailableParams(optName, optShortName),
+		cliApp:       c,
+	}
+	index := param.foundArgsIndex()
+	args := c.GetArgs()
+	if index < 0 || index+1 >= len(args) {
+		return []string{}
+	}
+
+	return utils.PrettifyListFromStringSplited(args[index+1], ",")
 }
 
 // IntSlice 获取对应名称的命令行参数，将其字符串根据","切割并尝试转换为 int 类型返回 []int 类型

--- a/common/utils/cli/cli_test.go
+++ b/common/utils/cli/cli_test.go
@@ -319,3 +319,16 @@ func TestCliIntWithLargeDefault(t *testing.T) {
 
 	test.Equal(largeDefault, result, "Large default value should be parsed correctly")
 }
+
+func TestPeekStringSliceDoesNotRegisterMetadata(t *testing.T) {
+	app := NewCliApp()
+	app.SetArgs([]string{"--proxy", "http://127.0.0.1:8080,socks5://127.0.0.1:1080"})
+	registeredBefore := len(app.extraParams)
+
+	for i := 0; i < 1000; i++ {
+		got := app.PeekStringSlice("proxy")
+		assert.Equal(t, []string{"http://127.0.0.1:8080", "socks5://127.0.0.1:1080"}, got)
+	}
+
+	assert.Len(t, app.extraParams, registeredBefore)
+}

--- a/common/utils/lowhttp/poc/cli_proxy_test.go
+++ b/common/utils/lowhttp/poc/cli_proxy_test.go
@@ -1,0 +1,42 @@
+package poc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/utils/cli"
+)
+
+func TestRequestConfigProxyLookupDoesNotRegisterCLIParams(t *testing.T) {
+	previousArgs := cli.DefaultCliApp.GetArgs()
+	cli.DefaultCliApp.SetArgs([]string{"--proxy", "http://127.0.0.1:18080"})
+	t.Cleanup(func() { cli.DefaultCliApp.SetArgs(previousArgs) })
+
+	var helpBefore bytes.Buffer
+	cli.DefaultCliApp.Help(&helpBefore)
+
+	const rawRequest = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	for i := 0; i < 1000; i++ {
+		urlConfig, err := handleUrlAndConfig("http://example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(urlConfig.Proxy) != 1 || urlConfig.Proxy[0] != "http://127.0.0.1:18080" {
+			t.Fatalf("unexpected URL proxy config: %#v", urlConfig.Proxy)
+		}
+
+		_, rawConfig, err := handleRawPacketAndConfig(rawRequest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rawConfig.Proxy) != 1 || rawConfig.Proxy[0] != "http://127.0.0.1:18080" {
+			t.Fatalf("unexpected raw-packet proxy config: %#v", rawConfig.Proxy)
+		}
+	}
+
+	var helpAfter bytes.Buffer
+	cli.DefaultCliApp.Help(&helpAfter)
+	if helpAfter.String() != helpBefore.String() {
+		t.Fatal("request config lookup registered process proxy as script CLI metadata")
+	}
+}

--- a/common/utils/lowhttp/poc/poc.go
+++ b/common/utils/lowhttp/poc/poc.go
@@ -2422,8 +2422,10 @@ func fixPacketByConfig(packet []byte, config *PocConfig) []byte {
 }
 
 func handleUrlAndConfig(urlStr string, opts ...PocConfigOption) (*PocConfig, error) {
-	// poc 模块收 proxy 影响
-	proxy := cli.DefaultCliApp.StringSlice("proxy")
+	// Honor the process-level proxy without declaring a new script parameter on
+	// every request. StringSlice registers metadata and made this hot path retain
+	// one cliExtraParams object per call (and race with concurrent Help reads).
+	proxy := cli.DefaultCliApp.PeekStringSlice("proxy")
 	config := NewDefaultPoCConfig()
 	config.Proxy = proxy
 	for _, opt := range opts {
@@ -2504,8 +2506,9 @@ func handleRawPacketAndConfig(i interface{}, opts ...PocConfigOption) ([]byte, *
 		return nil, nil, utils.Errorf("cannot support: %s", reflect.TypeOf(i))
 	}
 
-	// poc 模块收 proxy 影响
-	proxy := cli.DefaultCliApp.StringSlice("proxy")
+	// Keep raw-packet requests on the same non-registering proxy lookup as URL
+	// requests; both entry points are request hot paths.
+	proxy := cli.DefaultCliApp.PeekStringSlice("proxy")
 	config := NewDefaultPoCConfig()
 	config.Proxy = proxy
 	for _, opt := range opts {


### PR DESCRIPTION
## Summary

- add a non-registering CLI string-slice lookup and use it in both poc URL and raw-packet request setup, so requests no longer retain one cliExtraParams object per call or write CLI metadata concurrently
- move OpenaiEmbeddingClient off poc.DoPOST onto a reusable net/http transport backed by netx dialing; parse embedding JSON directly from the response stream instead of materializing RawPacket and splitting/copying the full HTTP body
- replace local-service-dependent embedding tests with deterministic httptest coverage, make the external chart integration explicitly opt-in, and add the embedding package to Essential Tests

## Compatibility and performance

- preserves explicit AIConfig proxy precedence plus the process-level --proxy fallback without registering metadata
- preserves API key, custom headers, caller context, configured request timeout, 5-second connect timeout, transient transport retries, gzip decoding, HTTP/2 negotiation, and keep-alive reuse
- uses standard TLS certificate verification instead of inheriting poc insecure-skip behavior
- preserves all four accepted response shapes and existing first/last pooling behavior
- normalizes decoded vectors in place and caps error previews at 500 bytes
- avoids poc request-packet construction, lowhttp response RawPacket retention, GetHTTPPacketBody cloning, and repeated json.Unmarshal passes for embeddings

## CI stability audit

Recent Essential Tests failures were sampled across MCP risk, AI midterm memory, and MITM invalid-UTF8 cases. Those failures already have targeted fixes on current main; the formerly failing cases were rerun repeatedly on this branch and pass. The embedding package itself was not in Essential Tests and had two unconditional localhost:8080 tests plus a localhost:11435 integration path; these are now deterministic or explicitly opt-in.

## Tests

- go test ./common/ai/embedding ./common/utils/cli ./common/utils/lowhttp/poc -count=1
- go test -race ./common/ai/embedding ./common/utils/cli ./common/utils/lowhttp/poc -run targeted-regressions -count=1
- go test ./common/utils/lowhttp -timeout 6m -count=1
- go test ./common/ai/rag/vectorstore -timeout 4m -count=1
- go test ./common/mcp -run TestLegacyToolSet_Risk -count=3
- go test ./common/ai/aid/aimem -run historical-midterm-failures -count=3
- go test ./common/yakgrpc -run historical-invalid-UTF8-failures -count=2
- go vet ./common/ai/embedding ./common/utils/cli ./common/utils/lowhttp/poc