### PR TITLE
fix(scannode): 优化专业任务源码准备失败提示

### DIFF
--- a/scannode/README.md
+++ b/scannode/README.md
@@ -1,5 +1,22 @@
 # scannode
 
+## Legion professional task source failures
+
+Source preparation runs before AI execution. A failure emits
+`source.workspace.failed` with code `source_workspace_materialize_failed`,
+followed by `ai.session.failed` with code `ai_session_bind_failed`. Both carry
+the same actionable Chinese message; the event names, codes and payload fields
+remain compatible with existing Legion consumers.
+
+Messages distinguish recognized DNS, timeout, connection, source-access,
+local-permission, capacity, trust, source-identity and invalid-ZIP failures.
+For network failures, check connectivity and the configured source proxy from
+the executing Node; an operator's browser or Provider connectivity does not
+prove that the Node can fetch the source. Uploading a source ZIP can bypass a
+Git endpoint connectivity problem. Unknown causes use a generic source-check
+message. Raw errors, repository URLs, credentials and local paths are never
+copied into either message.
+
 ## Legion HIDS
 
 - Linux HIDS packaging, host-readiness checks, desired spec validation, and degraded-host behavior are documented in `../docs/legion-linux-hids-readiness.md`.

--- a/scannode/legion_ai_bridge.go
+++ b/scannode/legion_ai_bridge.go
@@ -1134,6 +1134,7 @@ func (b *legionJobBridge) handleAISessionBind(ctx context.Context, raw []byte) e
 		failureErr := err
 		if strings.Contains(err.Error(), "prepare source workspace") ||
 			strings.Contains(err.Error(), "source_workspace") {
+			message := sourceWorkspaceFailureMessage(err)
 			if publishErr := b.ensureAIPublisher().PublishEvent(
 				ctx,
 				ref,
@@ -1141,12 +1142,12 @@ func (b *legionJobBridge) handleAISessionBind(ctx context.Context, raw []byte) e
 				"source.workspace.failed",
 				mustJSON(map[string]string{
 					"code":    "source_workspace_materialize_failed",
-					"message": "source workspace could not be materialized",
+					"message": message,
 				}),
 			); publishErr != nil {
 				return publishErr
 			}
-			failureErr = fmt.Errorf("source workspace materialization failed")
+			failureErr = errors.New(message)
 		}
 		if publishErr := b.publishAISessionCommandFailure(ctx, ref, "ai_session_bind_failed", failureErr); publishErr != nil {
 			return publishErr

--- a/scannode/legion_code_workspace_error.go
+++ b/scannode/legion_code_workspace_error.go
@@ -1,0 +1,53 @@
+package scannode
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// sourceWorkspaceFailureMessage preserves actionable causes without forwarding
+// raw Git/HTTP errors: those may contain credentials, signed URLs or local paths.
+// Keep the existing event codes and payload shape for older Legion consumers.
+func sourceWorkspaceFailureMessage(err error) string {
+	message := strings.ToLower(err.Error())
+	contains := func(parts ...string) bool {
+		for _, part := range parts {
+			if strings.Contains(message, part) {
+				return true
+			}
+		}
+		return false
+	}
+	var dnsErr *net.DNSError
+	var netErr net.Error
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "源码准备已取消，请重新发起任务。"
+	case errors.As(err, &dnsErr), contains("no such host", "temporary failure in name resolution"):
+		return "源码准备失败：无法解析源服务域名，请检查执行节点的 DNS 和网络配置。"
+	case errors.Is(err, context.DeadlineExceeded), errors.As(err, &netErr) && netErr.Timeout(), contains("i/o timeout", "context deadline exceeded", "connection timed out", "tls handshake timeout"):
+		return "源码准备失败：访问源服务超时，请检查执行节点到仓库或文件服务的网络及代理；Git 仓库也可改为上传源码 ZIP 后重试。"
+	case errors.Is(err, syscall.ENOSPC), contains("insufficient free space", "no space left on device", "disk quota exceeded", "required_minimum_bytes=", "available_inodes=0"):
+		return "源码准备失败：执行节点磁盘空间不足，请释放工作区磁盘空间后重试。"
+	case errors.Is(err, os.ErrPermission):
+		return "源码准备失败：执行节点无法读写本地工作区，请检查工作目录权限。"
+	case contains("authentication required", "authentication failed", "authorization failed", "permission denied (publickey)", "unable to authenticate", "status=401", "status=403"):
+		return "源码准备失败：源服务认证失败或访问被拒绝，请检查仓库凭据和读取权限；上传文件请检查节点会话及文件访问权限。"
+	case contains("repository not found", "remote repository is empty", "reference not found", "couldn't find remote ref", "status=404"):
+		return "源码准备失败：仓库、分支或源文件不存在或不可访问，请检查源地址、分支和读取权限；上传文件可重新上传后重试。"
+	case contains("connection refused", "network is unreachable", "no route to host", "connection reset by peer", "unexpected eof"):
+		return "源码准备失败：无法连接源服务或连接中断，请检查执行节点到仓库或文件服务的网络及代理后重试。"
+	case contains("x509:", "certificate verify failed", "host key mismatch", "knownhosts: key"):
+		return "源码准备失败：源服务证书或 SSH 主机身份校验失败，请检查执行节点的信任配置。"
+	case contains("sha256 mismatch", "revision mismatch"):
+		return "源码准备失败：源码版本或校验值与任务记录不一致，请确认源内容后重新发起任务。"
+	case contains("zip: not a valid zip file", "zip: checksum error"):
+		return "源码准备失败：源码 ZIP 无效或已损坏，请重新打包并上传后重试。"
+	default:
+		return "源码准备失败，尚未开始 AI 分析。请检查源地址、分支、读取权限及执行节点工作区；Git 仓库可改为上传源码 ZIP 后重试。"
+	}
+}

