### PR TITLE
fix: 热加载管理 修复 重命名会把Tags 置空的bug

### DIFF
--- a/common/yakgrpc/grpc_hotpatch_template_test.go
+++ b/common/yakgrpc/grpc_hotpatch_template_test.go
@@ -175,7 +175,29 @@ func TestHotPatchTemplate(t *testing.T) {
 	require.Len(t, gots, 1)
 	checkYpbHotPatchTemplate(t, 0, gots[0])
 
-	// clear tags
+	// keep tags: update without Data.Tags keeps the existing tags
+	updateResp, err = local.UpdateHotPatchTemplate(ctx, &ypb.UpdateHotPatchTemplateRequest{
+		Condition: &ypb.HotPatchTemplateRequest{
+			Name: []string{names[0]},
+		},
+		Data: &ypb.HotPatchTemplate{
+			Name: "renamed-" + names[0],
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), updateResp.GetMessage().EffectRows)
+	names[0] = "renamed-" + names[0]
+
+	queryResp, err = local.QueryHotPatchTemplate(ctx, &ypb.HotPatchTemplateRequest{
+		Name: []string{names[0]},
+	})
+	require.NoError(t, err)
+
+	gots = queryResp.GetData()
+	require.Len(t, gots, 1)
+	checkYpbHotPatchTemplate(t, 0, gots[0])
+
+	// clear tags: Data carries only empty tags, which the legacy frontend uses to clear
 	clearedTag := tagsList[0][0]
 	updateResp, err = local.UpdateHotPatchTemplate(ctx, &ypb.UpdateHotPatchTemplateRequest{
 		Condition: &ypb.HotPatchTemplateRequest{

--- a/common/yakgrpc/yakit/hotpatch_template.go
+++ b/common/yakgrpc/yakit/hotpatch_template.go
@@ -102,7 +102,12 @@ func UpdateHotPatchTemplate(db *gorm.DB, name, content, typ string, tags []strin
 	if typ != "" { // disallow empty type to avoid clearing the type
 		m["type"] = typ
 	}
-	m["tags"] = schema.StringSlice(normalizeHotPatchTemplateTags(tags)) // allow empty tags to clear the tags
+	normalizedTags := normalizeHotPatchTemplateTags(tags)
+	if len(normalizedTags) > 0 { // disallow empty tags to avoid clearing the tags
+		m["tags"] = schema.StringSlice(normalizedTags)
+	} else if len(m) == 0 { // only Data.Tags is set (and empty): treat as clearing the tags
+		m["tags"] = schema.StringSlice(normalizedTags)
+	}
 	db = db.Updates(m)
 	return db.RowsAffected, db.Error
 }


### PR DESCRIPTION
## 问题

ref: https://github.com/yaklang/yakit/issues/4174 

热加载管理中重命名模板会把 Tags 清空：`UpdateHotPatchTemplate` 之前无条件写 `m["tags"]`，导致只传 Name（或只更新其他字段）的请求也会把已有 Tags 覆盖为空。

## 修复

`common/yakgrpc/yakit/hotpatch_template.go`：

- Tags 规范化后非空时才更新 tags，避免重命名/改内容等操作误清空 Tags；
- 仅当本次请求只带了空 Tags（`len(m) == 0`，即没有其他字段被更新）时，才视为显式清空 Tags，兼容旧前端"只传空 Tags 清空标签"的用法。

## 测试

`common/yakgrpc/grpc_hotpatch_template_test.go` 新增用例：

- 只传 Name 重命名（不带 Tags），验证 Tags 保留；
- 原有"只传空 Tags 清空"用例保留，验证清空路径不受影响。

`go test ./common/yakgrpc/ -run '^TestHotPatchTemplate$'` 通过。