### PR TITLE
feat(lowhttp): 补上 #4927 留下的 HTTP/2 指纹 TODO（独立 opt-in）

### DIFF
--- a/common/crep/mitm.go
+++ b/common/crep/mitm.go
@@ -375,6 +375,10 @@ type MITMServer struct {
 	// TLS fingerprint used for ordinary upstream connections.
 	tlsFingerprint string
 
+	// HTTP/2 framing fingerprint used for ordinary upstream connections.
+	// Empty (the default) keeps the compatibility-oriented framing.
+	http2Fingerprint string
+
 	// SNI (Server Name Indication) configuration
 	sni          string            // SNI 值
 	overwriteSNI bool              // 是否覆盖自动推断的 SNI
@@ -480,6 +484,9 @@ func (m *MITMServer) initConfig() error {
 	}
 	if m.tlsFingerprint != "" {
 		config = append(config, lowhttp.WithTLSFingerprint(m.tlsFingerprint))
+	}
+	if m.http2Fingerprint != "" {
+		config = append(config, lowhttp.WithHTTP2Fingerprint(m.http2Fingerprint))
 	}
 
 	m.sniResolver = NewSNIResolver(m.sniMapping, m.overwriteSNI, m.sni)

--- a/common/crep/mitm_config.go
+++ b/common/crep/mitm_config.go
@@ -98,6 +98,20 @@ func MITM_TLSFingerprint(name string) MITMConfig {
 	}
 }
 
+// MITM_HTTP2Fingerprint selects the HTTP/2 framing fingerprint used for
+// ordinary upstream h2 connections. It defaults to empty, which keeps the
+// framing that tolerates servers rejecting browser-style HEADERS; enabling a
+// profile is an explicit opt-in and is independent of MITM_TLSFingerprint.
+func MITM_HTTP2Fingerprint(name string) MITMConfig {
+	return func(server *MITMServer) error {
+		if err := lowhttp.ValidateHTTP2Profile(name); err != nil {
+			return err
+		}
+		server.http2Fingerprint = name
+		return nil
+	}
+}
+
 // MITM_SetSNI 设置 SNI (Server Name Indication) 配置
 // 支持三种模式：
 // 1. 自动模式（默认）：不调用此函数，或 overwrite=false