--- a/scannode/legion_code_workspace_error_test.go
+++ b/scannode/legion_code_workspace_error_test.go
@@ -1,0 +1,55 @@
+package scannode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestSourceWorkspaceFailureMessage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"cancelled", context.Canceled, "已取消"},
+		{"deadline", context.DeadlineExceeded, "访问源服务超时"},
+		{"wrapped URL timeout", &url.Error{Op: "Get", URL: "https://user:secret@private.invalid/repo?token=secret", Err: context.DeadlineExceeded}, "访问源服务超时"},
+		{"DNS", &net.DNSError{Err: "no such host", Name: "private.invalid"}, "无法解析源服务域名"},
+		{"string timeout", errors.New("dial tcp private.invalid: i/o timeout"), "访问源服务超时"},
+		{"disk full", &os.PathError{Op: "write", Path: "/private/workspace", Err: syscall.ENOSPC}, "磁盘空间不足"},
+		{"preflight space", errors.New("SSA Git workdir preflight failed: directory=/private/workspace available_bytes=1 required_minimum_bytes=100; free disk space"), "磁盘空间不足"},
+		{"preflight inodes", errors.New("SSA Git workdir preflight failed: available_inodes=0; free inodes"), "磁盘空间不足"},
+		{"local permission", &os.PathError{Op: "mkdir", Path: "/private/workspace", Err: os.ErrPermission}, "本地工作区"},
+		{"git auth", errors.New("authentication required: https://user:secret@private.invalid"), "认证失败或访问被拒绝"},
+		{"SSH auth", errors.New("Permission denied (publickey)"), "认证失败或访问被拒绝"},
+		{"payload permission", errors.New("download managed source payload failed: status=403"), "认证失败或访问被拒绝"},
+		{"missing repo", errors.New("repository not found"), "不存在或不可访问"},
+		{"missing branch", errors.New("reference not found"), "不存在或不可访问"},
+		{"connection", errors.New("dial tcp: connection refused"), "无法连接源服务或连接中断"},
+		{"certificate", errors.New("x509: certificate signed by unknown authority"), "身份校验失败"},
+		{"revision", errors.New("source_workspace revision mismatch: expected=secret actual=other"), "校验值"},
+		{"bad zip", errors.New("zip: not a valid zip file"), "ZIP 无效或已损坏"},
+		{"unknown", errors.New("unrecognized failure: Bearer secret\n/private/workspace https://private.invalid/?token=secret"), "尚未开始 AI 分析"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message := sourceWorkspaceFailureMessage(fmt.Errorf("prepare source workspace: %w", tt.err))
+			if !strings.Contains(message, tt.want) {
+				t.Fatalf("message = %q, want %q", message, tt.want)
+			}
+			for _, secret := range []string{"secret", "private.invalid", "/private/workspace", "Bearer", "\n"} {
+				if strings.Contains(message, secret) {
+					t.Fatalf("message leaked input %q: %q", secret, message)
+				}
+			}
+		})
+	}
+}

