### PR TITLE
fix(brute/rdp): Windows 11 真机 NLA 爆破成败 + UnAuth 空等治理

### DIFF
--- a/common/brute/README.md
+++ b/common/brute/README.md
@@ -238,6 +238,18 @@ Unicode 正反、空密码）全通过——NTLMv2 客户端实现首次获得�
 | Windows 11 24H2 (10.0.26100) | 5 | 5/5 auth-rejected |
 | xrdp（Shodan 命中 1） | 1 | auth-rejected |
 
+**可控 Windows 11 Pro ARM（QEMU / OrbStack，`WIN-0GR4G6GOD7U`）正反实测**：
+
+| 凭证 | 结果 |
+|---|---|
+| `rdpuser` / `RdpPass123!` | **Ok=true Finished=true**，NLA 1.2s / 二次 0.5s |
+| `rdpuser` / `WrongPass!` | Ok=false Finished=false，`STATUS_LOGON_FAILURE` 300–400ms |
+| `no-such-user` / `x` | Ok=false，`STATUS_LOGON_FAILURE` 200–300ms |
+
+`YAK_BRUTE_RDP_ADDR=host:port go test ./common/utils/bruteutils/ -run TestRDPWindowsLive -v`
+
+UnAuthVerify 不再 sleep 3s、不再用 `administrator:""` 当未授权探测（NLA 无未授权访问）。
+
 ## Telnet 真实设备语料与判定增强（Shodan 100 样本）
 
 互联网 telnet 协议形态高度不标准。Shodan 采样 100 例 banner 分析：

