### PR TITLE
fix(ssa,python): repair ANTLR static-state races and scan compile-unit imports textually

### DIFF
--- a/common/yak/java/parser/parser_static_data_test.go
+++ b/common/yak/java/parser/parser_static_data_test.go
@@ -1,0 +1,72 @@
+package javaparser
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSerializedATNGettersKeepStaticStateLocked guards the sync.Once invariant:
+// the exported ATN getters must never rebuild the package-level static state,
+// otherwise shared DFA / PredictionContextCache access loses its atn.stateMu
+// serialization across concurrently created parsers.
+func TestSerializedATNGettersKeepStaticStateLocked(t *testing.T) {
+	JavaParserInit()
+	JavaLexerInit()
+
+	pAtn := JavaParserParserStaticData.atn
+	pDfa := JavaParserParserStaticData.decisionToDFA
+	pCache := JavaParserParserStaticData.PredictionContextCache
+	lAtn := JavaLexerLexerStaticData.atn
+	lCache := JavaLexerLexerStaticData.PredictionContextCache
+
+	if pAtn == nil || pDfa == nil || pCache == nil {
+		t.Fatal("parser static state not initialized")
+	}
+	if lAtn == nil || lCache == nil {
+		t.Fatal("lexer static state not initialized")
+	}
+
+	for i := 0; i < 8; i++ {
+		if len(GetJavaParserSerializedATN()) == 0 {
+			t.Fatal("empty parser serialized ATN")
+		}
+		if len(GetJavaLexerSerializedATN()) == 0 {
+			t.Fatal("empty lexer serialized ATN")
+		}
+	}
+
+	if got := JavaParserParserStaticData.atn; got != pAtn {
+		t.Fatal("GetJavaParserSerializedATN replaced the static parser ATN")
+	}
+	if got := JavaParserParserStaticData.decisionToDFA; &got[0] != &pDfa[0] {
+		t.Fatal("GetJavaParserSerializedATN replaced the static parser DFAs")
+	}
+	if got := JavaParserParserStaticData.PredictionContextCache; got != pCache {
+		t.Fatal("GetJavaParserSerializedATN replaced the static parser PredictionContextCache")
+	}
+	if got := JavaLexerLexerStaticData.atn; got != lAtn {
+		t.Fatal("GetJavaLexerSerializedATN replaced the static lexer ATN")
+	}
+	if got := JavaLexerLexerStaticData.PredictionContextCache; got != lCache {
+		t.Fatal("GetJavaLexerSerializedATN replaced the static lexer PredictionContextCache")
+	}
+}
+
+// TestConcurrentInitAndGettersAreSafe hammers the invariant from many
+// goroutines; run with -race it fails if init bypasses sync.Once again.
+func TestConcurrentInitAndGettersAreSafe(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_ = GetJavaParserSerializedATN()
+				_ = GetJavaLexerSerializedATN()
+				JavaParserInit()
+				JavaLexerInit()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/common/yak/java/parser/utils.go
+++ b/common/yak/java/parser/utils.go
@@ -2,8 +2,15 @@ package javaparser
 
 import "github.com/yaklang/antlr/v4"
 
+// GetJavaParserSerializedATN returns the serialized ATN for the Java parser.
+//
+// Like the Python equivalent it must go through JavaParserInit (sync.Once):
+// javaparserParserInit reassigns the package-level atn / decisionToDFA /
+// PredictionContextCache, so calling it directly rebuilds shared static state
+// concurrently with in-flight parsers and defeats the atn.stateMu guard that
+// serializes shared-cache mutation in the ANTLR runtime.
 func GetJavaParserSerializedATN() []int32 {
-	javaparserParserInit()
+	JavaParserInit()
 	return JavaParserParserStaticData.serializedATN
 }
 

--- a/common/yak/python/parser/parser_static_data_test.go
+++ b/common/yak/python/parser/parser_static_data_test.go
@@ -1,0 +1,74 @@
+package pythonparser
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSerializedATNGettersKeepStaticStateLocked guards the sync.Once invariant:
+// the exported ATN getters must never rebuild the package-level static state.
+// If they do, parsers created concurrently can end up sharing a
+// PredictionContextCache while locking different ATN mutexes, which aborts the
+// process with "fatal error: concurrent map read and map write".
+func TestSerializedATNGettersKeepStaticStateLocked(t *testing.T) {
+	PythonParserInit()
+	PythonLexerInit()
+
+	pAtn := PythonParserParserStaticData.atn
+	pDfa := PythonParserParserStaticData.decisionToDFA
+	pCache := PythonParserParserStaticData.PredictionContextCache
+	lAtn := PythonLexerLexerStaticData.atn
+	lDfa := PythonLexerLexerStaticData.decisionToDFA
+	lCache := PythonLexerLexerStaticData.PredictionContextCache
+
+	if pAtn == nil || pDfa == nil || pCache == nil {
+		t.Fatal("parser static state not initialized")
+	}
+	if lAtn == nil || lDfa == nil || lCache == nil {
+		t.Fatal("lexer static state not initialized")
+	}
+
+	for i := 0; i < 8; i++ {
+		if len(GetPythonParserSerializedATN()) == 0 {
+			t.Fatal("empty parser serialized ATN")
+		}
+		if len(GetPythonLexerSerializedATN()) == 0 {
+			t.Fatal("empty lexer serialized ATN")
+		}
+	}
+
+	if got := PythonParserParserStaticData.atn; got != pAtn {
+		t.Fatal("GetPythonParserSerializedATN replaced the static parser ATN")
+	}
+	if got := PythonParserParserStaticData.decisionToDFA; &got[0] != &pDfa[0] {
+		t.Fatal("GetPythonParserSerializedATN replaced the static parser DFAs")
+	}
+	if got := PythonParserParserStaticData.PredictionContextCache; got != pCache {
+		t.Fatal("GetPythonParserSerializedATN replaced the static parser PredictionContextCache")
+	}
+	if got := PythonLexerLexerStaticData.atn; got != lAtn {
+		t.Fatal("GetPythonLexerSerializedATN replaced the static lexer ATN")
+	}
+	if got := PythonLexerLexerStaticData.PredictionContextCache; got != lCache {
+		t.Fatal("GetPythonLexerSerializedATN replaced the static lexer PredictionContextCache")
+	}
+}
+
+// TestConcurrentInitAndGettersAreSafe hammers the same invariant from many
+// goroutines; run with -race it fails if init bypasses sync.Once again.
+func TestConcurrentInitAndGettersAreSafe(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_ = GetPythonParserSerializedATN()
+				_ = GetPythonLexerSerializedATN()
+				PythonParserInit()
+				PythonLexerInit()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/common/yak/python/parser/utils.go
+++ b/common/yak/python/parser/utils.go
@@ -5,8 +5,16 @@ import "github.com/yaklang/antlr/v4"
 // GetPythonParserSerializedATN returns the serialized ATN for the Python parser.
 // This is used for caching parser state to improve performance.
 // Similar to GetJavaParserSerializedATN in java/parser/utils.go
+//
+// It must go through PythonParserInit (sync.Once): pythonparserParserInit
+// reassigns the package-level atn / decisionToDFA / PredictionContextCache, so
+// calling it directly rebuilds the shared static state on every use. That both
+// races with in-flight parsers and splits the (ATN, DFA, context cache) triple
+// across parsers, which breaks the atn.stateMu guard the ANTLR runtime relies
+// on to serialize shared-cache mutation and can abort the process with
+// "fatal error: concurrent map read and map write".
 func GetPythonParserSerializedATN() []int32 {
-	pythonparserParserInit()
+	PythonParserInit()
 	return PythonParserParserStaticData.serializedATN
 }
 
@@ -34,4 +42,3 @@ func (p *PythonParser) SetInterpreter(atn *antlr.ATN, decisionToDFA []*antlr.DFA
 	// do nothing, just to override the method
 	p.Interpreter = antlr.NewParserATNSimulator(p, atn, decisionToDFA, predictionContextCache)
 }
-

--- a/common/yak/python/python2ssa/compile_unit.go
+++ b/common/yak/python/python2ssa/compile_unit.go
@@ -4,21 +4,22 @@ import (
 	"regexp"
 	"strings"
 
-	antlr "github.com/yaklang/antlr/v4"
-	pythonparser "github.com/yaklang/yaklang/common/yak/python/parser"
 	"github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
 	"github.com/yaklang/yaklang/common/yak/ssa"
 )
 
 // CompileUnitDependencies extracts Python import edges by resolving dotted
 // module names against a path index built from unit paths and file stems.
-// Imports are collected by parsing each file with the Python grammar
-// (extractPyImportsFromAST); files that fail to parse fall back to the legacy
-// regex scan (fallbackRegexImports) so a syntax error never silently drops
-// edges. It handles absolute imports ("import a.b", "from a.b import c"),
-// relative imports ("from . import x", "from ..pkg import y"), and dynamic
-// imports (importlib.import_module("a.b") / __import__("a.b") with a literal
-// argument).
+//
+// This runs for every .py file in the project before any unit is built, so
+// imports are collected by a regex scan (scanPyImportEdges) rather than by
+// parsing: building a syntax tree here would parse every file a second time
+// (the batch phase parses again to build SSA) and would reach the shared static
+// ANTLR caches from the planning step. The scan still covers absolute imports
+// ("import a.b", "from a.b import c"), relative imports ("from . import x",
+// "from ..pkg import y"), parenthesized/multi-line and semicolon-separated
+// forms, and literal dynamic imports (importlib.import_module("a.b") /
+// __import__("a.b")).
 func (*SSABuilder) CompileUnitDependencies(fs filesys_interface.FileSystem, units []*ssa.CompileUnit) []ssa.UnitRef {
 	pathToKey := pythonImportPathIndex(fs, units)
 	var edges []ssa.UnitRef
@@ -34,10 +35,7 @@ func (*SSABuilder) CompileUnitDependencies(fs filesys_interface.FileSystem, unit
 				continue
 			}
 			src := ssa.ReadUnitSource(fs, file)
-			imports, parsed := extractPyImportsFromAST(src)
-			if !parsed {
-				imports = fallbackRegexImports(src)
-			}
+			imports := scanPyImportEdges(src)
 			for _, imp := range imports {
 				switch imp.kind {
 				case pyImportRelative:
@@ -81,254 +79,6 @@ type pyImportEdge struct {
 	pkg    string
 }
 
-// extractPyImportsFromAST parses src with the Python grammar and collects every
-// import: import statements, from statements (including relative ones and
-// parenthesized multi-line lists), and dynamic imports
-// (__import__("m") / import_module("m") / importlib.import_module("m") /
-// ... with a string-literal first argument). The second return is false when
-// the source fails to parse, in which case the caller should fall back to the
-// regex scan instead of dropping the file's edges.
-func extractPyImportsFromAST(src string) ([]pyImportEdge, bool) {
-	root, err := FrontendWithCache(src)
-	if err != nil || root == nil {
-		return nil, false
-	}
-	var imports []pyImportEdge
-	seen := make(map[string]bool)
-	add := func(edge pyImportEdge) {
-		key := edge.kind.String() + "\x00" + edge.dots + "\x00" + edge.module + "\x00" + edge.pkg
-		if seen[key] {
-			return
-		}
-		seen[key] = true
-		imports = append(imports, edge)
-	}
-	// import a.b / from .mod import x / importlib.import_module("m") / __import__("m")
-	var walk func(node antlr.Tree)
-	walk = func(node antlr.Tree) {
-		if node == nil {
-			return
-		}
-		switch ctx := node.(type) {
-		case *pythonparser.Import_stmtContext:
-			if names, ok := ctx.Dotted_as_names().(*pythonparser.Dotted_as_namesContext); ok && names != nil {
-				for _, entry := range names.AllDotted_as_name() {
-					if as, ok := entry.(*pythonparser.Dotted_as_nameContext); ok && as != nil && as.Dotted_name() != nil {
-						add(pyImportEdge{kind: pyImportAbsolute, module: as.Dotted_name().GetText()})
-					}
-				}
-			}
-		case *pythonparser.From_stmtContext:
-			// Relative prefix from the DOT/ELLIPSIS tokens (each ELLIPSIS is
-			// three dots, matching resolvePyRelativeImport's dot counting),
-			// then the optional dotted module name.
-			prefix := strings.Repeat(".", len(ctx.AllDOT())) + strings.Repeat("...", len(ctx.AllELLIPSIS()))
-			module := ""
-			if dotted := ctx.Dotted_name(); dotted != nil {
-				module = dotted.GetText()
-			}
-			if prefix != "" {
-				add(pyImportEdge{kind: pyImportRelative, dots: prefix, module: module})
-			} else if module != "" {
-				add(pyImportEdge{kind: pyImportAbsolute, module: module})
-			}
-		case *pythonparser.ExprContext:
-			collectPyDynamicImport(ctx, add)
-		}
-		for i := 0; i < node.GetChildCount(); i++ {
-			walk(node.GetChild(i))
-		}
-	}
-	walk(root)
-	return imports, true
-}
-
-// collectPyDynamicImport matches an expr node that calls a dynamic import
-// builtin — __import__("m"), import_module("m") or importlib.import_module("m")
-// — with a string-literal first argument, and extracts the module name plus
-// the optional package= keyword argument. The grammar is
-// `expr: atom trailer*`, so the callee name is the atom text and each
-// trailing `.name` becomes a trailer: importlib.import_module("m") parses as
-// atom(importlib) + trailer(.import_module) + trailer((...)).
-func collectPyDynamicImport(expr *pythonparser.ExprContext, add func(pyImportEdge)) {
-	if expr == nil {
-		return
-	}
-	trailers := expr.AllTrailer()
-	if len(trailers) == 0 {
-		return
-	}
-	// The call trailer is the last one holding Arguments().
-	var call *pythonparser.TrailerContext
-	for _, t := range trailers {
-		if tc, ok := t.(*pythonparser.TrailerContext); ok && tc != nil && tc.Arguments() != nil {
-			call = tc
-		}
-	}
-	if call == nil {
-		return
-	}
-	// Build the callee's dotted name from the atom and the attribute trailers
-	// preceding the call: importlib + .import_module -> "importlib.import_module".
-	atomCtx, ok := expr.Atom().(*pythonparser.AtomContext)
-	if !ok || atomCtx == nil || atomCtx.Name() == nil {
-		return
-	}
-	name := atomCtx.Name().GetText()
-	for _, t := range trailers {
-		tc, ok := t.(*pythonparser.TrailerContext)
-		if !ok || tc == nil {
-			break
-		}
-		if tc == call {
-			// The call trailer itself may be attribute access:
-			// `trailer: DOT name arguments?` — importlib.import_module("m")
-			// parses as ONE trailer holding both name and arguments.
-			if tc.Name() != nil {
-				name += "." + tc.Name().GetText()
-			}
-			break
-		}
-		if tc.DOT() == nil || tc.Name() == nil {
-			return
-		}
-		name += "." + tc.Name().GetText()
-	}
-	if name != "__import__" && name != "import_module" && name != "importlib.import_module" {
-		return
-	}
-	args, ok := call.Arguments().(*pythonparser.ArgumentsContext)
-	if !ok || args == nil || args.OPEN_BRACKET() != nil {
-		return
-	}
-	// First positional argument: the module string literal. Keyword argument
-	// detection uses ASSIGN (grammar: `argument: test (comp_for | ASSIGN test)?`).
-	mod := ""
-	pkg := ""
-	if list, ok := args.Arglist().(*pythonparser.ArglistContext); ok && list != nil {
-		for _, entry := range list.AllArgument() {
-			arg, ok := entry.(*pythonparser.ArgumentContext)
-			if !ok || arg == nil || arg.Comp_for() != nil {
-				continue
-			}
-			tests := arg.AllTest()
-			if arg.ASSIGN() == nil && len(tests) == 1 {
-				if mod == "" {
-					mod = pyStringLiteral(tests[0])
-				}
-				continue
-			}
-			// keyword argument: key is Test(0), value is Test(1)
-			if arg.ASSIGN() != nil && len(tests) > 1 {
-				if key, ok := tests[0].(*pythonparser.TestContext); ok && key != nil && key.GetText() == "package" {
-					pkg = pyStringLiteral(tests[1])
-				}
-			}
-		}
-	}
-	if mod == "" {
-		return
-	}
-	add(pyImportEdge{kind: pyImportDynamic, module: mod, pkg: pkg})
-}
-
-// pyStringLiteral extracts the value of a test node that is a plain string
-// literal (possibly concatenated via the expr arithmetic chain), returning ""
-// otherwise.
-func pyStringLiteral(test pythonparser.ITestContext) string {
-	ctx, ok := test.(*pythonparser.TestContext)
-	if !ok || ctx == nil {
-		return ""
-	}
-	// A single string atom: STRING+ under `atom`.
-	if logical := ctx.Logical_test(0); logical != nil {
-		if logicalCtx, ok := logical.(*pythonparser.Logical_testContext); ok && logicalCtx != nil {
-			if comp := logicalCtx.Comparison(); comp != nil {
-				if expr := comp.Expr(); expr != nil {
-					if exprCtx, ok := expr.(*pythonparser.ExprContext); ok {
-						return pyExprStringLiteral(exprCtx)
-					}
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// pyExprStringLiteral renders an expr that consists purely of string literals
-// concatenated with `+` (or adjacent atoms), returning "" for anything else.
-func pyExprStringLiteral(expr *pythonparser.ExprContext) string {
-	if expr == nil {
-		return ""
-	}
-	atomCtx, ok := expr.Atom().(*pythonparser.AtomContext)
-	if !ok || atomCtx == nil {
-		return ""
-	}
-	literal := pyAtomStringLiteral(atomCtx)
-	if literal == "" {
-		return ""
-	}
-	// Only string atoms may carry trailers that still denote a literal? No —
-	// any trailer (call/subscript) makes it dynamic, so stop at the first one.
-	if len(expr.AllTrailer()) > 0 {
-		return ""
-	}
-	// Sibling exprs joined by `+`: "a" + "b" -> literal only when both sides are.
-	parts := []string{literal}
-	for _, sibling := range expr.AllExpr() {
-		other, ok := sibling.(*pythonparser.ExprContext)
-		if !ok {
-			return ""
-		}
-		if other.GetText() != "+" {
-			continue
-		}
-		part := pyExprStringLiteral(other)
-		if part == "" {
-			return ""
-		}
-		parts = append(parts, part)
-	}
-	return strings.Join(parts, "")
-}
-
-// pyAtomStringLiteral unquotes a string-literal atom (the grammar allows
-// adjacent STRING+ tokens), returning "" for non-string atoms and for
-// prefixed literals (f"..." / b"..." etc.), which are not static module names.
-func pyAtomStringLiteral(atom *pythonparser.AtomContext) string {
-	if atom == nil || len(atom.AllSTRING()) == 0 {
-		return ""
-	}
-	head := atom.GetText()
-	idx := strings.IndexAny(head, "\"'")
-	if idx > 0 {
-		switch strings.ToLower(head[:idx]) {
-		case "f", "b", "rb", "br", "fr", "rf", "u", "r", "ur":
-			return ""
-		}
-	}
-	joined := ""
-	for _, s := range atom.AllSTRING() {
-		joined += pyUnquote(s.GetText())
-	}
-	return joined
-}
-
-// pyUnquote strips surrounding quotes from a Python string token.
-func pyUnquote(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if len(raw) >= 2 {
-		switch raw[0] {
-		case '"', '\'':
-			if raw[len(raw)-1] == raw[0] {
-				return unescapePyString(raw[1 : len(raw)-1])
-			}
-		}
-	}
-	return ""
-}
-
 // unescapePyString applies the escapes that appear in module names in practice.
 func unescapePyString(raw string) string {
 	out := strings.Builder{}
@@ -358,6 +108,7 @@ func unescapePyString(raw string) string {
 	}
 	return out.String()
 }
+
 // String renders the import kind for the dedupe key.
 func (k pyImportKind) String() string {
 	switch k {
@@ -398,15 +149,9 @@ func pythonImportPathIndex(fs filesys_interface.FileSystem, units []*ssa.Compile
 	return index.Values()
 }
 
-// Legacy regex fallback for files that fail to parse (syntax errors, exotic
-// constructs): the pre-AST scanners, kept verbatim so a bad file degrades to
-// the old behavior instead of silently losing edges.
 var (
-	fallbackPyImportRe = regexp.MustCompile(`(?m)^\s*(?:from\s+([A-Za-z_][A-Za-z0-9_.]*)\s+import\b|import[ \t]+([^#\n]+))`)
-	fallbackPyRelRe    = regexp.MustCompile(`(?m)^\s*from\s+(\.+)([A-Za-z_][A-Za-z0-9_.]*)?\s+import\b`)
-	fallbackPyDynRe    = regexp.MustCompile(`(?:__import__|importlib\s*\.\s*import_module|import_module)\s*\(\s*["']([^"'\n]+)["'](?:\s*,[^)]*?package\s*=\s*["']([^"'\n]*)["'])?`)
-	pyModuleNameRe     = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.]*$`)
-	pyImportAsRe       = regexp.MustCompile(`\s+as\s+[A-Za-z_][A-Za-z0-9_]*$`)
+	pyModuleNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.]*$`)
+	pyImportAsRe   = regexp.MustCompile(`\s+as\s+[A-Za-z_][A-Za-z0-9_]*$`)
 )
 
 // resolvePyRelativeImport resolves a relative import ("from <dots><module> import ...")
@@ -489,31 +234,6 @@ func resolvePyDynamicImport(
 	return ssa.ResolvePathImport(pathToKey, ssa.UnitDir(fs, base))
 }
 
-// fallbackRegexImports scans src with the legacy regexes and returns the same
-// pyImportEdge shapes the AST extraction produces.
-func fallbackRegexImports(src string) []pyImportEdge {
-	var imports []pyImportEdge
-	add := func(edge pyImportEdge) {
-		imports = append(imports, edge)
-	}
-	for _, match := range fallbackPyImportRe.FindAllStringSubmatch(src, -1) {
-		if mod := match[1]; mod != "" {
-			add(pyImportEdge{kind: pyImportAbsolute, module: mod})
-			continue
-		}
-		for _, mod := range splitPyImportNames(match[2]) {
-			add(pyImportEdge{kind: pyImportAbsolute, module: mod})
-		}
-	}
-	for _, match := range fallbackPyRelRe.FindAllStringSubmatch(src, -1) {
-		add(pyImportEdge{kind: pyImportRelative, dots: match[1], module: match[2]})
-	}
-	for _, match := range fallbackPyDynRe.FindAllStringSubmatch(src, -1) {
-		add(pyImportEdge{kind: pyImportDynamic, module: match[1], pkg: strings.TrimSpace(match[2])})
-	}
-	return imports
-}
-
 // splitPyImportNames parses the tail of a plain `import` statement
 // ("a, b, c" or "a as b, c as d", possibly with a trailing comment) into the
 // list of imported module names, dropping aliases and anything that is not a
@@ -530,4 +250,187 @@ func splitPyImportNames(s string) []string {
 		names = append(names, part)
 	}
 	return names
+}
+
+// ---- regex-based import scanning (plan phase, no ANTLR) ----
+//
+// CompileUnitDependencies runs over every source file of the project before any
+// unit is built, so this step has to stay cheap: parsing each file with the
+// Python grammar here would parse every .py file twice (plan + batch) and grow
+// the shared static ANTLR caches for no lasting benefit. These scanners recover
+// the same edges the AST walk produced for every construct the corpus and the
+// test suite exercise:
+//
+//	import a.b, c.d as e             absolute, aliased, comma lists
+//	from a.b import c                absolute
+//	from . import x                  relative without a module
+//	from ..pkg.mod import x          relative with a dotted module
+//	from pkg import (x, y)           parenthesized / multi-line name lists
+//	import os; from b import c       semicolon-separated simple statements
+//	__import__("m"), importlib.import_module("m"), import_module("m", package="p")
+//
+// and, like the AST walk did, import-like text inside comments, one-line
+// strings and docstrings is ignored, as are dynamic calls whose argument is not
+// a plain string literal (variables, f-strings) or whose callee is some other
+// attribute (myobj.import_module).
+
+var (
+	// pyTrimSpaceRe strips whitespace around a captured dotted receiver.
+	pyTrimSpaceRe = strings.NewReplacer(" ", "", "\t", "")
+
+	// pyFromImportRe captures the module part of a from-statement. Alternation
+	// order matters: the relative forms come first so "from .. import x" is not
+	// swallowed by the absolute pattern, and the dotted-suffix form comes before
+	// the bare-dots form so "from .pkg import x" keeps its module.
+	pyFromImportRe = regexp.MustCompile(`^from[ \t]+(\.+[A-Za-z_][A-Za-z0-9_.]*|\.+|[A-Za-z_][A-Za-z0-9_.]*)[ \t]+import\b`)
+	// pyPlainImportRe captures the tail of an import statement; the tail is split
+	// into module names by splitPyImportNames.
+	pyPlainImportRe = regexp.MustCompile(`^import[ \t]+(.*)$`)
+	// pyDynamicImportRe captures an optional dotted receiver, the callee name and
+	// the string-literal argument, plus an optional package= literal. Go's regexp
+	// has no lookbehind, so a leading non-word/non-dot guard is matched
+	// explicitly and the receiver is validated in code.
+	pyDynamicImportRe = regexp.MustCompile(
+		`(?:^|[^\w.])((?:[A-Za-z_][A-Za-z0-9_]*[ \t]*\.[ \t]*)?)(?:__import__|import_module)` +
+			`[ \t]*\([ \t]*('[^'\n]*'|"[^"\n]*")` +
+			`(?:[^)\n]*?package[ \t]*=[ \t]*('[^'\n]*'|"[^"\n]*"))?`)
+)
+
+// scanPyImportEdges collects the import edges of a single source file without
+// building a syntax tree.
+func scanPyImportEdges(src string) []pyImportEdge {
+	var edges []pyImportEdge
+	seen := make(map[string]bool)
+	add := func(edge pyImportEdge) {
+		key := edge.kind.String() + "\x00" + edge.dots + "\x00" + edge.module + "\x00" + edge.pkg
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		edges = append(edges, edge)
+	}
+
+	// Statements are matched against text where comments and string bodies are
+	// blanked, so only real import statements remain.
+	code := pyBlankNonCode(src, true)
+	for _, line := range strings.Split(code, "\n") {
+		// A line may hold several simple statements: "import os; from b import c".
+		for _, stmt := range strings.Split(line, ";") {
+			stmt = strings.TrimSpace(stmt)
+			if stmt == "" {
+				continue
+			}
+			if m := pyFromImportRe.FindStringSubmatch(stmt); m != nil {
+				target := m[1]
+				if strings.HasPrefix(target, ".") {
+					dots := strings.TrimLeft(target, ".")
+					add(pyImportEdge{
+						kind:   pyImportRelative,
+						dots:   target[:len(target)-len(dots)],
+						module: dots,
+					})
+				} else {
+					add(pyImportEdge{kind: pyImportAbsolute, module: target})
+				}
+				continue
+			}
+			if m := pyPlainImportRe.FindStringSubmatch(stmt); m != nil {
+				for _, mod := range splitPyImportNames(m[1]) {
+					add(pyImportEdge{kind: pyImportAbsolute, module: mod})
+				}
+			}
+		}
+	}
+
+	// Dynamic calls need their string literal, so scan text that keeps one-line
+	// strings but still blanks comments and docstrings.
+	dyn := pyBlankNonCode(src, false)
+	for _, m := range pyDynamicImportRe.FindAllStringSubmatch(dyn, -1) {
+		switch receiver := pyTrimSpaceRe.Replace(m[1]); receiver {
+		case "", "importlib.":
+		default:
+			continue
+		}
+		mod := unescapePyString(strings.Trim(m[2], "\"'"))
+		if mod == "" {
+			continue
+		}
+		pkg := ""
+		if m[3] != "" {
+			pkg = unescapePyString(strings.Trim(m[3], "\"'"))
+		}
+		add(pyImportEdge{kind: pyImportDynamic, module: mod, pkg: pkg})
+	}
+	return edges
+}
+
+// pyBlankNonCode copies src and replaces comment text with spaces. When
+// blankStrings is set, one-line string bodies are blanked too. Triple-quoted
+// bodies are always blanked, because a docstring can hold import-looking lines
+// at column zero. Delimiters are kept and every scan advances past them, so
+// quotes inside comments (common in license headers) cannot cascade.
+func pyBlankNonCode(src string, blankStrings bool) string {
+	out := []byte(src)
+	blank := func(from, to int) {
+		for i := from; i < to && i < len(out); i++ {
+			if out[i] != '\n' && out[i] != '\r' {
+				out[i] = ' '
+			}
+		}
+	}
+	for i := 0; i < len(out); {
+		c := out[i]
+		switch {
+		case c == '#':
+			end := i
+			for end < len(out) && out[end] != '\n' {
+				end++
+			}
+			blank(i, end)
+			i = end
+		case c == '"' || c == '\'':
+			triple := i+2 < len(out) && out[i+1] == c && out[i+2] == c
+			closerLen, body := 1, i+1
+			if triple {
+				closerLen, body = 3, i+3
+			}
+			end := pyStringBodyEnd(out, body, c, triple)
+			if triple || blankStrings {
+				blank(body, end)
+			}
+			if end >= len(out) {
+				return string(out)
+			}
+			i = end + closerLen
+		default:
+			i++
+		}
+	}
+	return string(out)
+}
+
+// pyStringBodyEnd returns the index of the closing delimiter of a string
+// literal whose content starts at body, honouring backslash escapes. A
+// single-line literal also ends at end of line, so an unterminated quote cannot
+// swallow the rest of the file. Byte comparisons only: this runs per character.
+func pyStringBodyEnd(out []byte, body int, quote byte, triple bool) int {
+	for i := body; i < len(out); i++ {
+		if out[i] == '\\' {
+			i++
+			continue
+		}
+		if out[i] == '\n' && !triple {
+			return i
+		}
+		if out[i] != quote {
+			continue
+		}
+		if !triple {
+			return i
+		}
+		if i+2 < len(out) && out[i+1] == quote && out[i+2] == quote {
+			return i
+		}
+	}
+	return len(out)
 }

--- a/common/yak/python/python2ssa/compile_unit_import_scan_test.go
+++ b/common/yak/python/python2ssa/compile_unit_import_scan_test.go
@@ -1,0 +1,226 @@
+package python2ssa
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func pyEdgeKey(e pyImportEdge) string {
+	return e.kind.String() + "|" + e.dots + "|" + e.module + "|" + e.pkg
+}
+
+func scanKeys(src string) []string {
+	edges := scanPyImportEdges(src)
+	keys := make([]string, 0, len(edges))
+	for _, e := range edges {
+		keys = append(keys, pyEdgeKey(e))
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func requireScan(t *testing.T, src string, want ...string) {
+	t.Helper()
+	got := scanKeys(src)
+	expected := append([]string(nil), want...)
+	sort.Strings(expected)
+	if strings.Join(got, ",") != strings.Join(expected, ",") {
+		t.Fatalf("edges mismatch\n got: %v\nwant: %v\nsrc:\n%s", got, expected, src)
+	}
+}
+
+// TestScanPyImportEdgesCorpusForms pins the syntax forms found in the real
+// Python corpora used for SSA regression work (Apache Kafka kafkatest, Apache
+// TinkerPop gremlin_python, Apache Ranger, CRMEB and the wanwu RAG/agent
+// trees). Each case is a construct the plan-phase scanner must keep resolving
+// after the move away from parsing every file.
+func TestScanPyImportEdgesCorpusForms(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "kafka config.py bare relative import",
+			src:  "from . import config_property\n",
+			want: []string{"relative|.||"},
+		},
+		{
+			name: "tinkerpop two-level relative import",
+			src:  "from .. import statics\n",
+			want: []string{"relative|..||"},
+		},
+		{
+			name: "wanwu parenthesized relative import",
+			src:  "from .base import (\n    DialogueWithSharedMemoryChains\n)\n\n__all__ = [\n    \"DialogueWithSharedMemoryChains\"\n]\n",
+			want: []string{"relative|.|base|"},
+		},
+		{
+			name: "wanwu parenthesized absolute imports",
+			src:  "from models.base.base import (\n    BaseLLM,\n)\nfrom models.base.remote_rpc_model import (\n    RemoteModel,\n)\n",
+			want: []string{
+				"absolute||models.base.base|",
+				"absolute||models.base.remote_rpc_model|",
+			},
+		},
+		{
+			name: "tinkerpop indented try/except import split across lines",
+			src:  "        if transport_factory is None:\n            try:\n                from gremlin_python.driver.aiohttp.transport import (\n                    AiohttpTransport, AiohttpHTTPTransport)\n            except ImportError:\n                raise Exception(\"Please install AIOHTTP or pass \"\n                                \"custom transport factory\")\n",
+			want: []string{"absolute||gremlin_python.driver.aiohttp.transport|"},
+		},
+		{
+			name: "aliased from-imports including dunder names",
+			src:  "from kafkatest import __version__ as __kafkatest_version__\nfrom gremlin_python.process.graph_traversal import __ as AnonymousTraversal\nfrom xml.etree import ElementTree as ET\nimport getopt as opts\nimport models.shared as shared\n",
+			want: []string{
+				"absolute||getopt|",
+				"absolute||gremlin_python.process.graph_traversal|",
+				"absolute||kafkatest|",
+				"absolute||models.shared|",
+				"absolute||xml.etree|",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireScan(t, tt.src, tt.want...)
+		})
+	}
+}
+
+// TestScanPyImportEdgesIgnoresNonCode covers import-like text that is not a
+// statement. The license headers in the corpus put double quotes inside
+// comments and the wanwu/kafka modules open with docstrings, so both a quote
+// cascade across comments and a zero-column import inside a docstring must be
+// ignored.
+func TestScanPyImportEdgesIgnoresNonCode(t *testing.T) {
+	license := "# Licensed to the Apache Software Foundation (ASF) under one\n" +
+		"# or more contributor license agreements.  See the NOTICE file\n" +
+		"# \"License\"); you may not use this file except in compliance\n" +
+		"# with the License.  You may obtain a copy of the License at\n" +
+		"#\n" +
+		"#   http://www.apache.org/licenses/LICENSE-2.0\n" +
+		"#\n" +
+		"# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n" +
+		"\"\"\"\n" +
+		"import os\n" +
+		"from .mod import helper\n" +
+		"\"\"\"\n"
+	requireScan(t, license)
+
+	requireScan(t, "import io  # import logging\n", "absolute||io|")
+	requireScan(t, "msg = \"import os\"\nother = 'from .mod import f'\n")
+	requireScan(t, "def f():\n    return \"\"\"\nimport os\nfrom .mod import f\n\"\"\"\n")
+	// An unterminated quote must not swallow the rest of the file: the literal
+	// ends at end of line, so the import on the next line is still a statement.
+	requireScan(t, "text = \"unterminated\nimport os\nfrom .mod import f\n",
+		"absolute||os|", "relative|.|mod|")
+	requireScan(t, "s = \"\\\"quoted inner\\\"\"\nimport os\n", "absolute||os|")
+	requireScan(t, "import io  # noqa\nimport os\n", "absolute||io|", "absolute||os|")
+}
+
+// TestScanPyImportEdgesDynamicGuards keeps the guards the AST walk had for
+// dynamic imports: only a literal first argument on __import__, import_module
+// or importlib.import_module counts.
+func TestScanPyImportEdgesDynamicGuards(t *testing.T) {
+	requireScan(t, "mod = importlib.import_module(\"db.engine\")\n", "dynamic||db.engine|")
+	requireScan(t, "mod = __import__('db.utils')\n", "dynamic||db.utils|")
+	requireScan(t, "mod = import_module(\"a.b\")\n", "dynamic||a.b|")
+	requireScan(t, "mod = importlib.import_module(\".base\", package=\"pkg\")\n", "dynamic||.base|pkg")
+	requireScan(t, "mod = importlib.import_module(\".base\",package='pkg')\n", "dynamic||.base|pkg")
+	requireScan(t, "mod = importlib.import_module(name)\n")
+	requireScan(t, "mod = import_module(f\"db.engine\")\n")
+	requireScan(t, "mod = myobj.import_module(\"db.engine\")\n")
+	requireScan(t, "mod = a.b.import_module(\"db.engine\")\n")
+	requireScan(t, "mod = compat.__import__(\"db.engine\")\n")
+	requireScan(t, "value = 1\nimport_moduleX(\"db.engine\")\n")
+	requireScan(t, "mod = import_module(\"db.engine\")  # import_module(\"other\")\n", "dynamic||db.engine|")
+}
+
+// TestScanPyImportEdgesStatementForms covers statement shapes the scanner walks
+// line by line and splits on semicolons.
+func TestScanPyImportEdgesStatementForms(t *testing.T) {
+	requireScan(t, "import os,errno,sys,getopt\n",
+		"absolute||errno|", "absolute||getopt|", "absolute||os|", "absolute||sys|")
+	requireScan(t, "import os, sys\nimport pwd, grp\n",
+		"absolute||grp|", "absolute||os|", "absolute||pwd|", "absolute||sys|")
+	requireScan(t, "import os; from bdir import b\n", "absolute||bdir|", "absolute||os|")
+	requireScan(t, "from .mod import a; from ..other import b\n", "relative|.|mod|", "relative|..|other|")
+	requireScan(t, "from a import *\n", "absolute||a|")
+	requireScan(t, "\tfrom . import sibling\n", "relative|.||")
+	requireScan(t, "from ..pkg.sub import deep\n", "relative|..|pkg.sub|")
+	requireScan(t, "importlib.reload(mod)\n")
+	requireScan(t, "fromstring = 1\nimporter = 2\n")
+	requireScan(t, "")
+}
+
+// TestScanPyImportEdgesCorpusParity re-scans every .py file under a local
+// corpus and compares the result with expectations produced by Python's own ast
+// module. It is opt-in because the corpus lives outside the repository:
+//
+//	YAK_PYTHON_IMPORT_CORPUS=/path/to/python/files
+//	YAK_PYTHON_IMPORT_ORACLE=/path/to/expected.tsv
+//
+// The oracle TSV holds one edge per line:
+// <relpath>\t<kind>\t<dots>\t<module>\t<pkg>
+func TestScanPyImportEdgesCorpusParity(t *testing.T) {
+	root := os.Getenv("YAK_PYTHON_IMPORT_CORPUS")
+	oraclePath := os.Getenv("YAK_PYTHON_IMPORT_ORACLE")
+	if root == "" || oraclePath == "" {
+		t.Skip("set YAK_PYTHON_IMPORT_CORPUS and YAK_PYTHON_IMPORT_ORACLE to run corpus parity")
+	}
+	raw, err := os.ReadFile(oraclePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := make(map[string]map[string]bool)
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimRight(line, "\r")
+		parts := strings.Split(line, "\t")
+		if line == "" || len(parts) != 5 {
+			continue
+		}
+		if want[parts[0]] == nil {
+			want[parts[0]] = make(map[string]bool)
+		}
+		want[parts[0]][strings.Join(parts[1:], "|")] = true
+	}
+	var scanned, missing, extra int
+	var samples []string
+	for rel, wantSet := range want {
+		bs, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			continue
+		}
+		scanned++
+		got := make(map[string]bool)
+		for _, k := range scanKeys(string(bs)) {
+			got[k] = true
+		}
+		for k := range wantSet {
+			if !got[k] {
+				missing++
+				if len(samples) < 20 {
+					samples = append(samples, "missing "+rel+" "+k)
+				}
+			}
+		}
+		for k := range got {
+			if !wantSet[k] {
+				extra++
+				if len(samples) < 20 {
+					samples = append(samples, "extra "+rel+" "+k)
+				}
+			}
+		}
+	}
+	for _, s := range samples {
+		t.Error(s)
+	}
+	t.Logf("corpus parity: files=%d missing=%d extra=%d", scanned, missing, extra)
+	if missing != 0 || extra != 0 {
+		t.Fatalf("corpus parity broken: missing=%d extra=%d", missing, extra)
+	}
+}

--- a/common/yak/python/test/antlr_static_cache_race_test.go
+++ b/common/yak/python/test/antlr_static_cache_race_test.go
@@ -1,0 +1,75 @@
+package test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/yak/python/python2ssa"
+)
+
+// antlrRacePySamples are structurally diverse on purpose: PredictionContext
+// keys off ATN states rather than token text, so near-identical sources all
+// reuse the same cached contexts and never exercise concurrent cache inserts.
+var antlrRacePySamples = []string{
+	"import os\nimport sys\n\ndef f(a):\n    return a + 1\n",
+	"from typing import List\n\n\nclass C:\n    attr = 1\n\n    def m(self, *args, **kw):\n        return [x for x in args if x]\n",
+	"try:\n    import ujson as json\nexcept ImportError:\n    import json\nfinally:\n    pass\n",
+	"with open('f') as fh, open('g', 'w') as out:\n    for line in fh:\n        if line.strip():\n            out.write(line)\n        elif line:\n            out.write('\\n')\n",
+	"x = (lambda a, b=2, *c, **d: a if a > b else b)(1)\ny = {k: v for k, v in z.items() if k not in ('a', 'b')}\n",
+	"def g():\n    def h():\n        return 1\n    return h\n\n\n@decorator\ndef i():\n    yield from range(10)\n",
+	"from . import sibling\nfrom ..pkg import thing\nfrom .. import other\n",
+	"if a:\n    pass\nelif b:\n    pass\nelse:\n    while c:\n        break\n    else:\n        pass\n",
+}
+
+// TestConcurrentFrontendAndWorkerCacheInit reproduces the CI crash shape:
+// uncached Frontend parses (bound to the package-level static ANTLR caches)
+// running while new parse workers spin up and build their AntlrCache.
+//
+// The static caches are only safe because the ANTLR runtime serializes shared
+// cache mutation under atn.stateMu, and that holds only while each parser's
+// (ATN, DFA, PredictionContextCache) triple comes from a single, immutable
+// static generation. Regressing GetPythonParserSerializedATN to the raw init
+// function breaks that and aborts with
+// "fatal error: concurrent map read and map write" in JMap.Get.
+func TestConcurrentFrontendAndWorkerCacheInit(t *testing.T) {
+	const rounds = 12
+	var start, wg sync.WaitGroup
+	start.Add(1)
+
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			src := antlrRacePySamples[i%len(antlrRacePySamples)]
+			start.Wait()
+			for j := 0; j < rounds; j++ {
+				if _, err := python2ssa.Frontend(src); err != nil && !strings.Contains(err.Error(), "undefined") {
+					t.Errorf("static-path parse failed: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Worker spin-ups: each parse lane calls GetAntlrCache() exactly once, which
+	// is what previously re-ran the full static init.
+	builder := python2ssa.CreateBuilder()
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			start.Wait()
+			for j := 0; j < rounds; j++ {
+				cache := builder.GetAntlrCache()
+				if cache == nil {
+					t.Errorf("worker cache is nil")
+					return
+				}
+			}
+		}(i)
+	}
+
+	start.Done()
+	wg.Wait()
+}

--- a/common/yak/ssa/database_cache_type.go
+++ b/common/yak/ssa/database_cache_type.go
@@ -57,9 +57,16 @@ func (s *typeStore) remember(typ Type) Type {
 	}
 	id := typ.GetId()
 	if id <= 0 {
-		id = s.nextID.Inc()
-		typ.SetId(id)
-	} else {
+		if claimer, ok := typ.(interface {
+			claimIdIfUnset(int64) (int64, bool)
+		}); ok {
+			// Draw a candidate from the shared counter, then let the object
+			// itself decide the single winner.
+			id, _ = claimer.claimIdIfUnset(s.nextID.Inc())
+		} else {
+			id = s.nextID.Inc()
+			typ.SetId(id)
+		}
 		setAtomicMaxIfGreater(s.nextID, id)
 	}
 	s.resident.Set(id, typ)

--- a/common/yak/ssa/type.go
+++ b/common/yak/ssa/type.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/samber/lo"
 	"github.com/yaklang/yaklang/common/utils"
@@ -441,7 +442,10 @@ const (
 )
 
 type baseType struct {
-	id           int64
+	// id is read by every IR marshal of a shared type and assigned lazily by
+	// typeStore.remember, so it must never be a plain field: persist workers run
+	// concurrently over the same *FunctionType and friends.
+	id           atomic.Int64
 	method       map[string]*Function
 	methodGetter func() map[string]*Function
 	methodOnce   sync.Once
@@ -449,16 +453,31 @@ type baseType struct {
 }
 
 func NewBaseType() *baseType {
-	return &baseType{
-		id: -1,
-	}
+	b := new(baseType)
+	b.id.Store(-1)
+	return b
 }
 
 func (b *baseType) SetId(id int64) {
-	b.id = id
+	b.id.Store(id)
 }
 func (b *baseType) GetId() int64 {
-	return b.id
+	return b.id.Load()
+}
+
+// claimIdIfUnset assigns candidate only when this type has no id yet, and
+// reports whether the caller won. Losing the race returns the winner's id so a
+// type shared by several persist workers can never end up with two ids.
+func (b *baseType) claimIdIfUnset(candidate int64) (int64, bool) {
+	for {
+		current := b.id.Load()
+		if current > 0 {
+			return current, false
+		}
+		if b.id.CompareAndSwap(current, candidate) {
+			return candidate, true
+		}
+	}
 }
 
 func (b *baseType) SetMethodGetter(f func() map[string]*Function) {

--- a/common/yak/ssa/type_id_concurrency_test.go
+++ b/common/yak/ssa/type_id_concurrency_test.go
@@ -1,0 +1,85 @@
+package ssa
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/utils"
+	"go.uber.org/atomic"
+)
+
+// newTestTypeStore builds the slice of typeStore that id assignment touches:
+// the shared counter plus the resident index, without a DB or Program.
+func newTestTypeStore() *typeStore {
+	return &typeStore{
+		nextID:   atomic.NewInt64(0),
+		resident: utils.NewSafeMapWithKey[int64, Type](),
+	}
+}
+
+// TestSharedTypeIdIsAssignedOnce pins the invariant that broke in CI: types are
+// shared across instructions, and dbcache persist workers marshal them in
+// parallel, so several workers can reach typeStore.remember for the same object
+// at once. Exactly one id must win. Before the fix every worker could assign its
+// own id, so one type could be written to the DB under several ids and read back
+// inconsistently.
+func TestSharedTypeIdIsAssignedOnce(t *testing.T) {
+	store := newTestTypeStore()
+	shared := NewInterfaceType("shared", "example/pkg")
+
+	const workers = 32
+	var start, wg sync.WaitGroup
+	start.Add(1)
+	observed := make([]int64, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			start.Wait()
+			observed[i] = store.remember(shared).GetId()
+		}(i)
+	}
+	start.Done()
+	wg.Wait()
+
+	if observed[0] <= 0 {
+		t.Fatalf("type kept its unassigned id: %d", observed[0])
+	}
+	for i, id := range observed {
+		if id != observed[0] {
+			t.Fatalf("worker %d saw id %d but worker 0 saw %d: one type got several ids", i, id, observed[0])
+		}
+	}
+	if _, ok := store.resident.Get(observed[0]); !ok {
+		t.Fatalf("type is not indexed under its assigned id %d", observed[0])
+	}
+}
+
+// TestConcurrentTypeIdReadDuringAssign reproduces the reported race pair: an IR
+// marshal reading a shared type's id while another worker assigns it. Run with
+// -race it fails if baseType.id stops being atomic.
+func TestConcurrentTypeIdReadDuringAssign(t *testing.T) {
+	const rounds = 2000
+	shared := NewInterfaceType("shared", "example/pkg")
+	store := newTestTypeStore()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { // reader, like value2IrCode calling typ.GetId()
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			_ = shared.GetId()
+		}
+	}()
+	go func() { // writer, like saveTypeWithValue calling remember
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			store.remember(shared)
+		}
+	}()
+	wg.Wait()
+
+	if id := shared.GetId(); id <= 0 {
+		t.Fatalf("type never got an id: %d", id)
+	}
+}

--- a/common/yakgrpc/server.go
+++ b/common/yakgrpc/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/yaklang/yaklang/common/yak/yaklib/tools/dicts"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
-	"sync"
 )
 
 type Server struct {

--- a/go.work.sum
+++ b/go.work.sum
@@ -105,7 +105,6 @@ github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
-github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=


### PR DESCRIPTION
## 背景

CI 上 `buildin-rule-test` 的 `TestVerifiedRule` 随机挂（本地跑两遍都 ok，约 16s），日志里真正的错误是：

```
fatal error: concurrent map read and map write
github.com/yaklang/antlr/v4.(*JMap[...]).Get   jcollect.go:358
  <- PredictionContextCache.Get
  <- BaseATNSimulator.getCachedContext
  <- ParserATNSimulator.AdaptivePredict
  <- python/parser.(*PythonParser).Stmt / File_input / Root
  <- python2ssa.FrontendWithCache (builder.go:792)
  <- python2ssa.extractPyImportsFromAST (compile_unit.go:92)
  <- python2ssa.(*SSABuilder).CompileUnitDependencies
  <- ssaapi.buildCompileUnitPlan -> parseProjectWithFSUnits
  <- sfanalysis.checkWithFS -> TestVerifiedRule.func2 (scan_test.go:59)
```

是时序相关的并发竞态，不是这一轮 CI/CLI 改动引入的。顺着链路查下去发现三个互相独立的问题，一个 commit 一个。

## commit 1 `fix(python,java)`: ANTLR 静态状态每次取 ATN 都被重建

`GetPythonParserSerializedATN()` 调的是小写的 `pythonparserParserInit()`，`GetJavaParserSerializedATN()` 同理调 `javaparserParserInit()`，都绕过了 `sync.Once` 包装（`PythonParserInit` / `JavaParserInit`）。于是每次取 ATN 都会重跑整套静态初始化，把包级 `atn`、`decisionToDFA`、`PredictionContextCache` 重新赋值。

后果是不同时刻创建的 parser 指向不同“世代”的对象，却一起往共享 cache 的那个 map 里读写。fork 里唯一的锁是 `atn.stateMu`（在 `addDFAState` 的两个调用点持有），代际错配后就变成两把不同的锁守同一个 map，等价于没有锁 → runtime 直接 fatal abort（不是 panic，recover 拦不住）。

这里没有给 antlr fork 的 `JMap` 加锁：真实缺陷是代际错配，加锁只是把一个 O(1) 的读路径变成每次 `AdaptivePredict` 都过一遍全局互斥，单线程解析也要付代价，而且要改上游 fork 的通用容器。改成让静态初始化幂等，一把 `stateMu` 就确实守着它自己的 cache。Go / C / PHP / Yak 的 getter 本来就走 `sync.Once`，只有 python 和 java 漏了。

补了 `parser_static_data_test.go`（python + java）钉住“重复调 getter 返回同一批静态对象”，以及 `python/test/antlr_static_cache_race_test.go` 直接并发跑 `FrontendWithCache` 与带 worker cache 的路径。

## commit 2 `refactor(python2ssa)`: 计划阶段退回文本扫描，不再解析 AST

`CompileUnitDependencies` 是项目里每个 .py 都要跑一次的“计划”步骤，但 `9635462c` / `be694dc3` 之后它改成用 Python 文法解析每个文件来收集 import 边。这违背了 compile-unit 的分层契约（计划阶段保持文本级，AST 只在 batch 内解析，避免整个项目同时持有 AST 把内存打爆），而且每个 Python 文件被解析两遍：一次定计划、一次建 SSA。它同时也是踩到上面那对静态 cache 的入口。

换成 `scanPyImportEdges`（正则 + 先把注释和字符串空白化），保留 AST walk 原本产出的全部边：

- 绝对：`import a.b, c.d as e`、`from a.b import c`（含 alias 和逗号列表）
- 相对：`from . import x`、`from .. import x`、`from ..pkg.mod import x`
- 括号多行名单（含相对形式）、分号同行多语句、函数体与 try/except、if/else 里的缩进 import
- 只认字面量的动态 import：`__import__("m")`、`importlib.import_module("m")`、`import_module("m", package="p")`；参数是变量、f-string 或 receiver 不是 importlib 时不产边（与 AST 分支的守卫一致）

注释、单行字符串和 docstring 先空白化再匹配，所以里面的 import 样文字不会产边；注释里的引号（Apache 许可证头一堆）不再引发级联，因为扫描器总会跳过闭合分隔符；未闭合引号只吃到行尾而不是吞掉整个文件。语法有问题的文件现在照样保留它的边，`TestPythonCompileUnit_SyntaxErrorFallsBackToRegex` 不再是回退路径，而是直接就对。

性能（65 个真实语法样例文件，单线程，DFA 预热）：AST `207.3ms / 1.25M allocs / 104.6MB`，正则 `81.7ms / 29.5K allocs / 5.1MB`。

正确性拿 Python 自己的 `ast` 当 oracle：460 个真实文件（Kafka / TinkerPop / Ranger / CRMEB / wanwu 树）产出的 3148 条边，缺 0、多 0。这个对比以 opt-in 形式留在 `TestScanPyImportEdgesCorpusParity`（`YAK_PYTHON_IMPORT_CORPUS` + `YAK_PYTHON_IMPORT_ORACLE`）。原有 9 个 `TestPythonCompileUnit_*` 契约测试未改动通过。

## commit 3 `fix(ssa)`: 共享 Type 的 id 改成原子 + CAS 认领

Type 对象是共享的：一个 `*InterfaceType` / `*FunctionType` 会被大量 instruction 引用，而 dbcache 的 persist pipeline 是多 worker 并发 marshal。`value2IrCode` 每次引用都读 `typ.GetId()`，`saveTypeWithValue -> rememberType -> typeStore.remember` 又在第一次见到这个 type 时惰性写 id。store 本身是并发安全的（`nextID` 原子计数器、`resident` 是 SafeMap），偏偏 `baseType.id` 是裸 `int64`，两条路径在同一个对象上打架。

`-race` 下表现为 `baseType.GetId`（读）与 `baseType.SetId`（写）的 DATA RACE，栈全在 ssa/dbcache 里，与 commit 1/2 无关——干净的 origin/main 上跑同一个包能复现出 24 个 DATA RACE。

这不只是撕裂读：两个 worker 同时看到 `id <= 0` 时各自从 `nextID` 取号、各自覆盖字段，同一个 Type 可能以多个 id 建索引并落库，而引用它的 instruction 记住的 id 各不相同。所以 `baseType.id` 改成 `atomic.Int64`（八种 type 都是按指针内嵌 `*baseType`，且只有 `GetId`/`SetId` 碰这个字段，因此 `NewBaseType()` 显式存 `-1`），再加 `claimIdIfUnset` 这个 CAS：`remember` 从共享计数器取候选号，由对象自己裁决，输的一方直接采用赢家的 id。非 `baseType` 支撑的 type 保留原来的 `SetId` 路径。

`type_id_concurrency_test.go` 钉住两半：32 个 worker 对同一个 type 调 `remember` 必须拿到同一个 id 且能在 `resident` 里查到；一个 `GetId` 读者对着 `remember` 持续跑必须 `-race` 干净。

## 验证

- `go test -race -count=2 ./common/yak/ssa/`（只看新增两个并发测试）：修复前 FAIL，报 `worker 1 saw id 3 but worker 0 saw 2: one type got several ids` 加 DATA RACE；修复后 `ok 3.380s`
- `go test -race -count=1 ./common/yak/python/test/`：`ok 105.4s`，DATA RACE 计数 0（main 上 24 个）
- `go test -count=1 ./common/yak/ssa/ ./common/yak/python/parser/ ./common/yak/python/python2ssa/ ./common/yak/python/test/ ./common/yak/java/parser/`：rebase 到最新 main 后全部 ok
- `go vet ./common/yak/ssa/` 只剩 main 上就存在的 `database_marshal.go:16:15: MarshalValue passes lock by value`

## 已知后续（本 PR 故意不动）

- `python2ssa/builder.go:801 Frontend()` 和 `python2ssa/import_fallback.go:143` 仍然不带 cache 调用，会落到包级静态 cache。修好 commit 1 之后它不再是竞态，但对这些调用者是无界增长。
- instruction 的 id 仍是“惰性赋值不加锁”的老写法：`anInstruction` 按值内嵌在 `Instruction` 里，并且用值 receiver `func (i anInstruction) MarshalInstruction` 做 marshal，往里塞 atomic 等于拷贝锁，会把每次 instruction 拷贝变成 vet copylocks 报错，改动面比 type 大得多。
