### PR TITLE
fix(startup): defer SSA stats callbacks and license init to actual use

### DIFF
--- a/common/xlic/cmd/initializer.go
+++ b/common/xlic/cmd/initializer.go
@@ -43,6 +43,7 @@ func main() {
 		{
 			Name: "gen-request",
 			Action: func(c *cli.Context) error {
+				xlic.EnsureInitialized()
 				req, err := xlic.Machine.GenerateRequest()
 				if err != nil {
 					return err

--- a/common/xlic/license.go
+++ b/common/xlic/license.go
@@ -59,7 +59,10 @@ func initMachine() {
 	})
 }
 
-func init() {
+// EnsureInitialized lazily builds the license machine on first actual license use.
+// yaklang runtime paths do not need licenses, so nothing is initialized (and no
+// ephemeral-key warning is emitted) unless a license API is called.
+func EnsureInitialized() {
 	initMachine()
 }
 

--- a/common/xlic/license_test.go
+++ b/common/xlic/license_test.go
@@ -3,6 +3,7 @@ package xlic
 import "testing"
 
 func TestXLic(t *testing.T) {
+	EnsureInitialized()
 	if Machine == nil {
 		t.Fatal("Machine is nil")
 	}

--- a/common/yak/ssa/ssadb/database.go
+++ b/common/yak/ssa/ssadb/database.go
@@ -277,7 +277,6 @@ func ensureUniqueIrOffsetsIndex(db *gorm.DB) {
 
 func GetDB() *gorm.DB {
 	db := consts.GetGormSSAProjectDataBase()
-	EnsureDBOpCallbacks(db)
 	return db
 }
 

--- a/common/yakgrpc/grpc_license.go
+++ b/common/yakgrpc/grpc_license.go
@@ -33,6 +33,7 @@ func (s *Server) CheckLicense(ctx context.Context, r *ypb.CheckLicenseRequest) (
 	}
 
 	lic := r.GetLicenseActivation()
+	xlic.EnsureInitialized()
 	rsp, err := xlic.Machine.VerifyLicense(lic)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Two startup-time issues in yaklang engine:

1. **SSA DB op stats callbacks were registered unconditionally** — `ssadb.GetDB()` called `EnsureDBOpCallbacks` on every SSA database access, so every process start emitted ten `registering callback` info lines from GORM. The callbacks are only needed by the SSA debug/pprof collector, so registration now happens only in `StartPprofCollector` (debug scans).

2. **License machine was initialized eagerly via `xlic` package `init()`** — every yaklang process generated ephemeral RSA keys and printed the `official license certs not embedded` warning even when no license API was ever called. Replaced with lazy `EnsureInitialized()`; `CheckLicense` and the `gen-request` CLI call it before use.

## Changes

- `common/yak/ssa/ssadb/database.go`: remove unconditional `EnsureDBOpCallbacks` from `GetDB()`
- `common/xlic/license.go`: replace `init()` with lazy `EnsureInitialized()`
- `common/yakgrpc/grpc_license.go`: call `EnsureInitialized()` before verifying a license
- `common/xlic/cmd/initializer.go`: call `EnsureInitialized()` in `gen-request`
- `common/xlic/license_test.go`: initialize before asserting `Machine`

## Verification

- `go build` passes for affected packages (xlic, ssadb, ssaapi, yakgrpc, scannode)
- `go test ./common/xlic/` passes