### PR TITLE
perf(yakvm): reduce hot reload execution overhead

### DIFF
--- a/common/yak/antlr4yak/code_template_immutability_test.go
+++ b/common/yak/antlr4yak/code_template_immutability_test.go
@@ -1,0 +1,357 @@
+package antlr4yak
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+type compiledCodeTemplateState struct {
+	code       *yakvm.Code
+	opcode     yakvm.OpcodeFlag
+	unary      int
+	op1        *yakvm.Value
+	op2        *yakvm.Value
+	op1Type    string
+	op1Literal string
+	op1Symbol  int
+	function   *yakvm.Function
+	funcScope  uintptr
+	funcFrame  uintptr
+	funcBind   string
+}
+
+func privateFunctionPointer(t *testing.T, function *yakvm.Function, fieldName string) uintptr {
+	t.Helper()
+	field := reflect.ValueOf(function).Elem().FieldByName(fieldName)
+	require.True(t, field.IsValid(), "Function.%s disappeared", fieldName)
+	require.Equal(t, reflect.Ptr, field.Kind(), "Function.%s changed kind", fieldName)
+	return field.Pointer()
+}
+
+func snapshotCompiledCodeTemplates(t *testing.T, codes []*yakvm.Code) ([]compiledCodeTemplateState, bool, bool, bool) {
+	t.Helper()
+	states := make([]compiledCodeTemplateState, 0, len(codes))
+	seen := make(map[*yakvm.Code]struct{})
+	var sawFunctionPush0, sawFunctionPush1, sawEllipsisCall bool
+
+	var walk func([]*yakvm.Code)
+	walk = func(current []*yakvm.Code) {
+		for index, code := range current {
+			if code == nil {
+				continue
+			}
+			if _, ok := seen[code]; ok {
+				continue
+			}
+			seen[code] = struct{}{}
+
+			state := compiledCodeTemplateState{
+				code:   code,
+				opcode: code.Opcode,
+				unary:  code.Unary,
+				op1:    code.Op1,
+				op2:    code.Op2,
+			}
+			if code.Op1 != nil {
+				state.op1Type = code.Op1.TypeVerbose
+				state.op1Literal = code.Op1.Literal
+				state.op1Symbol = code.Op1.SymbolId
+				if function, ok := code.Op1.Value.(*yakvm.Function); ok {
+					state.function = function
+					state.funcScope = privateFunctionPointer(t, function, "scope")
+					state.funcFrame = privateFunctionPointer(t, function, "defineFrame")
+					state.funcBind = function.GetBindName()
+					if code.Opcode == yakvm.OpPush && code.Unary == 0 {
+						sawFunctionPush0 = true
+					}
+					if code.Opcode == yakvm.OpPush && code.Unary == 1 {
+						sawFunctionPush1 = true
+					}
+					walk(function.GetCodes())
+				}
+				if nested, ok := code.Op1.Value.([]*yakvm.Code); ok {
+					walk(nested)
+				}
+			}
+			states = append(states, state)
+
+			if code.Opcode == yakvm.OpEllipsis && index+1 < len(current) {
+				next := current[index+1]
+				sawEllipsisCall = next.Opcode == yakvm.OpCall || next.Opcode == yakvm.OpAsyncCall
+			}
+		}
+	}
+	walk(codes)
+	return states, sawFunctionPush0, sawFunctionPush1, sawEllipsisCall
+}
+
+func assertCompiledCodeTemplatesUnchanged(t *testing.T, states []compiledCodeTemplateState) {
+	t.Helper()
+	for _, state := range states {
+		require.Equal(t, state.opcode, state.code.Opcode)
+		require.Equal(t, state.unary, state.code.Unary, "compiled unary changed for %s", state.opcode)
+		require.Same(t, state.op1, state.code.Op1, "compiled Op1 changed for %s", state.opcode)
+		require.Same(t, state.op2, state.code.Op2, "compiled Op2 changed for %s", state.opcode)
+		if state.op1 != nil {
+			require.Equal(t, state.op1Type, state.code.Op1.TypeVerbose)
+			require.Equal(t, state.op1Literal, state.code.Op1.Literal)
+			require.Equal(t, state.op1Symbol, state.code.Op1.SymbolId)
+		}
+		if state.function != nil {
+			currentFunction, ok := state.code.Op1.Value.(*yakvm.Function)
+			require.True(t, ok)
+			require.Same(t, state.function, currentFunction, "compiled Function changed for %s", state.opcode)
+			require.Equal(t, state.funcScope, privateFunctionPointer(t, currentFunction, "scope"), "template Function.scope changed")
+			require.Equal(t, state.funcFrame, privateFunctionPointer(t, currentFunction, "defineFrame"), "template Function.defineFrame changed")
+			require.Equal(t, state.funcBind, currentFunction.GetBindName(), "template Function bind name changed")
+		}
+	}
+}
+
+// marshalCodePayload removes the symbol-table prefix. Symbol names are stored
+// from a Go map and may legitimately be emitted in a different order; the
+// remaining bytes are the deterministic recursive Code/Function payload.
+func marshalCodePayload(t *testing.T, symbolTable *yakvm.SymbolTable, codes []*yakvm.Code) []byte {
+	t.Helper()
+	raw, err := yakvm.NewCodesMarshaller().Marshal(symbolTable, codes)
+	require.NoError(t, err)
+
+	consumeVarint := func() uint64 {
+		value, size := protowire.ConsumeVarint(raw)
+		require.Positive(t, size, "invalid varint in marshalled symbol table")
+		raw = raw[size:]
+		return value
+	}
+	consumeBytes := func() {
+		_, size := protowire.ConsumeBytes(raw)
+		require.Positive(t, size, "invalid bytes field in marshalled symbol table")
+		raw = raw[size:]
+	}
+
+	tableCount := int(consumeVarint())
+	for tableIndex := 0; tableIndex < tableCount; tableIndex++ {
+		consumeVarint() // table index
+		consumeBytes()  // verbose
+		consumeVarint() // current symbol index
+		consumeVarint() // parent index
+		childCount := int(consumeVarint())
+		for childIndex := 0; childIndex < childCount; childIndex++ {
+			consumeVarint()
+		}
+		symbolCount := int(consumeVarint())
+		for symbolIndex := 0; symbolIndex < symbolCount; symbolIndex++ {
+			consumeBytes()
+			consumeVarint()
+		}
+	}
+
+	codeCount, size := protowire.ConsumeVarint(raw)
+	require.Positive(t, size, "missing marshalled code count")
+	require.Equal(t, len(codes), int(codeCount))
+	return append([]byte(nil), raw...)
+}
+
+func TestCompiledCodeTemplatesRemainImmutableAfterExecution(t *testing.T) {
+	const source = `
+factory = func(base) {
+    captured = func(delta) { return base + delta }
+    pure = func() { return 7 }
+    return captured(3) + pure()
+}
+closureResult = factory(10)
+
+sum = func(head, values...) {
+    total = head
+    for value in values { total += value }
+    return total
+}
+spreadResult = sum(100, [1, 2, 3]...)
+`
+
+	engine := New()
+	compiler, err := engine._compile(source, engine.rootSymbol)
+	require.NoError(t, err)
+	codes := compiler.GetOpcodes()
+	symbolTable := compiler.GetRootSymbolTable()
+
+	states, sawPush0, sawPush1, sawEllipsisCall := snapshotCompiledCodeTemplates(t, codes)
+	require.True(t, sawPush0, "fixture must contain the no-reference Function OpPush path")
+	require.True(t, sawPush1, "fixture must contain the Function-copy OpPush path")
+	require.True(t, sawEllipsisCall, "fixture must contain Ellipsis followed by Call")
+	for _, state := range states {
+		if state.function != nil {
+			require.Zero(t, state.funcScope, "compiled Function template unexpectedly has a scope")
+			require.Zero(t, state.funcFrame, "compiled Function template unexpectedly has a define frame")
+		}
+	}
+	beforePayload := marshalCodePayload(t, symbolTable, codes)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, engine.vm.ExecYakCode(ctx, source, codes, yakvm.None))
+	require.Equal(t, 20, engine.Var("closureResult"))
+	require.Equal(t, 106, engine.Var("spreadResult"))
+
+	assertCompiledCodeTemplatesUnchanged(t, states)
+	afterPayload := marshalCodePayload(t, symbolTable, codes)
+	require.Equal(t, beforePayload, afterPayload, "recursive compiled Code payload changed after execution")
+}
+
+func TestCachedMarshalOverlapsUnfinishedAsyncCodeSafely(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	const workerCount = 16
+
+	var ready sync.WaitGroup
+	ready.Add(workerCount)
+	allReady := make(chan struct{})
+	go func() {
+		ready.Wait()
+		close(allReady)
+	}()
+	start := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(start) })
+	var started sync.WaitGroup
+	started.Add(workerCount)
+	allStarted := make(chan struct{})
+	go func() {
+		started.Wait()
+		close(allStarted)
+	}()
+	var stop atomic.Bool
+
+	type workerResult struct {
+		round int
+		value int
+	}
+	results := make(map[int]workerResult, workerCount)
+	var resultsMu sync.Mutex
+	engine := New()
+	engine.ImportLibs(map[string]interface{}{
+		"templateTestReady":     func() { ready.Done() },
+		"templateTestWaitStart": func() { <-start },
+		"templateTestAwaitReady": func() {
+			select {
+			case <-allReady:
+			case <-time.After(10 * time.Second):
+				panic("timed out waiting for Yak async workers")
+			}
+		},
+		"templateTestRelease": func() { releaseOnce.Do(func() { close(start) }) },
+		"templateTestStarted": func() { started.Done() },
+		"templateTestAwaitStarted": func() {
+			select {
+			case <-allStarted:
+			case <-time.After(10 * time.Second):
+				panic("timed out waiting for Yak async workers to start executing")
+			}
+		},
+		"templateTestShouldStop": func() bool { return stop.Load() },
+		"templateTestYield":      runtime.Gosched,
+		"templateTestEvalSource": func(id int) string {
+			return fmt.Sprintf("templateDynamic%d = %d", id, id)
+		},
+		"templateTestRecord": func(id, round, value int) {
+			resultsMu.Lock()
+			results[id] = workerResult{round: round, value: value}
+			resultsMu.Unlock()
+		},
+	})
+
+	var source strings.Builder
+	fmt.Fprintf(&source, `
+workerCount = %d
+cases = [[], [1], [1, 2, 3], [1, 2, 3, 4, 5, 6, 7, 8]]
+
+countArgs = func(values...) {
+    count = 0
+    for value in values { count++ }
+    return count
+}
+invoke = func(values) { return countArgs(100, values...) }
+hot = func(id, round) {
+    base = id * 1000 + round
+    captured = func(delta) { return base + delta }
+    pure = func() { return 7 }
+    return captured(3) + pure() + invoke(cases[(id + round) %% 4])
+}
+worker = func(id) {
+    templateTestReady()
+    templateTestWaitStart()
+	// Signal before eval so the top-level frame can return and begin its
+	// deferred yakc marshal while these workers are still compiling unique
+	// symbols into the shared live SymbolTable.
+	templateTestStarted()
+	eval(templateTestEvalSource(id))
+    round = 0
+    last = hot(id, round)
+    for {
+        if templateTestShouldStop() { break }
+        round++
+        last = hot(id, round)
+        templateTestYield()
+    }
+    templateTestRecord(id, round, last)
+}
+for id := 0; id < workerCount; id++ { go worker(id) }
+templateTestAwaitReady()
+templateTestRelease()
+templateTestAwaitStarted()
+
+// Force the deferred cache marshaller to walk a large recursive Function body
+// while the released workers above are still executing the shared hot codes.
+padding = func() {
+`, workerCount)
+	for index := 0; index < 1200; index++ {
+		fmt.Fprintf(&source, "    paddingValue%d = %d\n", index, index)
+	}
+	fmt.Fprintf(&source, "    return 0\n}\n// cache-overlap-%s\n", t.TempDir())
+	code := source.String()
+	require.Greater(t, len(code), YAKC_CACHE_MAX_LENGTH)
+	hash := calcHash(code, nil)
+	t.Cleanup(func() { yakcCache.Remove(hash) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	evalErr := engine.SafeEval(ctx, code)
+	stop.Store(true)
+	waitDone := make(chan struct{})
+	go func() {
+		engine.vm.AsyncWait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-ctx.Done():
+		t.Fatalf("Yak async workers did not finish: %v", ctx.Err())
+	}
+	require.NoError(t, evalErr)
+
+	resultsMu.Lock()
+	require.Len(t, results, workerCount)
+	for id := 0; id < workerCount; id++ {
+		result := results[id]
+		caseLength := []int{0, 1, 3, 8}[(id+result.round)%4]
+		expected := id*1000 + result.round + 11 + caseLength
+		require.Equal(t, expected, result.value, "worker %d returned a crossed closure/spread result", id)
+	}
+	resultsMu.Unlock()
+
+	artifact, ok := HaveYakcCache(code)
+	require.True(t, ok, "cache-enabled Eval did not persist its yakc artifact")
+	symbolTable, cachedCodes, err := engine.UnMarshal(artifact, nil, code)
+	require.NoError(t, err)
+	require.NotNil(t, symbolTable)
+	require.NotEmpty(t, cachedCodes)
+}

--- a/common/yak/antlr4yak/cross_vm_sandbox_test.go
+++ b/common/yak/antlr4yak/cross_vm_sandbox_test.go
@@ -1,0 +1,303 @@
+package antlr4yak
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
+)
+
+type crossVMCapture struct {
+	index            int
+	line             int
+	runtimeID        string
+	value            string
+	engineLine       int
+	engineRuntimeID  string
+	engineRuntimeErr error
+}
+
+func newCrossVMSandboxFixture(t *testing.T, captures chan<- crossVMCapture) (*Engine, *yakvm.Function) {
+	t.Helper()
+
+	definitionEngine := New()
+	definitionEngine.SetVars(map[string]any{"runtimeId": "definition-runtime"})
+	definitionEngine.ImportLibs(map[string]any{
+		"outerOnly": func() string { return "outer-library" },
+		"capture": func(index, line int, runtimeID, value string) {
+			capture := crossVMCapture{
+				index:     index,
+				line:      line,
+				runtimeID: runtimeID,
+				value:     value,
+			}
+			engineLine, lineErr := definitionEngine.RuntimeInfo("line")
+			engineRuntimeID, runtimeIDErr := definitionEngine.RuntimeInfo("runtimeId")
+			if lineErr != nil {
+				capture.engineRuntimeErr = lineErr
+			} else if runtimeIDErr != nil {
+				capture.engineRuntimeErr = runtimeIDErr
+			} else {
+				capture.engineLine, _ = engineLine.(int)
+				capture.engineRuntimeID = fmt.Sprint(engineRuntimeID)
+			}
+			captures <- capture
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, definitionEngine.SafeEvalWithoutCache(ctx, `
+factory = func(prefix) {
+    return func(index) {
+        line = runtime.GetInfo("line")~
+        runtimeID = runtime.GetInfo("runtimeId")~
+        value = prefix + ":" + outerOnly()
+        capture(index, line, runtimeID, value)
+        return value
+    }
+}
+external = factory("closed")
+unstable = func(shouldPanic) {
+    if shouldPanic { panic("cross-vm-panic") }
+    return "recovered"
+}
+`))
+
+	rawFunction, ok := definitionEngine.GetVar("external")
+	require.True(t, ok)
+	function, ok := rawFunction.(*yakvm.Function)
+	require.True(t, ok)
+	require.NotNil(t, function)
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+	return definitionEngine, function
+}
+
+func assertCrossVMCapture(t *testing.T, capture crossVMCapture, index int) {
+	t.Helper()
+	require.Equal(t, index, capture.index)
+	require.Positive(t, capture.line)
+	require.Equal(t, "definition-runtime", capture.runtimeID)
+	require.Equal(t, "closed:outer-library", capture.value)
+	require.NoError(t, capture.engineRuntimeErr)
+	// The Yak query runs on its assignment while Engine.RuntimeInfo runs from
+	// inside capture(), so they intentionally observe different instructions in
+	// the same external function frame.
+	require.Positive(t, capture.engineLine)
+	require.Equal(t, capture.runtimeID, capture.engineRuntimeID)
+}
+
+func TestCrossVMSandboxFunctionUsesDefinitionFrame(t *testing.T) {
+	captures := make(chan crossVMCapture, 1)
+	definitionEngine, function := newCrossVMSandboxFixture(t, captures)
+
+	sandboxEngine := New()
+	sandboxEngine.SetVars(map[string]any{"runtimeId": "sandbox-runtime"})
+	sandboxEngine.ImportLibs(map[string]any{"external": function})
+	sandboxEngine.SetSandboxMode(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, sandboxEngine.SafeEvalWithoutCache(ctx, `result = external(7)`))
+	result, ok := sandboxEngine.GetVar("result")
+	require.True(t, ok)
+	require.Equal(t, "closed:outer-library", result)
+	assertCrossVMCapture(t, <-captures, 7)
+
+	// Both the orchestration VM and the definition VM must be back at an idle
+	// stack after the cross-VM call. A subsequent call proves that no stale top
+	// frame changes parent selection.
+	require.Nil(t, sandboxEngine.GetVM().CurrentFM())
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+	require.NoError(t, sandboxEngine.SafeEvalWithoutCache(ctx, `result = external(8)`))
+	assertCrossVMCapture(t, <-captures, 8)
+	require.Nil(t, sandboxEngine.GetVM().CurrentFM())
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+}
+
+func TestCrossVMSandboxPanicDoesNotPoisonNextCall(t *testing.T) {
+	captures := make(chan crossVMCapture, 1)
+	definitionEngine, function := newCrossVMSandboxFixture(t, captures)
+	rawUnstable, ok := definitionEngine.GetVar("unstable")
+	require.True(t, ok)
+	unstable, ok := rawUnstable.(*yakvm.Function)
+	require.True(t, ok)
+
+	sandboxEngine := New()
+	sandboxEngine.ImportLibs(map[string]any{
+		"external": function,
+		"unstable": unstable,
+	})
+	sandboxEngine.SetSandboxMode(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := sandboxEngine.SafeEvalWithoutCache(ctx, `unstable(true)`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cross-vm-panic")
+	require.Nil(t, sandboxEngine.GetVM().CurrentFM())
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+
+	// Recovering the first call must clear only that invocation's coroutine.
+	// A fresh call must not inherit its panic or a stale definition-side frame.
+	require.NoError(t, sandboxEngine.SafeEvalWithoutCache(ctx, `
+result = unstable(false)
+external(9)
+`))
+	result, ok := sandboxEngine.GetVar("result")
+	require.True(t, ok)
+	require.Equal(t, "recovered", result)
+	assertCrossVMCapture(t, <-captures, 9)
+	require.Nil(t, sandboxEngine.GetVM().CurrentFM())
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+}
+
+func TestCrossVMSandboxAsyncFunctionsUseDefinitionFrame(t *testing.T) {
+	const workers = 24
+	captures := make(chan crossVMCapture, workers)
+	definitionEngine, function := newCrossVMSandboxFixture(t, captures)
+
+	sandboxEngine := New()
+	sandboxEngine.SetVars(map[string]any{"runtimeId": "sandbox-runtime"})
+	sandboxEngine.ImportLibs(map[string]any{"external": function})
+	sandboxEngine.SetSandboxMode(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, sandboxEngine.SafeEvalWithoutCache(ctx, `
+for index in 24 {
+    go external(index)
+}
+waitAllAsyncCallFinish()
+`))
+
+	seen := make(map[int]struct{}, workers)
+	for i := 0; i < workers; i++ {
+		select {
+		case capture := <-captures:
+			assertCrossVMCapture(t, capture, capture.index)
+			seen[capture.index] = struct{}{}
+		case <-ctx.Done():
+			t.Fatalf("received %d/%d cross-VM async captures: %v", i, workers, ctx.Err())
+		}
+	}
+	require.Len(t, seen, workers)
+	require.Nil(t, sandboxEngine.GetVM().CurrentFM())
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+}
+
+func TestConcurrentCrossVMSandboxFunctionsKeepFramesIsolated(t *testing.T) {
+	const workers = 16
+	captures := make(chan crossVMCapture, workers)
+	definitionEngine, function := newCrossVMSandboxFixture(t, captures)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var wait sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			sandboxEngine := New()
+			sandboxEngine.SetVars(map[string]any{"runtimeId": fmt.Sprintf("sandbox-%d", index)})
+			sandboxEngine.ImportLibs(map[string]any{"external": function, "index": index})
+			sandboxEngine.SetSandboxMode(true)
+			errs <- sandboxEngine.SafeEvalWithoutCache(ctx, `external(index)`)
+		}(i)
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	seen := make(map[int]struct{}, workers)
+	for i := 0; i < workers; i++ {
+		capture := <-captures
+		assertCrossVMCapture(t, capture, capture.index)
+		seen[capture.index] = struct{}{}
+	}
+	require.Len(t, seen, workers)
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+}
+
+func TestConcurrentCrossVMSandboxPanicDoesNotLeakBetweenCallers(t *testing.T) {
+	const workers = 16
+	started := make(chan struct{}, workers)
+	release := make(chan struct{})
+
+	definitionEngine := New()
+	definitionEngine.ImportLibs(map[string]any{
+		"blockUntilReleased": func() {
+			started <- struct{}{}
+			<-release
+		},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, definitionEngine.SafeEvalWithoutCache(ctx, `
+concurrentUnstable = func(shouldPanic) {
+    blockUntilReleased()
+    if shouldPanic { panic("cross-vm-concurrent-panic") }
+    return "clean"
+}
+`))
+	rawFunction, ok := definitionEngine.GetVar("concurrentUnstable")
+	require.True(t, ok)
+	function, ok := rawFunction.(*yakvm.Function)
+	require.True(t, ok)
+
+	type outcome struct {
+		index  int
+		result any
+		err    error
+	}
+	outcomes := make(chan outcome, workers)
+	var wait sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			sandboxEngine := New()
+			sandboxEngine.SetVars(map[string]any{"shouldPanic": index%2 == 0})
+			sandboxEngine.ImportLibs(map[string]any{"concurrentUnstable": function})
+			sandboxEngine.SetSandboxMode(true)
+			err := sandboxEngine.SafeEvalWithoutCache(ctx, `result = concurrentUnstable(shouldPanic)`)
+			result, _ := sandboxEngine.GetVar("result")
+			outcomes <- outcome{index: index, result: result, err: err}
+		}(i)
+	}
+
+	// Release every invocation together so successful and panicking calls share
+	// the definition VM concurrently. Reusing the function's definition
+	// coroutine would let one invocation's lastPanic poison an unrelated caller.
+	for i := 0; i < workers; i++ {
+		select {
+		case <-started:
+		case <-ctx.Done():
+			t.Fatalf("started %d/%d cross-VM calls: %v", i, workers, ctx.Err())
+		}
+	}
+	close(release)
+	wait.Wait()
+	close(outcomes)
+
+	seen := make(map[int]struct{}, workers)
+	for result := range outcomes {
+		seen[result.index] = struct{}{}
+		if result.index%2 == 0 {
+			require.Error(t, result.err)
+			require.Contains(t, result.err.Error(), "cross-vm-concurrent-panic")
+			continue
+		}
+		require.NoError(t, result.err)
+		require.Equal(t, "clean", result.result)
+	}
+	require.Len(t, seen, workers)
+	require.Nil(t, definitionEngine.GetVM().CurrentFM())
+}

--- a/common/yak/antlr4yak/debugger_test.go
+++ b/common/yak/antlr4yak/debugger_test.go
@@ -2,9 +2,11 @@ package antlr4yak
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +29,102 @@ func RunTestDebugger(code string, debuggerInit, debuggerCallBack func(g *yakvm.D
 	engine.SetDebugCallback(debuggerCallBack)
 	engine.SetSourceFilePath("/xxx/test.yak")
 	engine.Eval(context.Background(), code)
+}
+
+func TestDebugger_CancelBeforeFirstOpcodeFinishesLifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	engine := New()
+	engine.SetDebugMode(true)
+	engine.SetSourceFilePath("/xxx/cancel-before-first-opcode.yak")
+
+	var debugger *yakvm.Debugger
+	var finishedCallbacks atomic.Int32
+	engine.SetDebugInit(func(g *yakvm.Debugger) {
+		debugger = g
+		// Debug init runs after the root frame is installed but before Frame.Exec.
+		// This deterministically exercises cancellation before ShouldCallback.
+		cancel()
+	})
+	engine.SetDebugCallback(func(g *yakvm.Debugger) {
+		if g.Finished() {
+			finishedCallbacks.Add(1)
+		}
+	})
+
+	err := engine.EvalWithoutCache(ctx, "a = 1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if debugger == nil {
+		t.Fatal("debugger init callback was not called")
+	}
+
+	started := make(chan struct{})
+	go func() {
+		debugger.StartWGWait()
+		close(started)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("debugger start waiter was not released by terminal callback")
+	}
+
+	if !debugger.Finished() {
+		t.Fatal("debugger was not marked finished")
+	}
+	if got := finishedCallbacks.Load(); got != 1 {
+		t.Fatalf("expected exactly one finished callback, got %d", got)
+	}
+}
+
+func TestDebugger_EmptySourceFinishesLifecycle(t *testing.T) {
+	for name, source := range map[string]string{
+		"empty":        "",
+		"comment-only": "// no executable opcode",
+	} {
+		t.Run(name, func(t *testing.T) {
+			engine := New()
+			engine.SetDebugMode(true)
+			engine.SetSourceFilePath("/xxx/" + name + ".yak")
+			engine.SetDebugInit(func(*yakvm.Debugger) {})
+
+			var finishedCallbacks atomic.Int32
+			engine.SetDebugCallback(func(g *yakvm.Debugger) {
+				if g.Finished() {
+					finishedCallbacks.Add(1)
+				}
+			})
+
+			if err := engine.EvalWithoutCache(context.Background(), source); err != nil {
+				t.Fatalf("empty debug execution failed: %v", err)
+			}
+			debugger := engine.GetVM().GetDebugger()
+			if debugger == nil {
+				t.Fatal("debugger was not initialized")
+			}
+
+			started := make(chan struct{})
+			go func() {
+				debugger.StartWGWait()
+				close(started)
+			}()
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("empty source left debugger start waiter blocked")
+			}
+
+			if !debugger.Finished() {
+				t.Fatal("empty source debugger was not marked finished")
+			}
+			if got := finishedCallbacks.Load(); got != 1 {
+				t.Fatalf("expected exactly one finished callback, got %d", got)
+			}
+		})
+	}
 }
 
 func TestDebugger_1(t *testing.T) {
@@ -552,6 +650,47 @@ c = 3`
 	}
 }
 
+func TestDebugger_StepInVariadicCall(t *testing.T) {
+	code := `result = 0
+func collect(a, b, c) {
+result = a + b + c
+}
+args = [1, 2, 3]
+collect(args...)
+assert result == 6`
+	requestedStepIn := false
+	enteredFunction := false
+	init := func(g *yakvm.Debugger) {
+		_, err := g.SetNormalBreakPoint(6)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	callback := func(g *yakvm.Debugger) {
+		if g.Finished() {
+			return
+		}
+		if !requestedStepIn {
+			requestedStepIn = true
+			if err := g.StepIn(); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		if g.StateName() == "collect" {
+			enteredFunction = true
+		}
+	}
+
+	RunTestDebugger(code, init, callback)
+	if !requestedStepIn {
+		t.Fatal("variadic call breakpoint was not reached")
+	}
+	if !enteredFunction {
+		t.Fatal("step-in treated an expanded argument as the callable")
+	}
+}
+
 func TestDebugger_StepOut(t *testing.T) {
 	code := `a = 0
 func test() {
@@ -637,9 +776,9 @@ a = 3`
 
 func TestDebugger_StackTrace(t *testing.T) {
 	code := `go fn {
-	for {
+	for i := 0; i < 1; i++ {
 		x = 1	
-		test_debugger_sleep(3)
+		test_debugger_sleep(2)
 	}
 }
 
@@ -657,6 +796,7 @@ x = v
 a = 1
 b = 2
 c(a+b)
+waitAllAsyncCallFinish()
 `
 	init := func(g *yakvm.Debugger) {
 		_, err := g.SetNormalBreakPoint(16)
@@ -671,8 +811,19 @@ c(a+b)
 		}
 		in = true
 		sts := g.GetStackTraces()
-		if len(sts) < 2 {
-			t.Fatal("goroutine 1 stack trace not found")
+		// The background goroutine is running rather than paused, so the
+		// debugger's visibility contract reports only the stopped root thread.
+		// Synchronous c -> d frames must retain that root thread ID instead of
+		// drifting to the last allocated async ID.
+		trace, ok := sts[g.CurrentThreadID()]
+		if !ok {
+			t.Fatal("current root thread stack trace not found")
+		}
+		if len(sts) != 1 {
+			t.Fatalf("unexpected visible thread count: %d", len(sts))
+		}
+		if len(trace.StackTraces) < 3 {
+			t.Fatalf("nested c -> d stack trace too short: %d", len(trace.StackTraces))
 		}
 	}
 

--- a/common/yak/antlr4yak/engine.go
+++ b/common/yak/antlr4yak/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"sync"
 
 	"github.com/yaklang/yaklang/common/go-funk"
 	"github.com/yaklang/yaklang/common/utils"
@@ -19,6 +20,7 @@ const YAKC_CACHE_MAX_LENGTH = 300
 type Engine struct {
 	rootSymbol            *yakvm.SymbolTable
 	vm                    *yakvm.VirtualMachine
+	compileMu             sync.Mutex
 	strictMode            bool
 	sourceFilePathPointer *string
 	// debug
@@ -40,6 +42,23 @@ func (e *Engine) RuntimeInfo(infoType string, params ...any) (res any, err error
 	frame := e.GetVM().CurrentFM()
 	if frame == nil {
 		return nil, fmt.Errorf("not found runtime.GetInfo")
+	}
+	// These are the runtime library's built-in queries. Resolve them directly
+	// from the goroutine-local frame already found above, avoiding another
+	// runtime.Stack lookup in the logging hot path.
+	switch infoType {
+	case "line":
+		code := frame.CurrentCode()
+		if code == nil {
+			return nil, fmt.Errorf("current code is empty")
+		}
+		return code.StartLineNumber, nil
+	case "runtimeId":
+		result, ok := frame.GlobalVariables.Load("runtimeId")
+		if !ok {
+			return "", nil
+		}
+		return result, nil
 	}
 	runtimeLib, ok := frame.GlobalVariables.Load("runtime")
 	if !ok || runtimeLib == nil {
@@ -373,6 +392,13 @@ func (n *Engine) MustCompile(code string) []*yakvm.Code {
 }
 
 func (n *Engine) _compile(code string, symbolTable *yakvm.SymbolTable) (*yakast.YakCompiler, error) {
+	// Dynamic eval compiles against the live scope's symbol table. Serialize
+	// compiler mutations per engine so concurrent hook invocations cannot both
+	// redefine a name between lookup and insertion and emit bytecode for each
+	// other's symbol IDs. Execution itself remains concurrent.
+	n.compileMu.Lock()
+	defer n.compileMu.Unlock()
+
 	compiler := yakast.NewYakCompilerWithSymbolTable(symbolTable)
 	compiler.SetStrictMode(n.strictMode)
 	if n.strictMode {

--- a/common/yak/antlr4yak/engine.go
+++ b/common/yak/antlr4yak/engine.go
@@ -407,14 +407,26 @@ func (n *Engine) HaveEvaluatedCode() bool {
 }
 
 func (n *Engine) Eval(ctx context.Context, code string) error {
-	return n.EvalWithInline(ctx, code, false)
+	return n.evalWithInline(ctx, code, false, true)
 }
 
 func (n *Engine) EvalInline(ctx context.Context, code string) error {
-	return n.EvalWithInline(ctx, code, true)
+	return n.evalWithInline(ctx, code, true, true)
 }
 
 func (n *Engine) EvalWithInline(ctx context.Context, code string, inline bool) error {
+	return n.evalWithInline(ctx, code, inline, true)
+}
+
+// EvalWithoutCache compiles and executes source without reading or persisting a
+// yakc artifact. It is intended for rapidly changing hot patches where every
+// source revision is normally unique and cache serialization becomes pure
+// overhead.
+func (n *Engine) EvalWithoutCache(ctx context.Context, code string) error {
+	return n.evalWithInline(ctx, code, false, false)
+}
+
+func (n *Engine) evalWithInline(ctx context.Context, code string, inline bool, cache bool) error {
 	flag := yakvm.None
 	if inline {
 		flag = yakvm.Inline
@@ -429,16 +441,18 @@ func (n *Engine) EvalWithInline(ctx context.Context, code string, inline bool) e
 	n.vm.SetCallFuncCallback(n.callFuncCallback)
 	// yakc缓存
 	codes, symtbl := compiler.GetOpcodes(), compiler.GetRootSymbolTable()
-	defer func() {
-		if len(code) <= YAKC_CACHE_MAX_LENGTH {
-			return
-		}
-		yc, err := n._marshal(symtbl, codes, nil)
-		if err != nil {
-			return
-		}
-		SaveYakcCache(code, yc)
-	}()
+	if cache {
+		defer func() {
+			if len(code) <= YAKC_CACHE_MAX_LENGTH {
+				return
+			}
+			yc, err := n._marshal(symtbl, codes, nil)
+			if err != nil {
+				return
+			}
+			SaveYakcCache(code, yc)
+		}()
+	}
 
 	err = n.vm.ExecYakCode(ctx, code, codes, flag)
 	if err != nil {
@@ -455,6 +469,16 @@ func (n *Engine) SafeEval(ctx context.Context, code string) (err error) {
 		}
 	}()
 	err = n.Eval(ctx, code)
+	return
+}
+
+func (n *Engine) SafeEvalWithoutCache(ctx context.Context, code string) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = utils.Error(fmt.Sprint(e))
+		}
+	}()
+	err = n.EvalWithoutCache(ctx, code)
 	return
 }
 

--- a/common/yak/antlr4yak/engine_benchmark_test.go
+++ b/common/yak/antlr4yak/engine_benchmark_test.go
@@ -1,0 +1,49 @@
+package antlr4yak
+
+import (
+	"context"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
+)
+
+func benchmarkYakFunction(b *testing.B, ctx context.Context) {
+	engine := New()
+	if err := engine.SafeEvalWithoutCache(context.Background(), `
+handler = () => {
+    total = 0
+    for i in 10 {
+        total += i
+    }
+    return total
+}
+`); err != nil {
+		b.Fatal(err)
+	}
+	raw, ok := engine.GetVar("handler")
+	if !ok {
+		b.Fatal("handler not found")
+	}
+	function, ok := raw.(*yakvm.Function)
+	if !ok {
+		b.Fatalf("handler has unexpected type %T", raw)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := engine.CallYakFunctionNative(ctx, function); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCallYakFunctionBackgroundContext(b *testing.B) {
+	benchmarkYakFunction(b, context.Background())
+}
+
+func BenchmarkCallYakFunctionCancelableContext(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+	benchmarkYakFunction(b, ctx)
+}

--- a/common/yak/antlr4yak/engine_compile_to_bytes.go
+++ b/common/yak/antlr4yak/engine_compile_to_bytes.go
@@ -33,7 +33,12 @@ func IsYakc(b []byte) bool {
 	return IsNormalYakc(b) || IsCryptoYakc(b)
 }
 
-var yakcCache = utils.NewTTLCache[[]byte](10 * time.Minute)
+const yakcMemoryCacheCapacity = 256
+
+var yakcCache = utils.NewCacheEx[[]byte](
+	utils.WithCacheCapacity(yakcMemoryCacheCapacity),
+	utils.WithCacheTTL(10*time.Minute),
+)
 
 func HaveYakcCache(code string) ([]byte, bool) {
 	return HaveYakcCacheWithKey(code, nil)

--- a/common/yak/antlr4yak/engine_compile_to_bytes_test.go
+++ b/common/yak/antlr4yak/engine_compile_to_bytes_test.go
@@ -28,6 +28,25 @@ func TestCalcHashIgnoresIncludeTextOutsideStatements(t *testing.T) {
 	require.Empty(t, includeCacheMaterial(code, make(map[string]struct{})))
 }
 
+func TestYakcMemoryCacheIsBounded(t *testing.T) {
+	yakcCache.Purge()
+	t.Cleanup(yakcCache.Purge)
+
+	keys := make([]string, 0, yakcMemoryCacheCapacity+32)
+	for index := 0; index < yakcMemoryCacheCapacity+32; index++ {
+		key := fmt.Sprintf("%s-%d", t.Name(), index)
+		keys = append(keys, key)
+		yakcCache.Set(key, []byte(key))
+	}
+
+	require.LessOrEqual(t, yakcCache.Count(), yakcMemoryCacheCapacity)
+	_, oldestExists := yakcCache.Get(keys[0])
+	require.False(t, oldestExists, "capacity must evict the oldest yakc entry")
+	newest, newestExists := yakcCache.Get(keys[len(keys)-1])
+	require.True(t, newestExists, "newest yakc entry was unexpectedly evicted")
+	require.Equal(t, []byte(keys[len(keys)-1]), newest)
+}
+
 func BenchmarkEvalUniqueSourceWithCache(b *testing.B) {
 	b.Setenv("YAKIT_HOME", b.TempDir())
 	padding := strings.Repeat("x", YAKC_CACHE_MAX_LENGTH)
@@ -72,4 +91,23 @@ func TestEvalWithoutCacheDoesNotPersistYakc(t *testing.T) {
 	cachePath := filepath.Join(os.Getenv("YAKIT_HOME"), "temp", fmt.Sprintf(".%s.yakc", hash))
 	_, err := os.Stat(cachePath)
 	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestEvalWithoutCacheIgnoresExistingYakc(t *testing.T) {
+	padding := strings.Repeat("x", YAKC_CACHE_MAX_LENGTH)
+	source := fmt.Sprintf(`value = "source" // %s-%s`, t.Name(), padding)
+	wrongSource := fmt.Sprintf(`value = "cached" // %s`, padding)
+	wrongYakc, err := New().Marshal(wrongSource, nil)
+	require.NoError(t, err)
+	hash := calcHash(source, nil)
+	yakcCache.Set(hash, wrongYakc)
+	t.Cleanup(func() { yakcCache.Remove(hash) })
+
+	engine := New()
+	require.NoError(t, engine.SafeEvalWithoutCache(context.Background(), source))
+	require.Equal(t, "source", engine.Var("value"))
+
+	stillCached, ok := HaveYakcCache(source)
+	require.True(t, ok)
+	require.Equal(t, wrongYakc, stillCached, "no-cache evaluation must neither read nor overwrite an existing artifact")
 }

--- a/common/yak/antlr4yak/engine_compile_to_bytes_test.go
+++ b/common/yak/antlr4yak/engine_compile_to_bytes_test.go
@@ -1,9 +1,11 @@
 package antlr4yak
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,4 +26,50 @@ func TestCalcHashTracksIncludedSource(t *testing.T) {
 func TestCalcHashIgnoresIncludeTextOutsideStatements(t *testing.T) {
 	code := `println("include") // include "missing.yak"`
 	require.Empty(t, includeCacheMaterial(code, make(map[string]struct{})))
+}
+
+func BenchmarkEvalUniqueSourceWithCache(b *testing.B) {
+	b.Setenv("YAKIT_HOME", b.TempDir())
+	padding := strings.Repeat("x", YAKC_CACHE_MAX_LENGTH)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		engine := New()
+		code := fmt.Sprintf("handler = () => { return %d } // %s", i, padding)
+		if err := engine.SafeEval(ctx, code); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEvalUniqueSourceWithoutCache(b *testing.B) {
+	b.Setenv("YAKIT_HOME", b.TempDir())
+	padding := strings.Repeat("x", YAKC_CACHE_MAX_LENGTH)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		engine := New()
+		code := fmt.Sprintf("handler = () => { return %d } // %s", i, padding)
+		if err := engine.SafeEvalWithoutCache(ctx, code); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEvalWithoutCacheDoesNotPersistYakc(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	code := fmt.Sprintf("handler = () => { return 1 } // %s", strings.Repeat("x", YAKC_CACHE_MAX_LENGTH))
+	hash := calcHash(code, nil)
+	engine := New()
+	require.NoError(t, engine.SafeEvalWithoutCache(context.Background(), code))
+
+	_, ok := yakcCache.Get(hash)
+	require.False(t, ok, "cache-disabled evaluation must not populate the memory cache")
+	cachePath := filepath.Join(os.Getenv("YAKIT_HOME"), "temp", fmt.Sprintf(".%s.yakc", hash))
+	_, err := os.Stat(cachePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/common/yak/antlr4yak/engine_runtime_info_test.go
+++ b/common/yak/antlr4yak/engine_runtime_info_test.go
@@ -1,0 +1,22 @@
+package antlr4yak
+
+import (
+	"context"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
+)
+
+func TestEngineRuntimeInfoLineRejectsFrameWithoutCurrentCode(t *testing.T) {
+	engine := New()
+	var infoErr error
+	err := engine.GetVM().Exec(context.Background(), func(_ *yakvm.Frame) {
+		_, infoErr = engine.RuntimeInfo("line")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if infoErr == nil {
+		t.Fatal("Engine.RuntimeInfo(line) accepted a frame without code")
+	}
+}

--- a/common/yak/antlr4yak/function_assignment_benchmark_test.go
+++ b/common/yak/antlr4yak/function_assignment_benchmark_test.go
@@ -1,0 +1,62 @@
+package antlr4yak
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
+)
+
+func TestAnonymousFunctionAssignmentKeepsTemplateAndAliasBindingsIndependent(t *testing.T) {
+	const source = `
+direct = func() { return 1 }
+directAlias = direct
+
+holders = [func() { return 2 }]
+first = holders[0]
+second = holders[0]
+`
+
+	engine := New()
+	codes, err := engine.Compile(source)
+	require.NoError(t, err)
+	templates, _, _, _ := snapshotCompiledCodeTemplates(t, codes)
+
+	require.NoError(t, engine.vm.ExecYakCode(context.Background(), source, codes, yakvm.None))
+
+	direct := engine.Var("direct").(*yakvm.Function)
+	directAlias := engine.Var("directAlias").(*yakvm.Function)
+	require.Same(t, direct, directAlias, "aliasing a bound function must preserve its original binding")
+	require.Equal(t, "direct", direct.GetBindName())
+
+	holder := engine.Var("holders").([]interface{})[0].(*yakvm.Function)
+	first := engine.Var("first").(*yakvm.Function)
+	second := engine.Var("second").(*yakvm.Function)
+	require.Empty(t, holder.GetBindName(), "publishing an anonymous function in a container must not bind the shared value")
+	require.NotSame(t, holder, first)
+	require.NotSame(t, holder, second)
+	require.NotSame(t, first, second)
+	require.Equal(t, "first", first.GetBindName())
+	require.Equal(t, "second", second.GetBindName())
+
+	assertCompiledCodeTemplatesUnchanged(t, templates)
+}
+
+func BenchmarkAnonymousFunctionDirectAssignment(b *testing.B) {
+	const source = `handler = func() { return 1 }`
+	engine := New()
+	codes, err := engine.Compile(source)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := engine.vm.ExecYakCode(ctx, source, codes, yakvm.None); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/common/yak/antlr4yak/member_method_binding_test.go
+++ b/common/yak/antlr4yak/member_method_binding_test.go
@@ -1,0 +1,127 @@
+package antlr4yak
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type memberMethodBindingConfig struct {
+	values map[string]string
+}
+
+func (c *memberMethodBindingConfig) GetConfig(key string) (string, bool) {
+	value, ok := c.values[key]
+	return value, ok
+}
+
+type memberMethodBindingTarget struct {
+	*memberMethodBindingConfig
+}
+
+func (*memberMethodBindingTarget) Ping() string {
+	return "pong"
+}
+
+func newMemberMethodBindingEngine() *Engine {
+	engine := New()
+	engine.ImportLibs(map[string]interface{}{
+		"memberBindingTarget": &memberMethodBindingTarget{
+			memberMethodBindingConfig: &memberMethodBindingConfig{
+				values: map[string]string{"answer": "42"},
+			},
+		},
+	})
+	return engine
+}
+
+func TestMemberMethodBinding(t *testing.T) {
+	t.Run("zero argument pointer method stays bound", func(t *testing.T) {
+		err := newMemberMethodBindingEngine().SafeEval(context.Background(), `
+assert(memberBindingTarget.Ping() == "pong")
+`)
+		if err != nil {
+			t.Fatalf("call bound zero-argument pointer method: %v", err)
+		}
+	})
+
+	t.Run("promoted method stays bound with one argument", func(t *testing.T) {
+		err := newMemberMethodBindingEngine().SafeEval(context.Background(), `
+value, ok = memberBindingTarget.GetConfig("answer")
+assert(ok)
+assert(value == "42")
+`)
+		if err != nil {
+			t.Fatalf("call bound promoted method: %v", err)
+		}
+	})
+
+	t.Run("promoted method preserves explicit argument count", func(t *testing.T) {
+		err := newMemberMethodBindingEngine().SafeEval(context.Background(), `
+memberBindingTarget.GetConfig()
+`)
+		if err == nil {
+			t.Fatal("expected missing promoted-method argument to fail")
+		}
+		if message := err.Error(); !strings.Contains(message, "GetConfig") ||
+			!strings.Contains(message, "need [1] params, actually got [0] params") {
+			t.Fatalf("unexpected promoted-method arity error: %v", err)
+		}
+	})
+}
+
+type mutableMemberLookupTarget struct {
+	mu    sync.RWMutex
+	value int
+}
+
+func (t *mutableMemberLookupTarget) Set(value int) {
+	t.mu.Lock()
+	t.value = value
+	t.mu.Unlock()
+}
+
+func (t *mutableMemberLookupTarget) Current() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.value
+}
+
+func TestConcurrentMemberLookupDoesNotFormatMutableReceiver(t *testing.T) {
+	target := &mutableMemberLookupTarget{}
+	engine := New()
+	engine.ImportLibs(map[string]interface{}{
+		// Returning the object through a native call deliberately produces a Yak
+		// Value without a source literal. Member lookup must describe it by type;
+		// formatting the live receiver would read its fields outside the lock.
+		"getMutableMemberTarget": func() *mutableMemberLookupTarget { return target },
+	})
+
+	stop := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for value := 0; ; value++ {
+			select {
+			case <-stop:
+				return
+			default:
+				target.Set(value)
+			}
+		}
+	}()
+
+	err := engine.SafeEvalWithoutCache(context.Background(), `
+receiver = getMutableMemberTarget()
+for index := 0; index < 20000; index++ {
+    value = receiver.Current()
+    assert value >= 0
+}
+`)
+	close(stop)
+	<-writerDone
+	if err != nil {
+		t.Fatalf("concurrent member lookup failed: %v", err)
+	}
+}

--- a/common/yak/antlr4yak/yakvm/current_frame_benchmark_test.go
+++ b/common/yak/antlr4yak/yakvm/current_frame_benchmark_test.go
@@ -1,0 +1,56 @@
+package yakvm
+
+import (
+	"context"
+	"testing"
+)
+
+var benchmarkFrameSink *Frame
+
+func BenchmarkExecFrameLifecycle(b *testing.B) {
+	vm := New()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := vm.Exec(ctx, func(frame *Frame) {
+			benchmarkFrameSink = frame
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNestedFrameLifecycle(b *testing.B) {
+	vm := New()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := vm.Exec(ctx, func(parent *Frame) {
+			if err := vm.exec(ctx, parent, func(child *Frame) {
+				benchmarkFrameSink = child
+			}, Sub); err != nil {
+				b.Fatal(err)
+			}
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIdleGetVar(b *testing.B) {
+	vm := New()
+	vm.SetVars(map[string]any{"hotpatch": 1})
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		value, ok := vm.GetVar("hotpatch")
+		if !ok || value != 1 {
+			b.Fatalf("unexpected value: %v, %v", value, ok)
+		}
+	}
+}

--- a/common/yak/antlr4yak/yakvm/current_frame_test.go
+++ b/common/yak/antlr4yak/yakvm/current_frame_test.go
@@ -2,6 +2,7 @@ package yakvm
 
 import (
 	"context"
+	"sync"
 	"testing"
 )
 
@@ -29,5 +30,115 @@ func TestExecPanicClearsCurrentFrame(t *testing.T) {
 	}
 	if frame := vm.CurrentFM(); frame != nil {
 		t.Fatalf("expected current frame to be cleared after panic, got %#v", frame)
+	}
+}
+
+func TestCurrentGoroutineID(t *testing.T) {
+	if id := currentGoroutineID(); id <= 0 {
+		t.Fatalf("expected a positive goroutine ID, got %d", id)
+	}
+}
+
+func TestConcurrentBareVMGetVarDoesNotRelinkGlobals(t *testing.T) {
+	vm := New()
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			if _, ok := vm.GetVar("missing"); ok {
+				t.Error("unexpected missing variable")
+			}
+		}()
+	}
+	close(start)
+	wait.Wait()
+}
+
+func TestNestedExecReusesGoroutineIDAndClearsFrames(t *testing.T) {
+	vm := New()
+
+	err := vm.Exec(context.Background(), func(parent *Frame) {
+		parentID := parent.ownerGoroutineID
+		if parentID <= 0 {
+			t.Fatalf("expected parent goroutine ID, got %d", parentID)
+		}
+
+		if err := vm.exec(context.Background(), parent, func(child *Frame) {
+			if child.ownerGoroutineID != parentID {
+				t.Fatalf("child goroutine ID %d does not match parent %d", child.ownerGoroutineID, parentID)
+			}
+			if current := vm.CurrentFM(); current != child {
+				t.Fatalf("expected child to be current frame, got %#v", current)
+			}
+		}, Sub); err != nil {
+			t.Fatalf("nested exec failed: %v", err)
+		}
+
+		if current := vm.CurrentFM(); current != parent {
+			t.Fatalf("expected parent frame after nested exec, got %#v", current)
+		}
+	})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if frame := vm.CurrentFM(); frame != nil {
+		t.Fatalf("expected all frames to be cleared, got %#v", frame)
+	}
+	if count := vm.activeFrames.Load(); count != 0 {
+		t.Fatalf("expected zero active frames, got %d", count)
+	}
+}
+
+func TestAsyncSubFrameUsesItsOwnGoroutineAndClearsFrames(t *testing.T) {
+	type asyncResult struct {
+		ownerID       int64
+		currentIsSelf bool
+		poppedIsSelf  bool
+	}
+
+	vm := New()
+	var parentID int64
+	err := vm.Exec(context.Background(), func(parent *Frame) {
+		parentID = parent.ownerGoroutineID
+		resultCh := make(chan asyncResult, 1)
+
+		go func() {
+			child := NewSubFrame(parent)
+			vm.pushCurrentFrame(child)
+			resultCh <- asyncResult{
+				ownerID:       child.ownerGoroutineID,
+				currentIsSelf: vm.CurrentFM() == child,
+				poppedIsSelf:  vm.popCurrentFrame(child) == child,
+			}
+		}()
+
+		result := <-resultCh
+		if result.ownerID <= 0 {
+			t.Fatalf("expected async child goroutine ID, got %d", result.ownerID)
+		}
+		if result.ownerID == parentID {
+			t.Fatalf("expected async child to use a different goroutine ID from parent %d", parentID)
+		}
+		if !result.currentIsSelf || !result.poppedIsSelf {
+			t.Fatalf("async frame lifecycle mismatch: current=%v popped=%v", result.currentIsSelf, result.poppedIsSelf)
+		}
+		if current := vm.CurrentFM(); current != parent {
+			t.Fatalf("expected parent frame after async child exit, got %#v", current)
+		}
+		if count := vm.activeFrames.Load(); count != 1 {
+			t.Fatalf("expected only the parent frame to remain active, got %d", count)
+		}
+	})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if frame := vm.CurrentFM(); frame != nil {
+		t.Fatalf("expected all frames to be cleared, got %#v", frame)
+	}
+	if count := vm.activeFrames.Load(); count != 0 {
+		t.Fatalf("expected zero active frames, got %d", count)
 	}
 }

--- a/common/yak/antlr4yak/yakvm/current_frame_test.go
+++ b/common/yak/antlr4yak/yakvm/current_frame_test.go
@@ -2,8 +2,10 @@ package yakvm
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestExecPanicClearsCurrentFrame(t *testing.T) {
@@ -92,6 +94,24 @@ func TestNestedExecReusesGoroutineIDAndClearsFrames(t *testing.T) {
 	}
 }
 
+func TestSubFrameKeepsParentVMThreadID(t *testing.T) {
+	vm := New()
+	parent := NewFrame(vm)
+	parent.ThreadID = 7
+	child := NewSubFrame(parent)
+	if child.ThreadID != parent.ThreadID {
+		t.Fatalf("subframe thread ID = %d, want parent ID %d", child.ThreadID, parent.ThreadID)
+	}
+
+	// A concurrent async spawn may advance the VM-wide counter, but executing a
+	// synchronous child must not make it drift to that unrelated ID.
+	vm.ThreadIDCount = 99
+	child.Exec(nil)
+	if child.ThreadID != parent.ThreadID {
+		t.Fatalf("executed subframe thread ID drifted to %d, want %d", child.ThreadID, parent.ThreadID)
+	}
+}
+
 func TestAsyncSubFrameUsesItsOwnGoroutineAndClearsFrames(t *testing.T) {
 	type asyncResult struct {
 		ownerID       int64
@@ -140,5 +160,151 @@ func TestAsyncSubFrameUsesItsOwnGoroutineAndClearsFrames(t *testing.T) {
 	}
 	if count := vm.activeFrames.Load(); count != 0 {
 		t.Fatalf("expected zero active frames, got %d", count)
+	}
+}
+
+func TestAsyncStartFailuresDoNotLeakWaitGroup(t *testing.T) {
+	waitReturns := func(t *testing.T, vm *VirtualMachine) {
+		t.Helper()
+		done := make(chan struct{})
+		go func() {
+			vm.AsyncWait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("AsyncWait stayed blocked after async startup failed")
+		}
+	}
+
+	t.Run("pre-canceled Yak function", func(t *testing.T) {
+		vm := New()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		parent := NewFrame(vm)
+		parent.ctx = ctx
+		function := NewFunction(nil, vm.rootScope.GetSymTable())
+		function.scope = vm.rootScope
+
+		parent.asyncCall(NewAutoValue(function), false, nil)
+		waitReturns(t, vm)
+	})
+
+	t.Run("invalid native arguments", func(t *testing.T) {
+		vm := New()
+		parent := NewFrame(vm)
+		parent.ctx = context.Background()
+		panicked := false
+		func() {
+			defer func() { panicked = recover() != nil }()
+			parent.asyncCall(NewAutoValue(func(_ int) {}), false, nil)
+		}()
+		if !panicked {
+			t.Fatal("expected invalid async native call to panic")
+		}
+		waitReturns(t, vm)
+	})
+}
+
+func TestTraceFailureClearsCurrentFrame(t *testing.T) {
+	t.Run("panic", func(t *testing.T) {
+		vm := New()
+		gotPanic := false
+		func() {
+			defer func() {
+				gotPanic = recover() != nil
+			}()
+			_ = vm.Exec(context.Background(), func(frame *Frame) {
+				panic("trace failed")
+			}, Trace)
+		}()
+
+		if !gotPanic {
+			t.Fatal("expected trace panic")
+		}
+		assertNoActiveFrames(t, vm)
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		vm := New()
+		ctx, cancel := context.WithCancel(context.Background())
+		err := vm.Exec(ctx, func(frame *Frame) {
+			cancel()
+		}, Trace)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+		assertNoActiveFrames(t, vm)
+	})
+}
+
+func TestSuccessfulTraceInlineKeepsExactlyOneFrame(t *testing.T) {
+	vm := New()
+	var traceFrame *Frame
+	if err := vm.Exec(context.Background(), func(frame *Frame) {
+		traceFrame = frame
+	}, Trace); err != nil {
+		t.Fatalf("trace exec failed: %v", err)
+	}
+
+	if current := vm.CurrentFM(); current != traceFrame {
+		t.Fatalf("expected retained trace frame, got %#v", current)
+	}
+	if count := vm.activeFrames.Load(); count != 1 {
+		t.Fatalf("expected one retained trace frame, got %d", count)
+	}
+
+	for i := 0; i < 100; i++ {
+		if err := vm.Exec(context.Background(), func(frame *Frame) {
+			if frame != traceFrame {
+				t.Fatalf("inline execution switched frame: got %#v want %#v", frame, traceFrame)
+			}
+		}, Inline); err != nil {
+			t.Fatalf("inline exec %d failed: %v", i, err)
+		}
+		if count := vm.activeFrames.Load(); count != 1 {
+			t.Fatalf("inline exec %d leaked a frame: active=%d", i, count)
+		}
+	}
+
+	if popped := vm.popCurrentFrame(traceFrame); popped != traceFrame {
+		t.Fatalf("failed to remove retained trace frame: %#v", popped)
+	}
+	assertNoActiveFrames(t, vm)
+}
+
+func TestPopCurrentFrameRefusesMismatchedFrame(t *testing.T) {
+	vm := New()
+	if err := vm.Exec(context.Background(), func(current *Frame) {
+		intruder := NewFrame(vm)
+		intruder.ownerGoroutineID = current.ownerGoroutineID
+		if popped := vm.popCurrentFrame(intruder); popped != nil {
+			t.Fatalf("mismatched pop removed %#v", popped)
+		}
+		if got := vm.CurrentFM(); got != current {
+			t.Fatalf("mismatched pop corrupted current frame: %#v", got)
+		}
+		if count := vm.activeFrames.Load(); count != 1 {
+			t.Fatalf("mismatched pop changed active count: %d", count)
+		}
+	}); err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	assertNoActiveFrames(t, vm)
+}
+
+func assertNoActiveFrames(t *testing.T, vm *VirtualMachine) {
+	t.Helper()
+	if frame := vm.CurrentFM(); frame != nil {
+		t.Fatalf("expected current frame to be empty, got %#v", frame)
+	}
+	if count := vm.activeFrames.Load(); count != 0 {
+		t.Fatalf("expected zero active frames, got %d", count)
+	}
+	vm.frameStacksMu.RLock()
+	defer vm.frameStacksMu.RUnlock()
+	if len(vm.frameStacks) != 0 {
+		t.Fatalf("expected no goroutine frame stacks, got %d", len(vm.frameStacks))
 	}
 }

--- a/common/yak/antlr4yak/yakvm/debugger.go
+++ b/common/yak/antlr4yak/yakvm/debugger.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/samber/lo"
+	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm/vmstack"
 
@@ -50,7 +52,7 @@ type Debugger struct {
 	once         sync.Once
 	startWG      sync.WaitGroup  // 用于等待程序启动
 	started      bool            // 表示程序是否已经启动
-	finished     bool            // 表示程序是否已经结束
+	finished     atomic.Bool     // 表示程序是否已经结束
 	wg           sync.WaitGroup  // 多个异步函数同时执行时回调断点,阻塞执行
 	initFunc     func(*Debugger) // 初始化函数
 	callbackFunc func(*Debugger) // 断点回调函数
@@ -99,7 +101,7 @@ type Debugger struct {
 	// 视为可见线程，保证 threads 列表与"程序已停止(AllThreadsStopped)"语义一致且稳定。
 	pausedThreads map[int]struct{}
 	pausedMu      sync.Mutex
-	rootThreadID  int
+	rootThreadID  atomic.Int64
 
 	// Reference,用于存储帧,作用域,变量引用的信息
 	Reference *Reference
@@ -147,11 +149,9 @@ func NewDebugger(vm *VirtualMachine, sourceCode string, codes []*Code, init, cal
 
 	debugger := &Debugger{
 		started:          false,
-		finished:         false,
-		StackTraces:      map[int]*vmstack.Stack{int(vm.ThreadIDCount): vmstack.New()},
+		StackTraces:      make(map[int]*vmstack.Stack),
 		ThreadStackTrace: make(map[int]*DebuggerState, 0),
 		pausedThreads:    make(map[int]struct{}),
-		rootThreadID:     int(vm.ThreadIDCount),
 		vm:               vm,
 		startWG:          sync.WaitGroup{},
 		wg:               sync.WaitGroup{},
@@ -213,9 +213,14 @@ func (g *Debugger) Init(codes []*Code) {
 
 	hasSet := false
 	sourceCodeFilePath := ""
-	var (
-		currentBundle *switchBundle
-	)
+	// Opcodes normally select their source bundle below. Empty/comment-only
+	// sources have no opcode to do that, and in-memory debugging may also omit a
+	// file path, so install a usable default bundle before scanning.
+	currentBundle := NewSwitchBundle()
+	g.switchBundleMap[""] = currentBundle
+	g.currentLinesFirstCodeStateMap = currentBundle.linesFirstCodeStateMap
+	g.currentBreakPointMap = currentBundle.breakpointMap
+	g.currentObserveBreakPointMap = currentBundle.observeBreakPointMap
 
 	for state, codes := range g.codes {
 		for index, code := range codes {
@@ -243,7 +248,7 @@ func (g *Debugger) Init(codes []*Code) {
 		}
 	}
 
-	if !hasSet {
+	if !hasSet && len(codes) != 0 {
 		panic(errors.New("debugger init error: can't find source code in opcodes"))
 	}
 }
@@ -316,12 +321,12 @@ func (g *Debugger) WaitGroupDone() {
 }
 
 func (g *Debugger) Finished() bool {
-	return g.finished
+	return g.finished.Load()
 }
 
 func (g *Debugger) SetFinished() {
 	g.description = "The program is finished"
-	g.finished = true
+	g.finished.Store(true)
 }
 
 func (g *Debugger) CurrentCodeIndex() int {
@@ -753,8 +758,11 @@ func (g *Debugger) StepIn() error {
 
 func (g *Debugger) StepOut() error {
 	stackTrace := g.CurrentStackTrace()
+	if stackTrace == nil {
+		return utils.Errorf("Can't not step out")
+	}
 	stackLen := stackTrace.Len()
-	if stackTrace != nil && stackLen > 0 {
+	if stackLen > 0 {
 		// 不会用到frame,所以设置为nil
 		g.stepoutState = &DebuggerState{
 			lineIndex: g.linePointer,
@@ -767,9 +775,66 @@ func (g *Debugger) StepOut() error {
 }
 
 func (g *Debugger) CurrentStackTracePop() {
-	stackTrace := g.CurrentStackTrace()
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	g.stackTracePopLocked(g.frame)
+}
+
+// StackTracePopForFrame removes the call stack entry owned by frame. Async
+// completion must not select the stack through Debugger.frame: another VM
+// thread may have become the debugger's most recently observed frame.
+func (g *Debugger) StackTracePopForFrame(frame *Frame) {
+	// Async frames finish outside ShouldCallback, while another VM thread may be
+	// updating the debugger's current frame and per-thread stack under g.lock.
+	// Use the same lock here so selecting and popping a stack is one operation.
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	g.stackTracePopLocked(frame)
+}
+
+func (g *Debugger) stackTracePopLocked(frame *Frame) {
+	if frame == nil {
+		return
+	}
+	stackTrace := g.StackTraces[frame.ThreadID]
 	if stackTrace != nil && stackTrace.Len() > 0 {
 		stackTrace.Pop()
+	}
+}
+
+// StackTracePopExpected pairs a synchronous call-site push with its caller.
+// Direct API executions and cross-VM calls that intentionally did not push a
+// caller state are no-ops instead of consuming an unrelated outer call.
+func (g *Debugger) StackTracePopExpected(caller *Frame) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	if caller == nil {
+		return
+	}
+	stackTrace := g.StackTraces[caller.ThreadID]
+	if stackTrace == nil || stackTrace.Len() == 0 {
+		return
+	}
+	state, ok := stackTrace.Peek().(*DebuggerState)
+	if !ok || state.frame != caller {
+		return
+	}
+	stackTrace.Pop()
+}
+
+func (g *Debugger) cleanupFinishedThreadLocked(frame *Frame) {
+	if frame == nil || int64(frame.ThreadID) == g.rootThreadID.Load() {
+		return
+	}
+	// Only an independent execution owns its thread entry. Ordinary nested
+	// synchronous frames share their parent's ID and leave cleanup to that root.
+	if !frame.ownsThreadID {
+		return
+	}
+	stackTrace := g.StackTraces[frame.ThreadID]
+	if stackTrace == nil || stackTrace.Len() == 0 {
+		delete(g.StackTraces, frame.ThreadID)
+		delete(g.ThreadStackTrace, frame.ThreadID)
 	}
 }
 
@@ -809,19 +874,81 @@ func (g *Debugger) HandleForBreakPoint() {
 	g.Callback()
 }
 
-func (g *Debugger) HandleForNormallyFinished() {
+func (g *Debugger) handleForNormallyFinishedLocked() {
+	if !g.finished.CompareAndSwap(false, true) {
+		return
+	}
+	g.description = "The program is finished"
 	g.SetStopReason("finished")
-	g.Callback()
+	g.callbackLockedNoPanic()
+}
+
+func (g *Debugger) HandleForNormallyFinished() {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	g.handleForNormallyFinishedLocked()
+}
+
+func (g *Debugger) handleForPanicLocked(vmPanic *VMPanic) {
+	if !g.finished.CompareAndSwap(false, true) {
+		return
+	}
+	g.SetVMPanic(vmPanic)
+	g.SetDescription("panic")
+	g.SetStopReason("exception")
+	g.callbackLockedNoPanic()
 }
 
 func (g *Debugger) HandleForPanic(vmPanic *VMPanic) {
-	if !g.Finished() {
-		g.SetFinished()
-		g.SetVMPanic(vmPanic)
-		g.SetDescription("panic")
-		g.SetStopReason("exception")
-		g.Callback()
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	g.handleForPanicLocked(vmPanic)
+}
+
+// HandleFrameExit serializes terminal state with debugger-thread cleanup.
+// Synchronous call-stack pushes are popped at their caller boundary; this
+// method only releases the independent per-thread entry after callbacks have
+// inspected the final state.
+func (g *Debugger) HandleFrameExit(frame *Frame, vmPanic *VMPanic, normallyFinished bool) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	defer g.cleanupFinishedThreadLocked(frame)
+
+	if vmPanic != nil {
+		g.handleForPanicLocked(vmPanic)
+		return
 	}
+	// Context cancellation can make a root frame finish after debugger init but
+	// before its first opcode reaches ShouldCallback. Bind that root here as a
+	// fallback so program-start waiters are released by the terminal callback.
+	if normallyFinished && frame != nil && frame.parent == nil {
+		g.rootThreadID.CompareAndSwap(0, int64(frame.ThreadID))
+	}
+	if normallyFinished && frame != nil && int64(frame.ThreadID) == g.rootThreadID.Load() {
+		g.handleForNormallyFinishedLocked()
+	}
+}
+
+func (g *Debugger) callbackLockedNoPanic() {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			// A debugger adapter failure must not replace the VM panic or recurse
+			// through the terminal callback indefinitely.
+			log.Errorf("yakvm debugger terminal callback panic: %v", recovered)
+		}
+	}()
+	g.Callback()
+}
+
+func debuggerTracksCallInCurrentVM(frame *Frame, callable *Value) bool {
+	if frame == nil || frame.vm == nil || !frame.vm.sandboxMode || callable == nil {
+		return true
+	}
+	function, ok := callable.Value.(*Function)
+	if !ok || function.defineFrame == nil || function.defineFrame.vm == nil {
+		return true
+	}
+	return function.defineFrame.vm == frame.vm
 }
 
 func (g *Debugger) ShouldCallback(frame *Frame) {
@@ -829,13 +956,19 @@ func (g *Debugger) ShouldCallback(frame *Frame) {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
+	codeIndex := frame.codePointer
+	g.UpdateByFrame(frame)
+	// A debugger is normally created before its root execution receives a
+	// thread ID. Bind lazily, but do not let an async or cross-VM child that
+	// happens to run first steal root visibility and normal-finish ownership.
+	if frame.parent == nil {
+		g.rootThreadID.CompareAndSwap(0, int64(frame.ThreadID))
+	}
+
 	if !g.started {
 		g.started = true
 		g.StartWGDone()
 	}
-
-	codeIndex := frame.codePointer
-	g.UpdateByFrame(frame)
 
 	state, stateName := g.State(), g.StateName()
 	code := g.GetCode(state, codeIndex)
@@ -848,9 +981,9 @@ func (g *Debugger) ShouldCallback(frame *Frame) {
 	stackTrace := g.CurrentStackTrace()
 
 	if code.Opcode == OpCall {
-		v := frame.peekN(code.Unary)
+		v := frame.peekN(frame.effectiveCallArgCount(code))
 		// 如果同步调用yak函数，则push stepIn栈
-		if v != nil && v.IsYakFunction() {
+		if v != nil && v.IsYakFunction() && debuggerTracksCallInCurrentVM(frame, v) {
 			defer func() {
 				if stackTrace != nil {
 					stackTrace.Push(&DebuggerState{
@@ -881,7 +1014,7 @@ func (g *Debugger) ShouldCallback(frame *Frame) {
 			} else {
 				g.description = fmt.Sprintf("Runtime error: %v", r)
 			}
-			g.HandleForPanic(NewVMPanic(r))
+			g.handleForPanicLocked(NewVMPanic(r))
 		}
 	}()
 
@@ -1048,7 +1181,7 @@ func (g *Debugger) markThreadResumed(threadID int) {
 
 func (g *Debugger) isThreadVisible(threadID int) bool {
 	// 根线程(主协程)始终可见；其余线程仅在当前挂起于回调时可见。
-	if threadID == g.rootThreadID {
+	if int64(threadID) == g.rootThreadID.Load() {
 		return true
 	}
 	g.pausedMu.Lock()

--- a/common/yak/antlr4yak/yakvm/debugger_concurrency_test.go
+++ b/common/yak/antlr4yak/yakvm/debugger_concurrency_test.go
@@ -1,0 +1,372 @@
+package yakvm
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm/vmstack"
+)
+
+func TestDebuggerPopsTheFinishingFramesStack(t *testing.T) {
+	frameA := &Frame{ThreadID: 1}
+	frameB := &Frame{ThreadID: 2}
+	stackA := vmstack.New()
+	stackB := vmstack.New()
+	stackA.Push(&DebuggerState{frame: frameA})
+	stackB.Push(&DebuggerState{frame: frameB})
+
+	debugger := &Debugger{
+		frame: frameB,
+		StackTraces: map[int]*vmstack.Stack{
+			frameA.ThreadID: stackA,
+			frameB.ThreadID: stackB,
+		},
+	}
+	debugger.StackTracePopForFrame(frameA)
+
+	if stackA.Len() != 0 {
+		t.Fatalf("finishing frame stack length = %d, want 0", stackA.Len())
+	}
+	if stackB.Len() != 1 {
+		t.Fatalf("most recently observed frame stack length = %d, want 1", stackB.Len())
+	}
+}
+
+func TestConcurrentRootExecutionsUseUniqueThreadIDs(t *testing.T) {
+	vm := New()
+	type result struct {
+		rootID  int
+		childID int
+		err     error
+	}
+	results := make(chan result, 2)
+	release := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(2)
+
+	for range 2 {
+		go func() {
+			var got result
+			got.err = vm.Exec(context.Background(), func(root *Frame) {
+				got.rootID = root.ThreadID
+				got.err = vm.exec(context.Background(), root, func(child *Frame) {
+					got.childID = child.ThreadID
+				}, Sub)
+				ready.Done()
+				<-release
+			})
+			results <- got
+		}()
+	}
+
+	readyDone := make(chan struct{})
+	go func() {
+		ready.Wait()
+		close(readyDone)
+	}()
+	select {
+	case <-readyDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent root executions did not overlap")
+	}
+	close(release)
+
+	first, second := <-results, <-results
+	for _, got := range []result{first, second} {
+		if got.err != nil {
+			t.Fatalf("execution failed: %v", got.err)
+		}
+		if got.rootID == 0 {
+			t.Fatal("root execution received thread ID zero")
+		}
+		if got.childID != got.rootID {
+			t.Fatalf("nested thread ID = %d, want root ID %d", got.childID, got.rootID)
+		}
+	}
+	if first.rootID == second.rootID {
+		t.Fatalf("concurrent roots shared thread ID %d", first.rootID)
+	}
+}
+
+func TestConcurrentCrossVMSandboxExecutionsUseDefinitionVMThreadIDs(t *testing.T) {
+	definitionVM := New()
+	definitionFrame := NewFrame(definitionVM)
+	definitionFrame.ThreadID = definitionVM.nextThreadID()
+
+	function := NewFunction(nil, definitionVM.rootScope.GetSymTable())
+	function.scope = definitionVM.rootScope
+	function.defineFrame = definitionFrame
+
+	callerVM := New()
+	callerVM.SetSandboxMode(true)
+
+	type result struct {
+		threadID int
+		vm       *VirtualMachine
+		err      error
+	}
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			got := result{}
+			_, got.err = callerVM.ExecYakFunctionEx(context.Background(), function, nil, func(frame *Frame) {
+				got.threadID = frame.ThreadID
+				got.vm = frame.vm
+			}, None)
+			results <- got
+		}()
+	}
+
+	first, second := <-results, <-results
+	for _, got := range []result{first, second} {
+		if got.err != nil {
+			t.Fatalf("cross-VM execution failed: %v", got.err)
+		}
+		if got.vm != definitionVM {
+			t.Fatalf("execution VM = %p, want definition VM %p", got.vm, definitionVM)
+		}
+		if got.threadID == 0 || got.threadID == definitionFrame.ThreadID {
+			t.Fatalf("cross-VM execution reused retained definition thread ID %d", got.threadID)
+		}
+	}
+	if first.threadID == second.threadID {
+		t.Fatalf("concurrent cross-VM executions shared thread ID %d", first.threadID)
+	}
+}
+
+func testDebuggerForCodes(t *testing.T, vm *VirtualMachine, source string, codes []*Code, callback func(*Debugger)) *Debugger {
+	t.Helper()
+	if callback == nil {
+		callback = func(*Debugger) {}
+	}
+	debugger := NewDebugger(vm, source, codes, func(*Debugger) {}, callback)
+	vm.debugMode = true
+	vm.debugger = debugger
+	return debugger
+}
+
+func testCode(source, path string, opcode OpcodeFlag, line int) *Code {
+	return &Code{
+		Opcode:             opcode,
+		SourceCodePointer:  &source,
+		SourceCodeFilePath: &path,
+		StartLineNumber:    line,
+		EndLineNumber:      line,
+	}
+}
+
+func TestDebuggerDoesNotPushCrossVMCallOnCallerStack(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		crossVM   bool
+		wantDepth int
+	}{
+		{name: "same VM", crossVM: false, wantDepth: 1},
+		{name: "cross VM", crossVM: true, wantDepth: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			callerVM := New()
+			callerVM.SetSandboxMode(true)
+			definitionVM := callerVM
+			if test.crossVM {
+				definitionVM = New()
+			}
+
+			definitionFrame := NewFrame(definitionVM)
+			function := NewFunction(nil, definitionVM.rootScope.GetSymTable())
+			function.defineFrame = definitionFrame
+			callable := NewAutoValue(function)
+
+			source, path := "f()", "debugger-cross-vm.yak"
+			callCode := testCode(source, path, OpCall, 1)
+			frame := NewFrame(callerVM)
+			frame.ThreadID = callerVM.nextThreadID()
+			frame.codes = []*Code{callCode}
+			frame.push(callable)
+
+			debugger := testDebuggerForCodes(t, callerVM, source, frame.codes, nil)
+			debugger.ShouldCallback(frame)
+			stack := debugger.StackTraces[frame.ThreadID]
+			if stack == nil {
+				t.Fatal("debugger did not create a thread stack")
+			}
+			if stack.Len() != test.wantDepth {
+				t.Fatalf("caller debugger stack depth = %d, want %d", stack.Len(), test.wantDepth)
+			}
+		})
+	}
+}
+
+func TestDebuggerTerminalPanicIsSerialized(t *testing.T) {
+	var callbackCount atomic.Int32
+	callbackEntered := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	debugger := &Debugger{
+		started: true,
+		callbackFunc: func(*Debugger) {
+			if callbackCount.Add(1) == 1 {
+				close(callbackEntered)
+			}
+			<-releaseCallback
+		},
+		pausedThreads: make(map[int]struct{}),
+	}
+
+	const workers = 16
+	panicValue := &VMPanic{contextInfos: vmstack.New(), data: "concurrent panic"}
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			debugger.HandleForPanic(panicValue)
+		}()
+	}
+
+	select {
+	case <-callbackEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal callback was not entered")
+	}
+	close(releaseCallback)
+	wg.Wait()
+
+	if got := callbackCount.Load(); got != 1 {
+		t.Fatalf("terminal callback count = %d, want 1", got)
+	}
+	if !debugger.Finished() {
+		t.Fatal("debugger was not marked finished")
+	}
+}
+
+func TestDebuggerCallbackPanicStillPopsExpectedCaller(t *testing.T) {
+	vm := New()
+	source, path := "panic(1)", "debugger-callback-panic.yak"
+	pushCode := testCode(source, path, OpPush, 1)
+	pushCode.Op1 = NewIntValue(1)
+	panicCode := testCode(source, path, OpPanic, 1)
+	codes := []*Code{pushCode, panicCode}
+
+	function := NewFunction(codes, vm.rootScope.GetSymTable())
+	function.scope = vm.rootScope
+	var callbackCount atomic.Int32
+	debugger := testDebuggerForCodes(t, vm, source, codes, func(*Debugger) {
+		callbackCount.Add(1)
+		panic("debugger adapter failed")
+	})
+	debugger.codes[function.GetUUID()] = codes
+
+	caller := NewFrame(vm)
+	caller.ctx = context.Background()
+	caller.ThreadID = vm.nextThreadID()
+	outer := NewFrame(vm)
+	callSite := testCode(source, path, OpCall, 1)
+	stack := vmstack.New()
+	stack.Push(&DebuggerState{frame: outer, code: callSite})
+	stack.Push(&DebuggerState{frame: caller, code: callSite})
+	debugger.StackTraces[caller.ThreadID] = stack
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		caller.CallYakFunction(false, function, nil)
+	}()
+	if recovered == nil {
+		t.Fatal("Yak panic did not propagate to the caller")
+	}
+	if got := callbackCount.Load(); got != 1 {
+		t.Fatalf("terminal callback count = %d, want 1", got)
+	}
+	if stack.Len() != 1 || stack.Peek().(*DebuggerState).frame != outer {
+		t.Fatalf("caller pop did not preserve the outer debugger frame; depth=%d", stack.Len())
+	}
+
+	// The terminal callback panic must not leave Debugger.lock held.
+	unlocked := make(chan struct{})
+	go func() {
+		debugger.StackTracePopExpected(outer)
+		close(unlocked)
+	}()
+	select {
+	case <-unlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("debugger lock remained held after terminal callback panic")
+	}
+}
+
+func TestDebuggerMultipleDefersPopCallStackOnce(t *testing.T) {
+	vm := New()
+	source, path := "defer a(); defer b()", "debugger-multiple-defer.yak"
+	firstDefer := testCode(source, path, OpDefer, 1)
+	firstDefer.Op1 = NewAutoValue([]*Code{})
+	secondDefer := testCode(source, path, OpDefer, 1)
+	secondDefer.Op1 = NewAutoValue([]*Code{})
+	codes := []*Code{firstDefer, secondDefer}
+
+	function := NewFunction(codes, vm.rootScope.GetSymTable())
+	function.scope = vm.rootScope
+	debugger := testDebuggerForCodes(t, vm, source, codes, nil)
+	debugger.codes[function.GetUUID()] = codes
+
+	caller := NewFrame(vm)
+	caller.ctx = context.Background()
+	caller.ThreadID = vm.nextThreadID()
+	outer := NewFrame(vm)
+	callSite := testCode(source, path, OpCall, 1)
+	stack := vmstack.New()
+	stack.Push(&DebuggerState{frame: outer, code: callSite})
+	stack.Push(&DebuggerState{frame: caller, code: callSite})
+	debugger.StackTraces[caller.ThreadID] = stack
+
+	caller.CallYakFunction(false, function, nil)
+	if stack.Len() != 1 || stack.Peek().(*DebuggerState).frame != outer {
+		t.Fatalf("multiple defers over-popped debugger stack; depth=%d", stack.Len())
+	}
+}
+
+func TestDebuggerArgumentValidationPopsCallStack(t *testing.T) {
+	vm := New()
+	debugger := &Debugger{
+		StackTraces:      make(map[int]*vmstack.Stack),
+		ThreadStackTrace: make(map[int]*DebuggerState),
+		pausedThreads:    make(map[int]struct{}),
+		Reference:        NewReference(),
+	}
+	vm.debugMode = true
+	vm.debugger = debugger
+
+	caller := NewFrame(vm)
+	caller.ctx = context.Background()
+	caller.ThreadID = vm.nextThreadID()
+	outer := NewFrame(vm)
+	stack := vmstack.New()
+	stack.Push(&DebuggerState{frame: outer})
+	stack.Push(&DebuggerState{frame: caller})
+	debugger.StackTraces[caller.ThreadID] = stack
+
+	function := NewFunction(nil, vm.rootScope.GetSymTable())
+	function.scope = vm.rootScope
+	function.paramSymbols = []int{1}
+	panicked := false
+	func() {
+		defer func() { panicked = recover() != nil }()
+		caller.CallYakFunction(false, function, nil)
+	}()
+	if !panicked {
+		t.Fatal("argument validation unexpectedly succeeded")
+	}
+
+	if stack.Len() != 1 || stack.Peek().(*DebuggerState).frame != outer {
+		t.Fatalf("argument validation panic left a phantom call frame; depth=%d", stack.Len())
+	}
+}
+
+func TestDebuggerStepOutWithoutFrameReturnsError(t *testing.T) {
+	debugger := &Debugger{StackTraces: make(map[int]*vmstack.Stack)}
+	if err := debugger.StepOut(); err == nil {
+		t.Fatal("StepOut without a current frame unexpectedly succeeded")
+	}
+}

--- a/common/yak/antlr4yak/yakvm/func.go
+++ b/common/yak/antlr4yak/yakvm/func.go
@@ -104,6 +104,7 @@ func (f *Function) Copy(s *Scope) *Function {
 		uuid:                      f.uuid,
 		paramSymbols:              f.paramSymbols,
 		isVariableParameter:       f.isVariableParameter,
+		FreeValue:                 f.FreeValue,
 		defineFrame:               f.defineFrame,
 
 		// only this:
@@ -246,6 +247,13 @@ func LuaVMValuesToFunctionMap(f *Function, vs []*Value) map[int]*Value {
 }
 
 func (vm *Frame) CallYakFunction(asyncCall bool, f *Function, vs []*Value) interface{} {
+	if !asyncCall && vm.vm.debugMode && vm.vm.debugger != nil {
+		// ShouldCallback records this exact caller at OpCall. Pair the pop at
+		// the synchronous call boundary so recursive Exec for Yak defer blocks
+		// cannot consume additional debugger frames. Register before argument
+		// validation so a parameter-count panic is paired as well.
+		defer vm.vm.debugger.StackTracePopExpected(vm)
+	}
 	params := YakVMValuesToFunctionMap(f, vs, vm.vm.config.GetFunctionNumberCheck())
 
 	if asyncCall {
@@ -258,6 +266,9 @@ func (vm *Frame) CallYakFunction(asyncCall bool, f *Function, vs []*Value) inter
 }
 
 func (vm *Frame) CallLuaFunction(asyncCall bool, f *Function, vs []*Value) interface{} {
+	if vm.vm.debugMode && vm.vm.debugger != nil {
+		defer vm.vm.debugger.StackTracePopExpected(vm)
+	}
 	params := LuaVMValuesToFunctionMap(f, vs)
 
 	// TODO: 目前lua暂不支持coroutine

--- a/common/yak/antlr4yak/yakvm/function_copy_test.go
+++ b/common/yak/antlr4yak/yakvm/function_copy_test.go
@@ -1,0 +1,22 @@
+package yakvm
+
+import "testing"
+
+func TestFunctionCopyPreservesRuntimeMetadata(t *testing.T) {
+	vm := New()
+	definitionFrame := NewFrame(vm)
+	function := NewFunction(nil, vm.rootScope.GetSymTable())
+	function.defineFrame = definitionFrame
+	function.FreeValue = []int{3, 7}
+
+	copied := function.Copy(vm.rootScope)
+	if copied == function {
+		t.Fatal("Function.Copy returned the original function")
+	}
+	if copied.defineFrame != definitionFrame {
+		t.Fatal("Function.Copy dropped the sandbox definition frame")
+	}
+	if len(copied.FreeValue) != 2 || copied.FreeValue[0] != 3 || copied.FreeValue[1] != 7 {
+		t.Fatalf("Function.Copy lost free-value metadata: %v", copied.FreeValue)
+	}
+}

--- a/common/yak/antlr4yak/yakvm/op_assign.go
+++ b/common/yak/antlr4yak/yakvm/op_assign.go
@@ -4,6 +4,92 @@ import (
 	"fmt"
 )
 
+// canBindDirectFunctionInPlace recognizes the compiler's single-value direct
+// assignment shape:
+//
+//	OpPush(function), OpList(1), OpPushLeftRef, OpList(1), OpAssign
+//
+// OpPush has already copied the compiled Function template for this Frame, and
+// none of the intervening structural opcodes can publish that copy. It is
+// therefore safe to attach the first bind name to this private instance. Other
+// paths (aliases, calls, container reads and multi-assignments) deliberately
+// return false so prepareAssignedFunction keeps copying before it changes
+// observable function metadata.
+func (v *Frame) canBindDirectFunctionInPlace(function *Function) bool {
+	const prefixLength = 4
+	if v.codePointer < prefixLength || v.codePointer >= len(v.codes) {
+		return false
+	}
+
+	functionPush := v.codes[v.codePointer-prefixLength]
+	rightList := v.codes[v.codePointer-3]
+	leftRef := v.codes[v.codePointer-2]
+	leftList := v.codes[v.codePointer-1]
+	if functionPush == nil || functionPush.Opcode != OpPush || functionPush.Op1 == nil ||
+		rightList == nil || rightList.Opcode != OpList || rightList.Unary != 1 ||
+		leftRef == nil || leftRef.Opcode != OpPushLeftRef ||
+		leftList == nil || leftList.Opcode != OpList || leftList.Unary != 1 {
+		return false
+	}
+
+	template, ok := functionPush.Op1.Value.(*Function)
+	return ok && function != template && function.uuid == template.uuid
+}
+
+// prepareAssignedFunction keeps Function immutable after it has been published
+// through a Value. Scope and the first useful anonymous bind name belong to the
+// assignment result, not to a shared RHS function that another frame may call
+// or alias concurrently.
+func (v *Frame) prepareAssignedFunction(left, right *Value) *Value {
+	leftValues := left.ValueList()
+	rightValues := right.ValueList()
+	if len(leftValues) == 0 || len(rightValues) == 0 {
+		return right
+	}
+
+	rightValue := rightValues[0]
+	function, ok := rightValue.Value.(*Function)
+	if !ok {
+		return right
+	}
+
+	scope := function.scope
+	needsCopy := scope == nil
+	if scope == nil {
+		scope = v.CurrentScope()
+	}
+
+	bindName := ""
+	if function.name == "anonymous" && function.anonymousFunctionBindName == "" {
+		if leftValue, err := leftValues[0].ConvertToLeftValue(); err == nil && leftValue.IsLeftValueRef() {
+			if name, ok := v.CurrentScope().symtbl.GetNameByVariableId(leftValue.SymbolId); ok {
+				bindName = name
+				if !needsCopy && v.canBindDirectFunctionInPlace(function) {
+					function.anonymousFunctionBindName = bindName
+					return right
+				}
+				needsCopy = true
+			}
+		}
+	}
+	if !needsCopy {
+		return right
+	}
+
+	assignedFunction := function.Copy(scope)
+	if bindName != "" {
+		assignedFunction.anonymousFunctionBindName = bindName
+	}
+	assignedValue := *rightValue
+	assignedValue.Value = assignedFunction
+
+	assignedValues := append([]*Value(nil), rightValues...)
+	assignedValues[0] = &assignedValue
+	assignedList := *right
+	assignedList.Value = assignedValues
+	return &assignedList
+}
+
 func (v *Frame) assign(left, right *Value) {
 	if !(left.IsValueList() && right.IsValueList()) {
 		panic("BUG: assign: left and right must be value list")

--- a/common/yak/antlr4yak/yakvm/op_call.go
+++ b/common/yak/antlr4yak/yakvm/op_call.go
@@ -50,7 +50,6 @@ func (v *Frame) asyncCall(caller *Value, wavy bool, args []*Value) {
 		v.vm.callFuncCallback(caller, wavy, args)
 	}
 	if caller.Callable() {
-		v.vm.AsyncStart()
 		caller.AsyncCall(v, wavy, args...)
 		return
 	}

--- a/common/yak/antlr4yak/yakvm/opcodes_marshal.go
+++ b/common/yak/antlr4yak/yakvm/opcodes_marshal.go
@@ -184,6 +184,17 @@ func (c *CodesMarshaller) consumeSymbolTable(buf []byte) (*SymbolTable, []byte, 
 }
 
 func (c *CodesMarshaller) marshalSymbolTable(buf []byte, tbl *SymbolTable) ([]byte, error) {
+	// A cached top-level script can finish while one of its Yak async workers is
+	// compiling eval code against the same live symbol table. Snapshot the table
+	// under the same read locks used by compiler/runtime lookups so cache
+	// serialization cannot race with symbol or nested-scope registration.
+	symbolMutex.RLock()
+	symbolTableMutex.RLock()
+	requireSymbolMutex.RLock()
+	defer symbolMutex.RUnlock()
+	defer symbolTableMutex.RUnlock()
+	defer requireSymbolMutex.RUnlock()
+
 	if tbl.parent != nil {
 		return nil, utils.Error("Symbol table is not root table.")
 	}

--- a/common/yak/antlr4yak/yakvm/runtime.go
+++ b/common/yak/antlr4yak/yakvm/runtime.go
@@ -1,32 +1,58 @@
 package yakvm
 
-import (
-	"fmt"
-)
+import "fmt"
 
-var runtimeLib = map[string]func(frame *Frame) interface{}{
-	"GetInfo": func(frame *Frame) interface{} {
-		return func(infoType string, args ...interface{}) (interface{}, error) {
-			switch infoType {
-			case "line":
-				return frame.CurrentCode().StartLineNumber, nil
-			case "runtimeId":
-				result, ok := frame.GlobalVariables.Load("runtimeId")
-				if !ok {
-					return "", nil
-				}
-				return result, nil
-			default:
-				return nil, fmt.Errorf("unknown info type: %s", infoType)
-			}
+func getRuntimeInfo(frame *Frame, infoType string, args ...interface{}) (interface{}, error) {
+	if frame == nil {
+		return nil, fmt.Errorf("current frame is empty")
+	}
+
+	switch infoType {
+	case "line":
+		code := frame.CurrentCode()
+		if code == nil {
+			return nil, fmt.Errorf("current code is empty")
 		}
-	},
+		return code.StartLineNumber, nil
+	case "runtimeId":
+		result, ok := frame.GlobalVariables.Load("runtimeId")
+		if !ok {
+			return "", nil
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unknown info type: %s", infoType)
+	}
 }
 
-func ImportRuntimeLib(frame *Frame) {
-	lib := map[string]interface{}{}
-	for k, v := range runtimeLib {
-		lib[k] = v(frame)
+func newRuntimeLib(vm *VirtualMachine) map[string]interface{} {
+	return map[string]interface{}{
+		// Resolve the frame at call time. Top-level executions share the VM's
+		// runtime globals, so binding this closure to whichever frame happened to
+		// be created last makes concurrent hooks report each other's line number.
+		"GetInfo": func(infoType string, args ...interface{}) (interface{}, error) {
+			return getRuntimeInfo(vm.CurrentFM(), infoType, args...)
+		},
 	}
-	frame.GlobalVariables.Store("runtime", lib)
+}
+
+// ImportRuntimeLib is kept for callers that explicitly refresh a frame's
+// runtime helpers. Preserve the historical frame-bound behavior for this
+// explicit API, including callers that execute a Frame directly without first
+// registering it in the VM's goroutine-local stack. New VMs use the dynamic
+// VM-bound helper installed during initialization for ordinary execution.
+func ImportRuntimeLib(frame *Frame) {
+	if frame == nil || frame.vm == nil {
+		return
+	}
+	// Frames normally point at the VM-wide runtime globals. Keep this explicit
+	// compatibility binding private to the supplied frame; otherwise one direct
+	// Frame.Exec caller would replace the dynamic helper for every concurrent
+	// execution on the VM.
+	frame.GlobalVariables = frame.GlobalVariables.Clone()
+	frame.GlobalVariables.Store("runtime", map[string]interface{}{
+		"GetInfo": func(infoType string, args ...interface{}) (interface{}, error) {
+			return getRuntimeInfo(frame, infoType, args...)
+		},
+	})
 }

--- a/common/yak/antlr4yak/yakvm/runtime_concurrency_test.go
+++ b/common/yak/antlr4yak/yakvm/runtime_concurrency_test.go
@@ -1,0 +1,138 @@
+package yakvm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type runtimeLineResult struct {
+	line int
+	err  error
+}
+
+func TestRuntimeInfoUsesCallingGoroutineFrame(t *testing.T) {
+	vm := New()
+	aReady := make(chan struct{})
+	bReady := make(chan struct{})
+	releaseB := make(chan struct{})
+	aResult := make(chan runtimeLineResult, 1)
+	bResult := make(chan runtimeLineResult, 1)
+	var workers sync.WaitGroup
+	workers.Add(2)
+
+	go func() {
+		defer workers.Done()
+		err := vm.Exec(context.Background(), func(frame *Frame) {
+			frame.codes = []*Code{{StartLineNumber: 101}}
+			close(aReady)
+			<-bReady
+			line, lineErr := runtimeLine(frame)
+			aResult <- runtimeLineResult{line: line, err: lineErr}
+		})
+		if err != nil {
+			aResult <- runtimeLineResult{err: err}
+		}
+	}()
+	<-aReady
+
+	go func() {
+		defer workers.Done()
+		err := vm.Exec(context.Background(), func(frame *Frame) {
+			frame.codes = []*Code{{StartLineNumber: 202}}
+			close(bReady)
+			line, lineErr := runtimeLine(frame)
+			bResult <- runtimeLineResult{line: line, err: lineErr}
+			<-releaseB
+		})
+		if err != nil {
+			bResult <- runtimeLineResult{err: err}
+		}
+	}()
+
+	a := <-aResult
+	b := <-bResult
+	close(releaseB)
+	workers.Wait()
+	if a.err != nil || a.line != 101 {
+		t.Fatalf("goroutine A runtime line mismatch: line=%d err=%v", a.line, a.err)
+	}
+	if b.err != nil || b.line != 202 {
+		t.Fatalf("goroutine B runtime line mismatch: line=%d err=%v", b.line, b.err)
+	}
+
+	assertNoActiveFrames(t, vm)
+}
+
+func TestRuntimeInfoLineRejectsFrameWithoutCurrentCode(t *testing.T) {
+	vm := New()
+	var lineErr error
+	err := vm.Exec(context.Background(), func(frame *Frame) {
+		if frame.CurrentCode() != nil {
+			t.Fatal("empty frame unexpectedly has a current code")
+		}
+		_, lineErr = runtimeLine(frame)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lineErr == nil {
+		t.Fatal("runtime.GetInfo(line) accepted a frame without code")
+	}
+	assertNoActiveFrames(t, vm)
+}
+
+func TestImportRuntimeLibKeepsExplicitFrameBinding(t *testing.T) {
+	vm := New()
+	frame := NewFrame(vm)
+	frame.codes = []*Code{{StartLineNumber: 303}}
+	ImportRuntimeLib(frame)
+
+	line, err := runtimeLine(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != 303 {
+		t.Fatalf("explicit frame runtime line = %d, want 303", line)
+	}
+
+	// The explicit frame binding must not replace the VM-wide dynamic runtime
+	// helper used by later or concurrent executions.
+	var dynamicLine int
+	err = vm.Exec(context.Background(), func(dynamicFrame *Frame) {
+		dynamicFrame.codes = []*Code{{StartLineNumber: 404}}
+		dynamicLine, err = runtimeLine(dynamicFrame)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dynamicLine != 404 {
+		t.Fatalf("dynamic VM runtime line = %d, want 404", dynamicLine)
+	}
+	assertNoActiveFrames(t, vm)
+}
+
+func runtimeLine(frame *Frame) (int, error) {
+	raw, ok := frame.GlobalVariables.Load("runtime")
+	if !ok {
+		return 0, fmt.Errorf("runtime library not found")
+	}
+	lib, ok := raw.(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("unexpected runtime library type %T", raw)
+	}
+	getInfo, ok := lib["GetInfo"].(func(string, ...interface{}) (interface{}, error))
+	if !ok {
+		return 0, fmt.Errorf("runtime.GetInfo has type %T", lib["GetInfo"])
+	}
+	line, err := getInfo("line")
+	if err != nil {
+		return 0, err
+	}
+	value, ok := line.(int)
+	if !ok {
+		return 0, fmt.Errorf("runtime line has type %T", line)
+	}
+	return value, nil
+}

--- a/common/yak/antlr4yak/yakvm/stack.go
+++ b/common/yak/antlr4yak/yakvm/stack.go
@@ -53,3 +53,26 @@ func (v *Frame) popArgN(n int) []*Value {
 	}
 	return v.popReverseN(n)
 }
+
+func (v *Frame) setPendingCallArgCount(code *Code, count int) {
+	v.pendingCallCode = code
+	v.pendingCallArgCount = count
+}
+
+func (v *Frame) effectiveCallArgCount(code *Code) int {
+	if v.pendingCallCode == code {
+		return v.pendingCallArgCount
+	}
+	return code.Unary
+}
+
+func (v *Frame) consumeCallArgCount(code *Code) int {
+	count := v.effectiveCallArgCount(code)
+	v.clearPendingCallArgCount()
+	return count
+}
+
+func (v *Frame) clearPendingCallArgCount() {
+	v.pendingCallCode = nil
+	v.pendingCallArgCount = 0
+}

--- a/common/yak/antlr4yak/yakvm/symboltable.go
+++ b/common/yak/antlr4yak/yakvm/symboltable.go
@@ -107,20 +107,30 @@ func NewSymbolTable() *SymbolTable {
 }
 
 func (s *SymbolTable) IsNew() bool {
-	return s.Verbose == "root" && (s.currentSymbolIndex == 0)
+	requireSymbolMutex.RLock()
+	defer requireSymbolMutex.RUnlock()
+	return s.Verbose == "root" && s.currentSymbolIndex == 0
 }
 func (s *SymbolTable) GetTableCount() int {
+	symbolTableMutex.RLock()
+	defer symbolTableMutex.RUnlock()
 	return s.tableCount
 }
 func (s *SymbolTable) SetIdIsInited(id int) {
+	symbolTableMutex.Lock()
+	defer symbolTableMutex.Unlock()
 	s.InitedId[id] = struct{}{}
 }
 func (s *SymbolTable) IdIsInited(id int) bool {
+	symbolTableMutex.RLock()
+	defer symbolTableMutex.RUnlock()
 	_, ok := s.InitedId[id]
 	return ok
 }
 
 func (s *SymbolTable) GetNameByVariableId(id int) (string, bool) {
+	symbolMutex.RLock()
+	defer symbolMutex.RUnlock()
 	for name, i := range s.symbolToId {
 		if i == id {
 			return name, true
@@ -136,7 +146,10 @@ func (s *SymbolTable) GetSymbolByVariableName(name string) (int, bool) {
 	if s == nil {
 		return 0, false
 	}
+	symbolMutex.RLock()
 	i, ok := s.symbolToId[name]
+	parent := s.parent
+	symbolMutex.RUnlock()
 	//if s.IsRoot {
 	// 如果定义域是根节点
 	//if ok {
@@ -148,13 +161,15 @@ func (s *SymbolTable) GetSymbolByVariableName(name string) (int, bool) {
 	if ok {
 		return i, true
 	}
-	return s.parent.GetSymbolByVariableName(name)
+	return parent.GetSymbolByVariableName(name)
 }
 
 func (s *SymbolTable) GetLocalSymbolByVariableName(name string) (int, bool) {
 	if s == nil {
 		return 0, false
 	}
+	symbolMutex.RLock()
+	defer symbolMutex.RUnlock()
 	i, ok := s.symbolToId[name]
 	return i, ok
 }
@@ -206,9 +221,9 @@ func (s *SymbolTable) GetLocalSymbolByVariableName(name string) (int, bool) {
 //}
 
 var (
-	symbolMutex        = new(sync.Mutex)
-	symbolTableMutex   = new(sync.Mutex)
-	requireSymbolMutex = new(sync.Mutex)
+	symbolMutex        = new(sync.RWMutex)
+	symbolTableMutex   = new(sync.RWMutex)
+	requireSymbolMutex = new(sync.RWMutex)
 )
 
 func (s *SymbolTable) requireId(target *SymbolTable) int {
@@ -257,13 +272,13 @@ func (s *SymbolTable) CreateSubSymbolTable(verbose ...string) *SymbolTable {
 		parent:     s,
 		InitedId:   make(map[int]struct{}),
 	}
-	s.children = append(s.children, sub)
 	root, err := s.GetRoot()
 	if err != nil {
 		panic(err)
 	}
 	symbolTableMutex.Lock()
 	defer symbolTableMutex.Unlock()
+	s.children = append(s.children, sub)
 	root.tableCount++
 	root.idToSymbolTable[root.tableCount] = sub
 	sub.index = root.tableCount
@@ -295,6 +310,8 @@ func (s *SymbolTable) MustRoot() *SymbolTable {
 }
 
 func (s *SymbolTable) GetTableIndex() int {
+	symbolTableMutex.RLock()
+	defer symbolTableMutex.RUnlock()
 	return s.tableCount
 }
 
@@ -307,5 +324,7 @@ func (s *SymbolTable) GetSymbolTableById(id int) *SymbolTable {
 	if err != nil {
 		panic(err)
 	}
+	symbolTableMutex.RLock()
+	defer symbolTableMutex.RUnlock()
 	return root.idToSymbolTable[id]
 }

--- a/common/yak/antlr4yak/yakvm/value.go
+++ b/common/yak/antlr4yak/yakvm/value.go
@@ -32,55 +32,68 @@ type Value struct {
 	ExtraInfo map[string]interface{}
 }
 
-const cachedRunesKey = "yakvm_cached_runes"
-
 func (v *Value) GetLiteral() string {
-	if v.Literal == "" {
-		switch ret := v.Value.(type) {
-		case bool:
-			v.Literal = strconv.FormatBool(ret)
-		case int:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case int8:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case int16:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case int32:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case int64:
-			v.Literal = strconv.FormatInt(ret, 10)
-		case uint8: // byte
-			v.Literal = string([]byte{ret})
-		case uint:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case uint16:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case uint32:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case uint64:
-			v.Literal = strconv.FormatInt(int64(ret), 10)
-		case float64:
-			v.Literal = strconv.FormatFloat(ret, 'f', 4, 64)
-		case float32:
-			v.Literal = strconv.FormatFloat(float64(ret), 'f', 4, 32)
-		case []byte:
-			v.Literal = strconv.Quote(string(ret))
-		case string:
-			v.Literal = strconv.Quote(ret)
-		default:
-			if v.Value != nil && v.NativeCallable() {
-				funcIns := runtime.FuncForPC(reflect.ValueOf(v.Value).Pointer())
-				funcName := funcIns.Name()
-				if funcName != "" {
-					v.Literal = funcName
-				}
-			}
-			if v.Literal == "" {
-				v.Literal = fmt.Sprint(ret)
+	if v.Literal != "" {
+		return v.Literal
+	}
+
+	var literal string
+	switch ret := v.Value.(type) {
+	case bool:
+		literal = strconv.FormatBool(ret)
+	case int:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case int8:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case int16:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case int32:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case int64:
+		literal = strconv.FormatInt(ret, 10)
+	case uint8: // byte
+		literal = string([]byte{ret})
+	case uint:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case uint16:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case uint32:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case uint64:
+		literal = strconv.FormatInt(int64(ret), 10)
+	case float64:
+		literal = strconv.FormatFloat(ret, 'f', 4, 64)
+	case float32:
+		literal = strconv.FormatFloat(float64(ret), 'f', 4, 32)
+	case []byte:
+		literal = strconv.Quote(string(ret))
+	case string:
+		literal = strconv.Quote(ret)
+	default:
+		if v.Value != nil && v.NativeCallable() {
+			if funcIns := runtime.FuncForPC(reflect.ValueOf(v.Value).Pointer()); funcIns != nil {
+				literal = funcIns.Name()
 			}
 		}
+		if literal == "" {
+			literal = fmt.Sprint(ret)
+		}
 	}
-	return v.Literal
+	return literal
+}
+
+// memberLiteral is used only to describe a derived member value. Avoid
+// formatting the caller's live Go object: concurrent method calls may mutate
+// that object, and its stable type is both cheaper and more useful in errors.
+func (v *Value) memberLiteral(member string) string {
+	prefix := v.Literal
+	if prefix == "" {
+		prefix = v.TypeVerbose
+	}
+	if prefix == "" {
+		prefix = "value"
+	}
+	return prefix + "." + member
 }
 
 func (v *Value) AddExtraInfo(key string, info interface{}) {
@@ -108,21 +121,43 @@ func ChannelValueListToValue(op *Value) *Value {
 	return op
 }
 
-func cacheRunes(val *Value) []rune {
+const (
+	frameRuneCacheMaxEntries = 16
+	frameRuneCacheMaxBytes   = 256 << 10
+)
+
+func (v *Frame) clearRuneCache() {
+	v.runeCache = nil
+	v.runeCacheBytes = 0
+}
+
+func (v *Frame) cacheRunes(val *Value) []rune {
 	if val == nil {
 		return nil
 	}
-	if cached := val.GetExtraInfo(cachedRunesKey); cached != nil {
-		if runes, ok := cached.([]rune); ok {
-			return runes
-		}
+	if runes, ok := v.runeCache[val]; ok {
+		return runes
 	}
 	s, ok := val.Value.(string)
 	if !ok {
 		return nil
 	}
 	runes := []rune(s)
-	val.AddExtraInfo(cachedRunesKey, runes)
+	// Account for the retained string bytes and rune backing array. Very large
+	// values are deliberately not cached: conversion still succeeds, but a
+	// long-lived Trace/Inline frame cannot retain them after the operation.
+	cost := len(s) + cap(runes)*4
+	if cost > frameRuneCacheMaxBytes {
+		return runes
+	}
+	if v.runeCache == nil {
+		v.runeCache = make(map[*Value][]rune, frameRuneCacheMaxEntries)
+	} else if len(v.runeCache) >= frameRuneCacheMaxEntries || v.runeCacheBytes+cost > frameRuneCacheMaxBytes {
+		clear(v.runeCache)
+		v.runeCacheBytes = 0
+	}
+	v.runeCache[val] = runes
+	v.runeCacheBytes += cost
 	return runes
 }
 
@@ -134,7 +169,7 @@ func (v *Frame) getValueForLeftIterableCall(args []*Value) *Value {
 	iterableValueType := reflect.TypeOf(iterableValue.Value)
 	if iterableValueType.Kind() == reflect.String {
 		if _, ok := iterableValue.Value.(string); ok {
-			runes := cacheRunes(iterableValue)
+			runes := v.cacheRunes(iterableValue)
 			if argsLength != 1 {
 				panic("left slice call args must be 1")
 			}

--- a/common/yak/antlr4yak/yakvm/value_call.go
+++ b/common/yak/antlr4yak/yakvm/value_call.go
@@ -17,11 +17,9 @@ func (v *Value) NativeCall(vm *Frame, wavy bool, vs ...*Value) interface{} {
 	return v.nativeCall(false, wavy, vm, vs...)
 }
 
-
 func (v *Value) nativeCall(asyncCall, wavy bool, vm *Frame, vs ...*Value) interface{} {
 	rets := reflect.ValueOf(v.Value)
 	funcType := rets.Type()
-	funcName := v.GetLiteral()
 	// 这儿很不完善，需要做大量兼容性处理
 	numin := funcType.NumIn()
 	if funcType.IsVariadic() {
@@ -58,7 +56,7 @@ func (v *Value) nativeCall(asyncCall, wavy bool, vm *Frame, vs ...*Value) interf
 			err := vm.AutoConvertReflectValueByType(&argVal, targetType)
 			if err != nil {
 				msg := fmt.Sprintf(
-					"native func `%s` calling failed: auto convert failed, cannot convert %v(passed) to %v(need)", funcName,
+					"native func `%s` calling failed: auto convert failed, cannot convert %v(passed) to %v(need)", v.GetLiteral(),
 					args[i].Type(), funcType.In(i),
 				)
 				panic(msg)
@@ -68,7 +66,7 @@ func (v *Value) nativeCall(asyncCall, wavy bool, vm *Frame, vs ...*Value) interf
 	} else {
 		// 不可变参数的话，输入的函数参数列表长度和需要的参数列表长度应该是相等的
 		if vm.vm.GetConfig().GetFunctionNumberCheck() && funcType.NumIn() != len(vs) {
-			msg := fmt.Sprintf("native func `%s` need [%v] params, actually got [%v] params", funcName, funcType.NumIn(), len(vs))
+			msg := fmt.Sprintf("native func `%s` need [%v] params, actually got [%v] params", v.GetLiteral(), funcType.NumIn(), len(vs))
 			panic(msg)
 		}
 		for i := 0; i < funcType.NumIn(); i++ {
@@ -76,7 +74,7 @@ func (v *Value) nativeCall(asyncCall, wavy bool, vm *Frame, vs ...*Value) interf
 			err := vm.AutoConvertReflectValueByType(&argVal, funcType.In(i))
 			if err != nil {
 				msg := fmt.Sprintf(
-					"native func `%s` calling failed: auto convert failed, cannot convert %v(passed) to %v(need)", funcName,
+					"native func `%s` calling failed: auto convert failed, cannot convert %v(passed) to %v(need)", v.GetLiteral(),
 					args[i].Type(), funcType.In(i),
 				)
 				panic(msg)
@@ -91,6 +89,9 @@ func (v *Value) nativeCall(asyncCall, wavy bool, vm *Frame, vs ...*Value) interf
 	//	println(a.Type().String())
 	//}
 	if asyncCall {
+		// Register only after argument validation has succeeded. A panic before a
+		// goroutine is created must not leave AsyncWait blocked forever.
+		vm.vm.AsyncStart()
 		go func() {
 			defer vm.vm.AsyncEnd()
 			rets.Call(args)
@@ -132,7 +133,7 @@ func (v *Value) nativeCall(asyncCall, wavy bool, vm *Frame, vs ...*Value) interf
 		if err, ok := lastValue.(error); ok || lastValue == nil {
 			vals = vals[:len(vals)-1]
 			if err != nil {
-				panic(utils.Errorf("native func `%s` call error: %v", funcName, err))
+				panic(utils.Errorf("native func `%s` call error: %v", v.GetLiteral(), err))
 			}
 		}
 	}

--- a/common/yak/antlr4yak/yakvm/value_concurrency_test.go
+++ b/common/yak/antlr4yak/yakvm/value_concurrency_test.go
@@ -1,0 +1,191 @@
+package yakvm
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func valueNativeLiteralTarget() {}
+
+func TestValueDerivedDataIsConcurrentSafe(t *testing.T) {
+	const workers = 32
+	nativeLiteral := runtime.FuncForPC(reflect.ValueOf(valueNativeLiteralTarget).Pointer()).Name()
+	waitGroup := new(sync.WaitGroup)
+	mutex := new(sync.Mutex)
+	values := []struct {
+		value   *Value
+		literal string
+	}{
+		{value: NewBoolValue(true), literal: "true"},
+		{value: NewIntValue(42), literal: "42"},
+		{value: NewAutoValue(float64(3.5)), literal: "3.5000"},
+		{value: NewStringValue("你好yak"), literal: `"你好yak"`},
+		{value: NewAutoValue(waitGroup), literal: fmt.Sprint(waitGroup)},
+		{value: NewAutoValue(mutex), literal: fmt.Sprint(mutex)},
+		{value: NewAutoValue(valueNativeLiteralTarget), literal: nativeLiteral},
+	}
+	stringValue := values[3].value
+	frames := make([]*Frame, workers)
+	for i := range frames {
+		frames[i] = &Frame{}
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(frame *Frame) {
+			defer wg.Done()
+			<-start
+			for iteration := 0; iteration < 100; iteration++ {
+				for _, testCase := range values {
+					if got := testCase.value.GetLiteral(); got != testCase.literal {
+						errs <- fmt.Errorf("GetLiteral() = %q, want %q", got, testCase.literal)
+						return
+					}
+				}
+				if got := string(frame.cacheRunes(stringValue)); got != "你好yak" {
+					errs <- fmt.Errorf("cacheRunes() = %q, want %q", got, "你好yak")
+					return
+				}
+			}
+		}(frames[worker])
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	for _, testCase := range values {
+		if testCase.value.Literal != "" {
+			t.Fatalf("GetLiteral mutated shared Literal to %q", testCase.value.Literal)
+		}
+	}
+}
+
+func assertRuneCacheReleased(t *testing.T, frame *Frame) {
+	t.Helper()
+	if frame.runeCache != nil || frame.runeCacheBytes != 0 {
+		t.Fatalf("rune cache retained %d entries / %d bytes", len(frame.runeCache), frame.runeCacheBytes)
+	}
+}
+
+func primeRuneCache(t *testing.T, frame *Frame) {
+	t.Helper()
+	value := NewStringValue("你好 yakvm")
+	if got := string(frame.cacheRunes(value)); got != "你好 yakvm" {
+		t.Fatalf("cacheRunes() = %q", got)
+	}
+	if len(frame.runeCache) != 1 || frame.runeCacheBytes == 0 {
+		t.Fatalf("rune cache was not populated: entries=%d bytes=%d", len(frame.runeCache), frame.runeCacheBytes)
+	}
+}
+
+func TestFrameRuneCacheIsBoundedAndReleased(t *testing.T) {
+	frame := NewFrame(New())
+	for i := 0; i < 512; i++ {
+		raw := fmt.Sprintf("%04d-%s", i, strings.Repeat("界", 8<<10))
+		value := NewStringValue(raw)
+		if got := string(frame.cacheRunes(value)); got != raw {
+			t.Fatalf("cacheRunes iteration %d changed the string", i)
+		}
+		if entries := len(frame.runeCache); entries > frameRuneCacheMaxEntries {
+			t.Fatalf("rune cache grew to %d entries, max %d", entries, frameRuneCacheMaxEntries)
+		}
+		if frame.runeCacheBytes > frameRuneCacheMaxBytes {
+			t.Fatalf("rune cache retained %d bytes, max %d", frame.runeCacheBytes, frameRuneCacheMaxBytes)
+		}
+	}
+
+	entries, retainedBytes := len(frame.runeCache), frame.runeCacheBytes
+	large := strings.Repeat("界", frameRuneCacheMaxBytes)
+	if got := string(frame.cacheRunes(NewStringValue(large))); got != large {
+		t.Fatal("oversized uncached conversion changed the string")
+	}
+	if len(frame.runeCache) != entries || frame.runeCacheBytes != retainedBytes {
+		t.Fatalf("oversized value entered cache: before=%d/%d after=%d/%d",
+			entries, retainedBytes, len(frame.runeCache), frame.runeCacheBytes)
+	}
+
+	t.Run("normal", func(t *testing.T) {
+		frame := NewFrame(New())
+		primeRuneCache(t, frame)
+		frame.Exec(nil)
+		assertRuneCacheReleased(t, frame)
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		frame := NewFrame(New())
+		primeRuneCache(t, frame)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		frame.ctx = ctx
+		frame.Exec([]*Code{{Opcode: OpPush, Op1: NewIntValue(1)}})
+		assertRuneCacheReleased(t, frame)
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		vm := New()
+		vm.GetConfig().SetStopRecover(true)
+		frame := NewFrame(vm)
+		frame.ctx = context.Background()
+		primeRuneCache(t, frame)
+		gotPanic := false
+		func() {
+			defer func() {
+				if recover() != nil {
+					gotPanic = true
+				}
+			}()
+			frame.Exec([]*Code{
+				{Opcode: OpPush, Op1: NewIntValue(1)},
+				{Opcode: OpExit, Op1: NewStringValue("cache release panic")},
+			})
+		}()
+		if !gotPanic {
+			t.Fatal("expected VM panic")
+		}
+		assertRuneCacheReleased(t, frame)
+	})
+}
+
+func TestRetainedTraceFrameDoesNotKeepRuneCacheBetweenInlineRuns(t *testing.T) {
+	vm := New()
+	ctx := context.Background()
+	var retained *Frame
+	if err := vm.Exec(ctx, func(frame *Frame) {
+		retained = frame
+		primeRuneCache(t, frame)
+		frame.Exec(nil)
+	}, Trace); err != nil {
+		t.Fatal(err)
+	}
+	assertRuneCacheReleased(t, retained)
+
+	for i := 0; i < 100; i++ {
+		if err := vm.Exec(ctx, func(frame *Frame) {
+			if frame != retained {
+				t.Fatalf("inline run %d changed retained frame", i)
+			}
+			value := NewStringValue(fmt.Sprintf("inline-%d-%s", i, strings.Repeat("界", 1024)))
+			if runes := frame.cacheRunes(value); len(runes) == 0 {
+				t.Fatalf("inline run %d did not convert string", i)
+			}
+			frame.Exec(nil)
+			assertRuneCacheReleased(t, frame)
+		}, Inline); err != nil {
+			t.Fatalf("inline run %d failed: %v", i, err)
+		}
+	}
+
+	if popped := vm.popCurrentFrame(retained); popped != retained {
+		t.Fatalf("failed to pop retained trace frame: %#v", popped)
+	}
+}

--- a/common/yak/antlr4yak/yakvm/virtual_machine.go
+++ b/common/yak/antlr4yak/yakvm/virtual_machine.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"strconv"
-	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/yaklang/yaklang/common/utils/limitedmap"
 
@@ -44,6 +43,7 @@ type (
 
 		frameStacksMu sync.RWMutex
 		frameStacks   map[int64]*vmstack.Stack
+		activeFrames  atomic.Int64
 		rootScope     *Scope
 
 		// asyncWaitGroup
@@ -154,6 +154,10 @@ func NewWithSymbolTable(table *SymbolTable) *VirtualMachine {
 		// debug
 		ThreadIDCount: 1, // 初始是1
 	}
+	// Establish the immutable-library parent before the VM can be shared. This
+	// keeps even a bare VM from lazily mutating the parent link on its first
+	// concurrent GetVar call; ImportLibs refreshes it when libraries are added.
+	v.runtimeGlobalVar.SetPred(v.globalVar)
 	return v
 }
 
@@ -262,7 +266,9 @@ func (v *VirtualMachine) execYakFunctionWithParentFrame(ctx context.Context, par
 	}
 	err := v.exec(ctx, parentFrame, func(frame *Frame) {
 		if v.sandboxMode && f.defineFrame != nil {
+			ownerGoroutineID := frame.ownerGoroutineID
 			frame = NewSubFrame(f.defineFrame)
+			frame.ownerGoroutineID = ownerGoroutineID
 		}
 		name := f.GetActualName()
 		frame.SetVerbose(fmt.Sprintf("function: %s", name))
@@ -324,7 +330,7 @@ func (v *VirtualMachine) ExecAsyncYakFunction(ctx context.Context, parentFrame *
 	go func() {
 		v.pushCurrentFrame(frame)
 		defer func() {
-			v.popCurrentFrame()
+			v.popCurrentFrame(frame)
 			v.AsyncEnd()
 			if err := frame.recover(); err != nil {
 				log.Errorf("yakvm async function panic: %v", err)
@@ -376,6 +382,11 @@ func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(fr
 			return utils.Error("BUG: current frame is empty(Sub)")
 		}
 		frame = NewSubFrame(parentFrame)
+		// Synchronous Yak function calls stay on the parent's goroutine. Reuse
+		// its already-resolved ID instead of calling runtime.Stack for every
+		// nested frame. Async calls do not go through this path and resolve their
+		// owner after the goroutine starts.
+		frame.ownerGoroutineID = parentFrame.ownerGoroutineID
 	} else if flag&Inline == Inline {
 		topFrame := v.peekCurrentFrame()
 
@@ -388,14 +399,13 @@ func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(fr
 		codes := frame.codes
 		p := frame.codePointer
 
-		frame.GlobalVariables = v.runtimeGlobalVar.SetPred(v.globalVar)
+		frame.GlobalVariables = v.runtimeGlobalVar
 		defer func() {
 			frame.codes = codes
 			frame.codePointer = p
 		}()
 	} else {
 		frame = NewFrame(v)
-		frame.GlobalVariables = v.runtimeGlobalVar.SetPred(v.globalVar)
 	}
 
 	if flag&Asnyc == Asnyc {
@@ -407,7 +417,7 @@ func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(fr
 	v.pushCurrentFrame(frame)
 	shouldPop := flag&Trace != Trace
 	if shouldPop {
-		defer v.popCurrentFrame()
+		defer v.popCurrentFrame(frame)
 	}
 
 	frame.debug = v.debug
@@ -439,44 +449,52 @@ func (v *VirtualMachine) CurrentFM() *Frame {
 }
 
 func currentGoroutineID() int64 {
-	buf := make([]byte, 64)
-	n := runtime.Stack(buf, false)
-	if n <= 0 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	const prefix = "goroutine "
+	if n <= len(prefix) {
 		return 0
 	}
-	fields := strings.Fields(string(buf[:n]))
-	if len(fields) < 2 {
-		return 0
+
+	var id int64
+	foundDigit := false
+	for i := len(prefix); i < n; i++ {
+		c := buf[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		foundDigit = true
+		id = id*10 + int64(c-'0')
 	}
-	id, err := strconv.ParseInt(fields[1], 10, 64)
-	if err != nil {
+	if !foundDigit {
 		return 0
 	}
 	return id
 }
 
-func (v *VirtualMachine) getGoroutineFrameStack(gid int64, create bool) *vmstack.Stack {
-	v.frameStacksMu.Lock()
-	defer v.frameStacksMu.Unlock()
-
-	stack, ok := v.frameStacks[gid]
-	if ok || !create {
-		return stack
+func (v *VirtualMachine) pushCurrentFrame(frame *Frame) {
+	gid := frame.ownerGoroutineID
+	if gid == 0 {
+		gid = currentGoroutineID()
+		frame.ownerGoroutineID = gid
 	}
 
-	stack = vmstack.New()
-	v.frameStacks[gid] = stack
-	return stack
-}
-
-func (v *VirtualMachine) pushCurrentFrame(frame *Frame) {
-	gid := currentGoroutineID()
-	stack := v.getGoroutineFrameStack(gid, true)
+	v.frameStacksMu.Lock()
+	defer v.frameStacksMu.Unlock()
+	stack, ok := v.frameStacks[gid]
+	if !ok {
+		stack = vmstack.New()
+		v.frameStacks[gid] = stack
+	}
 	stack.Push(frame)
+	v.activeFrames.Add(1)
 }
 
-func (v *VirtualMachine) popCurrentFrame() *Frame {
-	gid := currentGoroutineID()
+func (v *VirtualMachine) popCurrentFrame(expected *Frame) *Frame {
+	gid := expected.ownerGoroutineID
+	if gid == 0 {
+		gid = currentGoroutineID()
+	}
 
 	v.frameStacksMu.Lock()
 	defer v.frameStacksMu.Unlock()
@@ -486,6 +504,9 @@ func (v *VirtualMachine) popCurrentFrame() *Frame {
 		return nil
 	}
 	frame, _ := stack.Pop().(*Frame)
+	if frame != nil {
+		v.activeFrames.Add(-1)
+	}
 	if stack.Len() == 0 {
 		delete(v.frameStacks, gid)
 	}
@@ -493,6 +514,12 @@ func (v *VirtualMachine) popCurrentFrame() *Frame {
 }
 
 func (v *VirtualMachine) peekCurrentFrame() *Frame {
+	// Most external GetVar calls happen after compilation has finished, when
+	// there cannot be a current frame. Avoid runtime.Stack entirely in that
+	// common hot-load path.
+	if v.activeFrames.Load() == 0 {
+		return nil
+	}
 	gid := currentGoroutineID()
 
 	v.frameStacksMu.RLock()

--- a/common/yak/antlr4yak/yakvm/virtual_machine.go
+++ b/common/yak/antlr4yak/yakvm/virtual_machine.go
@@ -53,7 +53,7 @@ type (
 		debugMode     bool // 外部debugger
 		debugger      *Debugger
 		BreakPoint    []BreakPointFactoryFun
-		ThreadIDCount uint64
+		ThreadIDCount uint64 // atomically allocated VM execution thread IDs
 		config        *VirtualMachineConfig
 		// map[sha1(caller, callee)]func(any)any
 		hijackMapMemberCallHandlers sync.Map
@@ -151,14 +151,20 @@ func NewWithSymbolTable(table *SymbolTable) *VirtualMachine {
 		config:           NewVMConfig(),
 		// asyncWaitGroup
 		asyncWaitGroup: new(sync.WaitGroup),
-		// debug
-		ThreadIDCount: 1, // 初始是1
+		// Thread IDs start at one. ThreadIDCount stores the last allocated ID,
+		// so its zero value lets nextThreadID preserve that public convention.
+		ThreadIDCount: 0,
 	}
 	// Establish the immutable-library parent before the VM can be shared. This
 	// keeps even a bare VM from lazily mutating the parent link on its first
 	// concurrent GetVar call; ImportLibs refreshes it when libraries are added.
 	v.runtimeGlobalVar.SetPred(v.globalVar)
+	v.runtimeGlobalVar.Store("runtime", newRuntimeLib(v))
 	return v
+}
+
+func (v *VirtualMachine) nextThreadID() int {
+	return int(atomic.AddUint64(&v.ThreadIDCount, 1))
 }
 
 func New() *VirtualMachine {
@@ -264,12 +270,38 @@ func (v *VirtualMachine) execYakFunctionWithParentFrame(ctx context.Context, par
 	if len(flags) > 0 {
 		finalFlags = flags
 	}
-	err := v.exec(ctx, parentFrame, func(frame *Frame) {
-		if v.sandboxMode && f.defineFrame != nil {
-			ownerGoroutineID := frame.ownerGoroutineID
-			frame = NewSubFrame(f.defineFrame)
-			frame.ownerGoroutineID = ownerGoroutineID
+	var frameFactory func(*Frame) *Frame
+	if v.sandboxMode && f.defineFrame != nil {
+		// Sandbox functions execute against the frame in which they were
+		// defined. Select that frame before registering the execution with the
+		// VM so CurrentFM, runtime.GetInfo and engine-backed logging all observe
+		// the frame that is actually running, rather than the temporary Sub
+		// frame created by exec.
+		frameFactory = func(defaultFrame *Frame) *Frame {
+			frame := NewSubFrame(f.defineFrame)
+			// The definition frame supplies lexical scope, globals and VM
+			// capabilities, but its coroutine belongs to the execution that
+			// originally created the closure. Reusing it makes concurrent
+			// sandboxes race on lastPanic and can leak a panic across callers.
+			// Keep panic propagation within the current caller's chain instead.
+			frame.coroutine = defaultFrame.coroutine
+			frame.ownerGoroutineID = defaultFrame.ownerGoroutineID
+			if frame.vm == defaultFrame.vm {
+				// A same-VM sandbox call is still a synchronous nested call and
+				// therefore belongs to the caller's debugger thread.
+				frame.ThreadID = defaultFrame.ThreadID
+				frame.ownsThreadID = defaultFrame.ownsThreadID
+			} else {
+				// The definition VM owns this frame, its globals and its debugger.
+				// Give independent cross-VM calls distinct IDs in that VM so
+				// concurrent callers cannot share debugger stack state.
+				frame.ThreadID = frame.vm.nextThreadID()
+				frame.ownsThreadID = true
+			}
+			return frame
 		}
+	}
+	err := v.execWithFrameFactory(ctx, parentFrame, frameFactory, func(frame *Frame) {
 		name := f.GetActualName()
 		frame.SetVerbose(fmt.Sprintf("function: %s", name))
 		frame.SetFunction(f)
@@ -314,6 +346,18 @@ func (v *VirtualMachine) ExecAsyncYakFunction(ctx context.Context, parentFrame *
 	} else {
 		frame = NewSubFrame(parentFrame)
 	}
+	executionVM := frame.vm
+	if executionVM == nil {
+		executionVM = v
+	}
+	// Allocate the VM thread ID before the goroutine starts. Loading the shared
+	// counter inside Frame.Exec lets delayed siblings observe the same final ID
+	// and also makes synchronous subframes change IDs when another async call is
+	// spawned. A sandbox can invoke a function defined by another VM; in that
+	// case the frame keeps the definition VM's globals, operators and debugger,
+	// so its thread ID and current-frame registration must live there as well.
+	frame.ThreadID = executionVM.nextThreadID()
+	frame.ownsThreadID = true
 	frame.coroutine = NewCoroutine()
 
 	name := f.GetActualName()
@@ -327,10 +371,13 @@ func (v *VirtualMachine) ExecAsyncYakFunction(ctx context.Context, parentFrame *
 
 	frame.ctx = ctx
 
+	// Register only once the async frame is fully constructed. Early context or
+	// validation failures must not leave an unmatched WaitGroup increment.
+	v.AsyncStart()
 	go func() {
-		v.pushCurrentFrame(frame)
+		executionVM.pushCurrentFrame(frame)
 		defer func() {
-			v.popCurrentFrame(frame)
+			executionVM.popCurrentFrame(frame)
 			v.AsyncEnd()
 			if err := frame.recover(); err != nil {
 				log.Errorf("yakvm async function panic: %v", err)
@@ -366,6 +413,10 @@ func (v *VirtualMachine) Exec(ctx context.Context, f func(frame *Frame), flags .
 }
 
 func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(frame *Frame), flags ...ExecFlag) error {
+	return v.execWithFrameFactory(ctx, parentFrame, nil, f, flags...)
+}
+
+func (v *VirtualMachine) execWithFrameFactory(ctx context.Context, parentFrame *Frame, frameFactory func(*Frame) *Frame, f func(frame *Frame), flags ...ExecFlag) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -407,6 +458,27 @@ func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(fr
 	} else {
 		frame = NewFrame(v)
 	}
+	// Resolve the execution ID before a sandbox factory chooses the VM that
+	// will own the actual frame. Synchronous subframes inherit a non-zero ID;
+	// independent roots receive a fresh one.
+	if frame.ThreadID == 0 {
+		threadVM := frame.vm
+		if threadVM == nil {
+			threadVM = v
+		}
+		frame.ThreadID = threadVM.nextThreadID()
+		frame.ownsThreadID = true
+	}
+	if frameFactory != nil {
+		frame = frameFactory(frame)
+		if frame == nil {
+			return utils.Error("BUG: frame factory returned nil")
+		}
+	}
+	executionVM := frame.vm
+	if executionVM == nil {
+		executionVM = v
+	}
 
 	if flag&Asnyc == Asnyc {
 		frame.coroutine = NewCoroutine()
@@ -414,15 +486,20 @@ func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(fr
 
 	frame.ctx = ctx
 
-	v.pushCurrentFrame(frame)
-	shouldPop := flag&Trace != Trace
-	if shouldPop {
-		defer v.popCurrentFrame(frame)
-	}
+	executionVM.pushCurrentFrame(frame)
+	traceCompleted := false
+	defer func() {
+		// Trace deliberately retains a successfully initialized frame for later
+		// Inline execution. A panic or cancellation is not a usable trace and
+		// must not pin its scope, bytecode, or goroutine stack forever.
+		if flag&Trace != Trace || !traceCompleted {
+			executionVM.popCurrentFrame(frame)
+		}
+	}()
 
-	frame.debug = v.debug
-	if v.debugMode && v.debugger != nil && v.debugger.initFunc != nil {
-		v.debugger.InitCallBack()
+	frame.debug = executionVM.debug
+	if executionVM.debugMode && executionVM.debugger != nil && executionVM.debugger.initFunc != nil {
+		executionVM.debugger.InitCallBack()
 	}
 
 	f(frame)
@@ -441,6 +518,7 @@ func (v *VirtualMachine) exec(ctx context.Context, parentFrame *Frame, f func(fr
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+	traceCompleted = true
 	return nil
 }
 
@@ -500,7 +578,11 @@ func (v *VirtualMachine) popCurrentFrame(expected *Frame) *Frame {
 	defer v.frameStacksMu.Unlock()
 
 	stack, ok := v.frameStacks[gid]
-	if !ok || stack == nil {
+	if !ok || stack == nil || stack.Len() == 0 {
+		return nil
+	}
+	if stack.Peek() != expected {
+		log.Errorf("yakvm frame stack mismatch: refusing to pop a non-current frame")
 		return nil
 	}
 	frame, _ := stack.Pop().(*Frame)

--- a/common/yak/antlr4yak/yakvm/vm.go
+++ b/common/yak/antlr4yak/yakvm/vm.go
@@ -45,6 +45,7 @@ type Frame struct {
 	debug          bool
 	indebuggerEval bool // 在debugger中执行代码
 	ThreadID       int  // 当前线程的ID
+	ownsThreadID   bool // this frame owns cleanup for an independently allocated ID
 	// panic
 	//panics   []*VMPanic
 	tryStack *vmstack.Stack
@@ -54,6 +55,11 @@ type Frame struct {
 	hijackMapMemberCallHandlers sync.Map
 	ctx                         context.Context
 	contextData                 map[string]interface{} // 用于引擎执行时函数栈之间的数据传递
+	runeCache                   map[*Value][]rune      // bounded frame-local cache for immutable string values
+	runeCacheBytes              int
+	pendingCallCode             *Code // the call immediately following an ellipsis expansion
+	pendingCallArgCount         int
+	executionDepth              int // recursive Exec depth for this exact frame
 
 	coroutine *Coroutine
 
@@ -86,6 +92,9 @@ func (v *Frame) GetFunction() *Function {
 }
 
 func (v *Frame) CurrentCode() *Code {
+	if v == nil || v.codePointer < 0 || v.codePointer >= len(v.codes) {
+		return nil
+	}
 	return v.codes[v.codePointer]
 }
 func (v *Frame) GetVerbose() string {
@@ -138,6 +147,7 @@ func NewSubFrame(parent *Frame) *Frame {
 		ctx:           parent.ctx,
 		contextData:   parent.contextData,
 		coroutine:     parent.coroutine,
+		ThreadID:      parent.ThreadID,
 	}
 	parent.hijackMapMemberCallHandlers.Range(func(key, value any) bool {
 		frame.hijackMapMemberCallHandlers.Store(key, value)
@@ -162,6 +172,7 @@ func NewFrame(vm *VirtualMachine) *Frame {
 		exitCode:      NoneExit,
 		contextData:   make(map[string]interface{}),
 		coroutine:     NewCoroutine(),
+		ownsThreadID:  true,
 	}
 	if v1, ok := buildinBinaryOperatorHandler[vm.config.vmMode]; ok {
 		for k, v := range v1 {
@@ -188,6 +199,5 @@ func NewFrame(vm *VirtualMachine) *Frame {
 	if vm.debugMode && vm.debugger != nil {
 		vm.debugger.AddScopeRef(vm.rootScope)
 	}
-	ImportRuntimeLib(frame)
 	return frame
 }

--- a/common/yak/antlr4yak/yakvm/vm.go
+++ b/common/yak/antlr4yak/yakvm/vm.go
@@ -56,6 +56,11 @@ type Frame struct {
 	contextData                 map[string]interface{} // 用于引擎执行时函数栈之间的数据传递
 
 	coroutine *Coroutine
+
+	// ownerGoroutineID is resolved once for a top-level execution and reused by
+	// its synchronous subframes. It keeps goroutine-local frame isolation while
+	// avoiding runtime.Stack on every nested function entry and frame pop.
+	ownerGoroutineID int64
 }
 
 type Coroutine struct {
@@ -169,7 +174,11 @@ func NewFrame(vm *VirtualMachine) *Frame {
 		}
 	}
 
-	frame.GlobalVariables = vm.runtimeGlobalVar.SetPred(vm.globalVar)
+	// VM initialization and ImportLibs link runtimeGlobalVar to the immutable
+	// global library chain.
+	// Re-linking that shared SafeMap for every call races under concurrent hooks
+	// and is redundant after engine initialization.
+	frame.GlobalVariables = vm.runtimeGlobalVar
 	vm.hijackMapMemberCallHandlers.Range(func(key, value any) bool {
 		frame.hijackMapMemberCallHandlers.Store(key, value)
 		return true

--- a/common/yak/antlr4yak/yakvm/vm_exec.go
+++ b/common/yak/antlr4yak/yakvm/vm_exec.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync/atomic"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/yaklang/yaklang/common/log"
@@ -99,11 +98,28 @@ func (v *Frame) CheckExit() error {
 }
 
 func (v *Frame) execExWithContinueOption(isContinue bool) {
+	v.executionDepth++
+	isOutermostExecution := v.executionDepth == 1
+	defer func() {
+		v.executionDepth--
+	}()
+
+	// These caches and pending decoder state belong to one execution segment.
+	// Clear them on every exit path, including panic and context cancellation,
+	// so retained Trace frames cannot keep values from earlier Inline runs.
+	defer v.clearRuneCache()
+	defer v.clearPendingCallArgCount()
+	if !isContinue {
+		v.clearPendingCallArgCount()
+	}
 	if !isContinue {
 		v.codePointer = 0
 	}
 	// 设置线程ID
-	v.ThreadID = int(v.vm.ThreadIDCount)
+	if v.ThreadID == 0 {
+		v.ThreadID = v.vm.nextThreadID()
+		v.ownsThreadID = true
+	}
 
 	// 退出代码 // -1代表异常，0代表代码执行到最后，1代表通过panic、return等方式退出
 	v.exitCode = ErrorExit
@@ -162,18 +178,22 @@ func (v *Frame) execExWithContinueOption(isContinue bool) {
 				return
 			}
 			debugger := v.vm.debugger
+			if debugger == nil {
+				return
+			}
 			if vmPanic != nil {
 				log.Error(vmPanic)
-				if debugger != nil {
+			}
+			if !isOutermostExecution {
+				// Recursive Exec is used for Yak defer blocks. A panic remains a
+				// real debugger terminal event, but the shared Frame has not exited
+				// yet and must not be marked normally finished or cleaned up.
+				if vmPanic != nil {
 					debugger.HandleForPanic(vmPanic)
 				}
-			} else if v.parent == nil { // 程序正常退出
-				if debugger != nil {
-					debugger.SetFinished()
-					debugger.HandleForNormallyFinished()
-				}
+				return
 			}
-			debugger.CurrentStackTracePop()
+			debugger.HandleFrameExit(v, vmPanic, v.parent == nil)
 		}
 	}()
 
@@ -332,10 +352,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 		if c.Op1 != nil {
 			wavy = c.Op1.Bool()
 		}
-		// 增加线程ID
-		atomic.AddUint64(&v.vm.ThreadIDCount, 1)
-
-		args := v.popArgN(c.Unary)
+		args := v.popArgN(v.consumeCallArgCount(c))
 		callableValue := v.pop()
 		v.asyncCall(callableValue, wavy, args)
 	case OpAssign:
@@ -423,29 +440,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 		case LUA:
 			assignArgs := v.popArgN(2)
 			leftValues := assignArgs[1]
-			rightValues := assignArgs[0]
-			rightVal := rightValues.Value
-			leftVal := leftValues.Value
-
-			if v, ok := rightVal.([]*Value); ok && len(v) > 0 {
-				rightVal = v[0].Value
-			}
-			if _, ok := rightVal.(*Function); ok {
-				if rightVal.(*Function).scope == nil {
-					rightVal.(*Function).scope = v.CurrentScope()
-				}
-				if val, ok := leftVal.([]*Value); ok && len(val) > 0 {
-					lv, err := val[0].ConvertToLeftValue()
-					if err == nil {
-						if lv.IsLeftValueRef() {
-							funcName, ok := v.CurrentScope().symtbl.GetNameByVariableId(lv.SymbolId)
-							if ok {
-								rightVal.(*Function).anonymousFunctionBindName = funcName
-							}
-						}
-					}
-				}
-			}
+			rightValues := v.prepareAssignedFunction(leftValues, assignArgs[0])
 			if c.Unary == 0 {
 				v.luaGlobalAssign(leftValues, rightValues)
 			} else {
@@ -457,29 +452,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 		default:
 			assignArgs := v.popArgN(2)
 			leftValues := assignArgs[1]
-			rightValues := assignArgs[0]
-			rightVal := rightValues.Value
-			leftVal := leftValues.Value
-
-			if v, ok := rightVal.([]*Value); ok && len(v) > 0 {
-				rightVal = v[0].Value
-			}
-			if rv, ok := rightVal.(*Function); ok {
-				if rv.scope == nil {
-					rv.scope = v.CurrentScope()
-				}
-				if val, ok := leftVal.([]*Value); ok && len(val) > 0 {
-					lv, err := val[0].ConvertToLeftValue()
-					if err == nil {
-						if lv.IsLeftValueRef() {
-							funcName, ok := v.CurrentScope().symtbl.GetNameByVariableId(lv.SymbolId)
-							if ok {
-								rightVal.(*Function).anonymousFunctionBindName = funcName
-							}
-						}
-					}
-				}
-			}
+			rightValues := v.prepareAssignedFunction(leftValues, assignArgs[0])
 			// if leftVal
 			v.assign(leftValues, rightValues)
 			return
@@ -667,15 +640,18 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 			return
 		}
 		if c.Op1.IsYakFunction() {
-			fun := c.Op1.Value.(*Function)
+			// Code and its function Value are immutable after compilation. Every
+			// execution gets its own scope-bearing function instance; mutating the
+			// template here races when one cached Engine serves concurrent hooks.
+			// The private instance retains its defining frame because a Function can
+			// later be exported into a sandbox VM, which uses that frame to execute
+			// against the original libraries and lexical environment.
+			fun := c.Op1.Value.(*Function).Copy(v.scope)
 			fun.defineFrame = v
-
-			if c.Unary == 1 {
-				c.Op1 = NewAutoValue(fun.Copy(v.scope))
-			} else if c.Unary == 0 {
-				// check(v.scope)
-				fun.scope = v.scope
-			}
+			instance := *c.Op1
+			instance.Value = fun
+			v.push(&instance)
+			return
 		}
 		v.push(c.Op1)
 		return
@@ -1193,10 +1169,11 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 			return
 		}
 	case OpCall:
+		argCount := v.consumeCallArgCount(c)
 		switch v.vm.GetConfig().vmMode {
 		case NASL:
-			args := make([]*Value, c.Unary)
-			i := c.Unary - 1
+			args := make([]*Value, argCount)
+			i := argCount - 1
 			for i >= 0 {
 				arg := v.pop()
 				if arg.TypeVerbose == "ref" {
@@ -1290,7 +1267,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 			// funName, ok := symbolTable.GetNameByVariableId(idValue.Int())
 			return
 		case LUA:
-			args := v.popArgN(c.Unary)
+			args := v.popArgN(argCount)
 			callableValue := v.pop()
 			v.callLua(callableValue, args)
 		case YAK:
@@ -1301,7 +1278,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 			if c.Op1 != nil {
 				wavy = c.Op1.Bool()
 			}
-			args := v.popArgN(c.Unary)
+			args := v.popArgN(argCount)
 			callableValue := v.pop()
 			v.call(callableValue, wavy, args)
 		}
@@ -1381,14 +1358,14 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 			memberName := args[0].AsString()
 			value, ok := m.Get(memberName)
 			if ok {
-				literal := fmt.Sprintf("%s.%s", iterableValue.GetLiteral(), memberName)
+				literal := iterableValue.memberLiteral(memberName)
 				v.push(NewValue(fmt.Sprintf("%T", value), value, literal))
 				return
 			}
 		}
 
 		if iterableValueType.Kind() == reflect.String {
-			if runes := cacheRunes(iterableValue); runes != nil {
+			if runes := v.cacheRunes(iterableValue); runes != nil {
 				iterableValueRF = reflect.ValueOf(runes)
 			} else {
 				panic("cannot convert string to []byte/rune")
@@ -1878,7 +1855,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 
 				member := callerReflectValue.MapIndex(reflect.ValueOf(memberNameV.Value))
 				if member.IsValid() {
-					literal := fmt.Sprintf("%s.%s", caller.GetLiteral(), memberName)
+					literal := caller.memberLiteral(memberName)
 					value := NewValue(member.Type().String(), member.Interface(), literal)
 					value.CalleeRef = memberNameV
 					value.CallerRef = caller
@@ -1926,7 +1903,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 				}
 				fun := callerReflectValue.MethodByName(newMemberName)
 				if fun.IsValid() {
-					literal := fmt.Sprintf("%s.%s", caller.GetLiteral(), memberName)
+					literal := caller.memberLiteral(memberName)
 					value := NewValue(fun.Type().String(), fun.Interface(), literal)
 					value.CalleeRef = memberNameV
 					value.CallerRef = caller
@@ -1942,7 +1919,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 				isOrderedMap = true
 				value, ok := m.Get(memberName)
 				if ok {
-					literal := fmt.Sprintf("%s.%s", caller.GetLiteral(), memberName)
+					literal := caller.memberLiteral(memberName)
 					v.push(NewValue(fmt.Sprintf("%T", value), value, literal))
 					return
 				}
@@ -1965,10 +1942,12 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 				}
 				member := getMember()
 				if member.IsValid() {
-					literal := fmt.Sprintf("%s.%s", caller.GetLiteral(), memberName)
+					literal := caller.memberLiteral(memberName)
 
 					calleeValue := member.Interface()
-					calleeValue = v.execHijackMapMemberCallHandler(caller.GetLiteral(), memberName, calleeValue)
+					if caller.Literal != "" {
+						calleeValue = v.execHijackMapMemberCallHandler(caller.Literal, memberName, calleeValue)
+					}
 					value := NewValue(member.Type().String(), calleeValue, literal)
 					value.CalleeRef = memberNameV
 					value.CallerRef = caller
@@ -2019,7 +1998,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 				}
 				// 这里可能拿到结构体指针的方法
 				if member.CanInterface() {
-					literal := fmt.Sprintf("%s.%s", caller.GetLiteral(), memberName)
+					literal := caller.memberLiteral(memberName)
 					value := NewValue(member.Type().String(), member.Interface(), literal)
 					value.CalleeRef = memberNameV
 					value.CallerRef = caller
@@ -2077,21 +2056,24 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 		// AutoConvertReflectValueByType()
 		arrayRaw := v.pop()
 		code := v.peekNextCode()
+		if code == nil || (code.Opcode != OpCall && code.Opcode != OpAsyncCall) {
+			panic("BUG: ellipsis must be followed by a call")
+		}
 
 		if arrayRaw.IsBytes() {
 			d := arrayRaw.Bytes()
 			for _, r := range d {
 				v.push(NewValue("byte", r, fmt.Sprintf("%c", r)))
 			}
-			code.Unary = c.Unary + len(d) - 1
+			v.setPendingCallArgCount(code, c.Unary+len(d)-1)
 			return
 		}
 		if arrayRaw.IsString() {
-			if runes := cacheRunes(arrayRaw); runes != nil {
+			if runes := v.cacheRunes(arrayRaw); runes != nil {
 				for _, r := range runes {
 					v.push(NewValue("char", r, fmt.Sprintf("%c", r)))
 				}
-				code.Unary = c.Unary + len(runes) - 1
+				v.setPendingCallArgCount(code, c.Unary+len(runes)-1)
 				return
 			}
 		}
@@ -2100,7 +2082,7 @@ func (v *Frame) _execCode(c *Code, debug bool) {
 			for i := 0; i < refV.Len(); i++ {
 				v.push(NewValue("char", refV.Index(i).Interface(), fmt.Sprint(refV.Index(i).Interface())))
 			}
-			code.Unary = c.Unary + refV.Len() - 1
+			v.setPendingCallArgCount(code, c.Unary+refV.Len()-1)
 		}
 	case OpExit:
 		val := v.pop()

--- a/common/yak/hook_mixed_plugin_caller_test.go
+++ b/common/yak/hook_mixed_plugin_caller_test.go
@@ -347,12 +347,14 @@ hijackHTTPRequest = func(isHttps, url, req, forward, drop) {
 mirrorHTTPFlow = func(isHttps, url, req, rsp, body) {
 	s = "%s"
 }
-`, ksuid.New().String())
+`, ksuid.New().String()) + "\n// " + strings.Repeat("ordinary-plugin-cache-padding-", 20)
 	err = caller.LoadPluginEx(utils.TimeoutContextSeconds(2), &schema.YakScript{
 		ScriptName: pluginName,
 		Content:    pluginCode,
 	})
 	require.NoError(t, err)
+	_, cached = antlr4yak.HaveYakcCache(pluginCode)
+	require.True(t, cached, "ordinary MITM plugin must retain yakc caching")
 	checkCallerLoads(HOOK_HijackHTTPRequest, 1, utils.CalcSha1(code, HOOK_HijackHTTPRequest, HotPatchScriptName))
 	checkCallerLoads(HOOK_MirrorHTTPFlow, 2, utils.CalcSha1(code, HOOK_MirrorHTTPFlow, HotPatchScriptName), utils.CalcSha1(pluginCode, HOOK_MirrorHTTPFlow, pluginName))
 
@@ -361,12 +363,14 @@ mirrorHTTPFlow = func(isHttps, url, req, rsp, body) {
 mirrorHTTPFlow = func(isHttps, url, req, rsp, body) {
 	s = "%s"	
 }
-`, ksuid.New().String())
+`, ksuid.New().String()) + "\n// " + strings.Repeat("ordinary-plugin-reload-cache-padding-", 20)
 	err = caller.LoadPluginEx(utils.TimeoutContextSeconds(2), &schema.YakScript{
 		ScriptName: pluginName,
 		Content:    reloadPluginCode,
 	})
 	require.NoError(t, err)
+	_, cached = antlr4yak.HaveYakcCache(reloadPluginCode)
+	require.True(t, cached, "ordinary MITM plugin reload must retain yakc caching")
 	checkCallerLoads(HOOK_HijackHTTPRequest, 1, utils.CalcSha1(code, HOOK_HijackHTTPRequest, HotPatchScriptName))
 	checkCallerLoads(HOOK_MirrorHTTPFlow, 2, utils.CalcSha1(code, HOOK_MirrorHTTPFlow, HotPatchScriptName), utils.CalcSha1(reloadPluginCode, HOOK_MirrorHTTPFlow, pluginName))
 
@@ -378,9 +382,11 @@ mirrorHTTPFlow = func(isHttps, url, req, rsp, body) {
 hijackHTTPRequest = func(isHttps, url, req, forward, drop) {
 	s = "%s"
 }
-`, ksuid.New().String(), ksuid.New().String())
+`, ksuid.New().String(), ksuid.New().String()) + "\n// " + strings.Repeat("hot-reload-revision-reload-", 20)
 	err = caller.LoadHotPatch(utils.TimeoutContextSeconds(2), []*ypb.ExecParamItem{}, reloadHotPatchCode)
 	require.NoError(t, err)
+	_, cached = antlr4yak.HaveYakcCache(reloadHotPatchCode)
+	require.False(t, cached, "MITM hot reload revision must not persist yakc cache")
 	checkCallerLoads(HOOK_HijackHTTPRequest, 1, utils.CalcSha1(reloadHotPatchCode, HOOK_HijackHTTPRequest, HotPatchScriptName))
 	// because hot patch mirrorHTTPFlow caller remove first then add, so it should be second
 	checkCallerLoads(HOOK_MirrorHTTPFlow, 2, utils.CalcSha1(reloadPluginCode, HOOK_MirrorHTTPFlow, pluginName), utils.CalcSha1(reloadHotPatchCode, HOOK_MirrorHTTPFlow, HotPatchScriptName))

--- a/common/yak/hook_mixed_plugin_caller_test.go
+++ b/common/yak/hook_mixed_plugin_caller_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 
 	"github.com/yaklang/yaklang/common/consts"
@@ -308,6 +310,7 @@ aaa`)
 }
 
 func TestMixCaller_LoadHotPatch(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
 	caller, err := NewMixPluginCaller()
 	require.NoError(t, err)
 	caller.SetLoadPluginTimeout(1)
@@ -318,7 +321,7 @@ mirrorHTTPFlow = func(isHttps, url, req, rsp, body) {
 hijackHTTPRequest = func(isHttps, url, req, forward, drop) {
 	s = "%s"
 }
-`, ksuid.New().String(), ksuid.New().String())
+`, ksuid.New().String(), ksuid.New().String()) + "\n// " + strings.Repeat("hot-reload-revision-", 20)
 	checkCallerLoads := func(funcName string, wantLength int, hashes ...string) {
 		res, ok := caller.callers.table.Load(funcName)
 		require.True(t, ok)
@@ -333,6 +336,8 @@ hijackHTTPRequest = func(isHttps, url, req, forward, drop) {
 	// load hot patch
 	err = caller.LoadHotPatch(utils.TimeoutContextSeconds(2), []*ypb.ExecParamItem{}, code)
 	require.NoError(t, err)
+	_, cached := antlr4yak.HaveYakcCache(code)
+	require.False(t, cached, "MITM hot reload must not persist unique source revisions")
 	checkCallerLoads(HOOK_HijackHTTPRequest, 1, utils.CalcSha1(code, HOOK_HijackHTTPRequest, HotPatchScriptName))
 	checkCallerLoads(HOOK_MirrorHTTPFlow, 1, utils.CalcSha1(code, HOOK_MirrorHTTPFlow, HotPatchScriptName))
 

--- a/common/yak/hotpatch_chain.go
+++ b/common/yak/hotpatch_chain.go
@@ -207,7 +207,7 @@ func buildHotPatchTagEnv(ctx context.Context, code string) *antlr4yak.Engine {
 		return nil
 	}
 	engine := NewScriptEngine(1)
-	codeEnv, err := engine.ExecuteExWithContext(ctx, code, make(map[string]interface{}))
+	codeEnv, err := engine.ExecuteWithoutCacheWithContext(ctx, code, make(map[string]interface{}))
 	if err != nil {
 		log.Errorf("load hotPatch code error: %s", err)
 		return nil

--- a/common/yak/hotpatch_chain_test.go
+++ b/common/yak/hotpatch_chain_test.go
@@ -1,0 +1,193 @@
+package yak
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/mutate"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak"
+)
+
+func TestChainedHotPatchProductionPathDoesNotPersistYakc(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	padding := strings.Repeat("hot-patch-revision-padding-", 20)
+
+	for revision := 0; revision < 16; revision++ {
+		globalCode := fmt.Sprintf(`
+globalOnly = func(params) { return ["global-%d-" + params] }
+shared = func(params) { return ["global-shared-%d-" + params] }
+streamGlobal = func(params, yield) {
+    yield("global-a-%d-" + params)
+    yield("global-b-%d-" + params)
+}
+// %s
+`, revision, revision, revision, revision, padding)
+		moduleCode := fmt.Sprintf(`
+shared = func(params) { return ["module-%d-" + params] }
+streamModule = func(params, yield) {
+    yield("module-a-%d-" + params)
+    yield("module-b-%d-" + params)
+}
+// %s
+`, revision, revision, revision, padding)
+
+		opts := Fuzz_WithAllHotPatchChained(context.Background(), HotPatchChain{
+			GlobalCode: globalCode,
+			ModuleCode: moduleCode,
+		})
+		fuzzOpts := append(opts, mutate.Fuzz_WithEnableDangerousTag())
+
+		result, err := mutate.FuzzTagExec("{{yak(shared|x)}}", fuzzOpts...)
+		require.NoError(t, err)
+		require.Equal(t, []string{fmt.Sprintf("module-%d-x", revision)}, result)
+
+		result, err = mutate.FuzzTagExec("{{yak(globalOnly|x)}}", fuzzOpts...)
+		require.NoError(t, err)
+		require.Equal(t, []string{fmt.Sprintf("global-%d-x", revision)}, result)
+
+		result, err = mutate.FuzzTagExec("{{yak(streamModule|x)}}", fuzzOpts...)
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			fmt.Sprintf("module-a-%d-x", revision),
+			fmt.Sprintf("module-b-%d-x", revision),
+		}, result)
+
+		result, err = mutate.FuzzTagExec("{{yak:dyn(shared|x)}}", fuzzOpts...)
+		require.NoError(t, err)
+		require.Equal(t, []string{fmt.Sprintf("module-%d-x", revision)}, result)
+
+		_, cached := antlr4yak.HaveYakcCache(globalCode)
+		require.False(t, cached, "global hot-patch revision %d entered yakc cache", revision)
+		_, cached = antlr4yak.HaveYakcCache(moduleCode)
+		require.False(t, cached, "module hot-patch revision %d entered yakc cache", revision)
+	}
+
+	artifacts, err := filepath.Glob(filepath.Join(os.Getenv("YAKIT_HOME"), "temp", ".*.yakc*"))
+	require.NoError(t, err)
+	require.Empty(t, artifacts, "production chained hot reload left yakc artifacts: %v", artifacts)
+}
+
+func TestLegacyHotPatchAPIsDoNotPersistYakc(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildOpts func(context.Context, string) []mutate.FuzzConfigOpt
+		tags      []string
+	}{
+		{
+			name: "regular",
+			buildOpts: func(ctx context.Context, code string) []mutate.FuzzConfigOpt {
+				return []mutate.FuzzConfigOpt{Fuzz_WithHotPatch(ctx, code)}
+			},
+			tags: []string{"yak"},
+		},
+		{
+			name: "dynamic",
+			buildOpts: func(ctx context.Context, code string) []mutate.FuzzConfigOpt {
+				return []mutate.FuzzConfigOpt{Fuzz_WithDynHotPatch(ctx, code)}
+			},
+			tags: []string{"yak:dyn"},
+		},
+		{
+			name:      "all",
+			buildOpts: Fuzz_WithAllHotPatch,
+			tags:      []string{"yak", "yak:dyn"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("YAKIT_HOME", t.TempDir())
+			code := fmt.Sprintf(`
+legacy = func(params) { return ["%s-value-" + params] }
+legacyYield = func(params, yield) {
+    yield("%s-yield-a-" + params)
+    yield("%s-yield-b-" + params)
+}
+// %s %s
+`, test.name, test.name, test.name, os.Getenv("YAKIT_HOME"), strings.Repeat("legacy-hot-reload-padding-", 20))
+
+			opts := append(test.buildOpts(context.Background(), code), mutate.Fuzz_WithEnableDangerousTag())
+			for _, tag := range test.tags {
+				result, err := mutate.FuzzTagExec(fmt.Sprintf("{{%s(legacy|x)}}", tag), opts...)
+				require.NoError(t, err)
+				require.Equal(t, []string{fmt.Sprintf("%s-value-x", test.name)}, result)
+
+				result, err = mutate.FuzzTagExec(fmt.Sprintf("{{%s(legacyYield|x)}}", tag), opts...)
+				require.NoError(t, err)
+				expected := []string{
+					fmt.Sprintf("%s-yield-a-x", test.name),
+					fmt.Sprintf("%s-yield-b-x", test.name),
+				}
+				if tag == "yak:dyn" {
+					// Dynamic tags consume one yielded item per expansion step.
+					expected = expected[:1]
+				}
+				require.Equal(t, expected, result)
+			}
+
+			_, cached := antlr4yak.HaveYakcCache(code)
+			require.False(t, cached, "legacy %s hot-patch API entered yakc cache", test.name)
+			artifacts, err := filepath.Glob(filepath.Join(os.Getenv("YAKIT_HOME"), "temp", ".*.yakc*"))
+			require.NoError(t, err)
+			require.Empty(t, artifacts)
+		})
+	}
+}
+
+func TestOrdinaryScriptExecutionStillCachesYakc(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	// Include the isolated cache directory so repeated test-process runs do not
+	// hit the package-global memory cache populated by an earlier -count round.
+	code := fmt.Sprintf(`value = "ordinary" // %s %s`, os.Getenv("YAKIT_HOME"), strings.Repeat("ordinary-cache-padding-", 20))
+
+	engine := NewScriptEngine(1)
+	_, err := engine.ExecuteExWithContext(context.Background(), code, map[string]interface{}{})
+	require.NoError(t, err)
+	_, cached := antlr4yak.HaveYakcCache(code)
+	require.True(t, cached, "cache disabling must stay scoped to hot reload entrypoints")
+
+	yakcFiles, err := filepath.Glob(filepath.Join(os.Getenv("YAKIT_HOME"), "temp", ".*.yakc"))
+	require.NoError(t, err)
+	require.NotEmpty(t, yakcFiles)
+	sipFiles, err := filepath.Glob(filepath.Join(os.Getenv("YAKIT_HOME"), "temp", ".*.yakc.sip"))
+	require.NoError(t, err)
+	require.NotEmpty(t, sipFiles)
+}
+
+func BenchmarkScriptEngineStableSourceWithCache(b *testing.B) {
+	benchmarkScriptEngineStableSource(b, true)
+}
+
+func BenchmarkScriptEngineStableSourceWithoutCache(b *testing.B) {
+	benchmarkScriptEngineStableSource(b, false)
+}
+
+func benchmarkScriptEngineStableSource(b *testing.B, cache bool) {
+	b.Setenv("YAKIT_HOME", b.TempDir())
+	code := `handler = func(value) { return value + "-stable" } // ` + strings.Repeat("stable-global-padding-", 24)
+	ctx := context.Background()
+	if cache {
+		_, err := NewScriptEngine(1).ExecuteExWithContext(ctx, code, map[string]interface{}{})
+		require.NoError(b, err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		engine := NewScriptEngine(1)
+		var err error
+		if cache {
+			_, err = engine.ExecuteExWithContext(ctx, code, map[string]interface{}{})
+		} else {
+			_, err = engine.ExecuteWithoutCacheWithContext(ctx, code, map[string]interface{}{})
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/common/yak/sandbox_runtime_info_test.go
+++ b/common/yak/sandbox_runtime_info_test.go
@@ -1,0 +1,84 @@
+package yak
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/yaklib"
+)
+
+func TestSandboxNestedFunctionRuntimeInfoAndLogging(t *testing.T) {
+	const runtimeID = "sandbox-nested-runtime"
+
+	box := NewSandbox()
+	box.engine.SetVars(map[string]any{"runtimeId": runtimeID})
+
+	var loggedLine int
+	var loggedRuntimeID string
+	var loggingInfoErr error
+	logger := yaklib.CreateYakLogger("sandbox-runtime-info-test")
+	logger.SetOutput(io.Discard)
+	logger.SetLevel("info")
+	logger.Logger.SetVMRuntimeInfoGetter(func(infoType string) (any, error) {
+		value, err := box.engine.RuntimeInfo(infoType)
+		if err != nil {
+			loggingInfoErr = err
+			return nil, err
+		}
+		switch infoType {
+		case "line":
+			line, ok := value.(int)
+			if !ok {
+				loggingInfoErr = fmt.Errorf("line has type %T", value)
+				return nil, loggingInfoErr
+			}
+			loggedLine = line
+		case "runtimeId":
+			loggedRuntimeID = fmt.Sprint(value)
+		}
+		return value, nil
+	})
+	box.engine.ImportLibs(map[string]any{
+		"testlog": map[string]any{"info": logger.Infof},
+	})
+
+	ok, err := box.ExecuteAsBoolean(`
+(() => {
+    outer = () => {
+        inner = () => {
+            line = runtime.GetInfo("line")~
+            id = runtime.GetInfo("runtimeId")~
+            testlog.info("sandbox nested runtime info")
+            return line > 0 && id == "sandbox-nested-runtime"
+        }
+        return inner()
+    }
+    return outer()
+})()
+`)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, loggingInfoErr)
+	require.Positive(t, loggedLine)
+
+	// The normal logger currently asks only for the source line. Exercise the
+	// other engine-backed logging query while the nested sandbox frame is live.
+	box.engine.ImportLibs(map[string]any{
+		"captureRuntimeID": func() bool {
+			value, infoErr := box.engine.RuntimeInfo("runtimeId")
+			if infoErr != nil {
+				loggingInfoErr = infoErr
+				return false
+			}
+			loggedRuntimeID = fmt.Sprint(value)
+			return true
+		},
+	})
+	ok, err = box.ExecuteAsBoolean(`(() => (() => captureRuntimeID())())()`)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, loggingInfoErr)
+	require.Equal(t, runtimeID, loggedRuntimeID)
+}

--- a/common/yak/script_engine.go
+++ b/common/yak/script_engine.go
@@ -780,19 +780,25 @@ func (e *ScriptEngine) ExecuteWithTaskIDAndParams(ctx context.Context, taskId, c
 }
 
 func (e *ScriptEngine) ExecuteWithoutCache(code string, params map[string]interface{}) (*antlr4yak.Engine, error) {
-	runtimeId := utils.MapGetStringByManyFields(params, "RUNTIME_ID", "RUNTIME_ID", "runtime_id")
-	if runtimeId == "" {
-		runtimeId = uuid.New().String()
-	}
-	return e.exec(context.Background(), runtimeId, code, params, false)
+	return e.executeWithContext(context.Background(), code, params, false)
 }
 
 func (e *ScriptEngine) ExecuteWithoutCacheWithContext(ctx context.Context, code string, params map[string]interface{}) (*antlr4yak.Engine, error) {
+	return e.executeWithContext(ctx, code, params, false)
+}
+
+func (e *ScriptEngine) executeWithContext(ctx context.Context, code string, params map[string]interface{}, cache bool) (_ *antlr4yak.Engine, fErr error) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("execute with context error: %v", err)
+			fErr = utils.Errorf("final error: %v", err)
+		}
+	}()
 	runtimeId := utils.MapGetStringByManyFields(params, "RUNTIME_ID", "RUNTIME_ID", "runtime_id")
 	if runtimeId == "" {
 		runtimeId = uuid.New().String()
 	}
-	return e.exec(ctx, runtimeId, code, params, false)
+	return e.exec(ctx, runtimeId, code, params, cache)
 }
 
 func (e *ScriptEngine) ExecuteEx(code string, params map[string]interface{}) (*antlr4yak.Engine, error) {
@@ -804,17 +810,7 @@ func (e *ScriptEngine) ExecuteEx(code string, params map[string]interface{}) (*a
 }
 
 func (e *ScriptEngine) ExecuteExWithContext(ctx context.Context, code string, params map[string]interface{}) (_ *antlr4yak.Engine, fErr error) {
-	defer func() {
-		if err := recover(); err != nil {
-			log.Errorf("execute ex with context error: %v", err)
-			fErr = utils.Errorf("final error: %v", err)
-		}
-	}()
-	runtimeId := utils.MapGetStringByManyFields(params, "RUNTIME_ID", "RUNTIME_ID", "runtime_id")
-	if runtimeId == "" {
-		runtimeId = uuid.New().String()
-	}
-	return e.exec(ctx, runtimeId, code, params, true)
+	return e.executeWithContext(ctx, code, params, true)
 }
 
 func (e *ScriptEngine) Execute(code string) error {

--- a/common/yak/script_engine.go
+++ b/common/yak/script_engine.go
@@ -586,13 +586,11 @@ func (e *ScriptEngine) exec(ctx context.Context, id string, code string, params 
 	defer func() {
 		t.isRunning.UnSet()
 		t.isFinished.Set()
-
-		go func() {
-			select {
-			case <-time.After(3 * time.Second):
-				e.tasks.Delete(id)
-			}
-		}()
+		// Do not retain one sleeping goroutine per short-lived hot reload. The
+		// timer service invokes this callback after the task's observation window.
+		time.AfterFunc(3*time.Second, func() {
+			e.tasks.Delete(id)
+		})
 	}()
 
 	// log.Infof("recv code: %v", code)
@@ -758,7 +756,10 @@ func (e *ScriptEngine) exec(ctx context.Context, id string, code string, params 
 			return engine, engine.SafeExecYakcWithCode(ctx, yakcBytes, e.cryptoKey, code)
 		}
 	}
-	return engine, engine.SafeEval(ctx, code)
+	if cache {
+		return engine, engine.SafeEval(ctx, code)
+	}
+	return engine, engine.SafeEvalWithoutCache(ctx, code)
 }
 
 func (e *ScriptEngine) ExecuteWithTaskID(taskId, code string) error {
@@ -784,6 +785,14 @@ func (e *ScriptEngine) ExecuteWithoutCache(code string, params map[string]interf
 		runtimeId = uuid.New().String()
 	}
 	return e.exec(context.Background(), runtimeId, code, params, false)
+}
+
+func (e *ScriptEngine) ExecuteWithoutCacheWithContext(ctx context.Context, code string, params map[string]interface{}) (*antlr4yak.Engine, error) {
+	runtimeId := utils.MapGetStringByManyFields(params, "RUNTIME_ID", "RUNTIME_ID", "runtime_id")
+	if runtimeId == "" {
+		runtimeId = uuid.New().String()
+	}
+	return e.exec(ctx, runtimeId, code, params, false)
 }
 
 func (e *ScriptEngine) ExecuteEx(code string, params map[string]interface{}) (*antlr4yak.Engine, error) {

--- a/common/yak/script_engine_for_fuzz.go
+++ b/common/yak/script_engine_for_fuzz.go
@@ -69,7 +69,10 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 		return nil
 	})
 
-	engine, err = scriptEngine.ExecuteEx(raw, make(map[string]interface{}))
+	// Web Fuzzer hot patches change on nearly every reload. Avoid serializing
+	// and persisting a yakc file for revisions that will not be reused, and let
+	// cancellation stop top-level initialization work.
+	engine, err = scriptEngine.ExecuteWithoutCacheWithContext(ctx, raw, make(map[string]interface{}))
 	if err != nil {
 		log.Errorf("eval hookCode failed: %s", err)
 		return nil, nil, nil, nil, nil, nil

--- a/common/yak/script_engine_for_fuzz.go
+++ b/common/yak/script_engine_for_fuzz.go
@@ -139,9 +139,9 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 				var resultRequest any
 				var err error
 				if legacyBeforeRequest {
-					resultRequest, err = engine.CallYakFunction(context.Background(), "beforeRequest", []interface{}{req})
+					resultRequest, err = engine.CallYakFunction(ctx, "beforeRequest", []interface{}{req})
 				} else {
-					resultRequest, err = engine.CallYakFunction(context.Background(), "beforeRequest", []interface{}{https, originReq, req})
+					resultRequest, err = engine.CallYakFunction(ctx, "beforeRequest", []interface{}{https, originReq, req})
 				}
 				if err != nil {
 					log.Infof("eval beforeRequest hook failed: %s", err)
@@ -170,9 +170,9 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 				var resultResponse any
 				var err error
 				if legacyAfterRequest {
-					resultResponse, err = engine.CallYakFunction(context.Background(), "afterRequest", []interface{}{rsp})
+					resultResponse, err = engine.CallYakFunction(ctx, "afterRequest", []interface{}{rsp})
 				} else {
-					resultResponse, err = engine.CallYakFunction(context.Background(), "afterRequest", []interface{}{https, originReq, req, originRsp, rsp})
+					resultResponse, err = engine.CallYakFunction(ctx, "afterRequest", []interface{}{https, originReq, req, originRsp, rsp})
 				}
 				if err != nil {
 					log.Infof("eval afterRequest hook failed: %s", err)
@@ -203,9 +203,10 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 				if mirrorHTTPFlowNumIn > 2 {
 					params = []any{req, rsp, existed}
 				}
-				mirrorResult, err := engine.CallYakFunction(context.Background(), "mirrorHTTPFlow", params)
+				mirrorResult, err := engine.CallYakFunction(ctx, "mirrorHTTPFlow", params)
 				if err != nil {
-					log.Infof("eval afterRequest hook failed: %s", err)
+					log.Infof("eval mirrorHTTPFlow hook failed: %s", err)
+					return result
 				}
 				if ret := utils.InterfaceToMap(mirrorResult); ret != nil {
 					for k, v := range ret {
@@ -231,7 +232,7 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 				} else if retryHandlerInstanceNumIn == 3 {
 					params = []any{req, rsp, retryFunc}
 				}
-				_, err := engine.CallYakFunction(context.Background(), "retryHandler", params)
+				_, err := engine.CallYakFunction(ctx, "retryHandler", params)
 				if err != nil {
 					log.Infof("eval retryHandler hook failed: %s", err)
 				}
@@ -253,7 +254,7 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 				} else if customFailureCheckerInstanceNumIn == 2 {
 					params = []any{rsp, fail}
 				}
-				_, err := engine.CallYakFunction(context.Background(), "customFailureChecker", params)
+				_, err := engine.CallYakFunction(ctx, "customFailureChecker", params)
 				if err != nil {
 					log.Infof("eval customFailureChecker hook failed: %s", err)
 				}
@@ -275,7 +276,7 @@ func MutateHookCaller(ctx context.Context, raw string, caller YakitCallerIf, par
 				} else if mockHTTPRequestInstanceNumIn == 2 {
 					params = []any{req, mockResponse}
 				}
-				_, err := engine.CallYakFunction(context.Background(), "mockHTTPRequest", params)
+				_, err := engine.CallYakFunction(ctx, "mockHTTPRequest", params)
 				if err != nil {
 					log.Infof("eval mockHTTPRequest hook failed: %s", err)
 				}

--- a/common/yak/script_engine_for_fuzz_test.go
+++ b/common/yak/script_engine_for_fuzz_test.go
@@ -3,6 +3,7 @@ package yak
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -172,6 +173,20 @@ beforeRequest = func(isHttps, originReq, req) {
 		expected := fmt.Sprintf("req%d-done", i)
 		assert.Equal(t, expected, res, "result[%d] wrong", i)
 	}
+}
+
+func TestMutateHookCallerDoesNotPersistHotReloadCache(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	code := `
+beforeRequest = func(isHttps, originReq, req) {
+    return req
+}
+// ` + strings.Repeat("hot-reload-revision-", 20)
+
+	hookBefore, _, _, _, _, _ := MutateHookCaller(context.Background(), code, nil)
+	require.NotNil(t, hookBefore)
+	_, cached := antlr4yak.HaveYakcCache(code)
+	require.False(t, cached, "web fuzzer hot reload must not persist unique source revisions")
 }
 
 // 并发调用多层嵌套子函数(A→B→C)，验证context逐层传递正确

--- a/common/yak/script_engine_for_fuzz_test.go
+++ b/common/yak/script_engine_for_fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,9 +51,14 @@ func (s *testEventSync) signal(name string) {
 	})
 }
 
-func (s *testEventSync) wait(name string) {
+func (s *testEventSync) wait(t *testing.T, name string) {
+	t.Helper()
 	ch, _ := s.get(name)
-	<-ch
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for test event %q", name)
+	}
 }
 
 func newTestHookEngine(t *testing.T, script string, globals map[string]any) *antlr4yak.Engine {
@@ -279,14 +285,14 @@ beforeRequest = func(isHttps, originReq, req) {
 }
 `, map[string]any{
 		"signal": func(name string) { syncer.signal(name) },
-		"wait":   func(name string) { syncer.wait(name) },
+		"wait":   func(name string) { syncer.wait(t, name) },
 	})
 
 	fastResultCh := invokeBeforeRequestAsync(engine, "fast")
-	syncer.wait("fast-entered")
+	syncer.wait(t, "fast-entered")
 
 	slowResultCh := invokeBeforeRequestAsync(engine, "slow")
-	syncer.wait("slow-entered")
+	syncer.wait(t, "slow-entered")
 
 	// 此时 slow 的 frame 已经入栈，fast 继续执行 eval 必须仍然读取到自己的 localValue。
 	syncer.signal("allow-fast-eval")
@@ -319,14 +325,14 @@ beforeRequest = func(isHttps, originReq, req) {
 }
 `, map[string]any{
 		"signal": func(name string) { syncer.signal(name) },
-		"wait":   func(name string) { syncer.wait(name) },
+		"wait":   func(name string) { syncer.wait(t, name) },
 	})
 
 	fastResultCh := invokeBeforeRequestAsync(engine, "fast")
-	syncer.wait("fast-entered")
+	syncer.wait(t, "fast-entered")
 
 	slowResultCh := invokeBeforeRequestAsync(engine, "slow")
-	syncer.wait("slow-entered")
+	syncer.wait(t, "slow-entered")
 
 	// 先让 fast 返回；旧实现里这里会把 slow 的 frame 从共享栈顶错误弹掉。
 	syncer.signal("allow-fast-return")
@@ -339,4 +345,65 @@ beforeRequest = func(isHttps, originReq, req) {
 	slowResult := <-slowResultCh
 	require.NoError(t, slowResult.err)
 	require.Equal(t, "slow", slowResult.result)
+}
+
+func TestMutateHookCallerCancellationStopsAllHookKinds(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	before, after, mirror, retry, failure, mock := MutateHookCaller(ctx, `
+beforeRequest = func(isHttps, originReq, req) { for {} }
+afterRequest = func(isHttps, originReq, req, originRsp, rsp) { for {} }
+mirrorHTTPFlow = func(req, rsp) { for {} }
+retryHandler = func(req, rsp, retry) { for {} }
+customFailureChecker = func(rsp, fail) { for {} }
+mockHTTPRequest = func(isHttps, url, req, mockResponse) { for {} }
+`, nil)
+	require.NotNil(t, before)
+	require.NotNil(t, after)
+	require.NotNil(t, mirror)
+	require.NotNil(t, retry)
+	require.NotNil(t, failure)
+	require.NotNil(t, mock)
+
+	done := make(chan string, 6)
+	go func() {
+		before(false, nil, []byte("request"))
+		done <- "before"
+	}()
+	go func() {
+		after(false, nil, nil, nil, []byte("response"))
+		done <- "after"
+	}()
+	go func() {
+		mirror(nil, nil, map[string]string{})
+		done <- "mirror"
+	}()
+	go func() {
+		retry(false, 0, nil, nil, func(...[]byte) {})
+		done <- "retry"
+	}()
+	go func() {
+		failure(false, nil, nil, func(string) {})
+		done <- "failure"
+	}()
+	go func() {
+		mock(false, "http://example.invalid", nil, func(interface{}) {})
+		done <- "mock"
+	}()
+
+	// Give every hook a chance to enter Yak execution before canceling the
+	// stream context that owns this hot patch.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	returned := make(map[string]bool, 6)
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for len(returned) < 6 {
+		select {
+		case name := <-done:
+			returned[name] = true
+		case <-timer.C:
+			t.Fatalf("hot hooks did not stop after cancellation: returned=%v", returned)
+		}
+	}
 }

--- a/common/yak/script_engine_test.go
+++ b/common/yak/script_engine_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/utils/orderedmap"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak"
 	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
 	"testing"
 	"time"
@@ -74,4 +75,17 @@ func TestScriptEngine_YakScript_callback(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	require.True(t, nativeOk)
+}
+
+func TestExecuteWithoutCacheWithContextRecoversEngineHookPanic(t *testing.T) {
+	engine := NewScriptEngine(1)
+	engine.RegisterEngineHooks(func(engine *antlr4yak.Engine) error {
+		panic("hot reload hook panic")
+	})
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = engine.ExecuteWithoutCacheWithContext(context.Background(), "value = 1", map[string]any{})
+	})
+	require.ErrorContains(t, err, "hot reload hook panic")
 }

--- a/common/yak/testdata/vm_hot_reload/async_nested_eval.yak
+++ b/common/yak/testdata/vm_hot_reload/async_nested_eval.yak
@@ -1,0 +1,39 @@
+results = make(chan string, 16)
+
+level2 = func(id) {
+	eval(`
+dynamicOuter = func(base) {
+    dynamicInner = func(delta) {
+        return base + delta
+    }
+    return dynamicInner(3)
+}
+eval('evaluated = sprintf("worker-%d-ok-%d", id, dynamicOuter(id))')
+`)
+    return evaluated
+}
+
+level1 = func(id) {
+    return level2(id)
+}
+
+worker = func(id) {
+    results <- level1(id)
+}
+
+for i := 0; i < 16; i++ {
+    go worker(i)
+}
+
+seen = make(map[string]bool)
+for i := 0; i < 16; i++ {
+    value = <-results
+    seen[value] = true
+}
+waitAllAsyncCallFinish()
+
+assert len(seen) == 16, "async nested/eval results crossed frames: %v" % seen
+for i := 0; i < 16; i++ {
+    expected = sprintf("worker-%d-ok-%d", i, i + 3)
+    assert seen[expected], "missing async result %s" % expected
+}

--- a/common/yak/testdata/vm_hot_reload/async_static_closure.yak
+++ b/common/yak/testdata/vm_hot_reload/async_static_closure.yak
@@ -1,0 +1,70 @@
+workerCount = 48
+
+starts = make(chan bool)
+results = make(chan string, workerCount)
+
+// Both function literals below are static bytecode templates shared by every
+// concurrent call to factory. captured exercises a closure with free values;
+// pure exercises the no-free-value function path.
+factory = func(base) {
+    captured = func(delta) {
+        return base + delta
+    }
+    pure = func() {
+        return 7
+    }
+    return sprintf("worker-%d-%d-%d", base, captured(3), pure())
+}
+
+shared = func() {
+    return 11
+}
+
+worker = func(id) {
+    <-starts
+    // Aliasing a published function must not rewrite its diagnostic name or
+    // any other metadata while sibling workers use the same Value.
+    alias = shared
+    for round := 0; round < 32; round++ {
+        base = id * 1000 + round
+        expected = sprintf("worker-%d-%d-7", base, base + 3)
+        actual = factory(base)
+        assert actual == expected, "static closure scope crossed: got %s want %s" % [actual, expected]
+    }
+    results <- sprintf("worker-%d-%d-7-%d", id, id + 3, alias())
+}
+
+for i := 0; i < workerCount; i++ {
+    go worker(i)
+}
+for i := 0; i < workerCount; i++ {
+    starts <- true
+}
+
+seen = make(map[string]bool)
+for i := 0; i < workerCount; i++ {
+    value = <-results
+    seen[value] = true
+}
+waitAllAsyncCallFinish()
+
+assert len(seen) == workerCount, "static closure results crossed frames: %v" % seen
+for i := 0; i < workerCount; i++ {
+    expected = sprintf("worker-%d-%d-7-11", i, i + 3)
+    assert seen[expected], "missing static closure result %s" % expected
+}
+
+// A later alias must not rename the already-published function. The function
+// name appears in argument-count diagnostics and is useful to hot-patch users.
+nameProbe = func(required) {
+    return required
+}
+probeAlias = nameProbe
+try {
+    nameProbe()
+    assert false, "expected name probe to reject a missing argument"
+} catch err {
+    message = sprintf("%v", err)
+    assert str.Contains(message, "nameProbe"), "first function binding was lost: %s" % message
+    assert !str.Contains(message, "probeAlias params"), "alias renamed shared function: %s" % message
+}

--- a/common/yak/testdata/vm_hot_reload/async_variadic_ellipsis.yak
+++ b/common/yak/testdata/vm_hot_reload/async_variadic_ellipsis.yak
@@ -1,0 +1,107 @@
+workerCount = 64
+
+starts = make(chan bool)
+results = make(chan string, workerCount)
+cases = [
+    [],
+    [1],
+    [1, 2, 3],
+    [1, 2, 3, 4, 5, 6, 7, 8],
+]
+
+countAndSum = func(values...) {
+    total = 0
+    for value in values {
+        total += value
+    }
+    return sprintf("%d:%d", len(values), total)
+}
+
+// Every worker executes this same ellipsis+call Code pair with a different
+// expanded length. Argument count must therefore be Frame state, not Code state.
+invoke = func(values) {
+    return countAndSum(100, values...)
+}
+
+worker = func(id, values) {
+    <-starts
+    results <- sprintf("%d=%s", id, invoke(values))
+}
+
+for i := 0; i < workerCount; i++ {
+    go worker(i, cases[i % len(cases)])
+}
+for i := 0; i < workerCount; i++ {
+    starts <- true
+}
+
+seen = make(map[string]bool)
+for i := 0; i < workerCount; i++ {
+    value = <-results
+    seen[value] = true
+}
+waitAllAsyncCallFinish()
+
+assert len(seen) == workerCount, "ellipsis results crossed frames: %v" % seen
+expectedSuffixes = ["1:100", "2:101", "4:106", "9:136"]
+for i := 0; i < workerCount; i++ {
+    expected = sprintf("%d=%s", i, expectedSuffixes[i % len(expectedSuffixes)])
+    assert seen[expected], "missing ellipsis result %s" % expected
+}
+
+// Exercise the other expansion representations without mutating the following
+// call opcode. Strings expand by rune, bytes by byte.
+assert countAndSum("\x01\x02"...) == "2:3", "string ellipsis failed"
+assert countAndSum(b"\x01\x02\x03"...) == "3:6", "bytes ellipsis failed"
+countOnly = func(values...) {
+    return len(values)
+}
+assert countOnly("汉字"...) == 2, "unicode string ellipsis must expand by rune"
+assert countAndSum(10, [1, 2]...)~ == "3:13", "wavy ellipsis call failed"
+
+deferredResults = make(chan string, 1)
+deferredSink = func(values...) {
+    total = 0
+    for value in values {
+        total += value
+    }
+    deferredResults <- sprintf("%d:%d", len(values), total)
+}
+runDeferred = func(values) {
+    defer deferredSink(values...)
+}
+runDeferred([1, 2, 3, 4])
+deferredValue = <-deferredResults
+assert deferredValue == "4:10", "deferred ellipsis call failed: %s" % deferredValue
+
+// The go form rewrites the call after ellipsis to OpAsyncCall. Concurrent
+// launchers exercise the same Code with empty and differently sized slices.
+asyncResults = make(chan string, workerCount)
+asyncSink = func(id, values...) {
+    total = 0
+    for value in values {
+        total += value
+    }
+    asyncResults <- sprintf("%d=%d:%d", id, len(values), total)
+}
+launch = func(id, values) {
+    go asyncSink(id, values...)
+}
+
+for i := 0; i < workerCount; i++ {
+    go launch(i, cases[i % len(cases)])
+}
+
+asyncSeen = make(map[string]bool)
+for i := 0; i < workerCount; i++ {
+    value = <-asyncResults
+    asyncSeen[value] = true
+}
+waitAllAsyncCallFinish()
+
+assert len(asyncSeen) == workerCount, "async ellipsis results crossed frames: %v" % asyncSeen
+asyncExpectedSuffixes = ["0:0", "1:1", "3:6", "8:36"]
+for i := 0; i < workerCount; i++ {
+    expected = sprintf("%d=%s", i, asyncExpectedSuffixes[i % len(asyncExpectedSuffixes)])
+    assert asyncSeen[expected], "missing async ellipsis result %s" % expected
+}

--- a/common/yak/testdata/vm_hot_reload/include_dependency.yak
+++ b/common/yak/testdata/vm_hot_reload/include_dependency.yak
@@ -1,0 +1,4 @@
+includeBase = 40
+includeAdder = func(value) {
+    return includeBase + value
+}

--- a/common/yak/testdata/vm_hot_reload/include_main.yak
+++ b/common/yak/testdata/vm_hot_reload/include_main.yak
@@ -1,0 +1,2 @@
+include "testdata/vm_hot_reload/include_dependency.yak"
+assert includeAdder(2) == 42, "included closure returned stale or incorrect data"

--- a/common/yak/testdata/vm_hot_reload/sandbox_external_function.yak
+++ b/common/yak/testdata/vm_hot_reload/sandbox_external_function.yak
@@ -1,0 +1,41 @@
+definitionRuntimeID = runtime.GetInfo("runtimeId")~
+outerPrefix = "definition"
+
+factory = func(prefix) {
+    return func(index) {
+        line = runtime.GetInfo("line")~
+        runtimeID = runtime.GetInfo("runtimeId")~
+        return line > 0 && runtimeID == definitionRuntimeID && prefix == outerPrefix && index >= 0
+    }
+}
+
+external = factory("definition")
+
+box := sandbox.Create(sandbox.library({
+    "external": external,
+}))
+
+// The injected function keeps its definition VM, globals, closure and runtime
+// helper even though the independent sandbox VM orchestrates the call.
+for index := 0; index < 16; index++ {
+    ok = box.ExecuteAsBoolean("external(index)", {"index": index})~
+    assert ok, "cross-VM sandbox call failed at %d" % index
+}
+
+// Async workers are counted by the sandbox VM but execute the injected
+// function against the definition VM. Each worker must resolve its own frame.
+ok = box.ExecuteAsBoolean(`
+results = make(chan bool, 24)
+for index := 0; index < 24; index++ {
+    go func(current) {
+        results <- external(current)
+    }(index)
+}
+allOK = true
+for index := 0; index < 24; index++ {
+    allOK = allOK && <-results
+}
+waitAllAsyncCallFinish()
+allOK
+`)~
+assert ok, "cross-VM sandbox async functions used the wrong frame"

--- a/common/yak/testdata/vm_hot_reload/sandbox_nested_closure.yak
+++ b/common/yak/testdata/vm_hot_reload/sandbox_nested_closure.yak
@@ -1,0 +1,19 @@
+box := sandbox.Create()
+
+for seed := 0; seed < 32; seed++ {
+	runtimeID = "sandbox-runtime-%d" % seed
+    ok = box.ExecuteAsBoolean(`
+(() => {
+    outer = (base) => {
+        inner = (delta) => {
+			line = runtime.GetInfo("line")~
+			id = runtime.GetInfo("runtimeId")~
+			return base + delta == seed + 3 && line > 0 && id == expectedRuntimeID
+        }
+		return inner(3)
+    }
+	return outer(seed)
+})()
+`, {"seed": seed, "runtimeId": runtimeID, "expectedRuntimeID": runtimeID})~
+    assert ok, "sandbox nested closure failed for seed %d" % seed
+}

--- a/common/yak/testdata/vm_hot_reload/string_index_cache.yak
+++ b/common/yak/testdata/vm_hot_reload/string_index_cache.yak
@@ -1,0 +1,14 @@
+stable = "你Yak好"
+checksum = 0
+for i := 0; i < 4096; i++ {
+    checksum += int(stable[i % len(stable)])
+}
+assert checksum > 0, "repeated unicode string indexing failed"
+
+// A long-lived frame sees many distinct temporary Values here. Correctness is
+// verified in Yak while the VM unit test enforces the cache's entry/byte bound.
+for i := 0; i < 1024; i++ {
+    value = sprintf("你-%d-好", i)
+    assert value[0] == '你', "unicode first rune changed at %d" % i
+    assert value[-1] == '好', "unicode last rune changed at %d" % i
+}

--- a/common/yak/vm_hot_reload_corpus_test.go
+++ b/common/yak/vm_hot_reload_corpus_test.go
@@ -1,0 +1,105 @@
+package yak
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak"
+)
+
+func TestHotReloadVMYakFileCorpus(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	files := []string{
+		"yaktest/mustpass/files/buildin_len.yak",
+		"yaktest/mustpass/files/container_range.yak",
+		"yaktest/mustpass/files/eval.yak",
+		"yaktest/mustpass/files/forloopvar_go122.yak",
+		"yaktest/mustpass/files/grammar_test.yak",
+		"yaktest/mustpass/files/map_slice_auto_convert.yak",
+		"yaktest/mustpass/files/operator_channel_comparison.yak",
+		"yaktest/mustpass/files/defer-recover.yak",
+		"yaktest/mustpass/files/fuzz_param_array.yak",
+		"yaktest/mustpass/files/sandbox.yak",
+		"yaktest/mustpass/files/yaklang_programming_complex.yak",
+		"testdata/vm_hot_reload/async_nested_eval.yak",
+		"testdata/vm_hot_reload/async_static_closure.yak",
+		"testdata/vm_hot_reload/async_variadic_ellipsis.yak",
+		"testdata/vm_hot_reload/sandbox_nested_closure.yak",
+		"testdata/vm_hot_reload/sandbox_external_function.yak",
+		"testdata/vm_hot_reload/string_index_cache.yak",
+		"testdata/vm_hot_reload/include_main.yak",
+	}
+
+	for _, path := range files {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			for revision := 0; revision < 2; revision++ {
+				func() {
+					source := fmt.Sprintf("%s\n// hot-reload-corpus-revision-%d %s", raw, revision, strings.Repeat("x", 320))
+					ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+					defer cancel()
+
+					engine, execErr := NewScriptEngine(1).ExecuteWithoutCacheWithContext(ctx, source, map[string]interface{}{})
+					require.NoError(t, execErr, "revision %d", revision)
+					require.NotNil(t, engine)
+
+					waitDone := make(chan struct{})
+					go func() {
+						engine.GetVM().AsyncWait()
+						close(waitDone)
+					}()
+					select {
+					case <-waitDone:
+					case <-ctx.Done():
+						t.Fatalf("revision %d left Yak async calls running: %v", revision, ctx.Err())
+					}
+
+					require.Nil(t, engine.GetVM().CurrentFM(), "revision %d left a current frame", revision)
+					_, cached := antlr4yak.HaveYakcCache(source)
+					require.False(t, cached, "revision %d entered yakc cache", revision)
+				}()
+			}
+		})
+	}
+}
+
+func TestHotReloadVMIncludeDependencyRevision(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	dependencyPath := filepath.Join(t.TempDir(), "dependency.yak")
+	includePath := filepath.ToSlash(dependencyPath)
+
+	for revision := 0; revision < 4; revision++ {
+		dependency := fmt.Sprintf(`
+includeValue = func() {
+    return "dependency-revision-%d"
+}
+`, revision)
+		require.NoError(t, os.WriteFile(dependencyPath, []byte(dependency), 0o600))
+
+		source := fmt.Sprintf(`
+include "%s"
+assert includeValue() == "dependency-revision-%d", "stale include dependency at revision %d"
+// %s
+`, includePath, revision, revision, strings.Repeat("include-hot-reload-padding-", 16))
+		engine, err := NewScriptEngine(1).ExecuteWithoutCacheWithContext(context.Background(), source, map[string]interface{}{})
+		require.NoError(t, err, "revision %d", revision)
+		require.NotNil(t, engine)
+		require.Nil(t, engine.GetVM().CurrentFM(), "revision %d left a current frame", revision)
+
+		_, cached := antlr4yak.HaveYakcCache(source)
+		require.False(t, cached, "revision %d entered yakc cache", revision)
+	}
+
+	artifacts, err := filepath.Glob(filepath.Join(os.Getenv("YAKIT_HOME"), "temp", ".*.yakc*"))
+	require.NoError(t, err)
+	require.Empty(t, artifacts, "include hot reload left yakc artifacts: %v", artifacts)
+}

--- a/common/yak/yak_to_caller_manager.go
+++ b/common/yak/yak_to_caller_manager.go
@@ -1322,39 +1322,45 @@ func (y *YakToCallerManager) fetchFunctionFromSourceCode(pluginContext *YakitPlu
 					args = callArgHook(funcName, numIn, args)
 				}
 
-				errCh := make(chan error)
-				valueCh := make(chan any)
+				type callResult struct {
+					value any
+					err   error
+				}
+				// The caller may return as soon as subCtx is canceled. Keep one
+				// buffered result slot so the VM goroutine can still publish its
+				// terminal state and exit instead of leaking forever on a channel send.
+				resultCh := make(chan callResult, 1)
 				go func() {
+					result := callResult{}
 					defer func() {
+						printStack := false
 						if err := recover(); err != nil {
 							fmtErr := utils.Errorf("call hook function `%v` of `%v` plugin failed: %s", funcName, scriptName, err)
 							y.Err = fmtErr
-							//log.Error(fmtErr)
-							//fmt.Println()
-							errCh <- fmtErr
-							if os.Getenv("YAK_IN_TERMINAL_MODE") == "" {
-								utils.PrintCurrentGoroutineRuntimeStack()
-							}
+							result.err = fmtErr
+							printStack = os.Getenv("YAK_IN_TERMINAL_MODE") == ""
 						}
-						close(errCh)
+						resultCh <- result
+						// Publish the terminal result before potentially expensive
+						// diagnostics so cancellation and timeout callers are never
+						// held up by stack formatting.
+						if printStack {
+							utils.PrintCurrentGoroutineRuntimeStack()
+						}
 					}()
-					value, err := nIns.CallYakFunctionNativeWithFrameCallback(subCtx, callback, f, args...)
-					if err != nil {
-						errCh <- err
-					} else {
-						valueCh <- value
-					}
+					result.value, result.err = nIns.CallYakFunctionNativeWithFrameCallback(subCtx, callback, f, args...)
 				}()
 
 				select {
-				case value := <-valueCh:
-					return value
-				case err := <-errCh:
+				case result := <-resultCh:
 					//if err != nil && !errors.Is(err, context.Canceled) {
 					//	log.Errorf("call YakFunction (DividedCTX) error: \n%v", err)
 					//}
-					// 重要：抛出错误而不是返回nil，这样Call方法就能捕获到错误
-					panic(err)
+					if result.err != nil {
+						// 重要：抛出错误而不是返回nil，这样Call方法就能捕获到错误
+						panic(result.err)
+					}
+					return result.value
 				case <-subCtx.Done():
 					err := subCtx.Err()
 					if errors.Is(err, context.DeadlineExceeded) {

--- a/common/yak/yak_to_caller_manager.go
+++ b/common/yak/yak_to_caller_manager.go
@@ -219,6 +219,7 @@ type fetchFuncFromSrcCodeConfig struct {
 	engineHook        func(e *antlr4yak.Engine) error
 	callArgumentHooks map[string]callArgumentHookFunc
 	functionNames     []string
+	disableCache      bool
 }
 
 type fetchFuncFromSrcCodeOptions func(*fetchFuncFromSrcCodeConfig)
@@ -762,7 +763,7 @@ func (y *YakToCallerManager) Add(ctx context.Context, script *schema.YakScript, 
 		args = append(args, "--"+key, fmt.Sprintf("%s", value))
 	}
 	app := GetHookCliApp(args)
-	cTable, err := y.fetchFunctionFromSourceCode(y.getYakitPluginContext(ctx).WithCliApp(app),
+	fetchOptions := []fetchFuncFromSrcCodeOptions{
 		WithFetchScript(script),
 		WithFetchCode(code),
 		WithFetchEngineHook(func(e *antlr4yak.Engine) error {
@@ -780,7 +781,14 @@ func (y *YakToCallerManager) Add(ctx context.Context, script *schema.YakScript, 
 			return nil
 		}),
 		WithFetchFunctionNames(funcName...),
-	)
+	}
+	// The MITM hot patch is replaced for every editor revision. Persisting each
+	// unique source as yakc increases reload latency and leaves unbounded cache
+	// files without providing useful hits.
+	if id == HotPatchScriptName {
+		fetchOptions = append(fetchOptions, WithFetchCacheDisabled())
+	}
+	cTable, err := y.fetchFunctionFromSourceCode(y.getYakitPluginContext(ctx).WithCliApp(app), fetchOptions...)
 
 	if err != nil {
 		return err
@@ -1272,10 +1280,17 @@ func (y *YakToCallerManager) fetchFunctionFromSourceCode(pluginContext *YakitPlu
 
 	loadCtx, cancel := context.WithTimeout(pluginContext.Ctx, y.loadTimeout)
 	defer cancel()
-	ins, err := engine.ExecuteExWithContext(loadCtx, code, map[string]interface{}{
+	executeParams := map[string]interface{}{
 		"ROOT_CONTEXT": loadCtx,
 		"YAK_FILENAME": scriptName,
-	})
+	}
+	var ins *antlr4yak.Engine
+	var err error
+	if cfg.disableCache {
+		ins, err = engine.ExecuteWithoutCacheWithContext(loadCtx, code, executeParams)
+	} else {
+		ins, err = engine.ExecuteExWithContext(loadCtx, code, executeParams)
+	}
 	if err != nil {
 		log.Errorf("init execute plugin finished: %s", err)
 		return nil, utils.Errorf("load plugin failed: %s", err)
@@ -2378,12 +2393,18 @@ func WithFetchFunctionNames(names ...string) fetchFuncFromSrcCodeOptions {
 	}
 }
 
+func WithFetchCacheDisabled() fetchFuncFromSrcCodeOptions {
+	return func(c *fetchFuncFromSrcCodeConfig) {
+		c.disableCache = true
+	}
+}
+
 func buildHotpatchHandler(ctx context.Context, code string) func(s string, yield func(s string)) (err error) {
 	if strings.TrimSpace(code) == "" {
 		return nil
 	}
 	engine := NewScriptEngine(1)
-	codeEnv, err := engine.ExecuteExWithContext(ctx, code, make(map[string]interface{}))
+	codeEnv, err := engine.ExecuteWithoutCacheWithContext(ctx, code, make(map[string]interface{}))
 	if err != nil {
 		log.Errorf("load hotPatch code error: %s", err)
 		return nil

--- a/common/yak/yak_to_caller_manager_lifecycle_test.go
+++ b/common/yak/yak_to_caller_manager_lifecycle_test.go
@@ -1,0 +1,97 @@
+package yak
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak"
+)
+
+func TestYakFunctionCallerTimeoutDoesNotLeakResultSender(t *testing.T) {
+	const callCount = 32
+	started := make(chan struct{}, callCount)
+	nativeReturned := make(chan struct{}, callCount)
+	release := make(chan struct{})
+
+	manager := NewYakToCallerManager()
+	manager.callTimeout = 5 * time.Millisecond
+	callers, err := manager.fetchFunctionFromSourceCode(
+		CreateYakitPluginContext("timeout-leak-test").WithContext(context.Background()),
+		WithFetchCode(`
+spin = func() {
+    blockUntilReleased()
+    return "done"
+}
+`),
+		WithFetchEngineHook(func(engine *antlr4yak.Engine) error {
+			engine.SetVars(map[string]any{
+				// A native Go call deliberately ignores the Yak context. This
+				// forces the caller to time out first and the VM worker to publish
+				// its result only after the receiver has already returned.
+				"blockUntilReleased": func() {
+					started <- struct{}{}
+					<-release
+					nativeReturned <- struct{}{}
+				},
+			})
+			return nil
+		}),
+		WithFetchFunctionNames("spin"),
+		WithFetchCacheDisabled(),
+	)
+	require.NoError(t, err)
+	caller := callers["spin"]
+	require.NotNil(t, caller)
+
+	baseline := runtime.NumGoroutine()
+	for i := 0; i < callCount; i++ {
+		panicValue := callHandlerAndRecover(caller)
+		require.NotNil(t, panicValue)
+		require.ErrorIs(t, panicValue.(error), context.DeadlineExceeded)
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("native worker %d did not start", i)
+		}
+	}
+	close(release)
+	for i := 0; i < callCount; i++ {
+		select {
+		case <-nativeReturned:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("native worker %d did not return after release", i)
+		}
+	}
+
+	// A timed-out caller no longer receives the result. The VM worker must still
+	// publish into the one-slot result channel and terminate; an unbuffered
+	// channel leaves all callCount goroutines blocked in the handler's defer.
+	require.Eventually(t, func() bool {
+		var stacks bytes.Buffer
+		if err := pprof.Lookup("goroutine").WriteTo(&stacks, 2); err != nil {
+			return false
+		}
+		return !strings.Contains(strings.ToLower(stacks.String()), "fetchfunctionfromsourcecode.func")
+	}, 3*time.Second, 25*time.Millisecond)
+
+	// Keep the broader count as a secondary guard for leaks whose stack name
+	// changes during refactoring.
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return runtime.NumGoroutine() <= baseline+8
+	}, 3*time.Second, 25*time.Millisecond)
+}
+
+func callHandlerAndRecover(caller *YakFunctionCaller) (panicValue any) {
+	defer func() {
+		panicValue = recover()
+	}()
+	caller.Handler(nil)
+	return nil
+}

--- a/common/yakgrpc/grpc_fuzzer.go
+++ b/common/yakgrpc/grpc_fuzzer.go
@@ -270,7 +270,7 @@ func (s *Server) StringFuzzer(rootCtx context.Context, req *ypb.StringFuzzerRequ
 	if !enabled {
 		globalCode = ""
 	}
-	opts := yak.Fuzz_WithAllHotPatchChained(rootCtx, yak.HotPatchChain{
+	opts := yak.Fuzz_WithAllHotPatchChained(ctx, yak.HotPatchChain{
 		GlobalCode: globalCode,
 		ModuleCode: req.GetHotPatchCode(),
 	})

--- a/common/yakgrpc/grpc_fuzzer_hotpatch_test.go
+++ b/common/yakgrpc/grpc_fuzzer_hotpatch_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
@@ -475,6 +476,22 @@ func TestGRPCMUSTPASS_HTTPFuzzer_FuzzWithHotPatch(t *testing.T) {
 			t.Fatal(spew.Sprintf("hotpatch fail: %v,%v", template, code))
 		}
 	}
+}
+
+func TestStringFuzzerTimeoutCancelsHotPatch(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	started := time.Now()
+	_, err = client.StringFuzzer(ctx, &ypb.StringFuzzerRequest{
+		Template:       "{{yak(handle)}}",
+		TimeoutSeconds: 1,
+		HotPatchCode:   `handle = func(params) { for {} }`,
+	})
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 3*time.Second, "configured StringFuzzer timeout did not stop the hot patch")
 }
 
 func TestGRPCMUSTPASS_HTTPFuzzer_HotPatch_before_and_after_legacy(t *testing.T) {


### PR DESCRIPTION
## 背景与结论

本 PR 主要解决 MITM 热加载、Web Fuzzer 热加载和链式 hot-patch 在源码频繁变化时的 VM 执行开销、并发状态串扰以及生命周期泄漏问题。

改动范围仍以 YakVM 和执行链路为主。VM 外的生产代码只负责：

- 为明确的热加载入口选择 no-yakc 执行路径；
- 将请求 `context` 继续传入 Web Fuzzer hook；
- 避免 Yak 调用超时后结果发送 goroutine 永久阻塞；
- 让 StringFuzzer 的超时能够真正取消热补丁执行。

普通、稳定的 Yak 脚本仍保留 yakc 缓存，不会全局关闭缓存。

## 核心改动

- 增加真正不读取、不写入 yakc 的执行入口，并只接入 MITM/Web Fuzzer/fuzztag/chained hot-patch 等高频变化路径。
- Frame 栈改为按 goroutine 隔离；同步子 Frame 复用父执行 ID，异步和独立执行获得唯一 ID。
- 编译后的 `Code`/`Function` 作为不可变模板使用；运行时绑定发生在副本上，避免闭包、定义 Frame、ellipsis 参数和函数名并发串扰。
- `runtime.GetInfo`、runtime lib 和 sandbox/cross-VM 调用绑定到实际执行 Frame，不再依赖共享的“最近 Frame”。
- 失败或取消的 Trace 会回收；成功 Trace 只保留一个 Frame；字符串 rune cache 有容量上限并在所有退出路径清空。
- yakc 内存缓存限制为 256 项，避免唯一热补丁持续积累。
- YakToCaller 结果通道改为有缓冲，调用超时后 sender 不会在结果发送处泄漏。
- 加固 debugger 的线程 ID、同步调用栈 push/pop、terminal callback、递归 defer、panic/cancel、首 opcode 前取消以及空文件/纯注释文件生命周期。

## 性能基准

同一台 Apple Silicon darwin/arm64 主机，干净 `origin/main` 与本 PR 对比。每组均串行执行，`-benchtime=500ms -count=5`，取 5 次中位数：

| 场景 | origin/main | 本 PR | 变化 |
| --- | ---: | ---: | ---: |
| 唯一热加载源码：旧缓存路径 → 新 no-cache 路径 | 209,656 ns/op，840,077 B/op，444 allocs | 48,347 ns/op，22,806 B/op，391 allocs | **吞吐 4.34 倍；耗时 -76.9%；内存 -97.3%** |
| 稳定源码的 ScriptEngine 缓存执行 | 111,498 ns/op，79,848 B/op，728 allocs | 82,178 ns/op，78,550 B/op，713 allocs | **吞吐 1.36 倍；耗时 -26.3%** |
| 匿名函数直接赋值 | 13,919 ns/op，3,091 B/op，40 allocs | 8,550 ns/op，2,755 B/op，34 allocs | **吞吐 1.63 倍；耗时 -38.6%** |
| 顶层 Frame 生命周期 | 9,295 ns/op，1,312 B/op，22 allocs | 5,001 ns/op，720 B/op，14 allocs | **吞吐 1.86 倍；耗时 -46.2%** |
| 嵌套 Frame 生命周期 | 21,543 ns/op，2,008 B/op，33 allocs | 5,258 ns/op，1,112 B/op，19 allocs | **吞吐 4.10 倍；耗时 -75.6%** |
| VM 空闲时 `GetVar` | 3,154 ns/op，192 B/op，3 allocs | 32.65 ns/op，0 B/op，0 allocs | **吞吐 96.6 倍；清除全部分配** |

这里的 4.34 倍是 VM 热加载阶段的提升，不等同于完整 HTTP 请求端到端吞吐；实际收益取决于一次请求触发的 hook 数量和 hook 自身逻辑。

无限唯一源码如果仍主动使用持久 yakc 路径，本 PR 中位数为 295,266 ns/op，因为需要序列化并在 256 项之后持续淘汰；这些入口不再用于热加载。稳定脚本继续使用缓存，且缓存执行本身仍有提升。

## 测试变更审计（重要）

### 没有删除测试

相对 `origin/main` 做了机械比较：

- **没有删除任何测试文件；**
- **没有删除任何 `.yak` 测试语料；**
- **没有删除任何 `Test`、`Benchmark` 或 `Example` 函数；**
- 新增 **53 个 Test 函数、10 个 Benchmark、8 个文件型 Yak 语料**；
- 测试与语料共 30 个文件发生变化：23 个新增、7 个修改，合计 `+3128/-16`。

这 16 行删除全部有对应替换，不是通过移除失败断言让测试通过：

1. `TestDebugger_StackTrace` 是唯一改变旧行为期望的测试。旧测试使用无限后台循环，只断言可见线程数 `>= 2`；现在改为有限异步执行并等待清理，精确断言当前 root 可见、可见线程数为 1、`c -> d` 同步调用栈深度至少为 3。原因是 debugger 现在只公开 root 和真正暂停的线程，不再把仍在运行的后台 goroutine 当作 stopped thread。这个变化已额外增加 9 个 debugger 并发、线程 ID、跨 VM、panic 和栈清理测试补偿覆盖。
2. 两组 Web Fuzzer 并发测试把无限等待 channel 改成 5 秒超时失败；原执行结果断言全部保留，只是避免 CI 出错时永久挂住。
3. MITM hot-patch 测试给原脚本增加超过 yakc 阈值的 padding，并在原 caller 数量、hash 和 reload 顺序断言之外，新增“热加载不缓存、普通插件仍缓存”的边界断言。

因此整体以纯增量测试为主；上面第 1 项是唯一需要 reviewer 明确确认的既有 debugger 可见线程契约调整，没有隐藏或删除。

## 文件型 Yak 覆盖

热加载语料会执行 18 类 Yak 程序，每类运行两个源码 revision，并验证：

- async 完成且 `AsyncWait` 不残留；
- 执行结束后无 current Frame；
- no-cache 路径不生成内存或磁盘 yakc；
- include 依赖修改后不会运行旧 revision；
- nested eval、async closure、static closure、variadic ellipsis；
- sandbox、跨 VM 外部函数和 panic 恢复；
- 字符串索引/rune cache 生命周期。

此外完整构建并执行了 MustPass 包内 **146 个 `.yak` 文件**。

## 本地验证

- `go test -timeout 30m -tags ./common/yak/antlr4yak ./common/yak/antlr4yak -count=1`
- `go test -race ./common/yak/antlr4yak/yakvm -count=1 -timeout=15m`
- `go test ./common/yak/yaktest/mustpass -count=1 -timeout=20m`
- 文件型 hot-reload 语料在 `-race` 下完整重复两轮
- member receiver 竞态、yakc 容量、debugger cancel/empty 生命周期在 `-race` 下重复 5-10 轮
- MITM/Web Fuzzer 热加载、缓存边界、caller timeout、cross-VM、debugger、context 专项 `-race` 测试
- HTTP Fuzzer MUSTPASS 完整测试选择
- `git diff --check`

## CI 状态

当前远端 HEAD：`bb5d7d4beddf91bcbfe34ef966302dc9882cd23a`

- **36 项 SUCCESS**
- **0 项失败或取消**
- **1 项 SKIPPED：`Test ScanNode Focused`，由路径条件自动跳过，不是删除、禁用或修改测试**
- `Essential Tests Gate` 已通过

## 已知边界

- 永不返回且完全忽略 `context` 的原生 Go callback 无法被 VM 强制终止；但 callback 最终返回后不会再遗留结果 sender。
- 跨 VM sandbox 调用对 caller debugger 保持 opaque，不能跨两个 debugger `StepIn`；执行语义、Frame 归属和 runtime 信息已有专项测试。
- Web Fuzzer hook 现在继承请求 context；请求取消后再次调用 hook 会立即取消，这是有意的泄漏治理行为变化。
- SymbolTable 使用统一顺序的全局 RWMutex；未发现反序或死锁路径，但极高并发编译/序列化时可能产生短时锁竞争。
