### PR TITLE
fix(mcp): harden stdio output and transport serialization

### DIFF
--- a/common/log/mcp_stdio.go
+++ b/common/log/mcp_stdio.go
@@ -26,9 +26,9 @@ func ConfigureMCPStdioLogging(args []string) bool {
 	return true
 }
 
-// EnableMCPStdioLogging reserves stdout for MCP JSON-RPC and moves the shared
-// Yak logger to stderr. The operation is idempotent and also affects loggers
-// created later through GetLogger.
+// EnableMCPStdioLogging moves the shared Yak logger to stderr when stdout is
+// reserved for MCP JSON-RPC. The operation is idempotent and also affects
+// loggers created later through GetLogger.
 func EnableMCPStdioLogging() {
 	mcpStdioMode.Store(true)
 	SetOutput(os.Stderr)

--- a/common/mcp/command.go
+++ b/common/mcp/command.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/samber/lo"
@@ -67,11 +68,27 @@ var MCPCommand = &cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		transport := c.String("transport")
+		protocolStdout := os.Stdout
 		if transport == "stdio" {
-			// Re-apply at the action boundary as a defense for embedded callers
-			// that invoke MCPCommand without Yak's normal os.Args layout.
+			// Re-apply at the action boundary for embedded callers that invoke
+			// MCPCommand without Yak's normal os.Args layout. Then reserve the
+			// original stdout exclusively for JSON-RPC and redirect every other
+			// process-level stdout write to stderr. This also contains direct
+			// fmt/println output from tools and embedded Yak scripts.
 			log.EnableMCPStdioLogging()
 			log.SetLevel(log.FatalLevel)
+
+			var restoreStdout func() error
+			var isolateErr error
+			protocolStdout, restoreStdout, isolateErr = reserveMCPProtocolStdout()
+			if isolateErr != nil {
+				return utils.Wrap(isolateErr, "reserve stdout for MCP stdio")
+			}
+			defer func() {
+				if err := restoreStdout(); err != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "restore stdout after MCP stdio: %v\n", err)
+				}
+			}()
 		}
 
 		yakit.CallPostInitDatabase()
