### PR TITLE
perf(lowhttp): bound retained session and stream state

### DIFF
--- a/common/utils/lowhttp/config.go
+++ b/common/utils/lowhttp/config.go
@@ -969,7 +969,9 @@ func WithRedirectHandler(redirectHandler func(bool, []byte, []byte) bool) Lowhtt
 	}
 }
 
-// WithSession 指定 session 标识；cookie jar 在池中跨请求复用，调用方负责 RemoveCookiejar 或 poc.RemoveSession。
+// WithSession 指定 session 标识；cookie jar 在有界 LRU 池中跨请求复用。
+// 调用方仍应在确定不再使用时调用 RemoveCookiejar 或 poc.RemoveSession，
+// 以便及时释放 cookie；池达到容量时会自动淘汰最久未使用的 session。
 func WithSession(session string) LowhttpOpt {
 	return func(o *LowhttpExecConfig) {
 		o.Session = session

--- a/common/utils/lowhttp/conn_pool.go
+++ b/common/utils/lowhttp/conn_pool.go
@@ -47,6 +47,7 @@ func NewHttpConnPool(ctx context.Context, idleCount int, perHostCount int) *LowH
 		h2Tombstones:       newTombstoneQueue(defaultTombstoneQueueSize),
 		keepAliveTimeout:   30 * time.Second,
 		ctx:                ctx,
+		debugNotify:        make(chan struct{}, 1),
 	}
 	if idleCount > 0 {
 		pool.connSem = make(chan struct{}, idleCount)
@@ -73,8 +74,9 @@ type LowHttpConnPool struct {
 	h2Tombstones *tombstoneQueue         // bounded ring-buffer of recent close events (protected by h2Mu)
 
 	// debug: 每 5s 打印连接池状态；通过 EnableConnPoolDebug(true) 开启。
-	debugEnabled int32     // atomic bool (1 = on). controls the printer goroutine.
-	debugOnce    sync.Once // ensures the printer goroutine is started only once.
+	debugEnabled int32         // atomic bool (1 = on). controls the printer goroutine.
+	debugRunning int32         // atomic bool (1 = running). permits restart after disable.
+	debugNotify  chan struct{} // wakes the printer immediately on enable/disable.
 }
 
 func (l *LowHttpConnPool) HostConnFull(key *connectKey) bool {

--- a/common/utils/lowhttp/conn_pool_debug.go
+++ b/common/utils/lowhttp/conn_pool_debug.go
@@ -91,46 +91,71 @@ func (l *LowHttpConnPool) recordH2Tombstone(t h2ConnTombstone) {
 	l.h2Tombstones.push(t)
 }
 
-// EnableConnPoolDebug turns the periodic connection-pool status printer on
-// (true) or off (false).  When turned on, the first subsequent call to
-// getIdleConn will spawn a background goroutine that logs pool state every 5
-// seconds until the pool's context is cancelled.
+// EnableConnPoolDebug turns the periodic connection-pool status printer on or
+// off. Disabling stops the goroutine immediately; enabling can start it again.
 func (l *LowHttpConnPool) EnableConnPoolDebug(on bool) {
+	if l == nil {
+		return
+	}
 	if on {
 		atomic.StoreInt32(&l.debugEnabled, 1)
+		l.startDebugPrinter()
 	} else {
 		atomic.StoreInt32(&l.debugEnabled, 0)
 	}
+	l.notifyDebugPrinter()
 }
 
-// startDebugPrinter is called on every getIdleConn invocation.  At most one
-// printer goroutine is ever started (guarded by debugOnce).  The goroutine
-// exits automatically when the pool's context is cancelled.
-func (l *LowHttpConnPool) startDebugPrinter() {
-	if atomic.LoadInt32(&l.debugEnabled) == 0 {
-		return // debug not enabled, fast-exit without consuming the once
+func (l *LowHttpConnPool) notifyDebugPrinter() {
+	if l == nil || l.debugNotify == nil {
+		return
 	}
-	l.debugOnce.Do(func() {
-		go func() {
-			ticker := time.NewTicker(5 * time.Second)
-			defer ticker.Stop()
-			log.Infof("[connpool-debug] printer started (interval=5s)")
-			for {
-				select {
-				case <-l.ctx.Done():
-					log.Infof("[connpool-debug] printer stopped (pool context cancelled)")
-					return
-				case <-ticker.C:
-					if atomic.LoadInt32(&l.debugEnabled) == 0 {
-						// Debug was disabled at runtime; keep goroutine alive so
-						// it resumes if re-enabled without a new once.Do call.
-						continue
-					}
-					l.debugState()
-				}
+	select {
+	case l.debugNotify <- struct{}{}:
+	default:
+	}
+}
+
+// startDebugPrinter is called on enable and on every getIdleConn invocation.
+// The CAS permits at most one printer while allowing a stopped printer to be
+// restarted later.
+func (l *LowHttpConnPool) startDebugPrinter() {
+	if l == nil || atomic.LoadInt32(&l.debugEnabled) == 0 {
+		return
+	}
+	if !atomic.CompareAndSwapInt32(&l.debugRunning, 0, 1) {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		defer func() {
+			atomic.StoreInt32(&l.debugRunning, 0)
+			// Close the enable/exit race: if debug was re-enabled while the
+			// old goroutine was stopping, make sure a replacement is started.
+			if atomic.LoadInt32(&l.debugEnabled) == 1 && !l.contextDone() {
+				l.startDebugPrinter()
 			}
 		}()
-	})
+		log.Infof("[connpool-debug] printer started (interval=5s)")
+		for {
+			select {
+			case <-l.ctx.Done():
+				log.Infof("[connpool-debug] printer stopped (pool context cancelled)")
+				return
+			case <-l.debugNotify:
+				if atomic.LoadInt32(&l.debugEnabled) == 0 {
+					log.Infof("[connpool-debug] printer stopped (disabled)")
+					return
+				}
+			case <-ticker.C:
+				if atomic.LoadInt32(&l.debugEnabled) == 0 {
+					return
+				}
+				l.debugState()
+			}
+		}
+	}()
 }
 
 // debugState snapshots the pool and emits a structured log entry describing

--- a/common/utils/lowhttp/conn_pool_debug_lifecycle_test.go
+++ b/common/utils/lowhttp/conn_pool_debug_lifecycle_test.go
@@ -1,0 +1,36 @@
+package lowhttp
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnPoolDebugPrinterStopsAndRestarts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := NewHttpConnPool(ctx, 1, 1)
+
+	pool.EnableConnPoolDebug(true)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&pool.debugRunning) == 1
+	}, time.Second, time.Millisecond)
+
+	pool.EnableConnPoolDebug(false)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&pool.debugRunning) == 0
+	}, time.Second, time.Millisecond)
+
+	pool.EnableConnPoolDebug(true)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&pool.debugRunning) == 1
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&pool.debugRunning) == 0
+	}, time.Second, time.Millisecond)
+}

