### PR TITLE
feat(scannode): 支持 SyntaxFlow 规则任务真实调试

### DIFF
--- a/common/syntaxflow/sfvm/config.go
+++ b/common/syntaxflow/sfvm/config.go
@@ -49,6 +49,9 @@ type Config struct {
 	// ctx is cancelled (cancel) so the existing ctx-bail path surfaces partial
 	// results instead of a hard failure. nil = no budget (legacy behavior).
 	workBudget *RuleWorkBudget
+	// nativeCallGuard is a query-local authority boundary. It is inherited by
+	// nested queries; nil preserves the unrestricted engine behavior.
+	nativeCallGuard func(string) error
 }
 
 // RuleWorkBudget is a per-rule atomic counter+limit that bounds total fanout
@@ -212,6 +215,14 @@ func WithWorkBudget(b *RuleWorkBudget) Option {
 	}
 }
 
+// WithNativeCallGuard restricts native calls for one query and its children.
+// It never changes the process-wide native-call registry.
+func WithNativeCallGuard(guard func(string) error) Option {
+	return func(config *Config) {
+		config.nativeCallGuard = guard
+	}
+}
+
 func WithEnableDebug(b ...bool) Option {
 	return func(config *Config) {
 		if len(b) <= 0 {
@@ -260,6 +271,7 @@ func WithConfig(other *Config) Option {
 		self.diagnosticsEnabled = other.diagnosticsEnabled
 		self.diagnosticsRecorder = other.diagnosticsRecorder
 		self.workBudget = other.workBudget
+		self.nativeCallGuard = other.nativeCallGuard
 	}
 }
 
@@ -274,6 +286,7 @@ func (c *Config) Copy() *Config {
 		processCallback:           c.processCallback,
 		diagnosticsEnabled:        c.diagnosticsEnabled,
 		workBudget:                c.workBudget,
+		nativeCallGuard:           c.nativeCallGuard,
 		// diagnosticsRecorder:       c.diagnosticsRecorder,
 	}
 	if ret.diagnosticsEnabled {

--- a/common/syntaxflow/sfvm/frame_exec.go
+++ b/common/syntaxflow/sfvm/frame_exec.go
@@ -1389,6 +1389,11 @@ func (s *SFFrame) execSyntaxFlowOp(i *SFI) (bool, error) {
 // in recorder.Track (see the OpNativeCall case). On failure it pushes an empty
 // Values (preserving the original closure's behavior) and returns the error.
 func (s *SFFrame) execNativeCall(i *SFI) (Values, error) {
+	if s.config != nil && s.config.nativeCallGuard != nil {
+		if err := s.config.nativeCallGuard(i.UnaryStr); err != nil {
+			return nil, utils.Wrap(CriticalError, err.Error())
+		}
+	}
 	s.debugSubLog(">> pop")
 	value := s.stack.Pop()
 	if value == nil {

--- a/common/syntaxflow/sfvm/native_guard_test.go
+++ b/common/syntaxflow/sfvm/native_guard_test.go
@@ -1,0 +1,32 @@
+package sfvm
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestNativeCallGuardSurvivesNestedConfigCopies(t *testing.T) {
+	guard := func(name string) error { return fmt.Errorf("query-local denial: %s", name) }
+	parent := NewConfig(WithNativeCallGuard(guard))
+	for name, config := range map[string]*Config{
+		"parent":     parent,
+		"WithConfig": NewConfig(WithConfig(parent)),
+		"Copy":       parent.Copy(),
+		"nested":     NewConfig(WithConfig(parent.Copy())).Copy(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			frame := &SFFrame{config: config}
+			// A denied call must fail before touching even the input stack or
+			// looking up a native, including unknown future native extensions.
+			_, err := frame.execNativeCall(&SFI{OpCode: OpNativeCall, UnaryStr: "future-native"})
+			if !errors.Is(err, CriticalError) || !strings.Contains(err.Error(), "query-local denial: future-native") {
+				t.Fatalf("native authority guard was lost: %v", err)
+			}
+		})
+	}
+	if NewConfig().nativeCallGuard != nil {
+		t.Fatal("query-local guard leaked into ordinary engine config")
+	}
+}

--- a/common/utils/yakgit/clone.go
+++ b/common/utils/yakgit/clone.go
@@ -33,7 +33,7 @@ const defaultCloneTimeout = 30 * time.Minute
 // init / SetProxy / applyProxyTransport / installDefaultProxyTransport.
 // go-git's gitClient.InstallProtocol mutates a global registry, so concurrent
 // clones that swap transports would race without this lock.
-var protocolMu sync.Mutex
+var protocolMu sync.RWMutex
 
 func init() {
 	installDefaultProxyTransport()
@@ -76,12 +76,9 @@ func installDefaultProxyTransport() {
 // applyProxyTransport re-registers the global go-git https/http transports
 // with an HTTP client whose custom DialContext dials through the given proxy.
 //
-// Why this is needed: go-git's built-in ProxyOptions support relies on
-// http.Transport.Proxy, but yakgit's init() installs a transport with a
-// custom DialContext (netx.DialContext). When DialContext is set, http.Transport
-// bypasses the Proxy CONNECT path and dials directly, so go-git's ProxyOptions
-// is silently ignored. To make per-clone proxy actually work, we must re-register
-// a transport whose DialContext itself dials through the proxy.
+// The configured proxy is applied once, at the netx dial layer. Callers must
+// not also set go-git's ProxyOptions: that adds http.Transport.Proxy and makes
+// the proxy dialer tunnel to the proxy itself instead of the repository.
 //
 // The registry is process-global (gitClient.Protocols), so while a proxied
 // clone is in flight every other clone in the process observes this transport.
@@ -169,37 +166,14 @@ func Clone(u string, localPath string, opt ...Option) error {
 		}
 	}
 
-	// If a per-clone proxy is configured, re-register the global go-git
-	// transport with a DialContext that dials through that proxy. go-git's
-	// own ProxyOptions is silently ignored because yakgit's custom DialContext
-	// bypasses http.Transport.Proxy, so we must swap the transport ourselves.
-	//
-	// Hold protocolMu for the ENTIRE clone, not just the swap: gitClient.Protocols
-	// is a process-global map, and PlainCloneContext reads it at clone time, so
-	// releasing the lock before the clone finishes would let a concurrent clone
-	// (or SetProxy) overwrite the transport mid-flight, silently routing this
-	// clone's requests through the wrong proxy. Proxied clones are rare
-	// (scan-time, one per target) so serializing them is acceptable; no-proxy
-	// clones never touch the registry and stay fully concurrent.
-	//
-	// Restore the PREVIOUS transport (snapshotted before the swap) on exit,
-	// NOT the no-proxy default — a caller may have set a global proxy via
-	// SetProxy that should remain in effect after this per-clone proxy clone
-	// returns. Unconditionally calling installDefaultProxyTransport() here
-	// would silently wipe that global setting.
-	if c.Proxy.URL != "" {
-		full, err := c.Proxy.FullURL()
-		if err != nil {
-			return utils.Wrapf(err, "git clone: %v to %v failed: invalid proxy url", u, localPath)
-		}
-		protocolMu.Lock()
-		prevHTTPS, prevHTTP := snapshotProtocolTransports()
-		applyProxyTransport(full.String())
-		defer func() {
-			restoreProtocolTransports(prevHTTPS, prevHTTP)
-			protocolMu.Unlock()
-		}()
+	// Ordinary clones share a read lock; a per-operation proxy owns the write
+	// lock until the previous transport has been restored. Reads must also
+	// participate so another task's proxy cannot be observed mid-clone.
+	releaseTransport, err := lockGitProtocolTransport(c.Context, c.Proxy)
+	if err != nil {
+		return err
 	}
+	defer releaseTransport()
 
 	respos, err := git.PlainCloneContext(c.Context, localPath, false, buildCloneOptions(u, c))
 	if err != nil {
@@ -225,7 +199,6 @@ func buildCloneOptions(u string, c *config) *git.CloneOptions {
 		RecurseSubmodules: c.ToRecursiveSubmodule(),
 		InsecureSkipTLS:   !c.VerifyTLS,
 		Progress:          os.Stdout,
-		ProxyOptions:      c.Proxy,
 		ReferenceName:     cloneReferenceName(c.Branch),
 		SingleBranch:      c.SingleBranch,
 		Tags:              cloneTagMode(c),

--- a/common/utils/yakgit/clone.go
+++ b/common/utils/yakgit/clone.go
@@ -169,7 +169,8 @@ func Clone(u string, localPath string, opt ...Option) error {
 	// Ordinary clones share a read lock; a per-operation proxy owns the write
 	// lock until the previous transport has been restored. Reads must also
 	// participate so another task's proxy cannot be observed mid-clone.
-	releaseTransport, err := lockGitProtocolTransport(c.Context, c.Proxy)
+	dialProxy, _ := gitProxyOptionsForEndpoint(u, c.Proxy)
+	releaseTransport, err := lockGitProtocolTransport(c.Context, dialProxy)
 	if err != nil {
 		return err
 	}
@@ -192,6 +193,7 @@ func Clone(u string, localPath string, opt ...Option) error {
 // buildCloneOptions maps yakgit config to go-git CloneOptions. Branch names
 // without a refs/ prefix are treated as local branch names (refs/heads/...).
 func buildCloneOptions(u string, c *config) *git.CloneOptions {
+	_, endpointProxy := gitProxyOptionsForEndpoint(u, c.Proxy)
 	opts := &git.CloneOptions{
 		URL:               u,
 		Auth:              c.Auth,
@@ -199,6 +201,7 @@ func buildCloneOptions(u string, c *config) *git.CloneOptions {
 		RecurseSubmodules: c.ToRecursiveSubmodule(),
 		InsecureSkipTLS:   !c.VerifyTLS,
 		Progress:          os.Stdout,
+		ProxyOptions:      endpointProxy,
 		ReferenceName:     cloneReferenceName(c.Branch),
 		SingleBranch:      c.SingleBranch,
 		Tags:              cloneTagMode(c),

--- a/common/utils/yakgit/fetch_exact_revision.go
+++ b/common/utils/yakgit/fetch_exact_revision.go
@@ -47,7 +47,15 @@ func FetchExactRevision(ctx context.Context, local, revision string, opts ...Opt
 	if err != nil {
 		return err
 	}
-	releaseTransport, err := lockGitProtocolTransport(ctx, c.Proxy)
+	origin, err := repository.Remote("origin")
+	if err != nil {
+		return err
+	}
+	if len(origin.Config().URLs) == 0 {
+		return fmt.Errorf("git exact fetch requires a configured origin")
+	}
+	dialProxy, endpointProxy := gitProxyOptionsForEndpoint(origin.Config().URLs[0], c.Proxy)
+	releaseTransport, err := lockGitProtocolTransport(ctx, dialProxy)
 	if err != nil {
 		return err
 	}
@@ -58,8 +66,20 @@ func FetchExactRevision(ctx context.Context, local, revision string, opts ...Opt
 		Depth:           1,
 		Tags:            git.NoTags,
 		Auth:            c.Auth,
+		ProxyOptions:    endpointProxy,
 		InsecureSkipTLS: !c.VerifyTLS,
 	})
+}
+
+// HTTP(S) uses yakgit's netx dial transport; SSH/SCP must retain go-git's
+// endpoint proxy instead. Applying both doubles the HTTP proxy hop, while
+// dropping both silently bypasses an explicitly configured SSH proxy.
+func gitProxyOptionsForEndpoint(locator string, configured transport.ProxyOptions) (dial, endpoint transport.ProxyOptions) {
+	parsed, err := transport.NewEndpoint(locator)
+	if err == nil && (parsed.Protocol == "http" || parsed.Protocol == "https") {
+		return configured, transport.ProxyOptions{}
+	}
+	return transport.ProxyOptions{}, configured
 }
 
 // lockGitProtocolTransport protects the full transport lifetime, including

--- a/common/utils/yakgit/fetch_exact_revision.go
+++ b/common/utils/yakgit/fetch_exact_revision.go
@@ -1,0 +1,101 @@
+package yakgit
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+// FetchExactRevision retrieves one immutable commit from the checkout's
+// configured origin, without shared repository caching or an unbounded history
+// fetch. This Go-only helper is deliberately not exposed to Yak scripts.
+func FetchExactRevision(ctx context.Context, local, revision string, opts ...Option) error {
+	revision = strings.ToLower(strings.TrimSpace(revision))
+	decoded, err := hex.DecodeString(revision)
+	if err != nil || len(decoded) != 20 || revision == strings.Repeat("0", 40) {
+		return fmt.Errorf("git exact fetch requires a full nonzero commit hash")
+	}
+	c := NewConfig()
+	defer c.Cancel()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for _, option := range opts {
+		if err := option(c); err != nil {
+			c.Cancel()
+			return err
+		}
+	}
+	defer c.Cancel()
+	// The explicit caller context remains authoritative even if an Option has
+	// its own context. Bound a caller without a deadline, as Clone does.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultCloneTimeout)
+		defer cancel()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	repository, err := git.PlainOpen(local)
+	if err != nil {
+		return err
+	}
+	releaseTransport, err := lockGitProtocolTransport(ctx, c.Proxy)
+	if err != nil {
+		return err
+	}
+	defer releaseTransport()
+	return repository.FetchContext(ctx, &git.FetchOptions{
+		RemoteName:      "origin",
+		RefSpecs:        []gitconfig.RefSpec{gitconfig.RefSpec(revision + ":refs/legion/source-pin")},
+		Depth:           1,
+		Tags:            git.NoTags,
+		Auth:            c.Auth,
+		InsecureSkipTLS: !c.VerifyTLS,
+	})
+}
+
+// lockGitProtocolTransport protects the full transport lifetime, including
+// callers without a per-operation proxy. A cancelled operation must not wait
+// for another repository's potentially long transfer before it can clean up.
+func lockGitProtocolTransport(ctx context.Context, proxy transport.ProxyOptions) (func(), error) {
+	var proxyURL string
+	if proxy.URL != "" {
+		full, err := proxy.FullURL()
+		if err != nil {
+			return nil, fmt.Errorf("git transport has an invalid proxy URL")
+		}
+		proxyURL = full.String()
+	}
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if proxyURL == "" {
+			if protocolMu.TryRLock() {
+				return protocolMu.RUnlock, nil
+			}
+		} else if protocolMu.TryLock() {
+			previousHTTPS, previousHTTP := snapshotProtocolTransports()
+			applyProxyTransport(proxyURL)
+			return func() {
+				restoreProtocolTransports(previousHTTPS, previousHTTP)
+				protocolMu.Unlock()
+			}, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/common/utils/yakgit/fetch_exact_revision_test.go
+++ b/common/utils/yakgit/fetch_exact_revision_test.go
@@ -3,9 +3,12 @@ package yakgit
 import (
 	"context"
 	"crypto/x509"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -17,9 +20,12 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	gitHTTP "github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitSSH "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/netx"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 const exactFetchTestRevision = "0123456789abcdef0123456789abcdef01234567"
@@ -322,4 +328,164 @@ func TestCloneCannotUseAnotherFetchProxy(t *testing.T) {
 	require.Error(t, err)
 	require.EqualValues(t, 1, originRequests.Load(), "after restoration an ordinary clone must contact only its own origin")
 	require.EqualValues(t, 1, proxyRequests.Load())
+}
+
+// go-git consults known_hosts even with a HostKeyCallback when algorithms are
+// empty. Set them in the synthetic auth so this fixture never reads user SSH
+// files. The five-second dial timeout also bounds go-git's pre-session dial,
+// which does not yet inherit the operation's context.
+type exactFetchSSHPassword struct{ gitSSH.Password }
+
+func (a *exactFetchSSHPassword) ClientConfig() (*gossh.ClientConfig, error) {
+	cfg, err := a.Password.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg.HostKeyAlgorithms = []string{gossh.KeyAlgoED25519}
+	cfg.Timeout = 5 * time.Second
+	return cfg, nil
+}
+
+type exactFetchSOCKSObservation struct {
+	host              string
+	port              uint16
+	registryUntouched bool
+	sharedLockHeld    bool
+	err               error
+}
+
+func readExactFetchSOCKSRequest(conn net.Conn, beforeHTTPS, beforeHTTP transport.Transport) (result exactFetchSOCKSObservation) {
+	if result.err = conn.SetDeadline(time.Now().Add(5 * time.Second)); result.err != nil {
+		return
+	}
+	var greeting [2]byte
+	if _, result.err = io.ReadFull(conn, greeting[:]); result.err != nil {
+		return
+	}
+	if greeting[0] != 5 || greeting[1] == 0 {
+		result.err = fmt.Errorf("expected SOCKS5 method negotiation")
+		return
+	}
+	methods := make([]byte, int(greeting[1]))
+	if _, result.err = io.ReadFull(conn, methods); result.err != nil {
+		return
+	}
+	if _, result.err = conn.Write([]byte{5, 0}); result.err != nil {
+		return
+	}
+	var request [5]byte
+	if _, result.err = io.ReadFull(conn, request[:]); result.err != nil {
+		return
+	}
+	if request[0] != 5 || request[1] != 1 || request[2] != 0 || request[3] != 3 || request[4] == 0 {
+		result.err = fmt.Errorf("expected SOCKS5 CONNECT with a domain target")
+		return
+	}
+	target := make([]byte, int(request[4])+2)
+	if _, result.err = io.ReadFull(conn, target); result.err != nil {
+		return
+	}
+	result.host = string(target[:len(target)-2])
+	result.port = binary.BigEndian.Uint16(target[len(target)-2:])
+	if protocolMu.TryRLock() {
+		duringHTTPS, duringHTTP := snapshotProtocolTransports()
+		result.registryUntouched = beforeHTTPS == duringHTTPS && beforeHTTP == duringHTTP
+		protocolMu.RUnlock()
+		if protocolMu.TryLock() {
+			protocolMu.Unlock()
+		} else {
+			result.sharedLockHeld = true
+		}
+	}
+	return
+}
+
+func newExactFetchSOCKSFixture(t *testing.T, beforeHTTPS, beforeHTTP transport.Transport) (string, <-chan exactFetchSOCKSObservation) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	observed := make(chan exactFetchSOCKSObservation, 1)
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		conn, err := listener.Accept()
+		if err != nil {
+			observed <- exactFetchSOCKSObservation{err: err}
+			return
+		}
+		defer conn.Close()
+		result := readExactFetchSOCKSRequest(conn, beforeHTTPS, beforeHTTP)
+		observed <- result
+		if result.err == nil {
+			// SOCKS5 "connection not allowed". Never dial or forward the target.
+			_, _ = conn.Write([]byte{5, 2, 0, 1, 0, 0, 0, 0, 0, 0})
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-closed
+	})
+	return "socks5://" + listener.Addr().String(), observed
+}
+
+func TestFetchExactRevisionSSHAndSCPUseExplicitSOCKSProxy(t *testing.T) {
+	isolateExactFetchTransports(t)
+	previousSSHConfig := gitSSH.DefaultSSHConfig
+	gitSSH.DefaultSSHConfig = nil
+	t.Cleanup(func() { gitSSH.DefaultSSHConfig = previousSSHConfig })
+	// A regression that drops ProxyOptions must fail without external DNS or
+	// environment-proxy traffic, and it must not count as a successful test.
+	previousResolver := net.DefaultResolver
+	net.DefaultResolver = &net.Resolver{PreferGo: true, Dial: func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("external DNS is disabled by the SOCKS fixture")
+	}}
+	t.Cleanup(func() { net.DefaultResolver = previousResolver })
+	for _, name := range []string{"ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy"} {
+		t.Setenv(name, "")
+	}
+	for _, locator := range []struct{ name, value string }{
+		{name: "ssh_url", value: "ssh://git@syntaxflow-fetch-origin.invalid/repo"},
+		{name: "scp", value: "git@syntaxflow-fetch-origin.invalid:repo"},
+	} {
+		for _, operation := range []string{"fetch", "clone"} {
+			t.Run(operation+"_"+locator.name, func(t *testing.T) {
+				protocolMu.RLock()
+				beforeHTTPS, beforeHTTP := snapshotProtocolTransports()
+				protocolMu.RUnlock()
+				proxyURL, observed := newExactFetchSOCKSFixture(t, beforeHTTPS, beforeHTTP)
+				auth := &exactFetchSSHPassword{Password: gitSSH.Password{
+					User: "git", Password: "fixture-password",
+					HostKeyCallbackHelper: gitSSH.HostKeyCallbackHelper{HostKeyCallback: gossh.InsecureIgnoreHostKey()},
+				}}
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				opts := []Option{WithContext(ctx), WithProxy(proxyURL, "", ""), func(c *config) error {
+					c.Auth = auth
+					return nil
+				}}
+				var err error
+				if operation == "fetch" {
+					err = FetchExactRevision(ctx, newExactFetchRepository(t, locator.value), exactFetchTestRevision, opts...)
+				} else {
+					err = Clone(locator.value, filepath.Join(t.TempDir(), "clone"), opts...)
+				}
+				require.Error(t, err, "the fixture always rejects CONNECT")
+				select {
+				case request := <-observed:
+					require.NoError(t, request.err)
+					require.Equal(t, "syntaxflow-fetch-origin.invalid", request.host)
+					require.EqualValues(t, 22, request.port)
+					require.True(t, request.registryUntouched, "SSH must not swap the HTTP(S) registry")
+					require.True(t, request.sharedLockHeld, "SSH must share the transport read lock while dialing")
+				default:
+					t.Fatalf("the SOCKS5 fixture received no request; a direct-connect error is not proxy evidence: %v", err)
+				}
+				protocolMu.RLock()
+				afterHTTPS, afterHTTP := snapshotProtocolTransports()
+				protocolMu.RUnlock()
+				require.Same(t, beforeHTTPS, afterHTTPS)
+				require.Same(t, beforeHTTP, afterHTTP)
+			})
+		}
+	}
 }

--- a/common/utils/yakgit/fetch_exact_revision_test.go
+++ b/common/utils/yakgit/fetch_exact_revision_test.go
@@ -1,0 +1,325 @@
+package yakgit
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	gitHTTP "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/netx"
+)
+
+const exactFetchTestRevision = "0123456789abcdef0123456789abcdef01234567"
+
+// These tests mutate go-git's process-wide transport registry and must remain
+// sequential. Keep both the transport and the DNS guard local to each test.
+func isolateExactFetchTransports(t *testing.T) {
+	t.Helper()
+	protocolMu.Lock()
+	previousHTTPS, previousHTTP := snapshotProtocolTransports()
+	installDefaultProxyTransport()
+	protocolMu.Unlock()
+	t.Cleanup(func() {
+		protocolMu.Lock()
+		restoreProtocolTransports(previousHTTPS, previousHTTP)
+		protocolMu.Unlock()
+	})
+	previousDNS := netx.GetDefaultOptions()
+	netx.SetDefaultDNSOptions(append(previousDNS, netx.WithDNSDisabledDomain("*.invalid"))...)
+	t.Cleanup(func() { netx.SetDefaultDNSOptions(previousDNS...) })
+}
+
+func newExactFetchRepository(t *testing.T, origin string) string {
+	t.Helper()
+	local := t.TempDir()
+	repository, err := git.PlainInit(local, false)
+	require.NoError(t, err)
+	_, err = repository.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{origin}})
+	require.NoError(t, err)
+	return local
+}
+
+type exactFetchProxyRequest struct {
+	method string
+	host   string
+}
+
+func TestFetchExactRevisionUsesProxyAndRestoresTransportAfterFailure(t *testing.T) {
+	isolateExactFetchTransports(t)
+	for _, operation := range []string{"fetch", "clone"} {
+		t.Run(operation, func(t *testing.T) {
+			requests := make(chan exactFetchProxyRequest, 4)
+			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case requests <- exactFetchProxyRequest{method: r.Method, host: r.Host}:
+				default:
+				}
+				http.Error(w, "fixture proxy unavailable", http.StatusServiceUnavailable)
+			}))
+			defer proxy.Close()
+			const origin = "http://syntaxflow-fetch-origin.invalid/source.git"
+			protocolMu.RLock()
+			beforeHTTPS, beforeHTTP := snapshotProtocolTransports()
+			protocolMu.RUnlock()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			var err error
+			if operation == "fetch" {
+				err = FetchExactRevision(ctx, newExactFetchRepository(t, origin), exactFetchTestRevision,
+					WithProxy(proxy.URL, "", ""))
+			} else {
+				err = Clone(origin, filepath.Join(t.TempDir(), "clone"), WithContext(ctx), WithProxy(proxy.URL, "", ""))
+			}
+			require.Error(t, err)
+			protocolMu.RLock()
+			afterHTTPS, afterHTTP := snapshotProtocolTransports()
+			protocolMu.RUnlock()
+			require.Same(t, beforeHTTPS, afterHTTPS)
+			require.Same(t, beforeHTTP, afterHTTP)
+			select {
+			case request := <-requests:
+				require.Equal(t, http.MethodConnect, request.method)
+				require.Equal(t, "syntaxflow-fetch-origin.invalid:80", request.host,
+					"the proxy must target origin, not tunnel back to the proxy itself")
+			default:
+				t.Fatal("the configured local proxy received no request")
+			}
+		})
+	}
+}
+
+func TestFetchExactRevisionRejectsUntrustedTLSByDefault(t *testing.T) {
+	isolateExactFetchTransports(t)
+	var requests atomic.Int32
+	var receivedUser, receivedPassword, receivedPath string
+	fixture := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUser, receivedPassword, _ = r.BasicAuth()
+		receivedPath = r.URL.RequestURI()
+		requests.Add(1)
+		http.Error(w, "fixture repository unavailable", http.StatusServiceUnavailable)
+	}))
+	fixture.Config.ErrorLog = log.New(io.Discard, "", 0)
+	fixture.StartTLS()
+	defer fixture.Close()
+	local := newExactFetchRepository(t, fixture.URL+"/source.git")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := FetchExactRevision(ctx, local, exactFetchTestRevision)
+	var untrusted x509.UnknownAuthorityError
+	require.True(t, errors.As(err, &untrusted), "expected a certificate trust failure, got %v", err)
+	require.Zero(t, requests.Load(), "an untrusted server must not receive Git HTTP requests")
+
+	// The helper's explicit opt-out is only a test control. The Node caller
+	// always supplies WithVerifyTLS(true), including pinned-revision recovery.
+	err = FetchExactRevision(ctx, local, exactFetchTestRevision,
+		WithVerifyTLS(false), WithUsernamePassword("fixture-user", "fixture-password"))
+	require.Error(t, err)
+	require.EqualValues(t, 1, requests.Load())
+	require.Equal(t, "fixture-user", receivedUser)
+	require.Equal(t, "fixture-password", receivedPassword)
+	require.Equal(t, "/source.git/info/refs?service=git-upload-pack", receivedPath)
+
+	err = FetchExactRevision(ctx, local, exactFetchTestRevision)
+	require.True(t, errors.As(err, &untrusted), "explicit insecure options must not leak to later fetches")
+	require.EqualValues(t, 1, requests.Load())
+}
+
+func TestFetchExactRevisionRejectsInvalidHashesBeforeNetwork(t *testing.T) {
+	isolateExactFetchTransports(t)
+	var requests atomic.Int32
+	fixture := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected network request", http.StatusServiceUnavailable)
+	}))
+	defer fixture.Close()
+	local := newExactFetchRepository(t, fixture.URL+"/source.git")
+	for _, revision := range []string{
+		"", "main", "HEAD", "refs/heads/main", strings.Repeat("a", 39),
+		strings.Repeat("a", 41), strings.Repeat("g", 40), strings.Repeat("0", 40),
+		exactFetchTestRevision + "^", exactFetchTestRevision + ":refs/heads/main",
+	} {
+		t.Run(revision, func(t *testing.T) {
+			err := FetchExactRevision(context.Background(), local, revision)
+			require.ErrorContains(t, err, "full nonzero commit hash")
+		})
+	}
+	require.Zero(t, requests.Load())
+}
+
+func TestFetchExactRevisionCancellationWhileWaitingForTransport(t *testing.T) {
+	isolateExactFetchTransports(t)
+	var requests atomic.Int32
+	fixture := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected network request", http.StatusServiceUnavailable)
+	}))
+	defer fixture.Close()
+	local := newExactFetchRepository(t, fixture.URL+"/source.git")
+	for _, tc := range []struct {
+		name     string
+		proxy    bool
+		deadline bool
+	}{
+		{name: "read_lock_cancelled"},
+		{name: "write_lock_cancelled", proxy: true},
+		{name: "read_lock_deadline", deadline: true},
+		{name: "write_lock_deadline", proxy: true, deadline: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			protocolMu.Lock()
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(protocolMu.Unlock) }
+			defer release()
+			ctx, cancel := context.WithCancel(context.Background())
+			want := context.Canceled
+			if tc.deadline {
+				cancel()
+				ctx, cancel = context.WithTimeout(context.Background(), 75*time.Millisecond)
+				want = context.DeadlineExceeded
+			}
+			defer cancel()
+			// A separate option context must never replace the authoritative
+			// caller context and make a cancelled task wait indefinitely.
+			opts := []Option{WithContext(context.Background())}
+			if tc.proxy {
+				opts = append(opts, WithProxy(fixture.URL, "", ""))
+			}
+			done := make(chan error, 1)
+			started := time.Now()
+			go func() { done <- FetchExactRevision(ctx, local, exactFetchTestRevision, opts...) }()
+			if !tc.deadline {
+				timer := time.AfterFunc(25*time.Millisecond, cancel)
+				defer timer.Stop()
+			}
+			select {
+			case err := <-done:
+				require.ErrorIs(t, err, want)
+				require.Less(t, time.Since(started), 600*time.Millisecond)
+			case <-time.After(time.Second):
+				release()
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+				}
+				t.Fatal("fetch did not stop while the protocol transport lock remained held")
+			}
+		})
+	}
+	require.Zero(t, requests.Load())
+}
+
+type exactFetchRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn exactFetchRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return fn(r) }
+
+func TestFetchExactRevisionAddsDeadlineToActualRequest(t *testing.T) {
+	isolateExactFetchTransports(t)
+	fixture := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "fixture repository unavailable", http.StatusServiceUnavailable)
+	}))
+	defer fixture.Close()
+	local := newExactFetchRepository(t, fixture.URL+"/source.git")
+	baseTransport := &http.Transport{}
+	defer baseTransport.CloseIdleConnections()
+	var deadline time.Time
+	var hasDeadline bool
+	client := gitHTTP.NewClient(&http.Client{Transport: exactFetchRoundTripper(func(r *http.Request) (*http.Response, error) {
+		deadline, hasDeadline = r.Context().Deadline()
+		return baseTransport.RoundTrip(r)
+	})})
+	protocolMu.Lock()
+	restoreProtocolTransports(client, client)
+	protocolMu.Unlock()
+	started := time.Now()
+	err := FetchExactRevision(context.Background(), local, exactFetchTestRevision)
+	require.Error(t, err)
+	require.True(t, hasDeadline, "the real HTTP request must inherit a bounded operation context")
+	require.WithinDuration(t, started.Add(defaultCloneTimeout), deadline, time.Second)
+}
+
+func TestCloneCannotUseAnotherFetchProxy(t *testing.T) {
+	isolateExactFetchTransports(t)
+	var originRequests, proxyRequests atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		originRequests.Add(1)
+		http.Error(w, "fixture repository unavailable", http.StatusServiceUnavailable)
+	}))
+	defer origin.Close()
+	entered := make(chan exactFetchProxyRequest, 4)
+	unblock := make(chan struct{})
+	var unblockOnce sync.Once
+	releaseProxy := func() { unblockOnce.Do(func() { close(unblock) }) }
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyRequests.Add(1)
+		select {
+		case entered <- exactFetchProxyRequest{method: r.Method, host: r.Host}:
+		default:
+		}
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
+		http.Error(w, "fixture proxy unavailable", http.StatusServiceUnavailable)
+	}))
+	defer proxy.Close()
+	defer releaseProxy()
+	local := newExactFetchRepository(t, "http://syntaxflow-fetch-origin.invalid/source.git")
+	fetchCtx, cancelFetch := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelFetch()
+	fetchDone := make(chan error, 1)
+	go func() {
+		fetchDone <- FetchExactRevision(fetchCtx, local, exactFetchTestRevision, WithProxy(proxy.URL, "", ""))
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		releaseProxy()
+		<-fetchDone
+		t.Fatal("fetch never entered the local proxy")
+	}
+	cloneCtx, cancelClone := context.WithTimeout(context.Background(), 75*time.Millisecond)
+	defer cancelClone()
+	cloneDone := make(chan error, 1)
+	cloneLocal := filepath.Join(t.TempDir(), "blocked-clone")
+	go func() {
+		cloneDone <- Clone(origin.URL+"/source.git", cloneLocal,
+			WithContext(cloneCtx), WithVerifyTLS(true))
+	}()
+	var cloneErr error
+	select {
+	case cloneErr = <-cloneDone:
+	case <-time.After(time.Second):
+		releaseProxy()
+		<-fetchDone
+		<-cloneDone
+		t.Fatal("an ordinary clone failed to cancel behind a proxied fetch")
+	}
+	releaseProxy()
+	require.Error(t, <-fetchDone)
+	require.ErrorIs(t, cloneErr, context.DeadlineExceeded)
+	require.Zero(t, originRequests.Load(), "the cancelled clone must not start an HTTP request")
+	require.EqualValues(t, 1, proxyRequests.Load(), "another operation must not borrow the fetch proxy")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err := Clone(origin.URL+"/source.git", filepath.Join(t.TempDir(), "direct-clone"),
+		WithContext(ctx), WithVerifyTLS(true))
+	require.Error(t, err)
+	require.EqualValues(t, 1, originRequests.Load(), "after restoration an ordinary clone must contact only its own origin")
+	require.EqualValues(t, 1, proxyRequests.Load())
+}

