### PR TITLE
fix(ai): decode ReAct fail messages without JSON escape artifacts

### DIFF
--- a/common/ai/aid/aicommon/emitter.go
+++ b/common/ai/aid/aicommon/emitter.go
@@ -1067,14 +1067,20 @@ func (e *Emitter) EmitWarning(fmtlog string, items ...any) (*schema.AiOutputEven
 }
 
 func (e Emitter) EmitPlanExecFail(fmtlog string, items ...any) (*schema.AiOutputEvent, error) {
-	return e.EmitJSON(schema.EVENT_TYPE_FAIL_PLAN_AND_EXECUTION, "plan_exec_fail", fmt.Sprintf(fmtlog, items...))
+	return e.EmitJSON(schema.EVENT_TYPE_FAIL_PLAN_AND_EXECUTION, "plan_exec_fail", map[string]any{
+		"message": fmt.Sprintf(fmtlog, items...),
+	})
 }
 
 func (e Emitter) EmitReActFail(fmtlog string, items ...any) (*schema.AiOutputEvent, error) {
-	return e.EmitJSON(schema.EVENT_TYPE_FAIL_REACT, "re_act_fail", fmt.Sprintf(fmtlog, items...))
+	return e.EmitJSON(schema.EVENT_TYPE_FAIL_REACT, "re_act_fail", map[string]any{
+		"message": fmt.Sprintf(fmtlog, items...),
+	})
 }
 func (e Emitter) EmitReActSuccess(fmtlog string, items ...any) (*schema.AiOutputEvent, error) {
-	return e.EmitJSON(schema.EVENT_TYPE_SUCCESS_REACT, "re_act_success", fmt.Sprintf(fmtlog, items...))
+	return e.EmitJSON(schema.EVENT_TYPE_SUCCESS_REACT, "re_act_success", map[string]any{
+		"message": fmt.Sprintf(fmtlog, items...),
+	})
 }
 
 func (e *Emitter) EmitError(fmtlog string, items ...any) (*schema.AiOutputEvent, error) {

--- a/common/imcontrol/session.go
+++ b/common/imcontrol/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/notify"
+	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/notify/credential"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
@@ -782,7 +783,7 @@ func (e *Engine) readAgentOutput(sess *imSession, stream AIReActStream) {
 			continue
 
 		case "fail_react_task", "fail_plan_and_execution", "api_request_failed", "ai_call_failure":
-			content := strings.TrimSpace(string(ev.GetContent()))
+			content := schema.ExtractAIOutputDisplayMessage(ev.GetContent(), ev.GetIsJson())
 			if content != "" {
 				presenter.OnRunError(rc, RunEvent{
 					Type: RunEventError,

--- a/common/schema/ai_event.go
+++ b/common/schema/ai_event.go
@@ -597,6 +597,46 @@ func (e *AiOutputEvent) ToExecResult() *ypb.ExecResult {
 	}
 }
 
+// ExtractAIOutputDisplayMessage decodes AiOutputEvent.Content for UI/IM display.
+// EmitJSON often stores plain strings as JSON string values; consumers that treat
+// Content as raw text will see \u003c-style escapes instead of "<". This helper
+// unwraps JSON objects (message/content/...) and JSON string literals.
+func ExtractAIOutputDisplayMessage(content []byte, isJson bool) string {
+	raw := strings.TrimSpace(string(content))
+	if raw == "" {
+		return ""
+	}
+	if !isJson {
+		return raw
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(content, &obj); err == nil {
+		for _, key := range []string{"message", "content", "value", "title", "reason", "error", "path", "filename", "payload"} {
+			if v, ok := obj[key]; ok {
+				if str := strings.TrimSpace(utils.InterfaceToString(v)); str != "" {
+					return str
+				}
+			}
+		}
+		return ""
+	}
+
+	var str string
+	if err := json.Unmarshal(content, &str); err == nil {
+		return strings.TrimSpace(str)
+	}
+	return raw
+}
+
+// DisplayMessage returns a human-readable message decoded from this event's Content.
+func (e *AiOutputEvent) DisplayMessage() string {
+	if e == nil {
+		return ""
+	}
+	return ExtractAIOutputDisplayMessage(e.Content, e.IsJson)
+}
+
 func (e *AiOutputEvent) ToGRPC() *ypb.AIOutputEvent {
 	return &ypb.AIOutputEvent{
 		ID:                 int64(e.ID),

--- a/common/schema/ai_event_display_test.go
+++ b/common/schema/ai_event_display_test.go
@@ -1,0 +1,41 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractAIOutputDisplayMessage_JSONStringWithAngleBrackets(t *testing.T) {
+	msg := `No code generated in "write_code" action: the response is missing <|GEN_CODE_<nonce>|>...<|GEN_CODE_END_<nonce>|> after the @action JSON.`
+	raw, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	got := ExtractAIOutputDisplayMessage(raw, true)
+	assert.Equal(t, msg, got)
+	assert.Contains(t, got, "<|GEN_CODE_")
+	assert.NotContains(t, got, `\u003c`)
+}
+
+func TestExtractAIOutputDisplayMessage_JSONObjectMessage(t *testing.T) {
+	raw := []byte(`{"message":"ReAct task execution failed: reason: <|GEN_CODE_abcd|>"}`)
+	got := ExtractAIOutputDisplayMessage(raw, true)
+	assert.Equal(t, "ReAct task execution failed: reason: <|GEN_CODE_abcd|>", got)
+}
+
+func TestExtractAIOutputDisplayMessage_PlainText(t *testing.T) {
+	raw := []byte("plain error")
+	got := ExtractAIOutputDisplayMessage(raw, false)
+	assert.Equal(t, "plain error", got)
+}
+
+func TestAiOutputEvent_DisplayMessage(t *testing.T) {
+	msg := "fail: <|tag|>"
+	raw, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	ev := &AiOutputEvent{IsJson: true, Content: raw}
+	assert.Equal(t, msg, ev.DisplayMessage())
+}

--- a/common/yakgrpc/airaghttp/handler_chat.go
+++ b/common/yakgrpc/airaghttp/handler_chat.go
@@ -399,24 +399,7 @@ func cleanProgressMessage(s string) string {
 
 // extractEventMessage 从结构化内容中提取可读消息
 func extractEventMessage(rawContent string, isJson bool) string {
-	if rawContent == "" {
-		return ""
-	}
-	if !isJson {
-		return rawContent
-	}
-	var obj map[string]interface{}
-	if err := json.Unmarshal([]byte(rawContent), &obj); err != nil {
-		return rawContent
-	}
-	for _, key := range []string{"message", "content", "value", "title", "path", "filename", "payload"} {
-		if v, ok := obj[key]; ok {
-			if str := utils.InterfaceToString(v); str != "" {
-				return str
-			}
-		}
-	}
-	return ""
+	return schema.ExtractAIOutputDisplayMessage([]byte(rawContent), isJson)
 }
 
 // classifyEvent 根据事件类型与 nodeId 推导 kind/label; kind 为空表示丢弃

--- a/common/yakgrpc/airaghttp/handler_chat_test.go
+++ b/common/yakgrpc/airaghttp/handler_chat_test.go
@@ -1,6 +1,7 @@
 package airaghttp
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -161,4 +162,14 @@ func TestIsLightweightAIConfigured(t *testing.T) {
 
 	// 高质与轻量通道相互独立
 	require.False(t, cfg.IsAIConfigured(), "lightweight key should not flip high-quality channel")
+}
+
+func TestExtractEventMessage_DecodesJSONStringEscapes(t *testing.T) {
+	msg := `missing <|GEN_CODE_<nonce>|> after the @action JSON`
+	raw, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	got := extractEventMessage(string(raw), true)
+	require.Equal(t, msg, got)
+	require.Contains(t, got, "<|GEN_CODE_")
 }


### PR DESCRIPTION
## Summary
- Add `ExtractAIOutputDisplayMessage` to decode AI output event content for display, including JSON string literals that contain angle brackets.
- Emit ReAct/plan terminal events as structured `{message: ...}` objects instead of raw JSON strings.
- Use the decoder in airaghttp and imcontrol error presentation paths.

## Test plan
- [x] `go test ./common/schema/ -run TestExtractAIOutputDisplayMessage` 
- [x] `go test ./common/yakgrpc/airaghttp/ -run TestExtractEventMessage`

Made with [Cursor](https://cursor.com)