### PR TITLE
feat(risk): CountRiskByRuntimeIds 支持多 runtimeId 并按风险等级统计

### DIFF
--- a/common/ai/aid/aicommon/session_snapshot.go
+++ b/common/ai/aid/aicommon/session_snapshot.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
 
@@ -59,6 +60,11 @@ type SessionSnapshotExecution struct {
 	HTTPFlowCount     int `json:"http_flow_count"`
 	RiskCount         int `json:"risk_count"`
 	ModifiedFileCount int `json:"modified_file_count"`
+
+	// RiskLevelCount 按风险等级分别统计本次会话产生的风险（跨全部 callToolID 聚合）。
+	// 使用值类型：可随 stats 一起值拷贝，序列化时字段恒定存在，前端无需处理 null。
+	// RiskCount 保留为旧前端兼容字段，始终等于 RiskLevelCount.Total。
+	RiskLevelCount yakit.RiskLevelCount `json:"risk_level_count"`
 }
 
 type SessionSnapshotPerception struct {
@@ -541,16 +547,27 @@ func (c *Config) refreshSessionSnapshotRuntimeCountsLocked(state *sessionSnapsho
 		return
 	}
 	httpTotal := 0
-	riskTotal := 0
+	runtimeIDs := make([]string, 0, len(state.execution.callToolIDs))
 	for callToolID := range state.execution.callToolIDs {
 		httpTotal += yakit.CountHTTPFlowByRuntimeID(db, callToolID)
-		riskTotal += func() int {
-			count, _ := yakit.CountRiskByRuntimeId(db, callToolID)
-			return count
-		}()
+		if id := strings.TrimSpace(callToolID); id != "" {
+			runtimeIDs = append(runtimeIDs, id)
+		}
 	}
 	state.execution.stats.HTTPFlowCount = httpTotal
-	state.execution.stats.RiskCount = riskTotal
+
+	// 整体重置后再回填：callToolIDs 集合可能已缩小，累参加重会残留上一轮的等级计数。
+	// 一次 GROUP BY 查询完成多 runtime 的分级统计，避开 N 次 count。
+	riskLevel := yakit.RiskLevelCount{}
+	if len(runtimeIDs) > 0 {
+		if result, err := yakit.CountRiskByRuntimeIds(db, runtimeIDs...); err != nil {
+			log.Warnf("refresh session snapshot risk level count failed: %v", err)
+		} else if result != nil {
+			riskLevel = *result
+		}
+	}
+	state.execution.stats.RiskLevelCount = riskLevel
+	state.execution.stats.RiskCount = int(riskLevel.Total)
 }
 
 func (c *Config) prepareSessionSnapshotEndedAtForEmitLocked(state *sessionSnapshotState) {

--- a/common/ai/aid/aicommon/session_snapshot_test.go
+++ b/common/ai/aid/aicommon/session_snapshot_test.go
@@ -2,12 +2,18 @@ package aicommon
 
 import (
 	"context"
+	"encoding/json"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 )
 
 func TestSessionSnapshot_BuildAndRevision(t *testing.T) {
@@ -117,4 +123,55 @@ func TestBuildSessionSnapshotExecution_EndedAtOnEmit(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	afterFinal := cfg.BuildSessionSnapshotExecution(nil)
 	require.Equal(t, final.EndedAt, afterFinal.EndedAt)
+}
+
+func TestSessionSnapshot_RiskLevelCount(t *testing.T) {
+	originProjectDBPath := consts.GetCurrentProjectDatabasePath()
+	require.NoError(t, consts.SetGormProjectDatabase(filepath.Join(t.TempDir(), "snapshot-risk.db")))
+	t.Cleanup(func() {
+		require.NoError(t, consts.SetGormProjectDatabase(originProjectDBPath))
+	})
+
+	db := consts.GetGormProjectDatabase()
+	require.NoError(t, db.AutoMigrate(&schema.Risk{}).Error)
+
+	createRisk := func(runtimeId, severity, url string) {
+		risk := &schema.Risk{
+			RuntimeId: runtimeId, RiskType: "sqli", Severity: severity,
+			Url: url, Title: "t-" + utils.RandStringBytes(5),
+		}
+		require.NoError(t, yakit.CreateOrUpdateRisk(db, utils.RandStringBytes(16), risk))
+	}
+
+	// 会话内两个 runtime 的风险必须合并统计，middle 计入 warning
+	createRisk("snapshot-rt-a", "critical", "http://a/1")
+	createRisk("snapshot-rt-a", "middle", "http://a/2")
+	createRisk("snapshot-rt-b", "high", "http://b/1")
+	// 不属于本会话的 runtime，不应进入统计
+	createRisk("snapshot-rt-c", "critical", "http://c/1")
+
+	cfg := NewConfig(context.Background(), WithDisableAutoSkills(true))
+	cfg.ResetSessionSnapshotExecution("demo-task", "processing", time.Unix(1_700_000_000, 0))
+	cfg.RecordSessionSnapshotToolCall(&aitool.ToolResult{Name: "grep", Success: true, ToolCallID: "snapshot-rt-a"})
+	cfg.RecordSessionSnapshotToolCall(&aitool.ToolResult{Name: "fuzz", Success: true, ToolCallID: "snapshot-rt-b"})
+
+	exec := cfg.BuildSessionSnapshotExecution(nil)
+	require.NotNil(t, exec)
+	require.EqualValues(t, 1, exec.RiskLevelCount.Critical)
+	require.EqualValues(t, 1, exec.RiskLevelCount.High)
+	require.EqualValues(t, 1, exec.RiskLevelCount.Warning)
+	require.EqualValues(t, 0, exec.RiskLevelCount.Low)
+	require.EqualValues(t, 3, exec.RiskLevelCount.Total)
+	require.Equal(t, int(exec.RiskLevelCount.Total), exec.RiskCount)
+
+	raw, err := json.Marshal(exec)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"risk_level_count"`)
+
+	// 重置后不得残留上一轮执行的等级计数
+	cfg.ResetSessionSnapshotExecution("demo-task", "processing", time.Unix(1_700_000_000, 0))
+	empty := cfg.BuildSessionSnapshotExecution(nil)
+	require.NotNil(t, empty)
+	require.EqualValues(t, 0, empty.RiskLevelCount.Total)
+	require.Equal(t, 0, empty.RiskCount)
 }

--- a/common/yakgrpc/yakit/risk.go
+++ b/common/yakgrpc/yakit/risk.go
@@ -2,6 +2,7 @@ package yakit
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/yaklang/gorm"
@@ -90,12 +91,97 @@ func GetRisksByRuntimeId(db *gorm.DB, runtimeId string) ([]*schema.Risk, error) 
 	return r, nil
 }
 
-func CountRiskByRuntimeId(db *gorm.DB, runtimeId string) (int, error) {
-	var count int
-	if db := db.Model(&schema.Risk{}).Where("runtime_id = ?", runtimeId).Count(&count); db.Error != nil {
-		return 0, utils.Errorf("get Risks count failed: %s", db.Error)
+// RiskLevelCount 按照风险等级(severity)分别统计的结果
+type RiskLevelCount struct {
+	Critical int64 `json:"critical"` // 严重
+	High     int64 `json:"high"`     // 高危
+	Warning  int64 `json:"warning"`  // 中危(warning/middle/medium/warn)
+	Low      int64 `json:"low"`      // 低危
+	Info     int64 `json:"info"`     // 信息(info/debug/fingerprint/空值等)
+	Other    int64 `json:"other"`    // 无法归类的等级，保证 Total 不丢失数据
+	Total    int64 `json:"total"`    // 以上所有等级之和
+}
+
+// rawSeverityCount 用于接收 `GROUP BY severity` 的原始查询结果
+type rawSeverityCount struct {
+	Severity string `json:"severity"`
+	Count    int64  `json:"count"`
+}
+
+// NormalizeRiskSeverity 将历史上各种写法的风险等级归一化为
+// critical/high/warning/low/info 五个标准等级，无法识别的返回 "other"。
+// 与 WithRiskParam_Severity 的映射保持一致，同时兼容未走该选项写入的脏数据。
+func NormalizeRiskSeverity(severity string) string {
+	switch strings.TrimSpace(strings.ToLower(severity)) {
+	case "critical", "panic", "fatal":
+		return "critical"
+	case "high":
+		return "high"
+	case "warning", "warn", "middle", "medium":
+		return "warning"
+	case "low", "default":
+		return "low"
+	case "", "info", "debug", "trace", "fingerprint", "note", "fp":
+		return "info"
+	default:
+		return "other"
 	}
-	return count, nil
+}
+
+// CountRiskByRuntimeIds 统计一个或多个 runtimeId 产生的风险，并按风险等级分别计数。
+// 返回值为所有传入 runtimeId 的汇总统计；若未传入任何有效 runtimeId 则返回错误。
+func CountRiskByRuntimeIds(db *gorm.DB, runtimeIds ...string) (*RiskLevelCount, error) {
+	var ids []string
+	for _, id := range runtimeIds {
+		if id = strings.TrimSpace(id); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	ids = utils.RemoveRepeatStringSlice(ids)
+	if len(ids) == 0 {
+		return nil, utils.Errorf("count Risks failed: empty runtime ids")
+	}
+
+	var results []*rawSeverityCount
+	if db := db.Model(&schema.Risk{}).
+		Select("severity, COUNT(*) as count").
+		Where("runtime_id IN (?)", ids).
+		Group("severity").
+		Scan(&results); db.Error != nil {
+		return nil, utils.Errorf("get Risks count failed: %s", db.Error)
+	}
+
+	stat := &RiskLevelCount{}
+	for _, r := range results {
+		if r == nil {
+			continue
+		}
+		switch NormalizeRiskSeverity(r.Severity) {
+		case "critical":
+			stat.Critical += r.Count
+		case "high":
+			stat.High += r.Count
+		case "warning":
+			stat.Warning += r.Count
+		case "low":
+			stat.Low += r.Count
+		case "info":
+			stat.Info += r.Count
+		default:
+			stat.Other += r.Count
+		}
+		stat.Total += r.Count
+	}
+	return stat, nil
+}
+
+// CountRiskByRuntimeId 统计单个 runtimeId 产生的风险总数。
+func CountRiskByRuntimeId(db *gorm.DB, runtimeId string) (int, error) {
+	stat, err := CountRiskByRuntimeIds(db, runtimeId)
+	if err != nil {
+		return 0, err
+	}
+	return int(stat.Total), nil
 }
 
 func GetRiskByHash(db *gorm.DB, hash string) (*schema.Risk, error) {

--- a/common/yakgrpc/yakit/risk_count_test.go
+++ b/common/yakgrpc/yakit/risk_count_test.go
@@ -1,0 +1,82 @@
+package yakit
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func newRiskCountTestDB(t *testing.T) *gorm.DB {
+	db, err := consts.CreateProjectDatabase(filepath.Join(t.TempDir(), "risk-count.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.Risk{}).Error)
+	return db
+}
+
+func TestNormalizeRiskSeverity(t *testing.T) {
+	require.Equal(t, "critical", NormalizeRiskSeverity("PANIC"))
+	require.Equal(t, "critical", NormalizeRiskSeverity(" fatal "))
+	require.Equal(t, "high", NormalizeRiskSeverity("high"))
+	require.Equal(t, "warning", NormalizeRiskSeverity("Middle"))
+	require.Equal(t, "warning", NormalizeRiskSeverity("medium"))
+	require.Equal(t, "warning", NormalizeRiskSeverity("warn"))
+	require.Equal(t, "low", NormalizeRiskSeverity("default"))
+	require.Equal(t, "info", NormalizeRiskSeverity(""))
+	require.Equal(t, "info", NormalizeRiskSeverity("fingerprint"))
+	require.Equal(t, "other", NormalizeRiskSeverity("unknown-level"))
+}
+
+func TestCountRiskByRuntimeIds_MultiRuntime(t *testing.T) {
+	db := newRiskCountTestDB(t)
+
+	risks := []*schema.Risk{
+		{Hash: "h1", Url: "http://a/1", RuntimeId: "rt-1", RiskType: "sqli", Severity: "high", Title: "t1"},
+		{Hash: "h2", Url: "http://a/2", RuntimeId: "rt-1", RiskType: "xss", Severity: "critical", Title: "t2"},
+		{Hash: "h3", Url: "http://b/1", RuntimeId: "rt-2", RiskType: "info", Severity: "low", Title: "t3"},
+		// middle 属于历史写法，应当归入 warning 统计
+		{Hash: "h4", Url: "http://b/2", RuntimeId: "rt-2", RiskType: "info", Severity: "middle", Title: "t4"},
+		// 空等级应当归入 info
+		{Hash: "h5", Url: "http://b/3", RuntimeId: "rt-2", RiskType: "info", Title: "t5"},
+		// 不属于任何被统计的 runtime
+		{Hash: "h6", Url: "http://c/1", RuntimeId: "rt-3", RiskType: "sqli", Severity: "critical", Title: "t6"},
+		// 完全未知的等级归入 other，但依然计入 Total
+		{Hash: "h7", Url: "http://c/2", RuntimeId: "rt-2", RiskType: "sqli", Severity: "super-critical", Title: "t7"},
+	}
+	for _, r := range risks {
+		require.NoError(t, CreateOrUpdateRisk(db, r.Hash, r))
+	}
+
+	stat, err := CountRiskByRuntimeIds(db, "rt-1", "rt-2", "", "rt-1")
+	require.NoError(t, err)
+	require.NotNil(t, stat)
+
+	require.EqualValues(t, 1, stat.Critical)
+	require.EqualValues(t, 1, stat.High)
+	require.EqualValues(t, 1, stat.Warning)
+	require.EqualValues(t, 1, stat.Low)  // h3
+	require.EqualValues(t, 1, stat.Info) // h5，schema.BeforeSave 会将空等级补齐为 info
+	require.EqualValues(t, 1, stat.Other)
+	require.EqualValues(t, 6, stat.Total) // h6 属于 rt-3，不计入
+	require.EqualValues(t, stat.Critical+stat.High+stat.Warning+stat.Low+stat.Info+stat.Other, stat.Total)
+
+	// 单个 runtime 也支持
+	stat2, err := CountRiskByRuntimeIds(db, "rt-1")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, stat2.Total)
+	require.EqualValues(t, 1, stat2.High)
+	require.EqualValues(t, 1, stat2.Critical)
+
+	// 空 runtimeId 应当报错而不是全表统计
+	empty, err := CountRiskByRuntimeIds(db, "", "  ")
+	require.Error(t, err)
+	require.Nil(t, empty)
+
+	// 兼容旧的单 runtime 总数接口
+	total, err := CountRiskByRuntimeId(db, "rt-2")
+	require.NoError(t, err)
+	require.Equal(t, 4, total)
+}


### PR DESCRIPTION
## 背景
`yakit.CountRiskByRuntimeId` 只能按单个 runtimeId 返回一个总数，AI 会话快照（session snapshot）等场景需要「一次查询多个 runtime + 按风险等级分别统计」的能力。

## 变更

### 1. `common/yakgrpc/yakit/risk.go`
- 新增统计结构体 `RiskLevelCount`：`critical / high / warning / low / info / other / total`，`other` 兜底保证 total 不丢数据。
- 新增 `NormalizeRiskSeverity`：与 `WithRiskParam_Severity` 的映射保持一致，兼容 `panic/fatal → critical`、`middle/medium/warn → warning`、`default → low`、空值/`fingerprint → info` 等历史写法与脏数据。
- 新增 `CountRiskByRuntimeIds(db, runtimeIds...)`：
  - 单条 `GROUP BY severity` 查询完成多 runtime 的分级聚合（不再是 N 次 count）；
  - 自动 trim / 去重 / 过滤空 id，全部为空时返回错误，避免退化成全表统计。
- `CountRiskByRuntimeId` 保留为取 `Total` 的薄封装，现有 6 处调用方与 3 处测试无需改动。

### 2. `common/ai/aid/aicommon/session_snapshot.go`
- `SessionSnapshotExecution` 新增值类型字段 `RiskLevelCount yakit.RiskLevelCount`（JSON: `risk_level_count`）：随 stats 值拷贝，无共享指针；序列化字段恒定存在，前端无需处理 null。
- `refreshSessionSnapshotRuntimeCountsLocked` 改用 `CountRiskByRuntimeIds`，一次查询得到全量分级统计；统计结果整体重置后回填，避免 `callToolIDs` 集合缩小时残留上一轮等级计数；查询失败仅告警，不阻断快照 emit。
- `RiskCount` 保留为兼容字段，恒等于 `RiskLevelCount.Total`。

## 兼容性
- gRPC / 前端：`execution` 仅新增 `risk_level_count` 对象字段，`risk_count` 语义不变。
- 无 DB schema 变更。

## 测试
- 新增 `common/yakgrpc/yakit/risk_count_test.go`：等级归一化、多 runtime 汇总、重复/空 id 过滤、未知等级兜底、空 id 报错、旧接口兼容。
- 新增 `TestSessionSnapshot_RiskLevelCount`：多 runtime 合并、`middle → warning`、非本会话 runtime 排除、`risk_count == total`、JSON 输出、reset 后不残留。
- 已验证：`go build ./common/yak/yakscript/... ./common/yakgrpc/... ./common/ai/...`、`go test ./common/yakgrpc/yakit -run 'Risk'`、`go test ./common/ai/aid/aicommon -run 'TestSessionSnapshot|TestToolCallerInvoke_'` 均通过。