### PR TITLE
feat(aireact): add WithDisableMemoryTriage option to skip memory triage

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -293,7 +293,8 @@ type Config struct {
 	TimelineTotalContentLimit int // in tokens
 
 	// triage
-	MemoryTriage MemoryTriage
+	MemoryTriage        MemoryTriage
+	DisableMemoryTriage bool // 禁用 Memory Triage（智能记忆处理），默认为 false（即默认启用）
 
 	TimelineArchiveStore TimelineArchiveStore
 	MemoryPoolSize       int64
@@ -2305,6 +2306,23 @@ func WithMemoryTriage(mt MemoryTriage) ConfigOption {
 
 func WithNoOpMemoryTriage() ConfigOption {
 	return WithMemoryTriage(NewNoOpMemoryTriage())
+}
+
+// WithDisableMemoryTriage disables the built-in memory triage (intelligent memory
+// processing). When enabled, a no-op MemoryTriage is installed instead of the
+// default AIMemory instance, so no embedding/DB/AI calls are made for memory.
+// This is useful for lightweight or stateless sessions where memory overhead
+// is undesired.
+func WithDisableMemoryTriage(disable bool) ConfigOption {
+	return func(c *Config) error {
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		c.DisableMemoryTriage = disable
+		c.m.Unlock()
+		return nil
+	}
 }
 
 func WithMemoryPoolSize(sz int64) ConfigOption {

--- a/common/ai/aid/aireact/disable_memory_triage_test.go
+++ b/common/ai/aid/aireact/disable_memory_triage_test.go
@@ -1,0 +1,183 @@
+package aireact
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aimem"
+	"github.com/yaklang/yaklang/common/jsonpath"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// TestDisableMemoryTriage_InstallsNoOp verifies that when
+// WithDisableMemoryTriage(true) is passed, the ReAct instance uses a
+// no-op MemoryTriage instead of creating a real AIMemory (which would
+// require embedding/DB/AI calls).
+func TestDisableMemoryTriage_InstallsNoOp(t *testing.T) {
+	in := make(chan *ypb.AIInputEvent, 10)
+	out := make(chan *ypb.AIOutputEvent, 10)
+
+	ins, err := NewReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			return mockedFreeInputOutput(i, "disable-mem-flag")
+		}),
+		aicommon.WithEventInputChan(in),
+		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
+			out <- e.ToGRPC()
+		}),
+		aicommon.WithDisallowMCPServers(true),
+		aicommon.WithDisableSessionTitleGeneration(true),
+		aicommon.WithDisableIntentRecognition(true),
+		aicommon.WithDisablePerception(true),
+		aicommon.WithDisableAutoSkills(true),
+		aicommon.WithGenerateReport(false),
+		aicommon.WithDisableDynamicPlanning(true),
+		aicommon.WithPeriodicVerificationInterval(0),
+		aicommon.WithDisableIncreaseIteration(true),
+		// The key option under test:
+		aicommon.WithDisableMemoryTriage(true),
+	)
+	require.NoError(t, err)
+
+	// The memory triage must be a no-op, not a real AIMemory.
+	require.NotNil(t, ins.memoryTriage)
+	require.Equal(t, "noop", ins.memoryTriage.GetSessionID())
+
+	// No-op memory triage methods should all return empty/nil without error.
+	entities, err := ins.memoryTriage.AddRawText("some text")
+	require.NoError(t, err)
+	require.Empty(t, entities)
+
+	results, err := ins.memoryTriage.SearchBySemantics("query", 5)
+	require.NoError(t, err)
+	require.Empty(t, results)
+
+	tagResults, err := ins.memoryTriage.SearchByTags([]string{"tag"}, false, 5)
+	require.NoError(t, err)
+	require.Empty(t, tagResults)
+
+	require.NoError(t, ins.memoryTriage.HandleMemory("anything"))
+
+	smResult, err := ins.memoryTriage.SearchMemory("query", 1000)
+	require.NoError(t, err)
+	require.NotNil(t, smResult)
+	require.Empty(t, smResult.Memories)
+
+	noAIResult, err := ins.memoryTriage.SearchMemoryWithoutAI("query", 1000)
+	require.NoError(t, err)
+	require.NotNil(t, noAIResult)
+	require.Empty(t, noAIResult.Memories)
+
+	require.NoError(t, ins.memoryTriage.Close())
+
+	// Ensure config also reflects the no-op.
+	require.NotNil(t, ins.config.MemoryTriage)
+	require.Equal(t, "noop", ins.config.MemoryTriage.GetSessionID())
+}
+
+// TestDisableMemoryTriage_FullLoop verifies that a complete ReAct loop
+// (free input → directly answer → finish) works correctly when memory
+// triage is disabled. The task should complete without any memory-related
+// errors.
+func TestDisableMemoryTriage_FullLoop(t *testing.T) {
+	flag := ksuid.New().String()
+	in := make(chan *ypb.AIInputEvent, 10)
+	out := make(chan *ypb.AIOutputEvent, 10)
+
+	// NewTestReAct already injects WithMemoryTriage(MockMemoryTriage) in its
+	// basic options. Passing WithDisableMemoryTriage(true) after that should
+	// override it with NoOp — this is the priority we want to verify.
+	ins, err := NewTestReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			return mockedFreeInputOutput(i, flag)
+		}),
+		aicommon.WithDebug(false),
+		aicommon.WithEventInputChan(in),
+		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
+			out <- e.ToGRPC()
+		}),
+		aicommon.WithDisableMemoryTriage(true),
+	)
+	require.NoError(t, err)
+
+	// Confirm memory triage is disabled (NoOp), even though NewTestReAct
+	// injected a MockMemoryTriage earlier.
+	require.Equal(t, "noop", ins.memoryTriage.GetSessionID())
+
+	go func() {
+		in <- &ypb.AIInputEvent{
+			IsFreeInput: true,
+			FreeInput:   "abc",
+		}
+		close(in)
+	}()
+
+	after := time.After(15 * time.Second)
+	haveResult := false
+
+LOOP:
+	for {
+		select {
+		case e := <-out:
+			if e.NodeId == "result" {
+				result := jsonpath.FindFirst(e.GetContent(), "$..result")
+				if utils.InterfaceToString(result) == flag || bytes.Contains([]byte(e.GetContent()), []byte(flag)) {
+					haveResult = true
+					break LOOP
+				}
+			}
+			if e.NodeId == "react_task_status_changed" {
+				result := jsonpath.FindFirst(e.GetContent(), "$..react_task_now_status")
+				status := utils.InterfaceToString(result)
+				if status == "completed" || status == "failed" {
+					break LOOP
+				}
+			}
+		case <-after:
+			break LOOP
+		}
+	}
+
+	require.True(t, haveResult, "Expected to have at least one result event containing the flag")
+}
+
+// TestDisableMemoryTriage_OverridesExplicitMemoryTriage verifies that
+// DisableMemoryTriage=true takes priority over an explicitly provided
+// MemoryTriage (e.g. via WithMemoryTriage). This ensures the disable
+// flag is always authoritative.
+func TestDisableMemoryTriage_OverridesExplicitMemoryTriage(t *testing.T) {
+	in := make(chan *ypb.AIInputEvent, 10)
+
+	mockMT := aimem.NewMockMemoryTriage()
+
+	ins, err := NewReAct(
+		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			return mockedFreeInputOutput(i, "override-flag")
+		}),
+		aicommon.WithEventInputChan(in),
+		aicommon.WithDisallowMCPServers(true),
+		aicommon.WithDisableSessionTitleGeneration(true),
+		aicommon.WithDisableIntentRecognition(true),
+		aicommon.WithDisablePerception(true),
+		aicommon.WithDisableAutoSkills(true),
+		aicommon.WithGenerateReport(false),
+		aicommon.WithDisableDynamicPlanning(true),
+		aicommon.WithPeriodicVerificationInterval(0),
+		aicommon.WithDisableIncreaseIteration(true),
+		// Explicitly provide a mock memory triage...
+		aicommon.WithMemoryTriage(mockMT),
+		// ...but also disable memory triage. Disable should win.
+		aicommon.WithDisableMemoryTriage(true),
+	)
+	require.NoError(t, err)
+
+	// The instance should use no-op, not the mock.
+	require.NotNil(t, ins.memoryTriage)
+	require.Equal(t, "noop", ins.memoryTriage.GetSessionID())
+}

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -256,7 +256,11 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 	}
 
 	memoryLoadStart := time.Now()
