### PR TITLE
fix(ssa): cap dataflow path enumeration to prevent scan hang

### DIFF
--- a/common/yak/ssaapi/sfreport/dataflow.go
+++ b/common/yak/ssaapi/sfreport/dataflow.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/yaklang/gorm"
 	"github.com/lib/pq"
+	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
@@ -30,6 +30,20 @@ type DataflowDetailLevel string
 const (
 	DataflowDetailMinimal DataflowDetailLevel = "minimal"
 	DataflowDetailFull    DataflowDetailLevel = "full"
+)
+
+const (
+	// maxDataFlowPathCount bounds how many entry-to-sink paths are
+	// materialized per risk. Data flow sub-graphs can be combinatorial DAGs;
+	// without a cap a single risk can keep the scan CPU-bound for hours while
+	// enumerating all simple paths.
+	maxDataFlowPathCount = 256
+	// maxDataFlowPathLength bounds a single path so path copies stay small.
+	maxDataFlowPathLength = 1024
+	// maxDataFlowVisitBudget bounds total DFS steps regardless of graph
+	// topology (including dense cyclic graphs whose cycle-hits never emit a
+	// path), so the function always terminates with bounded work.
+	maxDataFlowVisitBudget = 200_000
 )
 
 // MarshalDataFlowPath serializes a DataFlowPath according to the given detail level.
