### PR TITLE
perf: reduce ShrinkString and embedding decode allocations

### DIFF
--- a/common/ai/embedding/base.go
+++ b/common/ai/embedding/base.go
@@ -75,8 +75,122 @@ type embeddingRequest struct {
 	Model          string `json:"model,omitempty"`
 }
 
-type embeddingRawItem struct {
-	Embedding json.RawMessage `json:"embedding"`
+type embeddingItem struct {
+	Embedding embeddingValue `json:"embedding"`
+}
+
+// embeddingValue decodes the vector while the enclosing item is being
+// decoded. This avoids retaining a copy of the complete vector as a
+// json.RawMessage and unmarshalling that copy in a second step.
+type embeddingValue struct {
+	vector  []float32
+	vectors [][]float32
+	multi   bool
+}
+
+func (value *embeddingValue) UnmarshalJSON(raw []byte) error {
+	*value = embeddingValue{}
+	raw = bytes.TrimSpace(raw)
+	if len(raw) < 2 || raw[0] != '[' {
+		return nil
+	}
+	inner := bytes.TrimSpace(raw[1:])
+	if len(inner) > 0 && inner[0] == '[' {
+		value.multi = true
+		value.vectors = make([][]float32, 0, countTopLevelJSONElements(raw))
+		return json.Unmarshal(raw, &value.vectors)
+	}
+	value.vector = make([]float32, 0, countFlatJSONElements(raw))
+	return json.Unmarshal(raw, &value.vector)
+}
+
+// countFlatJSONElements counts numeric array elements without fully parsing
+// them. Strings and nested values are rejected by []float32 unmarshalling, so
+// they deliberately disable preallocation rather than using their commas.
+func countFlatJSONElements(raw []byte) int {
+	if len(raw) < 2 || raw[0] != '[' {
+		return 0
+	}
+	index := 1
+	for index < len(raw) && isJSONSpace(raw[index]) {
+		index++
+	}
+	if index >= len(raw) || raw[index] == ']' {
+		return 0
+	}
+
+	count := 1
+	for ; index < len(raw); index++ {
+		switch raw[index] {
+		case ',':
+			count++
+		case '"', '[', '{':
+			return 0
+		case ']':
+			// A valid JSON array needs at least one byte per value and one
+			// separator between values. Avoid amplifying malformed input.
+			if count > (len(raw)-1)/2 {
+				return 0
+			}
+			return count
+		}
+	}
+	return 0
+}
+
+// countTopLevelJSONElements returns the number of top-level array elements without
+// interpreting commas inside strings or nested JSON values. Supplying the
+// capacity to encoding/json avoids the repeated slice growth that otherwise
+// dominates allocations for large embedding vectors.
+func countTopLevelJSONElements(raw []byte) int {
+	if len(raw) < 2 || raw[0] != '[' {
+		return 0
+	}
+	index := 1
+	for index < len(raw) && isJSONSpace(raw[index]) {
+		index++
+	}
+	if index >= len(raw) || raw[index] == ']' {
+		return 0
+	}
+
+	count, depth := 1, 1
+	inString, escaped := false, false
+	for ; index < len(raw); index++ {
+		character := raw[index]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if character == '\\' {
+				escaped = true
+			} else if character == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch character {
+		case '"':
+			inString = true
+		case '[', '{':
+			depth++
+		case ']', '}':
+			depth--
+			if depth == 0 {
+				return count
+			}
+		case ',':
+			if depth == 1 {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func isJSONSpace(character byte) bool {
+	return character == ' ' || character == '\t' || character == '\r' || character == '\n'
 }
 
 // 错误响应结构体
@@ -339,19 +453,19 @@ func decodeEmbeddingItems(decoder *json.Decoder, arrayAlreadyOpen, firstItemOnly
 			itemIndex++
 			continue
 		}
-		var item embeddingRawItem
+		var item embeddingItem
 		if err := decoder.Decode(&item); err != nil {
 			return nil, err
 		}
-		itemVectors, multi, err := decodeRawEmbedding(item.Embedding)
-		if err != nil {
-			return nil, err
-		}
 		if itemIndex == 0 {
-			isMultiVector = multi
-			vectors = append(vectors, itemVectors...)
-		} else if len(itemVectors) > 0 {
-			vectors = append(vectors, itemVectors[0])
+			isMultiVector = item.Embedding.multi
+			if isMultiVector {
+				vectors = append(vectors, item.Embedding.vectors...)
+			} else if len(item.Embedding.vector) > 0 {
+				vectors = append(vectors, item.Embedding.vector)
+			}
+		} else if vector, ok := item.Embedding.firstVector(); ok {
+			vectors = append(vectors, vector)
 		}
 		itemIndex++
 	}
@@ -361,27 +475,17 @@ func decodeEmbeddingItems(decoder *json.Decoder, arrayAlreadyOpen, firstItemOnly
 	return vectors, nil
 }
 
-func decodeRawEmbedding(raw json.RawMessage) ([][]float32, bool, error) {
-	raw = bytes.TrimSpace(raw)
-	if len(raw) < 2 || raw[0] != '[' {
-		return nil, false, nil
-	}
-	inner := bytes.TrimSpace(raw[1:])
-	if len(inner) > 0 && inner[0] == '[' {
-		var vectors [][]float32
-		if err := json.Unmarshal(raw, &vectors); err != nil {
-			return nil, true, err
+func (value *embeddingValue) firstVector() ([]float32, bool) {
+	if value.multi {
+		if len(value.vectors) == 0 {
+			return nil, false
 		}
-		return vectors, true, nil
+		return value.vectors[0], true
 	}
-	var vector []float32
-	if err := json.Unmarshal(raw, &vector); err != nil {
-		return nil, false, err
+	if len(value.vector) == 0 {
+		return nil, false
 	}
-	if len(vector) == 0 {
-		return nil, false, nil
-	}
-	return [][]float32{vector}, false, nil
+	return value.vector, true
 }
 
 func skipJSONValue(decoder *json.Decoder) error {

--- a/common/ai/embedding/base_http_test.go
+++ b/common/ai/embedding/base_http_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"net"
@@ -100,10 +101,10 @@ func TestDecodeEmbeddingResponseFormats(t *testing.T) {
 		body string
 		want [][]float32
 	}{
-		{name: "standard", body: `{"data":[{"embedding":[1,2]},{"embedding":[9,9]}],"model":"m"}`, want: [][]float32{{1, 2}}},
-		{name: "object 2d", body: `{"metadata":{"nested":[1,{"skip":true}]},"data":[{"embedding":[[1,2],[3,4]]},{"embedding":[[9,9]]}]}`, want: [][]float32{{1, 2}, {3, 4}}},
+		{name: "standard", body: `{"data":[{"embedding":[1,2]},{"embedding":["must be skipped"]}],"model":"m"}`, want: [][]float32{{1, 2}}},
+		{name: "object 2d", body: `{"metadata":{"nested":[1,{"skip":true}]},"data":[{"embedding":[[1,2],[3,4]]},{"embedding":["must be skipped"]}]}`, want: [][]float32{{1, 2}, {3, 4}}},
 		{name: "top level 1d", body: `[{"embedding":[1,2]},{"embedding":[3,4]}]`, want: [][]float32{{1, 2}, {3, 4}}},
-		{name: "top level 2d", body: `[{"embedding":[[1,2],[3,4]]},{"embedding":[[9,9]]}]`, want: [][]float32{{1, 2}, {3, 4}}},
+		{name: "top level 2d", body: `[{"embedding":[[1,2],[3,4]]},{"embedding":["must be skipped"]}]`, want: [][]float32{{1, 2}, {3, 4}}},
 	}
 
 	for _, test := range tests {
@@ -175,6 +176,38 @@ func TestNormalizeEmbeddingVectorsInPlace(t *testing.T) {
 	}
 	assert.InDelta(t, 1, math.Sqrt(norm), 1e-6)
 	assert.Equal(t, []float32{0, 0}, vectors[1])
+}
+
+var decodeEmbeddingBenchmarkSink [][]float32
+
+func BenchmarkDecodeEmbeddingResponse(b *testing.B) {
+	for _, dimensions := range []int{384, 1024, 1536, 3072} {
+		vector := make([]float32, dimensions)
+		for index := range vector {
+			vector[index] = float32(index%31+1) / 31
+		}
+		bodyBytes, err := json.Marshal(struct {
+			Data []struct {
+				Embedding []float32 `json:"embedding"`
+			} `json:"data"`
+		}{Data: []struct {
+			Embedding []float32 `json:"embedding"`
+		}{{Embedding: vector}}})
+		require.NoError(b, err)
+		body := string(bodyBytes)
+
+		b.Run(fmt.Sprintf("Dim%d", dimensions), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			for i := 0; i < b.N; i++ {
+				vectors, apiErr, err := decodeEmbeddingResponse(strings.NewReader(body))
+				if err != nil || apiErr != nil || len(vectors) != 1 || len(vectors[0]) != dimensions {
+					b.Fatalf("unexpected decode result: vectors=%d apiErr=%v err=%v", len(vectors), apiErr, err)
+				}
+				decodeEmbeddingBenchmarkSink = vectors
+			}
+		})
+	}
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/common/yak/yaklib/codec/shrink.go
+++ b/common/yak/yaklib/codec/shrink.go
@@ -3,6 +3,7 @@ package codec
 import (
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 func ShrinkStringDefault(r any) string {
@@ -26,10 +27,28 @@ func shrinkStringWithMultiLine(r any, size int, multiline bool) string {
 
 	verbose := AnyToString(r)
 	verbose = strings.TrimSpace(verbose)
-	runes := []rune(verbose)
-	if len(runes) > size {
-		runes = append(runes[:half], append([]rune("..."), runes[len(runes)-half:]...)...)
-		verbose = string(runes)
+	prefixEnd, runeCount := 0, 0
+	for offset := 0; offset < len(verbose) && runeCount <= size; {
+		_, width := utf8.DecodeRuneInString(verbose[offset:])
+		offset += width
+		runeCount++
+		if runeCount == half {
+			prefixEnd = offset
+		}
+	}
+	if runeCount > size {
+		suffixStart := len(verbose)
+		for count := 0; count < half; count++ {
+			_, width := utf8.DecodeLastRuneInString(verbose[:suffixStart])
+			suffixStart -= width
+		}
+
+		var builder strings.Builder
+		builder.Grow(prefixEnd + (len(verbose) - suffixStart) + len("..."))
+		writeRuneSlice(&builder, verbose[:prefixEnd])
+		builder.WriteString("...")
+		writeRuneSlice(&builder, verbose[suffixStart:])
+		verbose = builder.String()
 	}
 	if !multiline {
 		verbose = strconv.Quote(verbose)
@@ -41,4 +60,18 @@ func shrinkStringWithMultiLine(r any, size int, multiline bool) string {
 		verbose = strings.ReplaceAll(verbose, `\"`, "\"")
 	}
 	return verbose
+}
+
+// writeRuneSlice matches the conversion performed by string([]rune(value)),
+// including replacing each invalid UTF-8 byte with utf8.RuneError.
+func writeRuneSlice(builder *strings.Builder, value string) {
+	if utf8.ValidString(value) {
+		builder.WriteString(value)
+		return
+	}
+	for len(value) > 0 {
+		r, width := utf8.DecodeRuneInString(value)
+		builder.WriteRune(r)
+		value = value[width:]
+	}
 }

--- a/common/yak/yaklib/codec/shrink_test.go
+++ b/common/yak/yaklib/codec/shrink_test.go
@@ -1,0 +1,86 @@
+package codec
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func shrinkStringReference(r any, size int, multiline bool) string {
+	if size <= 6 {
+		size = 10
+	}
+
+	half := size / 2
+	verbose := strings.TrimSpace(AnyToString(r))
+	runes := []rune(verbose)
+	if len(runes) > size {
+		runes = append(runes[:half], append([]rune("..."), runes[len(runes)-half:]...)...)
+		verbose = string(runes)
+	}
+	if !multiline {
+		verbose = strconv.Quote(verbose)
+		verbose = verbose[1 : len(verbose)-1]
+		verbose = strings.ReplaceAll(verbose, `\r`, " ")
+		verbose = strings.ReplaceAll(verbose, `\n`, " ")
+		verbose = strings.ReplaceAll(verbose, `\t`, " ")
+		verbose = strings.ReplaceAll(verbose, `\"`, "\"")
+	}
+	return verbose
+}
+
+func TestShrinkStringMatchesReference(t *testing.T) {
+	invalidShort := string([]byte{'a', 0xff, 'b', 0xc0, 'c'})
+	invalidLong := string([]byte{0xff, 'a', 0xfe, 'b', 0xfd, 'c', 0xfc, 'd', 0xfb, 'e', 0xfa, 'f', 0xf9})
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{name: "empty", input: ""},
+		{name: "spaces", input: "   \t\r\n  "},
+		{name: "ascii under ten", input: "012345678"},
+		{name: "ascii exact ten", input: "0123456789"},
+		{name: "ascii over ten", input: "0123456789a"},
+		{name: "ascii", input: "abcdefghijklmnopqrstuvwxyz"},
+		{name: "chinese", input: "天地玄黄宇宙洪荒日月盈昃辰宿列张"},
+		{name: "emoji", input: "😀😃😄😁😆😅😂🤣😊😇🙂🙃😉😌😍🥰"},
+		{name: "combining", input: "e\u0301cole-A\u030angstro\u0308m-noe\u0308l"},
+		{name: "invalid utf8 short", input: invalidShort},
+		{name: "invalid utf8 long", input: invalidLong},
+		{name: "invalid utf8 bytes", input: []byte(invalidLong)},
+		{name: "newlines", input: "\nline one\r\nline two\nline three\n"},
+		{name: "tabs and quotes", input: "\t\"alpha\"\t\"beta\"\t"},
+		{name: "trimmed unicode spaces", input: "\u2003\u00a0content\u00a0\u2003"},
+	}
+	sizes := []int{-1, 0, 1, 6, 7, 8, 9, 10, 11, 15, 16, 17, 26, 27, 200}
+
+	for _, test := range tests {
+		for _, size := range sizes {
+			for _, multiline := range []bool{false, true} {
+				name := test.name + "/size=" + strconv.Itoa(size) + "/multiline=" + strconv.FormatBool(multiline)
+				t.Run(name, func(t *testing.T) {
+					want := shrinkStringReference(test.input, size, multiline)
+					got := shrinkStringWithMultiLine(test.input, size, multiline)
+					if got != want {
+						t.Fatalf("shrink result mismatch\n got: %q\nwant: %q", got, want)
+					}
+				})
+			}
+		}
+	}
+}
+
+var shrinkStringBenchmarkSink string
+
+func BenchmarkShrinkStringBase64(b *testing.B) {
+	for _, size := range []int{1 << 20, 8 << 20} {
+		payload := strings.Repeat("QUJD", size/4)
+		b.Run(strconv.Itoa(size>>20)+"MiB", func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(payload)))
+			for i := 0; i < b.N; i++ {
+				shrinkStringBenchmarkSink = ShrinkString(payload, 200)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- make `codec.ShrinkString` / `ShrinkTextBlock` truncate large inputs without materializing the complete input as `[]rune`
- decode embedding values directly into `[]float32` / `[][]float32` instead of copying them through `json.RawMessage`
- preallocate embedding vectors from their JSON element count to avoid repeated slice growth
- add differential/compatibility tests and 1 MiB, 8 MiB, 384/1024/1536/3072-dimension benchmarks

Base: `origin/main` at `e478a4cbe64c09f44311f23c7524a453ab81d413`.

## Root cause and implementation

`shrinkStringWithMultiLine` converted the complete trimmed string to `[]rune` before checking whether only 200 runes were needed. The new path scans at most `size+1` runes from the front, locates the suffix with `utf8.DecodeLastRuneInString`, and joins only the retained prefix/suffix with a preallocated builder. Truncated invalid UTF-8 bytes are still emitted as one replacement rune per byte, matching `string([]rune(input))`; non-truncated strings remain untouched.

Embedding items stored the full vector JSON in `json.RawMessage`, then parsed that copy again. `embeddingValue.UnmarshalJSON` now inspects the array shape and decodes into the final float slice while the enclosing item is decoded. It also preallocates the slice from a guarded element count. Object/top-level and 1-D/2-D response rules, first-item skipping, error responses, preview limits, cancellation, retries, TLS verification, and transport reuse are unchanged.

## Benchmarks

Apple arm64, Go 1.22.12, 10 samples, `-benchtime=500ms`:

| Benchmark | old time/op | new time/op | old B/op | new B/op | old allocs/op | new allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| ShrinkString Base64 1 MiB | 1206.250 us | 2.074 us (-99.83%) | 4,195,480.5 | 752 (-99.98%) | 6 | 4 |
| ShrinkString Base64 8 MiB | 9053.689 us | 1.943 us (-99.98%) | 33,555,602.5 | 752 (-100.00%) | 6 | 4 |
| Embedding 384 | 75.26 us | 76.32 us (+1.41%) | 23,432 | 16,776 (-28.41%) | 39 | 28 (-28.21%) |
| Embedding 1024 | 196.7 us | 199.1 us (+1.22%) | 55,432 | 35,720 (-35.56%) | 42 | 29 (-30.95%) |
| Embedding 1536 | 287.3 us | 292.8 us (+1.91%) | 69,128 | 37,768 (-45.37%) | 43 | 29 (-32.56%) |
| Embedding 3072 | 569.0 us | 582.1 us (+2.31%) | 130,569 | 76,680 (-41.27%) | 45 | 30 (-33.33%) |

Embedding geomean: `B/op -37.97%`, `allocs/op -31.29%`, isolated decode time `+1.71%` from the guarded element-count pass. The intended production tradeoff is substantially lower GC pressure without changing response semantics.

Commands:

```sh
go test ./common/yak/yaklib/codec ./common/ai/embedding -run '^$' -bench 'Benchmark(ShrinkStringBase64|DecodeEmbeddingResponse)$' -benchmem -benchtime=500ms -count=10
benchstat /tmp/yaklang_perf_old.txt /tmp/yaklang_perf_new_final.txt
```

## Verification

```sh
go test -count=1 ./common/yak/yaklib/codec ./common/ai/embedding
go test -race -count=1 ./common/yak/yaklib/codec ./common/ai/embedding
go vet ./common/yak/yaklib/codec ./common/ai/embedding
```

All passed. The codec differential suite covers ASCII, Chinese, emoji, combining characters, invalid UTF-8, empty/whitespace/newline/tab/quote inputs, the `size <= 6` fallback, odd/even sizes, and under/equal/over-limit lengths. Embedding compatibility covers object envelope and top-level arrays with both 1-D and 2-D values, error responses, and skipping unused items.

## Risk

- The rune boundary logic is more explicit than `[]rune`; differential tests guard the existing quoting, whitespace, multiline, and invalid UTF-8 behavior.
- Embedding preallocation adds a bounded linear scan over the selected vector JSON and a small isolated decode CPU cost, while removing the full `RawMessage` copy and repeated vector growth.
- No `aibalance-server` or `ytoken` files are changed. No merge, release, or deployment is included.
