### PR TITLE
perf(aim): default to fast context initialization and async memory loading

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -362,6 +362,7 @@ type Config struct {
 	EnhanceKnowledgeManager            *EnhanceKnowledgeManager
 	DisableEnhanceDirectlyAnswer       bool
 	DisableIntentRecognition           bool // 禁用意图识别（用于测试环境，避免子循环消耗 mock 响应）
+	AllowSyncInitContext               bool // 首轮同步增强上下文，默认 false；后续按需识别意图
 	SyncPerceptionTrigger              bool // 感知调度处同步调用 TriggerPerception（否则 goroutine 异步）
 	DisablePerception                  bool // 禁用感知层（用于测试环境，避免异步 AI 调用干扰 mock 回调）
 	EnableFunctionCallMode             bool // 启用原生 functioncall (tool_calls) 模式
@@ -706,7 +707,7 @@ func newConfig(ctx context.Context) *Config {
 		GoalMinIterations:                  DefaultGoalMinIterations,
 		MaxSubAgents:                       DefaultMaxSubAgentConcurrency,
 		GenerateReport:                     true,
-		EnableFunctionCallMode:            true, // 默认开启原生 functioncall 模式
+		EnableFunctionCallMode:             true,  // 默认开启原生 functioncall 模式
 		DisallowMCPServers:                 false, // 默认启用 MCP Servers
 		MemoryTriageId:                     "default",
 		m:                                  new(sync.Mutex),
@@ -2586,6 +2587,23 @@ func WithDisableEnhanceDirectlyAnswer(disable bool) ConfigOption {
 	}
 }
 
+// WithAllowSyncInitContext opts into synchronous context enrichment before the
+// default loop's first response. It defaults to false; planning, PE tasks and
+// explicit capability discovery can still enrich context during execution.
+// Memory loading remains asynchronous regardless of this option.
+func WithAllowSyncInitContext(allow bool) ConfigOption {
+	return func(c *Config) error {
+		if c.m == nil {
+			c.m = &sync.Mutex{}
+		}
+		c.m.Lock()
+		c.AllowSyncInitContext = allow
+		c.m.Unlock()
+		c.SetConfig("AllowSyncInitContext", allow)
+		return nil
+	}
+}
+
 // WithDisableIntentRecognition disables intent recognition in loop_default's buildInitTask.
 // This is primarily used in test environments where the mock AI callback cannot handle
 // the intent recognition sub-loop (loop_intent), which would consume mock responses
@@ -4369,6 +4387,7 @@ func ConvertConfigToOptions(i *Config) []ConfigOption {
 	if i.DisableIntentRecognition {
 		opts = append(opts, WithDisableIntentRecognition(true))
 	}
+	opts = append(opts, WithAllowSyncInitContext(i.AllowSyncInitContext))
 	if i.SyncPerceptionTrigger {
 		opts = append(opts, WithSyncPerceptionTrigger(true))
 	}

--- a/common/ai/aid/aicommon/config_sync_init_test.go
+++ b/common/ai/aid/aicommon/config_sync_init_test.go
@@ -1,0 +1,20 @@
+package aicommon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowSyncInitContextDefaultAndPropagation(t *testing.T) {
+	cfg := NewConfig(context.Background(), WithDisableAutoSkills(true))
+	require.False(t, cfg.AllowSyncInitContext)
+	require.False(t, cfg.GetConfigBool("AllowSyncInitContext"))
+	for _, allow := range []bool{true, false} {
+		require.NoError(t, WithAllowSyncInitContext(allow)(cfg))
+		child := NewConfig(context.Background(), ConvertConfigToOptions(cfg)...)
+		require.Equal(t, allow, child.AllowSyncInitContext)
+		require.Equal(t, allow, child.GetConfigBool("AllowSyncInitContext"))
+	}
+}

--- a/common/ai/aid/aimem/async_memory.go
+++ b/common/ai/aid/aimem/async_memory.go
@@ -1,0 +1,167 @@
+package aimem
+
+import (
+	"context"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// AsyncAIMemory initializes the memory backend in the background. Only memory
+// operations wait for readiness; creating a runtime and reading the session ID
+// never wait for embedding checks or index loading.
+type AsyncAIMemory struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	sessionID string
+	ready     chan struct{}
+	closed    chan struct{}
+	memory    *AIMemoryTriage // published by closing ready
+	err       error
+}
+
+var _ aicommon.MemoryTriage = (*AsyncAIMemory)(nil)
+var _ aicommon.TimelineArchiveStore = (*AsyncAIMemory)(nil)
+
+func NewAsyncAIMemory(ctx context.Context, sessionID string, opts ...Option) *AsyncAIMemory {
+	return newAsyncAIMemory(ctx, sessionID, func() (*AIMemoryTriage, error) {
+		return NewAIMemory(sessionID, opts...)
+	})
+}
+
+func NewAsyncAIMemoryForQuery(ctx context.Context, sessionID string, opts ...Option) *AsyncAIMemory {
+	return newAsyncAIMemory(ctx, sessionID, func() (*AIMemoryTriage, error) {
+		return NewAIMemoryForQuery(sessionID, opts...)
+	})
+}
+
+func newAsyncAIMemory(ctx context.Context, sessionID string, initialize func() (*AIMemoryTriage, error)) *AsyncAIMemory {
+	ctx, cancel := context.WithCancel(ctx)
+	m := &AsyncAIMemory{ctx: ctx, cancel: cancel, sessionID: sessionID, ready: make(chan struct{}), closed: make(chan struct{})}
+	go func() {
+		defer close(m.closed)
+		if ctx.Err() != nil {
+			m.err = ctx.Err()
+		} else {
+			m.memory, m.err = initialize()
+			if m.err == nil && m.memory == nil {
+				m.err = utils.Error("memory initializer returned no backend")
+			}
+		}
+		close(m.ready)
+		if m.err != nil {
+			log.Warnf("initialize asynchronous memory %s failed: %v", sessionID, m.err)
+		}
+		if m.memory != nil {
+			// Initialization may finish after cancellation. Close that backend too.
+			<-ctx.Done()
+			m.memory.Close()
+		}
+	}()
+	return m
+}
+
+// WaitReady waits only at an explicit memory operation, respecting both the
+// runtime lifetime and the caller's cancellation. Errors remain visible to all
+// callers instead of silently disabling memory.
+func (m *AsyncAIMemory) WaitReady(ctx context.Context) (*AIMemoryTriage, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-m.ctx.Done():
+		return nil, m.ctx.Err()
+	case <-m.ready:
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := m.ctx.Err(); err != nil {
+		return nil, err
+	}
+	return m.memory, m.err
+}
+
+func (m *AsyncAIMemory) GetSessionID() string { return m.sessionID }
+
+// Close cancels pending waits without waiting for an uninterruptible backend
+// constructor. The initialization goroutine owns eventual backend cleanup.
+func (m *AsyncAIMemory) Close() error { m.cancel(); return nil }
+
+func (m *AsyncAIMemory) SetInvoker(invoker aicommon.AIInvokeRuntime) {
+	if memory, err := m.WaitReady(m.ctx); err == nil {
+		memory.SetInvoker(invoker)
+	}
+}
+
+func (m *AsyncAIMemory) AddRawText(text string) ([]*aicommon.MemoryEntity, error) {
+	memory, err := m.WaitReady(m.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memory.AddRawText(text)
+}
+
+func (m *AsyncAIMemory) SaveMemoryEntities(entities ...*aicommon.MemoryEntity) error {
+	memory, err := m.WaitReady(m.ctx)
+	if err != nil {
+		return err
+	}
+	return memory.SaveMemoryEntities(entities...)
+}
+
+func (m *AsyncAIMemory) SearchBySemantics(query string, limit int) ([]*aicommon.SearchResult, error) {
+	memory, err := m.WaitReady(m.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memory.SearchBySemantics(query, limit)
+}
+
+func (m *AsyncAIMemory) SearchByTags(tags []string, matchAll bool, limit int) ([]*aicommon.MemoryEntity, error) {
+	memory, err := m.WaitReady(m.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memory.SearchByTags(tags, matchAll, limit)
+}
+
+func (m *AsyncAIMemory) HandleMemory(input any) error {
+	memory, err := m.WaitReady(m.ctx)
+	if err != nil {
+		return err
+	}
+	return memory.HandleMemory(input)
+}
+
+func (m *AsyncAIMemory) SearchMemory(input any, tokenLimit int) (*aicommon.SearchMemoryResult, error) {
+	memory, err := m.WaitReady(m.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memory.SearchMemory(input, tokenLimit)
+}
+
+func (m *AsyncAIMemory) SearchMemoryWithoutAI(input any, tokenLimit int) (*aicommon.SearchMemoryResult, error) {
+	memory, err := m.WaitReady(m.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memory.SearchMemoryWithoutAI(input, tokenLimit)
+}
+
+func (m *AsyncAIMemory) ArchiveCompressedBatch(ctx context.Context, batch *aicommon.TimelineArchiveBatch) (*aicommon.TimelineArchiveRef, error) {
+	memory, err := m.WaitReady(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memory.ArchiveCompressedBatch(ctx, batch)
+}
+
+func (m *AsyncAIMemory) SearchArchivedBatches(ctx context.Context, query *aicommon.TimelineArchiveSearchQuery) (*aicommon.TimelineArchiveSearchResult, error) {
+	memory, err := m.WaitReady(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return memory.SearchArchivedBatches(ctx, query)
+}

--- a/common/ai/aid/aimem/async_memory_test.go
+++ b/common/ai/aid/aimem/async_memory_test.go
@@ -1,0 +1,95 @@
+package aimem
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/rag/hnsw"
+)
+
+func TestAsyncMemoryInitializationDoesNotBlockAndPublishesBackend(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	release := make(chan struct{})
+	started := make(chan struct{})
+	backendCtx, closeBackend := context.WithCancel(context.Background())
+	backend := &AIMemoryTriage{ctx: backendCtx, cancel: closeBackend}
+	memory := newAsyncAIMemory(ctx, "test-session", func() (*AIMemoryTriage, error) {
+		close(started)
+		<-release
+		return backend, nil
+	})
+	require.Equal(t, "test-session", memory.GetSessionID())
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("initialization did not start")
+	}
+	select {
+	case <-memory.ready:
+		t.Fatal("initializer should still be blocked")
+	default:
+	}
+
+	waitCtx, stopWait := context.WithCancel(context.Background())
+	stopWait()
+	_, err := memory.WaitReady(waitCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	close(release)
+	readyCtx, stopReady := context.WithTimeout(ctx, time.Second)
+	defer stopReady()
+	got, err := memory.WaitReady(readyCtx)
+	require.NoError(t, err)
+	require.Same(t, backend, got)
+	require.NoError(t, memory.Close())
+	select {
+	case <-memory.closed:
+	case <-time.After(time.Second):
+		t.Fatal("backend was not closed")
+	}
+	require.ErrorIs(t, backendCtx.Err(), context.Canceled)
+}
+
+func TestAsyncMemoryCloseBeforeInitializationFinishes(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{})
+	backendCtx, closeBackend := context.WithCancel(context.Background())
+	memory := newAsyncAIMemory(context.Background(), "slow-session", func() (*AIMemoryTriage, error) {
+		close(started)
+		<-release
+		return &AIMemoryTriage{ctx: backendCtx, cancel: closeBackend}, nil
+	})
+	<-started
+	require.NoError(t, memory.Close())
+	_, err := memory.SearchMemory("query", 100)
+	require.ErrorIs(t, err, context.Canceled)
+	close(release)
+	select {
+	case <-memory.closed:
+	case <-time.After(time.Second):
+		t.Fatal("late backend was not closed")
+	}
+	require.ErrorIs(t, backendCtx.Err(), context.Canceled)
+}
+
+func TestAsyncMemoryInitializationErrorsReachOperations(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	expected := errors.New("backend unavailable")
+	memory := newAsyncAIMemory(ctx, "failed-session", func() (*AIMemoryTriage, error) { return nil, expected })
+	_, err := memory.SearchMemoryWithoutAI("query", 100)
+	require.ErrorIs(t, err, expected)
+	require.ErrorIs(t, memory.HandleMemory("remember this"), expected)
+	_, err = memory.SearchArchivedBatches(ctx, nil)
+	require.ErrorIs(t, err, expected)
+}
+
+func TestAsyncMemoryEmptyBackendClose(t *testing.T) {
+	backend := &AIMemoryHNSWBackend{}
+	require.NoError(t, backend.Close())
+	backend.graph.Store(hnsw.NewGraph[string]())
+	require.NoError(t, backend.Close(), "closing a fast session with no memories must not attempt to export an empty graph")
+}

--- a/common/ai/aid/aimem/coordinator_midterm.go
+++ b/common/ai/aid/aimem/coordinator_midterm.go
@@ -15,6 +15,14 @@ func EnsureTimelineMidtermArchiveStore(cfg *aicommon.Config) *AIMemoryTriage {
 	if store, ok := cfg.TimelineArchiveStore.(*AIMemoryTriage); ok && store != nil {
 		return store
 	}
+	if store, ok := cfg.TimelineArchiveStore.(*AsyncAIMemory); ok && store != nil {
+		memory, err := store.WaitReady(cfg.GetContext())
+		if err != nil {
+			log.Warnf("load midterm archive store failed: %v", err)
+			return nil
+		}
+		return memory
+	}
 	persistentSessionID := strings.TrimSpace(cfg.PersistentSessionId)
 	if persistentSessionID == "" {
 		return nil

--- a/common/ai/aid/aimem/hnsw_backend.go
+++ b/common/ai/aid/aimem/hnsw_backend.go
@@ -548,6 +548,15 @@ func (b *AIMemoryHNSWBackend) GetStats() map[string]interface{} {
 
 // Close 关闭后端，保存索引
 func (b *AIMemoryHNSWBackend) Close() error {
+	// Fast sessions can finish before any memories are added. There is no
+	// graph to persist in that case; exporting an empty graph reports an error.
+	b.graphMutex.RLock()
+	graph := b.graph.Load()
+	empty := graph == nil || graph.IsEmpty()
+	b.graphMutex.RUnlock()
+	if empty {
+		return nil
+	}
 	return b.SaveGraph()
 }
 

--- a/common/ai/aid/aireact/invoke_extra_capabilities_test.go
+++ b/common/ai/aid/aireact/invoke_extra_capabilities_test.go
@@ -74,6 +74,7 @@ func TestReAct_ExtraCapabilities_DeepIntent(t *testing.T) {
 		"Please help me discover relevant scanning blueprints, especially " + testForgeName + " related capabilities for penetration testing workflows."
 
 	ins, err := NewTestReAct(
+		aicommon.WithAllowSyncInitContext(true),
 		aicommon.WithDisableIntentRecognition(false), // override default: enable intent recognition
 		aicommon.WithAICallback(func(i aicommon.AICallerConfigIf, r *aicommon.AIRequest) (*aicommon.AIResponse, error) {
 			prompt := r.GetPrompt()

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -267,11 +267,7 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 		if memoryTriageId == "" {
 			memoryTriageId = "default"
 		}
-		var err error
-		react.memoryTriage, err = aimem.NewAIMemory(memoryTriageId, aimem.WithInvoker(react))
-		if err != nil {
-			return nil, utils.Errorf("create memory triage failed: %v", err)
-		}
+		react.memoryTriage = aimem.NewAsyncAIMemory(cfg.GetContext(), memoryTriageId, aimem.WithInvoker(react))
 		react.config.MemoryTriage = react.memoryTriage
 	}
 	memoryLoad := time.Now().Sub(memoryLoadStart)
@@ -283,13 +279,8 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 
 	if cfg.TimelineArchiveStore == nil && strings.TrimSpace(cfg.PersistentSessionId) != "" {
 		midtermSessionID := aimem.PersistentSessionToMidtermMemorySessionID(cfg.PersistentSessionId)
-		midtermStore, err := aimem.NewAIMemoryForQuery(midtermSessionID, aimem.WithDatabase(cfg.GetDB()), aimem.WithMidtermArchiveMode())
-		if err != nil {
-			log.Warnf("create timeline archive store failed for session %s: %v", cfg.PersistentSessionId, err)
-		} else {
-			cfg.TimelineArchiveStore = midtermStore
-			log.Infof("timeline archive store ready for persistent session %s", cfg.PersistentSessionId)
-		}
+		cfg.TimelineArchiveStore = aimem.NewAsyncAIMemoryForQuery(cfg.GetContext(), midtermSessionID,
+			aimem.WithDatabase(cfg.GetDB()), aimem.WithMidtermArchiveMode())
 	}
 	cfg.EnhanceKnowledgeManager.SetEmitter(cfg.Emitter)
 	if cfg.Timeline == nil {

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -732,11 +732,7 @@ func BuildReActInvoker(ctx context.Context, options ...aicommon.ConfigOption) (a
 		if memoryTriageId == "" {
 			memoryTriageId = "default"
 		}
-		var err error
-		invoker.memoryTriage, err = aimem.NewAIMemory(memoryTriageId, aimem.WithInvoker(invoker))
-		if err != nil {
-			return nil, utils.Errorf("create memory triage failed: %v", err)
-		}
+		invoker.memoryTriage = aimem.NewAsyncAIMemory(cfg.GetContext(), memoryTriageId, aimem.WithInvoker(invoker))
 		invoker.config.MemoryTriage = invoker.memoryTriage
 	}
 

--- a/common/ai/aid/aireact/reactloops/async_memory_test.go
+++ b/common/ai/aid/aireact/reactloops/async_memory_test.go
@@ -1,0 +1,126 @@
+package reactloops
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+)
+
+type blockedRecallMemory struct {
+	aicommon.MemoryTriage
+	release chan struct{}
+	started chan struct{}
+	once    sync.Once
+	calls   atomic.Int32
+}
+
+func (m *blockedRecallMemory) SearchMemoryWithoutAI(any, int) (*aicommon.SearchMemoryResult, error) {
+	m.calls.Add(1)
+	m.once.Do(func() { close(m.started) })
+	<-m.release
+	return &aicommon.SearchMemoryResult{
+		Memories: []*aicommon.MemoryEntity{{Id: "async-memory", Content: "remembered asynchronous context"}},
+	}, nil
+}
+
+func TestAsyncMemoryDoesNotBlockIterationsAndReachesLaterPrompt(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	memory := &blockedRecallMemory{MemoryTriage: aicommon.NewNoOpMemoryTriage(), release: make(chan struct{}), started: make(chan struct{})}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(memory.release) }) }
+	defer release()
+	prompts := make(chan string, 1)
+	responses := make(chan struct{}, 1)
+	cfg := aicommon.NewConfig(ctx,
+		aicommon.WithDisableAutoSkills(true),
+		aicommon.WithDisallowMCPServers(true),
+		aicommon.WithWorkdir(t.TempDir()),
+		aicommon.WithAICallback(func(c aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			select {
+			case prompts <- req.GetPrompt():
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			select {
+			case <-responses:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			response := c.NewAIResponse()
+			response.EmitOutputStream(bytes.NewBufferString(`{"@action":"advance"}`))
+			response.Close()
+			return response, nil
+		}),
+	)
+	invoker := mock.NewMockInvoker(ctx)
+	invoker.SetConfig(cfg)
+	steps := 0
+	loop, err := NewReActLoop("async-memory-test", invoker,
+		WithAllowToolCall(false),
+		WithAllowRAG(false),
+		WithAllowAIForge(false),
+		WithAllowPlanAndExec(false),
+		WithAllowUserInteract(false),
+		WithRegisterLoopAction("require_tool", "unused tool routing", nil, nil, nil),
+		WithMemoryTriage(memory),
+		WithDisableLoopPerception(true),
+		WithDisablePeriodicVerification(true),
+		WithDisableIncreaseIteration(true),
+		WithRegisterLoopAction("advance", "advance the test", nil, nil,
+			func(_ *ReActLoop, _ *aicommon.Action, op *LoopActionHandlerOperator) {
+				steps++
+				if steps == 3 {
+					op.Exit()
+				} else {
+					op.Continue()
+				}
+			}),
+	)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- loop.Execute("test-task", ctx, "perform the task") }()
+	nextPrompt := func() string {
+		t.Helper()
+		select {
+		case prompt := <-prompts:
+			return prompt
+		case err := <-done:
+			t.Fatalf("loop stopped before producing the next prompt: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("memory search blocked the main loop")
+		}
+		return ""
+	}
+	require.NotContains(t, nextPrompt(), "remembered asynchronous context")
+	select {
+	case <-memory.started:
+	case <-time.After(time.Second):
+		t.Fatal("recall did not start")
+	}
+	responses <- struct{}{}
+	require.NotContains(t, nextPrompt(), "remembered asynchronous context")
+	require.EqualValues(t, 1, memory.calls.Load(), "iterations must not stack up concurrent quick searches")
+
+	release()
+	require.Eventually(t, func() bool {
+		return strings.Contains(loop.GetCurrentMemoriesContent(), "remembered asynchronous context")
+	}, 2*time.Second, 10*time.Millisecond)
+	responses <- struct{}{}
+	require.Contains(t, nextPrompt(), "remembered asynchronous context")
+	responses <- struct{}{}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not finish")
+	}
+}

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -1061,10 +1061,6 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 	stopStallHeartbeat := r.startStallHeartbeat(task.GetContext(), task)
 	defer stopStallHeartbeat()
 
-	if r.GetCurrentMemoriesContent() == "" {
-		r.fastLoadSearchMemoryWithoutAI(task.GetUserInput())
-	}
-
 	// When regular memory is updated, also refresh midterm archive memory in
 	// parallel. Both fire at the same trigger point; midterm queries are based
 	// on the perception snapshot, consumed from the invoker.
@@ -1077,7 +1073,9 @@ func (r *ReActLoop) ExecuteWithExistedTask(task aicommon.AIStatefulTask) (finalE
 			if err != nil {
 				log.Warnf("search memory failed: %v", err)
 			}
-			r.PushMemory(result)
+			if task.GetContext().Err() == nil {
+				r.PushMemory(result)
+			}
 		}
 	}()
 
@@ -1124,36 +1122,10 @@ LOOP:
 			break LOOP
 		}
 
-		waitMem := make(chan struct{})
-		go func() {
-			defer func() {
-				close(waitMem)
-			}()
-			r.fastLoadSearchMemoryWithoutAI(task.GetUserInput())
-		}()
-
-		r.UserStatus(
-			"正在回顾相关信息",
-			"Reviewing relevant context",
-			aicommon.WithStatusCode("context.recalling"),
-		)
-		select {
-		case <-task.GetContext().Done():
-			return utils.Errorf("task context done before execute ReActLoop: %v", task.GetContext().Err())
-		case <-waitMem:
-			r.UserStatus(
-				"已经找到相关信息，正在继续",
-				"Relevant context found; continuing",
-				aicommon.WithStatusCode("context.ready"),
-			)
-		case <-time.After(200 * time.Millisecond):
-			r.UserStatus(
-				"已有信息足够，我会先继续处理",
-				"The available context is sufficient to continue",
-				aicommon.WithStatusCode("context.skipped"),
-				aicommon.WithStatusState(aicommon.StatusStateWarning),
-			)
+		if err := task.GetContext().Err(); err != nil {
+			return utils.Errorf("task context done before execute ReActLoop: %v", err)
 		}
+		r.refreshFastMemoryAsync(task)
 
 		r.UserStatus(
 			"正在推进下一步",

--- a/common/ai/aid/aireact/reactloops/loop_default/init.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/init.go
@@ -15,6 +15,12 @@ func buildInitTask(r aicommon.AIInvokeRuntime) func(loop *reactloops.ReActLoop, 
 		attachedDatas := task.GetAttachedDatas()
 		attachedResources := reactloops.RunAttachedExtraResourcesInit(r, loop, attachedDatas)
 
+		// Attachments remain available to the main loop. Expensive enrichment is
+		// opt-in so the first response can start before intent/knowledge calls.
+		if !config.GetConfigBool("AllowSyncInitContext") {
+			return
+		}
+
 		// Original logic: process attached data (knowledge bases, files, etc.)
 		mustProcessMentionedInfo := config.GetConfigBool("MustProcessAttachedData")
 		if mustProcessMentionedInfo && hasAttachedKnowledgeBaseResource(attachedResources) {

--- a/common/ai/aid/aireact/reactloops/loop_default/sync_init_context_test.go
+++ b/common/ai/aid/aireact/reactloops/loop_default/sync_init_context_test.go
@@ -1,0 +1,56 @@
+package loop_default
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/mock"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops"
+)
+
+type initContextInvoker struct {
+	*mock.MockInvoker
+	calls int
+}
+
+func (i *initContextInvoker) ExecuteLoopTaskIF(_ string, _ aicommon.AIStatefulTask, _ ...any) (bool, error) {
+	i.calls++
+	return true, nil
+}
+
+func TestDefaultLoopSyncInitContextOptIn(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		allow, disable bool
+		want           int
+	}{
+		{name: "default"},
+		{name: "opt in", allow: true, want: 1},
+		{name: "intent disabled", allow: true, disable: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := &initContextInvoker{MockInvoker: mock.NewMockInvoker(context.Background())}
+			cfg := inv.GetConfig()
+			cfg.SetConfig("AllowSyncInitContext", tc.allow)
+			cfg.SetConfig("DisableIntentRecognition", tc.disable)
+			loop := reactloops.NewMinimalReActLoop(cfg, inv)
+			task := aicommon.NewStatefulTaskBase("test", strings.Repeat("Please help analyze this task in detail. ", 5), cfg.GetContext(), cfg.GetEmitter())
+			loop.SetCurrentTask(task)
+			buildInitTask(inv)(loop, task, &reactloops.InitTaskOperator{})
+			require.Equal(t, tc.want, inv.calls)
+		})
+	}
+}
+
+func TestPETaskStillEnrichesContextAfterFastInitialization(t *testing.T) {
+	inv := &initContextInvoker{MockInvoker: mock.NewMockInvoker(context.Background())}
+	cfg := inv.GetConfig()
+	loop := reactloops.NewMinimalReActLoop(cfg, inv)
+	task := aicommon.NewStatefulTaskBase("pe-task", "execute the next step", cfg.GetContext(), cfg.GetEmitter())
+	loop.SetCurrentTask(task)
+	buildPETaskInitTask(inv)(loop, task, &reactloops.InitTaskOperator{})
+	require.Equal(t, 1, inv.calls)
+}

--- a/common/ai/aid/aireact/reactloops/loop_smart_qa/action_memory_search.go
+++ b/common/ai/aid/aireact/reactloops/loop_smart_qa/action_memory_search.go
@@ -79,6 +79,14 @@ func makeMemorySearchAction(r aicommon.AIInvokeRuntime) reactloops.ReActLoopOpti
 
 			var content string
 			var err error
+			if asyncMemory, ok := memTriage.(*aimem.AsyncAIMemory); ok {
+				memTriage, err = asyncMemory.WaitReady(op.GetTask().GetContext())
+				if err != nil {
+					op.Feedback(fmt.Sprintf("memory search failed: %v", err))
+					op.Continue()
+					return
+				}
+			}
 
 			if triage, ok := memTriage.(*aimem.AIMemoryTriage); ok {
 				content, err = doMemorySearch(triage, query, searchMode, limit, tokenLimit)

--- a/common/ai/aid/aireact/reactloops/memory_update.go
+++ b/common/ai/aid/aireact/reactloops/memory_update.go
@@ -20,6 +20,8 @@ func (r *ReActLoop) PushMemory(result *aicommon.SearchMemoryResult) {
 	if utils.IsNil(result) {
 		return
 	}
+	r.memoryUpdateMu.Lock()
+	defer r.memoryUpdateMu.Unlock()
 	// When regular memory is updated, also refresh midterm archive memory in
 	// parallel. Both fire at the same trigger point; midterm queries are based
 	// on the perception snapshot, consumed from the invoker.

--- a/common/ai/aid/aireact/reactloops/reactloop.go
+++ b/common/ai/aid/aireact/reactloops/reactloop.go
@@ -109,9 +109,12 @@ type ReActLoop struct {
 	currentTask aicommon.AIStatefulTask
 
 	// memory management
-	memorySizeLimit int
-	currentMemories *omap.OrderedMap[string, *aicommon.MemoryEntity]
-	memoryTriage    aicommon.MemoryTriage
+	memorySizeLimit          int
+	currentMemories          *omap.OrderedMap[string, *aicommon.MemoryEntity]
+	memoryTriage             aicommon.MemoryTriage
+	memoryUpdateMu           sync.Mutex
+	fastMemorySearchMu       sync.Mutex
+	fastMemorySearchInFlight bool
 
 	// midterm archive memory: loaded/updated alongside regular memory,
 	// rendered together with InjectedMemory in the dynamic section.

--- a/common/ai/aid/aireact/reactloops/search_memory.go
+++ b/common/ai/aid/aireact/reactloops/search_memory.go
@@ -11,45 +11,49 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 )
 
-func (r *ReActLoop) fastLoadSearchMemoryWithoutAI(input string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		r._fastLoadSearchMemoryWithoutAI(input)
-	}()
-
-	select {
-	case <-done:
-		// 正常完成
-		log.Info("fast load search memory completed successfully")
-	case <-ctx.Done():
-		// 超时
-		log.Warn("fast load search memory timeout")
+// refreshFastMemoryAsync never delays an iteration and allows only one quick
+// search in flight per loop, even when the backend is still initializing.
+func (r *ReActLoop) refreshFastMemoryAsync(task aicommon.AIStatefulTask) {
+	if utils.IsNil(r.memoryTriage) || task.GetContext().Err() != nil {
+		return
 	}
+	r.fastMemorySearchMu.Lock()
+	if r.fastMemorySearchInFlight {
+		r.fastMemorySearchMu.Unlock()
+		return
+	}
+	r.fastMemorySearchInFlight = true
+	r.fastMemorySearchMu.Unlock()
+	input, taskID, ctx := task.GetUserInput(), task.GetId(), task.GetContext()
+	go func() {
+		defer func() {
+			r.fastMemorySearchMu.Lock()
+			r.fastMemorySearchInFlight = false
+			r.fastMemorySearchMu.Unlock()
+		}()
+		r.fastLoadSearchMemoryWithoutAI(ctx, input, taskID)
+	}()
 }
 
-func (r *ReActLoop) _fastLoadSearchMemoryWithoutAI(input string) {
+func (r *ReActLoop) fastLoadSearchMemoryWithoutAI(ctx context.Context, input, taskId string) {
 	if r.memoryTriage == nil {
 		return
 	}
 	emitter := r.GetEmitter()
 
-	var taskId string
-	if r.GetCurrentTask() != nil {
-		taskId = r.GetCurrentTask().GetId()
-	}
-
 	log.Info("start to handle searching memory for ReActLoop without AI")
 	pr, pw := utils.NewPipe()
+	defer pw.Close()
 	emitter.EmitSystemStreamEvent("fast-memory-fetch", time.Now(), pr, taskId)
 	pw.WriteString("快速检索记忆：Searching relevant memories quickly...")
 	emitter.EmitJSON(schema.EVENT_TYPE_MEMORY_SEARCH_QUICKLY, "memory-search-quickly", map[string]any{
 		"query": input,
 	})
 	searchResult, err := r.memoryTriage.SearchMemoryWithoutAI(input, r.memorySizeLimit)
+	if ctx.Err() != nil {
+		return
+	}
+	r.PushMemory(searchResult)
 	if err != nil {
 		aicommon.TypeWriterWrite(pw, "... 快速检索失败，Reason: "+err.Error(), 300)
 	} else {
@@ -64,7 +68,6 @@ func (r *ReActLoop) _fastLoadSearchMemoryWithoutAI(input string) {
 		}
 	}
 	pw.Close()
-	r.PushMemory(searchResult)
 	if strings.TrimSpace(r.GetCurrentMemoriesContent()) != "" {
 		log.Infof("memory updated via fast search memory - ========================== \n%v\n==========================", r.GetCurrentMemoriesContent())
 	}

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -553,6 +553,7 @@ func buildReActOptions(ctx context.Context, config *AIEngineConfig, outputChan c
 		// S3c: PersistentSessionId/MemoryTriageId 移到字面量后 append,以便
 		// 无状态模式短路(留空 → re-act.go 四个落盘分支跳过)。
 		aicommon.WithEnablePETaskAnalyze(true),
+		aicommon.WithAllowSyncInitContext(config.AllowSyncInitContext),
 
 		// 事件处理
 		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {

--- a/common/aiengine/config.go
+++ b/common/aiengine/config.go
@@ -34,8 +34,9 @@ type AIEngineConfig struct {
 	UserUsageCallback func(*aispec.ChatUsage)
 
 	// 执行配置
-	MaxIteration int    // 最大迭代次数，默认 10
-	SessionID    string // 会话 ID，用于持久化
+	MaxIteration         int    // 最大迭代次数，默认 10
+	SessionID            string // 会话 ID，用于持久化
+	AllowSyncInitContext bool   // 允许首轮同步增强上下文，默认 false
 
 	// Stateless 为 true 时,引擎不持久化会话历史/memory/timeline 到本地 DB。
 	// 每轮由服务端打包 ContextPackage 注入历史,turn 完销毁引擎实例。
@@ -139,6 +140,20 @@ func notifySessionID(config *AIEngineConfig) {
 }
 
 // ========== 基础配置选项 ==========
+
+// WithAllowSyncInitContext 设置是否在首轮响应前同步初始化增强上下文（导出名为 aim.allowSyncInitContext）。
+// 默认 false，先开始主循环；后续仍可按需发现能力、识别意图。
+// 记忆始终在后台加载，不受此选项影响。
+//
+// Example:
+// ```
+// aim.InvokeReAct("分析任务", aim.allowSyncInitContext(true))
+// ```
+func WithAllowSyncInitContext(allow bool) AIEngineConfigOption {
+	return func(c *AIEngineConfig) {
+		c.AllowSyncInitContext = allow
+	}
+}
 
 // WithFocus 设置焦点，用于让引擎聚焦某个任务（导出名为 aim.focus）
 // 参数:

--- a/common/aiengine/config_sync_init_test.go
+++ b/common/aiengine/config_sync_init_test.go
@@ -1,0 +1,33 @@
+package aiengine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func TestAllowSyncInitContextEngineOption(t *testing.T) {
+	option, ok := Exports["allowSyncInitContext"].(func(bool) AIEngineConfigOption)
+	require.True(t, ok)
+	for _, tc := range []struct {
+		name string
+		opts []AIEngineConfigOption
+		want bool
+	}{
+		{name: "default"},
+		{name: "opt in", opts: []AIEngineConfigOption{option(true)}, want: true},
+		{name: "opt out", opts: []AIEngineConfigOption{option(true), option(false)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewAIEngineConfig(tc.opts...)
+			require.Equal(t, tc.want, cfg.AllowSyncInitContext)
+			opts := buildReActOptions(context.Background(), cfg, make(chan *schema.AiOutputEvent, 1))
+			opts = append(opts, aicommon.WithDisableAutoSkills(true), aicommon.WithDisallowMCPServers(true))
+			reactCfg := aicommon.NewConfig(context.Background(), opts...)
+			require.Equal(t, tc.want, reactCfg.GetConfigBool("AllowSyncInitContext"))
+		})
+	}
+}

--- a/common/aiengine/export.go
+++ b/common/aiengine/export.go
@@ -26,6 +26,7 @@ var Exports = map[string]interface{}{
 	"excludeToolNames":          WithExcludeToolNames,
 	"keywords":                  WithKeywords,
 	"allowUserInteract":         WithAllowUserInteract,
+	"allowSyncInitContext":      WithAllowSyncInitContext,
 	"reviewPolicy":              WithReviewPolicy,
 	"userInteractLimit":         WithUserInteractLimit,
 	"timelineContentLimit":      WithTimelineContentLimit,

--- a/common/yak/yakdoc/generate_web_doc/overviews/aim.md
+++ b/common/yak/yakdoc/generate_web_doc/overviews/aim.md
@@ -3,6 +3,7 @@
 典型使用场景：
 
 - 启动引擎：`aim.InvokeReAct` 同步执行一次 ReAct 任务，`aim.InvokeReActAsync` 异步返回 `*AIEngine` 句柄，`aim.NewAIEngine` 创建可复用引擎。
+- 快速首轮：`aim.allowSyncInitContext` 默认 `false`，首轮直接进入主循环，后续按需识别意图、发现能力；设置为 `true` 可在首轮前同步增强上下文。记忆后端与自动检索始终异步加载，就绪后供后续轮次使用。
 - 接入模型与能力：`aim.aiConfig` / `aim.aiCallback` 配置模型，`aim.attachedAITool` / `aim.attachedAIForge` / `aim.attachedKnowledgeBase` 挂载工具、Forge 与知识库，`aim.includeToolNames` / `aim.excludeToolNames` 精选工具集。
 - 过程观测与交互：`aim.onStream` / `aim.onStreamContent` / `aim.onEvent` / `aim.onFinished` 订阅流式输出与事件，`aim.onInputRequired` 处理需要人工补充输入的场景，`aim.maxIteration` / `aim.timeout` 控制迭代与超时。
 


### PR DESCRIPTION
`aim.InvokeReAct` 原先会在首轮响应前同步执行意图识别/上下文增强、创建记忆后端，并等待首次快速记忆检索；之后每轮还会等待检索最多 200 ms。这个 PR 让主循环先响应，再在执行过程中按需补充上下文。

- 新增 `aim.allowSyncInitContext(bool)` / `aicommon.WithAllowSyncInitContext(bool)`，默认 `false`。设为 `true` 可显式恢复默认循环的同步上下文增强，选项会传递到子配置；后续规划、PE 任务及显式能力发现仍可识别意图。
- ReAct 与纯 invoker 的默认记忆后端、会话中期归档改为后台初始化，初始化失败通过日志及记忆操作返回。实际记忆操作保留就绪等待和取消语义。
- 自动记忆检索不再阻塞首轮或后续迭代，同一循环只保留一个进行中的快速检索。结果就绪后注入后续提示词，并串行处理并发记忆更新。初始化期间取消会释放等待并清理晚到的后端，空记忆会话可以正常关闭。

验证：

- 默认值、显式开启/关闭、子配置传递、默认循环与后续 PE 意图识别测试通过。
- 受控阻塞检索测试通过：前两轮在记忆未返回时正常请求模型，第三轮读到返回的记忆，且没有重复堆积检索。
- `go test -race ./common/ai/aid/aimem ./common/ai/aid/aireact/reactloops -run TestAsyncMemory -count=1 -timeout=60s` 通过。
- 现有默认循环深度意图识别、PE/规划意图识别、关闭记忆功能的回归测试通过；相关配置和记忆内容测试通过。
- 使用 `go run common/yak/cmd/yak.go -c ...` 调用 `aim.InvokeReAct`，显式注入受控的普通/质量/速度模型回调：脚本开始后约 691 ms 发出首个主请求、696 ms 收到首段回答，随后主动取消验证返回。该数值不包含 Go 编译及脚本启动前的进程初始化，也不代表真实模型网络耗时。