--- a/common/yak/ssaapi/ssa_compile_fs.go
+++ b/common/yak/ssaapi/ssa_compile_fs.go
@@ -636,7 +636,9 @@ func (c *Config) parseProjectWithFSUnits(
 
 	p := NewProgram(prog, c)
 	SaveConfig(c, p)
-	SetProgramCache(p)
+	if !c.disableProgramCache {
+		SetProgramCache(p)
+	}
 	return p, nil
 }
 

--- a/common/yak/ssaapi/ssa_config.go
+++ b/common/yak/ssaapi/ssa_config.go
@@ -45,6 +45,7 @@ type Config struct {
 	// other build ssaconfig.Options
 	DatabaseProgramCacheHitter func(any)
 	EnableCache                bool
+	disableProgramCache        bool
 	// for hash
 	externInfo string
 	// process ctx
@@ -297,6 +298,12 @@ var WithProgramName = ssaconfig.WithProgramNames
 var WithSetProgramName = ssaconfig.WithSetProgramName
 
 var WithMemory = ssaconfig.WithCompileMemoryCompile
+
+// WithDisableProgramCache keeps task-private project IR out of the global
+// program-name cache. It is independent of persistent versus memory compile.
+var WithDisableProgramCache = ssaconfig.SetOption("ssa_compile/disable_program_cache", func(c *Config, disabled bool) {
+	c.disableProgramCache = disabled
+})
 
 var WithConcurrency = ssaconfig.WithCompileConcurrency
 

--- a/common/yak/ssaapi/ssa_recompile.go
+++ b/common/yak/ssaapi/ssa_recompile.go
@@ -12,7 +12,7 @@ import (
 // save to Profile SSAProgram
 func SaveConfig(c *Config, prog *Program) {
 	if c.databaseKind == ssa.ProgramCacheMemory || c.EnableCache {
-		if c.GetProgramName() != "" {
+		if c.GetProgramName() != "" && !c.disableProgramCache {
 			log.Errorf("Compile program cache to memory: %s", c.GetProgramName())
 			SetProgramCache(prog)
 		}

--- a/scannode/capability_keys.go
+++ b/scannode/capability_keys.go
@@ -11,6 +11,7 @@ const (
 	capabilityKeyAIBindEpochV1              = "ai.session.bind_epoch.v1"
 	capabilityKeyAITurnLifecycleV1          = "ai.session.turn_lifecycle.v1"
 	capabilityKeyAICodeWorkspaceV1          = "ai.code_workspace.v1"
+	capabilityKeyAISyntaxFlowRuleV1         = "ai.syntaxflow_rule.v1"
 )
 
 func normalizeScanNodeCapabilityKeys(input []string) []string {
@@ -27,7 +28,10 @@ func normalizeScanNodeCapabilityKeysForRuntime(input []string, runtimeMode strin
 		if trimmed == "" {
 			return
 		}
-		if trimmed == capabilityKeyAICodeWorkspaceV1 && runtimeMode == aiSessionRuntimeModeStateful {
+		if (trimmed == capabilityKeyAICodeWorkspaceV1 || trimmed == capabilityKeyAISyntaxFlowRuleV1) && runtimeMode == aiSessionRuntimeModeStateful {
+			return
+		}
+		if trimmed == capabilityKeyAISyntaxFlowRuleV1 && !legionSyntaxFlowRuntimeAvailable() {
 			return
 		}
 		if _, exists := seen[trimmed]; exists {

--- a/scannode/capability_keys_hids.go
+++ b/scannode/capability_keys_hids.go
@@ -11,5 +11,6 @@ func compiledScanNodeCapabilityKeys() []string {
 		capabilityKeyAIBindEpochV1,
 		capabilityKeyAITurnLifecycleV1,
 		capabilityKeyAICodeWorkspaceV1,
+		capabilityKeyAISyntaxFlowRuleV1,
 	}
 }

--- a/scannode/capability_keys_hids_test.go
+++ b/scannode/capability_keys_hids_test.go
@@ -20,6 +20,9 @@ func TestNormalizeScanNodeCapabilityKeysAddsHIDSCapabilityWhenCompiled(t *testin
 		capabilityKeyAITurnLifecycleV1,
 		capabilityKeyAICodeWorkspaceV1,
 	}
+	if legionSyntaxFlowRuntimeAvailable() {
+		want = append(want, capabilityKeyAISyntaxFlowRuleV1)
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}
@@ -43,8 +46,11 @@ func TestNormalizeScanNodeCapabilityKeysDeduplicatesCompiledHIDSCapability(t *te
 		capabilityKeyAIBindEpochV1,
 		capabilityKeyAITurnLifecycleV1,
 		capabilityKeyAICodeWorkspaceV1,
-		"extra.capability",
 	}
+	if legionSyntaxFlowRuntimeAvailable() {
+		want = append(want, capabilityKeyAISyntaxFlowRuleV1)
+	}
+	want = append(want, "extra.capability")
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}

--- a/scannode/capability_keys_nohids.go
+++ b/scannode/capability_keys_nohids.go
@@ -10,5 +10,6 @@ func compiledScanNodeCapabilityKeys() []string {
 		capabilityKeyAIBindEpochV1,
 		capabilityKeyAITurnLifecycleV1,
 		capabilityKeyAICodeWorkspaceV1,
+		capabilityKeyAISyntaxFlowRuleV1,
 	}
 }

--- a/scannode/capability_keys_nohids_test.go
+++ b/scannode/capability_keys_nohids_test.go
@@ -19,6 +19,9 @@ func TestNormalizeScanNodeCapabilityKeysDefaultsToNonHIDSBuildSurface(t *testing
 		capabilityKeyAITurnLifecycleV1,
 		capabilityKeyAICodeWorkspaceV1,
 	}
+	if legionSyntaxFlowRuntimeAvailable() {
+		want = append(want, capabilityKeyAISyntaxFlowRuleV1)
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}
@@ -41,8 +44,11 @@ func TestNormalizeScanNodeCapabilityKeysKeepsExplicitExtrasWithoutDuplicates(t *
 		capabilityKeyAIBindEpochV1,
 		capabilityKeyAITurnLifecycleV1,
 		capabilityKeyAICodeWorkspaceV1,
-		"extra.capability",
 	}
+	if legionSyntaxFlowRuntimeAvailable() {
+		want = append(want, capabilityKeyAISyntaxFlowRuleV1)
+	}
+	want = append(want, "extra.capability")
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected capability keys: got=%#v want=%#v", got, want)
 	}
@@ -52,11 +58,11 @@ func TestNormalizeScanNodeCapabilityKeysHidesCodeWorkspaceInStatefulRollbackMode
 	t.Parallel()
 
 	got := normalizeScanNodeCapabilityKeysForRuntime(
-		[]string{capabilityKeyAICodeWorkspaceV1, "extra.capability"},
+		[]string{capabilityKeyAICodeWorkspaceV1, capabilityKeyAISyntaxFlowRuleV1, "extra.capability"},
 		aiSessionRuntimeModeStateful,
 	)
 	for _, key := range got {
-		if key == capabilityKeyAICodeWorkspaceV1 {
+		if key == capabilityKeyAICodeWorkspaceV1 || key == capabilityKeyAISyntaxFlowRuleV1 {
 			t.Fatalf("stateful rollback mode advertised unsupported capability: %#v", got)
 		}
 	}

--- a/scannode/legion_ai_focus_contract.go
+++ b/scannode/legion_ai_focus_contract.go
@@ -103,8 +103,16 @@ func parseLegionFocusExecutionContract(raw string) (*legionFocusExecutionContrac
 		if _, exists := contract.resultByCap[result.Capability]; exists {
 			return nil, fmt.Errorf("Focus execution capability %q maps multiple result contracts", result.Capability)
 		}
+		if (result.Capability == serverFocusCapabilityRuleCandidate) != (result.Kind == legionSyntaxFlowRuleCandidateKind) {
+			return nil, fmt.Errorf("SyntaxFlow rule candidates require the dedicated result.rule_candidate.v1 contract and ai_syntaxflow_rule_v1 kind")
+		}
 		seenResults[result.Key] = struct{}{}
 		contract.resultByCap[result.Capability] = *result
+	}
+	if contract.allowsCapability(serverFocusCapabilityRuleCandidate) {
+		if _, ok := contract.resultByCap[serverFocusCapabilityRuleCandidate]; !ok {
+			return nil, fmt.Errorf("result.rule_candidate.v1 requires an immutable result contract")
+		}
 	}
 	canonicalView := contract
 	canonicalView.stageSet = nil

--- a/scannode/legion_ai_focus_runtime.go
+++ b/scannode/legion_ai_focus_runtime.go
@@ -207,6 +207,8 @@ func (r *legionServerFocusRuntime) Execute(
 			return nil, fmt.Errorf("source workspace is unavailable")
 		}
 		return r.workspace.search(params)
+	case serverFocusCapabilityOriginalSampleRead:
+		return r.readSyntaxFlowOriginalSample(params)
 	case serverFocusCapabilitySubmitFindingV1:
 		return r.submitFindingV1(capability, params)
 	case serverFocusCapabilitySubmitReportV1:

--- a/scannode/legion_ai_focus_runtime.go
+++ b/scannode/legion_ai_focus_runtime.go
@@ -78,9 +78,19 @@ type legionServerFocusRuntime struct {
 	authorizedFocusReleaseID string
 	activeFocusReleaseID     string
 	activeExecutionContract  *legionFocusExecutionContract
+	activeFocusContext       context.Context
+	activeFocusCancel        context.CancelFunc
+	activeFocusGeneration    uint64
 
-	mu           sync.Mutex
-	requestCount int
+	mu               sync.Mutex
+	requestCount     int
+	ruleMu           sync.Mutex
+	ruleCallCount    int
+	ruleDebugHistory []legionSyntaxFlowDebugResult
+	// Zero uses the immutable server defaults; nonzero values are used only
+	// by local deterministic cancellation/budget tests, never model input.
+	ruleDebugTimeout time.Duration
+	ruleWorkLimit    int64
 }
 
 func newLegionServerFocusRuntime(
@@ -201,6 +211,12 @@ func (r *legionServerFocusRuntime) Execute(
 		return r.submitFindingV1(capability, params)
 	case serverFocusCapabilitySubmitReportV1:
 		return r.submitReportV1(capability, params)
+	case serverFocusCapabilityRuleCheck:
+		return r.checkSyntaxFlowRule(params)
+	case serverFocusCapabilityRuleDebug:
+		return r.debugSyntaxFlowRule(params)
+	case serverFocusCapabilityRuleCandidate:
+		return r.submitSyntaxFlowRuleCandidate(params)
 	case serverFocusCapabilityTaskStage:
 		return r.publishTaskStage(params)
 	default:
@@ -235,6 +251,14 @@ func (r *legionServerFocusRuntime) activateFocusTurn(releaseID string, contracts
 	}
 	r.activeFocusReleaseID = releaseID
 	r.activeExecutionContract = contract
+	r.activeFocusGeneration++
+	parentContext := r.ctx
+	if parentContext == nil {
+		parentContext = context.Background()
+	}
+	r.activeFocusContext, r.activeFocusCancel = context.WithCancel(parentContext)
+	r.ruleCallCount = 0
+	r.ruleDebugHistory = nil
 	return nil
 }
 
@@ -245,8 +269,15 @@ func (r *legionServerFocusRuntime) deactivateFocusTurn(releaseID string) {
 	r.mu.Lock()
 	cleanup := false
 	if r.activeFocusReleaseID == strings.TrimSpace(releaseID) {
+		if r.activeFocusCancel != nil {
+			r.activeFocusCancel()
+		}
 		r.activeFocusReleaseID = ""
 		r.activeExecutionContract = nil
+		r.activeFocusContext = nil
+		r.activeFocusCancel = nil
+		r.ruleCallCount = 0
+		r.ruleDebugHistory = nil
 		cleanup = true
 	}
 	r.mu.Unlock()

--- a/scannode/legion_ai_result_sink.go
+++ b/scannode/legion_ai_result_sink.go
@@ -78,6 +78,9 @@ type aiFocusCodeAuditReport struct {
 	Title             string          `json:"title"`
 	Markdown          string          `json:"markdown"`
 	StructuredSummary json.RawMessage `json:"structured_summary"`
+	// A private integrity marker is set only by result.rule_candidate.v1.
+	// It is never deserialized from model parameters or transmitted.
+	validatedRuleCandidateSHA256 string
 }
 
 type aiFocusResultSink interface {
@@ -143,6 +146,7 @@ type legionAIFocusResultSink struct {
 	riskIDs                map[string]struct{}
 	targets                map[string]struct{}
 	requiredResultKinds    map[string]struct{}
+	ruleCandidateAllowed   bool
 	publishedResultKinds   map[string]struct{}
 	codeWorkspaceLockedRev string
 	codeWorkspaceSHA256    string
@@ -532,6 +536,11 @@ func (s *legionAIFocusResultSink) SubmitCodeAuditReport(
 	report aiFocusCodeAuditReport,
 ) (aiFocusResultReceipt, error) {
 	kind = strings.TrimSpace(kind)
+	if kind == legionSyntaxFlowRuleCandidateKind {
+		if err := s.validateRuleCandidateReport(report); err != nil {
+			return aiFocusResultReceipt{}, err
+		}
+	}
 	report.WorkspaceID = strings.TrimSpace(report.WorkspaceID)
 	report.Title = strings.TrimSpace(report.Title)
 	if report.Title == "" {
@@ -606,6 +615,7 @@ func (s *legionAIFocusResultSink) bindFocusExecutionContract(contract *legionFoc
 		return nil
 	}
 	s.requiredResultKinds = required
+	_, s.ruleCandidateAllowed = contract.resultForCapability(serverFocusCapabilityRuleCandidate)
 	return nil
 }
 

--- a/scannode/legion_ai_syntaxflow_candidate.go
+++ b/scannode/legion_ai_syntaxflow_candidate.go
@@ -1,0 +1,282 @@
+package scannode
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+)
+
+type legionSyntaxFlowRuleCandidateSummary struct {
+	SchemaVersion      string                        `json:"schema_version"`
+	RuleName           string                        `json:"rule_name"`
+	Language           string                        `json:"language"`
+	RuleContent        string                        `json:"rule_content"`
+	RuleSHA256         string                        `json:"rule_sha256"`
+	Explanation        string                        `json:"explanation"`
+	Limitations        []string                      `json:"limitations"`
+	VerificationStatus string                        `json:"verification_status"`
+	DebugResults       []legionSyntaxFlowDebugResult `json:"debug_results"`
+	WorkspaceRevision  string                        `json:"workspace_revision"`
+	SourceSHA256       string                        `json:"source_sha256"`
+}
+
+func (r *legionServerFocusRuntime) submitSyntaxFlowRuleCandidate(params map[string]any) (map[string]any, error) {
+	r.ruleMu.Lock()
+	defer r.ruleMu.Unlock()
+	ctx, generation, err := r.beginRuleOperation(serverFocusCapabilityRuleCandidate, false)
+	if err != nil {
+		return nil, err
+	}
+	// Evidence fields, selectors, and opaque summaries are not accepted.
+	if err := rejectLegionRuleExtraParams(params, "title", "rule_name", "language", "rule", "explanation", "limitations", "markdown"); err != nil {
+		return nil, err
+	}
+	title, err := legionRuleString(params, "title", 256, true)
+	if err != nil {
+		return nil, err
+	}
+	ruleName, err := legionRuleString(params, "rule_name", 128, true)
+	if err != nil {
+		return nil, err
+	}
+	if strings.ContainsAny(ruleName, "/\\\r\n") || strings.TrimSpace(ruleName) != ruleName {
+		return nil, fmt.Errorf("rule_name must be a simple name without a path")
+	}
+	languageText, err := legionRuleString(params, "language", 32, true)
+	if err != nil {
+		return nil, err
+	}
+	language, err := normalizeLegionSyntaxFlowLanguage(languageText)
+	if err != nil {
+		return nil, err
+	}
+	rule, err := legionRuleString(params, "rule", legionSyntaxFlowMaxRuleBytes, true)
+	if err != nil {
+		return nil, err
+	}
+	explanation, err := legionRuleString(params, "explanation", 8*1024, true)
+	if err != nil {
+		return nil, err
+	}
+	// Optional model Markdown is never the authoritative report. Validate its
+	// bounds for compatibility, then render the candidate and observed facts.
+	if _, err := legionRuleString(params, "markdown", 32*1024, false); err != nil {
+		return nil, err
+	}
+	limitations := []string{}
+	if raw, present := params["limitations"]; present {
+		limitations, err = legionRuleStringList(raw, 16)
+		if err != nil {
+			return nil, fmt.Errorf("limitations: %w", err)
+		}
+		for _, limitation := range limitations {
+			if len(limitation) > 1024 || !utf8.ValidString(limitation) || strings.ContainsRune(limitation, '\x00') {
+				return nil, fmt.Errorf("each limitation must be bounded UTF-8 text")
+			}
+		}
+	}
+	frame, err := compileLegionSyntaxFlowRule(rule)
+	if err != nil {
+		return nil, fmt.Errorf("rule candidate is invalid: %s", trimLegionRuleText(err.Error(), legionSyntaxFlowMaxDiagnosticBytes))
+	}
+	hasAlert := false
+	for _, code := range frame.Codes {
+		if code != nil && code.OpCode == sfvm.OpAlert && code.UnaryStr != "" {
+			hasAlert = true
+			break
+		}
+	}
+	if !hasAlert {
+		return nil, fmt.Errorf("rule candidate must contain a compiled alert definition; intermediate queries belong in check/debug")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.ruleGenerationActive(generation) || ctx.Err() != nil {
+		return nil, fmt.Errorf("rule candidate Turn is no longer active")
+	}
+	resultContract, ok := r.activeExecutionContract.resultForCapability(serverFocusCapabilityRuleCandidate)
+	if !ok || resultContract.Kind != legionSyntaxFlowRuleCandidateKind {
+		return nil, fmt.Errorf("rule candidate has no dedicated immutable result contract")
+	}
+	sink, ok := r.sink.(aiFocusCodeResultSink)
+	if !ok {
+		return nil, fmt.Errorf("result sink does not accept rule candidate reports")
+	}
+	summary := legionSyntaxFlowRuleCandidateSummary{
+		SchemaVersion: legionSyntaxFlowCandidateSchema, RuleName: ruleName,
+		Language: language.String(), RuleContent: rule, RuleSHA256: legionRuleHash(rule),
+		Explanation: explanation, Limitations: limitations,
+		DebugResults:      cloneLegionRuleDebugHistory(r.ruleDebugHistory),
+		WorkspaceRevision: r.workspace.lockedRevision, SourceSHA256: r.workspace.sha256,
+	}
+	summary.VerificationStatus = legionRuleVerificationStatus(summary.RuleSHA256, summary.Language, summary.DebugResults)
+	raw, err := marshalBoundedLegionRuleCandidate(&summary)
+	if err != nil {
+		return nil, err
+	}
+	report := aiFocusCodeAuditReport{
+		WorkspaceID: r.workspace.spec.WorkspaceID, Title: title,
+		Markdown:                     renderLegionRuleCandidateMarkdown(title, summary),
+		StructuredSummary:            raw,
+		validatedRuleCandidateSHA256: legionRuleHash(string(raw)),
+	}
+	// Hold the generation fence through submission. A follow-up cannot switch
+	// the active Focus or reuse this history while its report is being sent.
+	receipt, err := sink.SubmitCodeAuditReport(ctx, resultContract.Kind, report)
+	if err != nil {
+		return nil, err
+	}
+	result := focusResultReceiptMap(receipt)
+	result["rule_sha256"] = summary.RuleSHA256
+	result["verification_status"] = summary.VerificationStatus
+	return result, nil
+}
+
+func cloneLegionRuleDebugHistory(history []legionSyntaxFlowDebugResult) []legionSyntaxFlowDebugResult {
+	result := make([]legionSyntaxFlowDebugResult, 0, len(history))
+	for _, item := range history {
+		item.Matches = append([]legionSyntaxFlowMatch{}, item.Matches...)
+		item.Diagnostics = append([]string{}, item.Diagnostics...)
+		result = append(result, item)
+	}
+	return result
+}
+
+func legionRuleVerificationStatus(hash, language string, history []legionSyntaxFlowDebugResult) string {
+	status := "syntax_only"
+	for _, item := range history {
+		if item.RuleSHA256 != hash || item.Language != language {
+			continue
+		}
+		if item.Status == "completed" {
+			// "tested" means an actual debug execution, never regression
+			// acceptance or a claim that match_count==0 proves correctness.
+			return "tested"
+		}
+		status = "debug_failed"
+	}
+	return status
+}
+
+func marshalBoundedLegionRuleCandidate(summary *legionSyntaxFlowRuleCandidateSummary) ([]byte, error) {
+	for {
+		raw, err := json.Marshal(summary)
+		if err != nil {
+			return nil, err
+		}
+		if len(raw) <= maxInlineCodeAuditSummaryBytes {
+			return raw, nil
+		}
+		// Preserve the exact candidate and every distinct baseline/candidate
+		// run's status, hashes, expected result, and observed match count.
+		largest := -1
+		for i := range summary.DebugResults {
+			if len(summary.DebugResults[i].Matches) > 0 &&
+				(largest < 0 || len(summary.DebugResults[i].Matches) > len(summary.DebugResults[largest].Matches)) {
+				largest = i
+			}
+		}
+		if largest >= 0 {
+			item := &summary.DebugResults[largest]
+			item.Matches = item.Matches[:len(item.Matches)-1]
+			item.Truncated = true
+			continue
+		}
+		trimmed := false
+		for i := range summary.DebugResults {
+			item := &summary.DebugResults[i]
+			if len(item.Diagnostics) > 0 {
+				item.Diagnostics = []string{}
+				item.Truncated = true
+				trimmed = true
+			}
+		}
+		if trimmed {
+			continue
+		}
+		// A pathological rule/narrative can itself exceed the JSON transport
+		// limit after escaping. Never silently alter the candidate rule.
+		return nil, fmt.Errorf("rule candidate exceeds %d encoded bytes even without snippets; shorten the rule or explanation", maxInlineCodeAuditSummaryBytes)
+	}
+}
+
+func renderLegionRuleCandidateMarkdown(title string, summary legionSyntaxFlowRuleCandidateSummary) string {
+	var text strings.Builder
+	fmt.Fprintf(&text, "# %s\n\n", strings.ReplaceAll(strings.ReplaceAll(title, "\r", " "), "\n", " "))
+	fmt.Fprintf(&text, "规则名称：%s\n\n语言：%s\n\n规则 SHA-256：%s\n\n", summary.RuleName, summary.Language, summary.RuleSHA256)
+	fence := "```"
+	for strings.Contains(summary.RuleContent, fence) {
+		fence += "`"
+	}
+	fmt.Fprintf(&text, "## 候选规则\n\n%ssyntaxflow\n%s\n%s\n\n", fence, summary.RuleContent, fence)
+	fmt.Fprintf(&text, "## 规则说明（模型生成）\n\n%s\n\n", summary.Explanation)
+	fmt.Fprintf(&text, "## 运行时验证事实\n\n验证状态：%s。tested 仅表示当前规则在本次任务中完成过真实调试，不表示回归通过。\n\n", summary.VerificationStatus)
+	fmt.Fprintf(&text, "工作区版本：%s\n\n工作区摘要：%s\n\n", summary.WorkspaceRevision, summary.SourceSHA256)
+	if len(summary.DebugResults) == 0 {
+		text.WriteString("本次任务没有真实调试记录，仅完成语法检查。\n\n")
+	}
+	for _, result := range summary.DebugResults {
+		origin := "授权工作区文件"
+		if result.SourceKind == "inline_sample" {
+			origin = "生成或改写的内联样例（不代表原项目）"
+			if result.SampleOrigin == "user_supplied" {
+				origin = "用户提供的内联样例（不代表原项目）"
+			}
+		}
+		conclusion := "仅观察"
+		if result.Status != "completed" {
+			conclusion = "未完成，不能作验证结论"
+		} else if result.Expected == "match" {
+			conclusion = "未符合预期"
+			if result.MatchCount > 0 {
+				conclusion = "符合本条命中预期"
+			}
+		} else if result.Expected == "no_match" {
+			conclusion = "未符合预期"
+			if result.MatchCount == 0 {
+				conclusion = "符合本条不命中预期"
+			}
+		}
+		fmt.Fprintf(&text, "- 调试 %s；规则 %s；来源：%s；状态：%s；告警命中：%d；预期：%s；%s。\n", result.DebugID, result.RuleSHA256, origin, result.Status, result.MatchCount, result.Expected, conclusion)
+	}
+	text.WriteString("\n调试只覆盖显式选择的有界源码；零命中不能证明规则或项目没有问题。候选规则尚未发布，也不会自动修改风险处置。\n")
+	if len(summary.Limitations) > 0 {
+		text.WriteString("\n## 局限（模型说明）\n\n")
+		for _, limitation := range summary.Limitations {
+			fmt.Fprintf(&text, "- %s\n", limitation)
+		}
+	}
+	return text.String()
+}
+
+func (s *legionAIFocusResultSink) validateRuleCandidateReport(report aiFocusCodeAuditReport) error {
+	if report.validatedRuleCandidateSHA256 == "" || report.validatedRuleCandidateSHA256 != legionRuleHash(string(report.StructuredSummary)) {
+		return fmt.Errorf("rule candidate report requires runtime-computed evidence")
+	}
+	s.mu.Lock()
+	allowed := s.ruleCandidateAllowed
+	s.mu.Unlock()
+	if !allowed {
+		return fmt.Errorf("rule candidate report is not allowed by the bound immutable contract")
+	}
+	var summary legionSyntaxFlowRuleCandidateSummary
+	if err := json.Unmarshal(report.StructuredSummary, &summary); err != nil {
+		return fmt.Errorf("invalid rule candidate summary")
+	}
+	revision, sourceHash, err := s.codeWorkspaceEvidence()
+	if err != nil {
+		return err
+	}
+	if summary.SchemaVersion != legionSyntaxFlowCandidateSchema || summary.RuleSHA256 != legionRuleHash(summary.RuleContent) ||
+		summary.WorkspaceRevision != revision || summary.SourceSHA256 != sourceHash ||
+		summary.VerificationStatus != legionRuleVerificationStatus(summary.RuleSHA256, summary.Language, summary.DebugResults) {
+		return fmt.Errorf("rule candidate summary does not match its runtime evidence")
+	}
+	return nil
+}

--- a/scannode/legion_ai_syntaxflow_runtime.go
+++ b/scannode/legion_ai_syntaxflow_runtime.go
@@ -1,0 +1,634 @@
+package scannode
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+	"github.com/yaklang/yaklang/common/utils/filesys"
+	"github.com/yaklang/yaklang/common/utils/orderedmap"
+	"github.com/yaklang/yaklang/common/yak/ssaapi"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+const (
+	serverFocusCapabilityRuleCheck     = "syntaxflow.rule.check"
+	serverFocusCapabilityRuleDebug     = "syntaxflow.rule.debug"
+	serverFocusCapabilityRuleCandidate = "result.rule_candidate.v1"
+	legionSyntaxFlowRuleCandidateKind  = "ai_syntaxflow_rule_v1"
+	legionSyntaxFlowCheckSchema        = "legion.syntaxflow-check/v1"
+	legionSyntaxFlowDebugSchema        = "legion.syntaxflow-debug/v1"
+	legionSyntaxFlowCandidateSchema    = "legion.syntaxflow-rule-candidate/v1"
+	legionSyntaxFlowMaxRuleBytes       = 32 * 1024
+	legionSyntaxFlowMaxCalls           = 24
+	legionSyntaxFlowMaxPaths           = 32
+	legionSyntaxFlowMaxMatches         = 32
+	legionSyntaxFlowMaxSnippetBytes    = 512
+	legionSyntaxFlowMaxDiagnostics     = 8
+	legionSyntaxFlowMaxDiagnosticBytes = 512
+	legionSyntaxFlowDebugTimeout       = 20 * time.Second
+	legionSyntaxFlowWorkBudget         = int64(100_000)
+)
+
+// Keep cancelled compiles bounded even while a language parser finishes its
+// current (cooperative) step. The worker retains its slot until cleanup ends.
+var legionSyntaxFlowWorkers = make(chan struct{}, 2)
+
+type legionSyntaxFlowMatch struct {
+	Variable  string `json:"variable"`
+	Path      string `json:"path"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+	Code      string `json:"code"`
+}
+
+type legionSyntaxFlowDebugResult struct {
+	SchemaVersion     string                  `json:"schema_version"`
+	DebugID           string                  `json:"debug_id"`
+	RuleSHA256        string                  `json:"rule_sha256"`
+	SourceKind        string                  `json:"source_kind"`
+	SampleOrigin      string                  `json:"sample_origin,omitempty"`
+	SourceSHA256      string                  `json:"source_sha256"`
+	WorkspaceRevision string                  `json:"workspace_revision"`
+	Language          string                  `json:"language"`
+	Label             string                  `json:"label"`
+	Expected          string                  `json:"expected"`
+	Status            string                  `json:"status"`
+	MatchCount        int                     `json:"match_count"`
+	Matches           []legionSyntaxFlowMatch `json:"matches"`
+	Truncated         bool                    `json:"truncated"`
+	Diagnostics       []string                `json:"diagnostics"`
+}
+
+func legionSyntaxFlowRuntimeAvailable() bool {
+	for _, language := range []ssaconfig.Language{ssaconfig.JAVA, ssaconfig.GO, ssaconfig.PHP, ssaconfig.JS, ssaconfig.TS, ssaconfig.PYTHON, ssaconfig.C, ssaconfig.Yak} {
+		if ssaapi.LanguageBuilderCreater[language] == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeLegionSyntaxFlowLanguage(raw string) (ssaconfig.Language, error) {
+	language, err := ssaconfig.ValidateLanguage(raw)
+	if err != nil || language == "" || ssaapi.LanguageBuilderCreater[language] == nil {
+		return "", fmt.Errorf("unsupported SyntaxFlow debug language")
+	}
+	return language, nil
+}
+
+func legionRuleHash(rule string) string {
+	digest := sha256.Sum256([]byte(rule))
+	return hex.EncodeToString(digest[:])
+}
+
+func legionRuleString(params map[string]any, key string, limit int, required bool) (string, error) {
+	value, present := params[key]
+	if !present && !required {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok || !utf8.ValidString(text) || len(text) > limit || strings.ContainsRune(text, '\x00') || (required && strings.TrimSpace(text) == "") {
+		return "", fmt.Errorf("%s must be UTF-8 text of at most %d bytes", key, limit)
+	}
+	return text, nil
+}
+
+func rejectLegionRuleExtraParams(params map[string]any, names ...string) error {
+	allowed := make(map[string]bool, len(names))
+	for _, name := range names {
+		allowed[name] = true
+	}
+	for name := range params {
+		if !allowed[name] {
+			return fmt.Errorf("SyntaxFlow capability does not accept parameter %q", name)
+		}
+	}
+	return nil
+}
+
+// Even direct internal calls must pass the same active immutable-contract gate
+// as Execute. Generation fences prevent late workers from entering a new Turn.
+func (r *legionServerFocusRuntime) beginRuleOperation(capability string, count bool) (context.Context, uint64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.workspace == nil || !legionSyntaxFlowRuntimeAvailable() || r.activeFocusContext == nil ||
+		r.activeFocusReleaseID == "" || r.activeFocusReleaseID != r.authorizedFocusReleaseID ||
+		!r.activeExecutionContract.allowsCapability(capability) {
+		return nil, 0, fmt.Errorf("SyntaxFlow capability requires the active authorized Focus Turn and immutable execution contract")
+	}
+	if count {
+		if r.ruleCallCount >= legionSyntaxFlowMaxCalls {
+			return nil, 0, fmt.Errorf("SyntaxFlow per-Turn call budget exhausted")
+		}
+		r.ruleCallCount++
+	}
+	return r.activeFocusContext, r.activeFocusGeneration, nil
+}
+
+func (r *legionServerFocusRuntime) ruleGenerationActive(generation uint64) bool {
+	return r.activeFocusGeneration == generation && r.activeFocusReleaseID != "" &&
+		r.activeFocusReleaseID == r.authorizedFocusReleaseID && r.activeFocusContext != nil
+}
+
+func (r *legionServerFocusRuntime) checkSyntaxFlowRule(params map[string]any) (map[string]any, error) {
+	r.ruleMu.Lock()
+	defer r.ruleMu.Unlock()
+	ctx, generation, err := r.beginRuleOperation(serverFocusCapabilityRuleCheck, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectLegionRuleExtraParams(params, "rule"); err != nil {
+		return nil, err
+	}
+	rule, err := legionRuleString(params, "rule", legionSyntaxFlowMaxRuleBytes, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	_, compileErr := compileLegionSyntaxFlowRule(rule)
+	status := "valid"
+	diagnostics := []string{}
+	if compileErr != nil {
+		status = "invalid"
+		diagnostics = boundedLegionRuleDiagnostics([]string{compileErr.Error()})
+	}
+	r.mu.Lock()
+	active := r.ruleGenerationActive(generation)
+	r.mu.Unlock()
+	if !active || ctx.Err() != nil {
+		return nil, fmt.Errorf("SyntaxFlow check Turn is no longer active")
+	}
+	return map[string]any{
+		"schema_version": legionSyntaxFlowCheckSchema, "rule_sha256": legionRuleHash(rule),
+		"status": status, "diagnostics": diagnostics,
+	}, nil
+}
+
+func compileLegionSyntaxFlowRule(rule string) (*sfvm.SFFrame, error) {
+	frame, err := sfvm.NewSyntaxFlowVirtualMachine().Compile(rule)
+	if err != nil {
+		return nil, err
+	}
+	if frame == nil {
+		return nil, fmt.Errorf("SyntaxFlow compiler returned no rule")
+	}
+	// Runtime policy is also enforced on nested and dynamically compiled
+	// frames by WithNativeCallGuard. This pass gives immediate diagnostics.
+	for _, code := range frame.Codes {
+		if code != nil && code.OpCode == sfvm.OpNativeCall {
+			if err := legionSyntaxFlowNativeGuard(code.UnaryStr); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return frame, nil
+}
+
+func legionSyntaxFlowNativeGuard(name string) error {
+	// This is intentionally an explicit allowlist. New engine extensions do
+	// not acquire workspace, DB, network, or command authority automatically.
+	switch name {
+	case "const", "self", "len", "root", "var", "slice", "delete", "forbid",
+		"getReturns", "getFormalParams", "getFunc", "getCall", "getCallee",
+		"searchFunc", "getObject", "getMembers", "getMemberByKey", "getSiblings",
+		"typeName", "fullTypeName", "name", "string", "regexp", "strlower", "strupper",
+		"opcodes", "sourceCode", "scanPrevious", "scanNext", "scanInstruction", "dataflow",
+		"getCfg", "cfgGuards", "cfgDominates", "cfgPostDominates", "cfgReachable",
+		"cfgReachPath", "cfgCondition", "cfgConditionValues",
+		"getUsers", "getPredecessors", "getActualParams", "getActualParamLen",
+		"getCurrentBlueprint", "extendsBy", "getBluePrint", "getParentsBlueprint",
+		"getInterfaceBlueprint", "getRootParentBlueprint", "matchRegexpPath",
+		"getFullFileName", "FilenameByContent", "versionIn", "uaf", "npd",
+		"doubleFree", "heapAlloc", "freeCall", "derefSite", "memLeak", "nullCheck",
+		"pointsTo", "aliases":
+		return nil
+	default:
+		return fmt.Errorf("native call %q is unsupported in task-private SyntaxFlow debug", name)
+	}
+}
+
+func (r *legionServerFocusRuntime) debugSyntaxFlowRule(params map[string]any) (map[string]any, error) {
+	r.ruleMu.Lock()
+	defer r.ruleMu.Unlock()
+	turnCtx, generation, err := r.beginRuleOperation(serverFocusCapabilityRuleDebug, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectLegionRuleExtraParams(params, "rule", "language", "source_kind", "paths", "files", "label", "expected"); err != nil {
+		return nil, err
+	}
+	rule, err := legionRuleString(params, "rule", legionSyntaxFlowMaxRuleBytes, true)
+	if err != nil {
+		return nil, err
+	}
+	languageText, err := legionRuleString(params, "language", 32, true)
+	if err != nil {
+		return nil, err
+	}
+	language, err := normalizeLegionSyntaxFlowLanguage(languageText)
+	if err != nil {
+		return nil, err
+	}
+	label, err := legionRuleString(params, "label", 256, false)
+	if err != nil {
+		return nil, err
+	}
+	expected, err := legionRuleString(params, "expected", 16, false)
+	if err != nil {
+		return nil, err
+	}
+	if expected == "" {
+		expected = "observe"
+	}
+	if expected != "match" && expected != "no_match" && expected != "observe" {
+		return nil, fmt.Errorf("expected must be match, no_match, or observe")
+	}
+	files, sourceKind, sampleOrigin, err := r.ruleDebugSources(params)
+	if err != nil {
+		return nil, err
+	}
+	record := legionSyntaxFlowDebugResult{
+		SchemaVersion: legionSyntaxFlowDebugSchema, DebugID: uuid.NewString(),
+		RuleSHA256: legionRuleHash(rule), SourceKind: sourceKind, SampleOrigin: sampleOrigin,
+		SourceSHA256: legionInlineSourceDigest(files), Language: language.String(),
+		Label: label, Expected: expected, Status: "completed",
+		Matches: []legionSyntaxFlowMatch{}, Diagnostics: []string{},
+	}
+	if sourceKind == "workspace_files" {
+		record.WorkspaceRevision = r.workspace.lockedRevision
+	}
+	timeout := r.ruleDebugTimeout
+	if timeout <= 0 {
+		timeout = legionSyntaxFlowDebugTimeout
+	}
+	workLimit := r.ruleWorkLimit
+	if workLimit <= 0 {
+		workLimit = legionSyntaxFlowWorkBudget
+	}
+	ctx, cancel := context.WithTimeout(turnCtx, timeout)
+	defer cancel()
+	budget := sfvm.NewRuleWorkBudget(workLimit, cancel)
+	done := make(chan legionSyntaxFlowDebugResult, 1)
+	select {
+	case legionSyntaxFlowWorkers <- struct{}{}:
+		go func() {
+			defer func() { <-legionSyntaxFlowWorkers }()
+			done <- executeLegionSyntaxFlowDebug(ctx, rule, language, files, record, budget)
+		}()
+	case <-ctx.Done():
+	}
+	select {
+	case record = <-done:
+	case <-ctx.Done():
+		record.Status = legionRuleStoppedStatus(ctx, budget)
+		record.Diagnostics = []string{"调试已停止；不把部分结果视为完成。"}
+		record.Truncated = true
+	}
+	// A budget cancel can win the select even if the worker finished first.
+	if ctx.Err() != nil {
+		record.Status = legionRuleStoppedStatus(ctx, budget)
+		record.Truncated = true
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.ruleGenerationActive(generation) {
+		return nil, fmt.Errorf("SyntaxFlow debug Turn is no longer active")
+	}
+	r.ruleDebugHistory = append(r.ruleDebugHistory, record)
+	return legionRuleResultMap(record), nil
+}
+
+func legionRuleStoppedStatus(ctx context.Context, budget *sfvm.RuleWorkBudget) string {
+	if budget.Exceeded() {
+		return "work_budget_exceeded"
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "timeout"
+	}
+	return "cancelled"
+}
+
+func executeLegionSyntaxFlowDebug(
+	ctx context.Context, rule string, language ssaconfig.Language, files map[string]string,
+	record legionSyntaxFlowDebugResult, budget *sfvm.RuleWorkBudget,
+) (result legionSyntaxFlowDebugResult) {
+	result = record
+	phase := "compile_error"
+	defer func() {
+		if recover() != nil {
+			result.Status = phase
+			result.Diagnostics = []string{"引擎未能完成本次有界调试。"}
+			result.Truncated = true
+		}
+		if ctx.Err() != nil {
+			result.Status = legionRuleStoppedStatus(ctx, budget)
+			result.Truncated = true
+		}
+	}()
+	if ctx.Err() != nil {
+		return
+	}
+	frame, err := compileLegionSyntaxFlowRule(rule)
+	if err != nil {
+		result.Status = "invalid_rule"
+		result.Diagnostics = boundedLegionRuleDiagnostics([]string{err.Error()})
+		return
+	}
+	virtual := filesys.NewVirtualFs()
+	for _, path := range legionSortedSourcePaths(files) {
+		virtual.AddFile(path, files[path])
+	}
+	programs, err := ssaapi.ParseProjectWithFS(virtual,
+		ssaapi.WithLanguage(language), ssaapi.WithContext(ctx), ssaapi.WithMemory(true),
+		ssaapi.WithEnableCache(false), ssaapi.WithDisableProgramCache(true),
+		ssaapi.WithConcurrency(1), ssaapi.WithStrictMode(true),
+	)
+	defer func() {
+		for _, program := range programs {
+			if program != nil && program.Program != nil && program.Program.Cache != nil {
+				program.Program.Cache.CloseWithoutSave()
+			}
+		}
+	}()
+	if err != nil || len(programs) == 0 {
+		result.Status = "compile_error"
+		if err != nil {
+			result.Diagnostics = boundedLegionRuleDiagnostics([]string{err.Error()})
+		} else {
+			result.Diagnostics = []string{"没有可编译的源码。"}
+		}
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	phase = "query_error"
+	var rejectedNative atomic.Pointer[string]
+	guard := func(name string) error {
+		err := legionSyntaxFlowNativeGuard(name)
+		if err != nil {
+			message := err.Error()
+			rejectedNative.CompareAndSwap(nil, &message)
+		}
+		return err
+	}
+	query, err := ssaapi.QuerySyntaxflow(
+		ssaapi.QueryWithPrograms(programs), ssaapi.QueryWithFrame(frame),
+		ssaapi.QueryWithContext(ctx), ssaapi.QueryWithWorkBudget(budget),
+		ssaapi.QueryWithSFOption(sfvm.WithNativeCallGuard(guard)),
+		ssaapi.QueryWithUseCache(false),
+		// The default save kind is "none". QueryWithMemory would publish to
+		// the global result cache and create risks, so it must not be used.
+	)
+	// Some recursive predicates intentionally turn a child query error into
+	// "no match". A denied capability must still fail the whole debug record.
+	if denial := rejectedNative.Load(); denial != nil {
+		result.Status = "query_error"
+		result.Diagnostics = []string{*denial}
+		return
+	}
+	if err != nil || query == nil {
+		result.Status = "query_error"
+		if err != nil {
+			result.Diagnostics = boundedLegionRuleDiagnostics([]string{err.Error()})
+		}
+		return
+	}
+	if diagnostics := query.GetErrors(); len(diagnostics) > 0 {
+		result.Status = "query_error"
+		result.Diagnostics = boundedLegionRuleDiagnostics(diagnostics)
+		return
+	}
+	variables := append([]string(nil), query.GetAlertVariables()...)
+	sort.Strings(variables)
+	for _, variable := range variables {
+		seen := make(map[int64]bool)
+		for _, value := range query.GetValues(variable) {
+			if value == nil || seen[value.GetId()] {
+				continue
+			}
+			seen[value.GetId()] = true
+			result.MatchCount++
+			if len(result.Matches) >= legionSyntaxFlowMaxMatches {
+				result.Truncated = true
+				continue
+			}
+			match := legionSyntaxFlowMatch{Variable: trimLegionRuleText(variable, 128)}
+			if sourceRange := value.GetRange(); sourceRange != nil && sourceRange.GetEditor() != nil {
+				// Anonymous in-memory editors use /relative/path URLs.
+				// Only exact members of the authorized input map are emitted.
+				path := strings.TrimPrefix(strings.TrimPrefix(filepath.ToSlash(sourceRange.GetEditor().GetUrl()), "./"), "/")
+				if _, exists := files[path]; exists {
+					match.Path = path
+					match.StartLine = sourceRange.GetStart().GetLine()
+					match.EndLine = sourceRange.GetEnd().GetLine()
+					match.Code = trimLegionRuleText(sourceRange.GetText(), legionSyntaxFlowMaxSnippetBytes)
+					result.Truncated = result.Truncated || len(sourceRange.GetText()) > legionSyntaxFlowMaxSnippetBytes
+				}
+			}
+			result.Matches = append(result.Matches, match)
+		}
+	}
+	result.Diagnostics = boundedLegionRuleDiagnostics(query.GetCheckMsg())
+	return
+}
+
+func (r *legionServerFocusRuntime) ruleDebugSources(params map[string]any) (map[string]string, string, string, error) {
+	sourceKind, err := legionRuleString(params, "source_kind", 16, true)
+	if err != nil {
+		return nil, "", "", err
+	}
+	switch sourceKind {
+	case "inline":
+		if _, exists := params["paths"]; exists {
+			return nil, "", "", fmt.Errorf("inline debug cannot also select workspace paths")
+		}
+		files, err := legionRuleStringMap(params["files"])
+		if err != nil {
+			return nil, "", "", err
+		}
+		if err := validateLegionInlineFiles(files, false); err != nil {
+			return nil, "", "", err
+		}
+		origin := "generated_or_modified"
+		// Exact byte/path comparison against the immutable server-bound map;
+		// an unchanged subset is still supplied by the user.
+		if len(r.workspace.inlineFiles) > 0 {
+			matches := true
+			for path, content := range files {
+				bound, exists := r.workspace.inlineFiles[path]
+				matches = matches && exists && bound == content
+			}
+			if matches {
+				origin = "user_supplied"
+			}
+		}
+		return files, "inline_sample", origin, nil
+	case "workspace":
+		if _, exists := params["files"]; exists {
+			return nil, "", "", fmt.Errorf("workspace debug cannot also supply inline files")
+		}
+		paths, err := legionRuleStringList(params["paths"], legionSyntaxFlowMaxPaths)
+		if err != nil || len(paths) == 0 {
+			return nil, "", "", fmt.Errorf("workspace debug requires 1..%d explicit paths", legionSyntaxFlowMaxPaths)
+		}
+		files := make(map[string]string, len(paths))
+		total := 0
+		for _, raw := range paths {
+			path, err := cleanLegionRuleSourcePath(raw)
+			if err != nil {
+				return nil, "", "", err
+			}
+			if _, exists := files[path]; exists {
+				return nil, "", "", fmt.Errorf("workspace debug paths must be distinct")
+			}
+			// resolve confines the path to the bound workspace. Lstat each
+			// component additionally rejects even in-workspace symlinks.
+			current := r.workspace.root
+			for _, part := range strings.Split(path, "/") {
+				current = filepath.Join(current, part)
+				info, err := os.Lstat(current)
+				if err != nil || info.Mode()&os.ModeSymlink != 0 {
+					return nil, "", "", fmt.Errorf("workspace debug path is missing or traverses a symlink")
+				}
+			}
+			resolved, _, err := r.workspace.resolve(path)
+			if err != nil {
+				return nil, "", "", err
+			}
+			content, err := readLegionRuleSourceFile(resolved, r.workspace.spec.MaxReadBytes)
+			if err != nil {
+				return nil, "", "", err
+			}
+			if r.workspace.spec.Kind == legionCodeWorkspaceKindInlineSources {
+				if bound, ok := r.workspace.inlineFiles[path]; !ok || bound != content {
+					return nil, "", "", fmt.Errorf("inline workspace content no longer matches the bound source")
+				}
+			}
+			files[path] = content
+			total += len(content)
+			if total > legionInlineSourceMaxTotalBytes {
+				return nil, "", "", fmt.Errorf("workspace debug selection exceeds %d bytes", legionInlineSourceMaxTotalBytes)
+			}
+		}
+		return files, "workspace_files", "", nil
+	default:
+		return nil, "", "", fmt.Errorf("source_kind must be workspace or inline")
+	}
+}
+
+func readLegionRuleSourceFile(path string, workspaceLimit int64) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot open selected workspace source")
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	limit := int64(legionInlineSourceMaxFileBytes)
+	if workspaceLimit > 0 && workspaceLimit < limit {
+		limit = workspaceLimit
+	}
+	if err != nil || !info.Mode().IsRegular() || info.Size() > limit {
+		return "", fmt.Errorf("workspace debug requires regular files of at most %d bytes", limit)
+	}
+	content, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil || int64(len(content)) > limit || !utf8.Valid(content) || strings.ContainsRune(string(content), '\x00') {
+		return "", fmt.Errorf("workspace debug requires bounded UTF-8 source text")
+	}
+	return string(content), nil
+}
+
+func legionRuleStringMap(value any) (map[string]string, error) {
+	if typed, ok := value.(*orderedmap.OrderedMap); ok && typed != nil {
+		if len(typed.Keys()) > legionInlineSourceMaxFiles {
+			return nil, fmt.Errorf("too many inline source files")
+		}
+		raw := make(map[string]any, len(typed.Keys()))
+		typed.ForEach(func(key string, value any) { raw[key] = value })
+		value = raw
+	}
+	if typed, ok := value.(map[string]string); ok {
+		return cloneLegionInlineFiles(typed), nil
+	}
+	typed, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("files must be an explicit map of relative paths to source text")
+	}
+	result := make(map[string]string, len(typed))
+	for key, value := range typed {
+		text, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("file content must be a string")
+		}
+		result[key] = text
+	}
+	return result, nil
+}
+
+func legionRuleStringList(value any, limit int) ([]string, error) {
+	if typed, ok := value.([]string); ok {
+		if len(typed) > limit {
+			return nil, fmt.Errorf("too many list items")
+		}
+		return append([]string(nil), typed...), nil
+	}
+	typed, ok := value.([]any)
+	if !ok || len(typed) > limit {
+		return nil, fmt.Errorf("expected a bounded string list")
+	}
+	result := make([]string, 0, len(typed))
+	for _, value := range typed {
+		text, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("list items must be strings")
+		}
+		result = append(result, text)
+	}
+	return result, nil
+}
+
+func trimLegionRuleText(text string, limit int) string {
+	if len(text) <= limit {
+		return text
+	}
+	text = text[:limit]
+	for !utf8.ValidString(text) {
+		text = text[:len(text)-1]
+	}
+	return text
+}
+
+func boundedLegionRuleDiagnostics(input []string) []string {
+	output := make([]string, 0, min(len(input), legionSyntaxFlowMaxDiagnostics))
+	for _, diagnostic := range input {
+		if len(output) == legionSyntaxFlowMaxDiagnostics {
+			break
+		}
+		output = append(output, trimLegionRuleText(strings.ToValidUTF8(diagnostic, "�"), legionSyntaxFlowMaxDiagnosticBytes))
+	}
+	return output
+}
+
+func legionRuleResultMap(result legionSyntaxFlowDebugResult) map[string]any {
+	// A JSON copy prevents model/tool callers from mutating retained evidence.
+	raw, _ := json.Marshal(result)
+	var mapped map[string]any
+	_ = json.Unmarshal(raw, &mapped)
+	return mapped
+}

--- a/scannode/legion_ai_syntaxflow_runtime.go
+++ b/scannode/legion_ai_syntaxflow_runtime.go
@@ -33,7 +33,9 @@ const (
 	legionSyntaxFlowDebugSchema        = "legion.syntaxflow-debug/v1"
 	legionSyntaxFlowCandidateSchema    = "legion.syntaxflow-rule-candidate/v1"
 	legionSyntaxFlowMaxRuleBytes       = 32 * 1024
-	legionSyntaxFlowMaxCalls           = 24
+	// Matches the immutable Focus ceiling: 12 syntax checks, 16 candidate
+	// debug runs, and 2 trusted original-rule reproduction runs.
+	legionSyntaxFlowMaxCalls           = 30
 	legionSyntaxFlowMaxPaths           = 32
 	legionSyntaxFlowMaxMatches         = 32
 	legionSyntaxFlowMaxSnippetBytes    = 512

--- a/scannode/legion_ai_syntaxflow_runtime.go
+++ b/scannode/legion_ai_syntaxflow_runtime.go
@@ -25,14 +25,15 @@ import (
 )
 
 const (
-	serverFocusCapabilityRuleCheck     = "syntaxflow.rule.check"
-	serverFocusCapabilityRuleDebug     = "syntaxflow.rule.debug"
-	serverFocusCapabilityRuleCandidate = "result.rule_candidate.v1"
-	legionSyntaxFlowRuleCandidateKind  = "ai_syntaxflow_rule_v1"
-	legionSyntaxFlowCheckSchema        = "legion.syntaxflow-check/v1"
-	legionSyntaxFlowDebugSchema        = "legion.syntaxflow-debug/v1"
-	legionSyntaxFlowCandidateSchema    = "legion.syntaxflow-rule-candidate/v1"
-	legionSyntaxFlowMaxRuleBytes       = 32 * 1024
+	serverFocusCapabilityOriginalSampleRead = "syntaxflow.original_sample.read"
+	serverFocusCapabilityRuleCheck          = "syntaxflow.rule.check"
+	serverFocusCapabilityRuleDebug          = "syntaxflow.rule.debug"
+	serverFocusCapabilityRuleCandidate      = "result.rule_candidate.v1"
+	legionSyntaxFlowRuleCandidateKind       = "ai_syntaxflow_rule_v1"
+	legionSyntaxFlowCheckSchema             = "legion.syntaxflow-check/v1"
+	legionSyntaxFlowDebugSchema             = "legion.syntaxflow-debug/v1"
+	legionSyntaxFlowCandidateSchema         = "legion.syntaxflow-rule-candidate/v1"
+	legionSyntaxFlowMaxRuleBytes            = 32 * 1024
 	// Matches the immutable Focus ceiling: 12 syntax checks, 16 candidate
 	// debug runs, and 2 trusted original-rule reproduction runs.
 	legionSyntaxFlowMaxCalls           = 30
@@ -95,6 +96,51 @@ func normalizeLegionSyntaxFlowLanguage(raw string) (ssaconfig.Language, error) {
 func legionRuleHash(rule string) string {
 	digest := sha256.Sum256([]byte(rule))
 	return hex.EncodeToString(digest[:])
+}
+
+// readSyntaxFlowOriginalSample exposes only the exact private inline sample
+// pinned by the server for an improve task. It deliberately ignores the
+// materialized project tree, where a Git/archive workspace may contain a file
+// with the same relative path but different bytes.
+func (r *legionServerFocusRuntime) readSyntaxFlowOriginalSample(params map[string]any) (map[string]any, error) {
+	if len(params) != 0 {
+		return nil, fmt.Errorf("SyntaxFlow original sample read does not accept model parameters")
+	}
+	if r == nil || r.workspace == nil {
+		return nil, fmt.Errorf("source workspace is unavailable")
+	}
+	spec := r.workspace.spec
+	if !spec.SyntaxFlowRequireOriginalReproduction || spec.SyntaxFlowMode != "improve" {
+		return nil, fmt.Errorf("SyntaxFlow original sample is unavailable for this task")
+	}
+	path := spec.SyntaxFlowOriginalSamplePath
+	cleaned, err := cleanLegionRuleSourcePath(path)
+	if err != nil || cleaned != path || spec.SyntaxFlowOriginalSampleSHA256 == "" {
+		return nil, fmt.Errorf("SyntaxFlow original sample pin is invalid")
+	}
+	content, exists := r.workspace.inlineFiles[path]
+	if !exists {
+		return nil, fmt.Errorf("SyntaxFlow original sample bytes are unavailable")
+	}
+	files := map[string]string{path: content}
+	if err := validateLegionInlineFiles(files, false); err != nil {
+		return nil, fmt.Errorf("SyntaxFlow original sample bytes are invalid: %w", err)
+	}
+	digest := legionInlineSourceDigest(files)
+	if digest != spec.SyntaxFlowOriginalSampleSHA256 {
+		return nil, fmt.Errorf("SyntaxFlow original sample no longer matches its server pin")
+	}
+	return map[string]any{
+		"path":          path,
+		"offset":        0,
+		"content":       content,
+		"read_bytes":    len(content),
+		"file_size":     len(content),
+		"truncated":     false,
+		"source_kind":   "inline_sample",
+		"sample_origin": "user_supplied",
+		"source_sha256": digest,
+	}, nil
 }
 
 func legionRuleString(params map[string]any, key string, limit int, required bool) (string, error) {

--- a/scannode/legion_ai_syntaxflow_runtime_test.go
+++ b/scannode/legion_ai_syntaxflow_runtime_test.go
@@ -26,7 +26,7 @@ func testLegionRuleContract(t *testing.T) *legionFocusExecutionContract {
 		SchemaVersion: legionFocusExecutionContractSchemaV1,
 		Stages:        []legionFocusExecutionStage{{Key: "generate"}, {Key: "debug"}, {Key: "report"}},
 		Capabilities: []string{
-			serverFocusCapabilityRuleCheck, serverFocusCapabilityRuleDebug, serverFocusCapabilityRuleCandidate,
+			serverFocusCapabilityOriginalSampleRead, serverFocusCapabilityRuleCheck, serverFocusCapabilityRuleDebug, serverFocusCapabilityRuleCandidate,
 			serverFocusCapabilitySourceWorkspaceInfo, serverFocusCapabilitySourceList, serverFocusCapabilitySourceRead,
 			serverFocusCapabilitySourceSearch, serverFocusCapabilityTaskStage,
 		},
@@ -88,6 +88,70 @@ func testLegionRuleCandidateParams() map[string]any {
 	return map[string]any{
 		"title": "SyntaxFlow 规则候选", "rule_name": "bounded-print.sf", "language": "yak",
 		"rule": testLegionRule, "explanation": "检查 println 的参数。",
+	}
+}
+
+func TestLegionSyntaxFlowOriginalSampleReadUsesPrivateBoundBytes(t *testing.T) {
+	root := t.TempDir()
+	path := "negative/Sample.java"
+	if err := os.MkdirAll(filepath.Join(root, "negative"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	projectContent := `class ProjectCollision {}`
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(path)), []byte(projectContent), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	trustedContent := `class Negative { void run() throws Exception { Runtime.getRuntime().exec("echo safe"); } }`
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
+	spec.InlineFiles = map[string]string{path: trustedContent}
+	spec.SyntaxFlowMode = "improve"
+	spec.SyntaxFlowLanguage = "java"
+	spec.SyntaxFlowOriginalRule = "exec(,* as $cmd,)\nalert $cmd"
+	spec.SyntaxFlowOriginalRuleSHA256 = legionRuleHash(spec.SyntaxFlowOriginalRule)
+	spec.SyntaxFlowOriginalSamplePath = path
+	spec.SyntaxFlowOriginalSampleSHA256 = legionInlineSourceDigest(spec.InlineFiles)
+	spec.SyntaxFlowRequireOriginalReproduction = true
+	if err := normalizeLegionCodeWorkspaceSpec(&spec); err != nil {
+		t.Fatal(err)
+	}
+	workspace := &legionCodeWorkspaceRuntime{
+		spec:           publicLegionCodeWorkspaceSpec(spec),
+		root:           root,
+		lockedRevision: strings.Repeat("a", 40),
+		sha256:         strings.Repeat("b", 64),
+		inlineFiles:    cloneLegionInlineFiles(spec.InlineFiles),
+		originalRule:   spec.SyntaxFlowOriginalRule,
+	}
+	target, err := legionCodeWorkspaceSentinel(spec.WorkspaceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := newLegionServerFocusRuntime(context.Background(), target, &recordingServerFocusSink{}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := value.(*legionServerFocusRuntime)
+	runtime.authorizedFocusReleaseID = "syntaxflow_rule@1.0.0+abcdef123456"
+	if err := runtime.activateFocusTurn(runtime.authorizedFocusReleaseID, testLegionRuleContract(t)); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { runtime.deactivateFocusTurn(runtime.authorizedFocusReleaseID) })
+
+	read, err := runtime.Execute(serverFocusCapabilityOriginalSampleRead, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read["path"] != path || read["content"] != trustedContent || read["content"] == projectContent ||
+		read["offset"] != 0 || read["read_bytes"] != len(trustedContent) || read["file_size"] != len(trustedContent) || read["truncated"] != false ||
+		read["source_kind"] != "inline_sample" || read["sample_origin"] != "user_supplied" || read["source_sha256"] != spec.SyntaxFlowOriginalSampleSHA256 {
+		t.Fatalf("private original sample read lost its exact pin: %#v", read)
+	}
+	if _, err := runtime.Execute(serverFocusCapabilityOriginalSampleRead, map[string]any{"path": path}); err == nil {
+		t.Fatal("model-controlled original sample path was accepted")
+	}
+	workspace.inlineFiles[path] = `class Tampered {}`
+	if _, err := runtime.Execute(serverFocusCapabilityOriginalSampleRead, map[string]any{}); err == nil || !strings.Contains(err.Error(), "server pin") {
+		t.Fatalf("mutated private original sample failed open: %v", err)
 	}
 }
 

--- a/scannode/legion_ai_syntaxflow_runtime_test.go
+++ b/scannode/legion_ai_syntaxflow_runtime_test.go
@@ -1,0 +1,660 @@
+package scannode
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils/filesys"
+	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
+	"github.com/yaklang/yaklang/common/yak/ssaapi"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+const testLegionRule = "println(* as $input)\nalert $input"
+
+func testLegionRuleContract(t *testing.T) *legionFocusExecutionContract {
+	t.Helper()
+	contract := legionFocusExecutionContract{
+		SchemaVersion: legionFocusExecutionContractSchemaV1,
+		Stages:        []legionFocusExecutionStage{{Key: "generate"}, {Key: "debug"}, {Key: "report"}},
+		Capabilities: []string{
+			serverFocusCapabilityRuleCheck, serverFocusCapabilityRuleDebug, serverFocusCapabilityRuleCandidate,
+			serverFocusCapabilitySourceWorkspaceInfo, serverFocusCapabilitySourceList, serverFocusCapabilitySourceRead,
+			serverFocusCapabilitySourceSearch, serverFocusCapabilityTaskStage,
+		},
+		Results: []legionFocusExecutionResultContract{{
+			Key: "rule_candidate", Capability: serverFocusCapabilityRuleCandidate,
+			Kind: legionSyntaxFlowRuleCandidateKind, Required: true,
+		}},
+	}
+	sort.Strings(contract.Capabilities)
+	raw, err := json.Marshal(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := parseLegionFocusExecutionContract(string(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}
+
+func testLegionRuleRuntime(t *testing.T, ctx context.Context, files map[string]string) (*legionServerFocusRuntime, *recordingAIFocusRiskPublisher) {
+	t.Helper()
+	if !legionSyntaxFlowRuntimeAvailable() {
+		t.Skip("this build excludes the full SyntaxFlow language runtime")
+	}
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindInlineSources)
+	spec.Locator = ""
+	spec.InlineFiles = files
+	workspace, err := materializeLegionInlineWorkspace(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher := &recordingAIFocusRiskPublisher{}
+	sink, err := newLegionAIFocusResultSink(publisher, "bind-rule-candidate", validCodeAuditResultContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.(aiFocusCodeWorkspaceEvidenceBinder).bindCodeWorkspaceEvidence(workspace.lockedRevision, workspace.sha256); err != nil {
+		t.Fatal(err)
+	}
+	target, err := legionCodeWorkspaceSentinel(workspace.spec.WorkspaceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := newLegionServerFocusRuntime(ctx, target, sink, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := value.(*legionServerFocusRuntime)
+	runtime.authorizedFocusReleaseID = "syntaxflow_rule@1.0.0+abcdef123456"
+	if err := runtime.activateFocusTurn(runtime.authorizedFocusReleaseID, testLegionRuleContract(t)); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { runtime.deactivateFocusTurn(runtime.authorizedFocusReleaseID) })
+	return runtime, publisher
+}
+
+func testLegionRuleCandidateParams() map[string]any {
+	return map[string]any{
+		"title": "SyntaxFlow 规则候选", "rule_name": "bounded-print.sf", "language": "yak",
+		"rule": testLegionRule, "explanation": "检查 println 的参数。",
+	}
+}
+
+func testLegionRuleDebug(t *testing.T, runtime *legionServerFocusRuntime, params map[string]any) legionSyntaxFlowDebugResult {
+	t.Helper()
+	value, err := runtime.Execute(serverFocusCapabilityRuleDebug, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(value)
+	var result legionSyntaxFlowDebugResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func testLegionLastCandidate(t *testing.T, publisher *recordingAIFocusRiskPublisher) (aiFocusCodeAuditReport, legionSyntaxFlowRuleCandidateSummary) {
+	t.Helper()
+	if len(publisher.reports) == 0 {
+		t.Fatal("candidate report was not published")
+	}
+	var report aiFocusCodeAuditReport
+	if err := json.Unmarshal(publisher.reports[len(publisher.reports)-1], &report); err != nil {
+		t.Fatal(err)
+	}
+	var summary legionSyntaxFlowRuleCandidateSummary
+	if err := json.Unmarshal(report.StructuredSummary, &summary); err != nil {
+		t.Fatal(err)
+	}
+	return report, summary
+}
+
+func TestLegionSyntaxFlowCheckAndAuthority(t *testing.T) {
+	runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+	valid, err := runtime.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": testLegionRule})
+	if err != nil || valid["status"] != "valid" || valid["rule_sha256"] != legionRuleHash(testLegionRule) {
+		t.Fatalf("valid grammar: %#v err=%v", valid, err)
+	}
+	for _, rule := range []string{"println((", "<include(\"unbound-library\")>", "<eval(\"println(*)\")>", "<fuzztag(\"{{file(/etc/passwd)}}\")>"} {
+		result, err := runtime.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": rule})
+		if err != nil || result["status"] != "invalid" {
+			t.Fatalf("unsafe/invalid grammar accepted: %q result=%#v err=%v", rule, result, err)
+		}
+	}
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": strings.Repeat("a", legionSyntaxFlowMaxRuleBytes+1)}); err == nil {
+		t.Fatal("oversized rule accepted")
+	}
+	runtime.activeExecutionContract = testLegionCodeWorkspaceExecutionContract(t)
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": testLegionRule}); err == nil {
+		t.Fatal("missing immutable capability accepted")
+	}
+	runtime.deactivateFocusTurn(runtime.authorizedFocusReleaseID)
+	for _, capability := range []string{serverFocusCapabilityRuleCheck, serverFocusCapabilityRuleDebug, serverFocusCapabilityRuleCandidate} {
+		if _, err := runtime.Execute(capability, map[string]any{"rule": testLegionRule}); err == nil {
+			t.Fatalf("dormant Focus exposed %s", capability)
+		}
+	}
+	ordinary := &legionServerFocusRuntime{ctx: context.Background()}
+	if _, err := ordinary.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": testLegionRule}); err == nil {
+		t.Fatal("ordinary non-Focus runtime exposed rule check")
+	}
+}
+
+func TestLegionSyntaxFlowRealDebugAndCanonicalCandidate(t *testing.T) {
+	files := map[string]string{"src/main.yak": "println(\"unsafe\")"}
+	runtime, publisher := testLegionRuleRuntime(t, context.Background(), files)
+	result := testLegionRuleDebug(t, runtime, map[string]any{
+		"rule": testLegionRule, "language": "yak", "source_kind": "workspace",
+		"paths": []string{"src/main.yak"}, "expected": "match",
+	})
+	if result.Status != "completed" || result.MatchCount != 1 || len(result.Matches) != 1 {
+		t.Fatalf("real positive SSA query failed: %#v", result)
+	}
+	if result.SourceKind != "workspace_files" || result.WorkspaceRevision != runtime.workspace.lockedRevision ||
+		result.SourceSHA256 != legionInlineSourceDigest(files) || result.Matches[0].Path != "src/main.yak" || result.Matches[0].StartLine != 1 {
+		t.Fatalf("workspace provenance/locations are incorrect: %#v", result)
+	}
+	noMatch := testLegionRuleDebug(t, runtime, map[string]any{
+		"rule": testLegionRule, "language": "yak", "source_kind": "inline",
+		"files": map[string]string{"safe.yak": "other(\"safe\")"}, "expected": "no_match",
+	})
+	if noMatch.Status != "completed" || noMatch.MatchCount != 0 || noMatch.SourceKind != "inline_sample" ||
+		noMatch.SampleOrigin != "generated_or_modified" || noMatch.WorkspaceRevision != "" {
+		t.Fatalf("real negative SSA query/provenance failed: %#v", noMatch)
+	}
+	baseline := "not_present as $baseline\nalert $baseline"
+	baselineResult := testLegionRuleDebug(t, runtime, map[string]any{
+		"rule": baseline, "language": "yak", "source_kind": "inline", "files": files,
+	})
+	if baselineResult.Status != "completed" || baselineResult.SampleOrigin != "user_supplied" || baselineResult.RuleSHA256 == result.RuleSHA256 {
+		t.Fatalf("baseline observations lost: %#v", baselineResult)
+	}
+	forged := testLegionRuleCandidateParams()
+	forged["debug_results"] = []map[string]any{{"status": "completed", "match_count": 999}}
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, forged); err == nil {
+		t.Fatal("model-supplied evidence accepted")
+	}
+	params := testLegionRuleCandidateParams()
+	params["markdown"] = "FORGED verified all project tests passed"
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, params); err != nil {
+		t.Fatal(err)
+	}
+	report, summary := testLegionLastCandidate(t, publisher)
+	if publisher.reportKinds[0] != legionSyntaxFlowRuleCandidateKind || len(publisher.risks) != 0 {
+		t.Fatalf("candidate wrote the wrong transport: %#v", publisher)
+	}
+	if summary.RuleContent != testLegionRule || summary.RuleSHA256 != legionRuleHash(testLegionRule) ||
+		summary.VerificationStatus != "tested" || len(summary.DebugResults) != 3 ||
+		summary.DebugResults[2].RuleSHA256 != legionRuleHash(baseline) || strings.Contains(report.Markdown, "FORGED") {
+		t.Fatalf("candidate did not use canonical runtime evidence: %#v", summary)
+	}
+	if !strings.Contains(report.Markdown, "不代表原项目") || !strings.Contains(report.Markdown, "不表示回归通过") {
+		t.Fatalf("report overclaims debug evidence: %s", report.Markdown)
+	}
+	if err := runtime.sink.(*legionAIFocusResultSink).Succeed(context.Background(), nil); err != nil {
+		t.Fatalf("candidate did not satisfy required report contract: %v", err)
+	}
+}
+
+func TestLegionSyntaxFlowCannotReuseTurnOrRuleEvidence(t *testing.T) {
+	runtime, publisher := testLegionRuleRuntime(t, context.Background(), nil)
+	input := map[string]any{
+		"rule": testLegionRule, "language": "yak", "source_kind": "inline",
+		"files": map[string]string{"main.yak": "println(1)"},
+	}
+	value, err := runtime.Execute(serverFocusCapabilityRuleDebug, input)
+	if err != nil || value["status"] != "completed" {
+		t.Fatalf("initial debug: %#v %v", value, err)
+	}
+	// Mutating the returned map must not change retained runtime observations.
+	value["match_count"] = 999
+	value["rule_sha256"] = strings.Repeat("f", 64)
+	params := testLegionRuleCandidateParams()
+	params["rule"] = testLegionRule + "\n// changed candidate"
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, params); err != nil {
+		t.Fatal(err)
+	}
+	_, different := testLegionLastCandidate(t, publisher)
+	if different.VerificationStatus != "syntax_only" || different.DebugResults[0].MatchCount == 999 {
+		t.Fatalf("different rule or mutated evidence was reused: %#v", different)
+	}
+	params = testLegionRuleCandidateParams()
+	params["language"] = "java"
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, params); err != nil {
+		t.Fatal(err)
+	}
+	_, differentLanguage := testLegionLastCandidate(t, publisher)
+	if differentLanguage.VerificationStatus != "syntax_only" {
+		t.Fatalf("debug in another language was reused: %#v", differentLanguage)
+	}
+	release := runtime.authorizedFocusReleaseID
+	runtime.deactivateFocusTurn(release)
+	if err := runtime.activateFocusTurn(release, testLegionRuleContract(t)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, testLegionRuleCandidateParams()); err != nil {
+		t.Fatal(err)
+	}
+	_, nextTurn := testLegionLastCandidate(t, publisher)
+	if nextTurn.VerificationStatus != "syntax_only" || len(nextTurn.DebugResults) != 0 {
+		t.Fatalf("previous Turn evidence survived activation: %#v", nextTurn)
+	}
+}
+
+func TestLegionSyntaxFlowSourceSelectionBoundary(t *testing.T) {
+	runtime, _ := testLegionRuleRuntime(t, context.Background(), map[string]string{"main.yak": "println(1)"})
+	targets := []map[string]any{
+		{"source_kind": "workspace"},
+		{"source_kind": "workspace", "paths": []string{"../outside.yak"}},
+		{"source_kind": "workspace", "paths": []string{"/etc/passwd"}},
+		{"source_kind": "workspace", "paths": []string{"C:/secret.yak"}},
+		{"source_kind": "workspace", "paths": []string{"main.yak", "main.yak"}},
+		{"source_kind": "workspace", "paths": []string{"main.yak"}, "files": map[string]string{}},
+		{"source_kind": "inline", "files": map[string]string{}, "paths": []string{"main.yak"}},
+		{"source_kind": "inline", "files": map[string]string{"..\\outside.yak": "1"}},
+		{"source_kind": "inline", "files": map[string]string{"a.yak": strings.Repeat("x", legionInlineSourceMaxFileBytes+1)}},
+		{"source_kind": "inline", "files": map[string]any{"a.yak": 1}},
+		{"source_kind": "inline", "files": map[string]string{"a.yak": "1"}, "program_name": "another-user-program"},
+		{"source_kind": "inline", "files": map[string]string{"a.yak": "1"}, "sample_origin": "user_supplied"},
+	}
+	for i, params := range targets {
+		params["rule"], params["language"] = testLegionRule, "yak"
+		if _, err := runtime.Execute(serverFocusCapabilityRuleDebug, params); err == nil {
+			t.Fatalf("unsafe target %d accepted: %#v", i, params)
+		}
+	}
+	link := filepath.Join(runtime.workspace.root, "link.yak")
+	if err := os.Symlink("main.yak", link); err == nil {
+		if _, err := runtime.Execute(serverFocusCapabilityRuleDebug, map[string]any{
+			"rule": testLegionRule, "language": "yak", "source_kind": "workspace", "paths": []string{"link.yak"},
+		}); err == nil {
+			t.Fatal("in-workspace symlink accepted")
+		}
+	}
+	if len(runtime.ruleDebugHistory) != 0 {
+		t.Fatal("invalid source selections created debug evidence")
+	}
+}
+
+func TestLegionSyntaxFlowCancellationTimeoutBudgetAndFailure(t *testing.T) {
+	input := func() map[string]any {
+		return map[string]any{
+			"rule": testLegionRule, "language": "yak", "source_kind": "inline",
+			"files": map[string]string{"main.yak": "a=1\nb=2\nc=3\nprintln(a+b+c)"},
+		}
+	}
+	t.Run("timeout", func(t *testing.T) {
+		runtime, publisher := testLegionRuleRuntime(t, context.Background(), nil)
+		runtime.ruleDebugTimeout = time.Nanosecond
+		result := testLegionRuleDebug(t, runtime, input())
+		if result.Status != "timeout" {
+			t.Fatalf("timeout classified as success: %#v", result)
+		}
+		if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, testLegionRuleCandidateParams()); err != nil {
+			t.Fatal(err)
+		}
+		_, candidate := testLegionLastCandidate(t, publisher)
+		if candidate.VerificationStatus != "debug_failed" {
+			t.Fatalf("timed-out run became tested: %#v", candidate)
+		}
+	})
+	t.Run("cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		runtime, _ := testLegionRuleRuntime(t, ctx, nil)
+		cancel()
+		result := testLegionRuleDebug(t, runtime, input())
+		if result.Status != "cancelled" {
+			t.Fatalf("cancellation classified as success: %#v", result)
+		}
+	})
+	t.Run("work-budget", func(t *testing.T) {
+		runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+		runtime.ruleWorkLimit = 1
+		params := input()
+		params["rule"] = "println(* as $input)\n$input<typeName> as $types\nalert $types"
+		params["files"] = map[string]string{"main.yak": "println(1,2,3)"}
+		result := testLegionRuleDebug(t, runtime, params)
+		if result.Status != "work_budget_exceeded" {
+			t.Fatalf("real fanout budget not enforced: %#v", result)
+		}
+	})
+	t.Run("invalid-rule", func(t *testing.T) {
+		runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+		params := input()
+		params["rule"] = "println(("
+		result := testLegionRuleDebug(t, runtime, params)
+		if result.Status != "invalid_rule" {
+			t.Fatalf("invalid rule classification: %#v", result)
+		}
+	})
+	t.Run("compile-error", func(t *testing.T) {
+		runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+		params := input()
+		params["files"] = map[string]string{"main.yak": "println(\""}
+		result := testLegionRuleDebug(t, runtime, params)
+		if result.Status != "compile_error" {
+			t.Fatalf("invalid source classification: %#v", result)
+		}
+	})
+	t.Run("call-budget", func(t *testing.T) {
+		runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+		for i := 0; i < legionSyntaxFlowMaxCalls; i++ {
+			if _, err := runtime.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": testLegionRule}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := runtime.Execute(serverFocusCapabilityRuleDebug, input()); err == nil {
+			t.Fatal("per-Turn call budget was not enforced")
+		}
+	})
+}
+
+func TestLegionSyntaxFlowCandidateSinkRejectsForgedReport(t *testing.T) {
+	runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+	sink := runtime.sink.(aiFocusCodeResultSink)
+	if _, err := sink.SubmitCodeAuditReport(context.Background(), legionSyntaxFlowRuleCandidateKind, aiFocusCodeAuditReport{
+		WorkspaceID: runtime.workspace.spec.WorkspaceID, Title: "forged", Markdown: "passed",
+		StructuredSummary: json.RawMessage(`{"schema_version":"legion.syntaxflow-rule-candidate/v1","verification_status":"tested"}`),
+	}); err == nil {
+		t.Fatal("raw report bypassed dedicated candidate evidence primitive")
+	}
+	contract := testLegionRuleContract(t)
+	for _, change := range []func(*legionFocusExecutionContract){
+		func(c *legionFocusExecutionContract) {
+			c.Results[0].Capability = "result.report.v1"
+			c.Capabilities = append(c.Capabilities, "result.report.v1")
+		},
+		func(c *legionFocusExecutionContract) { c.Results[0].Kind = "ai_code_audit_v1" },
+		func(c *legionFocusExecutionContract) { c.Results = nil },
+	} {
+		candidate := cloneLegionFocusExecutionContract(contract)
+		change(candidate)
+		sort.Strings(candidate.Capabilities)
+		raw, _ := json.Marshal(candidate)
+		if _, err := parseLegionFocusExecutionContract(string(raw)); err == nil {
+			t.Fatalf("candidate result transport substitution accepted: %s", raw)
+		}
+	}
+}
+
+func TestLegionSyntaxFlowCandidateCapsEvidenceWithoutChangingRule(t *testing.T) {
+	records := make([]legionSyntaxFlowDebugResult, legionSyntaxFlowMaxCalls)
+	for i := range records {
+		records[i] = legionSyntaxFlowDebugResult{
+			SchemaVersion: legionSyntaxFlowDebugSchema, DebugID: strings.Repeat("a", 36),
+			RuleSHA256: legionRuleHash(testLegionRule), SourceSHA256: strings.Repeat("b", 64),
+			SourceKind: "inline_sample", SampleOrigin: "generated_or_modified", Language: "yak",
+			Status: "completed", MatchCount: 32, Matches: make([]legionSyntaxFlowMatch, 32),
+			Diagnostics: []string{}, Expected: "observe",
+		}
+		for j := range records[i].Matches {
+			records[i].Matches[j] = legionSyntaxFlowMatch{Code: strings.Repeat("x", legionSyntaxFlowMaxSnippetBytes), Variable: "input", Path: "main.yak", StartLine: 1, EndLine: 1}
+		}
+	}
+	summary := legionSyntaxFlowRuleCandidateSummary{
+		RuleContent: testLegionRule, RuleSHA256: legionRuleHash(testLegionRule), DebugResults: records,
+	}
+	raw, err := marshalBoundedLegionRuleCandidate(&summary)
+	if err != nil || len(raw) > maxInlineCodeAuditSummaryBytes || summary.RuleContent != testLegionRule || len(summary.DebugResults) != legionSyntaxFlowMaxCalls {
+		t.Fatalf("bounded summary changed source evidence identities: size=%d err=%v", len(raw), err)
+	}
+	wasTrimmed := false
+	for _, result := range summary.DebugResults {
+		wasTrimmed = wasTrimmed || result.Truncated
+		if result.MatchCount != 32 {
+			t.Fatal("trimming altered observed match count")
+		}
+	}
+	if !wasTrimmed {
+		t.Fatal("expected capped evidence")
+	}
+}
+
+func TestLegionSyntaxFlowLanguageAliases(t *testing.T) {
+	for alias, canonical := range map[string]string{"go": "golang", "golang": "golang", "javascript": "js", "js": "js", "typescript": "ts", "py": "python", "yaklang": "yak"} {
+		language, err := normalizeLegionSyntaxFlowLanguage(alias)
+		if err != nil || language.String() != canonical {
+			t.Fatalf("alias %q: %q %v", alias, language, err)
+		}
+	}
+	for _, invalid := range []string{"", "ruby", "general", "host:/tmp"} {
+		if _, err := normalizeLegionSyntaxFlowLanguage(invalid); err == nil {
+			t.Fatalf("unavailable language accepted: %s", invalid)
+		}
+	}
+}
+
+func TestLegionSyntaxFlowCandidateRequiresCompiledAlert(t *testing.T) {
+	runtime, publisher := testLegionRuleRuntime(t, context.Background(), nil)
+	for _, rule := range []string{
+		"println(* as $input)",
+		"println(* as $input)\n// alert $input",
+	} {
+		checked, err := runtime.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": rule})
+		if err != nil || checked["status"] != "valid" {
+			t.Fatalf("intermediate query must remain checkable: %#v %v", checked, err)
+		}
+		debugged := testLegionRuleDebug(t, runtime, map[string]any{
+			"rule": rule, "language": "yak", "source_kind": "inline", "files": map[string]string{"main.yak": "println(1)"},
+		})
+		if debugged.Status != "completed" || debugged.MatchCount != 0 {
+			t.Fatalf("generic variable matches must not count as alert evidence: %#v", debugged)
+		}
+		params := testLegionRuleCandidateParams()
+		params["rule"] = rule
+		if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, params); err == nil || !strings.Contains(err.Error(), "compiled alert") {
+			t.Fatalf("non-detecting candidate accepted: %v", err)
+		}
+	}
+	if len(publisher.reports) != 0 {
+		t.Fatal("intermediate query was persisted as a candidate")
+	}
+}
+
+func TestLegionSyntaxFlowRealLanguageSupport(t *testing.T) {
+	for _, sample := range []struct{ language, path, source string }{
+		{"yak", "main.yak", "sink(1)"},
+		{"js", "main.js", "sink(1);"},
+		{"ts", "main.ts", "function sink(x: number) {}\nsink(1);"},
+		{"golang", "main.go", "package main\nfunc sink(x int) {}\nfunc main() { sink(1) }"},
+		{"java", "Main.java", "class Main { void run() { sink(1); } void sink(int x) {} }"},
+		{"php", "main.php", "<?php function sink($x) {} sink(1);"},
+		{"python", "main.py", "def sink(x):\n    pass\nsink(1)\n"},
+		{"c", "main.c", "void sink(int x) {}\nint main() { sink(1); return 0; }"},
+	} {
+		t.Run(sample.language, func(t *testing.T) {
+			runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+			result := testLegionRuleDebug(t, runtime, map[string]any{
+				"rule": "sink(* as $input)\nalert $input", "language": sample.language,
+				"source_kind": "inline", "files": map[string]string{sample.path: sample.source},
+			})
+			if result.Status != "completed" || result.MatchCount < 1 {
+				t.Fatalf("advertised language failed real compile/query: %#v", result)
+			}
+		})
+	}
+}
+
+func TestLegionSyntaxFlowNestedNativeCannotEscape(t *testing.T) {
+	runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+	for _, native := range []string{"include(\"not-authorized\")", "eval(\"println(*)\")", "fuzztag(\"{{int(1)}}\")", "unknownTaskNative"} {
+		rule := "println(* as $input)\n$input<dataflow(<<<CODE\n*<" + native + ">\nCODE)>\nalert $input"
+		// Only the outer native is present in the compiled frame. The inner
+		// frame must inherit the authority guard when it is compiled at runtime.
+		if _, err := compileLegionSyntaxFlowRule(rule); err != nil {
+			t.Fatalf("test must reach the nested runtime guard: %v", err)
+		}
+		result := testLegionRuleDebug(t, runtime, map[string]any{
+			"rule": rule, "language": "yak", "source_kind": "inline", "files": map[string]string{"main.yak": "println(1)"},
+		})
+		if result.Status != "query_error" || !strings.Contains(strings.Join(result.Diagnostics, " "), "unsupported") {
+			t.Fatalf("nested native bypassed task authority: %s: %#v", native, result)
+		}
+	}
+}
+
+func TestLegionSyntaxFlowLeavesOrdinaryQueryAndCacheUnchanged(t *testing.T) {
+	previous, wasCached := ssaapi.ProgramCache.Get("")
+	defer func() {
+		if wasCached {
+			ssaapi.SetProgramCache(previous)
+		} else {
+			ssaapi.ProgramCache.Remove("")
+		}
+	}()
+	ordinaryQuery := func() {
+		fs := filesys.NewVirtualFs()
+		fs.AddFile("ordinary.yak", "println(1)")
+		programs, err := ssaapi.ParseProjectWithFS(fs, ssaapi.WithLanguage(ssaconfig.Yak), ssaapi.WithMemory(true))
+		if err != nil || len(programs) != 1 {
+			t.Fatalf("ordinary project compile: %v", err)
+		}
+		program := programs[0]
+		defer program.Program.Cache.CloseWithoutSave()
+		if cached, ok := ssaapi.ProgramCache.Get(""); !ok || cached != program {
+			t.Fatal("ordinary project compile lost its existing global cache behavior")
+		}
+		result, err := program.SyntaxFlowWithError("<eval(<<<CODE\nprintln(* as $input)\nalert $input\nCODE)>")
+		if err != nil || result == nil || len(result.GetValues("input")) == 0 {
+			t.Fatalf("ordinary unrestricted native query changed: %v", err)
+		}
+	}
+	ordinaryQuery()
+	cachedBefore, presentBefore := ssaapi.ProgramCache.Get("")
+	runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+	result := testLegionRuleDebug(t, runtime, map[string]any{
+		"rule": testLegionRule, "language": "yak", "source_kind": "inline", "files": map[string]string{"main.yak": "println(2)"},
+	})
+	if result.Status != "completed" || result.MatchCount != 1 {
+		t.Fatalf("task query failed: %#v", result)
+	}
+	cachedAfter, presentAfter := ssaapi.ProgramCache.Get("")
+	if presentBefore != presentAfter || cachedBefore != cachedAfter {
+		t.Fatal("anonymous task-private program escaped into the global program cache")
+	}
+	ordinaryQuery()
+}
+
+func TestLegionSyntaxFlowDoesNotPersistProgramsRulesOrRisks(t *testing.T) {
+	// Initialize the process's test database before measuring. The focused
+	// command supplies a task-owned YAKIT_HOME; no global DB is rebound.
+	database := ssadb.GetDB()
+	profile := consts.GetGormProfileDatabase()
+	snapshot := func() map[string]int64 {
+		t.Helper()
+		counts := map[string]int64{}
+		for name, model := range map[string]any{
+			"programs": &ssadb.IrProgram{}, "instructions": &ssadb.IrCode{},
+			"sources": &ssadb.IrSource{}, "results": &ssadb.AuditResult{}, "risks": &schema.SSARisk{},
+		} {
+			var count int64
+			if database.HasTable(model) {
+				if err := database.Model(model).Unscoped().Count(&count).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+			counts[name] = count
+		}
+		var rules int64
+		if profile.HasTable(&schema.SyntaxFlowRule{}) {
+			if err := profile.Model(&schema.SyntaxFlowRule{}).Unscoped().Count(&rules).Error; err != nil {
+				t.Fatal(err)
+			}
+		}
+		counts["rules"] = rules
+		return counts
+	}
+	before := snapshot()
+	runtime, _ := testLegionRuleRuntime(t, context.Background(), nil)
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCheck, map[string]any{"rule": testLegionRule}); err != nil {
+		t.Fatal(err)
+	}
+	result := testLegionRuleDebug(t, runtime, map[string]any{
+		"rule": testLegionRule, "language": "yak", "source_kind": "inline", "files": map[string]string{"main.yak": "println(3)"},
+	})
+	if result.Status != "completed" || result.MatchCount != 1 {
+		t.Fatalf("real debug failed: %#v", result)
+	}
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, testLegionRuleCandidateParams()); err != nil {
+		t.Fatal(err)
+	}
+	for kind, after := range snapshot() {
+		if after != before[kind] {
+			t.Fatalf("task-private rule execution persisted %s: before=%d after=%d", kind, before[kind], after)
+		}
+	}
+}
+
+func TestResilienceLegionSyntaxFlowTurnCancellationFencesWaitingWorker(t *testing.T) {
+	// Exhaust worker slots so the Turn switch deterministically happens
+	// before this query can compile. Release only these task-owned slots.
+	for i := 0; i < cap(legionSyntaxFlowWorkers); i++ {
+		select {
+		case legionSyntaxFlowWorkers <- struct{}{}:
+		case <-time.After(5 * time.Second):
+			t.Fatal("previous bounded debug workers did not finish")
+		}
+	}
+	defer func() {
+		for i := 0; i < cap(legionSyntaxFlowWorkers); i++ {
+			<-legionSyntaxFlowWorkers
+		}
+	}()
+	runtime, publisher := testLegionRuleRuntime(t, context.Background(), nil)
+	done := make(chan error, 1)
+	go func() {
+		_, err := runtime.Execute(serverFocusCapabilityRuleDebug, map[string]any{
+			"rule": testLegionRule, "language": "yak", "source_kind": "inline", "files": map[string]string{"main.yak": "println(1)"},
+		})
+		done <- err
+	}()
+	deadline := time.After(5 * time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+waiting:
+	for {
+		runtime.mu.Lock()
+		started := runtime.ruleCallCount > 0
+		runtime.mu.Unlock()
+		if started {
+			break waiting
+		}
+		select {
+		case <-deadline:
+			t.Fatal("debug operation did not start")
+		case <-ticker.C:
+		}
+	}
+	release := runtime.authorizedFocusReleaseID
+	runtime.deactivateFocusTurn(release)
+	if err := runtime.activateFocusTurn(release, testLegionRuleContract(t)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("old Turn produced observations after deactivation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Turn cancellation did not release the blocked operation")
+	}
+	if _, err := runtime.Execute(serverFocusCapabilityRuleCandidate, testLegionRuleCandidateParams()); err != nil {
+		t.Fatal(err)
+	}
+	_, candidate := testLegionLastCandidate(t, publisher)
+	if candidate.VerificationStatus != "syntax_only" || len(candidate.DebugResults) != 0 {
+		t.Fatalf("old worker polluted the next Turn: %#v", candidate)
+	}
+}

--- a/scannode/legion_ai_syntaxflow_runtime_test.go
+++ b/scannode/legion_ai_syntaxflow_runtime_test.go
@@ -208,6 +208,29 @@ func TestLegionSyntaxFlowRealDebugAndCanonicalCandidate(t *testing.T) {
 	}
 }
 
+func TestLegionSyntaxFlowJavaCallArgumentOpcodeFilter(t *testing.T) {
+	files := map[string]string{
+		"positive/Sample.java": `class Positive { void run(String command) throws Exception { Runtime.getRuntime().exec(command); } }`,
+		"negative/Sample.java": `class Negative { void run() throws Exception { Runtime.getRuntime().exec("echo safe"); } }`,
+	}
+	runtime, _ := testLegionRuleRuntime(t, context.Background(), files)
+	const rule = "exec(,*?{!opcode: const} as $cmd,)\nalert $cmd"
+	positive := testLegionRuleDebug(t, runtime, map[string]any{
+		"rule": rule, "language": "java", "source_kind": "workspace",
+		"paths": []string{"positive/Sample.java"}, "expected": "match", "label": "positive dynamic command",
+	})
+	negative := testLegionRuleDebug(t, runtime, map[string]any{
+		"rule": rule, "language": "java", "source_kind": "workspace",
+		"paths": []string{"negative/Sample.java"}, "expected": "no_match", "label": "negative literal command",
+	})
+	if positive.Status != "completed" || positive.MatchCount == 0 {
+		t.Fatalf("non-constant Java call argument was not matched: %#v", positive)
+	}
+	if negative.Status != "completed" || negative.MatchCount != 0 {
+		t.Fatalf("constant Java call argument was not excluded: %#v", negative)
+	}
+}
+
 func TestLegionSyntaxFlowCannotReuseTurnOrRuleEvidence(t *testing.T) {
 	runtime, publisher := testLegionRuleRuntime(t, context.Background(), nil)
 	input := map[string]any{

--- a/scannode/legion_code_workspace.go
+++ b/scannode/legion_code_workspace.go
@@ -85,6 +85,9 @@ type legionCodeWorkspaceSpec struct {
 	SyntaxFlowMode                        string            `json:"syntaxflow_mode,omitempty"`
 	SyntaxFlowOriginalRule                string            `json:"syntaxflow_original_rule,omitempty"`
 	SyntaxFlowOriginalRuleSHA256          string            `json:"syntaxflow_original_rule_sha256,omitempty"`
+	SyntaxFlowLanguage                    string            `json:"syntaxflow_language,omitempty"`
+	SyntaxFlowOriginalSamplePath          string            `json:"syntaxflow_original_sample_path,omitempty"`
+	SyntaxFlowOriginalSampleSHA256        string            `json:"syntaxflow_original_sample_sha256,omitempty"`
 	SyntaxFlowRequireOriginalReproduction bool              `json:"syntaxflow_require_original_reproduction,omitempty"`
 }
 
@@ -198,8 +201,25 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 	spec.PayloadID = strings.TrimSpace(spec.PayloadID)
 	spec.SyntaxFlowMode = strings.TrimSpace(spec.SyntaxFlowMode)
 	spec.SyntaxFlowOriginalRuleSHA256 = strings.ToLower(strings.TrimSpace(spec.SyntaxFlowOriginalRuleSHA256))
+	spec.SyntaxFlowLanguage = strings.TrimSpace(spec.SyntaxFlowLanguage)
+	spec.SyntaxFlowOriginalSamplePath = strings.TrimSpace(spec.SyntaxFlowOriginalSamplePath)
+	spec.SyntaxFlowOriginalSampleSHA256 = strings.ToLower(strings.TrimSpace(spec.SyntaxFlowOriginalSampleSHA256))
 	spec.ExpectedRevision = strings.TrimSpace(spec.ExpectedRevision)
 	spec.ExpectedSHA256 = strings.ToLower(strings.TrimSpace(spec.ExpectedSHA256))
+	if spec.SyntaxFlowLanguage != "" {
+		language, err := normalizeLegionSyntaxFlowLanguage(spec.SyntaxFlowLanguage)
+		if err != nil {
+			return fmt.Errorf("source_workspace syntaxflow_language is invalid")
+		}
+		spec.SyntaxFlowLanguage = language.String()
+	}
+	if spec.SyntaxFlowOriginalSamplePath != "" {
+		path, err := cleanLegionRuleSourcePath(spec.SyntaxFlowOriginalSamplePath)
+		if err != nil {
+			return fmt.Errorf("source_workspace syntaxflow_original_sample_path is invalid")
+		}
+		spec.SyntaxFlowOriginalSamplePath = path
+	}
 	switch {
 	case spec.WorkspaceID == "":
 		return fmt.Errorf("source_workspace workspace_id is required")
@@ -217,15 +237,21 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 		return fmt.Errorf("source_workspace payload_id is invalid")
 	case spec.SyntaxFlowMode != "" && spec.SyntaxFlowMode != "create" && spec.SyntaxFlowMode != "improve":
 		return fmt.Errorf("source_workspace syntaxflow_mode is invalid")
+	case spec.SyntaxFlowMode != "" && spec.SyntaxFlowLanguage == "":
+		return fmt.Errorf("source_workspace syntaxflow_language is required")
 	case spec.SyntaxFlowOriginalRuleSHA256 != "" && (len(spec.SyntaxFlowOriginalRuleSHA256) != sha256.Size*2 || !isLowerHex(spec.SyntaxFlowOriginalRuleSHA256)):
 		return fmt.Errorf("source_workspace syntaxflow_original_rule_sha256 is invalid")
+	case spec.SyntaxFlowOriginalSampleSHA256 != "" && (len(spec.SyntaxFlowOriginalSampleSHA256) != sha256.Size*2 || !isLowerHex(spec.SyntaxFlowOriginalSampleSHA256)):
+		return fmt.Errorf("source_workspace syntaxflow_original_sample_sha256 is invalid")
+	case (spec.SyntaxFlowOriginalSamplePath == "") != (spec.SyntaxFlowOriginalSampleSHA256 == ""):
+		return fmt.Errorf("source_workspace original sample path and hash must be pinned together")
 	case spec.SyntaxFlowOriginalRuleSHA256 != "" && spec.SyntaxFlowOriginalRule == "":
 		return fmt.Errorf("source_workspace syntaxflow original rule bytes are missing")
 	case spec.SyntaxFlowOriginalRule != "" && (!utf8.ValidString(spec.SyntaxFlowOriginalRule) || strings.ContainsRune(spec.SyntaxFlowOriginalRule, 0) || len(spec.SyntaxFlowOriginalRule) > legionSyntaxFlowMaxRuleBytes):
 		return fmt.Errorf("source_workspace syntaxflow_original_rule is invalid")
 	case spec.SyntaxFlowOriginalRule != "" && legionRuleHash(spec.SyntaxFlowOriginalRule) != spec.SyntaxFlowOriginalRuleSHA256:
 		return fmt.Errorf("source_workspace syntaxflow original rule hash mismatch")
-	case spec.SyntaxFlowRequireOriginalReproduction && (spec.SyntaxFlowMode != "improve" || spec.SyntaxFlowOriginalRule == ""):
+	case spec.SyntaxFlowRequireOriginalReproduction && (spec.SyntaxFlowMode != "improve" || spec.SyntaxFlowOriginalRule == "" || spec.SyntaxFlowOriginalSamplePath == ""):
 		return fmt.Errorf("source_workspace original rule reproduction pin is invalid")
 	}
 	if err := normalizeLegionCodeWorkspaceLocator(spec); err != nil {
@@ -233,6 +259,12 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 	}
 	if err := validateLegionInlineFiles(spec.InlineFiles, true); err != nil {
 		return fmt.Errorf("source_workspace inline_files: %w", err)
+	}
+	if spec.SyntaxFlowOriginalSamplePath != "" {
+		content, exists := spec.InlineFiles[spec.SyntaxFlowOriginalSamplePath]
+		if !exists || legionInlineSourceDigest(map[string]string{spec.SyntaxFlowOriginalSamplePath: content}) != spec.SyntaxFlowOriginalSampleSHA256 {
+			return fmt.Errorf("source_workspace original sample does not match bound inline files")
+		}
 	}
 	if spec.Kind == legionCodeWorkspaceKindInlineSources {
 		if spec.Branch != "" || spec.Subpath != "" || spec.PayloadID != "" || spec.Auth != nil || spec.Proxy != nil || spec.SizeBytes != 0 {
@@ -683,19 +715,22 @@ func (w *legionCodeWorkspaceRuntime) info() map[string]any {
 		return nil
 	}
 	workspaceInfo := map[string]any{
-		"workspace_id":                    w.spec.WorkspaceID,
-		"kind":                            w.spec.Kind,
-		"locator":                         w.spec.Locator,
-		"branch":                          w.spec.Branch,
-		"subpath":                         w.spec.Subpath,
-		"payload_id":                      w.spec.PayloadID,
-		"expected_revision":               w.spec.ExpectedRevision,
-		"expected_sha256":                 w.spec.ExpectedSHA256,
-		"read_only":                       true,
-		"max_read_bytes":                  w.spec.MaxReadBytes,
-		"max_search_results":              w.spec.MaxSearchResults,
-		"syntaxflow_mode":                 w.spec.SyntaxFlowMode,
-		"syntaxflow_original_rule_sha256": w.spec.SyntaxFlowOriginalRuleSHA256,
+		"workspace_id":                      w.spec.WorkspaceID,
+		"kind":                              w.spec.Kind,
+		"locator":                           w.spec.Locator,
+		"branch":                            w.spec.Branch,
+		"subpath":                           w.spec.Subpath,
+		"payload_id":                        w.spec.PayloadID,
+		"expected_revision":                 w.spec.ExpectedRevision,
+		"expected_sha256":                   w.spec.ExpectedSHA256,
+		"read_only":                         true,
+		"max_read_bytes":                    w.spec.MaxReadBytes,
+		"max_search_results":                w.spec.MaxSearchResults,
+		"syntaxflow_mode":                   w.spec.SyntaxFlowMode,
+		"syntaxflow_original_rule_sha256":   w.spec.SyntaxFlowOriginalRuleSHA256,
+		"syntaxflow_language":               w.spec.SyntaxFlowLanguage,
+		"syntaxflow_original_sample_path":   w.spec.SyntaxFlowOriginalSamplePath,
+		"syntaxflow_original_sample_sha256": w.spec.SyntaxFlowOriginalSampleSHA256,
 		"syntaxflow_require_original_reproduction": w.spec.SyntaxFlowRequireOriginalReproduction,
 	}
 	if w.originalRule != "" {
@@ -1171,12 +1206,31 @@ func validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw []byte) error {
 	if err := normalizeLegionCodeWorkspaceLocator(&receivedLocator); err != nil {
 		return fmt.Errorf("context source_workspace locator is invalid: %w", err)
 	}
+	boundLanguage := strings.TrimSpace(bound.SyntaxFlowLanguage)
+	receivedLanguage := strings.TrimSpace(received.SyntaxFlowLanguage)
+	if boundLanguage != "" {
+		language, err := normalizeLegionSyntaxFlowLanguage(boundLanguage)
+		if err != nil {
+			return fmt.Errorf("bind source_workspace syntaxflow_language is invalid")
+		}
+		boundLanguage = language.String()
+	}
+	if receivedLanguage != "" {
+		language, err := normalizeLegionSyntaxFlowLanguage(receivedLanguage)
+		if err != nil {
+			return fmt.Errorf("context source_workspace syntaxflow_language is invalid")
+		}
+		receivedLanguage = language.String()
+	}
 	if strings.TrimSpace(bound.WorkspaceID) != strings.TrimSpace(received.WorkspaceID) ||
 		strings.ToLower(strings.TrimSpace(bound.Kind)) != strings.ToLower(strings.TrimSpace(received.Kind)) ||
 		strings.TrimSpace(bound.ExpectedRevision) != strings.TrimSpace(received.ExpectedRevision) ||
 		strings.ToLower(strings.TrimSpace(bound.ExpectedSHA256)) != strings.ToLower(strings.TrimSpace(received.ExpectedSHA256)) ||
 		strings.TrimSpace(bound.SyntaxFlowMode) != strings.TrimSpace(received.SyntaxFlowMode) ||
 		strings.ToLower(strings.TrimSpace(bound.SyntaxFlowOriginalRuleSHA256)) != strings.ToLower(strings.TrimSpace(received.SyntaxFlowOriginalRuleSHA256)) ||
+		boundLanguage != receivedLanguage ||
+		strings.TrimSpace(bound.SyntaxFlowOriginalSamplePath) != strings.TrimSpace(received.SyntaxFlowOriginalSamplePath) ||
+		strings.ToLower(strings.TrimSpace(bound.SyntaxFlowOriginalSampleSHA256)) != strings.ToLower(strings.TrimSpace(received.SyntaxFlowOriginalSampleSHA256)) ||
 		bound.SyntaxFlowRequireOriginalReproduction != received.SyntaxFlowRequireOriginalReproduction {
 		return fmt.Errorf("context source_workspace pin does not match bind snapshot")
 	}

--- a/scannode/legion_code_workspace.go
+++ b/scannode/legion_code_workspace.go
@@ -81,7 +81,8 @@ type legionCodeWorkspaceSpec struct {
 	Proxy            *legionCodeWorkspaceProxy `json:"proxy,omitempty"`
 	// InlineFiles is bound by Legion, never supplied by the model or replay
 	// context. On Git/archive workspaces it contains optional user samples only.
-	InlineFiles map[string]string `json:"inline_files,omitempty"`
+	InlineFiles    map[string]string `json:"inline_files,omitempty"`
+	SyntaxFlowMode string            `json:"syntaxflow_mode,omitempty"`
 }
 
 type legionCodeWorkspaceMaterializeOptions struct {
@@ -191,6 +192,7 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 	spec.Branch = strings.TrimSpace(spec.Branch)
 	spec.Subpath = strings.TrimSpace(spec.Subpath)
 	spec.PayloadID = strings.TrimSpace(spec.PayloadID)
+	spec.SyntaxFlowMode = strings.TrimSpace(spec.SyntaxFlowMode)
 	spec.ExpectedRevision = strings.TrimSpace(spec.ExpectedRevision)
 	spec.ExpectedSHA256 = strings.ToLower(strings.TrimSpace(spec.ExpectedSHA256))
 	switch {
@@ -208,6 +210,8 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 		return fmt.Errorf("source_workspace expected_sha256 is invalid")
 	case spec.Kind == legionCodeWorkspaceKindUploadedArchive && !managedSourcePayloadIDPattern.MatchString(spec.PayloadID):
 		return fmt.Errorf("source_workspace payload_id is invalid")
+	case spec.SyntaxFlowMode != "" && spec.SyntaxFlowMode != "create" && spec.SyntaxFlowMode != "improve":
+		return fmt.Errorf("source_workspace syntaxflow_mode is invalid")
 	}
 	if err := normalizeLegionCodeWorkspaceLocator(spec); err != nil {
 		return err
@@ -674,6 +678,7 @@ func (w *legionCodeWorkspaceRuntime) info() map[string]any {
 			"read_only":          true,
 			"max_read_bytes":     w.spec.MaxReadBytes,
 			"max_search_results": w.spec.MaxSearchResults,
+			"syntaxflow_mode":    w.spec.SyntaxFlowMode,
 		},
 		"locked_revision": w.lockedRevision,
 		"sha256":          w.sha256,
@@ -1145,7 +1150,8 @@ func validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw []byte) error {
 	if strings.TrimSpace(bound.WorkspaceID) != strings.TrimSpace(received.WorkspaceID) ||
 		strings.ToLower(strings.TrimSpace(bound.Kind)) != strings.ToLower(strings.TrimSpace(received.Kind)) ||
 		strings.TrimSpace(bound.ExpectedRevision) != strings.TrimSpace(received.ExpectedRevision) ||
-		strings.ToLower(strings.TrimSpace(bound.ExpectedSHA256)) != strings.ToLower(strings.TrimSpace(received.ExpectedSHA256)) {
+		strings.ToLower(strings.TrimSpace(bound.ExpectedSHA256)) != strings.ToLower(strings.TrimSpace(received.ExpectedSHA256)) ||
+		strings.TrimSpace(bound.SyntaxFlowMode) != strings.TrimSpace(received.SyntaxFlowMode) {
 		return fmt.Errorf("context source_workspace pin does not match bind snapshot")
 	}
 	return nil

--- a/scannode/legion_code_workspace.go
+++ b/scannode/legion_code_workspace.go
@@ -81,8 +81,11 @@ type legionCodeWorkspaceSpec struct {
 	Proxy            *legionCodeWorkspaceProxy `json:"proxy,omitempty"`
 	// InlineFiles is bound by Legion, never supplied by the model or replay
 	// context. On Git/archive workspaces it contains optional user samples only.
-	InlineFiles    map[string]string `json:"inline_files,omitempty"`
-	SyntaxFlowMode string            `json:"syntaxflow_mode,omitempty"`
+	InlineFiles                           map[string]string `json:"inline_files,omitempty"`
+	SyntaxFlowMode                        string            `json:"syntaxflow_mode,omitempty"`
+	SyntaxFlowOriginalRule                string            `json:"syntaxflow_original_rule,omitempty"`
+	SyntaxFlowOriginalRuleSHA256          string            `json:"syntaxflow_original_rule_sha256,omitempty"`
+	SyntaxFlowRequireOriginalReproduction bool              `json:"syntaxflow_require_original_reproduction,omitempty"`
 }
 
 type legionCodeWorkspaceMaterializeOptions struct {
@@ -103,6 +106,7 @@ type legionCodeWorkspaceRuntime struct {
 	cleanupOnce    sync.Once
 	cleanupErr     error
 	inlineFiles    map[string]string
+	originalRule   string
 }
 
 type legionCodeWorkspaceRuntimeHandle struct {
@@ -193,6 +197,7 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 	spec.Subpath = strings.TrimSpace(spec.Subpath)
 	spec.PayloadID = strings.TrimSpace(spec.PayloadID)
 	spec.SyntaxFlowMode = strings.TrimSpace(spec.SyntaxFlowMode)
+	spec.SyntaxFlowOriginalRuleSHA256 = strings.ToLower(strings.TrimSpace(spec.SyntaxFlowOriginalRuleSHA256))
 	spec.ExpectedRevision = strings.TrimSpace(spec.ExpectedRevision)
 	spec.ExpectedSHA256 = strings.ToLower(strings.TrimSpace(spec.ExpectedSHA256))
 	switch {
@@ -212,6 +217,16 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 		return fmt.Errorf("source_workspace payload_id is invalid")
 	case spec.SyntaxFlowMode != "" && spec.SyntaxFlowMode != "create" && spec.SyntaxFlowMode != "improve":
 		return fmt.Errorf("source_workspace syntaxflow_mode is invalid")
+	case spec.SyntaxFlowOriginalRuleSHA256 != "" && (len(spec.SyntaxFlowOriginalRuleSHA256) != sha256.Size*2 || !isLowerHex(spec.SyntaxFlowOriginalRuleSHA256)):
+		return fmt.Errorf("source_workspace syntaxflow_original_rule_sha256 is invalid")
+	case spec.SyntaxFlowOriginalRuleSHA256 != "" && spec.SyntaxFlowOriginalRule == "":
+		return fmt.Errorf("source_workspace syntaxflow original rule bytes are missing")
+	case spec.SyntaxFlowOriginalRule != "" && (!utf8.ValidString(spec.SyntaxFlowOriginalRule) || strings.ContainsRune(spec.SyntaxFlowOriginalRule, 0) || len(spec.SyntaxFlowOriginalRule) > legionSyntaxFlowMaxRuleBytes):
+		return fmt.Errorf("source_workspace syntaxflow_original_rule is invalid")
+	case spec.SyntaxFlowOriginalRule != "" && legionRuleHash(spec.SyntaxFlowOriginalRule) != spec.SyntaxFlowOriginalRuleSHA256:
+		return fmt.Errorf("source_workspace syntaxflow original rule hash mismatch")
+	case spec.SyntaxFlowRequireOriginalReproduction && (spec.SyntaxFlowMode != "improve" || spec.SyntaxFlowOriginalRule == ""):
+		return fmt.Errorf("source_workspace original rule reproduction pin is invalid")
 	}
 	if err := normalizeLegionCodeWorkspaceLocator(spec); err != nil {
 		return err
@@ -453,6 +468,7 @@ func materializeLegionCodeGitWorkspace(
 	return &legionCodeWorkspaceRuntime{
 		spec:           publicLegionCodeWorkspaceSpec(spec),
 		inlineFiles:    cloneLegionInlineFiles(spec.InlineFiles),
+		originalRule:   spec.SyntaxFlowOriginalRule,
 		root:           root,
 		lockedRevision: lockedRevision,
 		sha256:         digest,
@@ -509,6 +525,7 @@ func materializeLegionCodeArchiveWorkspace(
 	return &legionCodeWorkspaceRuntime{
 		spec:           publicLegionCodeWorkspaceSpec(spec),
 		inlineFiles:    cloneLegionInlineFiles(spec.InlineFiles),
+		originalRule:   spec.SyntaxFlowOriginalRule,
 		root:           root,
 		lockedRevision: strings.TrimSpace(spec.ExpectedRevision),
 		sha256:         archiveSHA256,
@@ -665,25 +682,31 @@ func (w *legionCodeWorkspaceRuntime) info() map[string]any {
 	if w == nil {
 		return nil
 	}
+	workspaceInfo := map[string]any{
+		"workspace_id":                    w.spec.WorkspaceID,
+		"kind":                            w.spec.Kind,
+		"locator":                         w.spec.Locator,
+		"branch":                          w.spec.Branch,
+		"subpath":                         w.spec.Subpath,
+		"payload_id":                      w.spec.PayloadID,
+		"expected_revision":               w.spec.ExpectedRevision,
+		"expected_sha256":                 w.spec.ExpectedSHA256,
+		"read_only":                       true,
+		"max_read_bytes":                  w.spec.MaxReadBytes,
+		"max_search_results":              w.spec.MaxSearchResults,
+		"syntaxflow_mode":                 w.spec.SyntaxFlowMode,
+		"syntaxflow_original_rule_sha256": w.spec.SyntaxFlowOriginalRuleSHA256,
+		"syntaxflow_require_original_reproduction": w.spec.SyntaxFlowRequireOriginalReproduction,
+	}
+	if w.originalRule != "" {
+		workspaceInfo["syntaxflow_original_rule"] = w.originalRule
+	}
 	return map[string]any{
-		"source_workspace": map[string]any{
-			"workspace_id":       w.spec.WorkspaceID,
-			"kind":               w.spec.Kind,
-			"locator":            w.spec.Locator,
-			"branch":             w.spec.Branch,
-			"subpath":            w.spec.Subpath,
-			"payload_id":         w.spec.PayloadID,
-			"expected_revision":  w.spec.ExpectedRevision,
-			"expected_sha256":    w.spec.ExpectedSHA256,
-			"read_only":          true,
-			"max_read_bytes":     w.spec.MaxReadBytes,
-			"max_search_results": w.spec.MaxSearchResults,
-			"syntaxflow_mode":    w.spec.SyntaxFlowMode,
-		},
-		"locked_revision": w.lockedRevision,
-		"sha256":          w.sha256,
-		"files":           w.files,
-		"bytes":           w.bytes,
+		"source_workspace": workspaceInfo,
+		"locked_revision":  w.lockedRevision,
+		"sha256":           w.sha256,
+		"files":            w.files,
+		"bytes":            w.bytes,
 	}
 }
 
@@ -1111,6 +1134,7 @@ func publicLegionCodeWorkspaceSpec(spec legionCodeWorkspaceSpec) legionCodeWorks
 	spec.Auth = nil
 	spec.Proxy = nil
 	spec.InlineFiles = nil
+	spec.SyntaxFlowOriginalRule = ""
 	return spec
 }
 
@@ -1132,8 +1156,8 @@ func validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw []byte) error {
 		return fmt.Errorf("context source_workspace was not present at bind")
 	case received == nil:
 		return fmt.Errorf("context source_workspace pin is missing")
-	case received.Auth != nil || received.Proxy != nil || received.InlineFiles != nil:
-		return fmt.Errorf("context source_workspace must not contain auth, proxy, or inline_files")
+	case received.Auth != nil || received.Proxy != nil || received.InlineFiles != nil || received.SyntaxFlowOriginalRule != "":
+		return fmt.Errorf("context source_workspace must not contain auth, proxy, inline_files, or original rule bytes")
 	}
 	boundLocator := *bound
 	boundLocator.Kind = strings.ToLower(strings.TrimSpace(boundLocator.Kind))
@@ -1151,7 +1175,9 @@ func validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw []byte) error {
 		strings.ToLower(strings.TrimSpace(bound.Kind)) != strings.ToLower(strings.TrimSpace(received.Kind)) ||
 		strings.TrimSpace(bound.ExpectedRevision) != strings.TrimSpace(received.ExpectedRevision) ||
 		strings.ToLower(strings.TrimSpace(bound.ExpectedSHA256)) != strings.ToLower(strings.TrimSpace(received.ExpectedSHA256)) ||
-		strings.TrimSpace(bound.SyntaxFlowMode) != strings.TrimSpace(received.SyntaxFlowMode) {
+		strings.TrimSpace(bound.SyntaxFlowMode) != strings.TrimSpace(received.SyntaxFlowMode) ||
+		strings.ToLower(strings.TrimSpace(bound.SyntaxFlowOriginalRuleSHA256)) != strings.ToLower(strings.TrimSpace(received.SyntaxFlowOriginalRuleSHA256)) ||
+		bound.SyntaxFlowRequireOriginalReproduction != received.SyntaxFlowRequireOriginalReproduction {
 		return fmt.Errorf("context source_workspace pin does not match bind snapshot")
 	}
 	return nil

--- a/scannode/legion_code_workspace.go
+++ b/scannode/legion_code_workspace.go
@@ -30,6 +30,7 @@ import (
 const (
 	legionCodeWorkspaceKindGit             = "git"
 	legionCodeWorkspaceKindUploadedArchive = "uploaded_archive"
+	legionCodeWorkspaceKindInlineSources   = "inline_sources"
 	legionCodeWorkspaceArchiveLocator      = "managed-source"
 
 	legionCodeArchiveMaxFiles         = 20_000
@@ -78,6 +79,9 @@ type legionCodeWorkspaceSpec struct {
 	MaxSearchResults int                       `json:"max_search_results"`
 	Auth             *legionCodeWorkspaceAuth  `json:"auth,omitempty"`
 	Proxy            *legionCodeWorkspaceProxy `json:"proxy,omitempty"`
+	// InlineFiles is bound by Legion, never supplied by the model or replay
+	// context. On Git/archive workspaces it contains optional user samples only.
+	InlineFiles map[string]string `json:"inline_files,omitempty"`
 }
 
 type legionCodeWorkspaceMaterializeOptions struct {
@@ -97,6 +101,7 @@ type legionCodeWorkspaceRuntime struct {
 	cleanup        func() error
 	cleanupOnce    sync.Once
 	cleanupErr     error
+	inlineFiles    map[string]string
 }
 
 type legionCodeWorkspaceRuntimeHandle struct {
@@ -149,6 +154,7 @@ func prepareLegionCodeWorkspace(
 		return nil, cloneBytes(runtimeOptionSnapshotJSON), nil
 	}
 	spec := *runtimeOptions.SourceWorkspace
+	spec.InlineFiles = cloneLegionInlineFiles(spec.InlineFiles)
 	if spec.Auth != nil {
 		auth := *spec.Auth
 		spec.Auth = &auth
@@ -165,9 +171,7 @@ func prepareLegionCodeWorkspace(
 	if err != nil {
 		return nil, nil, err
 	}
-	publicSpec := spec
-	publicSpec.Auth = nil
-	publicSpec.Proxy = nil
+	publicSpec := publicLegionCodeWorkspaceSpec(spec)
 	runtimeOptions.SourceWorkspace = &publicSpec
 	sanitized, err := json.Marshal(runtimeOptions)
 	if err != nil {
@@ -194,9 +198,9 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 		return fmt.Errorf("source_workspace workspace_id is required")
 	case !legionCodeWorkspaceIDPattern.MatchString(spec.WorkspaceID):
 		return fmt.Errorf("source_workspace workspace_id is invalid")
-	case spec.Kind != legionCodeWorkspaceKindGit && spec.Kind != legionCodeWorkspaceKindUploadedArchive:
+	case spec.Kind != legionCodeWorkspaceKindGit && spec.Kind != legionCodeWorkspaceKindUploadedArchive && spec.Kind != legionCodeWorkspaceKindInlineSources:
 		return fmt.Errorf("source_workspace kind %q is unsupported", spec.Kind)
-	case spec.Locator == "":
+	case spec.Locator == "" && spec.Kind != legionCodeWorkspaceKindInlineSources:
 		return fmt.Errorf("source_workspace locator is required")
 	case !spec.ReadOnly:
 		return fmt.Errorf("source_workspace must be read_only")
@@ -207,6 +211,21 @@ func normalizeLegionCodeWorkspaceSpec(spec *legionCodeWorkspaceSpec) error {
 	}
 	if err := normalizeLegionCodeWorkspaceLocator(spec); err != nil {
 		return err
+	}
+	if err := validateLegionInlineFiles(spec.InlineFiles, true); err != nil {
+		return fmt.Errorf("source_workspace inline_files: %w", err)
+	}
+	if spec.Kind == legionCodeWorkspaceKindInlineSources {
+		if spec.Branch != "" || spec.Subpath != "" || spec.PayloadID != "" || spec.Auth != nil || spec.Proxy != nil || spec.SizeBytes != 0 {
+			return fmt.Errorf("source_workspace inline_sources must not contain another source target or credentials")
+		}
+		digest := legionInlineSourceDigest(spec.InlineFiles)
+		if spec.ExpectedSHA256 != "" && spec.ExpectedSHA256 != digest {
+			return fmt.Errorf("source_workspace inline_sources sha256 mismatch")
+		}
+		if spec.ExpectedRevision != "" && spec.ExpectedRevision != digest {
+			return fmt.Errorf("source_workspace inline_sources revision mismatch")
+		}
 	}
 	if spec.Subpath != "" {
 		if _, err := cleanLegionCodeRelativePath(spec.Subpath, false); err != nil {
@@ -227,6 +246,11 @@ func normalizeLegionCodeWorkspaceLocator(spec *legionCodeWorkspaceSpec) error {
 		return fmt.Errorf("source_workspace is required")
 	}
 	switch spec.Kind {
+	case legionCodeWorkspaceKindInlineSources:
+		if spec.Locator != "" {
+			return fmt.Errorf("source_workspace inline_sources locator must be empty")
+		}
+		return nil
 	case legionCodeWorkspaceKindGit:
 		locator, err := normalizeLegionCodeGitLocator(spec.Locator)
 		if err != nil {
@@ -311,6 +335,8 @@ func materializeLegionCodeWorkspace(
 	options legionCodeWorkspaceMaterializeOptions,
 ) (*legionCodeWorkspaceRuntime, error) {
 	switch spec.Kind {
+	case legionCodeWorkspaceKindInlineSources:
+		return materializeLegionInlineWorkspace(ctx, spec)
 	case legionCodeWorkspaceKindGit:
 		return materializeLegionCodeGitWorkspace(ctx, spec)
 	case legionCodeWorkspaceKindUploadedArchive:
@@ -342,6 +368,10 @@ func materializeLegionCodeGitWorkspace(
 	opts := []yakgit.Option{
 		yakgit.WithContext(ctx),
 		yakgit.WithRecuriveSubmodule(false),
+		yakgit.WithVerifyTLS(true),
+		yakgit.WithDepth(1),
+		yakgit.WithSingleBranch(true),
+		yakgit.WithNoFetchTags(true),
 	}
 	if spec.Branch != "" {
 		opts = append(opts, yakgit.WithBranch(spec.Branch))
@@ -389,6 +419,11 @@ func materializeLegionCodeGitWorkspace(
 	if err := cloneLegionCodeGitWorkspace(spec.Locator, local, opts...); err != nil {
 		return nil, ssagitworkdir.WrapCloneError(ctx, local, err)
 	}
+	if spec.ExpectedRevision != "" {
+		if err := restoreLegionCodeGitRevision(ctx, local, spec.ExpectedRevision, opts...); err != nil {
+			return nil, err
+		}
+	}
 	lockedRevision := strings.ToLower(strings.TrimSpace(yakgit.GetHeadHash(local)))
 	if lockedRevision == "" {
 		return nil, fmt.Errorf("source_workspace git clone has no HEAD revision")
@@ -413,6 +448,7 @@ func materializeLegionCodeGitWorkspace(
 	}
 	return &legionCodeWorkspaceRuntime{
 		spec:           publicLegionCodeWorkspaceSpec(spec),
+		inlineFiles:    cloneLegionInlineFiles(spec.InlineFiles),
 		root:           root,
 		lockedRevision: lockedRevision,
 		sha256:         digest,
@@ -468,6 +504,7 @@ func materializeLegionCodeArchiveWorkspace(
 	}
 	return &legionCodeWorkspaceRuntime{
 		spec:           publicLegionCodeWorkspaceSpec(spec),
+		inlineFiles:    cloneLegionInlineFiles(spec.InlineFiles),
 		root:           root,
 		lockedRevision: strings.TrimSpace(spec.ExpectedRevision),
 		sha256:         archiveSHA256,
@@ -1068,6 +1105,7 @@ func validateLegionCodeProxyURL(raw string) error {
 func publicLegionCodeWorkspaceSpec(spec legionCodeWorkspaceSpec) legionCodeWorkspaceSpec {
 	spec.Auth = nil
 	spec.Proxy = nil
+	spec.InlineFiles = nil
 	return spec
 }
 
@@ -1089,8 +1127,8 @@ func validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw []byte) error {
 		return fmt.Errorf("context source_workspace was not present at bind")
 	case received == nil:
 		return fmt.Errorf("context source_workspace pin is missing")
-	case received.Auth != nil || received.Proxy != nil:
-		return fmt.Errorf("context source_workspace must not contain auth or proxy")
+	case received.Auth != nil || received.Proxy != nil || received.InlineFiles != nil:
+		return fmt.Errorf("context source_workspace must not contain auth, proxy, or inline_files")
 	}
 	boundLocator := *bound
 	boundLocator.Kind = strings.ToLower(strings.TrimSpace(boundLocator.Kind))

--- a/scannode/legion_code_workspace_inline.go
+++ b/scannode/legion_code_workspace_inline.go
@@ -1,0 +1,166 @@
+package scannode
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	legionInlineSourceMaxFiles      = 16
+	legionInlineSourceMaxFileBytes  = 64 * 1024
+	legionInlineSourceMaxTotalBytes = 256 * 1024
+	legionInlineSourceMaxPathBytes  = 512
+)
+
+func cloneLegionInlineFiles(files map[string]string) map[string]string {
+	if files == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(files))
+	for path, content := range files {
+		cloned[path] = content
+	}
+	return cloned
+}
+
+func cleanLegionRuleSourcePath(raw string) (string, error) {
+	if len(raw) > legionInlineSourceMaxPathBytes || raw != strings.TrimSpace(raw) || strings.Contains(raw, ":") || !utf8.ValidString(raw) {
+		return "", fmt.Errorf("source path must be a bounded canonical relative path")
+	}
+	for _, ch := range raw {
+		if unicode.IsControl(ch) {
+			return "", fmt.Errorf("source path must not contain control characters")
+		}
+	}
+	cleaned, err := cleanLegionCodeRelativePath(raw, false)
+	if err != nil {
+		return "", err
+	}
+	for _, part := range strings.Split(cleaned, "/") {
+		if strings.EqualFold(part, ".git") {
+			return "", fmt.Errorf("source path must not access Git metadata")
+		}
+	}
+	return cleaned, nil
+}
+
+func validateLegionInlineFiles(files map[string]string, allowEmpty bool) error {
+	if len(files) > legionInlineSourceMaxFiles || (!allowEmpty && len(files) == 0) {
+		minimum := 1
+		if allowEmpty {
+			minimum = 0
+		}
+		return fmt.Errorf("inline sources must contain between %d and %d files", minimum, legionInlineSourceMaxFiles)
+	}
+	total := 0
+	seen := make(map[string]struct{}, len(files))
+	for raw, content := range files {
+		path, err := cleanLegionRuleSourcePath(raw)
+		if err != nil {
+			return err
+		}
+		if len(content) > legionInlineSourceMaxFileBytes || !utf8.ValidString(content) || strings.ContainsRune(content, '\x00') {
+			return fmt.Errorf("inline source %q must be UTF-8 text of at most %d bytes", path, legionInlineSourceMaxFileBytes)
+		}
+		total += len(content)
+		if total > legionInlineSourceMaxTotalBytes {
+			return fmt.Errorf("inline sources exceed %d bytes", legionInlineSourceMaxTotalBytes)
+		}
+		key := strings.ToLower(path)
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("inline sources contain colliding paths")
+		}
+		seen[key] = struct{}{}
+	}
+	for name := range seen {
+		parts := strings.Split(name, "/")
+		for i := 1; i < len(parts); i++ {
+			if _, exists := seen[strings.Join(parts[:i], "/")]; exists {
+				return fmt.Errorf("inline sources contain a file/directory collision")
+			}
+		}
+	}
+	return nil
+}
+
+// Hash the canonical relative path and exact UTF-8 bytes for every file. Source
+// bytes cannot contain NUL, so the separators make this encoding unambiguous.
+func legionInlineSourceDigest(files map[string]string) string {
+	hash := sha256.New()
+	for _, path := range legionSortedSourcePaths(files) {
+		_, _ = io.WriteString(hash, path+"\x00"+files[path]+"\x00")
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func legionSortedSourcePaths(files map[string]string) []string {
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func materializeLegionInlineWorkspace(ctx context.Context, spec legionCodeWorkspaceSpec) (_ *legionCodeWorkspaceRuntime, finalErr error) {
+	if err := normalizeLegionCodeWorkspaceSpec(&spec); err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	root, err := os.MkdirTemp("", "legion-inline-source-*")
+	if err != nil {
+		return nil, fmt.Errorf("create private inline source workspace: %w", err)
+	}
+	cleanup := func() error { return os.RemoveAll(root) }
+	defer func() {
+		if finalErr != nil {
+			_ = cleanup()
+		}
+	}()
+	var total int64
+	for _, path := range legionSortedSourcePaths(spec.InlineFiles) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		destination := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(destination), 0700); err != nil {
+			return nil, err
+		}
+		// A fresh private directory and validated non-colliding paths cannot
+		// resolve through an existing symlink or overwrite another file.
+		file, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0400)
+		if err != nil {
+			return nil, err
+		}
+		_, writeErr := io.WriteString(file, spec.InlineFiles[path])
+		closeErr := file.Close()
+		if writeErr != nil {
+			return nil, writeErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		total += int64(len(spec.InlineFiles[path]))
+	}
+	digest := legionInlineSourceDigest(spec.InlineFiles)
+	return &legionCodeWorkspaceRuntime{
+		spec: publicLegionCodeWorkspaceSpec(spec), root: root,
+		inlineFiles:    cloneLegionInlineFiles(spec.InlineFiles),
+		lockedRevision: digest, sha256: digest,
+		files: len(spec.InlineFiles), bytes: total, cleanup: cleanup,
+	}, nil
+}

--- a/scannode/legion_code_workspace_inline.go
+++ b/scannode/legion_code_workspace_inline.go
@@ -158,7 +158,7 @@ func materializeLegionInlineWorkspace(ctx context.Context, spec legionCodeWorksp
 	}
 	digest := legionInlineSourceDigest(spec.InlineFiles)
 	return &legionCodeWorkspaceRuntime{
-		spec: publicLegionCodeWorkspaceSpec(spec), root: root,
+		spec: publicLegionCodeWorkspaceSpec(spec), root: root, originalRule: spec.SyntaxFlowOriginalRule,
 		inlineFiles:    cloneLegionInlineFiles(spec.InlineFiles),
 		lockedRevision: digest, sha256: digest,
 		files: len(spec.InlineFiles), bytes: total, cleanup: cleanup,

--- a/scannode/legion_code_workspace_inline_test.go
+++ b/scannode/legion_code_workspace_inline_test.go
@@ -1,0 +1,137 @@
+package scannode
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLegionInlineSourceWorkspaceMaterializesAndSanitizes(t *testing.T) {
+	files := map[string]string{"src/main.yak": "println(\"private-source\")", "empty.yak": ""}
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindInlineSources)
+	spec.Locator, spec.InlineFiles = "", files
+	spec.ExpectedSHA256 = legionInlineSourceDigest(files)
+	spec.ExpectedRevision = spec.ExpectedSHA256
+	raw, _ := json.Marshal(yakRuntimeOptions{SourceWorkspace: &spec})
+	workspace, public, err := prepareLegionCodeWorkspace(context.Background(), raw, legionCodeWorkspaceMaterializeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = workspace.Cleanup() })
+	if strings.Contains(string(public), "private-source") || strings.Contains(string(public), "inline_files") {
+		t.Fatalf("private inline source leaked into public runtime options: %s", public)
+	}
+	if workspace.sha256 != spec.ExpectedSHA256 || workspace.lockedRevision != spec.ExpectedSHA256 || workspace.files != 2 {
+		t.Fatalf("inline sources were not immutably locked: %#v", workspace)
+	}
+	read, err := workspace.read(map[string]any{"path": "src/main.yak"})
+	if err != nil || read["content"] != files["src/main.yak"] {
+		t.Fatalf("bound source read failed: %#v %v", read, err)
+	}
+	files["src/main.yak"] = "changed-by-caller"
+	if workspace.inlineFiles["src/main.yak"] != "println(\"private-source\")" {
+		t.Fatal("runtime retained mutable caller-owned source map")
+	}
+	info, err := os.Stat(filepath.Join(workspace.root, "src/main.yak"))
+	if err != nil || info.Mode().Perm()&0222 != 0 {
+		t.Fatalf("inline source file is writable: %v %v", info, err)
+	}
+	if err := validateLegionCodeWorkspaceContextPin(raw, public); err != nil {
+		t.Fatalf("sanitized public context lost immutable source pin: %v", err)
+	}
+	if err := validateLegionCodeWorkspaceContextPin(raw, raw); err == nil {
+		t.Fatal("private file bytes accepted from replay context")
+	}
+	root := workspace.root
+	if err := workspace.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("private workspace not removed: %v", err)
+	}
+}
+
+func TestLegionInlineSourceWorkspaceAllowsRequirementsOnly(t *testing.T) {
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindInlineSources)
+	spec.Locator = ""
+	workspace, err := materializeLegionInlineWorkspace(context.Background(), spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workspace.Cleanup()
+	if workspace.files != 0 || workspace.bytes != 0 || workspace.sha256 != legionRuleHash("") {
+		t.Fatalf("requirements-only workspace invalid: %#v", workspace)
+	}
+	list, err := workspace.list(nil)
+	if err != nil || list["count"] != 0 {
+		t.Fatalf("empty workspace list: %#v %v", list, err)
+	}
+}
+
+func TestLegionInlineSourceWorkspaceRejectsInvalidAndMixedSources(t *testing.T) {
+	for _, path := range []string{"../a.yak", "/a.yak", "C:/a.yak", "a\\b.yak", "./a.yak", "a/../b.yak", " a.yak", ".git/config", "a\nb.yak", strings.Repeat("a", legionInlineSourceMaxPathBytes+1)} {
+		t.Run(path, func(t *testing.T) {
+			if err := validateLegionInlineFiles(map[string]string{path: "1"}, false); err == nil {
+				t.Fatalf("unsafe inline path accepted: %q", path)
+			}
+		})
+	}
+	for _, files := range []map[string]string{
+		{"a.yak": strings.Repeat("x", legionInlineSourceMaxFileBytes+1)},
+		{"a.yak": "a\x00b"},
+		{"a.yak": string([]byte{0xff})},
+		{"dir": "1", "dir/a.yak": "2"},
+		{"A.yak": "1", "a.yak": "2"},
+	} {
+		if err := validateLegionInlineFiles(files, false); err == nil {
+			t.Fatal("invalid source content or colliding paths accepted")
+		}
+	}
+	oversized := map[string]string{}
+	for i := 0; i < 5; i++ {
+		oversized[string(rune('a'+i))+".yak"] = strings.Repeat("x", legionInlineSourceMaxFileBytes)
+	}
+	if err := validateLegionInlineFiles(oversized, false); err == nil {
+		t.Fatal("total source budget not enforced")
+	}
+	tooMany := map[string]string{}
+	for i := 0; i <= legionInlineSourceMaxFiles; i++ {
+		tooMany[string(rune('a'+i))+".yak"] = ""
+	}
+	if err := validateLegionInlineFiles(tooMany, false); err == nil {
+		t.Fatal("file count budget not enforced")
+	}
+	for _, mutate := range []func(*legionCodeWorkspaceSpec){
+		func(s *legionCodeWorkspaceSpec) { s.Locator = "https://source.invalid/repo" },
+		func(s *legionCodeWorkspaceSpec) { s.PayloadID = "managed-payload" },
+		func(s *legionCodeWorkspaceSpec) { s.Branch = "main" },
+		func(s *legionCodeWorkspaceSpec) { s.Subpath = "src" },
+		func(s *legionCodeWorkspaceSpec) { s.Auth = &legionCodeWorkspaceAuth{Token: "private"} },
+		func(s *legionCodeWorkspaceSpec) { s.Proxy = &legionCodeWorkspaceProxy{URL: "http://proxy.invalid"} },
+		func(s *legionCodeWorkspaceSpec) { s.ExpectedSHA256 = strings.Repeat("0", 64) },
+		func(s *legionCodeWorkspaceSpec) { s.ExpectedRevision = "forged-revision" },
+		func(s *legionCodeWorkspaceSpec) { s.ReadOnly = false },
+	} {
+		spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindInlineSources)
+		spec.Locator = ""
+		mutate(&spec)
+		if err := normalizeLegionCodeWorkspaceSpec(&spec); err == nil {
+			t.Fatalf("mixed/forged inline workspace accepted: %#v", spec)
+		}
+	}
+}
+
+func TestLegionInlineSamplesDoNotChangeGitWorkspaceAuthority(t *testing.T) {
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
+	spec.InlineFiles = map[string]string{"sample.yak": "println(\"private-user-sample\")"}
+	if err := normalizeLegionCodeWorkspaceSpec(&spec); err != nil {
+		t.Fatal(err)
+	}
+	public := publicLegionCodeWorkspaceSpec(spec)
+	if public.Locator != spec.Locator || public.Kind != legionCodeWorkspaceKindGit || public.InlineFiles != nil {
+		t.Fatalf("sample metadata altered Git authority or leaked: %#v", public)
+	}
+}

--- a/scannode/legion_code_workspace_revision.go
+++ b/scannode/legion_code_workspace_revision.go
@@ -1,0 +1,66 @@
+package scannode
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/yaklang/yaklang/common/utils/yakgit"
+)
+
+// restoreLegionCodeGitRevision works only in the freshly cloned, task-owned
+// checkout. A branch moving after a Run was pinned must not change retry input.
+// Fetch exactly the pinned commit when the shallow clone does not contain it;
+// never fall back to HEAD or download unbounded history to hide a missing pin.
+func restoreLegionCodeGitRevision(ctx context.Context, local, revision string, opts ...yakgit.Option) error {
+	revision = strings.ToLower(strings.TrimSpace(revision))
+	decoded, err := hex.DecodeString(revision)
+	if err != nil || len(decoded) != 20 || revision == strings.Repeat("0", 40) {
+		return fmt.Errorf("source_workspace revision mismatch: expected revision must be a full commit hash")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	repository, err := git.PlainOpen(local)
+	if err != nil {
+		return fmt.Errorf("source_workspace revision mismatch: task checkout is unavailable")
+	}
+	hash := plumbing.NewHash(revision)
+	if _, err := repository.CommitObject(hash); err != nil {
+		if !errors.Is(err, plumbing.ErrObjectNotFound) {
+			return fmt.Errorf("source_workspace revision mismatch: pinned commit is unreadable")
+		}
+		err = yakgit.FetchExactRevision(ctx, local, revision, opts...)
+		if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// Transport errors can contain private remote/proxy details.
+			return fmt.Errorf("source_workspace revision mismatch: pinned commit cannot be fetched from origin")
+		}
+		// FetchExactRevision opens its own storage. Reopen here so an earlier
+		// missing-object lookup cannot retain the pre-fetch pack index.
+		repository, err = git.PlainOpen(local)
+		if err != nil {
+			return fmt.Errorf("source_workspace revision mismatch: fetched checkout is unavailable")
+		}
+		if _, err := repository.CommitObject(hash); err != nil {
+			return fmt.Errorf("source_workspace revision mismatch: pinned commit is unavailable")
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	worktree, err := repository.Worktree()
+	if err != nil {
+		return fmt.Errorf("source_workspace revision mismatch: task worktree is unavailable")
+	}
+	if err := worktree.Checkout(&git.CheckoutOptions{Hash: hash, Force: true}); err != nil {
+		return fmt.Errorf("source_workspace revision mismatch: pinned commit cannot be checked out")
+	}
+	return ctx.Err()
+}

--- a/scannode/legion_code_workspace_revision_test.go
+++ b/scannode/legion_code_workspace_revision_test.go
@@ -1,0 +1,98 @@
+package scannode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/yaklang/yaklang/common/utils/yakgit"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssagitworkdir"
+)
+
+func TestLegionCodeWorkspaceGitRestoresPinnedRevisionAfterBranchMoves(t *testing.T) {
+	managedRoot := t.TempDir()
+	t.Setenv(ssagitworkdir.WorkDirEnv, managedRoot)
+	t.Setenv(ssagitworkdir.MinFreeBytesEnv, "0")
+	source, originalRevision := createLocalGitRepository(t)
+	repository, err := git.PlainOpen(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := repository.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Raw.Section("uploadpack").SetOption("allowReachableSHA1InWant", "true")
+	if err := repository.SetConfig(config); err != nil {
+		t.Fatal(err)
+	}
+	worktree, err := repository.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "main.go"), []byte("package main\n// changed after the original run\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := worktree.Add("main.go"); err != nil {
+		t.Fatal(err)
+	}
+	latestRevision, err := worktree.Commit("move branch", &git.CommitOptions{Author: &object.Signature{
+		Name: "Test", Email: "test@example.invalid", When: time.Unix(2, 0),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalClone := cloneLegionCodeGitWorkspace
+	cloneLegionCodeGitWorkspace = func(_ string, local string, _ ...yakgit.Option) error {
+		cloned, err := git.PlainClone(local, false, &git.CloneOptions{URL: source, Depth: 1})
+		if err != nil {
+			return err
+		}
+		head, err := cloned.Head()
+		if err != nil || head.Hash() != latestRevision {
+			t.Fatalf("fixture did not clone the moved branch: %v", err)
+		}
+		if _, err := cloned.CommitObject(plumbing.NewHash(originalRevision)); !errors.Is(err, plumbing.ErrObjectNotFound) {
+			t.Fatalf("fixture must require fetching the historical commit, got %v", err)
+		}
+		return nil
+	}
+	t.Cleanup(func() { cloneLegionCodeGitWorkspace = originalClone })
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
+	spec.ExpectedRevision = originalRevision
+	workspace, err := materializeLegionCodeGitWorkspace(context.Background(), spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = workspace.Cleanup() })
+	content, err := os.ReadFile(filepath.Join(workspace.root, "main.go"))
+	if err != nil || string(content) != "package main\n" || workspace.lockedRevision != originalRevision {
+		t.Fatalf("retry did not recover the original input: revision=%s content=%q err=%v", workspace.lockedRevision, content, err)
+	}
+	if err := workspace.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(workspace.root); !os.IsNotExist(err) {
+		t.Fatalf("pinned workspace was not cleaned: %v", err)
+	}
+}
+
+func TestLegionCodeWorkspaceGitRevisionRejectsSymbolicInvalidAndCancelledPins(t *testing.T) {
+	for _, revision := range []string{"HEAD", "main", "HEAD~1", strings.Repeat("0", 40), strings.Repeat("z", 40), "1234567"} {
+		if err := restoreLegionCodeGitRevision(context.Background(), t.TempDir(), revision); err == nil || !strings.Contains(err.Error(), "revision mismatch") {
+			t.Fatalf("accepted invalid revision %q: %v", revision, err)
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := restoreLegionCodeGitRevision(ctx, t.TempDir(), strings.Repeat("a", 40)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled restoration lost cancellation: %v", err)
+	}
+}

--- a/scannode/legion_code_workspace_test.go
+++ b/scannode/legion_code_workspace_test.go
@@ -104,6 +104,21 @@ func TestLegionCodeWorkspaceIDRequiresFrozenFormat(t *testing.T) {
 	}
 }
 
+func TestLegionCodeWorkspaceValidatesSyntaxFlowMode(t *testing.T) {
+	for _, mode := range []string{"", "create", "improve"} {
+		spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
+		spec.SyntaxFlowMode = mode
+		if err := normalizeLegionCodeWorkspaceSpec(&spec); err != nil {
+			t.Fatalf("valid syntaxflow_mode %q rejected: %v", mode, err)
+		}
+	}
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
+	spec.SyntaxFlowMode = "publish"
+	if err := normalizeLegionCodeWorkspaceSpec(&spec); err == nil || !strings.Contains(err.Error(), "syntaxflow_mode is invalid") {
+		t.Fatalf("invalid syntaxflow_mode accepted: %v", err)
+	}
+}
+
 func TestLegionCodeWorkspaceLocatorRejectsPublicCredentialLeaks(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -372,6 +387,7 @@ func TestPrepareLegionCodeWorkspaceSanitizesBackendAuthAndProxy(t *testing.T) {
 	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
 	spec.Locator = "https://source.invalid/repository.git"
 	spec.ExpectedRevision = revision
+	spec.SyntaxFlowMode = "improve"
 	spec.Auth = &legionCodeWorkspaceAuth{
 		Kind: "token", UserName: "backend-user", Password: "backend-token",
 	}
@@ -401,8 +417,12 @@ func TestPrepareLegionCodeWorkspaceSanitizesBackendAuthAndProxy(t *testing.T) {
 	if publicOptions.SourceWorkspace == nil || publicOptions.SourceWorkspace.Auth != nil || publicOptions.SourceWorkspace.Proxy != nil {
 		t.Fatalf("public source workspace retained credentials: %s", publicRaw)
 	}
-	if publicOptions.SourceWorkspace.WorkspaceID != spec.WorkspaceID || publicOptions.SourceWorkspace.ExpectedRevision != revision {
+	if publicOptions.SourceWorkspace.WorkspaceID != spec.WorkspaceID || publicOptions.SourceWorkspace.ExpectedRevision != revision || publicOptions.SourceWorkspace.SyntaxFlowMode != "improve" {
 		t.Fatalf("public source workspace lost its pin: %#v", publicOptions.SourceWorkspace)
+	}
+	info := workspace.info()["source_workspace"].(map[string]any)
+	if info["syntaxflow_mode"] != "improve" {
+		t.Fatalf("trusted source workspace info lost SyntaxFlow mode: %#v", info)
 	}
 }
 
@@ -715,12 +735,19 @@ func TestStatelessCodeWorkspacePinRejectsMismatchAndPrivateFields(t *testing.T) 
 	bound := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
 	bound.ExpectedRevision = strings.Repeat("a", 40)
 	bound.ExpectedSHA256 = strings.Repeat("b", 64)
+	bound.SyntaxFlowMode = "improve"
 	bindRaw, _ := json.Marshal(yakRuntimeOptions{SourceWorkspace: &bound})
 	public := bound
 	contextRaw, _ := json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err != nil {
 		t.Fatalf("matching pin rejected: %v", err)
 	}
+	public.SyntaxFlowMode = "create"
+	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
+	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected SyntaxFlow mode pin mismatch, got %v", err)
+	}
+	public = bound
 	public.ExpectedRevision = strings.Repeat("c", 40)
 	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {

--- a/scannode/legion_code_workspace_test.go
+++ b/scannode/legion_code_workspace_test.go
@@ -108,12 +108,16 @@ func TestLegionCodeWorkspaceValidatesSyntaxFlowMode(t *testing.T) {
 	for _, mode := range []string{"", "create", "improve"} {
 		spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
 		spec.SyntaxFlowMode = mode
+		if mode != "" {
+			spec.SyntaxFlowLanguage = "java"
+		}
 		if err := normalizeLegionCodeWorkspaceSpec(&spec); err != nil {
 			t.Fatalf("valid syntaxflow_mode %q rejected: %v", mode, err)
 		}
 	}
 	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
 	spec.SyntaxFlowMode = "publish"
+	spec.SyntaxFlowLanguage = "java"
 	if err := normalizeLegionCodeWorkspaceSpec(&spec); err == nil || !strings.Contains(err.Error(), "syntaxflow_mode is invalid") {
 		t.Fatalf("invalid syntaxflow_mode accepted: %v", err)
 	}
@@ -125,6 +129,10 @@ func TestLegionCodeWorkspaceValidatesTrustedSyntaxFlowOriginalRule(t *testing.T)
 	spec.SyntaxFlowMode = "improve"
 	spec.SyntaxFlowOriginalRule = original
 	spec.SyntaxFlowOriginalRuleSHA256 = legionRuleHash(original)
+	spec.SyntaxFlowLanguage = "java"
+	spec.SyntaxFlowOriginalSamplePath = "negative/Sample.java"
+	spec.InlineFiles = map[string]string{spec.SyntaxFlowOriginalSamplePath: "class Negative {}"}
+	spec.SyntaxFlowOriginalSampleSHA256 = legionInlineSourceDigest(spec.InlineFiles)
 	spec.SyntaxFlowRequireOriginalReproduction = true
 	if err := normalizeLegionCodeWorkspaceSpec(&spec); err != nil {
 		t.Fatalf("valid original rule pin rejected: %v", err)
@@ -134,6 +142,14 @@ func TestLegionCodeWorkspaceValidatesTrustedSyntaxFlowOriginalRule(t *testing.T)
 		"invalid hash":       func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalRuleSHA256 = strings.Repeat("z", 64) },
 		"hash mismatch":      func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalRuleSHA256 = strings.Repeat("a", 64) },
 		"missing rule bytes": func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalRule = "" },
+		"invalid sample hash": func(value *legionCodeWorkspaceSpec) {
+			value.SyntaxFlowOriginalSampleSHA256 = strings.Repeat("z", 64)
+		},
+		"missing sample hash": func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalSampleSHA256 = "" },
+		"missing sample path": func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalSamplePath = "" },
+		"sample digest mismatch": func(value *legionCodeWorkspaceSpec) {
+			value.SyntaxFlowOriginalSampleSHA256 = strings.Repeat("a", 64)
+		},
 		"oversized rule": func(value *legionCodeWorkspaceSpec) {
 			value.SyntaxFlowOriginalRule = strings.Repeat("a", legionSyntaxFlowMaxRuleBytes+1)
 		},
@@ -420,6 +436,10 @@ func TestPrepareLegionCodeWorkspaceSanitizesBackendAuthAndProxy(t *testing.T) {
 	spec.SyntaxFlowMode = "improve"
 	spec.SyntaxFlowOriginalRule = "exec(,* as $arg,)\nalert $arg"
 	spec.SyntaxFlowOriginalRuleSHA256 = legionRuleHash(spec.SyntaxFlowOriginalRule)
+	spec.SyntaxFlowLanguage = "java"
+	spec.SyntaxFlowOriginalSamplePath = "negative/Sample.java"
+	spec.InlineFiles = map[string]string{spec.SyntaxFlowOriginalSamplePath: "class Negative {}"}
+	spec.SyntaxFlowOriginalSampleSHA256 = legionInlineSourceDigest(spec.InlineFiles)
 	spec.SyntaxFlowRequireOriginalReproduction = true
 	spec.Auth = &legionCodeWorkspaceAuth{
 		Kind: "token", UserName: "backend-user", Password: "backend-token",
@@ -452,12 +472,16 @@ func TestPrepareLegionCodeWorkspaceSanitizesBackendAuthAndProxy(t *testing.T) {
 	}
 	if publicOptions.SourceWorkspace.WorkspaceID != spec.WorkspaceID || publicOptions.SourceWorkspace.ExpectedRevision != revision || publicOptions.SourceWorkspace.SyntaxFlowMode != "improve" ||
 		publicOptions.SourceWorkspace.SyntaxFlowOriginalRule != "" || publicOptions.SourceWorkspace.SyntaxFlowOriginalRuleSHA256 != spec.SyntaxFlowOriginalRuleSHA256 ||
+		publicOptions.SourceWorkspace.SyntaxFlowLanguage != "java" || publicOptions.SourceWorkspace.SyntaxFlowOriginalSamplePath != spec.SyntaxFlowOriginalSamplePath ||
+		publicOptions.SourceWorkspace.SyntaxFlowOriginalSampleSHA256 != spec.SyntaxFlowOriginalSampleSHA256 ||
 		!publicOptions.SourceWorkspace.SyntaxFlowRequireOriginalReproduction {
 		t.Fatalf("public source workspace lost its pin: %#v", publicOptions.SourceWorkspace)
 	}
 	info := workspace.info()["source_workspace"].(map[string]any)
 	if info["syntaxflow_mode"] != "improve" || info["syntaxflow_original_rule"] != spec.SyntaxFlowOriginalRule ||
-		info["syntaxflow_original_rule_sha256"] != spec.SyntaxFlowOriginalRuleSHA256 || info["syntaxflow_require_original_reproduction"] != true {
+		info["syntaxflow_original_rule_sha256"] != spec.SyntaxFlowOriginalRuleSHA256 || info["syntaxflow_language"] != "java" ||
+		info["syntaxflow_original_sample_path"] != spec.SyntaxFlowOriginalSamplePath || info["syntaxflow_original_sample_sha256"] != spec.SyntaxFlowOriginalSampleSHA256 ||
+		info["syntaxflow_require_original_reproduction"] != true {
 		t.Fatalf("trusted source workspace info lost SyntaxFlow mode: %#v", info)
 	}
 }
@@ -774,6 +798,9 @@ func TestStatelessCodeWorkspacePinRejectsMismatchAndPrivateFields(t *testing.T) 
 	bound.SyntaxFlowMode = "improve"
 	bound.SyntaxFlowOriginalRule = "exec(,* as $arg,)\nalert $arg"
 	bound.SyntaxFlowOriginalRuleSHA256 = legionRuleHash(bound.SyntaxFlowOriginalRule)
+	bound.SyntaxFlowLanguage = "java"
+	bound.SyntaxFlowOriginalSamplePath = "negative/Sample.java"
+	bound.SyntaxFlowOriginalSampleSHA256 = strings.Repeat("b", 64)
 	bound.SyntaxFlowRequireOriginalReproduction = true
 	bindRaw, _ := json.Marshal(yakRuntimeOptions{SourceWorkspace: &bound})
 	public := publicLegionCodeWorkspaceSpec(bound)
@@ -797,6 +824,24 @@ func TestStatelessCodeWorkspacePinRejectsMismatchAndPrivateFields(t *testing.T) 
 	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
 		t.Fatalf("expected original reproduction pin mismatch, got %v", err)
+	}
+	public = publicLegionCodeWorkspaceSpec(bound)
+	public.SyntaxFlowLanguage = "python"
+	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
+	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected SyntaxFlow language pin mismatch, got %v", err)
+	}
+	public = publicLegionCodeWorkspaceSpec(bound)
+	public.SyntaxFlowOriginalSampleSHA256 = strings.Repeat("c", 64)
+	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
+	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected original sample pin mismatch, got %v", err)
+	}
+	public = publicLegionCodeWorkspaceSpec(bound)
+	public.SyntaxFlowOriginalSamplePath = "negative/Other.java"
+	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
+	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected original sample path pin mismatch, got %v", err)
 	}
 	public = publicLegionCodeWorkspaceSpec(bound)
 	public.SyntaxFlowOriginalRule = bound.SyntaxFlowOriginalRule

--- a/scannode/legion_code_workspace_test.go
+++ b/scannode/legion_code_workspace_test.go
@@ -119,6 +119,36 @@ func TestLegionCodeWorkspaceValidatesSyntaxFlowMode(t *testing.T) {
 	}
 }
 
+func TestLegionCodeWorkspaceValidatesTrustedSyntaxFlowOriginalRule(t *testing.T) {
+	const original = "exec(,* as $arg,)\nalert $arg"
+	spec := validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit)
+	spec.SyntaxFlowMode = "improve"
+	spec.SyntaxFlowOriginalRule = original
+	spec.SyntaxFlowOriginalRuleSHA256 = legionRuleHash(original)
+	spec.SyntaxFlowRequireOriginalReproduction = true
+	if err := normalizeLegionCodeWorkspaceSpec(&spec); err != nil {
+		t.Fatalf("valid original rule pin rejected: %v", err)
+	}
+
+	for name, mutate := range map[string]func(*legionCodeWorkspaceSpec){
+		"invalid hash":       func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalRuleSHA256 = strings.Repeat("z", 64) },
+		"hash mismatch":      func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalRuleSHA256 = strings.Repeat("a", 64) },
+		"missing rule bytes": func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowOriginalRule = "" },
+		"oversized rule": func(value *legionCodeWorkspaceSpec) {
+			value.SyntaxFlowOriginalRule = strings.Repeat("a", legionSyntaxFlowMaxRuleBytes+1)
+		},
+		"create reproduction": func(value *legionCodeWorkspaceSpec) { value.SyntaxFlowMode = "create" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			invalid := spec
+			mutate(&invalid)
+			if err := normalizeLegionCodeWorkspaceSpec(&invalid); err == nil {
+				t.Fatal("invalid original rule pin accepted")
+			}
+		})
+	}
+}
+
 func TestLegionCodeWorkspaceLocatorRejectsPublicCredentialLeaks(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -388,6 +418,9 @@ func TestPrepareLegionCodeWorkspaceSanitizesBackendAuthAndProxy(t *testing.T) {
 	spec.Locator = "https://source.invalid/repository.git"
 	spec.ExpectedRevision = revision
 	spec.SyntaxFlowMode = "improve"
+	spec.SyntaxFlowOriginalRule = "exec(,* as $arg,)\nalert $arg"
+	spec.SyntaxFlowOriginalRuleSHA256 = legionRuleHash(spec.SyntaxFlowOriginalRule)
+	spec.SyntaxFlowRequireOriginalReproduction = true
 	spec.Auth = &legionCodeWorkspaceAuth{
 		Kind: "token", UserName: "backend-user", Password: "backend-token",
 	}
@@ -417,11 +450,14 @@ func TestPrepareLegionCodeWorkspaceSanitizesBackendAuthAndProxy(t *testing.T) {
 	if publicOptions.SourceWorkspace == nil || publicOptions.SourceWorkspace.Auth != nil || publicOptions.SourceWorkspace.Proxy != nil {
 		t.Fatalf("public source workspace retained credentials: %s", publicRaw)
 	}
-	if publicOptions.SourceWorkspace.WorkspaceID != spec.WorkspaceID || publicOptions.SourceWorkspace.ExpectedRevision != revision || publicOptions.SourceWorkspace.SyntaxFlowMode != "improve" {
+	if publicOptions.SourceWorkspace.WorkspaceID != spec.WorkspaceID || publicOptions.SourceWorkspace.ExpectedRevision != revision || publicOptions.SourceWorkspace.SyntaxFlowMode != "improve" ||
+		publicOptions.SourceWorkspace.SyntaxFlowOriginalRule != "" || publicOptions.SourceWorkspace.SyntaxFlowOriginalRuleSHA256 != spec.SyntaxFlowOriginalRuleSHA256 ||
+		!publicOptions.SourceWorkspace.SyntaxFlowRequireOriginalReproduction {
 		t.Fatalf("public source workspace lost its pin: %#v", publicOptions.SourceWorkspace)
 	}
 	info := workspace.info()["source_workspace"].(map[string]any)
-	if info["syntaxflow_mode"] != "improve" {
+	if info["syntaxflow_mode"] != "improve" || info["syntaxflow_original_rule"] != spec.SyntaxFlowOriginalRule ||
+		info["syntaxflow_original_rule_sha256"] != spec.SyntaxFlowOriginalRuleSHA256 || info["syntaxflow_require_original_reproduction"] != true {
 		t.Fatalf("trusted source workspace info lost SyntaxFlow mode: %#v", info)
 	}
 }
@@ -736,8 +772,11 @@ func TestStatelessCodeWorkspacePinRejectsMismatchAndPrivateFields(t *testing.T) 
 	bound.ExpectedRevision = strings.Repeat("a", 40)
 	bound.ExpectedSHA256 = strings.Repeat("b", 64)
 	bound.SyntaxFlowMode = "improve"
+	bound.SyntaxFlowOriginalRule = "exec(,* as $arg,)\nalert $arg"
+	bound.SyntaxFlowOriginalRuleSHA256 = legionRuleHash(bound.SyntaxFlowOriginalRule)
+	bound.SyntaxFlowRequireOriginalReproduction = true
 	bindRaw, _ := json.Marshal(yakRuntimeOptions{SourceWorkspace: &bound})
-	public := bound
+	public := publicLegionCodeWorkspaceSpec(bound)
 	contextRaw, _ := json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err != nil {
 		t.Fatalf("matching pin rejected: %v", err)
@@ -747,19 +786,37 @@ func TestStatelessCodeWorkspacePinRejectsMismatchAndPrivateFields(t *testing.T) 
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
 		t.Fatalf("expected SyntaxFlow mode pin mismatch, got %v", err)
 	}
-	public = bound
+	public = publicLegionCodeWorkspaceSpec(bound)
+	public.SyntaxFlowOriginalRuleSHA256 = strings.Repeat("c", 64)
+	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
+	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected original rule hash pin mismatch, got %v", err)
+	}
+	public = publicLegionCodeWorkspaceSpec(bound)
+	public.SyntaxFlowRequireOriginalReproduction = false
+	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
+	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected original reproduction pin mismatch, got %v", err)
+	}
+	public = publicLegionCodeWorkspaceSpec(bound)
+	public.SyntaxFlowOriginalRule = bound.SyntaxFlowOriginalRule
+	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
+	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "original rule bytes") {
+		t.Fatalf("expected private original rule context rejection, got %v", err)
+	}
+	public = publicLegionCodeWorkspaceSpec(bound)
 	public.ExpectedRevision = strings.Repeat("c", 40)
 	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "does not match") {
 		t.Fatalf("expected pin mismatch, got %v", err)
 	}
-	public = bound
+	public = publicLegionCodeWorkspaceSpec(bound)
 	public.Auth = &legionCodeWorkspaceAuth{Kind: "token", Password: "secret"}
 	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "must not contain") {
 		t.Fatalf("expected private context rejection, got %v", err)
 	}
-	public = bound
+	public = publicLegionCodeWorkspaceSpec(bound)
 	public.Locator = "https://source.invalid/repository.git?access_token=backend-token"
 	contextRaw, _ = json.Marshal(yakRuntimeOptions{SourceWorkspace: &public})
 	if err := validateLegionCodeWorkspaceContextPin(bindRaw, contextRaw); err == nil || !strings.Contains(err.Error(), "locator is invalid") {


### PR DESCRIPTION
## 改动摘要

为 Legion 的“SyntaxFlow 规则开发”专业任务提供受控的 Yaklang Node 执行能力，使 AI 能在只读源码范围内编写规则、执行真实 SyntaxFlow 调试，并返回可由平台校验的结构化证据。

- 新增 `ai.syntaxflow_rule.v1` 能力和有界调试运行时，限制语言、文件数量、源码大小、规则大小、匹配数和执行时间。
- 支持上传项目源码、固定 Git revision 和内联源码样例，并保持工作区只读和任务级隔离。
- 返回规则 SHA-256、源码类型、样例来源、匹配位置和预期结果，供 Legion 校验最终候选规则。
- 改进模式绑定任务目标、原规则字节和指定负样例，可先复现原规则误报，再验证候选规则正负回归结果。
- 加固精确 Git revision 获取：隔离 clone/fetch 传输配置，保留显式 SSH/SOCKS 代理，并在失败或取消后恢复全局传输状态。
- 加固 SyntaxFlow 原生调用边界，避免规则通过不受允许的原生能力执行客户代码。

## 改动文件

- `scannode/legion_ai_syntaxflow_*`：SyntaxFlow 任务合同、运行时、候选结果与调试证据。
- `scannode/legion_code_workspace*`：内联源码、固定 revision 和只读工作区。
- `common/utils/yakgit`：精确 revision 获取与代理/传输隔离。
- `common/syntaxflow/sfvm`：原生调用安全边界。
- `common/yak/ssaapi`：任务级 SSA 编译配置与文件系统支持。

## 验证方式

- 当前提交：`699c0a5894e3ad2ddfcf4ca39456eecabed99b97`，已 rebase 到最新 `origin/main`。
- `go build -o <临时路径>/yak-current ./common/yak/cmd`，通过。
- `go test ./scannode -count=1`，通过。
- `go test ./common/syntaxflow/sfvm ./common/yak/ssaapi -count=1`，通过。
- `go test ./common/utils/yakgit -run 'Test(FetchExactRevision|CloneCannotUseAnotherFetchProxy|BuildCloneOptions|CloneReferenceName|WithSingleBranchOption|NewGitHTTPClient|CloneDefaultTimeoutConstant|CloneContextOptionPreservesCallerDeadline|SnapshotRestoreProtocolTransports)' -count=1`，通过。
- 整个 `common/utils/yakgit` 包中的既有 `TestBlameLocalTest` 依赖硬编码的 macOS 本地绝对路径，在当前 Linux 环境失败；本 PR 涉及的精确 revision、clone 与代理隔离用例均单独通过。
- 与配套 Legion 分支完成正式本地 T2：真实 Provider 驱动创建和改进任务；原规则在负样例上复现 1 次，最终候选规则正样例匹配 1 次、负样例匹配 0 次；结果回写、候选保存、权限和取消边界通过。
- rebase range-diff 显示七个功能补丁语义保持一致；最新主干的 SSA MinIO 上传调整无冲突合入。

## 边界

- 本能力只执行 SyntaxFlow 规则和受控 SSA 编译，不执行客户项目代码。
- 调试证据只覆盖显式选择的源码与样例，不扩展为全项目扫描结论。
- 本 PR 保持 Draft，不包含合并、发版或节点发布操作。