--- a/scannode/legion_code_workspace_failure_event_test.go
+++ b/scannode/legion_code_workspace_failure_event_test.go
@@ -1,0 +1,77 @@
+package scannode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/yaklang/yaklang/common/utils/yakgit"
+	aiv1 "github.com/yaklang/yaklang/scannode/gen/legionpb/legion/ai/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHandleAISessionBindPublishesActionableSourceFailure(t *testing.T) {
+	// Match the real Git materialization path without relying on external DNS.
+	oldPrepare, oldClone := prepareLegionCodeGitWorkspace, cloneLegionCodeGitWorkspace
+	t.Cleanup(func() {
+		prepareLegionCodeGitWorkspace, cloneLegionCodeGitWorkspace = oldPrepare, oldClone
+	})
+	cleaned := false
+	prepareLegionCodeGitWorkspace = func(context.Context, int) (string, func() error, error) {
+		return t.TempDir(), func() error { cleaned = true; return nil }, nil
+	}
+	cloneLegionCodeGitWorkspace = func(string, string, ...yakgit.Option) error {
+		return fmt.Errorf("Get https://user:secret@private.invalid/repo?token=secret: %w", context.DeadlineExceeded)
+	}
+	bridge, fakeJS, driver := newTestAISessionBridge(t)
+	command := validAISessionBindCommand()
+	command.ResultContext = validCodeAuditResultContext()
+	command.Session.RunId = command.ResultContext.FocusRunId
+	command.RuntimeOptionSnapshotJson = mustJSON(map[string]any{
+		"source_workspace": validLegionCodeWorkspaceSpec(legionCodeWorkspaceKindGit),
+	})
+	if err := bridge.handleAISessionBind(context.Background(), mustMarshalProto(t, command)); err != nil {
+		t.Fatal(err)
+	}
+	if !cleaned {
+		t.Fatal("failed clone workspace was not cleaned")
+	}
+	driver.mu.Lock()
+	bindings := len(driver.bindings)
+	driver.mu.Unlock()
+	if bindings != 0 {
+		t.Fatal("source failure started AI runtime")
+	}
+	first := waitForPublishedMessage(t, fakeJS, 0)
+	var workspace aiv1.AISessionEvent
+	if err := proto.Unmarshal(first.Data, &workspace); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct{ Code, Message string }
+	if err := json.Unmarshal(workspace.GetPayloadJson(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if workspace.GetEventType() != "source.workspace.failed" || payload.Code != "source_workspace_materialize_failed" {
+		t.Fatalf("changed event contract: %v, %#v", workspace.GetEventType(), payload)
+	}
+	if !strings.Contains(payload.Message, "访问源服务超时") || !strings.Contains(payload.Message, "代理") {
+		t.Fatalf("missing cause/action: %s", payload.Message)
+	}
+	second := waitForPublishedMessage(t, fakeJS, 1)
+	var failed aiv1.AISessionFailed
+	if err := proto.Unmarshal(second.Data, &failed); err != nil {
+		t.Fatal(err)
+	}
+	if second.Subject != "legion.event.ai.session.failed" || failed.GetErrorCode() != "ai_session_bind_failed" || failed.GetErrorMessage() != payload.Message {
+		t.Fatalf("bind failure lost the actionable message: %v", &failed)
+	}
+	for _, data := range [][]byte{first.Data, second.Data} {
+		for _, secret := range []string{"secret", "private.invalid", "user:"} {
+			if strings.Contains(string(data), secret) {
+				t.Fatalf("failure event leaked %q", secret)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 改动摘要

专业任务拉取源码或准备工作区失败时，节点此前将底层原因统一替换成通用错误，用户无法区分网络、认证和本地工作目录问题。

本次将已知原因转换为中文提示和处理建议，覆盖超时、DNS、连接中断、源服务认证、仓库或分支不可访问、本地权限、磁盘容量、证书信任、源码校验和 ZIP 损坏。未知错误使用安全兜底提示。工作区失败事件与会话失败事件携带相同提示，保留现有事件名、错误码及字段；原始错误中的凭据、私有地址与本地路径不进入提示。

## 改动文件

- `scannode/legion_code_workspace_error.go`：错误原因识别和安全提示。
- `scannode/legion_ai_bridge.go`：两个失败事件统一使用可排障提示。
- `scannode/legion_code_workspace_error_test.go`、`scannode/legion_code_workspace_failure_event_test.go`：分类、敏感信息保护及绑定入口回归。
- `scannode/README.md`：源文件准备失败的节点排障说明。

## 验证方式

T1 已通过：

- `go test ./scannode -run 'Test(SourceWorkspaceFailureMessage|HandleAISessionBindPublishesActionableSourceFailure|HandleAISessionBindPublishesReady|LegionCodeWorkspace)' -count=1`
- 将桥接文件暂时替换成旧实现，新入口回归按预期因缺少原因和处理建议失败；恢复修复后通过。
- 发布前无冲突 rebase 到最新 main；新增基线改动为 AI 初始上下文与记忆加载，不修改源码准备链路。`git range-diff` 确认本补丁完全一致，重跑独立错误分类测试通过。
- `git diff --check` 通过。

未部署到远程环境，未宣称真实专业任务 T2 已恢复。本 PR 仅优化源码准备阶段的错误提示。
