### PR TITLE
修复产品节点能力清单与实际编译能力不一致

### DIFF
--- a/.github/scripts/build-legion-product-node.sh
+++ b/.github/scripts/build-legion-product-node.sh
@@ -88,6 +88,15 @@ fi
 binary_sha="$(sha256sum "$binary" | awk '{print $1}')"
 binary_size="$(stat -c %s "$binary")"
 built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+capabilities_file="$repo_root/.github/scripts/legion-product-node-capabilities.json"
+capabilities_json="$(jq -ce '
+  if type == "array" and length > 0 and
+     all(.[]; type == "string" and length > 0) and
+     . == (sort | unique)
+  then .
+  else error("product-node capability contract must be a sorted unique string array")
+  end
+' "$capabilities_file")" || die "invalid Product Node capability contract: $capabilities_file"
 
 jq -n \
   --arg version "$version" \
@@ -102,6 +111,7 @@ jq -n \
   --arg binary_name "$binary_name" \
   --arg binary_sha "$binary_sha" \
   --argjson binary_size "$binary_size" \
+  --argjson capabilities "$capabilities_json" \
   --arg built_at "$built_at" \
   --arg ci_provider "${GITHUB_ACTIONS:+github-actions}" \
   --arg ci_run_id "${GITHUB_RUN_ID:-local}" \
@@ -133,7 +143,7 @@ jq -n \
       module_go_version: $module_go_version,
       go_version: $go_version
     },
-    capabilities: ["ai.runtime.host.v1", "ai.session.bind_epoch.v1", "ai.session.turn_lifecycle.v1", "hids", "ssa.rule_sync.export", "yak.execute"],
+    capabilities: $capabilities,
     binary: {
       path: $binary_name,
       sha256: $binary_sha,

--- a/.github/scripts/legion-product-node-capabilities.json
+++ b/.github/scripts/legion-product-node-capabilities.json
@@ -1,0 +1,10 @@
+[
+  "ai.code_workspace.v1",
+  "ai.runtime.host.v1",
+  "ai.session.bind_epoch.v1",
+  "ai.session.turn_lifecycle.v1",
+  "hids",
+  "ssa.rule_snapshot.execution.v2",
+  "ssa.rule_sync.export",
+  "yak.execute"
+]

--- a/.github/scripts/test-build-legion-node-engine-import-bundle.sh
+++ b/.github/scripts/test-build-legion-node-engine-import-bundle.sh
@@ -20,6 +20,7 @@ binary_size="$(stat -c %s "$artifact_dir/legion-smoke-node")"
 jq -n \
   --arg source_sha "$source_sha" \
   --arg binary_sha "$binary_sha" \
+  --argjson capabilities "$(jq -c . "$script_dir/legion-product-node-capabilities.json")" \
   --argjson binary_size "$binary_size" '
   {
     schema_version:"1",
@@ -28,7 +29,7 @@ jq -n \
     source:{repository:"yaklang/yaklang",commit:$source_sha,dirty:false},
     ci:{provider:"github-actions",run_id:"123",workflow:"Build Trusted Legion Product Node"},
     recipe:{goos:"linux",goarch:"amd64"},
-    capabilities:["yak.execute","hids"],
+    capabilities:$capabilities,
     binary:{sha256:$binary_sha,size:$binary_size}
   }
 ' >"$artifact_dir/PRODUCT_NODE_MANIFEST.json"
@@ -99,6 +100,8 @@ jq -e \
   .protocol_version == 1 and
   .rollback_safe == true and
   (.capability_keys | index("yak.execute") != null) and
+  (.capability_keys | index("ai.code_workspace.v1") != null) and
+  (.capability_keys | index("ssa.rule_snapshot.execution.v2") != null) and
   .runtime.archive_sha256 == $runtime_archive_sha and
   .runtime.producer_manifest_sha256 == $runtime_manifest_sha and
   .runtime.image_ref == $runtime_image_ref and

--- a/.github/workflows/build-legion-product-node.yml
+++ b/.github/workflows/build-legion-product-node.yml
@@ -125,9 +125,11 @@ jobs:
               .recipe.build_tags == "hids" and
               .ci.workflow == "Build Trusted Legion Product Node" and
               (.capabilities | index("hids") != null) and
+              (.capabilities | index("ai.code_workspace.v1") != null) and
               (.capabilities | index("ai.session.bind_epoch.v1") != null) and
               (.capabilities | index("ai.runtime.host.v1") != null) and
-              (.capabilities | index("ai.session.turn_lifecycle.v1") != null)
+              (.capabilities | index("ai.session.turn_lifecycle.v1") != null) and
+              (.capabilities | index("ssa.rule_snapshot.execution.v2") != null)
             ' PRODUCT_NODE_MANIFEST.json >/dev/null
 
       - name: Stage architecture-specific artifact contract

--- a/scannode/product_manifest_capabilities_test.go
+++ b/scannode/product_manifest_capabilities_test.go
@@ -1,0 +1,31 @@
+package scannode
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestProductNodeManifestCapabilitiesMatchCompiledSurface(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../.github/scripts/legion-product-node-capabilities.json")
+	if err != nil {
+		t.Fatalf("read product-node capability contract: %v", err)
+	}
+	var advertised []string
+	if err := json.Unmarshal(data, &advertised); err != nil {
+		t.Fatalf("decode product-node capability contract: %v", err)
+	}
+
+	want := append(compiledScanNodeCapabilityKeys(), AIRuntimeHostCapabilityKey)
+	if !slices.Contains(want, "hids") {
+		want = append(want, "hids")
+	}
+	slices.Sort(advertised)
+	slices.Sort(want)
+	if !slices.Equal(advertised, want) {
+		t.Fatalf("product-node manifest capabilities drifted from compiled surface: got=%#v want=%#v", advertised, want)
+	}
+}


### PR DESCRIPTION
## 问题

legion-smoke-node 已编译 ai.code_workspace.v1 和 ssa.rule_snapshot.execution.v2，但可信产品节点清单没有声明，导致 Legion 产品包更新后无法正确授权和调度 Professional Task。

## 修复

- 增加由 Yaklang 生产者维护的产品节点能力契约
- 构建脚本从该契约生成 PRODUCT_NODE_MANIFEST.json，不再维护独立硬编码列表
- 增加编译能力与清单能力的精确一致性测试，覆盖 HIDS 和非 HIDS 构建
- 可信构建工作流显式校验 workspace 与精确规则快照能力
- 节点引擎导入包测试验证这两项能力被完整保留

## 验证

- go test ./scannode -run TestProductNodeManifestCapabilitiesMatchCompiledSurface -count=1
- go test -tags hids ./scannode -run TestProductNodeManifestCapabilitiesMatchCompiledSurface -count=1
- go test -tags hids ./scannode -run TestNormalizeScanNodeCapabilityKeys -count=1
- bash .github/scripts/test-build-legion-node-engine-import-bundle.sh
- bash 语法及能力契约 JSON 校验通过

## 配套

Legion 侧授权迁移、bootstrap 能力交集和产品包门禁见 VillanCh/legion#446。