### PR TITLE
feat(fuzztag): add jpg:jfif/jpg:exif and tiff:mm/tiff:ii variant tags

### DIFF
--- a/common/mutate/fuzztag.go
+++ b/common/mutate/fuzztag.go
@@ -1081,8 +1081,28 @@ func init() {
 		Handler: func(s string) []string {
 			return []string{"\x4d\x4d", "\x49\x49"}
 		},
-		Description:         "生成一个 tiff 文件头，例如 `{{tiff}}`",
+		Description:         "生成一个 tiff 文件头：`{{tiff()}}` 生成大端 MM 和小端 II 两个变体；`{{tiff:mm()}}` 只生成 MM，`{{tiff:ii()}}` 只生成 II",
 		TagNameVerbose:      "生成tiff文件头",
+		ArgumentDescription: "",
+	})
+
+	AddFuzzTagToGlobal(&FuzzTagDescription{
+		TagName: "tiff:mm",
+		Handler: func(s string) []string {
+			return []string{"\x4d\x4d"}
+		},
+		Description:         "生成大端序 tiff 文件头，例如 `{{tiff:mm()}}`",
+		TagNameVerbose:      "生成大端tiff文件头",
+		ArgumentDescription: "",
+	})
+
+	AddFuzzTagToGlobal(&FuzzTagDescription{
+		TagName: "tiff:ii",
+		Handler: func(s string) []string {
+			return []string{"\x49\x49"}
+		},
+		Description:         "生成小端序 tiff 文件头，例如 `{{tiff:ii()}}`",
+		TagNameVerbose:      "生成小端tiff文件头",
 		ArgumentDescription: "",
 	})
 
@@ -1127,8 +1147,30 @@ func init() {
 			}
 		},
 		Alias:               []string{"jpeg"},
-		Description:         "生成 jpeg / jpg 文件头",
+		Description:         "生成 jpeg / jpg 文件头：`{{jpg()}}` 生成 JFIF 和 Exif 两个变体；`{{jpg:jfif(数据)}}` 只生成 JFIF，`{{jpg:exif(数据)}}` 只生成 Exif",
 		TagNameVerbose:      "生成jpeg文件头",
+		ArgumentDescription: "",
+	})
+
+	AddFuzzTagToGlobal(&FuzzTagDescription{
+		TagName: "jpg:jfif",
+		Handler: func(s string) []string {
+			return []string{"\xff\xd8\xff\xe0\x00\x10JFIF" + s + "\xff\xd9"}
+		},
+		Alias:               []string{"jpeg:jfif"},
+		Description:         "生成 JFIF 文件头，数据可选，例如 `{{jpg:jfif(数据)}}`",
+		TagNameVerbose:      "生成JFIF文件头",
+		ArgumentDescription: "",
+	})
+
+	AddFuzzTagToGlobal(&FuzzTagDescription{
+		TagName: "jpg:exif",
+		Handler: func(s string) []string {
+			return []string{"\xff\xd8\xff\xe1\x00\x1cExif" + s + "\xff\xd9"}
+		},
+		Alias:               []string{"jpeg:exif"},
+		Description:         "生成 Exif 文件头，数据可选，例如 `{{jpg:exif(数据)}}`",
+		TagNameVerbose:      "生成Exif文件头",
 		ArgumentDescription: "",
 	})
 

--- a/common/mutate/fuzztag.md
+++ b/common/mutate/fuzztag.md
@@ -29,7 +29,9 @@
 |`htmlhexenc`|`htmlhex, htmlhexencode, htmlhexescape`|HTML 十六进制实体编码，{{htmlhexenc(abc)}} => &#x61;&#x62;&#x63;|
 |`ico`|  |生成一个 ico 文件头，例如 `{{ico}}`|
 |`int`|`port, ports, integer, i, p`|生成一个整数以及范围，例如 {{int(1,2,3,4,5)}} 生成 1,2,3,4,5 中的一个整数，也可以使用 {{int(1-5)}} 生成 1-5 的整数，也可以使用 `{{int(1-5&#124;4)}}` 生成 1-5 的整数，但是每个整数都是 4 位数，例如 0001, 0002, 0003, 0004, 0005|