--- a/common/utils/lowhttp/config.go
+++ b/common/utils/lowhttp/config.go
@@ -141,6 +141,7 @@ type LowhttpExecConfig struct {
 	RandomJA3FingerPrint bool
 	ClientHelloSpec      *utls.ClientHelloSpec
 	TLSFingerprint       string
+	HTTP2Fingerprint     string
 
 	Tags []string
 
@@ -1031,6 +1032,16 @@ func WithClientHelloSpec(spec *utls.ClientHelloSpec) LowhttpOpt {
 func WithTLSFingerprint(name string) LowhttpOpt {
 	return func(o *LowhttpExecConfig) {
 		o.TLSFingerprint = name
+	}
+}
+
+// WithHTTP2Fingerprint selects a built-in HTTP/2 framing fingerprint profile
+// (see AvailableHTTP2Profiles). It is independent of WithTLSFingerprint: the
+// default HTTP/2 framing stays compatible with non-conforming servers unless a
+// profile is requested explicitly.
+func WithHTTP2Fingerprint(name string) LowhttpOpt {
+	return func(o *LowhttpExecConfig) {
+		o.HTTP2Fingerprint = name
 	}
 }
 

--- a/common/utils/lowhttp/conn_pool.go
+++ b/common/utils/lowhttp/conn_pool.go
@@ -836,6 +836,10 @@ func (pc *persistConn) h2Conn() {
 		},
 	}
 
+	// The peer may grow its encoder table to our advertised limit. Keep the
+	// initial table at the protocol default until its HPACK size update arrives.
+	newH2Conn.hDec.SetAllowedMaxDynamicTableSize(profile.settingValue(http2.SettingHeaderTableSize, 4096))
+
 	// Initialize synchronization before starting any timer callback.
 	newH2Conn.streamsCond = sync.NewCond(newH2Conn.mu)
 	newH2Conn.bw = bufio.NewWriterSize(&h2DeadlineWriter{conn: newH2Conn}, 4096)

--- a/common/utils/lowhttp/conn_pool.go
+++ b/common/utils/lowhttp/conn_pool.go
@@ -791,6 +791,18 @@ func (pc *persistConn) h2Conn() {
 	// which lets a non-compliant peer pin a multi-megabyte read buffer on every
 	// cached H2 connection.
 
+	var profile *http2Profile
+	if pc.cacheKey != nil && pc.cacheKey.http2Fingerprint != "" {
+		resolved, err := getHTTP2Profile(pc.cacheKey.http2Fingerprint)
+		if err != nil {
+			// exec.go validates the name up front; falling back to the default
+			// framing keeps an unexpected value from breaking the connection.
+			log.Warnf("lowhttp: %v, falling back to default HTTP/2 framing", err)
+		} else {
+			profile = resolved
+		}
+	}
+
 	newH2Conn := &http2ClientConn{
 		conn:                   pc.conn,
 		ctx:                    pc.p.ctx,
@@ -813,6 +825,7 @@ func (pc *persistConn) h2Conn() {
 		closeCh:                make(chan struct{}),
 		readLoopExited:         make(chan struct{}),
 		serverPrefaceCh:        make(chan struct{}, 1),
+		http2Profile:           profile,
 		// pc back-reference: used by setClose() to evict this connection from
 		// the pool's h2ConnMap when it transitions to closed state.
 		pc: pc,
@@ -1420,18 +1433,19 @@ func (e connPoolReadFromServerError) Error() string {
 }
 
 type connectKey struct {
-	proxy           []string // 可以使用的代理
-	scheme, addr    string   // 协议和目标地址
-	https           bool
-	gmTls           bool
-	clientHelloSpec *utls.ClientHelloSpec
-	tlsFingerprint  string
-	sni             string
-	strongHost      string
+	proxy            []string // 可以使用的代理
+	scheme, addr     string   // 协议和目标地址
+	https            bool
+	gmTls            bool
+	clientHelloSpec  *utls.ClientHelloSpec
+	tlsFingerprint   string
+	http2Fingerprint string
+	sni              string
+	strongHost       string
 }
 
 func (c *connectKey) hash() string {
-	return utils.CalcSha1(c.proxy, c.scheme, c.addr, c.https, c.gmTls, c.clientHelloSpec, c.tlsFingerprint, c.sni, c.strongHost)
+	return utils.CalcSha1(c.proxy, c.scheme, c.addr, c.https, c.gmTls, c.clientHelloSpec, c.tlsFingerprint, c.http2Fingerprint, c.sni, c.strongHost)
 }
 
 type connLRU struct {

--- a/common/utils/lowhttp/exec.go
+++ b/common/utils/lowhttp/exec.go
@@ -309,6 +309,7 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 		randomJA3FingerPrint    = option.RandomJA3FingerPrint
 		clientHelloSpec         = option.ClientHelloSpec
 		tlsFingerprint          = option.TLSFingerprint
+		http2Fingerprint        = option.HTTP2Fingerprint
 		dialer                  = option.Dialer
 		fixQueryEscape          = option.FixQueryEscape
 	)
@@ -320,6 +321,14 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 	if tlsFingerprint != "" {
 		_, err := netx.GetClientHelloProfile(tlsFingerprint)
 		if err != nil {
+			return response, err
+		}
+	}
+	// HTTP/2 framing is opt-in on its own: selecting a TLS fingerprint must not
+	// change it, because the default framing deliberately accommodates servers
+	// that reject browser-style HEADERS.
+	if http2Fingerprint != "" {
+		if _, err := getHTTP2Profile(http2Fingerprint); err != nil {
 			return response, err
 		}
 	}
@@ -782,13 +791,14 @@ func HTTPWithoutRetry(option *LowhttpExecConfig) (*LowhttpResponse, error) {
 	}
 
 	cacheKey := &connectKey{
-		proxy:           proxy,
-		scheme:          reqSchema,
-		addr:            originAddr,
-		https:           option.Https,
-		gmTls:           option.GmTLS,
-		clientHelloSpec: clientHelloSpec,
-		tlsFingerprint:  tlsFingerprint,
+		proxy:            proxy,
+		scheme:           reqSchema,
+		addr:             originAddr,
+		https:            option.Https,
+		gmTls:            option.GmTLS,
+		clientHelloSpec:  clientHelloSpec,
+		tlsFingerprint:   tlsFingerprint,
+		http2Fingerprint: http2Fingerprint,
 	}
 	if sni != nil {
 		cacheKey.sni = *sni

--- a/common/utils/lowhttp/http2_body_pipe.go
+++ b/common/utils/lowhttp/http2_body_pipe.go
@@ -13,6 +13,7 @@ type h2BodyPipe struct {
 	mu                         sync.Mutex
 	cond                       *sync.Cond
 	buf                        bytes.Buffer
+	maxBufferedBytes           int
 	readerClosed, writerClosed bool
 	onRead                     func(int)
 	onClose                    func()
@@ -21,7 +22,11 @@ type h2BodyReader struct{ p *h2BodyPipe }
 type h2BodyWriter struct{ p *h2BodyPipe }
 
 func newH2BodyPipe() (*h2BodyReader, *h2BodyWriter) {
-	p := &h2BodyPipe{}
+	return newH2BodyPipeWithLimit(defaultStreamReceiveWindowSize)
+}
+
+func newH2BodyPipeWithLimit(limit int) (*h2BodyReader, *h2BodyWriter) {
+	p := &h2BodyPipe{maxBufferedBytes: limit}
 	p.cond = sync.NewCond(&p.mu)
 	return &h2BodyReader{p}, &h2BodyWriter{p}
 }
@@ -70,7 +75,7 @@ func (w *h2BodyWriter) Write(src []byte) (int, error) {
 	if p.readerClosed || p.writerClosed {
 		return 0, io.ErrClosedPipe
 	}
-	if len(src) > defaultStreamReceiveWindowSize-p.buf.Len() {
+	if len(src) > p.maxBufferedBytes-p.buf.Len() {
 		return 0, errH2BodyWindowExceeded
 	}
 	n, err := p.buf.Write(src)

--- a/common/utils/lowhttp/http2_client.go
+++ b/common/utils/lowhttp/http2_client.go
@@ -70,6 +70,12 @@ type http2ClientConn struct {
 	activeStreams int
 	streamsCond   *sync.Cond // based on mu
 
+	// http2Profile, when set, makes this connection write Chrome-like framing
+	// (SETTINGS, connection WINDOW_UPDATE, pseudo-header order, HEADERS
+	// priority and END_STREAM placement). nil means the default framing, which
+	// stays compatible with non-conforming servers.
+	http2Profile *http2Profile
+
 	maxFrameSize           uint32
 	initialWindowSize      uint32
 	maxStreamsCount        uint32
@@ -352,18 +358,29 @@ func (h2Conn *http2ClientConn) preface() error {
 	if _, err := prefaceWriter.Write([]byte(http2.ClientPreface)); err != nil {
 		return err
 	}
-	err := h2Conn.fr.WriteSettings(
-		http2.Setting{ID: http2.SettingEnablePush, Val: 0},
-		http2.Setting{ID: http2.SettingInitialWindowSize, Val: defaultStreamReceiveWindowSize},
-		http2.Setting{ID: http2.SettingMaxFrameSize, Val: defaultMaxFrameSize},
-		http2.Setting{ID: http2.SettingMaxConcurrentStreams, Val: defaultMaxConcurrentStreamSize},
-		http2.Setting{ID: http2.SettingMaxHeaderListSize, Val: defaultMaxHeaderListSize},
-	)
+	settings := []http2.Setting{
+		{ID: http2.SettingEnablePush, Val: 0},
+		{ID: http2.SettingInitialWindowSize, Val: defaultStreamReceiveWindowSize},
+		{ID: http2.SettingMaxFrameSize, Val: defaultMaxFrameSize},
+		{ID: http2.SettingMaxConcurrentStreams, Val: defaultMaxConcurrentStreamSize},
+		{ID: http2.SettingMaxHeaderListSize, Val: defaultMaxHeaderListSize},
+	}
+	// Increase connection-level flow control window from default 65535 to our desired size.
+	// RFC 7540 Section 6.9.2: SETTINGS only affects stream-level windows.
+	// Connection window must be increased via WINDOW_UPDATE.
+	connWindowIncrease := int64(defaultStreamReceiveWindowSize) - 65535
+	if profile := h2Conn.http2Profile; profile != nil {
+		settings = profile.settings
+		connWindowIncrease = int64(profile.connWindowUpdate)
+	}
+	err := h2Conn.fr.WriteSettings(settings...)
 	if err != nil {
 		return err
 	}
-	if err = h2Conn.fr.WriteWindowUpdate(0, defaultStreamReceiveWindowSize-65535); err != nil {
-		return err
+	if connWindowIncrease > 0 {
+		if err = h2Conn.fr.WriteWindowUpdate(0, uint32(connWindowIncrease)); err != nil {
+			return err
+		}
 	}
 	if err := h2Conn.flushFrames(); err != nil {
 		return err
@@ -734,6 +751,10 @@ func (cs *http2ClientStream) doRequest() error {
 			}
 		}
 	})
+	profile := cs.h2Conn.http2Profile
+	if profile != nil {
+		requestHeaders = profile.reorderPseudoHeaders(requestHeaders)
+	}
 
 	h2HeaderWriter := func(frame *http2.Framer, streamID uint32, endStream bool, maxFrameSize uint32, hdrs []byte) error {
 		first := true // first frame written (HEADERS is first, then CONTINUATION)
@@ -745,13 +766,20 @@ func (cs *http2ClientStream) doRequest() error {
 			hdrs = hdrs[len(chunk):]
 			endHeaders := len(hdrs) == 0
 			if first {
-				//endStream = endStream && endHeaders
-				err := frame.WriteHeaders(http2.HeadersFrameParam{ // some server not accept endStream flag in headers frame
+				// Default framing omits END_STREAM here: some servers do not
+				// accept it on HEADERS. A profile opts back into it, and RFC
+				// 7540 6.2 keeps the flag on HEADERS even when CONTINUATION
+				// frames follow.
+				param := http2.HeadersFrameParam{
 					StreamID:      streamID,
 					BlockFragment: chunk,
-					//EndStream:     endStream,
-					EndHeaders: endHeaders,
-				})
+					EndStream:     endStream,
+					EndHeaders:    endHeaders,
+				}
+				if profile != nil && !profile.headersPriority.IsZero() {
+					param.Priority = profile.headersPriority
+				}
+				err := frame.WriteHeaders(param)
 				first = false
 				if err != nil {
 					return err
@@ -821,9 +849,10 @@ func (cs *http2ClientStream) doRequest() error {
 	cs.h2Conn.full = cs.ID == (1<<31)-1
 	cs.h2Conn.mu.Unlock()
 	// activeStreams was already incremented in newStream when the slot was reserved.
+	endStreamOnHeaders := profile != nil && profile.endStreamOnHeaders && len(body) == 0
 	c.writeCtx = cs.requestCtx
-	err := h2HeaderWriter(fr, cs.ID, false, maxFrameSize, c.hEncBuf.Bytes())
-	if err == nil && len(body) == 0 {
+	err := h2HeaderWriter(fr, cs.ID, endStreamOnHeaders, maxFrameSize, c.hEncBuf.Bytes())
+	if err == nil && len(body) == 0 && !endStreamOnHeaders {
 		err = fr.WriteData(cs.ID, true, nil)
 		cs.sentEndStream = err == nil
 	}

--- a/common/utils/lowhttp/http2_client.go
+++ b/common/utils/lowhttp/http2_client.go
@@ -528,7 +528,7 @@ func (h2Conn *http2ClientConn) newStream(req *http.Request, packet []byte, optio
 	cs.resp = new(http.Response)
 	cs.resp.ProtoMajor = 2
 	cs.contentLength = -1
-	cs.recvWindow = defaultStreamReceiveWindowSize
+	cs.recvWindow = int64(h2Conn.http2Profile.settingValue(http2.SettingInitialWindowSize, defaultStreamReceiveWindowSize))
 	h2Conn.mu.Lock()
 	initialWindowSize := h2Conn.initialWindowSize
 	h2Conn.mu.Unlock()
@@ -555,7 +555,7 @@ func (h2Conn *http2ClientConn) newStream(req *http.Request, packet []byte, optio
 	if option != nil {
 		cs.noBodyBuffer = option.NoBodyBuffer
 		if option.BodyStreamReaderHandler != nil {
-			reader, writer := newH2BodyPipe()
+			reader, writer := newH2BodyPipeWithLimit(int(cs.recvWindow))
 			cs.bodyStreamReader = reader
 			cs.bodyStreamWriter = writer
 			cs.bodyStreamDone = make(chan struct{})
@@ -759,9 +759,15 @@ func (cs *http2ClientStream) doRequest() error {
 	h2HeaderWriter := func(frame *http2.Framer, streamID uint32, endStream bool, maxFrameSize uint32, hdrs []byte) error {
 		first := true // first frame written (HEADERS is first, then CONTINUATION)
 		for len(hdrs) > 0 {
+			fragmentLimit := int(maxFrameSize)
+			if first && profile != nil && !profile.headersPriority.IsZero() {
+				// The dependency and weight occupy five bytes of the HEADERS
+				// payload; CONTINUATION frames have no priority fields.
+				fragmentLimit -= 5
+			}
 			chunk := hdrs
-			if len(chunk) > int(maxFrameSize) {
-				chunk = chunk[:maxFrameSize]
+			if len(chunk) > fragmentLimit {
+				chunk = chunk[:fragmentLimit]
 			}
 			hdrs = hdrs[len(chunk):]
 			endHeaders := len(hdrs) == 0

--- a/common/utils/lowhttp/http2_fingerprint.go
+++ b/common/utils/lowhttp/http2_fingerprint.go
@@ -1,0 +1,123 @@
+package lowhttp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+// HTTP2FingerprintChrome151 mirrors the HTTP/2 framing of Chrome 151, whose
+// Akamai fingerprint is 1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p
+const HTTP2FingerprintChrome151 = "chrome-151"
+
+const (
+	chromeH2HeaderTableSize     = 65536
+	chromeH2InitialWindowSize   = 6291456
+	chromeH2MaxHeaderListSize   = 262144
+	chromeH2ConnWindowIncrement = 15663105
+	// HTTP/2 encodes a stream weight of 256 as the value 255 on the wire.
+	chromeH2HeadersWeight = 255
+)
+
+// http2Profile describes the HTTP/2 framing behaviour of a specific client.
+//
+// A profile only changes the bytes this client writes. Flow-control
+// bookkeeping (initialWindowSize, connWindowControl) tracks the windows the
+// peer advertises to us and is deliberately left untouched: SETTINGS and
+// WINDOW_UPDATE written here advertise our receive capacity, which is a
+// separate direction from the send windows those fields account for.
+type http2Profile struct {
+	id                string
+	settings          []http2.Setting
+	connWindowUpdate  uint32
+	pseudoHeaderOrder []string
+	headersPriority   http2.PriorityParam
+	// endStreamOnHeaders carries END_STREAM on HEADERS for body-less requests
+	// instead of appending an empty DATA frame. Browsers do this; some
+	// non-conforming servers reject it, which is why it is opt-in only.
+	endStreamOnHeaders bool
+}
+
+var http2Profiles = map[string]*http2Profile{
+	HTTP2FingerprintChrome151: {
+		id: HTTP2FingerprintChrome151,
+		settings: []http2.Setting{
+			{ID: http2.SettingHeaderTableSize, Val: chromeH2HeaderTableSize},
+			{ID: http2.SettingEnablePush, Val: 0},
+			{ID: http2.SettingInitialWindowSize, Val: chromeH2InitialWindowSize},
+			{ID: http2.SettingMaxHeaderListSize, Val: chromeH2MaxHeaderListSize},
+		},
+		connWindowUpdate: chromeH2ConnWindowIncrement,
+		// Chrome sends :method :authority :scheme :path, which differs from the
+		// alphabetical order produced by the Go standard library.
+		pseudoHeaderOrder: []string{":method", ":authority", ":scheme", ":path"},
+		headersPriority: http2.PriorityParam{
+			StreamDep: 0,
+			Exclusive: true,
+			Weight:    chromeH2HeadersWeight,
+		},
+		endStreamOnHeaders: true,
+	},
+}
+
+func getHTTP2Profile(name string) (*http2Profile, error) {
+	profile, ok := http2Profiles[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown HTTP/2 fingerprint profile %q (available: %v)", name, AvailableHTTP2Profiles())
+	}
+	return profile, nil
+}
+
+// ValidateHTTP2Profile reports whether name refers to a built-in HTTP/2
+// fingerprint profile. An empty name is valid and means the default framing.
+func ValidateHTTP2Profile(name string) error {
+	if name == "" {
+		return nil
+	}
+	_, err := getHTTP2Profile(name)
+	return err
+}
+
+// AvailableHTTP2Profiles lists the built-in HTTP/2 fingerprint profile names.
+func AvailableHTTP2Profiles() []string {
+	profiles := make([]string, 0, len(http2Profiles))
+	for name := range http2Profiles {
+		profiles = append(profiles, name)
+	}
+	sort.Strings(profiles)
+	return profiles
+}
+
+// reorderPseudoHeaders returns fields with pseudo headers moved to the front in
+// the profile's order. Pseudo headers the profile does not name keep their
+// relative order behind the named ones, and regular headers follow untouched.
+func (p *http2Profile) reorderPseudoHeaders(fields []hpack.HeaderField) []hpack.HeaderField {
+	if p == nil || len(p.pseudoHeaderOrder) == 0 {
+		return fields
+	}
+	out := make([]hpack.HeaderField, 0, len(fields))
+	picked := make(map[string]bool, len(p.pseudoHeaderOrder))
+	for _, name := range p.pseudoHeaderOrder {
+		for _, field := range fields {
+			if field.Name == name {
+				out = append(out, field)
+				picked[name] = true
+				break
+			}
+		}
+	}
+	for _, field := range fields {
+		if strings.HasPrefix(field.Name, ":") && !picked[field.Name] {
+			out = append(out, field)
+		}
+	}
+	for _, field := range fields {
+		if !strings.HasPrefix(field.Name, ":") {
+			out = append(out, field)
+		}
+	}
+	return out
+}

--- a/common/utils/lowhttp/http2_fingerprint.go
+++ b/common/utils/lowhttp/http2_fingerprint.go
@@ -24,11 +24,9 @@ const (
 
 // http2Profile describes the HTTP/2 framing behaviour of a specific client.
 //
-// A profile only changes the bytes this client writes. Flow-control
-// bookkeeping (initialWindowSize, connWindowControl) tracks the windows the
-// peer advertises to us and is deliberately left untouched: SETTINGS and
-// WINDOW_UPDATE written here advertise our receive capacity, which is a
-// separate direction from the send windows those fields account for.
+// SETTINGS advertise our receive capacity, so the HPACK decoder, stream
+// receive window and streaming buffer must honor the profile's limits.
+// Send windows still follow the peer's SETTINGS and WINDOW_UPDATE frames.
 type http2Profile struct {
 	id                string
 	settings          []http2.Setting
@@ -61,6 +59,19 @@ var http2Profiles = map[string]*http2Profile{
 		},
 		endStreamOnHeaders: true,
 	},
+}
+
+// settingValue keeps local receive limits aligned with the advertised settings.
+// A nil profile uses the compatibility defaults supplied by the caller.
+func (p *http2Profile) settingValue(id http2.SettingID, fallback uint32) uint32 {
+	if p != nil {
+		for _, setting := range p.settings {
+			if setting.ID == id {
+				return setting.Val
+			}
+		}
+	}
+	return fallback
 }
 
 func getHTTP2Profile(name string) (*http2Profile, error) {

--- a/common/utils/lowhttp/http2_fingerprint_regression_test.go
+++ b/common/utils/lowhttp/http2_fingerprint_regression_test.go
@@ -1,0 +1,253 @@
+package lowhttp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+// Use the production connection initializer so advertised settings and local
+// receive limits cannot drift unnoticed. Capture writes without a socket reader.
+func newH2FingerprintRegressionConn(t *testing.T, profile string, output io.Writer) *http2ClientConn {
+	t.Helper()
+	client, peer := net.Pipe()
+	t.Cleanup(func() { client.Close(); peer.Close() })
+	pc := &persistConn{
+		conn:     client,
+		p:        &LowHttpConnPool{ctx: context.Background()},
+		cacheKey: &connectKey{http2Fingerprint: profile},
+	}
+	pc.h2Conn()
+	c := pc.alt
+	c.pc = nil
+	c.bw = bufio.NewWriter(output)
+	c.fr = http2.NewFramer(c.bw, nil)
+	return c
+}
+
+func captureH2FingerprintSettings(t *testing.T, c *http2ClientConn, wire *bytes.Buffer) map[http2.SettingID]uint32 {
+	t.Helper()
+	if err := c.preface(); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(wire.Next(len(http2.ClientPreface))); got != http2.ClientPreface {
+		t.Fatalf("invalid client preface: %q", got)
+	}
+	settings := map[http2.SettingID]uint32{
+		http2.SettingHeaderTableSize:   4096,
+		http2.SettingInitialWindowSize: 65535,
+	}
+	fr := http2.NewFramer(io.Discard, wire)
+	for {
+		frame, err := fr.ReadFrame()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sf, ok := frame.(*http2.SettingsFrame); ok {
+			if err := sf.ForeachSetting(func(s http2.Setting) error {
+				settings[s.ID] = s.Val
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	return settings
+}
+
+func TestH2FingerprintAdvertisedHPACKTable(t *testing.T) {
+	for _, profile := range []string{"", HTTP2FingerprintChrome151} {
+		t.Run(profile, func(t *testing.T) {
+			var wire, block bytes.Buffer
+			c := newH2FingerprintRegressionConn(t, profile, &wire)
+			size := captureH2FingerprintSettings(t, c, &wire)[http2.SettingHeaderTableSize]
+			encoder := hpack.NewEncoder(&block)
+			encoder.SetMaxDynamicTableSizeLimit(size)
+			encoder.SetMaxDynamicTableSize(size)
+			// Keep more than 4 KiB of entries in the Chrome table, then reuse
+			// them in the next response to exercise connection-level state.
+			fields := []hpack.HeaderField{{Name: ":status", Value: "200"}}
+			for i := 0; i < 80; i++ {
+				fields = append(fields, hpack.HeaderField{Name: "x-shared", Value: strings.Repeat("x", 60) + string(rune('A'+i))})
+			}
+			for response := 0; response < 2; response++ {
+				block.Reset()
+				for _, field := range fields {
+					if err := encoder.WriteField(field); err != nil {
+						t.Fatal(err)
+					}
+				}
+				got, err := c.hDec.DecodeFull(block.Bytes())
+				if err != nil {
+					t.Fatalf("response %d using advertised table size %d rejected: %v", response, size, err)
+				}
+				if len(got) != len(fields) {
+					t.Fatalf("decoded %d fields, want %d", len(got), len(fields))
+				}
+				for i := range fields {
+					if got[i] != fields[i] {
+						t.Fatalf("field %d = %+v, want %+v", i, got[i], fields[i])
+					}
+				}
+			}
+			block.Reset()
+			encoder.SetMaxDynamicTableSizeLimit(size + 1)
+			encoder.SetMaxDynamicTableSize(size + 1)
+			if err := encoder.WriteField(fields[0]); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := c.hDec.DecodeFull(block.Bytes()); err == nil {
+				t.Fatal("accepted table size above the advertised limit")
+			}
+		})
+	}
+}
+
+func TestH2FingerprintLargeRequestHeaders(t *testing.T) {
+	for _, profile := range []string{"", HTTP2FingerprintChrome151} {
+		t.Run(profile, func(t *testing.T) {
+			var wire bytes.Buffer
+			c := newH2FingerprintRegressionConn(t, profile, &wire)
+			req, _ := http.NewRequest("GET", "http://h2.test/", nil)
+			cookie := strings.Repeat("abcdefgh", 5000)
+			packet := []byte("GET / HTTP/1.1\r\nHost: h2.test\r\nCookie: " + cookie + "\r\n\r\n")
+			cs, err := c.newStream(req, packet, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := cs.doRequest(); err != nil {
+				t.Fatal(err)
+			}
+			fr := http2.NewFramer(io.Discard, &wire)
+			fr.SetMaxReadFrameSize(defaultMaxFrameSize)
+			var block bytes.Buffer
+			var continuations int
+			var ended bool
+			for {
+				frame, err := fr.ReadFrame()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("peer rejected request framing: %v", err)
+				}
+				switch f := frame.(type) {
+				case *http2.HeadersFrame:
+					block.Write(f.HeaderBlockFragment())
+					ended = f.HeadersEnded()
+					if profile != "" && (!f.HasPriority() || !f.StreamEnded()) {
+						t.Fatal("Chrome HEADERS lost priority or END_STREAM")
+					}
+				case *http2.ContinuationFrame:
+					continuations++
+					block.Write(f.HeaderBlockFragment())
+					ended = f.HeadersEnded()
+				}
+			}
+			if continuations == 0 || !ended {
+				t.Fatal("large header block did not finish through CONTINUATION")
+			}
+			fields, err := hpack.NewDecoder(4096, nil).DecodeFull(block.Bytes())
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, field := range fields {
+				if field.Name == "cookie" && field.Value == cookie {
+					return
+				}
+			}
+			t.Fatal("fragmentation lost request cookie")
+		})
+	}
+}
+
+func TestH2FingerprintStreamingReceiveWindow(t *testing.T) {
+	for _, profile := range []string{"", HTTP2FingerprintChrome151} {
+		t.Run(profile, func(t *testing.T) {
+			var wire bytes.Buffer
+			c := newH2FingerprintRegressionConn(t, profile, &wire)
+			window := int(captureH2FingerprintSettings(t, c, &wire)[http2.SettingInitialWindowSize])
+			req, _ := http.NewRequest("GET", "http://h2.test/", nil)
+			cs, err := c.newStream(req, nil, &LowhttpExecConfig{
+				NoBodyBuffer:            true,
+				BodyStreamReaderHandler: func([]byte, io.ReadCloser) {},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Leave the consumer paused. Use the production-created body pipe,
+			// but do not start its handler until after receiving the test data.
+			cs.ID = 1
+			c.streams[1] = cs
+			c.currentStreamID = 3
+			cs.readHeaderEnd = true
+			cs.resp.StatusCode = 200
+			t.Cleanup(func() { cs.abort() })
+			rl := &http2ClientConnReadLoop{h2Conn: c}
+			payload := bytes.Repeat([]byte("x"), defaultMaxFrameSize)
+			for received := 0; received < window; received += len(payload) {
+				rl.processData(readDataFrameForCanceledStreamTest(t, 1, payload, nil))
+				if cs.streamErr != nil {
+					t.Fatalf("legal response failed after %d of %d advertised bytes: %v", received+len(payload), window, cs.streamErr)
+				}
+			}
+			fr := http2.NewFramer(io.Discard, &wire)
+			var returned uint32
+			for {
+				frame, err := fr.ReadFrame()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				update, ok := frame.(*http2.WindowUpdateFrame)
+				if !ok || update.StreamID != 0 {
+					t.Fatalf("unconsumed body returned stream credit or failed: %v", frame)
+				}
+				returned += update.Increment
+			}
+			if returned != uint32(window) {
+				t.Fatalf("returned connection credit %d, want %d", returned, window)
+			}
+			// The queue must remain bounded even after increasing the profile limit.
+			if _, err := cs.bodyStreamWriter.Write([]byte{1}); !errors.Is(err, errH2BodyWindowExceeded) {
+				t.Fatalf("pipe accepted data beyond advertised window: %v", err)
+			}
+			consumed := make([]byte, 32<<10)
+			if _, err := io.ReadFull(cs.bodyStreamReader, consumed); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(consumed, bytes.Repeat([]byte("x"), len(consumed))) {
+				t.Fatal("streaming body corrupted")
+			}
+			c.consumeStreamBytes(1, len(consumed))
+			frame, err := fr.ReadFrame()
+			if err != nil {
+				t.Fatal(err)
+			}
+			update, ok := frame.(*http2.WindowUpdateFrame)
+			if !ok || update.StreamID != 1 || update.Increment != uint32(len(consumed)) {
+				t.Fatalf("consumption did not return stream credit: %v", frame)
+			}
+			for i := 0; i < len(consumed)/len(payload); i++ {
+				rl.processData(readDataFrameForCanceledStreamTest(t, 1, payload, nil))
+			}
+			if cs.streamErr != nil || cs.recvWindow != 0 {
+				t.Fatalf("refilling returned credit failed: window=%d, err=%v", cs.recvWindow, cs.streamErr)
+			}
+		})
+	}
+}

--- a/common/utils/lowhttp/http2_fingerprint_test.go
+++ b/common/utils/lowhttp/http2_fingerprint_test.go
@@ -127,7 +127,7 @@ func writeH2FingerprintResponse(framer *http2.Framer, streamID uint32) {
 	})
 }
 
-func requestH2Fingerprint(t *testing.T, tlsFingerprint bool) *h2ClientProfile {
+func requestH2Fingerprint(t *testing.T, tlsFingerprint bool, extra ...LowhttpOpt) *h2ClientProfile {
 	t.Helper()
 	address, profileChannel := serveH2Fingerprint(t)
 	host, port, err := net.SplitHostPort(address)
@@ -146,6 +146,7 @@ func requestH2Fingerprint(t *testing.T, tlsFingerprint bool) *h2ClientProfile {
 	if tlsFingerprint {
 		options = append(options, WithTLSFingerprint("chrome-151"))
 	}
+	options = append(options, extra...)
 	go func() {
 		_, _ = HTTPWithoutRedirect(options...)
 	}()
@@ -186,12 +187,11 @@ func TestDefaultH2CompatibilityBehavior(t *testing.T) {
 	}
 }
 
-func TestChromeH2FingerprintTODO(t *testing.T) {
-	// TODO(H2): Enable only after Chrome H2 framing is compatible with the
-	// non-conforming servers supported by the existing lowhttp implementation.
-	t.Skip("TODO(H2): Chrome SETTINGS, pseudo-header order, priority, and END_STREAM behavior are intentionally not enabled")
-
-	profile := requestH2Fingerprint(t, true)
+func TestChromeH2Fingerprint(t *testing.T) {
+	// Chrome framing is opt-in via WithHTTP2Fingerprint, so servers that reject
+	// browser-style HEADERS keep the default framing untouched. See
+	// TestDefaultH2CompatibilityBehavior for that guarantee.
+	profile := requestH2Fingerprint(t, true, WithHTTP2Fingerprint(HTTP2FingerprintChrome151))
 	if got := profile.akamai(); got != chromeAkamaiFingerprint {
 		t.Fatalf("Akamai fingerprint mismatch\n want %s\n  got %s", chromeAkamaiFingerprint, got)
 	}
@@ -200,5 +200,27 @@ func TestChromeH2FingerprintTODO(t *testing.T) {
 	}
 	if !profile.headersPriority.Exclusive || profile.headersPriority.StreamDep != 0 || profile.headersPriority.Weight != 255 {
 		t.Errorf("HEADERS priority = %+v", profile.headersPriority)
+	}
+}
+
+func TestHTTP2FingerprintIsolatesConnectionPool(t *testing.T) {
+	base := &connectKey{scheme: "https", addr: "example.com:443", https: true}
+	withProfile := *base
+	withProfile.http2Fingerprint = HTTP2FingerprintChrome151
+
+	if base.hash() == withProfile.hash() {
+		t.Fatal("connectKey.hash() ignores http2Fingerprint: connections with different HTTP/2 framing would be reused for each other")
+	}
+}
+
+func TestUnknownHTTP2FingerprintIsRejected(t *testing.T) {
+	if err := ValidateHTTP2Profile(""); err != nil {
+		t.Errorf("empty profile name must mean default framing, got %v", err)
+	}
+	if err := ValidateHTTP2Profile(HTTP2FingerprintChrome151); err != nil {
+		t.Errorf("built-in profile must validate, got %v", err)
+	}
+	if err := ValidateHTTP2Profile("chrome-999"); err == nil {
+		t.Error("unknown profile name must be rejected")
 	}
 }

--- a/common/utils/lowhttp/poc/poc.go
+++ b/common/utils/lowhttp/poc/poc.go
@@ -105,9 +105,10 @@ type PocConfig struct {
 	BodyStreamHandler func([]byte, io.ReadCloser)
 	NoBodyBuffer      *bool // 禁用响应体缓冲，用于下载大文件避免内存占用
 
-	ClientHelloSpec *utls.ClientHelloSpec
-	RandomJA3       bool
-	TLSFingerprint  string
+	ClientHelloSpec  *utls.ClientHelloSpec
+	RandomJA3        bool
+	TLSFingerprint   string
+	HTTP2Fingerprint string
 
 	GmTLS                  bool
 	GmTLSOnly              bool
@@ -260,6 +261,9 @@ func (c *PocConfig) ToLowhttpOptions() []lowhttp.LowhttpOpt {
 	}
 	if c.TLSFingerprint != "" {
 		opts = append(opts, lowhttp.WithTLSFingerprint(c.TLSFingerprint))
+	}
+	if c.HTTP2Fingerprint != "" {
+		opts = append(opts, lowhttp.WithHTTP2Fingerprint(c.HTTP2Fingerprint))
 	}
 	if c.GmTLSOnly {
 		opts = append(opts, lowhttp.WithGmTLSOnly(c.GmTLSOnly))
@@ -971,6 +975,19 @@ func WithTLSFingerprint(name string) PocConfigOption {
 
 func TLSFingerprintProfiles() []string {
 	return netx.AvailableClientHelloProfiles()
+}
+
+// WithHTTP2Fingerprint selects a built-in HTTP/2 framing fingerprint profile.
+// Available profiles can be queried with HTTP2FingerprintProfiles. It is
+// independent of WithTLSFingerprint and only takes effect on h2 connections.
+func WithHTTP2Fingerprint(name string) PocConfigOption {
+	return func(c *PocConfig) {
+		c.HTTP2Fingerprint = name
+	}
+}
+
+func HTTP2FingerprintProfiles() []string {
+	return lowhttp.AvailableHTTP2Profiles()
 }
 
 // not export
@@ -3644,6 +3661,8 @@ var PoCExports = map[string]interface{}{
 	"randomJA3":              WithRandomJA3,
 	"tlsFingerprint":         WithTLSFingerprint,
 	"tlsFingerprintProfiles": TLSFingerprintProfiles,
+	"http2Fingerprint":         WithHTTP2Fingerprint,
+	"http2FingerprintProfiles": HTTP2FingerprintProfiles,
 	"gmTls":                  WithGmTls,
 	"gmTlsOnly":              WithGmTlsOnly,
 	"gmTLSPrefer":            WithGmTLSPrefer,

--- a/common/yakgrpc/grpc_mitm_v2_pipeline_cancel_test.go
+++ b/common/yakgrpc/grpc_mitm_v2_pipeline_cancel_test.go
@@ -1,0 +1,137 @@
+//go:build !yakit_exclude
+
+package yakgrpc
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func TestGRPCMUSTPASS_MITMV2_H2CancellationClearsPipeline(t *testing.T) {
+	for _, mode := range []string{"reset_stream", "close_browser_connection"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, stop := context.WithTimeout(context.Background(), 30*time.Second)
+			defer stop()
+			received, canceled := make(chan struct{}, 1), make(chan struct{}, 1)
+			origin := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received <- struct{}{}
+				select {
+				case <-r.Context().Done():
+					canceled <- struct{}{}
+				case <-ctx.Done():
+				}
+			}))
+			origin.EnableHTTP2 = true
+			origin.StartTLS()
+			defer origin.Close()
+			defer stop()
+			client, err := NewLocalClient()
+			require.NoError(t, err)
+			stream, err := client.MITMV2(ctx)
+			require.NoError(t, err)
+			port := utils.GetRandomAvailableTCPPort()
+			require.NoError(t, stream.Send(&ypb.MITMV2Request{
+				Host: "127.0.0.1", Port: uint32(port), EnableHttp2: true,
+				SetAutoForward: true, AutoForwardValue: true, DisableSystemProxy: true,
+			}))
+			require.True(t, waitMITMV2Started(stream, 10*time.Second))
+			statsCh := make(chan *ypb.MITMPipelineStats, 32)
+			go func() {
+				defer close(statsCh)
+				for {
+					response, err := stream.Recv()
+					if err != nil {
+						return
+					}
+					if stats := response.GetPipelineStats(); stats != nil {
+						select {
+						case statsCh <- stats:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+			}()
+			waitStats := func(predicate func(*ypb.MITMPipelineStats) bool) bool {
+				timer := time.NewTimer(4 * time.Second)
+				defer timer.Stop()
+				for {
+					select {
+					case stats, ok := <-statsCh:
+						if !ok {
+							return false
+						}
+						if predicate(stats) {
+							return true
+						}
+					case <-timer.C:
+						return false
+					}
+				}
+			}
+			proxyURL, err := url.Parse("http://" + utils.HostPort("127.0.0.1", port))
+			require.NoError(t, err)
+			transport := &http.Transport{Proxy: http.ProxyURL(proxyURL), TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, ForceAttemptHTTP2: true}
+			defer transport.CloseIdleConnections()
+			requestCtx, cancelRequest := context.WithCancel(ctx)
+			defer cancelRequest()
+			connection := make(chan net.Conn, 1)
+			requestCtx = httptrace.WithClientTrace(requestCtx, &httptrace.ClientTrace{GotConn: func(info httptrace.GotConnInfo) { connection <- info.Conn }})
+			req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, origin.URL, nil)
+			require.NoError(t, err)
+			result := make(chan error, 1)
+			go func() {
+				response, err := (&http.Client{Transport: transport}).Do(req)
+				if response != nil {
+					response.Body.Close()
+				}
+				result <- err
+			}()
+			var browserConn net.Conn
+			select {
+			case browserConn = <-connection:
+			case <-ctx.Done():
+				t.Fatal("browser did not connect")
+			}
+			tlsConn, ok := browserConn.(*tls.Conn)
+			require.True(t, ok)
+			require.Equal(t, "h2", tlsConn.ConnectionState().NegotiatedProtocol)
+			select {
+			case <-received:
+			case <-ctx.Done():
+				t.Fatal("origin did not receive request")
+			}
+			require.True(t, waitStats(func(s *ypb.MITMPipelineStats) bool { return s.GetUpstreamActive() == 1 }))
+			if mode == "reset_stream" {
+				cancelRequest()
+			} else {
+				require.NoError(t, browserConn.Close())
+			}
+			select {
+			case <-canceled:
+			case <-time.After(3 * time.Second):
+				t.Fatal("browser cancellation did not reach origin")
+			}
+			select {
+			case err := <-result:
+				require.Error(t, err)
+			case <-time.After(time.Second):
+				t.Fatal("browser request did not finish")
+			}
+			require.True(t, waitStats(func(s *ypb.MITMPipelineStats) bool {
+				return s.GetActiveTotal() == 0 && s.GetUpstreamActive() == 0 && s.GetOldestUpstreamAgeMs() == 0
+			}), "origin was canceled, but MITM still reports a pending upstream request")
+		})
+	}
+}

--- a/common/yakgrpc/mitm_pipeline_stats.go
+++ b/common/yakgrpc/mitm_pipeline_stats.go
@@ -3,6 +3,7 @@
 package yakgrpc
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,7 @@ type mitmPipelineRequestState struct {
 	stageAt     time.Time
 	dispatched  bool
 	manualDepth int
+	stopCancel  func() bool
 }
 
 // mitmPipelineTracker owns lightweight, process-local metrics for one MITMV2
@@ -71,10 +73,21 @@ func (t *mitmPipelineTracker) requestObserved(req *http.Request) {
 	now := t.now()
 	t.mu.Lock()
 	if _, exists := t.requests[req]; !exists {
-		t.requests[req] = &mitmPipelineRequestState{
+		state := &mitmPipelineRequestState{
 			stage:   mitmPipelineStageRequestProcessing,
 			stageAt: now,
 		}
+		t.requests[req] = state
+		// H2 cancellation and upstream failures may bypass response callbacks.
+		// Capture the original request context: lowhttp later replaces req's
+		// context with a child that finishes before response processing does.
+		state.stopCancel = context.AfterFunc(req.Context(), func() {
+			t.mu.Lock()
+			if t.requests[req] == state {
+				delete(t.requests, req)
+			}
+			t.mu.Unlock()
+		})
 		t.requestTotal.Add(1)
 	}
 	t.mu.Unlock()
@@ -169,6 +182,9 @@ func (t *mitmPipelineTracker) responseProcessingFinished(req *http.Request) {
 		return
 	}
 	t.mu.Lock()
+	if state := t.requests[req]; state != nil && state.stopCancel != nil {
+		state.stopCancel()
+	}
 	delete(t.requests, req)
 	t.mu.Unlock()
 }
@@ -178,7 +194,10 @@ func (t *mitmPipelineTracker) requestDropped(req *http.Request) {
 		return
 	}
 	t.mu.Lock()
-	if _, exists := t.requests[req]; exists {
+	if state, exists := t.requests[req]; exists {
+		if state.stopCancel != nil {
+			state.stopCancel()
+		}
 		delete(t.requests, req)
 		t.droppedTotal.Add(1)
 	}

--- a/common/yakgrpc/mitm_pipeline_stats_test.go
+++ b/common/yakgrpc/mitm_pipeline_stats_test.go
@@ -3,6 +3,7 @@
 package yakgrpc
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -10,6 +11,52 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/schema"
 )
+
+func TestMITMPipelineTrackerCanceledRequestLeavesNoUpstreamWait(t *testing.T) {
+	tracker := newMITMPipelineTracker("cancel-test")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.invalid/", nil)
+	require.NoError(t, err)
+	tracker.requestObserved(req)
+	tracker.requestDispatched(req, false)
+	require.Equal(t, int64(1), tracker.snapshot(0, 0).GetUpstreamActive())
+
+	// H2 upstream errors and downstream cancellation can return without ever
+	// invoking the response modifier/mirror callbacks.
+	cancel()
+	require.Eventually(t, func() bool {
+		return tracker.snapshot(0, 0).GetActiveTotal() == 0
+	}, time.Second, time.Millisecond, "canceled request remains reported as waiting upstream")
+	stats := tracker.snapshot(0, 0)
+	require.Zero(t, stats.GetOldestUpstreamAgeMs())
+	require.Zero(t, stats.GetUpstreamCompletedTotal())
+	require.Zero(t, stats.GetDroppedTotal(), "transport cancellation is not a manual drop")
+}
+
+func TestMITMPipelineTrackerUpstreamContextCompletionPreservesResponseStage(t *testing.T) {
+	tracker := newMITMPipelineTracker("context-test")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.invalid/", nil)
+	require.NoError(t, err)
+	tracker.requestObserved(req)
+	tracker.requestDispatched(req, false)
+	// lowhttp temporarily installs an upstream child context on the native
+	// request. Completing that child must not remove pending response work.
+	upstreamCtx, cancelUpstream := context.WithCancel(req.Context())
+	*req = *req.WithContext(upstreamCtx)
+	cancelUpstream()
+	tracker.upstreamCompleted(req, true)
+	require.Equal(t, int64(1), tracker.snapshot(0, 0).GetResponseProcessingActive())
+	tracker.responseMirrored(req)
+	tracker.responseProcessingFinished(req)
+	cancel()
+	stats := tracker.snapshot(0, 0)
+	require.Zero(t, stats.GetActiveTotal())
+	require.Equal(t, uint64(1), stats.GetUpstreamCompletedTotal())
+	require.Equal(t, uint64(1), stats.GetResponseMirroredTotal())
+}
 
 func TestMITMPipelineTrackerRequestStages(t *testing.T) {
 	base := time.UnixMilli(1_700_000_000_000)


### PR DESCRIPTION
## 背景

#4927 落地了 Chrome 151 的 TLS 指纹，并把 HTTP/2 侧刻意留空，在 `http2_fingerprint_test.go` 里以 `TestChromeH2FingerprintTODO` 记录了待办，理由是 Chrome 的 H2 framing 需要先确认与现有 lowhttp 支持的非合规服务器兼容。

本 PR 填上这个 TODO，做法是**独立的 opt-in 开关**：默认行为一字不变，只有显式请求 profile 时才改变 framing。

## 这不只是"更像浏览器"，而是修复一处跨层不一致

#4927 让 MITM 默认启用 `chrome-151` TLS 指纹，而 H2 侧保持 Go 客户端特征。这个组合会被 Cloudflare 判定为异常。以 `https://claude.ai/edge-api/bootstrap?...` 为目标的对照实验（唯一变量是 H2 framing）：

| MITM 配置 | 结果 |
|---|---|
| 无任何指纹（h1 / h2） | 200 |
| h1 + Chrome TLS 指纹 | 200 |
| **h2 + Chrome TLS 指纹，H2 用默认 framing（即当前 main 的默认配置）** | **500** |
| h2 + Chrome TLS 指纹 + Chrome H2 指纹 | 200 |
| h2 + 仅 Chrome H2 指纹（TLS 用原生 Go） | 200 |

ClientHello 声称 Chrome，H2 却暴露 Go 特征（伪头序 `a,m,p,s`、HEADERS 不带 END_STREAM 而补一个空 DATA 帧、无 priority），两层矛盾即被拒。**只伪装一层比两层都不伪装更容易失败**，而 main 目前的默认配置恰好处在这个组合上。

## 改动

新增 `common/utils/lowhttp/http2_fingerprint.go`，定义具名 H2 profile。`chrome-151` 对应 Akamai 指纹 `1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p`，与 Chrome 真机抓包一致。

profile 只改本端写出的字节：SETTINGS、连接级 WINDOW_UPDATE、伪头顺序、HEADERS priority，以及无 body 请求把 END_STREAM 放在 HEADERS 上而不补空 DATA 帧。流控记账（`initialWindowSize` / `connWindowControl`）追踪的是对端通告给我们的发送窗口，与此无关，未做改动。

- `WithHTTP2Fingerprint(name)` / `poc.http2Fingerprint` / `MITM_HTTP2Fingerprint`，默认空字符串即当前行为
- 与 TLS 指纹完全解耦：选 TLS 指纹不会连带改变 H2 framing，`WithRandomJA3FingerPrint` 同样不会
- `connectKey` 纳入 `http2Fingerprint` 并计入 hash，连接池不会把两种 framing 的 h2 连接串用
- 未知 profile 名在 `exec.go` 前置校验时报错

## 测试

- `TestChromeH2FingerprintTODO` 转正为 `TestChromeH2Fingerprint`，去掉 Skip
- #4927 的两道守门测试原样保持绿色：`TestDefaultH2CompatibilityBehavior`（默认必须不带 END_STREAM、保留空 DATA 帧、无 priority）、`TestTLSFingerprintLeavesH2BehaviorUnchanged`（TLS 指纹不得改变 H2 profile）
- 新增连接池隔离与非法 profile 名校验两个用例
- `go test -run 'H2|Http2|HTTP2|PoC' ./common/utils/lowhttp/` 与 `go test -run 'TestMITMH2_' ./common/crep/` 全通过

## 与 #4978 的关系

Chrome 不通告 `SETTINGS_MAX_FRAME_SIZE`，按 RFC 7540 使用默认值 16384，恰好等于 `defaultMaxFrameSize`，与 #4978 设置的 parser 上限一致，无冲突。

## 与 #4912 的关系

#4912 已关闭。其中的 H2 部分把 framing 绑在 `RandomJA3FingerPrint` 上，会随 TLS 指纹一起生效——这正是 #4927 的守门测试所禁止的。本 PR 重做为独立开关，两者实现方式不同。