--- a/common/utils/bruteutils/rdp.go
+++ b/common/utils/bruteutils/rdp.go
@@ -33,43 +33,15 @@ var rdpAuth = &DefaultServiceAuthInfo{
 	UnAuthVerify: func(i *BruteItem) *BruteItemResult {
 		i.Target = appendDefaultPort(i.Target, 3389)
 		result := i.Result()
-
+		// NLA 没有“未授权访问”：空密码也是一次认证失败。
+		// 这里只做 TCP 可达性，避免 3s sleep + administrator:"" 误伤爆破节奏。
 		conn, err := defaultDialer.DialContext(utils.TimeoutContext(defaultTimeout), "tcp", i.Target)
 		if err != nil {
 			res := i.Result()
 			res.Finished = true
 			return res
 		}
-		conn.Close()
-
-		time.Sleep(3 * time.Second)
-
-		host, port, err := utils.ParseStringToHostPort(i.Target)
-		if err != nil {
-			log.Errorf("parse target[%v] failed: %s", i.Target, err)
-			result.Finished = true
-			return result
-		}
-
-		var r bool
-		if utils.IsIPv4(host) {
-			r, err = rdpLoginContext(i.Context, host, host, "administrator", "", port)
-		} else {
-			ip := netx.LookupFirst(host, netx.WithTimeout(5*time.Second))
-			r, err = rdpLoginContext(i.Context, ip, host, "administrator", "", port)
-		}
-
-		if err != nil {
-			// 192.3.138.219/24
-			autoSetFinishedByConnectionError(err, result)
-			return result
-		}
-		if r {
-			result.Finished = true
-			result.Ok = true
-			return result
-		}
-
+		_ = conn.Close()
 		return result
 	},
 	BrutePass: func(i *BruteItem) (result *BruteItemResult) {
@@ -227,8 +199,6 @@ func (g *rdpClient) Login(ctx context.Context, domain, user, pwd string) error {
 	if d, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(d)
 	}
-	glog.Info(conn.LocalAddr().String())
-
 	g.tpkt = tpkt.New(core.NewSocketLayer(conn), nla.NewNTLMv2(domain, user, pwd))
 	g.x224 = x224.New(g.tpkt)
 	g.mcs = t125.NewMCSClient(g.x224)
@@ -250,21 +220,23 @@ func (g *rdpClient) Login(ctx context.Context, domain, user, pwd string) error {
 	var doneOnce sync.Once
 	var finalErr error
 	wg.Add(1)
-	finish := func(e error) { doneOnce.Do(func() { finalErr = e; wg.Done() }) }
+	finish := func(e error) {
+		doneOnce.Do(func() {
+			if e != nil {
+				log.Errorf("rdp error: %v", e)
+			}
+			finalErr = e
+			wg.Done()
+		})
+	}
 
 	// 必须在 Connect 之前注册：NLA 在 localhost 上可能快于后续 On()。
-	g.x224.On("error", func(e error) {
-		log.Errorf("rdp error: %v", e)
-		finish(e)
-	})
+	g.x224.On("error", func(e error) { finish(e) })
 	g.x224.On("nla-ok", func() {
 		log.Info("rdp nla authentication succeeded")
 		finish(nil)
 	})
-	g.pdu.On("error", func(e error) {
-		log.Errorf("rdp error: %v", e)
-		finish(e)
-	})
+	g.pdu.On("error", func(e error) { finish(e) })
 	g.pdu.On("close", func() {
 		finish(errors.New("close"))
 	})

--- a/common/utils/bruteutils/rdp_win11_live_test.go
+++ b/common/utils/bruteutils/rdp_win11_live_test.go
@@ -1,0 +1,97 @@
+package bruteutils
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// 真实 Windows NLA 爆破（默认跳过）。
+//
+//	YAK_BRUTE_RDP_ADDR=127.0.0.1:13389 YAK_BRUTE_RDP_USER=rdpuser YAK_BRUTE_RDP_PASS=RdpPass123! \
+//	  go test ./common/utils/bruteutils/ -run TestRDPWindowsLive -v
+func TestRDPWindowsLiveBrute(t *testing.T) {
+	addr := os.Getenv("YAK_BRUTE_RDP_ADDR")
+	if addr == "" {
+		t.Skip("set YAK_BRUTE_RDP_ADDR to a Windows RDP you control")
+	}
+	user := os.Getenv("YAK_BRUTE_RDP_USER")
+	if user == "" {
+		user = "rdpuser"
+	}
+	pass := os.Getenv("YAK_BRUTE_RDP_PASS")
+	if pass == "" {
+		pass = "RdpPass123!"
+	}
+
+	hit := func(u, p string) *BruteItemResult {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		start := time.Now()
+		res := rdpAuth.BrutePass(&BruteItem{Type: "rdp", Target: addr, Username: u, Password: p, Context: ctx})
+		t.Logf("user=%q ok=%v finished=%v elapsed=%s", u, res.Ok, res.Finished, time.Since(start).Round(100*time.Millisecond))
+		return res
+	}
+
+	ok := hit(user, pass)
+	if !ok.Ok || !ok.Finished {
+		t.Errorf("correct creds: want ok+finished got ok=%v finished=%v", ok.Ok, ok.Finished)
+	}
+	bad := hit(user, "WrongPass!")
+	if bad.Ok {
+		t.Errorf("wrong password must not be ok")
+	}
+	if bad.Finished {
+		t.Errorf("wrong password must not mark target finished")
+	}
+	unk := hit("no-such-user", "x")
+	if unk.Ok {
+		t.Errorf("unknown user must not be ok")
+	}
+}
+
+func TestRDPWindowsLiveDictHunt(t *testing.T) {
+	addr := os.Getenv("YAK_BRUTE_RDP_ADDR")
+	if addr == "" {
+		t.Skip("set YAK_BRUTE_RDP_ADDR")
+	}
+	user := os.Getenv("YAK_BRUTE_RDP_USER")
+	if user == "" {
+		user = "rdpuser"
+	}
+	pass := os.Getenv("YAK_BRUTE_RDP_PASS")
+	if pass == "" {
+		pass = "RdpPass123!"
+	}
+
+	util, err := NewMultiTargetBruteUtilEx(
+		WithBruteCallback(rdpAuth.BrutePass),
+		WithOkToStop(true),
+		WithTargetsConcurrent(1),
+		WithTargetTasksConcurrent(1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	users := []string{"guest", user, "administrator"}
+	passes := []string{"123456", "admin", pass, "password"}
+	var found *BruteItemResult
+	start := time.Now()
+	if err := util.StreamBruteContext(context.Background(), "rdp", []string{addr}, users, passes, func(res *BruteItemResult) {
+		t.Logf("try user=%q ok=%v finished=%v", res.Username, res.Ok, res.Finished)
+		if res.Ok {
+			cp := *res
+			found = &cp
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if found == nil {
+		t.Fatal("scheduler did not hit")
+	}
+	if found.Username != user || found.Password != pass {
+		t.Fatalf("hit wrong creds user=%q pass=%q", found.Username, found.Password)
+	}
+	t.Logf("DICT HIT user=%q in %s", found.Username, time.Since(start).Round(time.Millisecond))
+}


### PR DESCRIPTION
## 背景

在 #4989 的 CredSSP v6 栈上，用本地 OrbStack + QEMU **Windows 11 Pro ARM**（`WIN-0GR4G6GOD7U`）做了可控真机爆破。

本 PR 相对 `feature/brute-minimal-probes` 只多 1 个提交；若 #4989 先合，rebase 后只剩这一笔。

## 真机结果

| 凭证 | 结果 |
|---|---|
| `rdpuser` / `RdpPass123!` | **Ok=true Finished=true**（NLA 0.4–1.2s） |
| `rdpuser` / `WrongPass!` | Ok=false Finished=false，`STATUS_LOGON_FAILURE` 300ms |
| 字典 3×4 | 错的全失败不短路，命中后 `ok-to-stop`（3.4s） |

## 代码

- UnAuthVerify 去掉 3s sleep 和 `administrator:""`（NLA 无未授权访问）
- 错误日志只打一次
- `YAK_BRUTE_RDP_ADDR` 门控真机测试，CI 默认跳过