--- a/common/utils/lowhttp/cookie.go
+++ b/common/utils/lowhttp/cookie.go
@@ -11,22 +11,42 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/samber/lo"
 	"github.com/yaklang/yaklang/common/go-funk"
 	"github.com/yaklang/yaklang/common/utils"
 )
 
-var cookiejarPool = utils.NewSafeMapWithKey[string, http.CookieJar]()
+// Keep persistent sessions reusable without allowing caller-controlled session
+// names to grow a process-wide map forever. A hit refreshes the LRU position,
+// so ordinary long-lived sessions are retained while abandoned sessions are
+// evicted under pressure.
+const cookiejarPoolCapacity = 1024
+
+var (
+	cookiejarPool         = utils.NewLRUCacheWithKey[string, http.CookieJar](cookiejarPoolCapacity)
+	cookiejarPoolCreateMu sync.Mutex
+)
 
 func RemoveCookiejar(session string) {
 	if session == "" {
 		return
 	}
-	cookiejarPool.Delete(session)
+	cookiejarPoolCreateMu.Lock()
+	defer cookiejarPoolCreateMu.Unlock()
+	cookiejarPool.Remove(session)
 }
 
 func GetCookiejar(session string) http.CookieJar {
+	if jar, ok := cookiejarPool.Get(session); ok {
+		return jar
+	}
+
+	// Serialize only cache misses. The second lookup makes creation atomic for
+	// one session while keeping the common hit path concurrent.
+	cookiejarPoolCreateMu.Lock()
+	defer cookiejarPoolCreateMu.Unlock()
 	if jar, ok := cookiejarPool.Get(session); ok {
 		return jar
 	}

--- a/common/utils/lowhttp/http2_client.go
+++ b/common/utils/lowhttp/http2_client.go
@@ -480,6 +480,10 @@ func (h2Conn *http2ClientConn) newStream(req *http.Request, packet []byte, optio
 	}
 
 	cs := h2Conn.http2StreamPool.Get().(*http2ClientStream)
+	// A stream returned by sync.Pool may contain state from its previous
+	// request. Zero it before initialization so protocol flags and callbacks
+	// can never bleed into the next stream.
+	*cs = http2ClientStream{}
 	cs.h2Conn = h2Conn
 	cs.ID = 0 // assigned later in doRequest under frWriteMutex to guarantee wire order
 	cs.resp = new(http.Response)
@@ -837,8 +841,21 @@ func (cs *http2ClientStream) waitResponse(ctx context.Context, timeout time.Dura
 	cs.respPacket, _ = utils.DumpHTTPResponse(cs.resp, len(cs.bodyBuffer.Bytes()) > 0)
 	resp := *cs.resp
 	responsePacket := cs.respPacket
-	cs.h2Conn.http2StreamPool.Put(cs) // gc
+	cs.recycle()
 	return resp, responsePacket, err
+}
+
+// recycle drops every request-owned reference before returning the stream to
+// sync.Pool. Without the reset, an idle HTTP/2 connection can retain the most
+// recent request, response, packet buffers, callbacks, and configuration until
+// the pool entry is reused or a GC cycle discards it.
+func (cs *http2ClientStream) recycle() {
+	if cs == nil || cs.h2Conn == nil || cs.h2Conn.http2StreamPool == nil {
+		return
+	}
+	pool := cs.h2Conn.http2StreamPool
+	*cs = http2ClientStream{}
+	pool.Put(cs)
 }
 
 // releaseSlot removes a stream from the connection without affecting other
@@ -866,7 +883,7 @@ func (cs *http2ClientStream) abort() {
 	}
 	cs.resetStream(http2.ErrCodeCancel)
 	cs.releaseSlot()
-	cs.h2Conn.http2StreamPool.Put(cs)
+	cs.recycle()
 }
 
 func (cs *http2ClientStream) resetStream(code http2.ErrCode) {

--- a/common/utils/lowhttp/http2_stream_retention_test.go
+++ b/common/utils/lowhttp/http2_stream_retention_test.go
@@ -1,0 +1,76 @@
+package lowhttp
+
+import (
+	"bytes"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP2StreamRecycleDropsRequestOwnedReferences(t *testing.T) {
+	streamPool := &sync.Pool{New: func() any { return new(http2ClientStream) }}
+	h2Conn := &http2ClientConn{http2StreamPool: streamPool}
+	stream := &http2ClientStream{
+		h2Conn:                 h2Conn,
+		ID:                     9,
+		req:                    &http.Request{},
+		reqPacket:              bytes.Repeat([]byte("q"), 1<<20),
+		resp:                   &http.Response{Header: make(http.Header)},
+		bodyBuffer:             bytes.NewBuffer(bytes.Repeat([]byte("b"), 1<<20)),
+		respPacket:             bytes.Repeat([]byte("r"), 1<<20),
+		hPackByte:              bytes.NewBuffer(bytes.Repeat([]byte("h"), 4096)),
+		readHeaderEnd:          true,
+		callbackLock:           new(sync.Mutex),
+		readFirstFrameCallback: func() {},
+		option:                 &LowhttpExecConfig{Payloads: []string{"retained"}},
+		bodyStreamDone:         make(chan struct{}),
+	}
+
+	stream.recycle()
+	recycled := streamPool.Get().(*http2ClientStream)
+	require.Nil(t, recycled.h2Conn)
+	require.Zero(t, recycled.ID)
+	require.Nil(t, recycled.req)
+	require.Nil(t, recycled.reqPacket)
+	require.Nil(t, recycled.resp)
+	require.Nil(t, recycled.bodyBuffer)
+	require.Nil(t, recycled.respPacket)
+	require.Nil(t, recycled.hPackByte)
+	require.False(t, recycled.readHeaderEnd)
+	require.Nil(t, recycled.readFirstFrameCallback)
+	require.Nil(t, recycled.option)
+	require.Nil(t, recycled.bodyStreamDone)
+}
+
+func TestHTTP2NewStreamClearsReusedProtocolState(t *testing.T) {
+	streamPool := &sync.Pool{New: func() any { return new(http2ClientStream) }}
+	streamPool.Put(&http2ClientStream{
+		readHeaderEnd:          true,
+		headersHandled:         true,
+		respPacket:             []byte("old response"),
+		readFirstFrameCallback: func() {},
+	})
+
+	idleTimer := time.NewTimer(time.Hour)
+	defer idleTimer.Stop()
+	h2Conn := &http2ClientConn{
+		mu:              new(sync.Mutex),
+		maxStreamsCount: 1,
+		idleTimer:       idleTimer,
+		http2StreamPool: streamPool,
+	}
+	h2Conn.streamsCond = sync.NewCond(h2Conn.mu)
+
+	stream, err := h2Conn.newStream(&http.Request{}, []byte("GET / HTTP/2\r\n\r\n"), nil)
+	require.NoError(t, err)
+	require.False(t, stream.readHeaderEnd)
+	require.False(t, stream.headersHandled)
+	require.Nil(t, stream.respPacket)
+	require.Nil(t, stream.readFirstFrameCallback)
+
+	stream.releaseSlot()
+	stream.recycle()
+}

--- a/common/utils/lowhttp/poc/poc.go
+++ b/common/utils/lowhttp/poc/poc.go
@@ -3400,8 +3400,8 @@ func extractContentLength(headerBytes []byte) int64 {
 	return size
 }
 
-// RemoveSession 清除指定的 session，删除其关联的 cookiejar
-// 这在完成一系列请求后清理资源时很有用
+// RemoveSession 清除指定的 session，删除其关联的 cookiejar。
+// session 池本身有容量上限，但主动清理可以更早释放 cookie 数据。
 // 参数:
 //   - session: 要清除的 session 标识符
 //

--- a/common/utils/lowhttp/session_cookiejar_leak_test.go
+++ b/common/utils/lowhttp/session_cookiejar_leak_test.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/utils"
 )
@@ -34,22 +34,53 @@ func httpGetSetCookie(t *testing.T, addr string, opts ...LowhttpOpt) {
 	require.NoError(t, err)
 }
 
-// 显式 WithSession 且未 RemoveCookiejar：jar 留在池中（持久 session）。
-func TestCookiejarPool_persistentSessionWithoutCleanup(t *testing.T) {
-	baseline := CookiejarPoolCount()
-	addr := cookiejarLeakMockAddr(t)
+func resetCookiejarPoolForTest(t *testing.T) {
+	t.Helper()
+	cookiejarPool.Purge()
+	t.Cleanup(cookiejarPool.Purge)
+}
 
-	const n = 30
-	for i := 0; i < n; i++ {
-		httpGetSetCookie(t, addr, WithSession(uuid.NewString()))
+// 调用方可控的 session 名不能让进程级 cookiejar 池无限增长。
+func TestCookiejarPool_persistentSessionsAreBounded(t *testing.T) {
+	resetCookiejarPoolForTest(t)
+
+	const extra = 64
+	for i := 0; i < cookiejarPoolCapacity+extra; i++ {
+		GetCookiejar(fmt.Sprintf("session-%d", i))
 	}
 
-	require.GreaterOrEqual(t, CookiejarPoolCount()-baseline, n-3)
+	require.Equal(t, cookiejarPoolCapacity, CookiejarPoolCount())
+	_, oldestStillPresent := cookiejarPool.Get("session-0")
+	require.False(t, oldestStillPresent, "least-recently-used session should be evicted")
+}
+
+func TestCookiejarPool_concurrentSameSessionUsesOneJar(t *testing.T) {
+	resetCookiejarPoolForTest(t)
+
+	const workers = 64
+	jars := make([]http.CookieJar, workers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range jars {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			jars[index] = GetCookiejar("shared")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 1; i < len(jars); i++ {
+		require.True(t, jars[i] == jars[0], "same session created more than one cookie jar")
+	}
+	require.Equal(t, 1, CookiejarPoolCount())
 }
 
 // 未传 session：HTTP() 内 session 为空时自动分配并在结束后清理。
 func TestCookiejarPool_ephemeralSessionWithoutExplicitSession(t *testing.T) {
-	baseline := CookiejarPoolCount()
+	resetCookiejarPoolForTest(t)
 	addr := cookiejarLeakMockAddr(t)
 
 	const n = 30
@@ -57,12 +88,12 @@ func TestCookiejarPool_ephemeralSessionWithoutExplicitSession(t *testing.T) {
 		httpGetSetCookie(t, addr)
 	}
 
-	require.LessOrEqual(t, CookiejarPoolCount()-baseline, 2)
+	require.Zero(t, CookiejarPoolCount())
 }
 
 // DisableSession：不分配 session，cookie jar 池不增长。
 func TestCookiejarPool_disableSessionDoesNotUseCookiejar(t *testing.T) {
-	baseline := CookiejarPoolCount()
+	resetCookiejarPoolForTest(t)
 	addr := cookiejarLeakMockAddr(t)
 
 	const n = 30
@@ -70,5 +101,5 @@ func TestCookiejarPool_disableSessionDoesNotUseCookiejar(t *testing.T) {
 		httpGetSetCookie(t, addr, WithDisableSession(true))
 	}
 
-	require.LessOrEqual(t, CookiejarPoolCount()-baseline, 0)
+	require.Zero(t, CookiejarPoolCount())
 }


### PR DESCRIPTION
## Summary

- bound explicit-session cookie jars with a 1024-entry access-refreshed LRU and serialize same-session creation
- clear all HTTP/2 stream state before reuse and drop request/config/packet/body/callback references before returning streams to `sync.Pool`
- make the connection-pool debug printer stop on disable and restart safely without retaining temporary pools
- add focused retention, concurrency, reuse-state, and goroutine-lifecycle regression tests

## Why

The process-wide cookie jar registry grew forever when callers supplied unbounded unique session IDs. HTTP/2 pooled streams also retained complete request-owned object graphs until pool reuse or GC, and stale protocol fields could survive reuse. Disabling pool debug output muted logging but did not stop its background goroutine.

## Compatibility

- normal persistent-session behavior is unchanged below the 1024-session bound
- least-recently-used inactive sessions are evicted only after the bound is exceeded; callers can still use `poc.RemoveSession` for deterministic cleanup
- HTTP wire behavior and public request APIs are unchanged
- this is independent from and based on the already-merged #4986

## Tests

- `go test -race ./common/utils/lowhttp -run TestCookiejarPool_|TestHTTP2...|TestConnPoolDebugPrinterStopsAndRestarts -count=10`
- `go test ./common/utils/lowhttp ./common/utils/lowhttp/poc -timeout 6m -count=1`
- `git diff --check origin/main...HEAD`

## Follow-ups intentionally excluded

The remaining high-risk areas need separate API and compatibility work: fully buffered `WithMaxContentLength` handling, unbounded WebSocket frame/decompression allocation, and a global HTTP/2 burst-connection cap.