-	if cfg.MemoryTriage != nil {
+	if cfg.DisableMemoryTriage {
+		react.memoryTriage = aicommon.NewNoOpMemoryTriage()
+		react.config.MemoryTriage = react.memoryTriage
+		log.Infof("memory triage disabled (no-op) for ReAct instance: %s", react.config.Id)
+	} else if cfg.MemoryTriage != nil {
 		react.memoryTriage = cfg.MemoryTriage
 	} else {
 		memoryTriageId := cfg.MemoryTriageId

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -691,7 +691,11 @@ func BuildReActInvoker(ctx context.Context, options ...aicommon.ConfigOption) (a
 		cfg.SetBrowserSessionTracker(invoker)
 	}
 
-	if cfg.MemoryTriage != nil {
+	if cfg.DisableMemoryTriage {
+		invoker.memoryTriage = aicommon.NewNoOpMemoryTriage()
+		invoker.config.MemoryTriage = invoker.memoryTriage
+		log.Infof("memory triage disabled (no-op) for invoker instance")
+	} else if cfg.MemoryTriage != nil {
 		invoker.memoryTriage = cfg.MemoryTriage
 	} else {
 		memoryTriageId := cfg.MemoryTriageId


### PR DESCRIPTION
## Summary

为 ReAct 的 memory triage 初始化添加一个可配置开关 `WithDisableMemoryTriage(true)`，开启后安装 NoOp 实现而非创建真实 AIMemory，跳过 embedding/DB/AI 调用。

## Problem

`re-act.go:259` 和 `re-act_mainloop.go:694` 处的 memory triage 初始化**无条件**创建真实 `AIMemory` 实例（涉及 embedding/DB/AI 调用），没有开关可以在运行时关闭。对于轻量级或无状态会话，这些开销是不必要的。

## Changes

| 文件 | 改动 |
|---|---|
| `aicommon/config.go` | 新增 `DisableMemoryTriage bool` 字段 + `WithDisableMemoryTriage(bool)` ConfigOption |
| `aireact/re-act.go` | `NewReAct` memory triage 初始化入口增加 `DisableMemoryTriage` 检查分支 |
| `aireact/re-act_mainloop.go` | `BuildReActInvoker` 同样处理 |
| `aireact/disable_memory_triage_test.go` | 新增 3 个测试用例 |

## Design

- **优先级最高**：`DisableMemoryTriage` 判断在 `cfg.MemoryTriage != nil` 之前，即使外部已传入 `WithMemoryTriage(...)`，Disable 标志也能权威覆盖
- **零侵入**：NoOp 实现所有方法为空操作，不影响主循环逻辑
- **符合现有模式**：与 `DisallowMCPServers`、`DisableWebSearch`、`DisableAutoSkills` 等已有开关一致

## Usage

```go
react, err := aireact.NewReAct(
    aicommon.WithDisableMemoryTriage(true),
    // ... 其他配置
)
```

## Tests

- ✅ `TestDisableMemoryTriage_InstallsNoOp` — 验证 NoOp 安装 + 所有接口方法空操作
- ✅ `TestDisableMemoryTriage_FullLoop` — 端到端验证 ReAct 循环在禁用 memory 后正常执行
- ✅ `TestDisableMemoryTriage_OverridesExplicitMemoryTriage` — 验证 Disable 优先级高于显式传入的 MemoryTriage

```
=== RUN   TestDisableMemoryTriage_InstallsNoOp
--- PASS: TestDisableMemoryTriage_InstallsNoOp (0.04s)
=== RUN   TestDisableMemoryTriage_FullLoop
--- PASS: TestDisableMemoryTriage_FullLoop (0.48s)
=== RUN   TestDisableMemoryTriage_OverridesExplicitMemoryTriage
--- PASS: TestDisableMemoryTriage_OverridesExplicitMemoryTriage (0.00s)
PASS
```