-|`jpg`|`jpeg`|生成 jpeg / jpg 文件头|
+|`jpg`|`jpeg`|生成 jpeg / jpg 文件头：`{{jpg()}}` 生成 JFIF 和 Exif 两个变体；`{{jpg:jfif(数据)}}` 只生成 JFIF，`{{jpg:exif(数据)}}` 只生成 Exif|
+|`jpg:jfif`|`jpeg:jfif`|生成 JFIF 文件头，数据可选，例如 `{{jpg:jfif(数据)}}`|
+|`jpg:exif`|`jpeg:exif`|生成 Exif 文件头，数据可选，例如 `{{jpg:exif(数据)}}`|
 |`lower`|  |把传入的内容都设置成小写 {{lower(Abc)}} => abc|
 |`md5`|  |进行 md5 编码，{{md5(abc)}} => 900150983cd24fb0d6963f7d28e17f72|
 |`network`|`host, hosts, cidr, ip, net`|生成一个网络地址，例如 `{{network(192.168.1.1/24)}}` 对应 cidr 192.168.1.1/24 所有地址，可以逗号分隔，例如 `{{network(8.8.8.8,192.168.1.1/25,example.com)}}`|
@@ -56,7 +58,9 @@
 |`sha384`|  ||
 |`sha512`|  |进行 sha512 编码，{{sha512(abc)}} => ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f|
 |`sm3`|  |计算 sm3 哈希值，{{sm3(abc)}} => 66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a3f0b8ddb27d8a7eb3|
-|`tiff`|  |生成一个 tiff 文件头，例如 `{{tiff}}`|
+|`tiff`|  |生成一个 tiff 文件头：`{{tiff()}}` 生成大端 MM 和小端 II 两个变体；`{{tiff:mm()}}` 只生成 MM，`{{tiff:ii()}}` 只生成 II|
+|`tiff:mm`|  |生成大端序 tiff 文件头，例如 `{{tiff:mm()}}`|
+|`tiff:ii`|  |生成小端序 tiff 文件头，例如 `{{tiff:ii()}}`|
 |`timestamp`|  |生成一个时间戳，默认单位为秒，可指定单位：s, ms, ns: {{timestamp(s)}}|
 |`trim`|  |去除字符串两边的空格，一般配合其他 tag 使用，如：{{trim({{x(dict)}})}}|
 |`unquote`|  |把内容进行 strconv.Unquote 转化|

--- a/common/mutate/fuzztag_test.go
+++ b/common/mutate/fuzztag_test.go
@@ -678,3 +678,77 @@ func TestGhostBitsFuzzTag(t *testing.T) {
 		require.Equal(t, 1, len([]rune(results[0])), "单字符编码后应为单个 rune")
 	})
 }
