### PR TITLE
scannode: register Legion script failure codes in job failure registry

### DIFF
--- a/scannode/job_failure_codes.go
+++ b/scannode/job_failure_codes.go
@@ -28,6 +28,17 @@ const (
 	// node-reported codes when callers choose to normalize before persistence.
 	JobFailureCodeUnknownNodeReported = "node_reported_failure_unknown"
 
+	// Script-reported failure codes supplied by Legion-owned yak scripts via
+	// ReturnData.error_code. They must stay registered here, otherwise
+	// prepareJobFailureForPublish buckets them as unknown and Legion loses the
+	// fine-grained failure_code its console catalog translates.
+	JobFailureCodeGitCloneError          = "gitCloneError"
+	JobFailureCodeNotFoundFileCanCompile = "notFoundFileCanCompile"
+	JobFailureCodeSourceConfigInvalid    = "sourceConfigInvalid"
+	JobFailureCodeSourceWorkspaceFailed  = "sourceWorkspaceFailed"
+	JobFailureCodeSourceExtractFailed    = "sourceExtractFailed"
+	JobFailureCodeScanFailed             = "scan_failed"
+
 	// Platform-inferred codes: never emitted by scannode, documented here so
 	// Legion and yaklang share one registry for retry decisions.
 	JobFailureCodeAttemptMissingFromHeartbeat = "attempt_missing_from_heartbeat"
@@ -45,6 +56,12 @@ type jobFailureCodeSpec struct {
 
 // jobFailureCodeRegistry is the canonical map shared by scannode (emit) and
 // Legion (validate / retry). Add new node-reported codes here before use.
+//
+// Script-reported codes carry policies for the error_detail metadata only;
+// the Legion scheduler makes retry decisions from its dispatch contract plus
+// its own non-retryable code set. gitCloneError is transient because remote
+// Git hosts (e.g. github.com) regularly drop connections mid-clone; the other
+// script codes describe deterministic input or environment problems.
 var jobFailureCodeRegistry = map[string]jobFailureCodeSpec{
 	JobFailureCodeNodeCapacityExceeded:      {policy: JobFailureRetryPolicyReschedule},
 	JobFailureCodeInvalidDispatchCommand:    {policy: JobFailureRetryPolicyNone},
@@ -53,6 +70,13 @@ var jobFailureCodeRegistry = map[string]jobFailureCodeSpec{
 	JobFailureCodeScriptExecutionPanic:      {policy: JobFailureRetryPolicyTransient},
 	JobFailureCodeStartedEventPublishFailed: {policy: JobFailureRetryPolicyTransient},
 	JobFailureCodeAttemptMissingFromHeartbeat: {policy: JobFailureRetryPolicyReschedule},
+
+	JobFailureCodeGitCloneError:          {policy: JobFailureRetryPolicyTransient},
+	JobFailureCodeNotFoundFileCanCompile: {policy: JobFailureRetryPolicyNone},
+	JobFailureCodeSourceConfigInvalid:    {policy: JobFailureRetryPolicyNone},
+	JobFailureCodeSourceWorkspaceFailed:  {policy: JobFailureRetryPolicyNone},
+	JobFailureCodeSourceExtractFailed:    {policy: JobFailureRetryPolicyNone},
+	JobFailureCodeScanFailed:             {policy: JobFailureRetryPolicyNone},
 }
 
 // JobFailureResolution is the output of ResolveJobFailureCode.

--- a/scannode/job_failure_codes_test.go
+++ b/scannode/job_failure_codes_test.go
@@ -19,6 +19,14 @@ func TestResolveJobFailureCodeKnownCodes(t *testing.T) {
 		{JobFailureCodeScriptExecutionPanic, JobFailureRetryPolicyTransient},
 		{JobFailureCodeStartedEventPublishFailed, JobFailureRetryPolicyTransient},
 		{JobFailureCodeAttemptMissingFromHeartbeat, JobFailureRetryPolicyReschedule},
+		// Script-reported codes from Legion-owned yak scripts must resolve as
+		// known so prepareJobFailureForPublish forwards them verbatim.
+		{JobFailureCodeGitCloneError, JobFailureRetryPolicyTransient},
+		{JobFailureCodeNotFoundFileCanCompile, JobFailureRetryPolicyNone},
+		{JobFailureCodeSourceConfigInvalid, JobFailureRetryPolicyNone},
+		{JobFailureCodeSourceWorkspaceFailed, JobFailureRetryPolicyNone},
+		{JobFailureCodeSourceExtractFailed, JobFailureRetryPolicyNone},
+		{JobFailureCodeScanFailed, JobFailureRetryPolicyNone},
 	}
 
 	for _, tc := range tests {
@@ -84,6 +92,27 @@ func TestPrepareJobFailureForPublishKnownCode(t *testing.T) {
 	}
 	if detail["script_release_id"] != "release-a" {
 		t.Fatalf("lost dispatch detail: %#v", detail)
+	}
+}
+
+func TestPrepareJobFailureForPublishScriptCodePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	// A Legion yak script supplies ReturnData.error_code; the dispatch bridge
+	// forwards it and publish normalization must keep it intact instead of
+	// bucketing it into node_reported_failure_unknown.
+	code, detail := prepareJobFailureForPublish(JobFailureCodeGitCloneError, nil)
+	if code != JobFailureCodeGitCloneError {
+		t.Fatalf("code = %q", code)
+	}
+	if detail[jobFailureDetailCodeKnown] != "true" {
+		t.Fatalf("detail = %#v", detail)
+	}
+	if detail[jobFailureDetailRetryPolicy] != string(JobFailureRetryPolicyTransient) {
+		t.Fatalf("retry policy = %q", detail[jobFailureDetailRetryPolicy])
+	}
+	if _, exists := detail[jobFailureDetailRawCode]; exists {
+		t.Fatalf("raw code must not appear for known codes: %#v", detail)
 	}
 }
 


### PR DESCRIPTION
## 背景

Legion 的 yak 脚本（`ssa_source_scan.yak` / `ssa_compile*.yak`）通过 `ReturnData.error_code` 上报细分失败码（`gitCloneError`、`notFoundFileCanCompile` 等），但 `prepareJobFailureForPublish` 会把未注册码归一成 `node_reported_failure_unknown`，导致 Legion 控制台丢失可翻译的细分 failure_code，只能显示兜底的「执行失败」。

## 改动

- `jobFailureCodeRegistry` 注册脚本失败码：
  - `gitCloneError` → `transient`（远端 Git 仓库 clone 常见瞬时网络中断）
  - `notFoundFileCanCompile` / `sourceConfigInvalid` / `sourceWorkspaceFailed` / `sourceExtractFailed` / `scan_failed` → `none`（确定性失败）
- 注册后脚本码在发布归一化中原样透传（`failure_code_known=true`，无 `raw_error_code` 降级）
- 扩展 `TestResolveJobFailureCodeKnownCodes` 码表，新增 `TestPrepareJobFailureForPublishScriptCodePassesThrough` 透传回归测试

## 说明

- registry 的 policy 仅作为 `error_detail_json` 元数据发布；实际重试决策由 Legion 侧 dispatch contract + 不可重试码集合决定
- 配套 Legion 平台改动：VillanCh/legion#439（source-scan 自动重试 + 失败原因细分）

## 测试

`go test ./scannode/ -run "TestResolveJobFailureCode|TestPrepareJobFailureForPublish" -count=1` 全部通过（本仓库 scannode 在 Windows 环境另有 9 个与本次改动无关的既有失败用例，已在干净基线验证）