@@ -184,7 +198,7 @@ func GenerateDataFlowAnalysis(risk *schema.SSARisk, minimal bool, values ...*ssa
 }
 
 func computeDataFlowPaths(nodes []*NodeInfo, edges []*EdgeInfo) [][]string {
-	adj := make(map[string][]string)
+	adj := make(map[string][]string, len(edges))
 	for _, e := range edges {
 		if e == nil {
 			continue
@@ -206,40 +220,44 @@ func computeDataFlowPaths(nodes []*NodeInfo, edges []*EdgeInfo) [][]string {
 		return nil
 	}
 
-	hasOutgoing := make(map[string]bool)
-	for _, e := range edges {
-		if e != nil {
-			hasOutgoing[e.FromNodeID] = true
-		}
-	}
-
-	var paths [][]string
-	visited := make(map[string]bool)
+	paths := make([][]string, 0, 8)
+	visited := make(map[string]struct{}, len(nodes))
+	steps := 0
 
 	var dfs func(nodeID string, current []string)
 	dfs = func(nodeID string, current []string) {
-		if visited[nodeID] {
+		if len(paths) >= maxDataFlowPathCount {
 			return
 		}
-		visited[nodeID] = true
+		if steps >= maxDataFlowVisitBudget {
+			return
+		}
+		if _, ok := visited[nodeID]; ok {
+			return
+		}
+
+		steps++
+		visited[nodeID] = struct{}{}
 		current = append(current, nodeID)
 
 		neighbors := adj[nodeID]
-		isSink := !hasOutgoing[nodeID]
-		if isSink || len(neighbors) == 0 {
+		if len(neighbors) == 0 || len(current) >= maxDataFlowPathLength {
 			pathCopy := make([]string, len(current))
 			copy(pathCopy, current)
 			paths = append(paths, pathCopy)
 		} else {
 			for _, next := range neighbors {
+				if len(paths) >= maxDataFlowPathCount {
+					break
+				}
 				dfs(next, current)
 			}
 		}
 
-		visited[nodeID] = false
+		delete(visited, nodeID)
 	}
 
-	dfs(entryNodeID, []string{})
+	dfs(entryNodeID, make([]string, 0, 16))
 	return paths
 }
 

--- a/common/yak/ssaapi/sfreport/dataflow_paths_test.go
+++ b/common/yak/ssaapi/sfreport/dataflow_paths_test.go
@@ -1,0 +1,167 @@
+package sfreport
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeDataFlowPathsBasic(t *testing.T) {
+	t.Run("empty nodes", func(t *testing.T) {
+		require.Nil(t, computeDataFlowPaths(nil, nil))
+	})
+
+	t.Run("single entry node", func(t *testing.T) {
+		paths := computeDataFlowPaths(
+			[]*NodeInfo{{NodeID: "n1", IsEntryNode: true}},
+			nil,
+		)
+		assert.Equal(t, [][]string{{"n1"}}, paths)
+	})
+
+	t.Run("linear chain", func(t *testing.T) {
+		nodes := chainNodes(3)
+		nodes[0].IsEntryNode = true
+		edges := []*EdgeInfo{
+			{EdgeID: "e1", FromNodeID: "n0", ToNodeID: "n1"},
+			{EdgeID: "e2", FromNodeID: "n1", ToNodeID: "n2"},
+		}
+		assert.Equal(t, [][]string{{"n0", "n1", "n2"}}, computeDataFlowPaths(nodes, edges))
+	})
+
+	t.Run("branch and merge", func(t *testing.T) {
+		nodes := chainNodes(4)
+		nodes[0].IsEntryNode = true
+		edges := []*EdgeInfo{
+			{EdgeID: "e1", FromNodeID: "n0", ToNodeID: "n1"},
+			{EdgeID: "e2", FromNodeID: "n0", ToNodeID: "n2"},
+			{EdgeID: "e3", FromNodeID: "n1", ToNodeID: "n3"},
+			{EdgeID: "e4", FromNodeID: "n2", ToNodeID: "n3"},
+		}
+		paths := computeDataFlowPaths(nodes, edges)
+		assert.ElementsMatch(t, [][]string{{"n0", "n1", "n3"}, {"n0", "n2", "n3"}}, paths)
+	})
+
+	t.Run("cycle does not loop forever", func(t *testing.T) {
+		nodes := chainNodes(3)
+		nodes[0].IsEntryNode = true
+		edges := []*EdgeInfo{
+			{EdgeID: "e1", FromNodeID: "n0", ToNodeID: "n1"},
+			{EdgeID: "e2", FromNodeID: "n1", ToNodeID: "n0"},
+			{EdgeID: "e3", FromNodeID: "n1", ToNodeID: "n2"},
+		}
+		assert.Equal(t, [][]string{{"n0", "n1", "n2"}}, computeDataFlowPaths(nodes, edges))
+	})
+
+	t.Run("nil entries are skipped", func(t *testing.T) {
+		nodes := []*NodeInfo{nil, {NodeID: "n0", IsEntryNode: true}, {NodeID: "n1"}}
+		edges := []*EdgeInfo{nil, {EdgeID: "e1", FromNodeID: "n0", ToNodeID: "n1"}}
+		assert.Equal(t, [][]string{{"n0", "n1"}}, computeDataFlowPaths(nodes, edges))
+	})
+
+	t.Run("falls back to first node", func(t *testing.T) {
+		nodes := chainNodes(2)
+		paths := computeDataFlowPaths(nodes, nil)
+		assert.Equal(t, [][]string{{"n0"}}, paths)
+	})
+}
+
+func TestComputeDataFlowPaths_CapsPathCount(t *testing.T) {
+	// Full binary tree with 13 levels would produce 4096 simple paths;
+	// the cap must stop enumeration at maxDataFlowPathCount.
+	depth := 12
+	total := 1<<(depth+1) - 1
+	nodes := make([]*NodeInfo, total)
+	for i := range nodes {
+		nodes[i] = &NodeInfo{NodeID: fmt.Sprintf("n%d", i)}
+	}
+	nodes[0].IsEntryNode = true
+
+	edges := make([]*EdgeInfo, 0, total-1)
+	for i := 0; i < total/2; i++ {
+		left := 2*i + 1
+		right := 2*i + 2
+		edges = append(edges,
+			&EdgeInfo{EdgeID: fmt.Sprintf("e%d-%d", i, left), FromNodeID: fmt.Sprintf("n%d", i), ToNodeID: fmt.Sprintf("n%d", left)},
+			&EdgeInfo{EdgeID: fmt.Sprintf("e%d-%d", i, right), FromNodeID: fmt.Sprintf("n%d", i), ToNodeID: fmt.Sprintf("n%d", right)},
+		)
+	}
+
+	validEdges := make(map[string]map[string]bool, len(edges))
+	for _, e := range edges {
+		if validEdges[e.FromNodeID] == nil {
+			validEdges[e.FromNodeID] = make(map[string]bool)
+		}
+		validEdges[e.FromNodeID][e.ToNodeID] = true
+	}
+
+	paths := computeDataFlowPaths(nodes, edges)
+	require.Len(t, paths, maxDataFlowPathCount)
+	for _, p := range paths {
+		require.NotEmpty(t, p)
+		require.Equal(t, "n0", p[0])
+		for i := 1; i < len(p); i++ {
+			require.True(t, validEdges[p[i-1]][p[i]], "edge %s -> %s must exist", p[i-1], p[i])
+		}
+	}
+}
+
+func TestComputeDataFlowPaths_BoundedStepsOnDeadEnds(t *testing.T) {
+	// A wide graph where every leaf only points to itself has no sink, so the
+	// uncapped DFS would walk every node and never emit a path. The visit
+	// budget must stop it with bounded work.
+	total := maxDataFlowVisitBudget + 1
+	nodes := make([]*NodeInfo, total)
+	for i := range nodes {
+		nodes[i] = &NodeInfo{NodeID: fmt.Sprintf("n%d", i)}
+	}
+	nodes[0].IsEntryNode = true
+
+	edges := make([]*EdgeInfo, 0, total*2-1)
+	for i := 0; i < total; i++ {
+		self := fmt.Sprintf("n%d", i)
+		edges = append(edges, &EdgeInfo{EdgeID: self + "-self", FromNodeID: self, ToNodeID: self})
+		if i > 0 {
+			edges = append(edges, &EdgeInfo{EdgeID: self + "-from-entry", FromNodeID: "n0", ToNodeID: self})
+		}
+	}
+
+	paths := computeDataFlowPaths(nodes, edges)
+	assert.Empty(t, paths)
+}
+
+func TestComputeDataFlowPaths_TruncatesLongChain(t *testing.T) {
+	// A chain longer than the length cap must return one bounded path instead
+	// of either exhausting the stack or silently dropping the flow.
+	total := maxDataFlowPathLength + 100
+	nodes := make([]*NodeInfo, total)
+	for i := range nodes {
+		nodes[i] = &NodeInfo{NodeID: fmt.Sprintf("n%d", i)}
+	}
+	nodes[0].IsEntryNode = true
+
+	edges := make([]*EdgeInfo, 0, total-1)
+	for i := 0; i+1 < total; i++ {
+		edges = append(edges, &EdgeInfo{
+			EdgeID:     fmt.Sprintf("e%d", i),
+			FromNodeID: fmt.Sprintf("n%d", i),
+			ToNodeID:   fmt.Sprintf("n%d", i+1),
+		})
+	}
+
+	paths := computeDataFlowPaths(nodes, edges)
+	require.Len(t, paths, 1)
+	require.Len(t, paths[0], maxDataFlowPathLength)
+	assert.Equal(t, "n0", paths[0][0])
+	assert.Equal(t, fmt.Sprintf("n%d", maxDataFlowPathLength-1), paths[0][maxDataFlowPathLength-1])
+}
+
+func chainNodes(n int) []*NodeInfo {
+	nodes := make([]*NodeInfo, n)
+	for i := range nodes {
+		nodes[i] = &NodeInfo{NodeID: fmt.Sprintf("n%d", i)}
+	}
+	return nodes
+}


### PR DESCRIPTION
数据流路径枚举在组合型 DAG 上可能呈指数级增长，单条风险就能让扫描长时间 CPU 占用。此提交为路径数量、单路径长度和总 DFS 访问预算加上上限，保证 GenerateDataFlowAnalysis 在有界工作量内终止，并补充了路径、环、死路、长链和预算相关回归测试。