@@ -163,7 +180,7 @@ var MCPCommand = &cli.Command{
 		}
 		switch transport {
 		case "stdio":
-			err = s.ServeStdio()
+			err = s.ServeStdioWithIO(os.Stdin, protocolStdout)
 		case "sse":
 			if port == 0 {
 				port = utils.GetRandomAvailableTCPPort()

--- a/common/mcp/command_stdio_integration_test.go
+++ b/common/mcp/command_stdio_integration_test.go
@@ -38,7 +38,12 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 		t.Fatalf("build yak command: %v\n%s", buildErr, output)
 	}
 
-	request := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stdio-regression-test","version":"1"}}}` + "\n"
+	const stdoutSentinel = "MCP_STDOUT_SENTINEL"
+	request := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stdio-regression-test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"exec_yak_script","arguments":{"pluginType":"yak","code":"println(\"` + stdoutSentinel + `\")"}}}`,
+	}, "\n") + "\n"
 	runContext, cancelRun := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancelRun()
 	run := exec.CommandContext(
@@ -48,6 +53,8 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 		"--transport",
 		"stdio",
 		"--enable-aitool-framework",
+		"--tool",
+		"yak_script",
 	)
 	run.Env = appendWithoutEnvKeys(
 		os.Environ(),
@@ -72,8 +79,14 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 	if bytes.ContainsRune(stdout.Bytes(), '\x1b') {
 		t.Fatalf("stdout contains ANSI escape bytes: %q", stdout.String())
 	}
+	if bytes.Contains(stdout.Bytes(), []byte(stdoutSentinel)) {
+		t.Fatalf("tool stdout leaked into JSON-RPC stream: %q", stdout.String())
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte(stdoutSentinel)) {
+		t.Fatalf("tool stdout was not redirected to stderr; stderr: %q", stderr.String())
+	}
 
-	responseCount := 0
+	responseIDs := make(map[int]bool)
 	scanner := bufio.NewScanner(bytes.NewReader(stdout.Bytes()))
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
@@ -85,6 +98,7 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 		}
 		var response struct {
 			JSONRPC string `json:"jsonrpc"`
+			ID      int    `json:"id"`
 		}
 		if decodeErr := json.Unmarshal(line, &response); decodeErr != nil {
 			t.Fatalf("decode stdout response: %v", decodeErr)
@@ -92,13 +106,15 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 		if response.JSONRPC != "2.0" {
 			t.Fatalf("stdout JSON is not JSON-RPC 2.0: %s", line)
 		}
-		responseCount++
+		if response.ID != 0 {
+			responseIDs[response.ID] = true
+		}
 	}
 	if scanErr := scanner.Err(); scanErr != nil {
 		t.Fatalf("scan stdout: %v", scanErr)
 	}
-	if responseCount != 1 {
-		t.Fatalf("got %d JSON-RPC responses, want 1; stdout: %q", responseCount, stdout.String())
+	if !responseIDs[1] || !responseIDs[2] {
+		t.Fatalf("missing initialize or tools/call response; response IDs: %v; stdout: %q", responseIDs, stdout.String())
 	}
 }
 

--- a/common/mcp/mcp-go/client/no_stdout_test.go
+++ b/common/mcp/mcp-go/client/no_stdout_test.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMCPClientProductionCodeDoesNotWriteStdout reserves process stdout for
+// an enclosing stdio MCP transport. This is especially important when these
+// clients are used by the external-MCP bridge inside another MCP server.
+func TestMCPClientProductionCodeDoesNotWriteStdout(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read client package: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		path := filepath.Join(".", name)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := selector.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+
+			if pkg.Name == "os" && selector.Sel.Name == "Stdout" {
+				t.Errorf("%s: MCP client production code must not write os.Stdout", fset.Position(selector.Pos()))
+			}
+			if pkg.Name == "fmt" && (selector.Sel.Name == "Print" || selector.Sel.Name == "Printf" || selector.Sel.Name == "Println") {
+				t.Errorf("%s: MCP client production code must not call fmt.%s", fset.Position(selector.Pos()), selector.Sel.Name)
+			}
+			return true
+		})
+	}
+}

--- a/common/mcp/mcp-go/client/sse.go
+++ b/common/mcp/mcp-go/client/sse.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -214,7 +215,7 @@ func (c *SSEMCPClient) handleSSEEvent(event, data string) {
 	case "endpoint":
 		endpoint, err := url.Parse(data)
 		if err != nil {
-			fmt.Printf("Error parsing endpoint URL: %v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "MCP SSE client: error parsing endpoint URL: %v\n", err)
 			return
 		}
 		if endpoint.Host == "" {
@@ -223,7 +224,7 @@ func (c *SSEMCPClient) handleSSEEvent(event, data string) {
 			endpoint.User = c.baseURL.User
 		} else {
 			if endpoint.Host != c.baseURL.Host {
-				fmt.Printf("Endpoint origin does not match connection origin\n")
+				_, _ = fmt.Fprintln(os.Stderr, "MCP SSE client: endpoint origin does not match connection origin")
 				return
 			}
 		}
@@ -243,7 +244,7 @@ func (c *SSEMCPClient) handleSSEEvent(event, data string) {
 		}
 
 		if err := json.Unmarshal([]byte(data), &baseMessage); err != nil {
-			fmt.Printf("Error unmarshaling message: %v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "MCP SSE client: error unmarshaling message: %v\n", err)
 			return
 		}
 

--- a/common/mcp/mcp-go/client/stdio.go
+++ b/common/mcp/mcp-go/client/stdio.go
@@ -113,7 +113,7 @@ func (c *StdioMCPClient) readResponses() {
 			line, err := c.stdout.ReadString('\n')
 			if err != nil {
 				if err != io.EOF {
-					fmt.Printf("Error reading response: %v\n", err)
+					_, _ = fmt.Fprintf(os.Stderr, "MCP stdio client: error reading response: %v\n", err)
 				}
 				return
 			}

--- a/common/mcp/mcp-go/client/streamable_http.go
+++ b/common/mcp/mcp-go/client/streamable_http.go
@@ -28,6 +28,7 @@ type StreamableHTTPMCPClient struct {
 	initialized     bool
 	protocolVersion string
 	sessionID       string
+	stateMu         sync.RWMutex
 
 	notifications []func(mcp.JSONRPCNotification)
 	notifyMu      sync.RWMutex
@@ -80,12 +81,39 @@ func (c *StreamableHTTPMCPClient) applyHeaders(req *http.Request) {
 	for key, value := range c.headers {
 		req.Header.Set(key, value)
 	}
-	if c.sessionID != "" {
-		req.Header.Set(mcp.HeaderSessionID, c.sessionID)
+
+	state := c.snapshotState()
+	if state.sessionID != "" {
+		req.Header.Set(mcp.HeaderSessionID, state.sessionID)
 	}
-	if c.protocolVersion != "" {
-		req.Header.Set(mcp.HeaderProtocolVersion, c.protocolVersion)
+	if state.protocolVersion != "" {
+		req.Header.Set(mcp.HeaderProtocolVersion, state.protocolVersion)
 	}
+}
+
+type streamableHTTPClientState struct {
+	initialized     bool
+	protocolVersion string
+	sessionID       string
+}
+
+func (c *StreamableHTTPMCPClient) snapshotState() streamableHTTPClientState {
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
+
+	return streamableHTTPClientState{
+		initialized:     c.initialized,
+		protocolVersion: c.protocolVersion,
+		sessionID:       c.sessionID,
+	}
+}
+
+func (c *StreamableHTTPMCPClient) markInitialized(protocolVersion string) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+
+	c.protocolVersion = protocolVersion
+	c.initialized = true
 }
 
 func (c *StreamableHTTPMCPClient) sendRequest(
@@ -93,7 +121,7 @@ func (c *StreamableHTTPMCPClient) sendRequest(
 	method string,
 	params interface{},
 ) (*json.RawMessage, error) {
-	if !c.initialized && method != "initialize" {
+	if !c.snapshotState().initialized && method != "initialize" {
 		return nil, fmt.Errorf("client not initialized")
 	}
 
@@ -239,8 +267,7 @@ func (c *StreamableHTTPMCPClient) Initialize(
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
-	c.protocolVersion = result.ProtocolVersion
-	c.initialized = true
+	c.markInitialized(result.ProtocolVersion)
 
 	if err := c.sendNotification(ctx, "notifications/initialized", nil); err != nil {
 		return nil, fmt.Errorf("failed to send initialized notification: %w", err)
@@ -427,7 +454,7 @@ func (c *StreamableHTTPMCPClient) Close() error {
 		cancel()
 	}
 
-	if c.sessionID != "" {
+	if c.snapshotState().sessionID != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -451,10 +478,12 @@ func (c *StreamableHTTPMCPClient) Close() error {
 }
 
 func (c *StreamableHTTPMCPClient) ensureEventStream() {
+	state := c.snapshotState()
+
 	c.streamMu.Lock()
 	defer c.streamMu.Unlock()
 
-	if c.sessionID == "" || c.eventStreamCancel != nil {
+	if state.sessionID == "" || c.eventStreamCancel != nil {
 		return
 	}
 
@@ -572,13 +601,17 @@ func (c *StreamableHTTPMCPClient) dispatchSSEPayload(payload json.RawMessage) {
 }
 
 func (c *StreamableHTTPMCPClient) updateSessionFromHeaders(header http.Header) {
-	if sessionID := header.Get(mcp.HeaderSessionID); sessionID != "" {
-		c.sessionID = sessionID
+	sessionID := header.Get(mcp.HeaderSessionID)
+	if sessionID == "" {
+		sessionID = header.Get(mcp.LegacyHeaderSessionID)
+	}
+	if sessionID == "" {
 		return
 	}
-	if sessionID := header.Get(mcp.LegacyHeaderSessionID); sessionID != "" {
-		c.sessionID = sessionID
-	}
+
+	c.stateMu.Lock()
+	c.sessionID = sessionID
+	c.stateMu.Unlock()
 }
 
 func decodeJSONRPCResponseBody(reader io.Reader) (*json.RawMessage, error) {

--- a/common/mcp/mcp-go/client/streamable_http_test.go
+++ b/common/mcp/mcp-go/client/streamable_http_test.go
@@ -2,6 +2,9 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -9,6 +12,71 @@ import (
 	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
 	"github.com/yaklang/yaklang/common/mcp/mcp-go/server"
 )
+
+func TestStreamableHTTPMCPClientSessionStateConcurrentAccess(t *testing.T) {
+	client, err := NewStreamableHTTPMCPClient("http://127.0.0.1/mcp")
+	require.NoError(t, err)
+
+	client.markInitialized(mcp.LATEST_PROTOCOL_VERSION)
+	initialHeader := make(http.Header)
+	initialHeader.Set(mcp.HeaderSessionID, "initial-session")
+	client.updateSessionFromHeaders(initialHeader)
+
+	const (
+		writerCount = 4
+		readerCount = 8
+		iterations  = 1_000
+	)
+
+	errorsCh := make(chan error, readerCount)
+	var wg sync.WaitGroup
+	for writer := 0; writer < writerCount; writer++ {
+		writer := writer
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for iteration := 0; iteration < iterations; iteration++ {
+				header := make(http.Header)
+				header.Set(mcp.HeaderSessionID, fmt.Sprintf("session-%d-%d", writer, iteration))
+				client.updateSessionFromHeaders(header)
+			}
+		}()
+	}
+
+	for reader := 0; reader < readerCount; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for iteration := 0; iteration < iterations; iteration++ {
+				req, requestErr := http.NewRequest(http.MethodGet, "http://127.0.0.1/mcp", nil)
+				if requestErr != nil {
+					errorsCh <- requestErr
+					return
+				}
+				client.applyHeaders(req)
+
+				if got := req.Header.Get(mcp.HeaderProtocolVersion); got != mcp.LATEST_PROTOCOL_VERSION {
+					errorsCh <- fmt.Errorf("unexpected protocol version header %q", got)
+					return
+				}
+				if got := req.Header.Get(mcp.HeaderSessionID); got == "" {
+					errorsCh <- fmt.Errorf("missing session ID header")
+					return
+				}
+				if !client.snapshotState().initialized {
+					errorsCh <- fmt.Errorf("client unexpectedly became uninitialized")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errorsCh)
+	for concurrentErr := range errorsCh {
+		require.NoError(t, concurrentErr)
+	}
+}
 
 func TestStreamableHTTPMCPClient(t *testing.T) {
 	observedClientCh := make(chan server.NotificationContext, 1)

--- a/common/mcp/mcp-go/server/sse.go
+++ b/common/mcp/mcp-go/server/sse.go
@@ -78,9 +78,30 @@ func (s *sseSession) Close() {
 }
 
 func (sess *sseSession) writeMessageEvent(eventData []byte) (err error) {
+	// Assemble the complete event before taking the session lock. All endpoint,
+	// message, and keep-alive frames ultimately pass through writeFrameLocked,
+	// which prevents concurrent ResponseWriter use and frame interleaving. TCP is
+	// still free to split a frame across packets, as required by stream semantics.
+	frame := make([]byte, 0, len("event: message\ndata: ")+len(eventData)+2)
+	frame = append(frame, "event: message\ndata: "...)
+	frame = append(frame, eventData...)
+	frame = append(frame, '\n', '\n')
+	return sess.writeFrame(frame)
+}
+
+func (sess *sseSession) writeKeepAlive() error {
+	return sess.writeFrame([]byte(":keepalive\n\n"))
+}
+
+func (sess *sseSession) writeFrame(frame []byte) error {
 	sess.mu.Lock()
 	defer sess.mu.Unlock()
+	return sess.writeFrameLocked(frame)
+}
 
+// writeFrameLocked is the only code path that writes to the SSE
+// ResponseWriter. The caller must hold sess.mu.
+func (sess *sseSession) writeFrameLocked(frame []byte) (err error) {
 	select {
 	case <-sess.done:
 		return fmt.Errorf("session closed")
@@ -92,23 +113,6 @@ func (sess *sseSession) writeMessageEvent(eventData []byte) (err error) {
 			err = fmt.Errorf("sse write: %v", r)
 		}
 	}()
-
-	// Assemble the complete SSE frame in a single buffer before writing.
-	// http.ResponseWriter wraps a bufio.Writer (default 4 KiB). If we call
-	// fmt.Fprintf with a large payload the runtime may auto-flush mid-write,
-	// sending the "event: message\ndata: " prefix and part of the JSON in one
-	// TCP chunk and the rest (including the mandatory "\n\n" terminator) in a
-	// later chunk. SSE clients that feed each received chunk directly to a JSON
-	// parser will then see a truncated / incomplete string and report errors like
-	// "Unterminated string" – a symptom visible especially with multi-byte UTF-8
-	// content (Chinese characters, etc.) that exceeds the buffer boundary.
-	//
-	// Writing the entire frame atomically ensures the SSE event is always
-	// delivered as a coherent unit.
-	frame := make([]byte, 0, len("event: message\ndata: ")+len(eventData)+2)
-	frame = append(frame, "event: message\ndata: "...)
-	frame = append(frame, eventData...)
-	frame = append(frame, '\n', '\n')
 
 	if _, werr := sess.writer.Write(frame); werr != nil {
 		return werr
@@ -279,15 +283,21 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		endpointBase,
 		sessionID,
 	)
-	// Register the session before sending the endpoint event to the client.
-	// The client extracts the sessionId from this event and may immediately POST
-	// its first JSON-RPC request (e.g. "initialize") to /message. If the session
-	// is stored only after flushing, a fast round-trip can reach handleMessage
-	// before the session exists, producing an intermittent
-	// "Invalid session ID" rejection.
+	endpointFrame := []byte(fmt.Sprintf("event: endpoint\ndata: %s\r\n\r\n", messageEndpoint))
+
+	// Register while holding the session write lock, then write and flush the
+	// endpoint event before unlocking. A client may POST immediately after
+	// receiving the endpoint: it will find the session, but its response write
+	// cannot overtake or race the endpoint frame.
+	session.mu.Lock()
 	s.sessions.Store(sessionID, session)
-	fmt.Fprintf(w, "event: endpoint\ndata: %s\r\n\r\n", messageEndpoint)
-	flusher.Flush()
+	endpointErr := session.writeFrameLocked(endpointFrame)
+	session.mu.Unlock()
+	if endpointErr != nil {
+		s.sessions.Delete(sessionID)
+		session.Close()
+		return
+	}
 	defer s.sessions.Delete(sessionID)
 
 	// Send periodic SSE keep-alive comments to prevent client body timeouts.
@@ -302,16 +312,9 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 			session.Close()
 			return
 		case <-ticker.C:
-			session.mu.Lock()
-			select {
-			case <-session.done:
-				session.mu.Unlock()
+			if err := session.writeKeepAlive(); err != nil {
 				session.Close()
 				return
-			default:
-				_, _ = session.writer.Write([]byte(":keepalive\n\n"))
-				session.flusher.Flush()
-				session.mu.Unlock()
 			}
 		}
 	}

--- a/common/mcp/mcp-go/server/stdio.go
+++ b/common/mcp/mcp-go/server/stdio.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
@@ -20,6 +21,7 @@ import (
 type StdioServer struct {
 	server    *MCPServer
 	errLogger *log.Logger
+	writeMu   sync.Mutex
 }
 
 // NewStdioServer creates a new stdio server wrapper around an MCPServer.
@@ -166,7 +168,14 @@ func (s *StdioServer) writeResponse(
 		return err
 	}
 
-	// Write response followed by newline
+	// Responses from the request loop and notifications from the dispatcher
+	// share the same stdout transport. Serialize the complete JSON-RPC frame so
+	// concurrent writes cannot interleave and corrupt the newline-delimited
+	// protocol stream.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	// Write response followed by newline.
 	if _, err := fmt.Fprintf(writer, "%s\n", responseBytes); err != nil {
 		return err
 	}
@@ -178,6 +187,13 @@ func (s *StdioServer) writeResponse(
 // It sets up signal handling for graceful shutdown on SIGTERM and SIGINT.
 // Returns an error if the server encounters any issues during operation.
 func ServeStdio(server *MCPServer) error {
+	return ServeStdioWithIO(server, os.Stdin, os.Stdout)
+}
+
+// ServeStdioWithIO serves MCP over the provided streams. Supplying the
+// protocol writer explicitly lets applications reserve their inherited stdout
+// for JSON-RPC while redirecting unrelated process output elsewhere.
+func ServeStdioWithIO(server *MCPServer, stdin io.Reader, stdout io.Writer) error {
 	s := NewStdioServer(server)
 	s.SetErrorLogger(log.New(os.Stderr, "", log.LstdFlags))
 
@@ -193,5 +209,5 @@ func ServeStdio(server *MCPServer) error {
 		cancel()
 	}()
 
-	return s.Listen(ctx, os.Stdin, os.Stdout)
+	return s.Listen(ctx, stdin, stdout)
 }

--- a/common/mcp/mcp-go/server/stdio_test.go
+++ b/common/mcp/mcp-go/server/stdio_test.go
@@ -2,12 +2,46 @@ package server
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
 	"log"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
 )
+
+type concurrentWriteDetector struct {
+	active     atomic.Int32
+	overlapped atomic.Bool
+	mu         sync.Mutex
+	buffer     bytes.Buffer
+}
+
+func (w *concurrentWriteDetector) Write(p []byte) (int, error) {
+	if w.active.Add(1) > 1 {
+		w.overlapped.Store(true)
+	}
+	defer w.active.Add(-1)
+
+	// Keep the write window open long enough for unsynchronized callers to
+	// overlap deterministically.
+	time.Sleep(time.Millisecond)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buffer.Write(p)
+}
+
+func (w *concurrentWriteDetector) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return bytes.Clone(w.buffer.Bytes())
+}
 
 func TestStdioServer(t *testing.T) {
 	t.Run("Can instantiate", func(t *testing.T) {
@@ -108,6 +142,53 @@ func TestStdioServer(t *testing.T) {
 		// Check for server errors
 		if err := <-serverErrCh; err != nil {
 			t.Errorf("unexpected server error: %v", err)
+		}
+	})
+
+	t.Run("Serializes concurrent responses and notifications", func(t *testing.T) {
+		stdioServer := NewStdioServer(NewMCPServer("test", "1.0.0"))
+		writer := &concurrentWriteDetector{}
+
+		const messageCount = 64
+		var wg sync.WaitGroup
+		errs := make(chan error, messageCount)
+		for i := 0; i < messageCount; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				err := stdioServer.writeResponse(mcp.JSONRPCResponse{
+					JSONRPC: mcp.JSONRPC_VERSION,
+					ID:      id,
+					Result:  map[string]int{"id": id},
+				}, writer)
+				if err != nil {
+					errs <- err
+				}
+			}(i)
+		}
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			t.Fatalf("write response: %v", err)
+		}
+		if writer.overlapped.Load() {
+			t.Fatal("stdio writer was used concurrently")
+		}
+
+		scanner := bufio.NewScanner(bytes.NewReader(writer.Bytes()))
+		lines := 0
+		for scanner.Scan() {
+			if !json.Valid(scanner.Bytes()) {
+				t.Fatalf("invalid JSON-RPC frame: %q", scanner.Bytes())
+			}
+			lines++
+		}
+		if err := scanner.Err(); err != nil {
+			t.Fatalf("scan responses: %v", err)
+		}
+		if lines != messageCount {
+			t.Fatalf("got %d response frames, want %d", lines, messageCount)
 		}
 	})
 }

--- a/common/mcp/mcp-go/server/streamable_http.go
+++ b/common/mcp/mcp-go/server/streamable_http.go
@@ -84,6 +84,11 @@ type streamableHTTPEventStream struct {
 }
 
 func (s *streamableHTTPEventStream) Close() {
+	// The HTTP handler must not return while a dispatcher is still writing to
+	// its ResponseWriter. Serialize close with Send so either the current frame
+	// finishes first, or later sends observe the closed stream and stop.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
 	s.closeOnce.Do(func() {
 		close(s.done)
 	})
@@ -94,17 +99,29 @@ func (s *streamableHTTPEventStream) Send(message interface{}) error {
 	if err != nil {
 		return err
 	}
+	frame := make([]byte, 0, len("data: ")+len(eventData)+2)
+	frame = append(frame, "data: "...)
+	frame = append(frame, eventData...)
+	frame = append(frame, '\n', '\n')
+	return s.writeFrame(frame)
+}
 
+func (s *streamableHTTPEventStream) writeFrame(frame []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.writeFrameLocked(frame)
+}
+
+// writeFrameLocked is the only code path that writes to this stream's
+// ResponseWriter. The caller must hold s.writeMu.
+func (s *streamableHTTPEventStream) writeFrameLocked(frame []byte) error {
 	select {
 	case <-s.done:
 		return fmt.Errorf("stream closed")
 	default:
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
-	if _, err := fmt.Fprintf(s.writer, "data: %s\n\n", eventData); err != nil {
+	if _, err := s.writer.Write(frame); err != nil {
 		return err
 	}
 	s.flusher.Flush()
@@ -282,16 +299,22 @@ func (s *StreamableHTTPServer) handleGet(
 		done:    make(chan struct{}),
 	}
 
+	// Publish the stream while holding its write lock, then prime it before
+	// unlocking. A concurrent notification can discover the stream immediately,
+	// but cannot overtake or race the priming frame.
+	stream.writeMu.Lock()
 	session.streams.Store(streamID, stream)
+	primeErr := stream.writeFrameLocked([]byte(": connected\n\n"))
+	stream.writeMu.Unlock()
+	if primeErr != nil {
+		session.streams.Delete(streamID)
+		stream.Close()
+		return
+	}
 	defer func() {
 		session.streams.Delete(streamID)
 		stream.Close()
 	}()
-
-	stream.writeMu.Lock()
-	_, _ = fmt.Fprint(w, ": connected\n\n")
-	flusher.Flush()
-	stream.writeMu.Unlock()
 
 	select {
 	case <-r.Context().Done():

--- a/common/mcp/server.go
+++ b/common/mcp/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -204,10 +205,14 @@ func (s *MCPServer) ServeHTTPCompat(addr, baseURL string) (err error) {
 }
 
 func (s *MCPServer) ServeStdio() (err error) {
+	return s.ServeStdioWithIO(os.Stdin, os.Stdout)
+}
+
+func (s *MCPServer) ServeStdioWithIO(stdin io.Reader, stdout io.Writer) (err error) {
 	if err = s.ensureLocalClient(); err != nil {
 		return err
 	}
-	return server.ServeStdio(s.server)
+	return server.ServeStdioWithIO(s.server, stdin, stdout)
 }
 
 func (s *MCPServer) closeBridgeClients() {

--- a/common/mcp/stdio_output_fallback.go
+++ b/common/mcp/stdio_output_fallback.go
@@ -1,0 +1,22 @@
+//go:build !darwin && !linux && !windows
+
+package mcp
+
+import (
+	"os"
+	"sync"
+)
+
+func reserveMCPProtocolStdout() (*os.File, func() error, error) {
+	protocolStdout := os.Stdout
+	os.Stdout = os.Stderr
+
+	var once sync.Once
+	restore := func() error {
+		once.Do(func() {
+			os.Stdout = protocolStdout
+		})
+		return nil
+	}
+	return protocolStdout, restore, nil
+}

--- a/common/mcp/stdio_output_unixfd.go
+++ b/common/mcp/stdio_output_unixfd.go
@@ -1,0 +1,48 @@
+//go:build darwin || linux
+
+package mcp
+
+import (
+	"os"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// reserveMCPProtocolStdout duplicates the inherited stdout for the protocol
+// writer, then points file descriptor 1 at stderr. Redirecting the descriptor
+// (rather than only assigning os.Stdout) also contains writers cached by
+// libraries or embedded runtimes before the MCP command starts.
+func reserveMCPProtocolStdout() (*os.File, func() error, error) {
+	stdoutFD := int(os.Stdout.Fd())
+	protocolFD, err := unix.Dup(stdoutFD)
+	if err != nil {
+		return nil, nil, err
+	}
+	unix.CloseOnExec(protocolFD)
+
+	protocolStdout := os.NewFile(uintptr(protocolFD), "mcp-protocol-stdout")
+	if protocolStdout == nil {
+		_ = unix.Close(protocolFD)
+		return nil, nil, os.ErrInvalid
+	}
+
+	if err := unix.Dup2(int(os.Stderr.Fd()), stdoutFD); err != nil {
+		_ = protocolStdout.Close()
+		return nil, nil, err
+	}
+
+	var once sync.Once
+	var restoreErr error
+	restore := func() error {
+		once.Do(func() {
+			restoreErr = unix.Dup2(int(protocolStdout.Fd()), stdoutFD)
+			if closeErr := protocolStdout.Close(); restoreErr == nil {
+				restoreErr = closeErr
+			}
+		})
+		return restoreErr
+	}
+
+	return protocolStdout, restore, nil
+}

--- a/common/mcp/stdio_output_windows.go
+++ b/common/mcp/stdio_output_windows.go
@@ -1,0 +1,64 @@
+//go:build windows
+
+package mcp
+
+import (
+	"os"
+	"sync"
+
+	"golang.org/x/sys/windows"
+)
+
+func reserveMCPProtocolStdout() (*os.File, func() error, error) {
+	originalStdout := os.Stdout
+	originalHandle, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE)
+	if err != nil {
+		return nil, nil, err
+	}
+	stderrHandle, err := windows.GetStdHandle(windows.STD_ERROR_HANDLE)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Keep the protocol pipe on a private, non-inheritable handle. SetStdHandle
+	// only changes the process standard-handle slot; the duplicate remains bound
+	// to the caller's original stdout and is owned exclusively by the MCP writer.
+	var protocolHandle windows.Handle
+	currentProcess := windows.CurrentProcess()
+	if err := windows.DuplicateHandle(
+		currentProcess,
+		originalHandle,
+		currentProcess,
+		&protocolHandle,
+		0,
+		false,
+		windows.DUPLICATE_SAME_ACCESS,
+	); err != nil {
+		return nil, nil, err
+	}
+	protocolStdout := os.NewFile(uintptr(protocolHandle), "mcp-protocol-stdout")
+	if protocolStdout == nil {
+		_ = windows.CloseHandle(protocolHandle)
+		return nil, nil, os.ErrInvalid
+	}
+
+	if err := windows.SetStdHandle(windows.STD_OUTPUT_HANDLE, stderrHandle); err != nil {
+		_ = protocolStdout.Close()
+		return nil, nil, err
+	}
+	os.Stdout = os.Stderr
+
+	var once sync.Once
+	var restoreErr error
+	restore := func() error {
+		once.Do(func() {
+			restoreErr = windows.SetStdHandle(windows.STD_OUTPUT_HANDLE, originalHandle)
+			os.Stdout = originalStdout
+			if closeErr := protocolStdout.Close(); restoreErr == nil {
+				restoreErr = closeErr
+			}
+		})
+		return restoreErr
+	}
+	return protocolStdout, restore, nil
+}


### PR DESCRIPTION
## Summary

- reserve the inherited stdout exclusively for MCP stdio JSON-RPC and redirect ordinary process output to stderr
- serialize stdio, legacy SSE, and Streamable HTTP event writes to prevent frame interleaving
- remove direct MCP client stdout diagnostics and guard Streamable HTTP client session metadata against races
- use a private non-inheritable protocol handle on Windows

## Tests

- `go test -race ./common/log ./common/mcp/mcp-go/client ./common/mcp/mcp-go/server`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test ./common/mcp/stdio_output_windows.go`
- `go test ./common/mcp -run "^TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly$" -count=1`
- `go build -o build/yak-mcp-stdio common/yak/cmd/yak.go`

## Base branch note

Current `origin/main` contains a duplicate `sync` import in `common/yakgrpc/server.go`. The command-level test and build pass after temporarily removing that duplicate import. That unrelated file is restored to the exact `origin/main` version and is not included in this PR.