+
+func TestJpgTiffVariantFuzzTags(t *testing.T) {
+	t.Run("jpg default keeps two variants", func(t *testing.T) {
+		results := MutateQuick(`{{jpg()}}`)
+		require.Len(t, results, 2)
+		require.Equal(t, "\xff\xd8\xff\xe0\x00\x10JFIF\xff\xd9", results[0])
+		require.Equal(t, "\xff\xd8\xff\xe1\x00\x1cExif\xff\xd9", results[1])
+	})
+
+	t.Run("jpg:jfif generates only JFIF header", func(t *testing.T) {
+		results := MutateQuick(`{{jpg:jfif()}}`)
+		require.Len(t, results, 1)
+		require.Equal(t, "\xff\xd8\xff\xe0\x00\x10JFIF\xff\xd9", results[0])
+	})
+
+	t.Run("jpg:exif generates only Exif header", func(t *testing.T) {
+		results := MutateQuick(`{{jpg:exif()}}`)
+		require.Len(t, results, 1)
+		require.Equal(t, "\xff\xd8\xff\xe1\x00\x1cExif\xff\xd9", results[0])
+	})
+
+	t.Run("jpg:jfif embeds data", func(t *testing.T) {
+		results := MutateQuick(`{{jpg:jfif(xx)}}`)
+		require.Len(t, results, 1)
+		require.Equal(t, "\xff\xd8\xff\xe0\x00\x10JFIFxx\xff\xd9", results[0])
+	})
+
+	t.Run("jpg:exif embeds data", func(t *testing.T) {
+		results := MutateQuick(`{{jpg:exif(xx)}}`)
+		require.Len(t, results, 1)
+		require.Equal(t, "\xff\xd8\xff\xe1\x00\x1cExifxx\xff\xd9", results[0])
+	})
+
+	t.Run("jpeg aliases work", func(t *testing.T) {
+		require.Equal(t, []string{"\xff\xd8\xff\xe0\x00\x10JFIF\xff\xd9"}, MutateQuick(`{{jpeg:jfif()}}`))
+		require.Equal(t, []string{"\xff\xd8\xff\xe1\x00\x1cExif\xff\xd9"}, MutateQuick(`{{jpeg:exif()}}`))
+	})
+
+	t.Run("jpg with unknown param keeps legacy behavior", func(t *testing.T) {
+		results := MutateQuick(`{{jpg(foo)}}`)
+		require.Len(t, results, 2)
+		require.Equal(t, "\xff\xd8\xff\xe0\x00\x10JFIFfoo\xff\xd9", results[0])
+		require.Equal(t, "\xff\xd8\xff\xe1\x00\x1cExiffoo\xff\xd9", results[1])
+	})
+
+	t.Run("jpg:jfif supports nested fuzztag data", func(t *testing.T) {
+		results := MutateQuick(`{{jpg:jfif({{int(1-2)}})}}`)
+		require.Len(t, results, 2)
+		require.Equal(t, "\xff\xd8\xff\xe0\x00\x10JFIF1\xff\xd9", results[0])
+		require.Equal(t, "\xff\xd8\xff\xe0\x00\x10JFIF2\xff\xd9", results[1])
+	})
+
+	t.Run("tiff default keeps two variants", func(t *testing.T) {
+		results := MutateQuick(`{{tiff()}}`)
+		require.Len(t, results, 2)
+		require.Equal(t, "\x4d\x4d", results[0])
+		require.Equal(t, "\x49\x49", results[1])
+	})
+
+	t.Run("tiff:mm generates only big-endian header", func(t *testing.T) {
+		require.Equal(t, []string{"\x4d\x4d"}, MutateQuick(`{{tiff:mm()}}`))
+	})
+
+	t.Run("tiff:ii generates only little-endian header", func(t *testing.T) {
+		require.Equal(t, []string{"\x49\x49"}, MutateQuick(`{{tiff:ii()}}`))
+	})
+
+	t.Run("tiff with unknown param keeps legacy behavior", func(t *testing.T) {
+		results := MutateQuick(`{{tiff(foo)}}`)
+		require.Len(t, results, 2)
+		require.Equal(t, "\x4d\x4d", results[0])
+		require.Equal(t, "\x49\x49", results[1])
+	})
+}


### PR DESCRIPTION
## 背景

`{{jpg()}}` 和 `{{tiff()}}` 目前固定生成两个文件头变体（JFIF/Exif、MM/II），无法只取其中一个。之前尝试用参数选择（如 `{{jpg(jfif)}}`），但会改变现有参数语义（参数原本是写入文件头的内容），且 `first`/`nth` 等 tag 无法收敛嵌套多结果。

## 改动

采用仓库既有的冒号变体命名惯例，新增独立 tag，不改动原 tag 行为：

| tag | 结果 |
|---|---|
| `{{jpg:jfif(数据)}}` | 只生成 JFIF 头，数据可选嵌入 |
| `{{jpg:exif(数据)}}` | 只生成 Exif 头，数据可选嵌入 |
| `{{tiff:mm()}}` | 只生成大端 MM |
| `{{tiff:ii()}}` | 只生成小端 II |

- `jpeg:jfif` / `jpeg:exif` 作为别名
- `{{jpg(任意数据)}}` / `{{tiff(任意数据)}}` 行为完全不变
- 同步更新 fuzztag.md 文档

## 测试

新增 `TestJpgTiffVariantFuzzTags`，覆盖默认双变体、单变体、数据嵌入、别名、未知参数向后兼容、嵌套 fuzztag 展开。