### PR TITLE
refactor(yakgrpc): decouple ReAct session runtime

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -185,6 +185,7 @@ type Config struct {
 	HotPatchBroadcaster *chanx.Broadcaster[ConfigOption]
 	HotPatchOptionChan  *chanx.UnlimitedChan[ConfigOption]
 	StartHotPatchOnce   sync.Once
+	hotPatchLoopWG      sync.WaitGroup
 
 	// output Event Handle
 	EventHandler           func(e *schema.AiOutputEvent)

--- a/common/ai/aid/aicommon/config_hotpatch.go
+++ b/common/ai/aid/aicommon/config_hotpatch.go
@@ -22,7 +22,9 @@ func (c *Config) StartHotPatchLoop(ctx context.Context) {
 			return
 		}
 		validator := make(chan struct{})
+		c.hotPatchLoopWG.Add(1)
 		go func() {
+			defer c.hotPatchLoopWG.Done()
 			for {
 				select {
 				case <-validator:
@@ -52,6 +54,17 @@ func (c *Config) StartHotPatchLoop(ctx context.Context) {
 		case <-ctx.Done():
 		}
 	})
+}
+
+// WaitHotPatchLoopStopped waits until the hot-patch consumer has completely
+// exited. Session lifecycle owners use it before deleting persistent session
+// data, because a final hot-patch may still emit and persist config events while
+// the main input loop is already stopping.
+func (c *Config) WaitHotPatchLoopStopped() {
+	if c == nil {
+		return
+	}
+	c.hotPatchLoopWG.Wait()
 }
 
 func (c *Config) SimpleInfoMap() map[string]interface{} {

--- a/common/ai/aid/aicommon/config_hotpatch_test.go
+++ b/common/ai/aid/aicommon/config_hotpatch_test.go
@@ -73,6 +73,43 @@ func TestHotPatchConfig(t *testing.T) {
 	require.True(t, c.GetSyncPerceptionTrigger())
 }
 
+func TestWaitHotPatchLoopStoppedWaitsForInFlightOption(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := NewTestConfig(ctx)
+	c.StartHotPatchLoop(ctx)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	c.HotPatchOptionChan.SafeFeed(func(*Config) error {
+		close(started)
+		<-release
+		return nil
+	})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("hot-patch option did not start")
+	}
+
+	cancel()
+	waited := make(chan struct{})
+	go func() {
+		c.WaitHotPatchLoopStopped()
+		close(waited)
+	}()
+	select {
+	case <-waited:
+		t.Fatal("hot-patch lifecycle wait returned while an option was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-waited:
+	case <-time.After(time.Second):
+		t.Fatal("hot-patch lifecycle wait did not finish after the option returned")
+	}
+}
+
 func TestConfigHotpatch_PersistSessionStartParams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/common/ai/aid/aireact/re-act.go
+++ b/common/ai/aid/aireact/re-act.go
@@ -101,7 +101,12 @@ type ReAct struct {
 	artifacts            *filesys.RelLocalFs
 
 	wg           *sync.WaitGroup
+	lifecycleWG  *sync.WaitGroup
 	memoryTriage aicommon.MemoryTriage
+
+	taskHandoffMu      sync.Mutex
+	taskHandoffs       int
+	taskHandoffVersion uint64
 
 	midtermRecallMutex           sync.Mutex
 	pendingMidtermTimelineRecall bool
@@ -238,6 +243,7 @@ func NewReAct(opts ...aicommon.ConfigOption) (*ReAct, error) {
 		saveTimelineThrottle: utils.NewThrottleEx(3, true, true),
 		artifacts:            nil, // lazy: created in ensureWorkDirectory
 		wg:                   new(sync.WaitGroup),
+		lifecycleWG:          new(sync.WaitGroup),
 		browserSessionIDs:    make(map[string]struct{}),
 	}
 
@@ -492,6 +498,209 @@ func (r *ReAct) SendInputEvent(event *ypb.AIInputEvent) (ret error) {
 	return nil
 }
 
+// SendInputEventAndWaitAccepted synchronously dispatches config hot-patches and
+// admits plain free-input events into the ReAct task queue. Session coordinators
+// use this narrower entry point both to preserve the event loop's
+// "hot-patch before following input" order and to make "check session idle ->
+// enqueue task" atomic with respect to an external reservation. Other event
+// kinds retain the asynchronous event-loop behavior of SendInputEvent.
+func (r *ReAct) SendInputEventAndWaitAccepted(event *ypb.AIInputEvent) (ret error) {
+	defer func() {
+		if retErr := recover(); retErr != nil {
+			ret = utils.Errorf("SendInputEventAndWaitAccepted panic: %v", retErr)
+		}
+	}()
+	if event == nil {
+		return fmt.Errorf("input event is nil")
+	}
+	if r == nil || r.config == nil {
+		return fmt.Errorf("re-act runtime is nil")
+	}
+	if err := r.config.GetContext().Err(); err != nil {
+		return err
+	}
+
+	// Preserve Config.StartEventLoopEx's precedence rule: a hot-patch is
+	// converted and queued before the loop receives the following input. Without
+	// doing this synchronously, a directly-admitted free input could overtake a
+	// hot-patch still waiting in EventInputChan.
+	if event.GetIsConfigHotpatch() {
+		hotPatchOptions := r.config.ProcessHotPatchMessage(event)
+		r.config.PersistSessionStartParamsFromHotpatch(event)
+		for _, option := range hotPatchOptions {
+			r.config.HotPatchOptionChan.SafeFeed(option)
+		}
+		return nil
+	}
+
+	// Interactive and sync messages retain Config.processInputEvent's existing
+	// asynchronous execution behavior.
+	if !event.GetIsFreeInput() || event.GetIsInteractiveMessage() || event.GetIsSyncMessage() {
+		return r.SendInputEvent(event)
+	}
+	if r.config.InputEventManager != nil {
+		r.config.InputEventManager.CallMirrorOfAIInputEvent(event)
+	}
+	return r.handleFreeValue(event)
+}
+
+// CancelTaskByUserInputUUID cancels the root task admitted from a particular
+// input event. A transport-independent session owner uses it to stop only its
+// task when it is attached to a ReAct runtime owned by somebody else.
+func (r *ReAct) CancelTaskByUserInputUUID(inputUUID string) bool {
+	inputUUID = strings.TrimSpace(inputUUID)
+	if r == nil || inputUUID == "" {
+		return false
+	}
+	cancelTask := func(task aicommon.AIStatefulTask) bool {
+		if task == nil || task.IsFinished() {
+			return false
+		}
+		r.CancelTask(task, &ypb.AIInputEvent{})
+		return true
+	}
+	for _, task := range r.GetRuntimeTasks() {
+		if task != nil && task.GetUserInputUUID() == inputUUID && cancelTask(task) {
+			return true
+		}
+	}
+	for _, task := range r.GetQueueingTasks() {
+		if task == nil || task.GetUserInputUUID() != inputUUID {
+			continue
+		}
+		if r.taskQueue.RemoveTask(task.GetId()) && cancelTask(task) {
+			return true
+		}
+	}
+	// The queue processor may have moved the task between the two snapshots.
+	for _, task := range r.GetRuntimeTasks() {
+		if task != nil && task.GetUserInputUUID() == inputUUID && cancelTask(task) {
+			return true
+		}
+	}
+	return false
+}
+
+// CancelTaskByUserInputUUIDAndWait retries cancellation across the queue to
+// runtime hand-off, then waits until processReActTask's deferred persistence and
+// cleanup have finished. A single lookup is insufficient because dequeue hooks
+// run after removing the task from the queue and before runtime publication.
+func (r *ReAct) CancelTaskByUserInputUUIDAndWait(ctx context.Context, inputUUID string) error {
+	inputUUID = strings.TrimSpace(inputUUID)
+	if r == nil || inputUUID == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		_, versionBefore := r.taskQueueHandoffState()
+		r.CancelTaskByUserInputUUID(inputUUID)
+		handoffActive, versionAfter := r.taskQueueHandoffState()
+		if !handoffActive && versionBefore == versionAfter {
+			break
+		}
+		if !handoffActive {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+	return r.WaitTaskByUserInputUUIDStopped(ctx, inputUUID)
+}
+
+func (r *ReAct) hasTaskByUserInputUUID(inputUUID string) bool {
+	for _, task := range r.GetRuntimeTasks() {
+		if task != nil && task.GetUserInputUUID() == inputUUID {
+			return true
+		}
+	}
+	for _, task := range r.GetQueueingTasks() {
+		if task != nil && task.GetUserInputUUID() == inputUUID {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ReAct) beginTaskQueueHandoff() func() {
+	if r == nil {
+		return func() {}
+	}
+	r.taskHandoffMu.Lock()
+	r.taskHandoffs++
+	r.taskHandoffVersion++
+	r.taskHandoffMu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.taskHandoffMu.Lock()
+			if r.taskHandoffs > 0 {
+				r.taskHandoffs--
+			}
+			r.taskHandoffVersion++
+			r.taskHandoffMu.Unlock()
+		})
+	}
+}
+
+func (r *ReAct) hasTaskQueueHandoff() bool {
+	hasHandoff, _ := r.taskQueueHandoffState()
+	return hasHandoff
+}
+
+func (r *ReAct) taskQueueHandoffState() (bool, uint64) {
+	if r == nil {
+		return false, 0
+	}
+	r.taskHandoffMu.Lock()
+	hasHandoff := r.taskHandoffs > 0
+	version := r.taskHandoffVersion
+	r.taskHandoffMu.Unlock()
+	return hasHandoff, version
+}
+
+// WaitTaskByUserInputUUIDStopped waits for a task to leave both the queue and
+// the runtime list. A terminal status event is emitted before processReActTask's
+// deferred persistence and cleanup have returned, so observing that event alone
+// is not sufficient for session deletion safety.
+func (r *ReAct) WaitTaskByUserInputUUIDStopped(ctx context.Context, inputUUID string) error {
+	inputUUID = strings.TrimSpace(inputUUID)
+	if r == nil || inputUUID == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Require two consecutive absent observations as a final stability check.
+	// processReActFromQueue also publishes an explicit hand-off marker while a
+	// task is between the queue and runtime lists, because dequeue hooks may block
+	// long enough that time-based polling alone cannot safely bridge that window.
+	absentOnce := false
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if r.hasTaskByUserInputUUID(inputUUID) || r.hasTaskQueueHandoff() {
+			absentOnce = false
+		} else if absentOnce {
+			return nil
+		} else {
+			absentOnce = true
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 // AddToTimeline 添加条目到时间线
 func (r *ReAct) AddToTimeline(entryType, content string) {
 	r.addToTimelineWithPromptProjection(entryType, content, "")
@@ -548,7 +757,13 @@ func (r *ReAct) getTimelineTotal() int {
 func (r *ReAct) startQueueProcessor(ctx context.Context, done chan struct{}) {
 	closeDoneOnce := new(sync.Once)
 	r.queueProcessor.Do(func() {
+		if r.lifecycleWG != nil {
+			r.lifecycleWG.Add(1)
+		}
 		go func() {
+			if r.lifecycleWG != nil {
+				defer r.lifecycleWG.Done()
+			}
 			defer func() {
 				closeDoneOnce.Do(func() {
 					close(done)
@@ -657,6 +872,9 @@ func (r *ReAct) processInputEvent(event *ypb.AIInputEvent) error {
 // startEventLoop starts the background event processing loop
 func (r *ReAct) startEventLoop(ctx context.Context, done chan struct{}) {
 	doneOnce := new(sync.Once)
+	if r.lifecycleWG != nil {
+		r.lifecycleWG.Add(1)
+	}
 	if !r.pureInvokerMode {
 		r.config.InputEventManager.SetFreeInputCallback(r.handleFreeValue)
 	}
@@ -670,6 +888,9 @@ func (r *ReAct) startEventLoop(ctx context.Context, done chan struct{}) {
 			})
 		},
 		func() {
+			if r.lifecycleWG != nil {
+				r.lifecycleWG.Done()
+			}
 			r.UnRegisterReActSyncEvent()
 			r.CloseTrackedBrowserSessions()
 			doneOnce.Do(func() {
@@ -692,6 +913,19 @@ func (r *ReAct) Wait() {
 		return
 	}
 	r.wg.Wait()
+}
+
+// WaitLifecycleStopped waits for the long-lived input and task-queue loops to
+// exit after their context is cancelled. It is separate from Wait so existing
+// AIEngine/ReAct callers keep the original Wait behavior.
+func (r *ReAct) WaitLifecycleStopped() {
+	if r == nil || r.lifecycleWG == nil {
+		return
+	}
+	r.lifecycleWG.Wait()
+	if r.config != nil {
+		r.config.WaitHotPatchLoopStopped()
+	}
 }
 
 // loadMCPServers loads AI tools from enabled MCP servers asynchronously

--- a/common/ai/aid/aireact/re-act_input_order_test.go
+++ b/common/ai/aid/aireact/re-act_input_order_test.go
@@ -1,0 +1,120 @@
+package aireact
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/utils/chanx"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func TestSendInputEventAndWaitAcceptedDispatchesHotpatchBeforeReturning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hotpatchChan := chanx.NewUnlimitedChan[aicommon.ConfigOption](ctx, 1)
+	cfg := aicommon.NewConfig(ctx,
+		aicommon.WithHotPatchOptionChan(hotpatchChan),
+		aicommon.WithEnablePlanAndExec(true),
+	)
+	react := &ReAct{config: cfg}
+
+	err := react.SendInputEventAndWaitAccepted(&ypb.AIInputEvent{
+		IsConfigHotpatch: true,
+		HotpatchType:     aicommon.HotPatchType_EnablePlan,
+		Params:           &ypb.AIStartParams{EnablePlan: false},
+	})
+	require.NoError(t, err)
+
+	select {
+	case option := <-hotpatchChan.OutputChannel():
+		require.NotNil(t, option)
+		require.NoError(t, option(cfg))
+		require.False(t, cfg.GetEnablePlanAndExec())
+	case <-time.After(time.Second):
+		t.Fatal("hot-patch was not dispatched before SendInputEventAndWaitAccepted returned")
+	}
+}
+
+func TestWaitTaskByUserInputUUIDStoppedWaitsForRuntimeCleanup(t *testing.T) {
+	task := aicommon.NewStatefulTaskBase("task", "input", context.Background(), nil)
+	task.SetUserInputUUID("scheduled-input")
+	task.SetStatus(aicommon.AITaskState_Completed)
+	react := &ReAct{RuntimeTasks: []aicommon.AIStatefulTask{task}, taskQueue: NewTaskQueue("test")}
+
+	waited := make(chan error, 1)
+	go func() {
+		waited <- react.WaitTaskByUserInputUUIDStopped(context.Background(), "scheduled-input")
+	}()
+	select {
+	case err := <-waited:
+		t.Fatalf("task wait returned before runtime cleanup: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	react.updateRuntimeTasks()
+	select {
+	case err := <-waited:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("task wait did not finish after runtime cleanup")
+	}
+	require.Empty(t, react.GetRuntimeTasks(), "skipped/completed/aborted tasks must all be pruned")
+}
+
+func TestWaitTaskByUserInputUUIDStoppedWaitsForQueueRuntimeHandoff(t *testing.T) {
+	react := &ReAct{taskQueue: NewTaskQueue("test")}
+	finishHandoff := react.beginTaskQueueHandoff()
+
+	waited := make(chan error, 1)
+	go func() {
+		waited <- react.WaitTaskByUserInputUUIDStopped(context.Background(), "scheduled-input")
+	}()
+	select {
+	case err := <-waited:
+		t.Fatalf("task wait returned during queue/runtime handoff: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	finishHandoff()
+	select {
+	case err := <-waited:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("task wait did not finish after queue/runtime handoff")
+	}
+}
+
+func TestCancelTaskByUserInputUUIDAndWaitRetriesAcrossHandoff(t *testing.T) {
+	task := aicommon.NewStatefulTaskBase("task", "input", context.Background(), aicommon.NewDummyEmitter())
+	task.SetUserInputUUID("scheduled-input")
+	task.SetStatus(aicommon.AITaskState_Processing)
+	react := &ReAct{Emitter: aicommon.NewDummyEmitter(), taskQueue: NewTaskQueue("test")}
+	finishHandoff := react.beginTaskQueueHandoff()
+
+	cancelled := make(chan error, 1)
+	go func() {
+		cancelled <- react.CancelTaskByUserInputUUIDAndWait(context.Background(), "scheduled-input")
+	}()
+	select {
+	case err := <-cancelled:
+		t.Fatalf("cancel returned while the task was hidden by handoff: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	react.UpdateRuntimeTaskMutex.Lock()
+	react.RuntimeTasks = append(react.RuntimeTasks, task)
+	react.UpdateRuntimeTaskMutex.Unlock()
+	finishHandoff()
+	require.Eventually(t, task.IsFinished, time.Second, 10*time.Millisecond,
+		"cancellation was not retried after runtime publication")
+	react.updateRuntimeTasks()
+	select {
+	case err := <-cancelled:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not finish after task cleanup")
+	}
+}

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -68,10 +68,7 @@ func (r *ReAct) updateRuntimeTasks() {
 	newRuntimeTasks := make([]aicommon.AIStatefulTask, 0)
 
 	for _, task := range r.RuntimeTasks {
-		if task.GetStatus() == aicommon.AITaskState_Completed {
-			continue
-		}
-		if task.GetStatus() == aicommon.AITaskState_Aborted {
+		if task.IsFinished() {
 			continue
 		}
 		newRuntimeTasks = append(newRuntimeTasks, task)
@@ -111,8 +108,11 @@ func (r *ReAct) processReActFromQueue() {
 
 	// 从队列获取下一个任务
 	log.Infof("start to get first task from queue for ReAct instance: %s", r.config.Id)
+	finishHandoff := r.beginTaskQueueHandoff()
+	defer finishHandoff()
 	nextTask := r.taskQueue.GetFirst()
 	if nextTask == nil {
+		finishHandoff()
 		return
 	}
 
@@ -120,6 +120,7 @@ func (r *ReAct) processReActFromQueue() {
 	r.setCurrentTask(nextTask)
 	r.persistTaskUserInput(nextTask)
 	nextTask.SetStatus(aicommon.AITaskState_Processing)
+	finishHandoff()
 	if r.config.DebugEvent {
 		log.Infof("Processing task from queue: %s", nextTask.GetId())
 	}
@@ -717,6 +718,7 @@ func BuildReActInvoker(ctx context.Context, options ...aicommon.ConfigOption) (a
 		saveTimelineThrottle: utils.NewThrottleEx(3, true, true),
 		artifacts:            nil, // lazy: created in ensureWorkDirectory
 		wg:                   new(sync.WaitGroup),
+		lifecycleWG:          new(sync.WaitGroup),
 		pureInvokerMode:      true,
 	}
 	// Inherit parent tracker when passed via ConvertConfigToOptions; otherwise

--- a/common/ai/aid/aireact/reactloops/docs/13-yak-focus-mode.md
+++ b/common/ai/aid/aireact/reactloops/docs/13-yak-focus-mode.md
@@ -514,7 +514,7 @@ require.Greater(t, utils.InterfaceToInt(loop.GetVariable("greet_count")), 0,
 | 触发点 | 实现 |
 |---|---|
 | `QueryAIFocus` gRPC 调用（UI 拉列表） | [grpc_ai_focus.go](../../../../../yakgrpc/grpc_ai_focus.go) 入口调 `EnsureUserFocusModesLoaded` |
-| `StartAIReAct` gRPC 调用（开新会话） | [grpc_ai_re-act.go](../../../../../yakgrpc/grpc_ai_re-act.go) 入口调 `EnsureUserFocusModesLoaded` |
+| `ReActSessionRuntime.Connect`（gRPC / scheduler / IM 的统一会话入口） | [ai_react_runtime.go](../../../../../yakgrpc/ai_react_runtime.go) 在创建或复用 ReAct 前调 `EnsureUserFocusModesLoaded` |
 | `yak ai-focus --file ...` CLI | 不依赖目录扫描，CLI 显式注册 `--file` 指向的文件 |
 
 ### 行为约定

--- a/common/ai/aid/aireact/session_registry.go
+++ b/common/ai/aid/aireact/session_registry.go
@@ -58,6 +58,19 @@ func IsSessionStarting(sessionID string) bool {
 	return ok
 }
 
+// EnumerateStartingSessions returns session IDs currently protected by the
+// process-wide creation reservation. It lets lifecycle coordinators avoid
+// deleting session data while a ReAct owned elsewhere is still being built.
+func EnumerateStartingSessions() []string {
+	sessionStartState.Lock()
+	defer sessionStartState.Unlock()
+	ids := make([]string, 0, len(sessionStartState.starting))
+	for sessionID := range sessionStartState.starting {
+		ids = append(ids, sessionID)
+	}
+	return ids
+}
+
 func registerRunningSession(sessionID string, react *ReAct) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" || react == nil {

--- a/common/ai/aid/aireact/sessionruntime/recovery.go
+++ b/common/ai/aid/aireact/sessionruntime/recovery.go
@@ -1,0 +1,97 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+const attachedRecoveryHistoryBlockLimit = 20
+
+func sendAttachedRecoveryHistory(
+	ctx context.Context,
+	db *gorm.DB,
+	send func(*schema.AiOutputEvent) error,
+	persistentSession string,
+	event *ypb.AIInputEvent,
+) error {
+	if db == nil {
+		return sendAttachedSyncError(send, "recovery_history", utils.Errorf("db is nil"), event.GetSyncID())
+	}
+
+	sessionID := persistentSession
+	startID := int64(0)
+	limit := attachedRecoveryHistoryBlockLimit
+
+	if raw := event.GetSyncJsonInput(); raw != "" {
+		var params map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &params); err != nil {
+			return sendAttachedSyncError(send, "recovery_history", utils.Errorf("failed to parse recovery history params: %v", err), event.GetSyncID())
+		}
+		if sid := utils.InterfaceToString(params["session_id"]); sid != "" {
+			sessionID = sid
+		}
+		if rawStartID, ok := params["start_id"]; ok {
+			startID = int64(utils.InterfaceToInt(rawStartID))
+		}
+		if rawLimit, ok := params["limit"]; ok {
+			if parsedLimit := utils.InterfaceToInt(rawLimit); parsedLimit > 0 {
+				limit = parsedLimit
+			}
+		}
+	}
+
+	if sessionID == "" {
+		return sendAttachedSyncError(send, "recovery_history", utils.Errorf("session_id is empty"), event.GetSyncID())
+	}
+
+	eventCh, result, err := yakit.YieldAIEventRecoveryHistory(ctx, db, sessionID, startID, limit)
+	if err != nil {
+		return sendAttachedSyncError(send, "recovery_history", err, event.GetSyncID())
+	}
+	for recoveredEvent := range eventCh {
+		if recoveredEvent == nil {
+			continue
+		}
+		recoveredEvent.IsSync = true
+		if err := send(recoveredEvent); err != nil {
+			return err
+		}
+	}
+
+	return sendAttachedSyncJSON(send, schema.EVENT_TYPE_STRUCTURED, "recovery_history", map[string]interface{}{
+		"session_id":         sessionID,
+		"requested_start_id": startID,
+		"block_count":        result.BlockCount,
+		"event_count":        result.EventCount,
+		"next_start_id":      result.NextStartID,
+		"has_more":           result.HasMore,
+	}, event.GetSyncID())
+}
+
+func sendAttachedSyncError(send func(*schema.AiOutputEvent) error, nodeID string, err error, syncID string) error {
+	if err == nil {
+		return nil
+	}
+	return sendAttachedSyncJSON(send, schema.EVENT_TYPE_STRUCTURED, nodeID, map[string]any{
+		"error": err.Error(),
+	}, syncID)
+}
+
+func sendAttachedSyncJSON(send func(*schema.AiOutputEvent) error, eventType schema.EventType, nodeID string, payload any, syncID string) error {
+	return send(&schema.AiOutputEvent{
+		Type:      eventType,
+		NodeId:    nodeID,
+		IsJson:    true,
+		IsSync:    true,
+		Content:   utils.Jsonify(payload),
+		Timestamp: time.Now().Unix(),
+		SyncID:    syncID,
+	})
+}

--- a/common/ai/aid/aireact/sessionruntime/runtime.go
+++ b/common/ai/aid/aireact/sessionruntime/runtime.go
@@ -1,4 +1,4 @@
-package yakgrpc
+package sessionruntime
 
 import (
 	"context"
@@ -46,13 +46,16 @@ type ReActEventHandler func(*schema.AiOutputEvent) error
 type ConnectRequest struct {
 	StartParams *ypb.AIStartParams
 	Reservation SessionReservation
-	options     *reActConnectOptions
+	Options     *ConnectOptions
 }
 
-type reActConnectOptions struct {
-	loadBuiltinTools bool
-	configOptions    []aicommon.ConfigOption
-	onEventError     func(error)
+// ConnectOptions contains caller-specific delivery and construction options.
+// Production callers normally leave LoadBuiltinTools enabled; ConfigOptions is
+// primarily useful to inject deterministic dependencies in lifecycle tests.
+type ConnectOptions struct {
+	LoadBuiltinTools bool
+	ConfigOptions    []aicommon.ConfigOption
+	OnEventError     func(error)
 }
 
 // SessionReservation is an execution lease, not merely a creation lock. A
@@ -184,72 +187,13 @@ func (g *reActSessionQuiescence) Release() {
 	g.once.Do(func() { g.runtime.releaseQuiescence(g.ids, g.all) })
 }
 
-func newReActSessionRuntime(projectDB func() *gorm.DB) *reActSessionRuntime {
+func New(projectDB func() *gorm.DB) ReActSessionRuntime {
 	return &reActSessionRuntime{
 		projectDB: projectDB,
 		newReAct:  aireact.NewReAct,
 		entries:   make(map[string]*reActSessionState),
 		changed:   make(chan struct{}),
 	}
-}
-
-func (s *Server) getReActSessionRuntime() ReActSessionRuntime {
-	if s == nil {
-		return nil
-	}
-	s.reActRuntimeMu.Lock()
-	defer s.reActRuntimeMu.Unlock()
-	if s.reActRuntime == nil {
-		s.reActRuntime = newReActSessionRuntime(s.GetProjectDatabase)
-		s.reActRuntimeRetired = false
-	}
-	return s.reActRuntime
-}
-
-// retireReActSessionRuntime stops every session owned by the current runtime and
-// permanently quiesces that runtime before it is detached from the server. This
-// is used when the project database changes: a ReAct created for the old project
-// must never be attached through the new project context.
-func (s *Server) retireReActSessionRuntime(ctx context.Context) error {
-	if s == nil {
-		return nil
-	}
-	s.reActRuntimeMu.Lock()
-	if s.reActRuntimeRetired {
-		s.reActRuntimeMu.Unlock()
-		return nil
-	}
-	runtime := s.reActRuntime
-	if runtime == nil {
-		runtime = newReActSessionRuntime(s.GetProjectDatabase)
-		s.reActRuntime = runtime
-	}
-	s.reActRuntimeMu.Unlock()
-
-	// Intentionally keep the returned guard: stale holders of this runtime must
-	// continue to reject reservations and connections. The retired runtime also
-	// stays installed until the database switch completes, closing the gap where
-	// a concurrent caller could otherwise create against the old project DB.
-	if _, err := runtime.QuiesceAll(ctx); err != nil {
-		return err
-	}
-
-	s.reActRuntimeMu.Lock()
-	if s.reActRuntime == runtime {
-		s.reActRuntimeRetired = true
-	}
-	s.reActRuntimeMu.Unlock()
-	return nil
-}
-
-func (s *Server) resetReActSessionRuntimeAfterProjectSwitch() {
-	if s == nil {
-		return
-	}
-	s.reActRuntimeMu.Lock()
-	s.reActRuntime = nil
-	s.reActRuntimeRetired = false
-	s.reActRuntimeMu.Unlock()
 }
 
 func normalizeReActSessionID(sessionID string) string {
@@ -405,9 +349,9 @@ func (r *reActSessionRuntime) IsSessionBusy(sessionID string) bool {
 func (r *reActSessionRuntime) Connect(ctx context.Context, req ConnectRequest, onEvent ReActEventHandler) (ReActConnection, error) {
 	loadBuiltinTools := true
 	var configOptions []aicommon.ConfigOption
-	if req.options != nil {
-		loadBuiltinTools = req.options.loadBuiltinTools
-		configOptions = req.options.configOptions
+	if req.Options != nil {
+		loadBuiltinTools = req.Options.LoadBuiltinTools
+		configOptions = req.Options.ConfigOptions
 	}
 	return r.connectWithOptions(ctx, req, onEvent, loadBuiltinTools, configOptions...)
 }
@@ -431,8 +375,8 @@ func (r *reActSessionRuntime) connectWithOptions(
 	}
 	sessionID := normalizeReActSessionID(startParams.GetTimelineSessionID())
 	var onEventError func(error)
-	if req.options != nil {
-		onEventError = req.options.onEventError
+	if req.Options != nil {
+		onEventError = req.Options.OnEventError
 	}
 
 	// 启动 ReAct 之前懒扫描用户的 ~/yakit-projects/ai-focus/，
@@ -585,7 +529,7 @@ func (r *reActSessionRuntime) createRuntime(
 	loadBuiltinTools bool,
 	additionalOptions ...aicommon.ConfigOption,
 ) (*ownedReActRuntime, error) {
-	resolvedStartParams, err := resolveAISessionStartParams(
+	resolvedStartParams, err := ResolveSessionStartParams(
 		r.projectDatabase(),
 		sessionID,
 		startParams,
@@ -627,7 +571,7 @@ func (r *reActSessionRuntime) createRuntime(
 	// optsFromStartParams (containing WithAICallback) must be applied BEFORE
 	// tiered overrides, otherwise WithAICallback overwrites all three callbacks
 	// (Original, Quality, Speed) to the same frontend-selected model.
-	configOptions = append(configOptions, ConvertYPBAIStartParamsToReActConfig(resolvedStartParams)...)
+	configOptions = append(configOptions, ConvertStartParamsToReActConfig(resolvedStartParams)...)
 	if aiconfig.IsTieredAIConfig() {
 		configOptions = append(configOptions, aicommon.WithAutoTieredAICallback(defaultAI))
 	}

--- a/common/ai/aid/aireact/sessionruntime/runtime_test.go
+++ b/common/ai/aid/aireact/sessionruntime/runtime_test.go
@@ -1,19 +1,32 @@
-package yakgrpc
+package sessionruntime
 
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aimem"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact"
+	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
+
+type noOpTimelineArchiveStore struct{}
+
+func (*noOpTimelineArchiveStore) ArchiveCompressedBatch(context.Context, *aicommon.TimelineArchiveBatch) (*aicommon.TimelineArchiveRef, error) {
+	return nil, nil
+}
+
+func (*noOpTimelineArchiveStore) SearchArchivedBatches(context.Context, *aicommon.TimelineArchiveSearchQuery) (*aicommon.TimelineArchiveSearchResult, error) {
+	return &aicommon.TimelineArchiveSearchResult{}, nil
+}
 
 func TestReActEventDeliveryKeepsNormalOutputBestEffortAndReportsSyncFailure(t *testing.T) {
 	deliveryErr := errors.New("subscriber delivery failed")
@@ -77,7 +90,7 @@ func TestReActSessionRuntimeHonorsProcessWideStartReservation(t *testing.T) {
 	require.True(t, ok)
 	defer release()
 
-	runtime := newReActSessionRuntime(nil)
+	runtime := New(nil).(*reActSessionRuntime)
 	var createCount atomic.Int32
 	runtime.newReAct = func(...aicommon.ConfigOption) (*aireact.ReAct, error) {
 		createCount.Add(1)
@@ -158,7 +171,7 @@ func TestReActSessionRuntimeCoordinationBusyReasons(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			runtime := newReActSessionRuntime(nil)
+			runtime := New(nil).(*reActSessionRuntime)
 			sessionID := "coordination-busy-reason-" + test.name
 			test.setup(runtime, sessionID)
 
@@ -173,7 +186,7 @@ func TestReActSessionRuntimeWillNotQuiesceAnotherRuntimeStart(t *testing.T) {
 	release, ok := aireact.TryBeginSessionStart(sessionID)
 	require.True(t, ok)
 
-	runtime := newReActSessionRuntime(nil)
+	runtime := New(nil).(*reActSessionRuntime)
 	_, err := runtime.QuiesceSessions(context.Background(), []string{sessionID})
 	require.ErrorContains(t, err, "starting outside this runtime")
 	require.True(t, aireact.IsSessionStarting(sessionID))
@@ -189,7 +202,7 @@ func TestReActSessionRuntimeWillNotQuiesceAnotherRuntimeStart(t *testing.T) {
 }
 
 func TestReActSessionRuntimeReservationAndQuiescence(t *testing.T) {
-	runtime := newReActSessionRuntime(nil)
+	runtime := New(nil).(*reActSessionRuntime)
 	reservation, err := runtime.ReserveSession(context.Background(), "lease-session", "execution-1")
 	require.NoError(t, err)
 	require.True(t, runtime.IsSessionBusy("lease-session"))
@@ -242,7 +255,7 @@ func TestReActSessionRuntimeReservationAndQuiescence(t *testing.T) {
 }
 
 func TestReActSessionRuntimeOnlyTaskAdmissionBlocksReservation(t *testing.T) {
-	runtime := newReActSessionRuntime(nil)
+	runtime := New(nil).(*reActSessionRuntime)
 	runtime.entries["input-admission"] = &reActSessionState{admitting: 1}
 	reservation, err := runtime.ReserveSession(context.Background(), "input-admission", "execution")
 	require.NoError(t, err, "non-task sync/hot-patch admission must not make a schedule skip")
@@ -253,41 +266,11 @@ func TestReActSessionRuntimeOnlyTaskAdmissionBlocksReservation(t *testing.T) {
 	require.Error(t, err, "free-input admission must remain atomic with schedule reservation")
 }
 
-func TestServerRetireReActSessionRuntime(t *testing.T) {
-	server := newScheduleTestServer(t)
-	oldRuntime := server.getReActSessionRuntime().(*reActSessionRuntime)
-	reservation, err := oldRuntime.ReserveSession(context.Background(), "old-project-session", "old-execution")
-	require.NoError(t, err)
-
-	retired := make(chan error, 1)
-	go func() { retired <- server.retireReActSessionRuntime(context.Background()) }()
-	select {
-	case <-reservation.Context().Done():
-	case <-time.After(time.Second):
-		t.Fatal("retiring the project runtime did not cancel its reservation")
-	}
-	reservation.Release()
-	select {
-	case err := <-retired:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("project runtime retirement did not finish")
-	}
-
-	_, err = oldRuntime.ReserveSession(context.Background(), "stale-session", "stale-execution")
-	require.Error(t, err, "a retired runtime must stay permanently quiesced")
-	require.Same(t, oldRuntime, server.getReActSessionRuntime(), "the retired runtime must cover the project-switch window")
-	server.resetReActSessionRuntimeAfterProjectSwitch()
-	newRuntime := server.getReActSessionRuntime().(*reActSessionRuntime)
-	require.NotSame(t, oldRuntime, newRuntime)
-	newReservation, err := newRuntime.ReserveSession(context.Background(), "new-project-session", "new-execution")
-	require.NoError(t, err)
-	newReservation.Release()
-}
-
 func TestReActSessionRuntimeCreatesOnceAttachesAndGatesReservedInput(t *testing.T) {
-	server := newScheduleTestServer(t)
-	runtime := server.getReActSessionRuntime().(*reActSessionRuntime)
+	db, err := consts.CreateProjectDatabase(filepath.Join(t.TempDir(), "runtime.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	runtime := New(func() *gorm.DB { return db }).(*reActSessionRuntime)
 	originalFactory := runtime.newReAct
 	var createCount atomic.Int32
 	factoryEntered := make(chan struct{})

--- a/common/ai/aid/aireact/sessionruntime/start_params.go
+++ b/common/ai/aid/aireact/sessionruntime/start_params.go
@@ -1,0 +1,192 @@
+package sessionruntime
+
+import (
+	"strings"
+
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/ai/aid"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/aiconfig"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// FixOptionsWithServiceName preserves the legacy AIService selection behavior
+// for every ReAct caller, rather than leaving it in the gRPC adapter.
+func FixOptionsWithServiceName(serviceName string, opts ...aicommon.ConfigOption) []aicommon.ConfigOption {
+	aiCb, err := aicommon.CreateCallbackFromConfig(aiconfig.GetGlobalManager().GetFirstConfigByTierAndProviderAndModel(consts.TierIntelligent, serviceName, ""))
+	if err != nil {
+		log.Errorf("load ai service failed: %v", err)
+	} else {
+		opts = append(opts, aicommon.WithAutoTieredAICallback(aiCb))
+	}
+	log.Warnf("AIStartParams.AIService/AIModelName for WithAIChatInfo is deprecated, " +
+		"model info is now auto-detected from the actual AI gateway call")
+	return opts
+}
+
+// ConvertStartParamsToReActConfig converts the shared protobuf input model to
+// ReAct config options. The protobuf model is retained because ReAct itself
+// still consumes it; this package is independent of the gRPC stream transport.
+func ConvertStartParamsToReActConfig(i *ypb.AIStartParams) []aicommon.ConfigOption {
+	opts := make([]aicommon.ConfigOption, 0)
+	if i == nil {
+		return opts
+	}
+	enableMultiAgent, goalModeEnabled, goalMinIterations, maxSubAgents := resolveAIExecutionStrategy(i)
+	if i.DisallowRequireForUserPrompt {
+		opts = append(opts, aicommon.WithAllowRequireForUserInteract(false))
+	} else {
+		opts = append(opts, aicommon.WithAllowRequireForUserInteract(true))
+	}
+
+	if i.ReviewPolicy != "" {
+		opts = append(opts, aicommon.WithAgreePolicy(aicommon.AgreePolicyType(i.ReviewPolicy)))
+	}
+
+	if i.GetAIReviewRiskControlScore() > 0 {
+		opts = append(opts, aicommon.WithAgreeAIRiskCtrlScore(i.GetAIReviewRiskControlScore()))
+	}
+
+	if i.ReActMaxIteration > 0 {
+		maxIterations := i.GetReActMaxIteration()
+		// Goal-mode entry-point normalization: raise a too-small ceiling so the
+		// finish gate (GoalMinIterations) can open before iterations run out.
+		// loop_default.resolveMaxIterations applies the same bump idempotently
+		// as a safety net for programmatic (non-gRPC) entry paths.
+		if goalModeEnabled {
+			maxIterations = aicommon.EnsureGoalModeMaxIterations(maxIterations, goalMinIterations)
+		}
+		opts = append(opts, aicommon.WithMaxIterationCount(maxIterations))
+	}
+
+	if i.GetTimelineContentSizeLimit() > 0 {
+		opts = append(opts, aicommon.WithTimelineContentLimit(int(i.GetTimelineContentSizeLimit())))
+	}
+
+	if i.UserInteractLimit > 0 {
+		opts = append(opts, aicommon.WithPlanUserInteractMaxCount(i.UserInteractLimit))
+	}
+
+	if i.GetDisableToolUse() {
+		opts = append(opts, aicommon.WithDisableToolUse(true))
+	}
+	if i.GetEnableAISearchTool() {
+		opts = append(opts, aid.WithAiToolsSearchTool())
+	}
+	if enableMultiAgent {
+		opts = append(opts,
+			aicommon.WithEnableMultiAgentMode(true),
+			aicommon.WithMaxSubAgents(maxSubAgents),
+		)
+	}
+	if len(i.GetExcludeToolNames()) > 0 {
+		opts = append(opts, aicommon.WithDisableToolsName(i.GetExcludeToolNames()...))
+	}
+	if len(i.GetIncludeSuggestedToolNames()) > 0 {
+		opts = append(opts, aicommon.WithEnableToolsName(i.GetIncludeSuggestedToolNames()...))
+	}
+	if len(i.GetIncludeSuggestedToolKeywords()) > 0 {
+		opts = append(opts, aicommon.WithKeywords(i.GetIncludeSuggestedToolKeywords()...))
+	}
+	if i.GetAIService() != "" {
+		opts = FixOptionsWithServiceName(i.GetAIService(), opts...)
+	}
+
+	if !i.GetDisableAISearchForge() {
+		opts = append(opts, aid.WithAiForgeSearchTool())
+	}
+
+	// EnablePlan 晚于 DisableAISearchForge 应用，用于控制 PE / 蓝图动作；与 AI 搜索 Forge 工具独立。
+	opts = append(opts, aicommon.WithEnablePlanAndExec(i.GetEnablePlan()))
+	if i.GetEnableDetachedPlan() {
+		opts = append(opts, aicommon.WithEnableDetachedPlan(true))
+	}
+
+	if i.GetAICallTokenLimit() > 0 {
+		opts = append(opts, aicommon.WithAiCallTokenLimit(int64(i.GetAICallTokenLimit())))
+	}
+
+	if i.GetDisableToolIntervalReview() {
+		opts = append(opts, aicommon.WithDisableToolCallerIntervalReview(true))
+	}
+	if i.GetSyncPerceptionTrigger() {
+		opts = append(opts, aicommon.WithSyncPerceptionTrigger(true))
+	}
+	if goalModeEnabled {
+		opts = append(opts,
+			aicommon.WithEnableGoalMode(true),
+			aicommon.WithGoalMinIterations(goalMinIterations),
+		)
+	}
+
+	if i.GetUserPresetPrompt() != "" {
+		opts = append(opts, aicommon.WithUserPresetPrompt(i.GetUserPresetPrompt()))
+	}
+
+	if i.GetPlanExecTaskConcurrency() > 0 {
+		opts = append(opts, aicommon.WithPlanExecTaskConcurrency(int(i.GetPlanExecTaskConcurrency())))
+	}
+
+	if i.GetUserPlanPrompt() != "" {
+		opts = append(opts, aicommon.WithPlanPrompt(i.GetUserPlanPrompt()))
+	}
+
+	if i.GetSource() != "" {
+		opts = append(opts, aicommon.WithSessionSource(i.GetSource()))
+	}
+
+	if caps := aicommon.ParseEnabledCapabilitiesFromProto(i); len(caps) > 0 {
+		opts = append(opts, aicommon.WithEnabledCapabilities(caps...))
+	}
+
+	if i.GetDisableMemoryTriage() {
+		opts = append(opts, aicommon.WithDisableMemoryTriage(true))
+	}
+
+	return opts
+}
+
+func resolveAIExecutionStrategy(i *ypb.AIStartParams) (enableMultiAgent bool, enableGoalMode bool, goalMinIterations int64, maxSubAgents int64) {
+	if i == nil {
+		return false, false, aicommon.DefaultGoalMinIterations, aicommon.DefaultMaxSubAgentConcurrency
+	}
+	if strategy := i.GetStrategy(); strategy != nil {
+		enableMultiAgent = strategy.GetEnableMultiAgent()
+		enableGoalMode = strategy.GetEnableGoalMode()
+		goalMinIterations = strategy.GetGoalMinIterations()
+		maxSubAgents = strategy.GetMaxSubAgents()
+	}
+	goalMinIterations = aicommon.NormalizeGoalMinIterations(goalMinIterations)
+	return
+}
+
+// ResolveSessionStartParams optionally overlays request parameters on the
+// durable session config. Keeping this in the runtime package gives every
+// transport and background caller identical startup semantics.
+func ResolveSessionStartParams(db *gorm.DB, sessionID string, request *ypb.AIStartParams, preferCached bool) (*ypb.AIStartParams, error) {
+	if request == nil {
+		request = &ypb.AIStartParams{}
+	}
+	if !preferCached || db == nil || strings.TrimSpace(sessionID) == "" {
+		return request, nil
+	}
+
+	if _, err := yakit.GetAISessionMetaBySessionID(db, sessionID); err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return request, nil
+		}
+		return nil, err
+	}
+
+	cached, err := yakit.GetAISessionMetaStartParamsBySessionID(db, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if cached == nil {
+		return request, nil
+	}
+	return yakit.MergeCachedAISessionStartParams(cached, request), nil
+}

--- a/common/ai/aid/aireactscheduler/scheduler.go
+++ b/common/ai/aid/aireactscheduler/scheduler.go
@@ -1,4 +1,4 @@
-package yakgrpc
+package aireactscheduler
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
 	"github.com/yaklang/yaklang/common/ai/aid/aischedule"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
@@ -23,8 +24,8 @@ const (
 	aiReActSchedulePollInterval  = 30 * time.Second
 	aiReActScheduleMaxConcurrent = 3
 
-	aiReActScheduleTriggerSchedule = "schedule"
-	aiReActScheduleTriggerManual   = "manual"
+	TriggerSchedule = "schedule"
+	TriggerManual   = "manual"
 
 	scheduledOutcomeSucceeded      = "succeeded"
 	scheduledOutcomeFailed         = "failed"
@@ -43,7 +44,7 @@ type scheduledReActJob struct {
 	ctx                 context.Context
 	cancel              context.CancelFunc
 	unregisterExecution func()
-	reservation         SessionReservation
+	reservation         sessionruntime.SessionReservation
 	workerReserved      bool
 	done                chan struct{}
 }
@@ -55,8 +56,8 @@ type scheduleEnqueueError struct {
 
 func (e *scheduleEnqueueError) Error() string { return e.message }
 
-type aiReActScheduler struct {
-	runtime ReActSessionRuntime
+type Scheduler struct {
+	runtime sessionruntime.ReActSessionRuntime
 	db      *gorm.DB
 
 	ctx    context.Context
@@ -64,16 +65,25 @@ type aiReActScheduler struct {
 	wake   chan struct{}
 	worker chan struct{}
 
+	lifecycleMu      sync.Mutex
+	started          bool
 	jobsMu           sync.Mutex
 	jobs             map[string]*scheduledReActJob
 	activeBySchedule map[string]string
 	wg               sync.WaitGroup
 }
 
-func newAIReActScheduler(server *Server, db *gorm.DB) *aiReActScheduler {
+// ActiveExecution is an immutable view of one in-memory scheduled run.
+type ActiveExecution struct {
+	ExecutionID string
+	SessionID   string
+	Done        <-chan struct{}
+}
+
+func NewScheduler(runtime sessionruntime.ReActSessionRuntime, db *gorm.DB) *Scheduler {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &aiReActScheduler{
-		runtime:          server.getReActSessionRuntime(),
+	return &Scheduler{
+		runtime:          runtime,
 		db:               db,
 		ctx:              ctx,
 		cancel:           cancel,
@@ -84,86 +94,41 @@ func newAIReActScheduler(server *Server, db *gorm.DB) *aiReActScheduler {
 	}
 }
 
-// StartAIReActScheduler starts the project-scoped scheduler. Task definitions
-// are durable, while active execution state intentionally remains in memory.
-// It is safe to call more than once and is independent of UI streams.
-func (s *Server) StartAIReActScheduler() {
-	s.ensureAIReActScheduler()
-}
-
-func (s *Server) ensureAIReActScheduler() {
-	if s == nil {
+// Start begins the project-scoped polling loop. A Scheduler is started once;
+// callers create a new instance when the active project changes.
+func (m *Scheduler) Start() {
+	if m == nil {
 		return
 	}
-	s.aiReActSchedulerMu.Lock()
-	defer s.aiReActSchedulerMu.Unlock()
-	if s.aiReActScheduler != nil && s.aiReActScheduler.ctx.Err() == nil {
+	m.lifecycleMu.Lock()
+	defer m.lifecycleMu.Unlock()
+	if m.started || m.ctx.Err() != nil {
 		return
 	}
-	manager := newAIReActScheduler(s, s.GetProjectDatabase())
-	s.aiReActScheduler = manager
-	manager.wg.Add(1)
-	go manager.loop()
+	// Add while holding the same lifecycle lock used by Stop. This prevents a
+	// concurrent Stop from observing a zero WaitGroup and returning immediately
+	// before Start publishes the polling goroutine.
+	m.started = true
+	m.wg.Add(1)
+	go m.loop()
 }
 
-// StopAIReActScheduler stops the project-scoped scheduler and waits for its
-// in-memory executions to release their resources.
-func (s *Server) StopAIReActScheduler() {
-	s.stopAIReActScheduler()
-}
-
-func (s *Server) stopAIReActScheduler() {
-	if s == nil {
-		return
-	}
-	s.aiReActSchedulerMu.Lock()
-	manager := s.aiReActScheduler
-	s.aiReActScheduler = nil
-	s.aiReActSchedulerMu.Unlock()
-	if manager != nil {
-		manager.stop()
-	}
-}
-
-func (s *Server) wakeAIReActScheduler() {
-	s.aiReActSchedulerMu.Lock()
-	manager := s.aiReActScheduler
-	s.aiReActSchedulerMu.Unlock()
-	if manager != nil {
-		manager.notify()
-	}
-}
-
-func (s *Server) currentAIReActScheduler() *aiReActScheduler {
-	s.aiReActSchedulerMu.Lock()
-	defer s.aiReActSchedulerMu.Unlock()
-	return s.aiReActScheduler
-}
-
-func (s *Server) enqueueAIReActSchedule(schedule *schema.AIReActSchedule, scheduledAt time.Time, trigger string) error {
-	manager := s.currentAIReActScheduler()
-	if manager == nil {
-		return utils.Error("AI ReAct scheduler is not running")
-	}
-	return manager.enqueue(schedule, scheduledAt, trigger)
-}
-
-func (s *Server) cancelAIReActScheduleExecution(scheduleUUID string) {
-	aischedule.CancelExecution(scheduleUUID)
-	if manager := s.currentAIReActScheduler(); manager != nil {
-		manager.cancelSchedule(scheduleUUID)
-	}
-}
-
-func (m *aiReActScheduler) notify() {
+func (m *Scheduler) Notify() {
 	select {
 	case m.wake <- struct{}{}:
 	default:
 	}
 }
 
-func (m *aiReActScheduler) stop() {
+// Stop waits for the polling loop and all in-memory executions to release
+// their resources.
+func (m *Scheduler) Stop() {
+	if m == nil {
+		return
+	}
+	m.lifecycleMu.Lock()
 	m.cancel()
+	m.lifecycleMu.Unlock()
 	m.jobsMu.Lock()
 	for _, job := range m.jobs {
 		job.cancel()
@@ -172,7 +137,7 @@ func (m *aiReActScheduler) stop() {
 	m.wg.Wait()
 }
 
-func (m *aiReActScheduler) loop() {
+func (m *Scheduler) loop() {
 	defer m.wg.Done()
 	ticker := time.NewTicker(aiReActSchedulePollInterval)
 	defer ticker.Stop()
@@ -187,7 +152,7 @@ func (m *aiReActScheduler) loop() {
 	}
 }
 
-func (m *aiReActScheduler) dispatchDue() {
+func (m *Scheduler) dispatchDue() {
 	if m == nil || m.db == nil || m.ctx.Err() != nil {
 		return
 	}
@@ -217,7 +182,7 @@ func (m *aiReActScheduler) dispatchDue() {
 			m.recordScheduleSkipped(schedule.UUID, "misfire", "scheduled occurrence exceeded its misfire grace period")
 			continue
 		}
-		if err := m.enqueue(schedule, occurrence, aiReActScheduleTriggerSchedule); err != nil {
+		if err := m.Enqueue(schedule, occurrence, TriggerSchedule); err != nil {
 			if skip, ok := err.(*scheduleEnqueueError); ok {
 				if skip.reason != "schedule_inactive" {
 					m.recordScheduleSkipped(schedule.UUID, skip.reason, skip.message)
@@ -230,7 +195,7 @@ func (m *aiReActScheduler) dispatchDue() {
 	}
 }
 
-func (m *aiReActScheduler) advanceSchedule(schedule *schema.AIReActSchedule, occurrence, now time.Time) (bool, error) {
+func (m *Scheduler) advanceSchedule(schedule *schema.AIReActSchedule, occurrence, now time.Time) (bool, error) {
 	rule, err := aischedule.Parse(schedule.RRule, schedule.Timezone, schedule.StartAt)
 	if err != nil {
 		result := m.db.Model(&schema.AIReActSchedule{}).Where("uuid = ? AND status = ?", schedule.UUID, schema.AIReActScheduleStatusActive).Updates(map[string]any{
@@ -255,11 +220,11 @@ func (m *aiReActScheduler) advanceSchedule(schedule *schema.AIReActSchedule, occ
 	return result.RowsAffected > 0, result.Error
 }
 
-func (m *aiReActScheduler) enqueue(schedule *schema.AIReActSchedule, scheduledAt time.Time, trigger string) error {
+func (m *Scheduler) Enqueue(schedule *schema.AIReActSchedule, scheduledAt time.Time, trigger string) error {
 	if schedule == nil {
 		return utils.Error("schedule is nil")
 	}
-	if trigger == aiReActScheduleTriggerSchedule {
+	if trigger == TriggerSchedule {
 		latest, err := aischedule.GetRecord(m.db, schedule.UUID)
 		if err != nil {
 			return err
@@ -289,7 +254,7 @@ func (m *aiReActScheduler) enqueue(schedule *schema.AIReActSchedule, scheduledAt
 		}
 	}
 	executionID := uuid.NewString()
-	sessionID := scheduleExecutionSessionID(schedule, executionID)
+	sessionID := ScheduleExecutionSessionID(schedule, executionID)
 	jobCtx, cancel := context.WithCancel(m.ctx)
 	job := &scheduledReActJob{
 		executionID:  executionID,
@@ -344,7 +309,7 @@ func (m *aiReActScheduler) enqueue(schedule *schema.AIReActSchedule, scheduledAt
 	// its Wait.
 	m.wg.Add(1)
 	m.jobsMu.Unlock()
-	if trigger == aiReActScheduleTriggerManual {
+	if trigger == TriggerManual {
 		if err := m.db.Model(&schema.AIReActSchedule{}).Where("uuid = ?", schedule.UUID).
 			UpdateColumn("last_run_at", scheduledAt.UTC()).Error; err != nil {
 			cancel()
@@ -357,7 +322,7 @@ func (m *aiReActScheduler) enqueue(schedule *schema.AIReActSchedule, scheduledAt
 	return nil
 }
 
-func (m *aiReActScheduler) unregisterJob(job *scheduledReActJob) {
+func (m *Scheduler) unregisterJob(job *scheduledReActJob) {
 	if job == nil {
 		return
 	}
@@ -385,7 +350,8 @@ func (m *aiReActScheduler) unregisterJob(job *scheduledReActJob) {
 	}
 }
 
-func (m *aiReActScheduler) cancelSchedule(scheduleUUID string) {
+func (m *Scheduler) CancelSchedule(scheduleUUID string) {
+	aischedule.CancelExecution(scheduleUUID)
 	m.jobsMu.Lock()
 	activeID := m.activeBySchedule[strings.TrimSpace(scheduleUUID)]
 	job := m.jobs[activeID]
@@ -395,6 +361,24 @@ func (m *aiReActScheduler) cancelSchedule(scheduleUUID string) {
 	}
 }
 
+func (m *Scheduler) ActiveExecution(scheduleUUID string) (ActiveExecution, bool) {
+	if m == nil {
+		return ActiveExecution{}, false
+	}
+	m.jobsMu.Lock()
+	defer m.jobsMu.Unlock()
+	activeID := m.activeBySchedule[strings.TrimSpace(scheduleUUID)]
+	job := m.jobs[activeID]
+	if job == nil {
+		return ActiveExecution{}, false
+	}
+	return ActiveExecution{
+		ExecutionID: job.executionID,
+		SessionID:   job.sessionID,
+		Done:        job.done,
+	}, true
+}
+
 type scheduledReActOutcome struct {
 	status       string
 	errorMessage string
@@ -402,7 +386,7 @@ type scheduledReActOutcome struct {
 	reactTaskID  string
 }
 
-func (m *aiReActScheduler) execute(job *scheduledReActJob) {
+func (m *Scheduler) execute(job *scheduledReActJob) {
 	defer m.wg.Done()
 	defer func() {
 		job.cancel()
@@ -410,7 +394,7 @@ func (m *aiReActScheduler) execute(job *scheduledReActJob) {
 		yakit.BroadcastAISessionChanged(yakit.AISessionPushActionFinished, job.sessionID)
 	}()
 
-	schedule, err := getAIReActScheduleRecord(m.db, job.scheduleUUID)
+	schedule, err := aischedule.GetRecord(m.db, job.scheduleUUID)
 	if err != nil {
 		log.Infof("scheduled AI ReAct execution %s ended before start: %v", job.executionID, err)
 		return
@@ -425,13 +409,13 @@ func (m *aiReActScheduler) execute(job *scheduledReActJob) {
 	}).Error
 	maxRuntime := schedule.MaxRuntimeSeconds
 	if maxRuntime <= 0 {
-		maxRuntime = defaultAIReActScheduleRuntime
+		maxRuntime = aischedule.DefaultMaxRuntime
 	}
 	runCtx, runCancel := context.WithTimeout(job.ctx, time.Duration(maxRuntime)*time.Second)
 	defer runCancel()
 	sessionID := job.sessionID
 	if sessionID == "" {
-		sessionID = scheduleExecutionSessionID(schedule, job.executionID)
+		sessionID = ScheduleExecutionSessionID(schedule, job.executionID)
 	}
 
 	outcome := m.runReAct(runCtx, schedule, job, sessionID)
@@ -456,14 +440,14 @@ func isolatedScheduleSessionID(executionID string) string {
 	return "ai-schedule-" + strings.TrimSpace(executionID)
 }
 
-func scheduleExecutionSessionID(schedule *schema.AIReActSchedule, executionID string) string {
+func ScheduleExecutionSessionID(schedule *schema.AIReActSchedule, executionID string) string {
 	if schedule != nil && schedule.TargetMode == schema.AIReActScheduleTargetContinueSession {
 		return strings.TrimSpace(schedule.TargetSessionID)
 	}
 	return isolatedScheduleSessionID(executionID)
 }
 
-func (m *aiReActScheduler) finishScheduleExecution(scheduleUUID string, outcome scheduledReActOutcome) {
+func (m *Scheduler) finishScheduleExecution(scheduleUUID string, outcome scheduledReActOutcome) {
 	if strings.TrimSpace(scheduleUUID) == "" {
 		return
 	}
@@ -482,7 +466,7 @@ func (m *aiReActScheduler) finishScheduleExecution(scheduleUUID string, outcome 
 	}
 }
 
-func (m *aiReActScheduler) recordScheduleSkipped(scheduleUUID, reason, message string) {
+func (m *Scheduler) recordScheduleSkipped(scheduleUUID, reason, message string) {
 	if m == nil || m.db == nil || strings.TrimSpace(scheduleUUID) == "" {
 		return
 	}
@@ -498,8 +482,8 @@ func (m *aiReActScheduler) recordScheduleSkipped(scheduleUUID, reason, message s
 	}
 }
 
-func scheduleRunStartParams(db *gorm.DB, schedule *schema.AIReActSchedule, captured *ypb.AIStartParams) (*ypb.AIStartParams, error) {
-	params, err := normalizeScheduleStartParams(captured)
+func ScheduleRunStartParams(db *gorm.DB, schedule *schema.AIReActSchedule, captured *ypb.AIStartParams) (*ypb.AIStartParams, error) {
+	params, err := aischedule.NormalizeStartParams(captured)
 	if err != nil {
 		return nil, err
 	}
@@ -525,13 +509,13 @@ func scheduleRunStartParams(db *gorm.DB, schedule *schema.AIReActSchedule, captu
 	return params, nil
 }
 
-// prepareIsolatedScheduleSession makes a new-session-per-run execution visible
+// PrepareIsolatedScheduleSession makes a new-session-per-run execution visible
 // to history queries before the ReAct loop starts producing output. Interactive
 // sessions are announced optimistically by the renderer; scheduled sessions
 // persist the same durable row and then push an invalidation to the renderer.
 // Use the schedule name as the stable title instead of waiting for asynchronous
 // title generation near the end of the run.
-func prepareIsolatedScheduleSession(
+func PrepareIsolatedScheduleSession(
 	db *gorm.DB,
 	schedule *schema.AIReActSchedule,
 	params *ypb.AIStartParams,
@@ -554,22 +538,22 @@ func prepareIsolatedScheduleSession(
 	return nil
 }
 
-func (m *aiReActScheduler) runReAct(
+func (m *Scheduler) runReAct(
 	ctx context.Context,
 	schedule *schema.AIReActSchedule,
 	job *scheduledReActJob,
 	sessionID string,
 ) scheduledReActOutcome {
-	payload, err := unmarshalSchedulePayload(schedule)
+	payload, err := aischedule.UnmarshalPayload(schedule)
 	if err != nil {
 		return scheduledReActOutcome{status: scheduledOutcomeFailed, errorMessage: err.Error()}
 	}
-	params, err := scheduleRunStartParams(m.db, schedule, payload.GetStartParams())
+	params, err := ScheduleRunStartParams(m.db, schedule, payload.GetStartParams())
 	if err != nil {
 		return scheduledReActOutcome{status: scheduledOutcomeFailed, errorMessage: err.Error()}
 	}
 	params.TimelineSessionID = sessionID
-	if err := prepareIsolatedScheduleSession(m.db, schedule, params, sessionID, time.Now()); err != nil {
+	if err := PrepareIsolatedScheduleSession(m.db, schedule, params, sessionID, time.Now()); err != nil {
 		// Keep the execution semantics consistent with interactive ReAct startup:
 		// metadata persistence failure is observable in logs but does not suppress
 		// the actual task.
@@ -668,7 +652,7 @@ func (m *aiReActScheduler) runReAct(
 		&ypb.AttachedResourceInfo{Type: aicommon.USER_INPUT_SCHEDULE_CONTEXT, Key: aicommon.USER_INPUT_SCHEDULED_AT, Value: job.scheduledAt.Format(time.RFC3339)},
 		&ypb.AttachedResourceInfo{Type: aicommon.USER_INPUT_SCHEDULE_CONTEXT, Key: aicommon.USER_INPUT_SCHEDULE_TRIGGER, Value: job.trigger},
 	)
-	connection, err := m.runtime.Connect(ctx, ConnectRequest{
+	connection, err := m.runtime.Connect(ctx, sessionruntime.ConnectRequest{
 		StartParams: params,
 		Reservation: job.reservation,
 	}, onOutput)

--- a/common/ai/aid/aireactscheduler/scheduler_test.go
+++ b/common/ai/aid/aireactscheduler/scheduler_test.go
@@ -1,0 +1,231 @@
+package aireactscheduler
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
+	"github.com/yaklang/yaklang/common/ai/aid/aischedule"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func newSchedulerTest(t *testing.T) (*Scheduler, sessionruntime.ReActSessionRuntime, *gorm.DB) {
+	t.Helper()
+	db, err := consts.CreateProjectDatabase(filepath.Join(t.TempDir(), "schedule.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.AIReActSchedule{}, &schema.AISession{}).Error)
+	runtime := sessionruntime.New(func() *gorm.DB { return db })
+	scheduler := NewScheduler(runtime, db)
+	t.Cleanup(func() {
+		scheduler.Stop()
+		require.NoError(t, db.Close())
+	})
+	return scheduler, runtime, db
+}
+
+func TestSchedulerConcurrentStartAndStop(t *testing.T) {
+	scheduler := NewScheduler(sessionruntime.New(nil), nil)
+	var callers sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		callers.Add(2)
+		go func() {
+			defer callers.Done()
+			scheduler.Start()
+		}()
+		go func() {
+			defer callers.Done()
+			scheduler.Stop()
+		}()
+	}
+	callers.Wait()
+	scheduler.Stop()
+	require.ErrorIs(t, scheduler.ctx.Err(), context.Canceled)
+}
+
+func TestAIReActSchedulerSkipsMisfireAndAdvances(t *testing.T) {
+	manager, _, db := newSchedulerTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	due := now.Add(-10 * time.Minute)
+	schedule := &schema.AIReActSchedule{
+		UUID:                  "misfire-schedule",
+		Name:                  "misfire",
+		Status:                schema.AIReActScheduleStatusActive,
+		TargetMode:            schema.AIReActScheduleTargetNewSession,
+		Prompt:                "test",
+		StartParams:           `{}`,
+		AttachedResourceInfos: `[]`,
+		RRule:                 "RRULE:FREQ=HOURLY;INTERVAL=1",
+		Timezone:              "UTC",
+		StartAt:               now.Add(-time.Hour),
+		NextRunAt:             &due,
+		MisfireGraceSeconds:   1,
+		MaxRuntimeSeconds:     60,
+	}
+	require.NoError(t, db.Create(schedule).Error)
+	manager.dispatchDue()
+
+	manager.jobsMu.Lock()
+	require.Empty(t, manager.jobs)
+	require.Empty(t, manager.activeBySchedule)
+	manager.jobsMu.Unlock()
+
+	updated, err := aischedule.GetRecord(db, schedule.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.NextRunAt)
+	require.True(t, updated.NextRunAt.After(now))
+	require.Equal(t, scheduledOutcomeSkipped, updated.LastOutcome)
+	require.Equal(t, "misfire", updated.LastSkipReason)
+}
+
+func TestAIReActSchedulerSkipsAtTriggerBoundary(t *testing.T) {
+	manager, runtime, db := newSchedulerTest(t)
+	const sessionID = "starting-user-session"
+	_, err := yakit.CreateOrUpdateAISessionMetaStartParams(db, sessionID, &ypb.AIStartParams{})
+	require.NoError(t, err)
+	reservation, err := runtime.ReserveSession(context.Background(), sessionID, "frontend-start")
+	require.NoError(t, err)
+	defer reservation.Release()
+
+	schedule := &schema.AIReActSchedule{
+		UUID: "busy-boundary", TargetMode: schema.AIReActScheduleTargetContinueSession, TargetSessionID: sessionID,
+		Status: schema.AIReActScheduleStatusActive,
+	}
+	require.NoError(t, db.Create(schedule).Error)
+	err = manager.Enqueue(schedule, time.Now(), TriggerSchedule)
+	var skip *scheduleEnqueueError
+	require.ErrorAs(t, err, &skip)
+	require.Equal(t, "session_busy", skip.reason)
+	require.Empty(t, manager.jobs)
+}
+
+func TestAIReActSchedulerUsesBoundedParallelCapacity(t *testing.T) {
+	manager, _, db := newSchedulerTest(t)
+	for i := 0; i < aiReActScheduleMaxConcurrent; i++ {
+		manager.worker <- struct{}{}
+	}
+	schedule := &schema.AIReActSchedule{
+		UUID: "over-capacity", TargetMode: schema.AIReActScheduleTargetNewSession,
+		Status: schema.AIReActScheduleStatusActive,
+	}
+	require.NoError(t, db.Create(schedule).Error)
+	err := manager.Enqueue(schedule, time.Now(), TriggerSchedule)
+	var skip *scheduleEnqueueError
+	require.ErrorAs(t, err, &skip)
+	require.Equal(t, "scheduler_capacity", skip.reason)
+}
+
+func TestAIReActSchedulerRejectsEnqueueAfterStop(t *testing.T) {
+	manager, _, db := newSchedulerTest(t)
+	manager.cancel()
+
+	schedule, err := aischedule.BuildRecord(&ypb.AIReActSchedule{
+		Name:       "stopped",
+		Status:     schema.AIReActScheduleStatusActive,
+		TargetMode: schema.AIReActScheduleTargetNewSession,
+		Payload: &ypb.AIReActSchedulePayload{
+			Prompt:      "test",
+			StartParams: &ypb.AIStartParams{UseDefaultAIConfig: true},
+		},
+		Schedule: &ypb.AIReActScheduleSpec{
+			RRule:    "RRULE:FREQ=DAILY;INTERVAL=1",
+			Timezone: "UTC",
+			StartAt:  time.Now().Add(time.Hour).Unix(),
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(schedule).Error)
+	err = manager.Enqueue(schedule, time.Now(), TriggerSchedule)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, manager.jobs)
+	require.Empty(t, manager.activeBySchedule)
+	require.Empty(t, manager.worker)
+}
+
+func TestScheduledReActRuntimeErrorPreservesContextClassification(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	outcome := scheduledReActRuntimeError(ctx, context.Canceled)
+	require.Empty(t, outcome.status)
+	require.Empty(t, outcome.errorMessage)
+
+	outcome = scheduledReActRuntimeError(context.Background(), context.Canceled)
+	require.Equal(t, scheduledOutcomeFailed, outcome.status)
+	require.ErrorContains(t, context.Canceled, outcome.errorMessage)
+}
+
+func TestAIReActSchedulerCancelsActiveExecutionInMemory(t *testing.T) {
+	manager, runtime, _ := newSchedulerTest(t)
+	jobCtx, cancel := context.WithCancel(manager.ctx)
+	reservation, err := runtime.ReserveSession(jobCtx, "ai-schedule-active-execution", "active-execution")
+	require.NoError(t, err)
+	job := &scheduledReActJob{
+		executionID:  "active-execution",
+		scheduleUUID: "schedule",
+		sessionID:    "ai-schedule-active-execution",
+		ctx:          reservation.Context(),
+		cancel:       cancel,
+		reservation:  reservation,
+		done:         make(chan struct{}),
+	}
+	manager.jobs[job.executionID] = job
+	manager.activeBySchedule[job.scheduleUUID] = job.executionID
+	require.True(t, runtime.IsSessionBusy(job.sessionID))
+
+	manager.CancelSchedule(job.scheduleUUID)
+	require.Eventually(t, func() bool { return job.ctx.Err() == context.Canceled }, time.Second, 10*time.Millisecond)
+	manager.unregisterJob(job)
+	require.Empty(t, manager.jobs)
+	require.Empty(t, manager.activeBySchedule)
+	require.False(t, runtime.IsSessionBusy(job.sessionID))
+}
+
+func TestScheduleAttentionWaitsForActualAIEscalation(t *testing.T) {
+	pending := make(map[string]struct{})
+	reviewRequest := &ypb.AIOutputEvent{
+		Type:    string(schema.EVENT_TYPE_TOOL_USE_REVIEW_REQUIRE),
+		Content: json.RawMessage(`{"id":"review-1"}`),
+	}
+	attention, _ := scheduleAttentionForEvent(reviewRequest, true, pending)
+	require.False(t, attention, "starting AI review must not pause a scheduled run")
+	require.Contains(t, pending, "review-1")
+
+	autoApproved := &ypb.AIOutputEvent{
+		Type:    string(schema.EVENT_TYPE_AI_REVIEW_END),
+		Content: json.RawMessage(`{"interactive_id":"review-1","level":"low","requires_user":false}`),
+	}
+	attention, _ = scheduleAttentionForEvent(autoApproved, true, pending)
+	require.False(t, attention, "low-risk AI review should continue unattended")
+	require.NotContains(t, pending, "review-1")
+
+	attention, _ = scheduleAttentionForEvent(&ypb.AIOutputEvent{
+		Type:    string(schema.EVENT_TYPE_PLAN_REVIEW_REQUIRE),
+		Content: json.RawMessage(`{"id":"review-2"}`),
+	}, true, pending)
+	require.False(t, attention)
+
+	attention, message := scheduleAttentionForEvent(&ypb.AIOutputEvent{
+		Type: string(schema.EVENT_TYPE_AI_REVIEW_END),
+		Content: json.RawMessage(
+			`{"interactive_id":"review-2","level":"high","requires_user":true,"reason":"dangerous operation"}`,
+		),
+	}, true, pending)
+	require.True(t, attention, "only an explicit high-risk escalation should need the user")
+	require.Contains(t, message, "dangerous operation")
+}
+
+func TestScheduleAttentionForExplicitUserInteraction(t *testing.T) {
+	attention, message := scheduleAttentionForEvent(&ypb.AIOutputEvent{
+		Type: string(schema.EVENT_TYPE_REQUIRE_USER_INTERACTIVE),
+	}, true, make(map[string]struct{}))
+	require.True(t, attention)
+	require.Contains(t, message, "user interaction")
+}

--- a/common/ai/aid/reactservice/default.go
+++ b/common/ai/aid/reactservice/default.go
@@ -1,0 +1,11 @@
+package reactservice
+
+import "github.com/yaklang/yaklang/common/consts"
+
+var defaultService = New(consts.GetGormProjectDatabase)
+
+// Default returns the process-wide ReAct service used by the normal Yak engine.
+// Explicitly configured embedded/test servers may inject an isolated Service.
+func Default() *Service {
+	return defaultService
+}

--- a/common/ai/aid/reactservice/service.go
+++ b/common/ai/aid/reactservice/service.go
@@ -1,0 +1,227 @@
+package reactservice
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
+	"github.com/yaklang/yaklang/common/ai/aid/aireactscheduler"
+	"github.com/yaklang/yaklang/common/ai/aid/aischedule"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// Service owns the process-level ReAct entry point and the scheduler for the
+// currently bound project. Transports are adapters: they may retain a Service
+// reference, but they do not own Session Runtime or Scheduler lifecycle.
+//
+// A project switch retires the current scope before BindProject installs a new
+// one. The retired Runtime remains quiesced so stale references cannot create a
+// ReAct against the old project database.
+type Service struct {
+	// lifecycleMu serializes project-scope transitions. In particular, a
+	// concurrent StartScheduler cannot recreate the old project's scheduler in
+	// the gap between stopping it and quiescing its Runtime.
+	lifecycleMu sync.Mutex
+	mu          sync.Mutex
+
+	projectDB      func() *gorm.DB
+	runtime        sessionruntime.ReActSessionRuntime
+	runtimeRetired bool
+	scheduler      *aireactscheduler.Scheduler
+}
+
+type Option func(*Service)
+
+// WithRuntime injects a Session Runtime. It is intended for embedding and
+// deterministic tests; production normally lets Service create the Runtime.
+func WithRuntime(runtime sessionruntime.ReActSessionRuntime) Option {
+	return func(service *Service) {
+		service.runtime = runtime
+	}
+}
+
+func New(projectDB func() *gorm.DB, options ...Option) *Service {
+	service := &Service{projectDB: projectDB}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	return service
+}
+
+func (s *Service) runtimeLocked() sessionruntime.ReActSessionRuntime {
+	if s.runtime == nil {
+		s.runtime = sessionruntime.New(s.projectDB)
+		s.runtimeRetired = false
+	}
+	return s.runtime
+}
+
+func (s *Service) Runtime() sessionruntime.ReActSessionRuntime {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.runtimeLocked()
+}
+
+// StartScheduler starts the scheduler for the current project scope. Calls are
+// idempotent until StopScheduler or RetireCurrentProject detaches that scope.
+func (s *Service) StartScheduler() {
+	if s == nil {
+		return
+	}
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.mu.Lock()
+	if s.scheduler != nil {
+		s.mu.Unlock()
+		return
+	}
+	if s.runtimeRetired {
+		s.mu.Unlock()
+		return
+	}
+	runtime := s.runtimeLocked()
+	db := s.projectDB
+	var projectDB *gorm.DB
+	if db != nil {
+		projectDB = db()
+	}
+	scheduler := aireactscheduler.NewScheduler(runtime, projectDB)
+	s.scheduler = scheduler
+	s.mu.Unlock()
+	scheduler.Start()
+}
+
+// StopScheduler prevents new scheduled work and waits for in-memory executions
+// to finish their cancellation and cleanup.
+func (s *Service) StopScheduler() {
+	if s == nil {
+		return
+	}
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.stopSchedulerLocked()
+}
+
+// stopSchedulerLocked requires lifecycleMu and may wait for active executions.
+func (s *Service) stopSchedulerLocked() {
+	s.mu.Lock()
+	scheduler := s.scheduler
+	s.scheduler = nil
+	s.mu.Unlock()
+	if scheduler != nil {
+		scheduler.Stop()
+	}
+}
+
+func (s *Service) WakeScheduler() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	scheduler := s.scheduler
+	s.mu.Unlock()
+	if scheduler != nil {
+		scheduler.Notify()
+	}
+}
+
+func (s *Service) EnqueueSchedule(schedule *schema.AIReActSchedule, scheduledAt time.Time, trigger string) error {
+	if s == nil {
+		return utils.Error("AI ReAct service is not configured")
+	}
+	s.mu.Lock()
+	scheduler := s.scheduler
+	s.mu.Unlock()
+	if scheduler == nil {
+		return utils.Error("AI ReAct scheduler is not running")
+	}
+	return scheduler.Enqueue(schedule, scheduledAt, trigger)
+}
+
+func (s *Service) CancelSchedule(scheduleUUID string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	scheduler := s.scheduler
+	s.mu.Unlock()
+	if scheduler != nil {
+		scheduler.CancelSchedule(scheduleUUID)
+		return
+	}
+	aischedule.CancelExecution(scheduleUUID)
+}
+
+func (s *Service) ActiveExecution(scheduleUUID string) (aireactscheduler.ActiveExecution, bool) {
+	if s == nil {
+		return aireactscheduler.ActiveExecution{}, false
+	}
+	s.mu.Lock()
+	scheduler := s.scheduler
+	s.mu.Unlock()
+	if scheduler == nil {
+		return aireactscheduler.ActiveExecution{}, false
+	}
+	return scheduler.ActiveExecution(scheduleUUID)
+}
+
+// RetireCurrentProject stops scheduling, permanently quiesces the active
+// Runtime, and keeps that Runtime installed until BindProject closes the
+// project-switch window.
+func (s *Service) RetireCurrentProject(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.stopSchedulerLocked()
+	s.mu.Lock()
+	if s.runtimeRetired {
+		s.mu.Unlock()
+		return nil
+	}
+	runtime := s.runtimeLocked()
+	s.mu.Unlock()
+
+	// Intentionally keep the returned guard: stale holders of this runtime must
+	// continue to reject reservations and connections.
+	if _, err := runtime.QuiesceAll(ctx); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	if s.runtime == runtime {
+		s.runtimeRetired = true
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// BindProject installs a fresh project scope after the caller has switched the
+// durable database binding. It does not start the Scheduler automatically.
+func (s *Service) BindProject(projectDB func() *gorm.DB) {
+	if s == nil {
+		return
+	}
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.stopSchedulerLocked()
+	s.mu.Lock()
+	s.projectDB = projectDB
+	s.runtime = nil
+	s.runtimeRetired = false
+	s.mu.Unlock()
+}
+
+// Stop shuts down all project-scoped background execution owned by the service.
+func (s *Service) Stop(ctx context.Context) error {
+	return s.RetireCurrentProject(ctx)
+}

--- a/common/ai/aid/reactservice/service_test.go
+++ b/common/ai/aid/reactservice/service_test.go
@@ -1,0 +1,83 @@
+package reactservice
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultServiceIsProcessWide(t *testing.T) {
+	require.Same(t, Default(), Default())
+}
+
+func TestRetireKeepsOldRuntimeQuiescedUntilProjectBind(t *testing.T) {
+	service := New(nil)
+	oldRuntime := service.Runtime()
+	reservation, err := oldRuntime.ReserveSession(context.Background(), "old-project-session", "old-execution")
+	require.NoError(t, err)
+
+	retired := make(chan error, 1)
+	go func() { retired <- service.RetireCurrentProject(context.Background()) }()
+	select {
+	case <-reservation.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("retiring the project service did not cancel its reservation")
+	}
+	reservation.Release()
+	select {
+	case err := <-retired:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("project service retirement did not finish")
+	}
+
+	_, err = oldRuntime.ReserveSession(context.Background(), "stale-session", "stale-execution")
+	require.Error(t, err, "a retired runtime must stay permanently quiesced")
+	require.Equal(t, oldRuntime, service.Runtime(), "the retired runtime must cover the project-switch window")
+
+	service.BindProject(nil)
+	newRuntime := service.Runtime()
+	require.NotEqual(t, oldRuntime, newRuntime)
+	newReservation, err := newRuntime.ReserveSession(context.Background(), "new-project-session", "new-execution")
+	require.NoError(t, err)
+	newReservation.Release()
+}
+
+func TestRetireSerializesConcurrentSchedulerStart(t *testing.T) {
+	service := New(nil)
+	service.StartScheduler()
+	reservation, err := service.Runtime().ReserveSession(context.Background(), "retiring-session", "retiring-owner")
+	require.NoError(t, err)
+
+	retired := make(chan error, 1)
+	go func() { retired <- service.RetireCurrentProject(context.Background()) }()
+	select {
+	case <-reservation.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("project retirement did not reach runtime quiescence")
+	}
+
+	startReturned := make(chan struct{})
+	go func() {
+		service.StartScheduler()
+		close(startReturned)
+	}()
+	select {
+	case <-startReturned:
+		t.Fatal("scheduler start crossed an in-progress project retirement")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	reservation.Release()
+	require.NoError(t, <-retired)
+	select {
+	case <-startReturned:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler start remained blocked after project retirement")
+	}
+	service.mu.Lock()
+	require.Nil(t, service.scheduler, "a retired project must not acquire a new scheduler")
+	service.mu.Unlock()
+}

--- a/common/yak/cmd/yak.go
+++ b/common/yak/cmd/yak.go
@@ -42,6 +42,7 @@ import (
 	systemLog "log"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/yaklang/yaklang/common/ai/aid/reactservice"
 	"github.com/yaklang/yaklang/common/consts"
 	_ "github.com/yaklang/yaklang/common/coreplugin"
 	"github.com/yaklang/yaklang/common/cybertunnel"
@@ -971,8 +972,11 @@ var startGRPCServerCommand = cli.Command{
 				}
 			}()
 		}
-		s.StartAIReActScheduler()
-		defer s.StopAIReActScheduler()
+		// Scheduled ReAct is an engine-process service. The gRPC Server below is
+		// only one adapter to it and does not own its lifecycle.
+		reActService := reactservice.Default()
+		reActService.StartScheduler()
+		defer reActService.StopScheduler()
 
 		actualAddress := lis.Addr().String()
 		instanceId := utils.RandStringBytes(8)

--- a/common/yakgrpc/ai_react_runtime.go
+++ b/common/yakgrpc/ai_react_runtime.go
@@ -1,0 +1,1131 @@
+package yakgrpc
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon/aiconfig"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops/reactloops_yak"
+	"github.com/yaklang/yaklang/common/ai/rag"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/chanx"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+const (
+	reActSessionAttachTimeout = time.Minute
+	reActSessionStopTimeout   = 10 * time.Second
+)
+
+// ReActSessionRuntime is the process-local, transport-independent entry point
+// for a persistent ReAct session. Its payloads intentionally remain the
+// existing protobuf DTOs for now; the boundary removes the gRPC stream
+// dependency without changing ReAct's public input model at the same time.
+type ReActSessionRuntime interface {
+	ReserveSession(ctx context.Context, sessionID, ownerID string) (SessionReservation, error)
+	Connect(ctx context.Context, req ConnectRequest, onEvent ReActEventHandler) (ReActConnection, error)
+	IsSessionBusy(sessionID string) bool
+	QuiesceSessions(ctx context.Context, sessionIDs []string) (SessionQuiescence, error)
+	QuiesceAll(ctx context.Context) (SessionQuiescence, error)
+}
+
+// ReActEventHandler reports a subscriber-local delivery failure. Normal ReAct
+// output remains best-effort and never fails the shared runtime because one
+// subscriber is gone; synchronous connection responses may return this error to
+// the caller so they cannot report success after the response was lost.
+type ReActEventHandler func(*schema.AiOutputEvent) error
+
+type ConnectRequest struct {
+	StartParams *ypb.AIStartParams
+	Reservation SessionReservation
+	options     *reActConnectOptions
+}
+
+type reActConnectOptions struct {
+	loadBuiltinTools bool
+	configOptions    []aicommon.ConfigOption
+	onEventError     func(error)
+}
+
+// SessionReservation is an execution lease, not merely a creation lock. A
+// scheduler holds it from the trigger boundary until its job has completely
+// finalized and unregistered. This lets session deletion cancel the owner and
+// wait for the scheduled task's deferred persistence and cleanup to finish.
+type SessionReservation interface {
+	Context() context.Context
+	SessionID() string
+	OwnerID() string
+	Release()
+	runtimeReservation() *sessionReservation
+}
+
+type ReActConnection interface {
+	Send(*ypb.AIInputEvent) error
+	Close() error
+	Done() <-chan struct{}
+	CreatedRuntime() bool
+}
+
+// SessionQuiescence keeps one or more sessions closed to new reservations,
+// connections and inputs while their durable data is being removed.
+type SessionQuiescence interface {
+	Release()
+}
+
+type reActSessionRuntime struct {
+	projectDB func() *gorm.DB
+	newReAct  func(...aicommon.ConfigOption) (*aireact.ReAct, error)
+
+	mu           sync.Mutex
+	entries      map[string]*reActSessionState
+	changed      chan struct{}
+	allQuiescing bool
+}
+
+type reActSessionState struct {
+	reservation   *sessionReservation
+	starting      *reActSessionStart
+	runtime       *ownedReActRuntime
+	admitting     int
+	taskAdmitting int
+	quiescing     bool
+}
+
+// reActSessionBusyReason explains why a session cannot currently be treated as
+// idle. "Busy" is intentionally broader than "an AI task is running": session
+// creation, scheduler ownership, input admission and shutdown are all boundary
+// states in which starting another scheduled task would be unsafe.
+type reActSessionBusyReason uint8
+
+const (
+	reActSessionAvailable reActSessionBusyReason = iota
+	// Runtime/session shutdown barriers reject every new operation until their
+	// quiescence guard is released.
+	reActSessionBusyRuntimeQuiescing
+	reActSessionBusySessionQuiescing
+	// Ownership and creation states reserve the next task or ReAct instance even
+	// though no task may be visible in aireact yet.
+	reActSessionBusyReserved
+	reActSessionBusyStarting
+	// Boundary states close the gaps before task-queue publication and after
+	// running-session unregistration.
+	reActSessionBusyTaskAdmitting
+	reActSessionBusyRuntimeTransition
+	// The ReAct layer reports a process-wide start, queued task or running task.
+	reActSessionBusyReAct
+)
+
+type reActSessionStart struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	done     chan struct{}
+	doneOnce sync.Once
+}
+
+func (s *reActSessionStart) finish() {
+	if s != nil {
+		s.doneOnce.Do(func() { close(s.done) })
+	}
+}
+
+type ownedReActRuntime struct {
+	sessionID string
+	react     *aireact.ReAct
+	cancel    context.CancelFunc
+	done      chan struct{}
+}
+
+type sessionReservation struct {
+	runtime   *reActSessionRuntime
+	sessionID string
+	ownerID   string
+	ctx       context.Context
+	cancel    context.CancelFunc
+	done      chan struct{}
+	once      sync.Once
+}
+
+func (r *sessionReservation) Context() context.Context { return r.ctx }
+func (r *sessionReservation) SessionID() string        { return r.sessionID }
+func (r *sessionReservation) OwnerID() string          { return r.ownerID }
+func (r *sessionReservation) runtimeReservation() *sessionReservation {
+	return r
+}
+func (r *sessionReservation) Release() {
+	if r == nil {
+		return
+	}
+	r.once.Do(func() {
+		r.cancel()
+		r.runtime.releaseReservation(r)
+		close(r.done)
+	})
+}
+
+type reActSessionQuiescence struct {
+	runtime *reActSessionRuntime
+	ids     []string
+	all     bool
+	once    sync.Once
+}
+
+func (g *reActSessionQuiescence) Release() {
+	if g == nil || g.runtime == nil {
+		return
+	}
+	g.once.Do(func() { g.runtime.releaseQuiescence(g.ids, g.all) })
+}
+
+func newReActSessionRuntime(projectDB func() *gorm.DB) *reActSessionRuntime {
+	return &reActSessionRuntime{
+		projectDB: projectDB,
+		newReAct:  aireact.NewReAct,
+		entries:   make(map[string]*reActSessionState),
+		changed:   make(chan struct{}),
+	}
+}
+
+func (s *Server) getReActSessionRuntime() ReActSessionRuntime {
+	if s == nil {
+		return nil
+	}
+	s.reActRuntimeMu.Lock()
+	defer s.reActRuntimeMu.Unlock()
+	if s.reActRuntime == nil {
+		s.reActRuntime = newReActSessionRuntime(s.GetProjectDatabase)
+		s.reActRuntimeRetired = false
+	}
+	return s.reActRuntime
+}
+
+// retireReActSessionRuntime stops every session owned by the current runtime and
+// permanently quiesces that runtime before it is detached from the server. This
+// is used when the project database changes: a ReAct created for the old project
+// must never be attached through the new project context.
+func (s *Server) retireReActSessionRuntime(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.reActRuntimeMu.Lock()
+	if s.reActRuntimeRetired {
+		s.reActRuntimeMu.Unlock()
+		return nil
+	}
+	runtime := s.reActRuntime
+	if runtime == nil {
+		runtime = newReActSessionRuntime(s.GetProjectDatabase)
+		s.reActRuntime = runtime
+	}
+	s.reActRuntimeMu.Unlock()
+
+	// Intentionally keep the returned guard: stale holders of this runtime must
+	// continue to reject reservations and connections. The retired runtime also
+	// stays installed until the database switch completes, closing the gap where
+	// a concurrent caller could otherwise create against the old project DB.
+	if _, err := runtime.QuiesceAll(ctx); err != nil {
+		return err
+	}
+
+	s.reActRuntimeMu.Lock()
+	if s.reActRuntime == runtime {
+		s.reActRuntimeRetired = true
+	}
+	s.reActRuntimeMu.Unlock()
+	return nil
+}
+
+func (s *Server) resetReActSessionRuntimeAfterProjectSwitch() {
+	if s == nil {
+		return
+	}
+	s.reActRuntimeMu.Lock()
+	s.reActRuntime = nil
+	s.reActRuntimeRetired = false
+	s.reActRuntimeMu.Unlock()
+}
+
+func normalizeReActSessionID(sessionID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return "default"
+	}
+	return sessionID
+}
+
+func (r *reActSessionRuntime) entryLocked(sessionID string) *reActSessionState {
+	entry := r.entries[sessionID]
+	if entry == nil {
+		entry = &reActSessionState{}
+		r.entries[sessionID] = entry
+	}
+	return entry
+}
+
+func (r *reActSessionRuntime) notifyLocked() {
+	close(r.changed)
+	r.changed = make(chan struct{})
+}
+
+func (r *reActSessionRuntime) cleanupEntryLocked(sessionID string, entry *reActSessionState) {
+	if entry != nil && entry.reservation == nil && entry.starting == nil && entry.runtime == nil && entry.admitting == 0 && entry.taskAdmitting == 0 && !entry.quiescing {
+		delete(r.entries, sessionID)
+	}
+}
+
+// sessionCoordinationBusyReasonLocked reports Runtime-owned coordination state;
+// callers must hold r.mu. It deliberately does not inspect ReAct task state so
+// IsSessionBusy can release r.mu before taking locks owned by aireact.
+func (r *reActSessionRuntime) sessionCoordinationBusyReasonLocked(sessionID string, entry *reActSessionState) reActSessionBusyReason {
+	if r.allQuiescing {
+		return reActSessionBusyRuntimeQuiescing
+	}
+	if entry == nil {
+		return reActSessionAvailable
+	}
+	if entry.quiescing {
+		return reActSessionBusySessionQuiescing
+	}
+	if entry.reservation != nil {
+		return reActSessionBusyReserved
+	}
+	if entry.starting != nil {
+		return reActSessionBusyStarting
+	}
+	if entry.taskAdmitting > 0 {
+		return reActSessionBusyTaskAdmitting
+	}
+	if entry.runtime == nil {
+		return reActSessionAvailable
+	}
+
+	// The running-session registry is removed when the ReAct input loop exits,
+	// before the queue processor and deferred task cleanup necessarily finish.
+	// A missing or different registry entry therefore remains busy until the
+	// Runtime-owned lifecycle reaches owner.done and clears entry.runtime.
+	running, ok := aireact.GetRunningSession(sessionID)
+	if !ok || running != entry.runtime.react {
+		return reActSessionBusyRuntimeTransition
+	}
+	return reActSessionAvailable
+}
+
+func (r *reActSessionRuntime) sessionCoordinationBusyReason(sessionID string) reActSessionBusyReason {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sessionCoordinationBusyReasonLocked(sessionID, r.entries[sessionID])
+}
+
+func (r *reActSessionRuntime) sessionBusyReason(sessionID string) reActSessionBusyReason {
+	if reason := r.sessionCoordinationBusyReason(sessionID); reason != reActSessionAvailable {
+		return reason
+	}
+	// ReAct owns the actual task/queue state. Keep this check outside r.mu so a
+	// read-only status query does not nest Runtime and ReAct lifecycle locks.
+	if aireact.IsSessionBusy(sessionID) {
+		return reActSessionBusyReAct
+	}
+	return reActSessionAvailable
+}
+
+func (r *reActSessionRuntime) ReserveSession(ctx context.Context, sessionID, ownerID string) (SessionReservation, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sessionID = normalizeReActSessionID(sessionID)
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return nil, utils.Error("session reservation owner id is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.entryLocked(sessionID)
+	reason := r.sessionCoordinationBusyReasonLocked(sessionID, entry)
+	if reason == reActSessionBusyRuntimeQuiescing || reason == reActSessionBusySessionQuiescing {
+		return nil, utils.Errorf("AI ReAct session is stopping: %s", sessionID)
+	}
+	if reason != reActSessionAvailable || aireact.IsSessionBusy(sessionID) {
+		return nil, utils.Errorf("AI ReAct session is busy: %s", sessionID)
+	}
+	reservationCtx, cancel := context.WithCancel(ctx)
+	reservation := &sessionReservation{
+		runtime:   r,
+		sessionID: sessionID,
+		ownerID:   ownerID,
+		ctx:       reservationCtx,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+	entry.reservation = reservation
+	r.notifyLocked()
+	return reservation, nil
+}
+
+func (r *reActSessionRuntime) releaseReservation(reservation *sessionReservation) {
+	if reservation == nil {
+		return
+	}
+	r.mu.Lock()
+	entry := r.entries[reservation.sessionID]
+	if entry != nil && entry.reservation == reservation {
+		entry.reservation = nil
+		r.cleanupEntryLocked(reservation.sessionID, entry)
+		r.notifyLocked()
+	}
+	r.mu.Unlock()
+}
+
+func (r *reActSessionRuntime) validReservationLocked(entry *reActSessionState, reservation SessionReservation, sessionID string) (*sessionReservation, bool) {
+	if reservation == nil {
+		return nil, entry == nil || entry.reservation == nil
+	}
+	raw := reservation.runtimeReservation()
+	if raw == nil || raw.runtime != r || raw.sessionID != sessionID || entry == nil || entry.reservation != raw {
+		return nil, false
+	}
+	return raw, true
+}
+
+func (r *reActSessionRuntime) IsSessionBusy(sessionID string) bool {
+	sessionID = normalizeReActSessionID(sessionID)
+	return r.sessionBusyReason(sessionID) != reActSessionAvailable
+}
+
+func (r *reActSessionRuntime) Connect(ctx context.Context, req ConnectRequest, onEvent ReActEventHandler) (ReActConnection, error) {
+	loadBuiltinTools := true
+	var configOptions []aicommon.ConfigOption
+	if req.options != nil {
+		loadBuiltinTools = req.options.loadBuiltinTools
+		configOptions = req.options.configOptions
+	}
+	return r.connectWithOptions(ctx, req, onEvent, loadBuiltinTools, configOptions...)
+}
+
+func (r *reActSessionRuntime) connectWithOptions(
+	ctx context.Context,
+	req ConnectRequest,
+	onEvent ReActEventHandler,
+	loadBuiltinTools bool,
+	additionalOptions ...aicommon.ConfigOption,
+) (ReActConnection, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	startParams := req.StartParams
+	if startParams == nil {
+		startParams = &ypb.AIStartParams{}
+	}
+	sessionID := normalizeReActSessionID(startParams.GetTimelineSessionID())
+	var onEventError func(error)
+	if req.options != nil {
+		onEventError = req.options.onEventError
+	}
+
+	// 启动 ReAct 之前懒扫描用户的 ~/yakit-projects/ai-focus/，
+	// 防止客户端跳过 QueryAIFocus 直接发带 FocusModeLoop 的 free input 时
+	// 找不到注册项。冷却由 EnsureUserFocusModesLoaded 内部控制，失败只 log。
+	// 关键词: start ai re-act ensure user focus modes
+	if err := reactloops_yak.EnsureUserFocusModesLoaded(); err != nil {
+		log.Warnf("ensure user yak focus modes failed: %v", err)
+	}
+	delivery := newReActEventDelivery(ctx, onEvent, onEventError)
+
+	waitCtx := ctx
+	var cancelWait context.CancelFunc
+	if startParams.GetAttach() {
+		waitCtx, cancelWait = context.WithTimeout(ctx, reActSessionAttachTimeout)
+		defer cancelWait()
+	}
+
+	for {
+		if err := waitCtx.Err(); err != nil {
+			delivery.cancel()
+			if startParams.GetAttach() && err == context.DeadlineExceeded {
+				return nil, utils.Errorf("wait running aireact session timeout: %s", sessionID)
+			}
+			return nil, err
+		}
+
+		r.mu.Lock()
+		entry := r.entryLocked(sessionID)
+		if r.allQuiescing || entry.quiescing {
+			r.mu.Unlock()
+			delivery.cancel()
+			return nil, utils.Errorf("AI ReAct session is stopping: %s", sessionID)
+		}
+		reservation, reservationValid := r.validReservationLocked(entry, req.Reservation, sessionID)
+		if req.Reservation != nil && !reservationValid {
+			r.mu.Unlock()
+			delivery.cancel()
+			return nil, utils.Errorf("invalid or expired AI ReAct session reservation: %s", sessionID)
+		}
+
+		// Do not attach to the registry entry that NewReAct publishes midway
+		// through construction. Waiting for the start attempt makes the runtime
+		// handle and its cancellation ownership visible atomically.
+		if entry.starting == nil && !aireact.IsSessionStarting(sessionID) {
+			if runningReAct, ok := aireact.GetRunningSession(sessionID); ok {
+				owner := entry.runtime
+				if owner != nil && owner.react != runningReAct {
+					owner = nil
+				}
+				r.mu.Unlock()
+				return r.attachConnection(ctx, delivery, sessionID, startParams, runningReAct, owner, reservation)
+			}
+		}
+		// The compatibility registry is removed when the input loop exits, while
+		// owned runtime shutdown also waits for the queue processor and hot-patch
+		// loop. Do not create a replacement in that transition window.
+		if entry.runtime != nil {
+			changed := r.changed
+			r.mu.Unlock()
+			if err := waitForReActRuntimeChange(waitCtx, changed); err != nil {
+				delivery.cancel()
+				return nil, err
+			}
+			continue
+		}
+
+		// A scheduled run reserves its target session at the trigger boundary. A
+		// user turn arriving in the narrow interval before that run publishes its
+		// ReAct instance waits and attaches, so it cannot steal initialization and
+		// make the scheduled occurrence execute late behind it.
+		if entry.starting != nil || (entry.reservation != nil && reservation == nil) || startParams.GetAttach() {
+			changed := r.changed
+			r.mu.Unlock()
+			if err := waitForReActRuntimeChange(waitCtx, changed); err != nil {
+				delivery.cancel()
+				if startParams.GetAttach() && err == context.DeadlineExceeded {
+					return nil, utils.Errorf("wait running aireact session timeout: %s", sessionID)
+				}
+				return nil, err
+			}
+			continue
+		}
+
+		// This closes the small gap between the initial registry lookup and
+		// NewReAct publishing its running session. Exactly one connection may
+		// initialize a persistent session; racing connections wait and attach to
+		// that instance.
+		releaseGlobalStart, ownsGlobalStart := aireact.TryBeginSessionStart(sessionID)
+		if !ownsGlobalStart {
+			changed := r.changed
+			r.mu.Unlock()
+			if err := waitForReActRuntimeChange(waitCtx, changed); err != nil {
+				delivery.cancel()
+				return nil, err
+			}
+			continue
+		}
+		startCtx, startCancel := context.WithCancel(ctx)
+		start := &reActSessionStart{ctx: startCtx, cancel: startCancel, done: make(chan struct{})}
+		entry.starting = start
+		r.notifyLocked()
+		r.mu.Unlock()
+
+		owner, err := func() (*ownedReActRuntime, error) {
+			defer releaseGlobalStart()
+			return r.createRuntime(start, delivery, sessionID, startParams, loadBuiltinTools, additionalOptions...)
+		}()
+		if err != nil {
+			startCancel()
+			r.finishStart(sessionID, start, nil)
+			delivery.cancel()
+			return nil, err
+		}
+		if err := r.publishRuntime(sessionID, start, owner); err != nil {
+			delivery.cancel()
+			return nil, err
+		}
+		return newReActConnection(r, ctx, delivery, sessionID, owner.react, owner, reservation, true, nil), nil
+	}
+}
+
+func waitForReActRuntimeChange(ctx context.Context, changed <-chan struct{}) error {
+	// The short fallback tick also observes legacy/programmatic ReAct sessions
+	// that still publish only through aireact's compatibility registry.
+	timer := time.NewTimer(50 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-changed:
+		return nil
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (r *reActSessionRuntime) projectDatabase() *gorm.DB {
+	if r == nil || r.projectDB == nil {
+		return nil
+	}
+	return r.projectDB()
+}
+
+func (r *reActSessionRuntime) createRuntime(
+	start *reActSessionStart,
+	delivery *reActEventDelivery,
+	sessionID string,
+	startParams *ypb.AIStartParams,
+	loadBuiltinTools bool,
+	additionalOptions ...aicommon.ConfigOption,
+) (*ownedReActRuntime, error) {
+	resolvedStartParams, err := resolveAISessionStartParams(
+		r.projectDatabase(),
+		sessionID,
+		startParams,
+		startParams.GetPreferSessionCachedConfig(),
+	)
+	if err != nil {
+		return nil, utils.Errorf("resolve session cached config failed: %v", err)
+	}
+	if _, err := yakit.CreateOrUpdateAISessionMetaOnStart(r.projectDatabase(), sessionID, resolvedStartParams, time.Now()); err != nil {
+		log.Warnf("persist ai session start meta failed for %s: %v", sessionID, err)
+	}
+
+	inputEvent := chanx.NewUnlimitedChan[*ypb.AIInputEvent](start.ctx, 10)
+	hotpatchChan := chanx.NewUnlimitedChan[aicommon.ConfigOption](start.ctx, 10)
+	if aiconfig.IsTieredAIConfig() {
+		log.Info("tiered ai config is enabled. the old-styled ai config is override")
+	}
+	defaultAI, err := aicommon.GetDefaultAIModelCallback()
+	if err != nil {
+		defaultAI, _ = aicommon.GetDefaultAIModelCallback()
+		log.Warnf("get default AI model callback failed: %v", err)
+	}
+
+	configOptions := []aicommon.ConfigOption{
+		aicommon.WithEventHandler(delivery.deliver),
+		aicommon.WithEventInputChanx(inputEvent),
+		aicommon.WithContext(start.ctx),
+	}
+	if loadBuiltinTools {
+		configOptions = append(configOptions, aireact.WithBuiltinTools())
+	}
+	configOptions = append(configOptions,
+		aicommon.WithEnhanceKnowledgeManager(rag.NewRagEnhanceKnowledgeManager()),
+		aicommon.WithPersistentSessionId(sessionID),
+		aicommon.WithHotPatchOptionChan(hotpatchChan),
+		aicommon.WithEnablePETaskAnalyze(true),
+		aicommon.WithEnableDispatchSubReactAgent(true), // 仅仅允许顶层 ReAct 分发子 ReAct Agent，子 Agent 仍然可以使用原始的 AI 回调。
+	)
+	// optsFromStartParams (containing WithAICallback) must be applied BEFORE
+	// tiered overrides, otherwise WithAICallback overwrites all three callbacks
+	// (Original, Quality, Speed) to the same frontend-selected model.
+	configOptions = append(configOptions, ConvertYPBAIStartParamsToReActConfig(resolvedStartParams)...)
+	if aiconfig.IsTieredAIConfig() {
+		configOptions = append(configOptions, aicommon.WithAutoTieredAICallback(defaultAI))
+	}
+	configOptions = append(configOptions, additionalOptions...)
+
+	reAct, err := r.newReAct(configOptions...)
+	if err != nil {
+		log.Errorf("create re-act failed: %v", err)
+		return nil, utils.Errorf("create re-act instance failed: %v", err)
+	}
+	reAct.GetConfig().SetConfig("MustProcessAttachedData", true)
+	owner := &ownedReActRuntime{
+		sessionID: sessionID,
+		react:     reAct,
+		cancel:    start.cancel,
+		done:      make(chan struct{}),
+	}
+	go func() {
+		reAct.WaitLifecycleStopped()
+		close(owner.done)
+	}()
+	return owner, nil
+}
+
+func (r *reActSessionRuntime) finishStart(sessionID string, start *reActSessionStart, owner *ownedReActRuntime) {
+	r.mu.Lock()
+	entry := r.entries[sessionID]
+	if entry != nil && entry.starting == start {
+		entry.starting = nil
+		if owner != nil {
+			entry.runtime = owner
+		}
+		start.finish()
+		r.cleanupEntryLocked(sessionID, entry)
+		r.notifyLocked()
+	}
+	r.mu.Unlock()
+}
+
+func (r *reActSessionRuntime) publishRuntime(sessionID string, start *reActSessionStart, owner *ownedReActRuntime) error {
+	r.mu.Lock()
+	entry := r.entries[sessionID]
+	if entry == nil || entry.starting != start {
+		r.mu.Unlock()
+		owner.cancel()
+		<-owner.done
+		start.finish()
+		return utils.Errorf("AI ReAct session start ownership changed: %s", sessionID)
+	}
+	if r.allQuiescing || entry.quiescing {
+		r.mu.Unlock()
+		owner.cancel()
+		<-owner.done
+		r.finishStart(sessionID, start, nil)
+		return utils.Errorf("AI ReAct session is stopping: %s", sessionID)
+	}
+	entry.runtime = owner
+	entry.starting = nil
+	start.finish()
+	r.notifyLocked()
+	r.mu.Unlock()
+
+	go func() {
+		<-owner.done
+		r.mu.Lock()
+		entry := r.entries[sessionID]
+		if entry != nil && entry.runtime == owner {
+			entry.runtime = nil
+			r.cleanupEntryLocked(sessionID, entry)
+			r.notifyLocked()
+		}
+		r.mu.Unlock()
+	}()
+	return nil
+}
+
+func (r *reActSessionRuntime) attachConnection(
+	ctx context.Context,
+	delivery *reActEventDelivery,
+	sessionID string,
+	startParams *ypb.AIStartParams,
+	reAct *aireact.ReAct,
+	owner *ownedReActRuntime,
+	reservation *sessionReservation,
+) (ReActConnection, error) {
+	log.Infof("attach connection to running aireact session: %s", sessionID)
+	if _, err := yakit.CreateOrUpdateAISessionMetaOnStart(r.projectDatabase(), sessionID, startParams, time.Now()); err != nil {
+		log.Warnf("persist ai session start meta failed for %s: %v", sessionID, err)
+	}
+	unsubscribe, ok := aireact.SubscribeRunningSession(sessionID, delivery.deliver)
+	if !ok {
+		delivery.cancel()
+		return nil, utils.Errorf("failed to subscribe running aireact session: %s", sessionID)
+	}
+	return newReActConnection(r, ctx, delivery, sessionID, reAct, owner, reservation, false, unsubscribe), nil
+}
+
+type reActEventDelivery struct {
+	ctx          context.Context
+	cancelFn     context.CancelFunc
+	onEvent      ReActEventHandler
+	onEventError func(error)
+	printer      *aicommon.DebugStreamPrinter
+}
+
+func newReActEventDelivery(parent context.Context, onEvent ReActEventHandler, onEventError func(error)) *reActEventDelivery {
+	ctx, cancel := context.WithCancel(parent)
+	// debugStreamPrinter 在 DEBUG=1 时把流式 delta 合并到单行，避免每个
+	// token 单独换行造成的刷屏；非流事件来临时先 FlushIfActive 收尾，让
+	// 后续 log / 普通事件都从新行开始，消除"夹心"现象。
+	// 关键词: DEBUG=1 流式输出体验, AI stream delta debug print
+	debugStreamPrinter := aicommon.GetDefaultDebugStreamPrinter()
+	// 同步把 common/log 默认输出包装上一层 flush, 让任何日志写入前先把
+	// 流缓冲刷出, 彻底消灭日志被夹在流中间的视觉混乱。
+	// 关键词: EnsureLogFlushWrapperInstalled grpc_ai_react entry
+	aicommon.EnsureLogFlushWrapperInstalled()
+	return &reActEventDelivery{
+		ctx:          ctx,
+		cancelFn:     cancel,
+		onEvent:      onEvent,
+		onEventError: onEventError,
+		printer:      debugStreamPrinter,
+	}
+}
+
+func (d *reActEventDelivery) cancel() {
+	if d != nil && d.cancelFn != nil {
+		d.cancelFn()
+	}
+}
+
+func (d *reActEventDelivery) deliver(event *schema.AiOutputEvent) {
+	if err := d.deliverWithResult(event); err != nil && d.onEventError != nil {
+		d.onEventError(err)
+	}
+}
+
+func (d *reActEventDelivery) deliverWithResult(event *schema.AiOutputEvent) error {
+	if d == nil || event == nil || d.ctx.Err() != nil {
+		return nil
+	}
+	if event.Timestamp <= 0 {
+		event.Timestamp = time.Now().Unix() // fallback
+	}
+	utils.Debug(func() {
+		if event.IsStream {
+			d.printer.PrintStreamDelta(event)
+		} else {
+			d.printer.FlushIfActive()
+		}
+	})
+	if d.onEvent != nil && d.ctx.Err() == nil {
+		return d.onEvent(event)
+	}
+	return nil
+}
+
+type reActConnection struct {
+	runtime     *reActSessionRuntime
+	sessionID   string
+	react       *aireact.ReAct
+	owner       *ownedReActRuntime
+	reservation *sessionReservation
+	created     bool
+	delivery    *reActEventDelivery
+	unsubscribe func()
+	done        chan struct{}
+	closeOnce   sync.Once
+	inputMu     sync.Mutex
+	inputUUIDs  []string
+	inputClosed bool
+}
+
+func newReActConnection(
+	runtime *reActSessionRuntime,
+	ctx context.Context,
+	delivery *reActEventDelivery,
+	sessionID string,
+	react *aireact.ReAct,
+	owner *ownedReActRuntime,
+	reservation *sessionReservation,
+	created bool,
+	unsubscribe func(),
+) *reActConnection {
+	connection := &reActConnection{
+		runtime:     runtime,
+		sessionID:   sessionID,
+		react:       react,
+		owner:       owner,
+		reservation: reservation,
+		created:     created,
+		delivery:    delivery,
+		unsubscribe: unsubscribe,
+		done:        make(chan struct{}),
+	}
+	go func() {
+		if owner == nil {
+			<-ctx.Done()
+			connection.close(true)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			connection.close(true)
+		case <-owner.done:
+			connection.close(false)
+		}
+	}()
+	return connection
+}
+
+func (c *reActConnection) CreatedRuntime() bool { return c != nil && c.created }
+func (c *reActConnection) Done() <-chan struct{} {
+	if c == nil {
+		done := make(chan struct{})
+		close(done)
+		return done
+	}
+	return c.done
+}
+
+func (c *reActConnection) Close() error {
+	if c != nil {
+		c.close(true)
+	}
+	return nil
+}
+
+func (c *reActConnection) close(stopOwned bool) {
+	c.closeOnce.Do(func() {
+		c.delivery.cancel()
+		if stopOwned && !c.created && c.reservation != nil && c.react != nil {
+			c.inputMu.Lock()
+			c.inputClosed = true
+			inputUUIDs := append([]string(nil), c.inputUUIDs...)
+			c.inputMu.Unlock()
+			// Task status is emitted before its deferred timeline persistence and
+			// cleanup finish. Keep the scheduler's reservation alive until the task
+			// has actually left the shared ReAct runtime.
+			for _, inputUUID := range inputUUIDs {
+				if err := c.react.CancelTaskByUserInputUUIDAndWait(context.Background(), inputUUID); err != nil {
+					log.Warnf("wait for attached ReAct task %s to stop failed: %v", inputUUID, err)
+				}
+			}
+		}
+		if c.unsubscribe != nil {
+			c.unsubscribe()
+		}
+		if stopOwned && c.created && c.owner != nil {
+			c.owner.cancel()
+			<-c.owner.done
+		}
+		close(c.done)
+	})
+}
+
+func (c *reActConnection) Send(event *ypb.AIInputEvent) error {
+	if c == nil || c.runtime == nil || c.react == nil {
+		return utils.Error("AI ReAct connection is closed")
+	}
+	if event == nil {
+		return utils.Error("AI ReAct input event is nil")
+	}
+	select {
+	case <-c.done:
+		return utils.Error("AI ReAct connection is closed")
+	default:
+	}
+	if event.GetIsStart() {
+		return nil
+	}
+	if !c.created && event.GetIsSyncMessage() && event.GetSyncType() == aicommon.SYNC_TYPE_RECOVERY_HISTORY {
+		return sendAttachedRecoveryHistory(c.delivery.ctx, c.runtime.projectDatabase(), c.delivery.deliverWithResult, c.sessionID, event)
+	}
+	return c.runtime.sendInput(c, event)
+}
+
+func (r *reActSessionRuntime) sendInput(connection *reActConnection, event *ypb.AIInputEvent) error {
+	// Match Config.StartEventLoopEx/processInputEvent precedence. Events carrying
+	// hot-patch, interactive or sync semantics are not considered task-producing
+	// free input even if a malformed client also sets IsFreeInput.
+	ordinaryFreeInput := event.GetIsFreeInput() &&
+		!event.GetIsConfigHotpatch() &&
+		!event.GetIsInteractiveMessage() &&
+		!event.GetIsSyncMessage()
+	for {
+		if err := connection.delivery.ctx.Err(); err != nil {
+			return err
+		}
+		r.mu.Lock()
+		entry := r.entryLocked(connection.sessionID)
+		if r.allQuiescing || entry.quiescing {
+			r.mu.Unlock()
+			return utils.Errorf("AI ReAct session is stopping: %s", connection.sessionID)
+		}
+		if current, ok := aireact.GetRunningSession(connection.sessionID); !ok || current != connection.react {
+			r.mu.Unlock()
+			return utils.Errorf("AI ReAct session is no longer running: %s", connection.sessionID)
+		}
+		if ordinaryFreeInput && entry.reservation != nil && entry.reservation != connection.reservation {
+			changed := r.changed
+			r.mu.Unlock()
+			if err := waitForReActRuntimeChange(connection.delivery.ctx, changed); err != nil {
+				return err
+			}
+			continue
+		}
+		if connection.reservation != nil && entry.reservation != connection.reservation {
+			r.mu.Unlock()
+			return utils.Errorf("AI ReAct session reservation expired: %s", connection.sessionID)
+		}
+		entry.admitting++
+		if ordinaryFreeInput {
+			entry.taskAdmitting++
+		}
+		r.notifyLocked()
+		r.mu.Unlock()
+
+		var err error
+		if ordinaryFreeInput || event.GetIsConfigHotpatch() {
+			err = connection.react.SendInputEventAndWaitAccepted(event)
+		} else {
+			err = connection.react.SendInputEvent(event)
+		}
+
+		r.mu.Lock()
+		entry = r.entries[connection.sessionID]
+		if entry != nil && entry.admitting > 0 {
+			entry.admitting--
+			if ordinaryFreeInput && entry.taskAdmitting > 0 {
+				entry.taskAdmitting--
+			}
+			r.cleanupEntryLocked(connection.sessionID, entry)
+			r.notifyLocked()
+		}
+		r.mu.Unlock()
+		if err == nil && ordinaryFreeInput && connection.reservation != nil {
+			for _, resource := range event.GetAttachedResourceInfo() {
+				if resource.GetType() == aicommon.USER_FREE_INPUT_UUID && strings.TrimSpace(resource.GetValue()) != "" {
+					inputUUID := strings.TrimSpace(resource.GetValue())
+					connection.inputMu.Lock()
+					closed := connection.inputClosed
+					if !closed {
+						connection.inputUUIDs = append(connection.inputUUIDs, inputUUID)
+					}
+					connection.inputMu.Unlock()
+					if closed {
+						connection.react.CancelTaskByUserInputUUID(inputUUID)
+					}
+					break
+				}
+			}
+		}
+		return err
+	}
+}
+
+func (r *reActSessionRuntime) QuiesceSessions(ctx context.Context, sessionIDs []string) (SessionQuiescence, error) {
+	// This generalizes the scheduler's former cancelSessionExecutionsAndWait:
+	// session data is not removed until every matching reservation, start attempt,
+	// owned ReAct runtime and in-flight input admission has stopped.
+	ids := make([]string, 0, len(sessionIDs))
+	seen := make(map[string]struct{}, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		sessionID = normalizeReActSessionID(sessionID)
+		if _, ok := seen[sessionID]; ok {
+			continue
+		}
+		seen[sessionID] = struct{}{}
+		ids = append(ids, sessionID)
+	}
+	return r.quiesce(ctx, ids, false)
+}
+
+func (r *reActSessionRuntime) QuiesceAll(ctx context.Context) (SessionQuiescence, error) {
+	return r.quiesce(ctx, nil, true)
+}
+
+func (r *reActSessionRuntime) quiesce(ctx context.Context, ids []string, all bool) (SessionQuiescence, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, reActSessionStopTimeout)
+	defer cancel()
+
+	r.mu.Lock()
+	if r.allQuiescing {
+		r.mu.Unlock()
+		return nil, utils.Error("all AI ReAct sessions are already stopping")
+	}
+	if all {
+		ids = ids[:0]
+		for sessionID := range r.entries {
+			ids = append(ids, sessionID)
+		}
+		for _, sessionID := range aireact.EnumerateStartingSessions() {
+			sessionID = normalizeReActSessionID(sessionID)
+			if _, ok := r.entries[sessionID]; !ok {
+				r.entries[sessionID] = &reActSessionState{}
+				ids = append(ids, sessionID)
+			}
+		}
+		for _, sessionID := range aireact.EnumerateRunningSessions() {
+			sessionID = normalizeReActSessionID(sessionID)
+			if _, ok := r.entries[sessionID]; !ok {
+				r.entries[sessionID] = &reActSessionState{}
+				ids = append(ids, sessionID)
+			}
+		}
+	}
+	for _, sessionID := range ids {
+		entry := r.entryLocked(sessionID)
+		if entry.quiescing {
+			r.mu.Unlock()
+			return nil, utils.Errorf("AI ReAct session is already stopping: %s", sessionID)
+		}
+		if entry.starting == nil && aireact.IsSessionStarting(sessionID) {
+			r.mu.Unlock()
+			return nil, utils.Errorf("AI ReAct session %s is starting outside this runtime", sessionID)
+		}
+		if entry.runtime == nil {
+			if _, running := aireact.GetRunningSession(sessionID); running && entry.starting == nil {
+				r.mu.Unlock()
+				return nil, utils.Errorf("AI ReAct session %s is running outside this runtime", sessionID)
+			}
+		}
+	}
+	if all {
+		r.allQuiescing = true
+	}
+
+	waits := make([]<-chan struct{}, 0, len(ids)*2)
+	cancels := make([]context.CancelFunc, 0, len(ids)*2)
+	for _, sessionID := range ids {
+		entry := r.entryLocked(sessionID)
+		entry.quiescing = true
+		if entry.reservation != nil {
+			cancels = append(cancels, entry.reservation.cancel)
+			waits = append(waits, entry.reservation.done)
+		}
+		if entry.starting != nil {
+			cancels = append(cancels, entry.starting.cancel)
+			waits = append(waits, entry.starting.done)
+		}
+		if entry.runtime != nil {
+			cancels = append(cancels, entry.runtime.cancel)
+			waits = append(waits, entry.runtime.done)
+		}
+	}
+	r.notifyLocked()
+	r.mu.Unlock()
+
+	for _, cancelFn := range cancels {
+		cancelFn()
+	}
+	for {
+		r.mu.Lock()
+		admitting := false
+		for _, sessionID := range ids {
+			if entry := r.entries[sessionID]; entry != nil && entry.admitting > 0 {
+				admitting = true
+				break
+			}
+		}
+		changed := r.changed
+		r.mu.Unlock()
+		if !admitting {
+			break
+		}
+		if err := waitForReActRuntimeChange(waitCtx, changed); err != nil {
+			r.releaseQuiescence(ids, all)
+			return nil, utils.Errorf("wait for AI ReAct input admission to stop failed: %v", err)
+		}
+	}
+	for _, done := range waits {
+		select {
+		case <-done:
+		case <-waitCtx.Done():
+			r.releaseQuiescence(ids, all)
+			return nil, utils.Errorf("wait for AI ReAct session shutdown failed: %v", waitCtx.Err())
+		}
+	}
+	return &reActSessionQuiescence{runtime: r, ids: ids, all: all}, nil
+}
+
+func (r *reActSessionRuntime) releaseQuiescence(ids []string, all bool) {
+	r.mu.Lock()
+	if all {
+		r.allQuiescing = false
+	}
+	for _, sessionID := range ids {
+		entry := r.entries[sessionID]
+		if entry == nil {
+			continue
+		}
+		entry.quiescing = false
+		r.cleanupEntryLocked(sessionID, entry)
+	}
+	r.notifyLocked()
+	r.mu.Unlock()
+}

--- a/common/yakgrpc/ai_react_runtime_test.go
+++ b/common/yakgrpc/ai_react_runtime_test.go
@@ -1,0 +1,406 @@
+package yakgrpc
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aimem"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func TestReActEventDeliveryKeepsNormalOutputBestEffortAndReportsSyncFailure(t *testing.T) {
+	deliveryErr := errors.New("subscriber delivery failed")
+	normalErrors := make(chan error, 1)
+	delivery := newReActEventDelivery(context.Background(), func(*schema.AiOutputEvent) error {
+		return deliveryErr
+	}, func(err error) {
+		normalErrors <- err
+	})
+	t.Cleanup(delivery.cancel)
+
+	event := &schema.AiOutputEvent{}
+	delivery.deliver(event)
+	require.ErrorIs(t, <-normalErrors, deliveryErr)
+	require.Positive(t, event.Timestamp)
+
+	err := delivery.deliverWithResult(&schema.AiOutputEvent{IsSync: true})
+	require.ErrorIs(t, err, deliveryErr)
+	select {
+	case err := <-normalErrors:
+		t.Fatalf("synchronous delivery error was also reported as a normal output error: %v", err)
+	default:
+	}
+}
+
+func TestAttachedReActConnectionCloseWaitsForTaskCleanup(t *testing.T) {
+	task := aicommon.NewStatefulTaskBase("task", "input", context.Background(), nil)
+	task.SetUserInputUUID("scheduled-input")
+	task.SetStatus(aicommon.AITaskState_Completed)
+	react := &aireact.ReAct{RuntimeTasks: []aicommon.AIStatefulTask{task}}
+	connection := &reActConnection{
+		react:       react,
+		reservation: &sessionReservation{},
+		delivery:    newReActEventDelivery(context.Background(), nil, nil),
+		done:        make(chan struct{}),
+		inputUUIDs:  []string{"scheduled-input"},
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- connection.Close() }()
+	select {
+	case err := <-closed:
+		t.Fatalf("connection closed before its task cleanup finished: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	react.UpdateRuntimeTaskMutex.Lock()
+	react.RuntimeTasks = nil
+	react.UpdateRuntimeTaskMutex.Unlock()
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("connection did not close after its task left the runtime")
+	}
+}
+
+func TestReActSessionRuntimeHonorsProcessWideStartReservation(t *testing.T) {
+	const sessionID = "runtime-global-start-reservation"
+	release, ok := aireact.TryBeginSessionStart(sessionID)
+	require.True(t, ok)
+	defer release()
+
+	runtime := newReActSessionRuntime(nil)
+	var createCount atomic.Int32
+	runtime.newReAct = func(...aicommon.ConfigOption) (*aireact.ReAct, error) {
+		createCount.Add(1)
+		return nil, errors.New("must not create while the process-wide start reservation is held")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := runtime.Connect(ctx, ConnectRequest{StartParams: &ypb.AIStartParams{TimelineSessionID: sessionID}}, nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Zero(t, createCount.Load())
+}
+
+func TestReActSessionRuntimeCoordinationBusyReasons(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*reActSessionRuntime, string)
+		want  reActSessionBusyReason
+	}{
+		{
+			name: "available",
+			setup: func(runtime *reActSessionRuntime, sessionID string) {
+				runtime.entries[sessionID] = &reActSessionState{}
+			},
+			want: reActSessionAvailable,
+		},
+		{
+			name: "non_task_input_admission_is_available_to_scheduler",
+			setup: func(runtime *reActSessionRuntime, sessionID string) {
+				runtime.entries[sessionID] = &reActSessionState{admitting: 1}
+			},
+			want: reActSessionAvailable,
+		},
+		{
+			name: "runtime_quiescing",
+			setup: func(runtime *reActSessionRuntime, _ string) {
+				runtime.allQuiescing = true
+			},
+			want: reActSessionBusyRuntimeQuiescing,
+		},
+		{
+			name: "session_quiescing",
+			setup: func(runtime *reActSessionRuntime, sessionID string) {
+				runtime.entries[sessionID] = &reActSessionState{quiescing: true}
+			},
+			want: reActSessionBusySessionQuiescing,
+		},
+		{
+			name: "reserved",
+			setup: func(runtime *reActSessionRuntime, sessionID string) {
+				runtime.entries[sessionID] = &reActSessionState{reservation: &sessionReservation{}}
+			},
+			want: reActSessionBusyReserved,
+		},
+		{
+			name: "starting",
+			setup: func(runtime *reActSessionRuntime, sessionID string) {
+				runtime.entries[sessionID] = &reActSessionState{starting: &reActSessionStart{}}
+			},
+			want: reActSessionBusyStarting,
+		},
+		{
+			name: "task_admitting",
+			setup: func(runtime *reActSessionRuntime, sessionID string) {
+				runtime.entries[sessionID] = &reActSessionState{admitting: 1, taskAdmitting: 1}
+			},
+			want: reActSessionBusyTaskAdmitting,
+		},
+		{
+			name: "owned_runtime_transition",
+			setup: func(runtime *reActSessionRuntime, sessionID string) {
+				runtime.entries[sessionID] = &reActSessionState{
+					runtime: &ownedReActRuntime{react: &aireact.ReAct{}},
+				}
+			},
+			want: reActSessionBusyRuntimeTransition,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtime := newReActSessionRuntime(nil)
+			sessionID := "coordination-busy-reason-" + test.name
+			test.setup(runtime, sessionID)
+
+			require.Equal(t, test.want, runtime.sessionCoordinationBusyReason(sessionID))
+			require.Equal(t, test.want != reActSessionAvailable, runtime.IsSessionBusy(sessionID))
+		})
+	}
+}
+
+func TestReActSessionRuntimeWillNotQuiesceAnotherRuntimeStart(t *testing.T) {
+	const sessionID = "runtime-external-start-reservation"
+	release, ok := aireact.TryBeginSessionStart(sessionID)
+	require.True(t, ok)
+
+	runtime := newReActSessionRuntime(nil)
+	_, err := runtime.QuiesceSessions(context.Background(), []string{sessionID})
+	require.ErrorContains(t, err, "starting outside this runtime")
+	require.True(t, aireact.IsSessionStarting(sessionID))
+	release()
+
+	const allSessionID = "runtime-external-start-reservation-all"
+	releaseAll, ok := aireact.TryBeginSessionStart(allSessionID)
+	require.True(t, ok)
+	defer releaseAll()
+	_, err = runtime.QuiesceAll(context.Background())
+	require.ErrorContains(t, err, "starting outside this runtime")
+	require.True(t, aireact.IsSessionStarting(allSessionID))
+}
+
+func TestReActSessionRuntimeReservationAndQuiescence(t *testing.T) {
+	runtime := newReActSessionRuntime(nil)
+	reservation, err := runtime.ReserveSession(context.Background(), "lease-session", "execution-1")
+	require.NoError(t, err)
+	require.True(t, runtime.IsSessionBusy("lease-session"))
+	_, err = runtime.ReserveSession(context.Background(), "lease-session", "execution-2")
+	require.Error(t, err)
+
+	result := make(chan struct {
+		guard SessionQuiescence
+		err   error
+	}, 1)
+	go func() {
+		guard, quiesceErr := runtime.QuiesceSessions(context.Background(), []string{"lease-session"})
+		result <- struct {
+			guard SessionQuiescence
+			err   error
+		}{guard: guard, err: quiesceErr}
+	}()
+
+	select {
+	case <-reservation.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("quiescence did not cancel the reservation owner")
+	}
+	select {
+	case <-result:
+		t.Fatal("quiescence returned before the execution lease was released")
+	default:
+	}
+
+	reservation.Release()
+	var quiesced struct {
+		guard SessionQuiescence
+		err   error
+	}
+	select {
+	case quiesced = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("quiescence did not finish after lease release")
+	}
+	require.NoError(t, quiesced.err)
+	require.NotNil(t, quiesced.guard)
+	_, err = runtime.ReserveSession(context.Background(), "lease-session", "execution-3")
+	require.Error(t, err, "the deletion guard must reject restarts")
+
+	quiesced.guard.Release()
+	next, err := runtime.ReserveSession(context.Background(), "lease-session", "execution-4")
+	require.NoError(t, err)
+	next.Release()
+	require.False(t, runtime.IsSessionBusy("lease-session"))
+}
+
+func TestReActSessionRuntimeOnlyTaskAdmissionBlocksReservation(t *testing.T) {
+	runtime := newReActSessionRuntime(nil)
+	runtime.entries["input-admission"] = &reActSessionState{admitting: 1}
+	reservation, err := runtime.ReserveSession(context.Background(), "input-admission", "execution")
+	require.NoError(t, err, "non-task sync/hot-patch admission must not make a schedule skip")
+	reservation.Release()
+
+	runtime.entries["task-admission"] = &reActSessionState{admitting: 1, taskAdmitting: 1}
+	_, err = runtime.ReserveSession(context.Background(), "task-admission", "execution")
+	require.Error(t, err, "free-input admission must remain atomic with schedule reservation")
+}
+
+func TestServerRetireReActSessionRuntime(t *testing.T) {
+	server := newScheduleTestServer(t)
+	oldRuntime := server.getReActSessionRuntime().(*reActSessionRuntime)
+	reservation, err := oldRuntime.ReserveSession(context.Background(), "old-project-session", "old-execution")
+	require.NoError(t, err)
+
+	retired := make(chan error, 1)
+	go func() { retired <- server.retireReActSessionRuntime(context.Background()) }()
+	select {
+	case <-reservation.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("retiring the project runtime did not cancel its reservation")
+	}
+	reservation.Release()
+	select {
+	case err := <-retired:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("project runtime retirement did not finish")
+	}
+
+	_, err = oldRuntime.ReserveSession(context.Background(), "stale-session", "stale-execution")
+	require.Error(t, err, "a retired runtime must stay permanently quiesced")
+	require.Same(t, oldRuntime, server.getReActSessionRuntime(), "the retired runtime must cover the project-switch window")
+	server.resetReActSessionRuntimeAfterProjectSwitch()
+	newRuntime := server.getReActSessionRuntime().(*reActSessionRuntime)
+	require.NotSame(t, oldRuntime, newRuntime)
+	newReservation, err := newRuntime.ReserveSession(context.Background(), "new-project-session", "new-execution")
+	require.NoError(t, err)
+	newReservation.Release()
+}
+
+func TestReActSessionRuntimeCreatesOnceAttachesAndGatesReservedInput(t *testing.T) {
+	server := newScheduleTestServer(t)
+	runtime := server.getReActSessionRuntime().(*reActSessionRuntime)
+	originalFactory := runtime.newReAct
+	var createCount atomic.Int32
+	factoryEntered := make(chan struct{})
+	allowFactory := make(chan struct{})
+	runtime.newReAct = func(options ...aicommon.ConfigOption) (*aireact.ReAct, error) {
+		if createCount.Add(1) == 1 {
+			close(factoryEntered)
+		}
+		<-allowFactory
+		return originalFactory(options...)
+	}
+
+	mockKnowledgeManager, _ := aicommon.NewMockEKManagerAndToken()
+	options := []aicommon.ConfigOption{
+		aicommon.WithMemoryTriage(aimem.NewMockMemoryTriage()),
+		aicommon.WithTimelineArchiveStore(&noOpTimelineArchiveStore{}),
+		aicommon.WithEnhanceKnowledgeManager(mockKnowledgeManager),
+		aicommon.WithDisallowMCPServers(true),
+		aicommon.WithDisableSessionTitleGeneration(true),
+		aicommon.WithDisableIntentRecognition(true),
+		aicommon.WithDisablePerception(true),
+		aicommon.WithDisableAutoSkills(true),
+		aicommon.WithGenerateReport(false),
+		aicommon.WithDisableDynamicPlanning(true),
+		aicommon.WithPeriodicVerificationInterval(0),
+		aicommon.WithDisableIncreaseIteration(true),
+	}
+	const sessionID = "runtime-create-once"
+	params := &ypb.AIStartParams{TimelineSessionID: sessionID, DisableAISearchForge: true, DisableToolUse: true}
+	type connectResult struct {
+		connection ReActConnection
+		err        error
+	}
+	firstResult := make(chan connectResult, 1)
+	secondResult := make(chan connectResult, 1)
+	go func() {
+		connection, err := runtime.connectWithOptions(context.Background(), ConnectRequest{StartParams: params}, nil, false, options...)
+		firstResult <- connectResult{connection: connection, err: err}
+	}()
+	select {
+	case <-factoryEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first connection did not enter the ReAct factory")
+	}
+	go func() {
+		connection, err := runtime.connectWithOptions(context.Background(), ConnectRequest{StartParams: params}, nil, false, options...)
+		secondResult <- connectResult{connection: connection, err: err}
+	}()
+	close(allowFactory)
+
+	first := <-firstResult
+	second := <-secondResult
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	require.Equal(t, int32(1), createCount.Load())
+	require.True(t, first.connection.CreatedRuntime())
+	require.False(t, second.connection.CreatedRuntime())
+	react := first.connection.(*reActConnection).react
+
+	reservation, err := runtime.ReserveSession(context.Background(), sessionID, "scheduled-execution")
+	require.NoError(t, err)
+	scheduled, err := runtime.connectWithOptions(context.Background(), ConnectRequest{
+		StartParams: params,
+		Reservation: reservation,
+	}, nil, false, options...)
+	require.NoError(t, err)
+	require.False(t, scheduled.CreatedRuntime(), "the scheduled execution must attach to the existing frontend runtime")
+	require.NoError(t, scheduled.Send(&ypb.AIInputEvent{
+		IsFreeInput: true,
+		FreeInput:   "scheduled input that must be canceled with its connection",
+		AttachedResourceInfo: []*ypb.AttachedResourceInfo{{
+			Type:  aicommon.USER_FREE_INPUT_UUID,
+			Value: "scheduled-execution",
+		}},
+	}))
+	require.NoError(t, scheduled.Close())
+	require.Eventually(t, func() bool {
+		for _, task := range react.GetRuntimeTasks() {
+			if task.GetUserInputUUID() == "scheduled-execution" && !task.IsFinished() {
+				return false
+			}
+		}
+		for _, task := range react.GetQueueingTasks() {
+			if task.GetUserInputUUID() == "scheduled-execution" && !task.IsFinished() {
+				return false
+			}
+		}
+		return true
+	}, time.Second, 10*time.Millisecond, "closing an attached scheduler connection must cancel only its admitted task")
+
+	blockedSend := make(chan error, 1)
+	go func() {
+		blockedSend <- second.connection.Send(&ypb.AIInputEvent{IsFreeInput: true, FreeInput: "queued after the reservation"})
+	}()
+	select {
+	case err := <-blockedSend:
+		t.Fatalf("unreserved input bypassed the scheduler lease: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	reservation.Release()
+	select {
+	case err := <-blockedSend:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("input did not resume after the scheduler lease was released")
+	}
+	_, err = runtime.ReserveSession(context.Background(), sessionID, "racing-execution")
+	require.Error(t, err, "an accepted input must make the session busy before ReserveSession can win")
+
+	require.NoError(t, second.connection.Close())
+	require.NoError(t, first.connection.Close())
+	require.Eventually(t, func() bool {
+		_, ok := aireact.GetRunningSession(sessionID)
+		return !ok
+	}, time.Second, 10*time.Millisecond)
+}

--- a/common/yakgrpc/ai_react_scheduler.go
+++ b/common/yakgrpc/ai_react_scheduler.go
@@ -3,7 +3,6 @@ package yakgrpc
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"strings"
 	"sync"
 	"time"
@@ -11,21 +10,18 @@ import (
 	"github.com/google/uuid"
 	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
-	"github.com/yaklang/yaklang/common/ai/aid/aireact"
 	"github.com/yaklang/yaklang/common/ai/aid/aischedule"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 )
 
 const (
-	aiReActSchedulePollInterval   = 30 * time.Second
-	aiReActScheduleMaxConcurrent  = 3
-	aiReActScheduleReleaseTimeout = 10 * time.Second
+	aiReActSchedulePollInterval  = 30 * time.Second
+	aiReActScheduleMaxConcurrent = 3
 
 	aiReActScheduleTriggerSchedule = "schedule"
 	aiReActScheduleTriggerManual   = "manual"
@@ -47,6 +43,7 @@ type scheduledReActJob struct {
 	ctx                 context.Context
 	cancel              context.CancelFunc
 	unregisterExecution func()
+	reservation         SessionReservation
 	workerReserved      bool
 	done                chan struct{}
 }
@@ -59,8 +56,8 @@ type scheduleEnqueueError struct {
 func (e *scheduleEnqueueError) Error() string { return e.message }
 
 type aiReActScheduler struct {
-	server *Server
-	db     *gorm.DB
+	runtime ReActSessionRuntime
+	db      *gorm.DB
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -70,15 +67,13 @@ type aiReActScheduler struct {
 	jobsMu           sync.Mutex
 	jobs             map[string]*scheduledReActJob
 	activeBySchedule map[string]string
-	activeBySession  map[string]string
-	startAIReAct     func(ypb.Yak_StartAIReActServer) error
 	wg               sync.WaitGroup
 }
 
 func newAIReActScheduler(server *Server, db *gorm.DB) *aiReActScheduler {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &aiReActScheduler{
-		server:           server,
+		runtime:          server.getReActSessionRuntime(),
 		db:               db,
 		ctx:              ctx,
 		cancel:           cancel,
@@ -86,8 +81,6 @@ func newAIReActScheduler(server *Server, db *gorm.DB) *aiReActScheduler {
 		worker:           make(chan struct{}, aiReActScheduleMaxConcurrent),
 		jobs:             make(map[string]*scheduledReActJob),
 		activeBySchedule: make(map[string]string),
-		activeBySession:  make(map[string]string),
-		startAIReAct:     server.StartAIReAct,
 	}
 }
 
@@ -309,17 +302,15 @@ func (m *aiReActScheduler) enqueue(schedule *schema.AIReActSchedule, scheduledAt
 		done:         make(chan struct{}),
 	}
 	m.jobsMu.Lock()
+	if err := m.ctx.Err(); err != nil {
+		m.jobsMu.Unlock()
+		cancel()
+		return err
+	}
 	if _, active := m.activeBySchedule[schedule.UUID]; active {
 		m.jobsMu.Unlock()
 		cancel()
 		return &scheduleEnqueueError{reason: "schedule_overlap", message: "schedule already has a queued or running execution"}
-	}
-	if sessionID != "" {
-		if _, active := m.activeBySession[sessionID]; active || isAIReActSessionBusy(sessionID) {
-			m.jobsMu.Unlock()
-			cancel()
-			return &scheduleEnqueueError{reason: "session_busy", message: "target session is busy"}
-		}
 	}
 	select {
 	case m.worker <- struct{}{}:
@@ -329,22 +320,39 @@ func (m *aiReActScheduler) enqueue(schedule *schema.AIReActSchedule, scheduledAt
 		cancel()
 		return &scheduleEnqueueError{reason: "scheduler_capacity", message: "scheduled execution capacity is full"}
 	}
+	reservation, err := m.runtime.ReserveSession(jobCtx, sessionID, executionID)
+	if err != nil {
+		contextErr := jobCtx.Err()
+		<-m.worker
+		job.workerReserved = false
+		m.jobsMu.Unlock()
+		cancel()
+		if contextErr != nil {
+			// A concurrent scheduler stop is cancellation, not a skipped occurrence
+			// caused by a busy target session.
+			return contextErr
+		}
+		return &scheduleEnqueueError{reason: "session_busy", message: "target session is busy"}
+	}
+	job.reservation = reservation
+	job.ctx = reservation.Context()
 	m.jobs[job.executionID] = job
 	m.activeBySchedule[schedule.UUID] = job.executionID
-	if sessionID != "" {
-		m.activeBySession[sessionID] = job.executionID
-	}
 	job.unregisterExecution = aischedule.RegisterExecution(schedule.UUID, cancel)
+	// Reserve the execution wait slot while jobsMu still serializes enqueue with
+	// stop. Once stop has acquired jobsMu, no later WaitGroup.Add can race with
+	// its Wait.
+	m.wg.Add(1)
 	m.jobsMu.Unlock()
 	if trigger == aiReActScheduleTriggerManual {
 		if err := m.db.Model(&schema.AIReActSchedule{}).Where("uuid = ?", schedule.UUID).
 			UpdateColumn("last_run_at", scheduledAt.UTC()).Error; err != nil {
 			cancel()
 			m.unregisterJob(job)
+			m.wg.Done()
 			return err
 		}
 	}
-	m.wg.Add(1)
 	go m.execute(job)
 	return nil
 }
@@ -361,9 +369,6 @@ func (m *aiReActScheduler) unregisterJob(job *scheduledReActJob) {
 	if activeID := m.activeBySchedule[job.scheduleUUID]; activeID == job.executionID {
 		delete(m.activeBySchedule, job.scheduleUUID)
 	}
-	if activeID := m.activeBySession[job.sessionID]; job.sessionID != "" && activeID == job.executionID {
-		delete(m.activeBySession, job.sessionID)
-	}
 	if job.workerReserved {
 		select {
 		case <-m.worker:
@@ -372,6 +377,9 @@ func (m *aiReActScheduler) unregisterJob(job *scheduledReActJob) {
 		}
 	}
 	m.jobsMu.Unlock()
+	if job.reservation != nil {
+		job.reservation.Release()
+	}
 	if job.done != nil {
 		close(job.done)
 	}
@@ -385,70 +393,6 @@ func (m *aiReActScheduler) cancelSchedule(scheduleUUID string) {
 	if job != nil {
 		job.cancel()
 	}
-}
-
-func (m *aiReActScheduler) isSessionReserved(sessionID string) bool {
-	if m == nil || strings.TrimSpace(sessionID) == "" {
-		return false
-	}
-	m.jobsMu.Lock()
-	_, ok := m.activeBySession[strings.TrimSpace(sessionID)]
-	m.jobsMu.Unlock()
-	return ok
-}
-
-// cancelSessionExecutionsAndWait is used by DeleteAISession to make the
-// scheduler's active maps authoritative: session data is not removed until
-// every matching execution has cancelled and unregistered itself.
-func (m *aiReActScheduler) cancelSessionExecutionsAndWait(ctx context.Context, sessionIDs []string, all bool) error {
-	if m == nil {
-		return nil
-	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	waitCtx, cancel := context.WithTimeout(ctx, aiReActScheduleReleaseTimeout)
-	defer cancel()
-
-	m.jobsMu.Lock()
-	jobs := make([]*scheduledReActJob, 0, len(sessionIDs))
-	seen := make(map[string]struct{})
-	if all {
-		for executionID, job := range m.jobs {
-			if job == nil {
-				continue
-			}
-			seen[executionID] = struct{}{}
-			jobs = append(jobs, job)
-		}
-	} else {
-		for _, sessionID := range sessionIDs {
-			executionID := m.activeBySession[strings.TrimSpace(sessionID)]
-			if executionID == "" {
-				continue
-			}
-			if _, exists := seen[executionID]; exists {
-				continue
-			}
-			if job := m.jobs[executionID]; job != nil {
-				seen[executionID] = struct{}{}
-				jobs = append(jobs, job)
-			}
-		}
-	}
-	m.jobsMu.Unlock()
-
-	for _, job := range jobs {
-		job.cancel()
-	}
-	for _, job := range jobs {
-		select {
-		case <-job.done:
-		case <-waitCtx.Done():
-			return utils.Errorf("wait for scheduled execution %s to release session %s failed: %v", job.executionID, job.sessionID, waitCtx.Err())
-		}
-	}
-	return nil
 }
 
 type scheduledReActOutcome struct {
@@ -517,10 +461,6 @@ func scheduleExecutionSessionID(schedule *schema.AIReActSchedule, executionID st
 		return strings.TrimSpace(schedule.TargetSessionID)
 	}
 	return isolatedScheduleSessionID(executionID)
-}
-
-func isAIReActSessionBusy(sessionID string) bool {
-	return aireact.IsSessionBusy(strings.TrimSpace(sessionID))
 }
 
 func (m *aiReActScheduler) finishScheduleExecution(scheduleUUID string, outcome scheduledReActOutcome) {
@@ -638,13 +578,16 @@ func (m *aiReActScheduler) runReAct(
 	yakit.BroadcastAISessionChanged(yakit.AISessionPushActionStarted, sessionID)
 
 	outcomeCh := make(chan scheduledReActOutcome, 1)
-	serverErrCh := make(chan error, 1)
 	var stateMu sync.Mutex
 	state := scheduledReActOutcome{}
 	pendingReviewIDs := make(map[string]struct{})
-	stream := newInProcessAIReActStream(ctx, func(event *ypb.AIOutputEvent) {
+	onOutput := func(output *schema.AiOutputEvent) error {
+		if output == nil {
+			return nil
+		}
+		event := output.ToGRPC()
 		if event == nil {
-			return
+			return nil
 		}
 		stateMu.Lock()
 		defer stateMu.Unlock()
@@ -675,20 +618,20 @@ func (m *aiReActScheduler) runReAct(
 			case outcomeCh <- state:
 			default:
 			}
-			return
+			return nil
 		}
 		if event.GetNodeId() != "react_task_status_changed" {
-			return
+			return nil
 		}
 		var content struct {
 			TaskID string `json:"react_task_id"`
 			Status string `json:"react_task_now_status"`
 		}
 		if json.Unmarshal(event.GetContent(), &content) != nil || content.Status == "" {
-			return
+			return nil
 		}
 		if state.reactTaskID == "" || content.TaskID != state.reactTaskID {
-			return
+			return nil
 		}
 		switch content.Status {
 		case "completed":
@@ -701,14 +644,14 @@ func (m *aiReActScheduler) runReAct(
 			state.status = scheduledOutcomeSkipped
 			state.errorMessage = "AI ReAct task skipped"
 		default:
-			return
+			return nil
 		}
 		select {
 		case outcomeCh <- state:
 		default:
 		}
-	})
-	stream.push(&ypb.AIInputEvent{IsStart: true, Params: params})
+		return nil
+	}
 	attachedResources := append([]*ypb.AttachedResourceInfo(nil), payload.GetAttachedResourceInfos()...)
 	attachedResources = append(attachedResources,
 		&ypb.AttachedResourceInfo{
@@ -725,43 +668,45 @@ func (m *aiReActScheduler) runReAct(
 		&ypb.AttachedResourceInfo{Type: aicommon.USER_INPUT_SCHEDULE_CONTEXT, Key: aicommon.USER_INPUT_SCHEDULED_AT, Value: job.scheduledAt.Format(time.RFC3339)},
 		&ypb.AttachedResourceInfo{Type: aicommon.USER_INPUT_SCHEDULE_CONTEXT, Key: aicommon.USER_INPUT_SCHEDULE_TRIGGER, Value: job.trigger},
 	)
-	stream.push(&ypb.AIInputEvent{
+	connection, err := m.runtime.Connect(ctx, ConnectRequest{
+		StartParams: params,
+		Reservation: job.reservation,
+	}, onOutput)
+	if err != nil {
+		return scheduledReActRuntimeError(ctx, err)
+	}
+	// Do not unregister the job while its Runtime connection is alive.
+	// DeleteAISession may remove the session immediately after job.done.
+	defer connection.Close()
+	if err := connection.Send(&ypb.AIInputEvent{
 		IsFreeInput:          true,
 		FreeInput:            payload.GetPrompt(),
 		AttachedResourceInfo: attachedResources,
 		FocusModeLoop:        payload.GetFocusModeLoop(),
-	})
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
-		startAIReAct := m.startAIReAct
-		if startAIReAct == nil {
-			startAIReAct = m.server.StartAIReAct
-		}
-		serverErrCh <- startAIReAct(stream)
-	}()
+	}); err != nil {
+		return scheduledReActRuntimeError(ctx, err)
+	}
 	select {
 	case outcome := <-outcomeCh:
-		stream.cancel()
-		<-serverErrCh
 		return outcome
-	case err := <-serverErrCh:
+	case <-connection.Done():
 		stateMu.Lock()
 		defer stateMu.Unlock()
-		if err != nil && ctx.Err() == nil {
-			state.status = scheduledOutcomeFailed
-			state.errorMessage = err.Error()
-		}
 		return state
 	case <-ctx.Done():
-		stream.cancel()
-		// Do not unregister the job while its in-process gRPC handler is alive.
-		// DeleteAISession may remove the session immediately after job.done.
-		<-serverErrCh
 		stateMu.Lock()
 		defer stateMu.Unlock()
 		return state
 	}
+}
+
+func scheduledReActRuntimeError(ctx context.Context, err error) scheduledReActOutcome {
+	if ctx != nil && ctx.Err() != nil {
+		// Preserve the former in-process stream behavior: cancellation and timeout
+		// are classified by execute from the run context, not as runtime failures.
+		return scheduledReActOutcome{}
+	}
+	return scheduledReActOutcome{status: scheduledOutcomeFailed, errorMessage: err.Error()}
 }
 
 func scheduleAttentionForEvent(event *ypb.AIOutputEvent, taskStarted bool, pendingReviewIDs map[string]struct{}) (bool, string) {
@@ -809,74 +754,4 @@ func scheduleAttentionForEvent(event *ypb.AIOutputEvent, taskStarted bool, pendi
 	default:
 		return false, ""
 	}
-}
-
-type inProcessAIReActStream struct {
-	ctx      context.Context
-	cancelFn context.CancelFunc
-	input    chan *ypb.AIInputEvent
-	onOutput func(*ypb.AIOutputEvent)
-}
-
-func newInProcessAIReActStream(parent context.Context, onOutput func(*ypb.AIOutputEvent)) *inProcessAIReActStream {
-	ctx, cancel := context.WithCancel(parent)
-	return &inProcessAIReActStream{ctx: ctx, cancelFn: cancel, input: make(chan *ypb.AIInputEvent, 2), onOutput: onOutput}
-}
-
-func (s *inProcessAIReActStream) push(event *ypb.AIInputEvent) {
-	select {
-	case s.input <- event:
-	case <-s.ctx.Done():
-	}
-}
-
-func (s *inProcessAIReActStream) cancel() { s.cancelFn() }
-
-func (s *inProcessAIReActStream) Recv() (*ypb.AIInputEvent, error) {
-	select {
-	case event := <-s.input:
-		return event, nil
-	case <-s.ctx.Done():
-		return nil, s.ctx.Err()
-	}
-}
-
-func (s *inProcessAIReActStream) Send(event *ypb.AIOutputEvent) error {
-	if s.ctx.Err() != nil {
-		return s.ctx.Err()
-	}
-	if s.onOutput != nil {
-		s.onOutput(event)
-	}
-	return nil
-}
-
-func (s *inProcessAIReActStream) SetHeader(metadata.MD) error  { return nil }
-func (s *inProcessAIReActStream) SendHeader(metadata.MD) error { return nil }
-func (s *inProcessAIReActStream) SetTrailer(metadata.MD)       {}
-func (s *inProcessAIReActStream) Context() context.Context     { return s.ctx }
-
-func (s *inProcessAIReActStream) SendMsg(message any) error {
-	event, ok := message.(*ypb.AIOutputEvent)
-	if !ok {
-		return utils.Error("invalid AI ReAct output message")
-	}
-	return s.Send(event)
-}
-
-func (s *inProcessAIReActStream) RecvMsg(message any) error {
-	event, err := s.Recv()
-	if err != nil {
-		if err == context.Canceled {
-			return io.EOF
-		}
-		return err
-	}
-	target, ok := message.(*ypb.AIInputEvent)
-	if !ok {
-		return utils.Error("invalid AI ReAct input message")
-	}
-	proto.Reset(target)
-	proto.Merge(target, event)
-	return nil
 }

--- a/common/yakgrpc/grpc_ai_re-act.go
+++ b/common/yakgrpc/grpc_ai_re-act.go
@@ -2,18 +2,12 @@ package yakgrpc
 
 import (
 	"context"
-	"encoding/json"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/samber/lo"
 	"github.com/yaklang/gorm"
-	"github.com/yaklang/yaklang/common/ai/aid/aicommon/aiconfig"
-	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
-
-	"github.com/yaklang/yaklang/common/ai/aid"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/log"
@@ -23,173 +17,15 @@ import (
 )
 
 func fixOptionsWithServiceName(serviceName string, opts ...aicommon.ConfigOption) []aicommon.ConfigOption {
-	aiCb, err := aicommon.CreateCallbackFromConfig(aiconfig.GetGlobalManager().GetFirstConfigByTierAndProviderAndModel(consts.TierIntelligent, serviceName, ""))
-	if err != nil {
-		log.Errorf("load ai service failed: %v", err)
-	} else {
-		opts = append(opts, aicommon.WithAutoTieredAICallback(aiCb))
-	}
-	log.Warnf("AIStartParams.AIService/AIModelName for WithAIChatInfo is deprecated, " +
-		"model info is now auto-detected from the actual AI gateway call")
-	return opts
+	return sessionruntime.FixOptionsWithServiceName(serviceName, opts...)
 }
 
 func ConvertYPBAIStartParamsToReActConfig(i *ypb.AIStartParams) []aicommon.ConfigOption {
-	opts := make([]aicommon.ConfigOption, 0)
-	if i == nil {
-		return opts
-	}
-	enableMultiAgent, goalModeEnabled, goalMinIterations, maxSubAgents := resolveAIExecutionStrategy(i)
-	if i.DisallowRequireForUserPrompt {
-		opts = append(opts, aicommon.WithAllowRequireForUserInteract(false))
-	} else {
-		opts = append(opts, aicommon.WithAllowRequireForUserInteract(true))
-	}
-
-	if i.ReviewPolicy != "" {
-		opts = append(opts, aicommon.WithAgreePolicy(aicommon.AgreePolicyType(i.ReviewPolicy)))
-	}
-
-	if i.GetAIReviewRiskControlScore() > 0 {
-		opts = append(opts, aicommon.WithAgreeAIRiskCtrlScore(i.GetAIReviewRiskControlScore()))
-	}
-
-	if i.ReActMaxIteration > 0 {
-		maxIterations := i.GetReActMaxIteration()
-		// Goal-mode entry-point normalization: raise a too-small ceiling so the
-		// finish gate (GoalMinIterations) can open before iterations run out.
-		// loop_default.resolveMaxIterations applies the same bump idempotently
-		// as a safety net for programmatic (non-gRPC) entry paths.
-		if goalModeEnabled {
-			maxIterations = aicommon.EnsureGoalModeMaxIterations(maxIterations, goalMinIterations)
-		}
-		opts = append(opts, aicommon.WithMaxIterationCount(maxIterations))
-	}
-
-	if i.GetTimelineContentSizeLimit() > 0 {
-		opts = append(opts, aicommon.WithTimelineContentLimit(int(i.GetTimelineContentSizeLimit())))
-	}
-
-	if i.UserInteractLimit > 0 {
-		opts = append(opts, aicommon.WithPlanUserInteractMaxCount(i.UserInteractLimit))
-	}
-
-	if i.GetDisableToolUse() {
-		opts = append(opts, aicommon.WithDisableToolUse(true))
-	}
-	if i.GetEnableAISearchTool() {
-		opts = append(opts, aid.WithAiToolsSearchTool())
-	}
-	if enableMultiAgent {
-		opts = append(opts,
-			aicommon.WithEnableMultiAgentMode(true),
-			aicommon.WithMaxSubAgents(maxSubAgents),
-		)
-	}
-	if len(i.GetExcludeToolNames()) > 0 {
-		opts = append(opts, aicommon.WithDisableToolsName(i.GetExcludeToolNames()...))
-	}
-	if len(i.GetIncludeSuggestedToolNames()) > 0 {
-		opts = append(opts, aicommon.WithEnableToolsName(i.GetIncludeSuggestedToolNames()...))
-	}
-	if len(i.GetIncludeSuggestedToolKeywords()) > 0 {
-		opts = append(opts, aicommon.WithKeywords(i.GetIncludeSuggestedToolKeywords()...))
-	}
-	if i.GetAIService() != "" {
-		opts = fixOptionsWithServiceName(i.GetAIService(), opts...)
-	}
-
-	if !i.GetDisableAISearchForge() {
-		opts = append(opts, aid.WithAiForgeSearchTool())
-	}
-
-	// EnablePlan 晚于 DisableAISearchForge 应用，用于控制 PE / 蓝图动作；与 AI 搜索 Forge 工具独立。
-	opts = append(opts, aicommon.WithEnablePlanAndExec(i.GetEnablePlan()))
-	if i.GetEnableDetachedPlan() {
-		opts = append(opts, aicommon.WithEnableDetachedPlan(true))
-	}
-
-	if i.GetAICallTokenLimit() > 0 {
-		opts = append(opts, aicommon.WithAiCallTokenLimit(int64(i.GetAICallTokenLimit())))
-	}
-
-	if i.GetDisableToolIntervalReview() {
-		opts = append(opts, aicommon.WithDisableToolCallerIntervalReview(true))
-	}
-	if i.GetSyncPerceptionTrigger() {
-		opts = append(opts, aicommon.WithSyncPerceptionTrigger(true))
-	}
-	if goalModeEnabled {
-		opts = append(opts,
-			aicommon.WithEnableGoalMode(true),
-			aicommon.WithGoalMinIterations(goalMinIterations),
-		)
-	}
-
-	if i.GetUserPresetPrompt() != "" {
-		opts = append(opts, aicommon.WithUserPresetPrompt(i.GetUserPresetPrompt()))
-	}
-
-	if i.GetPlanExecTaskConcurrency() > 0 {
-		opts = append(opts, aicommon.WithPlanExecTaskConcurrency(int(i.GetPlanExecTaskConcurrency())))
-	}
-
-	if i.GetUserPlanPrompt() != "" {
-		opts = append(opts, aicommon.WithPlanPrompt(i.GetUserPlanPrompt()))
-	}
-
-	if i.GetSource() != "" {
-		opts = append(opts, aicommon.WithSessionSource(i.GetSource()))
-	}
-
-	if caps := aicommon.ParseEnabledCapabilitiesFromProto(i); len(caps) > 0 {
-		opts = append(opts, aicommon.WithEnabledCapabilities(caps...))
-	}
-
-	if i.GetDisableMemoryTriage() {
-		opts = append(opts, aicommon.WithDisableMemoryTriage(true))
-	}
-
-	return opts
-}
-
-func resolveAIExecutionStrategy(i *ypb.AIStartParams) (enableMultiAgent bool, enableGoalMode bool, goalMinIterations int64, maxSubAgents int64) {
-	if i == nil {
-		return false, false, aicommon.DefaultGoalMinIterations, aicommon.DefaultMaxSubAgentConcurrency
-	}
-	if strategy := i.GetStrategy(); strategy != nil {
-		enableMultiAgent = strategy.GetEnableMultiAgent()
-		enableGoalMode = strategy.GetEnableGoalMode()
-		goalMinIterations = strategy.GetGoalMinIterations()
-		maxSubAgents = strategy.GetMaxSubAgents()
-	}
-	goalMinIterations = aicommon.NormalizeGoalMinIterations(goalMinIterations)
-	return
+	return sessionruntime.ConvertStartParamsToReActConfig(i)
 }
 
 func resolveAISessionStartParams(db *gorm.DB, sessionID string, request *ypb.AIStartParams, preferCached bool) (*ypb.AIStartParams, error) {
-	if request == nil {
-		request = &ypb.AIStartParams{}
-	}
-	if !preferCached || db == nil || strings.TrimSpace(sessionID) == "" {
-		return request, nil
-	}
-
-	if _, err := yakit.GetAISessionMetaBySessionID(db, sessionID); err != nil {
-		if gorm.IsRecordNotFoundError(err) {
-			return request, nil
-		}
-		return nil, err
-	}
-
-	cached, err := yakit.GetAISessionMetaStartParamsBySessionID(db, sessionID)
-	if err != nil {
-		return nil, err
-	}
-	if cached == nil {
-		return request, nil
-	}
-	return yakit.MergeCachedAISessionStartParams(cached, request), nil
+	return sessionruntime.ResolveSessionStartParams(db, sessionID, request, preferCached)
 }
 
 func (s *Server) StartAIReAct(stream ypb.Yak_StartAIReActServer) error {
@@ -229,12 +65,12 @@ func (s *Server) startAIReActWithOptions(stream ypb.Yak_StartAIReActServer, load
 	if runtime == nil {
 		return utils.Error("AI ReAct session runtime is not configured")
 	}
-	request := ConnectRequest{
+	request := sessionruntime.ConnectRequest{
 		StartParams: startParams,
-		options: &reActConnectOptions{
-			loadBuiltinTools: loadBuiltinTools,
-			configOptions:    additionalOptions,
-			onEventError: func(err error) {
+		Options: &sessionruntime.ConnectOptions{
+			LoadBuiltinTools: loadBuiltinTools,
+			ConfigOptions:    additionalOptions,
+			OnEventError: func(err error) {
 				// Keep the original streaming behavior: a failed subscriber
 				// delivery is observable, but it does not fail the shared ReAct.
 				log.Errorf("send re-act event to stream failed: %v", err)
@@ -315,90 +151,6 @@ func (s *Server) startAIReActWithOptions(stream ypb.Yak_StartAIReActServer, load
 			}
 		}
 	}
-}
-
-const attachedRecoveryHistoryBlockLimit = 20
-
-func sendAttachedRecoveryHistory(
-	ctx context.Context,
-	db *gorm.DB,
-	send func(*schema.AiOutputEvent) error,
-	persistentSession string,
-	event *ypb.AIInputEvent,
-) error {
-	if db == nil {
-		return sendAttachedSyncError(send, "recovery_history", utils.Errorf("db is nil"), event.GetSyncID())
-	}
-
-	sessionID := persistentSession
-	startID := int64(0)
-	limit := attachedRecoveryHistoryBlockLimit
-
-	if raw := event.GetSyncJsonInput(); raw != "" {
-		var params map[string]interface{}
-		if err := json.Unmarshal([]byte(raw), &params); err != nil {
-			return sendAttachedSyncError(send, "recovery_history", utils.Errorf("failed to parse recovery history params: %v", err), event.GetSyncID())
-		}
-		if sid := utils.InterfaceToString(params["session_id"]); sid != "" {
-			sessionID = sid
-		}
-		if rawStartID, ok := params["start_id"]; ok {
-			startID = int64(utils.InterfaceToInt(rawStartID))
-		}
-		if rawLimit, ok := params["limit"]; ok {
-			if parsedLimit := utils.InterfaceToInt(rawLimit); parsedLimit > 0 {
-				limit = parsedLimit
-			}
-		}
-	}
-
-	if sessionID == "" {
-		return sendAttachedSyncError(send, "recovery_history", utils.Errorf("session_id is empty"), event.GetSyncID())
-	}
-
-	eventCh, result, err := yakit.YieldAIEventRecoveryHistory(ctx, db, sessionID, startID, limit)
-	if err != nil {
-		return sendAttachedSyncError(send, "recovery_history", err, event.GetSyncID())
-	}
-	for recoveredEvent := range eventCh {
-		if recoveredEvent == nil {
-			continue
-		}
-		recoveredEvent.IsSync = true
-		if err := send(recoveredEvent); err != nil {
-			return err
-		}
-	}
-
-	return sendAttachedSyncJSON(send, schema.EVENT_TYPE_STRUCTURED, "recovery_history", map[string]interface{}{
-		"session_id":         sessionID,
-		"requested_start_id": startID,
-		"block_count":        result.BlockCount,
-		"event_count":        result.EventCount,
-		"next_start_id":      result.NextStartID,
-		"has_more":           result.HasMore,
-	}, event.GetSyncID())
-}
-
-func sendAttachedSyncError(send func(*schema.AiOutputEvent) error, nodeID string, err error, syncID string) error {
-	if err == nil {
-		return nil
-	}
-	return sendAttachedSyncJSON(send, schema.EVENT_TYPE_STRUCTURED, nodeID, map[string]any{
-		"error": err.Error(),
-	}, syncID)
-}
-
-func sendAttachedSyncJSON(send func(*schema.AiOutputEvent) error, eventType schema.EventType, nodeID string, payload any, syncID string) error {
-	return send(&schema.AiOutputEvent{
-		Type:      eventType,
-		NodeId:    nodeID,
-		IsJson:    true,
-		IsSync:    true,
-		Content:   utils.Jsonify(payload),
-		Timestamp: time.Now().Unix(),
-		SyncID:    syncID,
-	})
 }
 
 func (s *Server) GetRandomAIMaterials(ctx context.Context, req *ypb.GetRandomAIMaterialsRequest) (*ypb.GetRandomAIMaterialsResponse, error) {

--- a/common/yakgrpc/grpc_ai_re-act.go
+++ b/common/yakgrpc/grpc_ai_re-act.go
@@ -14,13 +14,8 @@ import (
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 
 	"github.com/yaklang/yaklang/common/ai/aid"
-	"github.com/yaklang/yaklang/common/utils/chanx"
-
-	"github.com/yaklang/yaklang/common/ai/rag"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
-	"github.com/yaklang/yaklang/common/ai/aid/aireact"
-	"github.com/yaklang/yaklang/common/ai/aid/aireact/reactloops/reactloops_yak"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/utils"
@@ -202,7 +197,9 @@ func (s *Server) StartAIReAct(stream ypb.Yak_StartAIReActServer) error {
 }
 
 // startAIReActWithOptions keeps production behavior unchanged while allowing
-// lifecycle tests to replace external AI dependencies.
+// lifecycle tests to replace external AI dependencies. It is now only the gRPC
+// protocol adapter; session arbitration, ownership and input delivery live in
+// ReActSessionRuntime.
 func (s *Server) startAIReActWithOptions(stream ypb.Yak_StartAIReActServer, loadBuiltinTools bool, additionalOptions ...aicommon.ConfigOption) error {
 	firstMsg, err := stream.Recv()
 	if err != nil {
@@ -210,242 +207,16 @@ func (s *Server) startAIReActWithOptions(stream ypb.Yak_StartAIReActServer, load
 		return utils.Errorf("recv first mgs failed: %v", err)
 	}
 
-	if !firstMsg.IsStart {
+	if firstMsg == nil || !firstMsg.GetIsStart() {
 		log.Errorf("recv re-act first config msg is invalid: %v", firstMsg)
 		return utils.Error("first msg is not a start/config message, set IsStart to true")
 	}
-
-	// 启动 ReAct 之前懒扫描用户的 ~/yakit-projects/ai-focus/，
-	// 防止客户端跳过 QueryAIFocus 直接发带 FocusModeLoop 的 free input 时
-	// 找不到注册项。冷却由 EnsureUserFocusModesLoaded 内部控制，失败只 log。
-	// 关键词: start ai re-act ensure user focus modes
-	if err := reactloops_yak.EnsureUserFocusModesLoaded(); err != nil {
-		log.Warnf("ensure user yak focus modes failed: %v", err)
-	}
-
-	startParams := firstMsg.Params
-
-	baseCtx, cancel := context.WithCancel(stream.Context())
-	defer cancel()
-
-	inputEvent := chanx.NewUnlimitedChan[*ypb.AIInputEvent](baseCtx, 10)
-
-	var currentCoordinatorId = startParams.CoordinatorId
-	_ = currentCoordinatorId
-	var coordinatorIdOnce = new(sync.Once)
+	startParams := firstMsg.GetParams()
 	var sendMu sync.Mutex
-	// debugStreamPrinter 在 DEBUG=1 时把流式 delta 合并到单行，避免每个
-	// token 单独换行造成的刷屏；非流事件来临时先 FlushIfActive 收尾，让
-	// 后续 log / 普通事件都从新行开始，消除"夹心"现象。
-	// 关键词: DEBUG=1 流式输出体验, AI stream delta debug print
-	debugStreamPrinter := aicommon.GetDefaultDebugStreamPrinter()
-	// 同步把 common/log 默认输出包装上一层 flush, 让任何日志写入前先把
-	// 流缓冲刷出, 彻底消灭日志被夹在流中间的视觉混乱。
-	// 关键词: EnsureLogFlushWrapperInstalled grpc_ai_react entry
-	aicommon.EnsureLogFlushWrapperInstalled()
-
-	feedback := func(e *schema.AiOutputEvent) {
-		if e.Timestamp <= 0 {
-			e.Timestamp = time.Now().Unix() // fallback
-		}
-		if e.CoordinatorId != "" {
-			coordinatorIdOnce.Do(func() {
-				currentCoordinatorId = e.CoordinatorId
-			})
-		}
-
-		utils.Debug(func() {
-			if e.IsStream {
-				debugStreamPrinter.PrintStreamDelta(e)
-			} else {
-				debugStreamPrinter.FlushIfActive()
-			}
-		})
-
-		if stream.Context().Err() != nil {
-			return
-		}
-		sendMu.Lock()
-		defer sendMu.Unlock()
-		err := stream.Send(e.ToGRPC())
-		if err != nil {
-			log.Errorf("send re-act event to stream failed: %v", err)
-		}
-	}
-
-	persistentSession := startParams.GetTimelineSessionID()
-	if persistentSession == "" {
-		persistentSession = "default"
-	}
-
-	if startParams.GetAttach() {
-		runningReAct, err := aireact.WaitRunningSession(persistentSession, time.Minute)
-		if err != nil {
-			return err
-		}
-		return s.attachToRunningAIReActSession(stream, baseCtx, runningReAct, firstMsg, persistentSession, startParams)
-	}
-
-	if runningReAct, ok := aireact.GetRunningSession(persistentSession); ok {
-		return s.attachToRunningAIReActSession(stream, baseCtx, runningReAct, firstMsg, persistentSession, startParams)
-	}
-
-	// A scheduled run reserves its target session at the trigger boundary. A
-	// user turn arriving in the narrow interval before that run publishes its
-	// ReAct instance waits and attaches, so it cannot steal initialization and
-	// make the scheduled occurrence execute late behind it.
-	_, isScheduledStream := stream.(*inProcessAIReActStream)
-	if !isScheduledStream {
-		for {
-			manager := s.currentAIReActScheduler()
-			if manager == nil || !manager.isSessionReserved(persistentSession) {
-				break
-			}
-			if runningReAct, ok := aireact.GetRunningSession(persistentSession); ok {
-				return s.attachToRunningAIReActSession(stream, baseCtx, runningReAct, firstMsg, persistentSession, startParams)
-			}
-			select {
-			case <-baseCtx.Done():
-				return nil
-			case <-time.After(20 * time.Millisecond):
-			}
-		}
-	}
-
-	releaseSessionStart, ownsSessionStart := aireact.TryBeginSessionStart(persistentSession)
-	if !ownsSessionStart {
-		runningReAct, err := aireact.WaitRunningSession(persistentSession, time.Minute)
-		if err != nil {
-			return err
-		}
-		return s.attachToRunningAIReActSession(stream, baseCtx, runningReAct, firstMsg, persistentSession, startParams)
-	}
-	sessionStartHeld := true
-	defer func() {
-		if sessionStartHeld {
-			releaseSessionStart()
-		}
-	}()
-
-	resolvedStartParams, err := resolveAISessionStartParams(
-		s.GetProjectDatabase(),
-		persistentSession,
-		startParams,
-		startParams.GetPreferSessionCachedConfig(),
-	)
-	if err != nil {
-		return utils.Errorf("resolve session cached config failed: %v", err)
-	}
-	startParams = resolvedStartParams
-	firstMsg.Params = resolvedStartParams
-
-	if _, err := yakit.CreateOrUpdateAISessionMetaOnStart(s.GetProjectDatabase(), persistentSession, startParams, time.Now()); err != nil {
-		log.Warnf("persist ai session start meta failed for %s: %v", persistentSession, err)
-	}
-
-	optsFromStartParams := ConvertYPBAIStartParamsToReActConfig(startParams)
-	var hotpatchChan = chanx.NewUnlimitedChan[aicommon.ConfigOption](baseCtx, 10)
-
-	if aiconfig.IsTieredAIConfig() {
-		log.Info("tiered ai config is enabled. the old-styled ai config is override")
-	}
-
-	defaultAI, err := aicommon.GetDefaultAIModelCallback()
-	if err != nil {
-		defaultAI, _ = aicommon.GetDefaultAIModelCallback()
-		log.Warnf("get default AI model callback failed: %v", err)
-	}
-
-	var configOptions = []aicommon.ConfigOption{
-		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
-			feedback(e)
-		}),
-		aicommon.WithEventInputChanx(inputEvent),
-		aicommon.WithContext(baseCtx),
-	}
-	if loadBuiltinTools {
-		configOptions = append(configOptions, aireact.WithBuiltinTools())
-	}
-	configOptions = append(configOptions,
-		aicommon.WithEnhanceKnowledgeManager(rag.NewRagEnhanceKnowledgeManager()),
-		aicommon.WithPersistentSessionId(persistentSession),
-		aicommon.WithHotPatchOptionChan(hotpatchChan),
-		aicommon.WithEnablePETaskAnalyze(true),
-		aicommon.WithEnableDispatchSubReactAgent(true), // 仅仅允许顶层 ReAct 分发子 ReAct Agent，子 Agent 仍然可以使用原始的 AI 回调。
-	)
-	// optsFromStartParams (containing WithAICallback) must be applied BEFORE
-	// tiered overrides, otherwise WithAICallback overwrites all three callbacks
-	// (Original, Quality, Speed) to the same frontend-selected model.
-	configOptions = append(configOptions, optsFromStartParams...)
-	if aiconfig.IsTieredAIConfig() {
-		configOptions = append(configOptions, aicommon.WithAutoTieredAICallback(defaultAI))
-	}
-	configOptions = append(configOptions, additionalOptions...)
-
-	reAct, err := aireact.NewReAct(configOptions...)
-	if err != nil {
-		log.Errorf("create re-act failed: %v", err)
-		return utils.Errorf("create re-act instance failed: %v", err)
-	}
-	releaseSessionStart()
-	sessionStartHeld = false
-
-	reAct.GetConfig().SetConfig("MustProcessAttachedData", true)
-
-	_ = reAct // ensure reAct is not nil
-	for {
-		select {
-		case <-baseCtx.Done():
-			log.Info("AIReAct stream context done, stopping re-act")
-			return nil
-		default:
-			// continue processing
-		}
-
-		event, err := stream.Recv()
-		if err != nil {
-			log.Errorf("recv re-act msg failed: %v", err)
-			continue
-		}
-
-		inputEvent.SafeFeed(event)
-	}
-}
-
-func (s *Server) attachToRunningAIReActSession(
-	stream ypb.Yak_StartAIReActServer,
-	baseCtx context.Context,
-	runningReAct *aireact.ReAct,
-	firstMsg *ypb.AIInputEvent,
-	persistentSession string,
-	startParams *ypb.AIStartParams,
-) error {
-	log.Infof("attach grpc stream to running aireact session: %s", persistentSession)
-
-	if _, err := yakit.CreateOrUpdateAISessionMetaOnStart(s.GetProjectDatabase(), persistentSession, startParams, time.Now()); err != nil {
-		log.Warnf("persist ai session start meta failed for %s: %v", persistentSession, err)
-	}
-
-	var sendMu sync.Mutex
-	debugStreamPrinter := aicommon.GetDefaultDebugStreamPrinter()
-	aicommon.EnsureLogFlushWrapperInstalled()
-
-	sendEvent := func(e *schema.AiOutputEvent) error {
+	feedback := func(e *schema.AiOutputEvent) error {
 		if e == nil {
 			return nil
 		}
-		if e.Timestamp <= 0 {
-			e.Timestamp = time.Now().Unix()
-		}
-
-		utils.Debug(func() {
-			if e.IsStream {
-				debugStreamPrinter.PrintStreamDelta(e)
-			} else {
-				debugStreamPrinter.FlushIfActive()
-			}
-		})
-
 		if stream.Context().Err() != nil {
 			return nil
 		}
@@ -454,61 +225,107 @@ func (s *Server) attachToRunningAIReActSession(
 		return stream.Send(e.ToGRPC())
 	}
 
-	feedback := func(e *schema.AiOutputEvent) {
-		if err := sendEvent(e); err != nil {
-			log.Errorf("send re-act event to attached stream failed: %v", err)
+	runtime := s.getReActSessionRuntime()
+	if runtime == nil {
+		return utils.Error("AI ReAct session runtime is not configured")
+	}
+	request := ConnectRequest{
+		StartParams: startParams,
+		options: &reActConnectOptions{
+			loadBuiltinTools: loadBuiltinTools,
+			configOptions:    additionalOptions,
+			onEventError: func(err error) {
+				// Keep the original streaming behavior: a failed subscriber
+				// delivery is observable, but it does not fail the shared ReAct.
+				log.Errorf("send re-act event to stream failed: %v", err)
+			},
+		},
+	}
+	connection, err := runtime.Connect(stream.Context(), request, feedback)
+	if err != nil {
+		return err
+	}
+	defer connection.Close()
+	createdRuntime := connection.CreatedRuntime()
+	type recvResult struct {
+		event *ypb.AIInputEvent
+		err   error
+	}
+	recvResults := make(chan recvResult, 1)
+	go func() {
+		for {
+			event, err := stream.Recv()
+			select {
+			case recvResults <- recvResult{event: event, err: err}:
+			case <-stream.Context().Done():
+				return
+			case <-connection.Done():
+				return
+			}
+			if err != nil && !createdRuntime {
+				return
+			}
 		}
-	}
-
-	unsubscribe, ok := aireact.SubscribeRunningSession(persistentSession, feedback)
-	if !ok {
-		return utils.Errorf("failed to subscribe running aireact session: %s", persistentSession)
-	}
-	defer unsubscribe()
-
-	if firstMsg != nil && !firstMsg.GetIsStart() {
-		if err := runningReAct.SendInputEvent(firstMsg); err != nil {
-			log.Warnf("forward first input to running session failed: %v", err)
-		}
-	}
+	}()
 
 	for {
 		select {
-		case <-baseCtx.Done():
-			log.Info("attached AIReAct stream context done")
-			return nil
-		default:
-		}
-
-		event, err := stream.Recv()
-		if err != nil {
-			log.Infof("attached AIReAct stream recv ended: %v", err)
-			return nil
-		}
-		if event.GetIsStart() {
-			continue
-		}
-		if event.GetIsSyncMessage() && event.GetSyncType() == aicommon.SYNC_TYPE_RECOVERY_HISTORY {
-			if err := s.sendAttachedRecoveryHistory(stream.Context(), sendEvent, persistentSession, event); err != nil {
-				log.Warnf("send attached recovery history failed: %v", err)
+		case <-stream.Context().Done():
+			if createdRuntime {
+				log.Info("AIReAct stream context done, stopping re-act")
+			} else {
+				log.Info("attached AIReAct stream context done")
 			}
-			continue
-		}
-		if err := runningReAct.SendInputEvent(event); err != nil {
-			log.Warnf("forward input to running session failed: %v", err)
+			return nil
+		case <-connection.Done():
+			return nil
+		case result := <-recvResults:
+			event, err := result.event, result.err
+			if err != nil {
+				if createdRuntime {
+					log.Errorf("recv re-act msg failed: %v", err)
+					continue
+				}
+				log.Infof("attached AIReAct stream recv ended: %v", err)
+				return nil
+			}
+			if event == nil {
+				if createdRuntime {
+					log.Errorf("recv re-act msg failed: nil event")
+					continue
+				}
+				log.Infof("attached AIReAct stream recv ended: nil event")
+				return nil
+			}
+			if event.GetIsStart() {
+				continue
+			}
+			if err := connection.Send(event); err != nil {
+				if !createdRuntime && event.GetIsSyncMessage() && event.GetSyncType() == aicommon.SYNC_TYPE_RECOVERY_HISTORY {
+					log.Warnf("send attached recovery history failed: %v", err)
+					continue
+				}
+				if createdRuntime {
+					// The old creator path admitted input asynchronously. Processing
+					// failures were logged by the event loop and did not close the stream.
+					log.Errorf("ReAct event processing failed: %v", err)
+				} else {
+					log.Warnf("forward input to running session failed: %v", err)
+				}
+			}
 		}
 	}
 }
 
 const attachedRecoveryHistoryBlockLimit = 20
 
-func (s *Server) sendAttachedRecoveryHistory(
+func sendAttachedRecoveryHistory(
 	ctx context.Context,
+	db *gorm.DB,
 	send func(*schema.AiOutputEvent) error,
 	persistentSession string,
 	event *ypb.AIInputEvent,
 ) error {
-	db := s.GetProjectDatabase()
 	if db == nil {
 		return sendAttachedSyncError(send, "recovery_history", utils.Errorf("db is nil"), event.GetSyncID())
 	}

--- a/common/yakgrpc/grpc_ai_react_schedule_test.go
+++ b/common/yakgrpc/grpc_ai_react_schedule_test.go
@@ -2,14 +2,16 @@ package yakgrpc
 
 import (
 	"context"
-	"encoding/json"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
+	"github.com/yaklang/yaklang/common/ai/aid/aireactscheduler"
 	"github.com/yaklang/yaklang/common/ai/aid/aischedule"
+	"github.com/yaklang/yaklang/common/ai/aid/reactservice"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
@@ -17,11 +19,11 @@ import (
 )
 
 type connectOverrideRuntime struct {
-	ReActSessionRuntime
-	connect func(context.Context, ConnectRequest, ReActEventHandler) (ReActConnection, error)
+	sessionruntime.ReActSessionRuntime
+	connect func(context.Context, sessionruntime.ConnectRequest, sessionruntime.ReActEventHandler) (sessionruntime.ReActConnection, error)
 }
 
-func (r *connectOverrideRuntime) Connect(ctx context.Context, req ConnectRequest, onEvent ReActEventHandler) (ReActConnection, error) {
+func (r *connectOverrideRuntime) Connect(ctx context.Context, req sessionruntime.ConnectRequest, onEvent sessionruntime.ReActEventHandler) (sessionruntime.ReActConnection, error) {
 	return r.connect(ctx, req, onEvent)
 }
 
@@ -109,8 +111,8 @@ func TestAIReActScheduleSupportsBothSessionTargets(t *testing.T) {
 	require.Equal(t, "busy-user-session", record.TargetSessionID)
 
 	const runUUID = "17ea0eb4-acde-40c1-965e-3661c62347f2"
-	require.Equal(t, "busy-user-session", scheduleExecutionSessionID(record, runUUID))
-	require.Equal(t, "ai-schedule-"+runUUID, scheduleExecutionSessionID(&schema.AIReActSchedule{
+	require.Equal(t, "busy-user-session", aireactscheduler.ScheduleExecutionSessionID(record, runUUID))
+	require.Equal(t, "ai-schedule-"+runUUID, aireactscheduler.ScheduleExecutionSessionID(&schema.AIReActSchedule{
 		TargetMode: schema.AIReActScheduleTargetNewSession,
 	}, runUUID))
 }
@@ -126,16 +128,15 @@ func TestPrepareIsolatedScheduleSessionIsImmediatelyQueryable(t *testing.T) {
 		TargetMode: schema.AIReActScheduleTargetNewSession,
 	}
 
-	require.NoError(t, prepareIsolatedScheduleSession(
+	require.NoError(t, aireactscheduler.PrepareIsolatedScheduleSession(
 		server.GetProjectDatabase(),
 		schedule,
 		params,
 		sessionID,
 		startedAt,
 	))
-	manager := newAIReActScheduler(server, server.GetProjectDatabase())
-	server.aiReActScheduler = manager
-	reservation, err := manager.runtime.ReserveSession(context.Background(), sessionID, "running-execution")
+	runtime := server.getReActSessionRuntime()
+	reservation, err := runtime.ReserveSession(context.Background(), sessionID, "running-execution")
 	require.NoError(t, err)
 
 	response, err := server.QueryAISession(context.Background(), &ypb.QueryAISessionRequest{
@@ -173,7 +174,7 @@ func TestContinueSessionScheduleKeepsChatReviewPolicy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	params, err := scheduleRunStartParams(server.GetProjectDatabase(), &schema.AIReActSchedule{
+	params, err := aireactscheduler.ScheduleRunStartParams(server.GetProjectDatabase(), &schema.AIReActSchedule{
 		TargetMode:      schema.AIReActScheduleTargetContinueSession,
 		TargetSessionID: sessionID,
 	}, &ypb.AIStartParams{ReviewPolicy: "yolo"})
@@ -183,7 +184,7 @@ func TestContinueSessionScheduleKeepsChatReviewPolicy(t *testing.T) {
 	require.False(t, params.GetAttach())
 	require.False(t, params.GetPreferSessionCachedConfig())
 
-	isolated, err := scheduleRunStartParams(server.GetProjectDatabase(), &schema.AIReActSchedule{
+	isolated, err := aireactscheduler.ScheduleRunStartParams(server.GetProjectDatabase(), &schema.AIReActSchedule{
 		TargetMode: schema.AIReActScheduleTargetNewSession,
 	}, &ypb.AIStartParams{ReviewPolicy: "manual"})
 	require.NoError(t, err)
@@ -200,43 +201,6 @@ func TestPreviewAIReActScheduleTimes(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, response.GetTimestamps(), 3)
 	require.Equal(t, start.Unix(), response.GetTimestamps()[0])
-}
-
-func TestAIReActSchedulerSkipsMisfireAndAdvances(t *testing.T) {
-	server := newScheduleTestServer(t)
-	now := time.Now().UTC().Truncate(time.Second)
-	due := now.Add(-10 * time.Minute)
-	schedule := &schema.AIReActSchedule{
-		UUID:                  "misfire-schedule",
-		Name:                  "misfire",
-		Status:                schema.AIReActScheduleStatusActive,
-		TargetMode:            schema.AIReActScheduleTargetNewSession,
-		Prompt:                "test",
-		StartParams:           `{}`,
-		AttachedResourceInfos: `[]`,
-		RRule:                 "RRULE:FREQ=HOURLY;INTERVAL=1",
-		Timezone:              "UTC",
-		StartAt:               now.Add(-time.Hour),
-		NextRunAt:             &due,
-		MisfireGraceSeconds:   1,
-		MaxRuntimeSeconds:     60,
-	}
-	require.NoError(t, server.GetProjectDatabase().Create(schedule).Error)
-	manager := newAIReActScheduler(server, server.GetProjectDatabase())
-	defer manager.cancel()
-	manager.dispatchDue()
-
-	manager.jobsMu.Lock()
-	require.Empty(t, manager.jobs)
-	require.Empty(t, manager.activeBySchedule)
-	manager.jobsMu.Unlock()
-
-	updated, err := getAIReActScheduleRecord(server.GetProjectDatabase(), schedule.UUID)
-	require.NoError(t, err)
-	require.NotNil(t, updated.NextRunAt)
-	require.True(t, updated.NextRunAt.After(now))
-	require.Equal(t, scheduledOutcomeSkipped, updated.LastOutcome)
-	require.Equal(t, "misfire", updated.LastSkipReason)
 }
 
 func TestAIReActScheduleFiltersAndSessionLifecycle(t *testing.T) {
@@ -276,103 +240,6 @@ func TestAIReActScheduleFiltersAndSessionLifecycle(t *testing.T) {
 	require.Equal(t, schema.AIReActScheduleTargetNewSession, remaining.TargetMode)
 }
 
-func TestAIReActSchedulerSkipsAtTriggerBoundary(t *testing.T) {
-	server := newScheduleTestServer(t)
-	manager := newAIReActScheduler(server, server.GetProjectDatabase())
-	defer manager.cancel()
-	const sessionID = "starting-user-session"
-	_, err := yakit.CreateOrUpdateAISessionMetaStartParams(server.GetProjectDatabase(), sessionID, &ypb.AIStartParams{})
-	require.NoError(t, err)
-	reservation, err := manager.runtime.ReserveSession(context.Background(), sessionID, "frontend-start")
-	require.NoError(t, err)
-	defer reservation.Release()
-
-	schedule := &schema.AIReActSchedule{
-		UUID: "busy-boundary", TargetMode: schema.AIReActScheduleTargetContinueSession, TargetSessionID: sessionID,
-		Status: schema.AIReActScheduleStatusActive,
-	}
-	require.NoError(t, server.GetProjectDatabase().Create(schedule).Error)
-	err = manager.enqueue(schedule, time.Now(), aiReActScheduleTriggerSchedule)
-	var skip *scheduleEnqueueError
-	require.ErrorAs(t, err, &skip)
-	require.Equal(t, "session_busy", skip.reason)
-	require.Empty(t, manager.jobs)
-}
-
-func TestAIReActSchedulerUsesBoundedParallelCapacity(t *testing.T) {
-	server := newScheduleTestServer(t)
-	manager := newAIReActScheduler(server, server.GetProjectDatabase())
-	defer manager.cancel()
-	for i := 0; i < aiReActScheduleMaxConcurrent; i++ {
-		manager.worker <- struct{}{}
-	}
-	schedule := &schema.AIReActSchedule{
-		UUID: "over-capacity", TargetMode: schema.AIReActScheduleTargetNewSession,
-		Status: schema.AIReActScheduleStatusActive,
-	}
-	require.NoError(t, server.GetProjectDatabase().Create(schedule).Error)
-	err := manager.enqueue(schedule, time.Now(), aiReActScheduleTriggerSchedule)
-	var skip *scheduleEnqueueError
-	require.ErrorAs(t, err, &skip)
-	require.Equal(t, "scheduler_capacity", skip.reason)
-}
-
-func TestAIReActSchedulerRejectsEnqueueAfterStop(t *testing.T) {
-	server := newScheduleTestServer(t)
-	manager := newAIReActScheduler(server, server.GetProjectDatabase())
-	manager.cancel()
-
-	schedule, err := buildScheduleRecord(validScheduleRequest(time.Now().Add(time.Hour)).GetSchedule(), nil)
-	require.NoError(t, err)
-	require.NoError(t, server.GetProjectDatabase().Create(schedule).Error)
-	err = manager.enqueue(schedule, time.Now(), aiReActScheduleTriggerSchedule)
-	require.ErrorIs(t, err, context.Canceled)
-	require.Empty(t, manager.jobs)
-	require.Empty(t, manager.activeBySchedule)
-	require.Empty(t, manager.worker)
-}
-
-func TestScheduledReActRuntimeErrorPreservesContextClassification(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	outcome := scheduledReActRuntimeError(ctx, context.Canceled)
-	require.Empty(t, outcome.status)
-	require.Empty(t, outcome.errorMessage)
-
-	outcome = scheduledReActRuntimeError(context.Background(), context.Canceled)
-	require.Equal(t, scheduledOutcomeFailed, outcome.status)
-	require.ErrorContains(t, context.Canceled, outcome.errorMessage)
-}
-
-func TestAIReActSchedulerCancelsActiveExecutionInMemory(t *testing.T) {
-	server := newScheduleTestServer(t)
-	manager := newAIReActScheduler(server, server.GetProjectDatabase())
-	defer manager.cancel()
-
-	jobCtx, cancel := context.WithCancel(manager.ctx)
-	reservation, err := manager.runtime.ReserveSession(jobCtx, "ai-schedule-active-execution", "active-execution")
-	require.NoError(t, err)
-	job := &scheduledReActJob{
-		executionID:  "active-execution",
-		scheduleUUID: "schedule",
-		sessionID:    "ai-schedule-active-execution",
-		ctx:          reservation.Context(),
-		cancel:       cancel,
-		reservation:  reservation,
-		done:         make(chan struct{}),
-	}
-	manager.jobs[job.executionID] = job
-	manager.activeBySchedule[job.scheduleUUID] = job.executionID
-	require.True(t, manager.runtime.IsSessionBusy(job.sessionID))
-
-	manager.cancelSchedule(job.scheduleUUID)
-	require.Eventually(t, func() bool { return job.ctx.Err() == context.Canceled }, time.Second, 10*time.Millisecond)
-	manager.unregisterJob(job)
-	require.Empty(t, manager.jobs)
-	require.Empty(t, manager.activeBySchedule)
-	require.False(t, manager.runtime.IsSessionBusy(job.sessionID))
-}
-
 func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
 	server := newScheduleTestServer(t)
 	db := server.GetProjectDatabase()
@@ -384,7 +251,6 @@ func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
 		&schema.AISessionPlanAndExec{},
 	).Error)
 
-	manager := newAIReActScheduler(server, db)
 	executionCancelled := make(chan struct{})
 	allowShutdown := make(chan struct{})
 	var cancellationReported atomic.Bool
@@ -395,8 +261,9 @@ func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
 		}
 	}
 	defer releaseShutdown()
-	overrideRuntime := &connectOverrideRuntime{ReActSessionRuntime: manager.runtime}
-	overrideRuntime.connect = func(ctx context.Context, _ ConnectRequest, _ ReActEventHandler) (ReActConnection, error) {
+	baseRuntime := sessionruntime.New(server.GetProjectDatabase)
+	overrideRuntime := &connectOverrideRuntime{ReActSessionRuntime: baseRuntime}
+	overrideRuntime.connect = func(ctx context.Context, _ sessionruntime.ConnectRequest, _ sessionruntime.ReActEventHandler) (sessionruntime.ReActConnection, error) {
 		<-ctx.Done()
 		if cancellationReported.CompareAndSwap(false, true) {
 			close(executionCancelled)
@@ -404,34 +271,31 @@ func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
 		<-allowShutdown
 		return nil, ctx.Err()
 	}
-	manager.runtime = overrideRuntime
-	server.reActRuntime = overrideRuntime
-	server.aiReActSchedulerMu.Lock()
-	server.aiReActScheduler = manager
-	server.aiReActSchedulerMu.Unlock()
+	service := reactservice.New(server.GetProjectDatabase, reactservice.WithRuntime(overrideRuntime))
+	server.reActService = service
+	service.StartScheduler()
+	defer service.StopScheduler()
 
 	created, err := server.CreateAIReActSchedule(context.Background(), validScheduleRequest(time.Now().Add(time.Hour)))
 	require.NoError(t, err)
 	_, err = server.RunAIReActScheduleNow(context.Background(), &ypb.RunAIReActScheduleNowRequest{UUID: created.GetUUID()})
 	require.NoError(t, err)
 
-	var firstJob *scheduledReActJob
+	var firstJob aireactscheduler.ActiveExecution
 	require.Eventually(t, func() bool {
-		manager.jobsMu.Lock()
-		defer manager.jobsMu.Unlock()
-		executionID := manager.activeBySchedule[created.GetUUID()]
-		firstJob = manager.jobs[executionID]
-		return firstJob != nil
+		var ok bool
+		firstJob, ok = service.ActiveExecution(created.GetUUID())
+		return ok
 	}, time.Second, 10*time.Millisecond)
 	require.Eventually(t, func() bool {
-		_, queryErr := yakit.GetAISessionMetaBySessionID(db, firstJob.sessionID)
+		_, queryErr := yakit.GetAISessionMetaBySessionID(db, firstJob.SessionID)
 		return queryErr == nil
 	}, time.Second, 10*time.Millisecond)
 
 	deleteDone := make(chan error, 1)
 	go func() {
 		_, deleteErr := server.DeleteAISession(context.Background(), &ypb.DeleteAISessionRequest{
-			Filter: &ypb.DeleteAISessionFilter{SessionID: []string{firstJob.sessionID}},
+			Filter: &ypb.DeleteAISessionFilter{SessionID: []string{firstJob.SessionID}},
 		})
 		deleteDone <- deleteErr
 	}()
@@ -454,74 +318,28 @@ func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
 		t.Fatal("DeleteAISession did not finish after scheduler shutdown")
 	}
 	select {
-	case <-firstJob.done:
+	case <-firstJob.Done:
 	default:
 		t.Fatal("DeleteAISession returned before the scheduler job unregistered")
 	}
-	manager.jobsMu.Lock()
-	require.NotContains(t, manager.jobs, firstJob.executionID)
-	require.NotContains(t, manager.activeBySchedule, created.GetUUID())
-	manager.jobsMu.Unlock()
-	require.False(t, manager.runtime.IsSessionBusy(firstJob.sessionID))
+	_, active := service.ActiveExecution(created.GetUUID())
+	require.False(t, active)
+	require.False(t, baseRuntime.IsSessionBusy(firstJob.SessionID))
 
 	// Reproduce the UI sequence from the bug report: delete the running
 	// independent session and immediately run the same schedule again.
 	_, err = server.RunAIReActScheduleNow(context.Background(), &ypb.RunAIReActScheduleNowRequest{UUID: created.GetUUID()})
 	require.NoError(t, err)
-	var secondJob *scheduledReActJob
+	var secondJob aireactscheduler.ActiveExecution
 	require.Eventually(t, func() bool {
-		manager.jobsMu.Lock()
-		defer manager.jobsMu.Unlock()
-		executionID := manager.activeBySchedule[created.GetUUID()]
-		secondJob = manager.jobs[executionID]
-		return secondJob != nil && secondJob.executionID != firstJob.executionID
+		var ok bool
+		secondJob, ok = service.ActiveExecution(created.GetUUID())
+		return ok && secondJob.ExecutionID != firstJob.ExecutionID
 	}, time.Second, 10*time.Millisecond)
-	manager.cancelSchedule(created.GetUUID())
+	service.CancelSchedule(created.GetUUID())
 	select {
-	case <-secondJob.done:
+	case <-secondJob.Done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("replacement scheduled execution did not stop")
 	}
-}
-
-func TestScheduleAttentionWaitsForActualAIEscalation(t *testing.T) {
-	pending := make(map[string]struct{})
-	reviewRequest := &ypb.AIOutputEvent{
-		Type:    string(schema.EVENT_TYPE_TOOL_USE_REVIEW_REQUIRE),
-		Content: json.RawMessage(`{"id":"review-1"}`),
-	}
-	attention, _ := scheduleAttentionForEvent(reviewRequest, true, pending)
-	require.False(t, attention, "starting AI review must not pause a scheduled run")
-	require.Contains(t, pending, "review-1")
-
-	autoApproved := &ypb.AIOutputEvent{
-		Type:    string(schema.EVENT_TYPE_AI_REVIEW_END),
-		Content: json.RawMessage(`{"interactive_id":"review-1","level":"low","requires_user":false}`),
-	}
-	attention, _ = scheduleAttentionForEvent(autoApproved, true, pending)
-	require.False(t, attention, "low-risk AI review should continue unattended")
-	require.NotContains(t, pending, "review-1")
-
-	attention, _ = scheduleAttentionForEvent(&ypb.AIOutputEvent{
-		Type:    string(schema.EVENT_TYPE_PLAN_REVIEW_REQUIRE),
-		Content: json.RawMessage(`{"id":"review-2"}`),
-	}, true, pending)
-	require.False(t, attention)
-
-	attention, message := scheduleAttentionForEvent(&ypb.AIOutputEvent{
-		Type: string(schema.EVENT_TYPE_AI_REVIEW_END),
-		Content: json.RawMessage(
-			`{"interactive_id":"review-2","level":"high","requires_user":true,"reason":"dangerous operation"}`,
-		),
-	}, true, pending)
-	require.True(t, attention, "only an explicit high-risk escalation should need the user")
-	require.Contains(t, message, "dangerous operation")
-}
-
-func TestScheduleAttentionForExplicitUserInteraction(t *testing.T) {
-	attention, message := scheduleAttentionForEvent(&ypb.AIOutputEvent{
-		Type: string(schema.EVENT_TYPE_REQUIRE_USER_INTERACTIVE),
-	}, true, make(map[string]struct{}))
-	require.True(t, attention)
-	require.Contains(t, message, "user interaction")
 }

--- a/common/yakgrpc/grpc_ai_react_schedule_test.go
+++ b/common/yakgrpc/grpc_ai_react_schedule_test.go
@@ -9,13 +9,21 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/yaklang/yaklang/common/ai/aid/aireact"
 	"github.com/yaklang/yaklang/common/ai/aid/aischedule"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
+
+type connectOverrideRuntime struct {
+	ReActSessionRuntime
+	connect func(context.Context, ConnectRequest, ReActEventHandler) (ReActConnection, error)
+}
+
+func (r *connectOverrideRuntime) Connect(ctx context.Context, req ConnectRequest, onEvent ReActEventHandler) (ReActConnection, error) {
+	return r.connect(ctx, req, onEvent)
+}
 
 func newScheduleTestServer(t *testing.T) *Server {
 	t.Helper()
@@ -127,7 +135,8 @@ func TestPrepareIsolatedScheduleSessionIsImmediatelyQueryable(t *testing.T) {
 	))
 	manager := newAIReActScheduler(server, server.GetProjectDatabase())
 	server.aiReActScheduler = manager
-	manager.activeBySession[sessionID] = "running-execution"
+	reservation, err := manager.runtime.ReserveSession(context.Background(), sessionID, "running-execution")
+	require.NoError(t, err)
 
 	response, err := server.QueryAISession(context.Background(), &ypb.QueryAISessionRequest{
 		Pagination: &ypb.Paging{Page: 1, Limit: 10, OrderBy: "last_used_at", Order: "desc"},
@@ -143,7 +152,7 @@ func TestPrepareIsolatedScheduleSessionIsImmediatelyQueryable(t *testing.T) {
 	require.Equal(t, startedAt.Unix(), visible.GetLastUsedAt())
 	require.True(t, visible.GetIsRunning())
 
-	delete(manager.activeBySession, sessionID)
+	reservation.Release()
 	response, err = server.QueryAISession(context.Background(), &ypb.QueryAISessionRequest{
 		Pagination: &ypb.Paging{Page: 1, Limit: 10},
 		Filter:     &ypb.AISessionFilter{SessionID: []string{sessionID}},
@@ -274,9 +283,9 @@ func TestAIReActSchedulerSkipsAtTriggerBoundary(t *testing.T) {
 	const sessionID = "starting-user-session"
 	_, err := yakit.CreateOrUpdateAISessionMetaStartParams(server.GetProjectDatabase(), sessionID, &ypb.AIStartParams{})
 	require.NoError(t, err)
-	release, ok := aireact.TryBeginSessionStart(sessionID)
-	require.True(t, ok)
-	defer release()
+	reservation, err := manager.runtime.ReserveSession(context.Background(), sessionID, "frontend-start")
+	require.NoError(t, err)
+	defer reservation.Release()
 
 	schedule := &schema.AIReActSchedule{
 		UUID: "busy-boundary", TargetMode: schema.AIReActScheduleTargetContinueSession, TargetSessionID: sessionID,
@@ -308,30 +317,60 @@ func TestAIReActSchedulerUsesBoundedParallelCapacity(t *testing.T) {
 	require.Equal(t, "scheduler_capacity", skip.reason)
 }
 
+func TestAIReActSchedulerRejectsEnqueueAfterStop(t *testing.T) {
+	server := newScheduleTestServer(t)
+	manager := newAIReActScheduler(server, server.GetProjectDatabase())
+	manager.cancel()
+
+	schedule, err := buildScheduleRecord(validScheduleRequest(time.Now().Add(time.Hour)).GetSchedule(), nil)
+	require.NoError(t, err)
+	require.NoError(t, server.GetProjectDatabase().Create(schedule).Error)
+	err = manager.enqueue(schedule, time.Now(), aiReActScheduleTriggerSchedule)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, manager.jobs)
+	require.Empty(t, manager.activeBySchedule)
+	require.Empty(t, manager.worker)
+}
+
+func TestScheduledReActRuntimeErrorPreservesContextClassification(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	outcome := scheduledReActRuntimeError(ctx, context.Canceled)
+	require.Empty(t, outcome.status)
+	require.Empty(t, outcome.errorMessage)
+
+	outcome = scheduledReActRuntimeError(context.Background(), context.Canceled)
+	require.Equal(t, scheduledOutcomeFailed, outcome.status)
+	require.ErrorContains(t, context.Canceled, outcome.errorMessage)
+}
+
 func TestAIReActSchedulerCancelsActiveExecutionInMemory(t *testing.T) {
 	server := newScheduleTestServer(t)
 	manager := newAIReActScheduler(server, server.GetProjectDatabase())
 	defer manager.cancel()
 
 	jobCtx, cancel := context.WithCancel(manager.ctx)
+	reservation, err := manager.runtime.ReserveSession(jobCtx, "ai-schedule-active-execution", "active-execution")
+	require.NoError(t, err)
 	job := &scheduledReActJob{
 		executionID:  "active-execution",
 		scheduleUUID: "schedule",
 		sessionID:    "ai-schedule-active-execution",
-		ctx:          jobCtx,
+		ctx:          reservation.Context(),
 		cancel:       cancel,
+		reservation:  reservation,
+		done:         make(chan struct{}),
 	}
 	manager.jobs[job.executionID] = job
 	manager.activeBySchedule[job.scheduleUUID] = job.executionID
-	manager.activeBySession[job.sessionID] = job.executionID
-	require.True(t, manager.isSessionReserved(job.sessionID))
+	require.True(t, manager.runtime.IsSessionBusy(job.sessionID))
 
 	manager.cancelSchedule(job.scheduleUUID)
 	require.Eventually(t, func() bool { return job.ctx.Err() == context.Canceled }, time.Second, 10*time.Millisecond)
 	manager.unregisterJob(job)
 	require.Empty(t, manager.jobs)
 	require.Empty(t, manager.activeBySchedule)
-	require.Empty(t, manager.activeBySession)
+	require.False(t, manager.runtime.IsSessionBusy(job.sessionID))
 }
 
 func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
@@ -356,14 +395,17 @@ func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
 		}
 	}
 	defer releaseShutdown()
-	manager.startAIReAct = func(stream ypb.Yak_StartAIReActServer) error {
-		<-stream.Context().Done()
+	overrideRuntime := &connectOverrideRuntime{ReActSessionRuntime: manager.runtime}
+	overrideRuntime.connect = func(ctx context.Context, _ ConnectRequest, _ ReActEventHandler) (ReActConnection, error) {
+		<-ctx.Done()
 		if cancellationReported.CompareAndSwap(false, true) {
 			close(executionCancelled)
 		}
 		<-allowShutdown
-		return nil
+		return nil, ctx.Err()
 	}
+	manager.runtime = overrideRuntime
+	server.reActRuntime = overrideRuntime
 	server.aiReActSchedulerMu.Lock()
 	server.aiReActScheduler = manager
 	server.aiReActSchedulerMu.Unlock()
@@ -419,8 +461,8 @@ func TestDeleteRunningScheduleSessionReleasesBeforeRunNow(t *testing.T) {
 	manager.jobsMu.Lock()
 	require.NotContains(t, manager.jobs, firstJob.executionID)
 	require.NotContains(t, manager.activeBySchedule, created.GetUUID())
-	require.NotContains(t, manager.activeBySession, firstJob.sessionID)
 	manager.jobsMu.Unlock()
+	require.False(t, manager.runtime.IsSessionBusy(firstJob.sessionID))
 
 	// Reproduce the UI sequence from the bug report: delete the running
 	// independent session and immediately run the same schedule again.

--- a/common/yakgrpc/grpc_ai_react_stream_cancel_test.go
+++ b/common/yakgrpc/grpc_ai_react_stream_cancel_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/ai/aid/aimem"
 	"github.com/yaklang/yaklang/common/ai/aid/aireact"
+	"github.com/yaklang/yaklang/common/ai/aid/reactservice"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 	"google.golang.org/grpc/metadata"
@@ -172,7 +173,7 @@ func TestStartAIReActReturnsWhenRuntimeConnectionStops(t *testing.T) {
 	defer cancel()
 	connection := &imConnectionStub{done: make(chan struct{})}
 	runtime := &imRuntimeStub{connection: connection}
-	server := &Server{reActRuntime: runtime}
+	server := &Server{reActService: reactservice.New(nil, reactservice.WithRuntime(runtime))}
 	stream := newCancelableAIReActServerStream(ctx, &ypb.AIInputEvent{
 		IsStart: true,
 		Params:  &ypb.AIStartParams{TimelineSessionID: "runtime-stopped"},

--- a/common/yakgrpc/grpc_ai_react_stream_cancel_test.go
+++ b/common/yakgrpc/grpc_ai_react_stream_cancel_test.go
@@ -164,4 +164,40 @@ func TestStartAIReActFrontendStreamCancelReleasesFreeInput(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 	require.False(t, aireact.IsSessionBusy(sessionID))
 	require.False(t, aireact.IsSessionStarting(sessionID))
+	require.False(t, server.getReActSessionRuntime().IsSessionBusy(sessionID))
+}
+
+func TestStartAIReActReturnsWhenRuntimeConnectionStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	connection := &imConnectionStub{done: make(chan struct{})}
+	runtime := &imRuntimeStub{connection: connection}
+	server := &Server{reActRuntime: runtime}
+	stream := newCancelableAIReActServerStream(ctx, &ypb.AIInputEvent{
+		IsStart: true,
+		Params:  &ypb.AIStartParams{TimelineSessionID: "runtime-stopped"},
+	})
+
+	streamDone := make(chan error, 1)
+	go func() { streamDone <- server.StartAIReAct(stream) }()
+	require.Eventually(t, func() bool {
+		runtime.mu.Lock()
+		defer runtime.mu.Unlock()
+		return len(runtime.requests) == 1
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, connection.Close())
+	select {
+	case err := <-streamDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("gRPC adapter remained blocked in Recv after the runtime connection stopped")
+	}
+}
+
+func TestStartAIReActRejectsNilFirstMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server := &Server{}
+	stream := newCancelableAIReActServerStream(ctx, nil)
+	require.ErrorContains(t, server.StartAIReAct(stream), "first msg is not a start/config message")
 }

--- a/common/yakgrpc/grpc_ai_session.go
+++ b/common/yakgrpc/grpc_ai_session.go
@@ -92,10 +92,8 @@ func (s *Server) isAISessionRunning(sessionID string) bool {
 	if sessionID == "" {
 		return false
 	}
-	if manager := s.currentAIReActScheduler(); manager != nil && manager.isSessionReserved(sessionID) {
-		return true
-	}
-	return isAIReActSessionBusy(sessionID)
+	runtime := s.getReActSessionRuntime()
+	return runtime != nil && runtime.IsSessionBusy(sessionID)
 }
 
 func (s *Server) UpdateAISessionTitle(ctx context.Context, req *ypb.UpdateAISessionTitleRequest) (*ypb.DbOperateMessage, error) {
@@ -170,11 +168,11 @@ func (s *Server) DeleteAISession(ctx context.Context, req *ypb.DeleteAISessionRe
 		if err != nil {
 			return nil, err
 		}
-		if manager := s.currentAIReActScheduler(); manager != nil {
-			if err := manager.cancelSessionExecutionsAndWait(ctx, nil, true); err != nil {
-				return nil, err
-			}
+		quiescence, err := s.getReActSessionRuntime().QuiesceAll(ctx)
+		if err != nil {
+			return nil, err
 		}
+		defer quiescence.Release()
 		for _, scheduleUUID := range attachedScheduleUUIDs {
 			s.cancelAIReActScheduleExecution(scheduleUUID)
 		}
@@ -234,11 +232,11 @@ func (s *Server) DeleteAISession(ctx context.Context, req *ypb.DeleteAISessionRe
 	if err != nil {
 		return nil, err
 	}
-	if manager := s.currentAIReActScheduler(); manager != nil {
-		if err := manager.cancelSessionExecutionsAndWait(ctx, targetSessionIDs, false); err != nil {
-			return nil, err
-		}
+	quiescence, err := s.getReActSessionRuntime().QuiesceSessions(ctx, targetSessionIDs)
+	if err != nil {
+		return nil, err
 	}
+	defer quiescence.Release()
 	for _, scheduleUUID := range attachedScheduleUUIDs {
 		s.cancelAIReActScheduleExecution(scheduleUUID)
 	}

--- a/common/yakgrpc/grpc_im_control.go
+++ b/common/yakgrpc/grpc_im_control.go
@@ -52,7 +52,9 @@ func (s *Server) StartIMControl(ctx context.Context, req *ypb.StartIMControlRequ
 		PlatformConfigs:           buildIMRuntimePlatformConfigs(req.GetPlatformConfigs()),
 	}
 	engine := imcontrol.New(cfg)
-	engine.SetAIBackend(&imAIReActBackend{runtime: s.getReActSessionRuntime()}, s)
+	// Keep the stable Service, not its current project-scoped Runtime. The IM
+	// engine survives project switches, while the Service binds a fresh Runtime.
+	engine.SetAIBackend(&imAIReActBackend{runtimeProvider: s.getReActService()}, s)
 	if err := engine.Start(); err != nil {
 		log.Errorf("start im engine failed: %v", err)
 		signalIMEngineLifecycleLocked()

--- a/common/yakgrpc/grpc_im_control.go
+++ b/common/yakgrpc/grpc_im_control.go
@@ -52,7 +52,7 @@ func (s *Server) StartIMControl(ctx context.Context, req *ypb.StartIMControlRequ
 		PlatformConfigs:           buildIMRuntimePlatformConfigs(req.GetPlatformConfigs()),
 	}
 	engine := imcontrol.New(cfg)
-	engine.SetAIBackend(&imAIReActBackend{server: s}, s)
+	engine.SetAIBackend(&imAIReActBackend{runtime: s.getReActSessionRuntime()}, s)
 	if err := engine.Start(); err != nil {
 		log.Errorf("start im engine failed: %v", err)
 		signalIMEngineLifecycleLocked()

--- a/common/yakgrpc/grpc_project.go
+++ b/common/yakgrpc/grpc_project.go
@@ -48,6 +48,9 @@ func (s *Server) SetCurrentProject(ctx context.Context, req *ypb.SetCurrentProje
 		switch req.GetType() {
 		case yakit.TypeProject:
 			s.stopAIReActScheduler()
+			if err := s.retireReActSessionRuntime(ctx); err != nil {
+				return nil, utils.Errorf("stop AI ReAct runtime before closing project: %s", err)
+			}
 			consts.GetGormProjectDatabase().Close()
 		case yakit.TypeSSAProject:
 			consts.GetGormSSAProjectDataBase().Close()
@@ -100,9 +103,13 @@ func (s *Server) SetCurrentProject(ctx context.Context, req *ypb.SetCurrentProje
 	switch req.GetType() {
 	case yakit.TypeProject:
 		s.stopAIReActScheduler()
+		if stopErr := s.retireReActSessionRuntime(ctx); stopErr != nil {
+			return nil, utils.Errorf("stop AI ReAct runtime before switching project: %s", stopErr)
+		}
 		consts.SetDefaultYakitProjectDatabaseName(path)
 		err = consts.SetGormProjectDatabase(path)
 		if err == nil {
+			s.resetReActSessionRuntimeAfterProjectSwitch()
 			s.StartAIReActScheduler()
 		}
 	case yakit.TypeSSAProject:

--- a/common/yakgrpc/im_ai_react_backend.go
+++ b/common/yakgrpc/im_ai_react_backend.go
@@ -15,7 +15,15 @@ import (
 )
 
 type imAIReActBackend struct {
-	runtime sessionruntime.ReActSessionRuntime
+	runtimeProvider reActSessionRuntimeProvider
+}
+
+// reActSessionRuntimeProvider is the stable process/project service boundary
+// used by IM. A project switch replaces the project-scoped Runtime inside the
+// provider, so each newly opened IM stream must resolve it at start time rather
+// than retaining a stale Runtime from StartIMControl.
+type reActSessionRuntimeProvider interface {
+	Runtime() sessionruntime.ReActSessionRuntime
 }
 
 // StartAIReAct retains IM's asynchronous stream contract while routing the
@@ -23,14 +31,18 @@ type imAIReActBackend struct {
 // and terminal error delivery match the former in-process gRPC bridge, without
 // constructing a fake ypb.Yak_StartAIReActServer.
 func (b *imAIReActBackend) StartAIReAct(ctx context.Context) (imcontrol.AIReActStream, error) {
-	if b == nil || b.runtime == nil {
+	if b == nil || b.runtimeProvider == nil {
+		return nil, fmt.Errorf("AI ReAct session runtime is not configured")
+	}
+	runtime := b.runtimeProvider.Runtime()
+	if runtime == nil {
 		return nil, fmt.Errorf("AI ReAct session runtime is not configured")
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	stream := &imReActRuntimeStream{
 		ctx:       ctx,
 		cancel:    cancel,
-		runtime:   b.runtime,
+		runtime:   runtime,
 		toRuntime: make(chan *ypb.AIInputEvent, 32),
 		fromSrv:   make(chan *ypb.AIOutputEvent, 128),
 		done:      make(chan error, 1),

--- a/common/yakgrpc/im_ai_react_backend.go
+++ b/common/yakgrpc/im_ai_react_backend.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
 	"github.com/yaklang/yaklang/common/imcontrol"
 	"github.com/yaklang/yaklang/common/log"
 	"github.com/yaklang/yaklang/common/schema"
@@ -14,7 +15,7 @@ import (
 )
 
 type imAIReActBackend struct {
-	server *Server
+	runtime sessionruntime.ReActSessionRuntime
 }
 
 // StartAIReAct retains IM's asynchronous stream contract while routing the
@@ -22,18 +23,14 @@ type imAIReActBackend struct {
 // and terminal error delivery match the former in-process gRPC bridge, without
 // constructing a fake ypb.Yak_StartAIReActServer.
 func (b *imAIReActBackend) StartAIReAct(ctx context.Context) (imcontrol.AIReActStream, error) {
-	if b == nil || b.server == nil {
-		return nil, fmt.Errorf("yakgrpc server is not configured")
-	}
-	runtime := b.server.getReActSessionRuntime()
-	if runtime == nil {
+	if b == nil || b.runtime == nil {
 		return nil, fmt.Errorf("AI ReAct session runtime is not configured")
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	stream := &imReActRuntimeStream{
 		ctx:       ctx,
 		cancel:    cancel,
-		runtime:   runtime,
+		runtime:   b.runtime,
 		toRuntime: make(chan *ypb.AIInputEvent, 32),
 		fromSrv:   make(chan *ypb.AIOutputEvent, 128),
 		done:      make(chan error, 1),
@@ -45,7 +42,7 @@ func (b *imAIReActBackend) StartAIReAct(ctx context.Context) (imcontrol.AIReActS
 type imReActRuntimeStream struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
-	runtime   ReActSessionRuntime
+	runtime   sessionruntime.ReActSessionRuntime
 	toRuntime chan *ypb.AIInputEvent
 	fromSrv   chan *ypb.AIOutputEvent
 	done      chan error
@@ -116,11 +113,11 @@ func (s *imReActRuntimeStream) serveRuntime() error {
 		return fmt.Errorf("first msg is not a start/config message, set IsStart to true")
 	}
 
-	connection, err := s.runtime.Connect(s.ctx, ConnectRequest{
+	connection, err := s.runtime.Connect(s.ctx, sessionruntime.ConnectRequest{
 		StartParams: first.GetParams(),
-		options: &reActConnectOptions{
-			loadBuiltinTools: true,
-			onEventError: func(err error) {
+		Options: &sessionruntime.ConnectOptions{
+			LoadBuiltinTools: true,
+			OnEventError: func(err error) {
 				log.Errorf("send re-act event to stream failed: %v", err)
 			},
 		},

--- a/common/yakgrpc/im_ai_react_backend.go
+++ b/common/yakgrpc/im_ai_react_backend.go
@@ -6,52 +6,54 @@ import (
 	"io"
 	"sync"
 
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
 	"github.com/yaklang/yaklang/common/imcontrol"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
-	"google.golang.org/grpc/metadata"
 )
 
 type imAIReActBackend struct {
 	server *Server
 }
 
+// StartAIReAct retains IM's asynchronous stream contract while routing the
+// stream actor directly to ReActSessionRuntime. The bounded input/output queues
+// and terminal error delivery match the former in-process gRPC bridge, without
+// constructing a fake ypb.Yak_StartAIReActServer.
 func (b *imAIReActBackend) StartAIReAct(ctx context.Context) (imcontrol.AIReActStream, error) {
 	if b == nil || b.server == nil {
 		return nil, fmt.Errorf("yakgrpc server is not configured")
 	}
+	runtime := b.server.getReActSessionRuntime()
+	if runtime == nil {
+		return nil, fmt.Errorf("AI ReAct session runtime is not configured")
+	}
 	ctx, cancel := context.WithCancel(ctx)
-	client := &inProcessAIReActClientStream{
-		ctx:      ctx,
-		cancel:   cancel,
-		toServer: make(chan *ypb.AIInputEvent, 32),
-		fromSrv:  make(chan *ypb.AIOutputEvent, 128),
-		done:     make(chan error, 1),
+	stream := &imReActRuntimeStream{
+		ctx:       ctx,
+		cancel:    cancel,
+		runtime:   runtime,
+		toRuntime: make(chan *ypb.AIInputEvent, 32),
+		fromSrv:   make(chan *ypb.AIOutputEvent, 128),
+		done:      make(chan error, 1),
 	}
-	server := &inProcessAIReActServerStream{
-		ctx:        ctx,
-		toServer:   client.toServer,
-		fromServer: client.fromSrv,
-	}
-	go func() {
-		err := b.server.StartAIReAct(server)
-		close(client.fromSrv)
-		client.done <- err
-		close(client.done)
-		cancel()
-	}()
-	return client, nil
+	go stream.serve()
+	return stream, nil
 }
 
-type inProcessAIReActClientStream struct {
+type imReActRuntimeStream struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
-	toServer  chan *ypb.AIInputEvent
+	runtime   ReActSessionRuntime
+	toRuntime chan *ypb.AIInputEvent
 	fromSrv   chan *ypb.AIOutputEvent
 	done      chan error
 	closeOnce sync.Once
+	outputMu  sync.Mutex
 }
 
-func (s *inProcessAIReActClientStream) Send(event *ypb.AIInputEvent) (err error) {
+func (s *imReActRuntimeStream) Send(event *ypb.AIInputEvent) (err error) {
 	if event == nil {
 		return fmt.Errorf("nil AIInputEvent")
 	}
@@ -63,12 +65,12 @@ func (s *inProcessAIReActClientStream) Send(event *ypb.AIInputEvent) (err error)
 	select {
 	case <-s.ctx.Done():
 		return s.ctx.Err()
-	case s.toServer <- event:
+	case s.toRuntime <- event:
 		return nil
 	}
 }
 
-func (s *inProcessAIReActClientStream) Recv() (*ypb.AIOutputEvent, error) {
+func (s *imReActRuntimeStream) Recv() (*ypb.AIOutputEvent, error) {
 	ev, ok := <-s.fromSrv
 	if ok {
 		return ev, nil
@@ -79,75 +81,96 @@ func (s *inProcessAIReActClientStream) Recv() (*ypb.AIOutputEvent, error) {
 	return nil, io.EOF
 }
 
-func (s *inProcessAIReActClientStream) CloseSend() error {
+func (s *imReActRuntimeStream) CloseSend() error {
 	s.closeOnce.Do(func() {
-		close(s.toServer)
+		close(s.toRuntime)
 		s.cancel()
 	})
 	return nil
 }
 
-type inProcessAIReActServerStream struct {
-	ctx        context.Context
-	toServer   <-chan *ypb.AIInputEvent
-	fromServer chan<- *ypb.AIOutputEvent
+func (s *imReActRuntimeStream) serve() {
+	err := s.serveRuntime()
+	close(s.fromSrv)
+	s.done <- err
+	close(s.done)
+	s.cancel()
 }
 
-func (s *inProcessAIReActServerStream) Recv() (*ypb.AIInputEvent, error) {
+func (s *imReActRuntimeStream) serveRuntime() error {
+	var first *ypb.AIInputEvent
 	select {
 	case <-s.ctx.Done():
-		return nil, s.ctx.Err()
-	case ev, ok := <-s.toServer:
+		err := s.ctx.Err()
+		log.Errorf("recv re-act first config msg failed: %v", err)
+		return fmt.Errorf("recv first mgs failed: %v", err)
+	case event, ok := <-s.toRuntime:
 		if !ok {
-			return nil, io.EOF
+			log.Errorf("recv re-act first config msg failed: %v", io.EOF)
+			return fmt.Errorf("recv first mgs failed: %v", io.EOF)
 		}
-		return ev, nil
+		first = event
 	}
-}
-
-func (s *inProcessAIReActServerStream) Send(event *ypb.AIOutputEvent) error {
-	if event == nil {
-		return fmt.Errorf("nil AIOutputEvent")
+	if !first.GetIsStart() {
+		log.Errorf("recv re-act first config msg is invalid: %v", first)
+		return fmt.Errorf("first msg is not a start/config message, set IsStart to true")
 	}
-	select {
-	case <-s.ctx.Done():
-		return s.ctx.Err()
-	case s.fromServer <- event:
-		return nil
-	}
-}
 
-func (s *inProcessAIReActServerStream) SetHeader(metadata.MD) error {
-	return nil
-}
-
-func (s *inProcessAIReActServerStream) SendHeader(metadata.MD) error {
-	return nil
-}
-
-func (s *inProcessAIReActServerStream) SetTrailer(metadata.MD) {}
-
-func (s *inProcessAIReActServerStream) Context() context.Context {
-	return s.ctx
-}
-
-func (s *inProcessAIReActServerStream) SendMsg(m any) error {
-	ev, ok := m.(*ypb.AIOutputEvent)
-	if !ok {
-		return fmt.Errorf("unexpected AIReAct server send message type %T", m)
-	}
-	return s.Send(ev)
-}
-
-func (s *inProcessAIReActServerStream) RecvMsg(m any) error {
-	ev, ok := m.(*ypb.AIInputEvent)
-	if !ok {
-		return fmt.Errorf("unexpected AIReAct server recv message type %T", m)
-	}
-	next, err := s.Recv()
+	connection, err := s.runtime.Connect(s.ctx, ConnectRequest{
+		StartParams: first.GetParams(),
+		options: &reActConnectOptions{
+			loadBuiltinTools: true,
+			onEventError: func(err error) {
+				log.Errorf("send re-act event to stream failed: %v", err)
+			},
+		},
+	}, func(output *schema.AiOutputEvent) error {
+		if output == nil {
+			return fmt.Errorf("nil AIOutputEvent")
+		}
+		// The former in-process gRPC path serialized stream.Send with sendMu.
+		// Preserve that single-writer ordering for concurrent Runtime emitters.
+		s.outputMu.Lock()
+		defer s.outputMu.Unlock()
+		select {
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		case s.fromSrv <- output.ToGRPC():
+			return nil
+		}
+	})
 	if err != nil {
 		return err
 	}
-	*ev = *next
-	return nil
+	// Do not finish the stream actor while its Runtime connection is alive.
+	// Session deletion may remove durable data immediately after the actor exits.
+	defer connection.Close()
+	createdRuntime := connection.CreatedRuntime()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return nil
+		case <-connection.Done():
+			return nil
+		case event, ok := <-s.toRuntime:
+			if !ok {
+				return nil
+			}
+			if event.GetIsStart() {
+				continue
+			}
+			if err := connection.Send(event); err != nil {
+				if !createdRuntime && event.GetIsSyncMessage() && event.GetSyncType() == aicommon.SYNC_TYPE_RECOVERY_HISTORY {
+					log.Warnf("send attached recovery history failed: %v", err)
+					continue
+				}
+				if createdRuntime {
+					log.Errorf("ReAct event processing failed: %v", err)
+				} else {
+					log.Warnf("forward input to running session failed: %v", err)
+				}
+			}
+		}
+	}
 }

--- a/common/yakgrpc/im_ai_react_backend_test.go
+++ b/common/yakgrpc/im_ai_react_backend_test.go
@@ -20,6 +20,23 @@ type imRuntimeStub struct {
 	connection *imConnectionStub
 }
 
+type imRuntimeProviderStub struct {
+	mu      sync.Mutex
+	runtime sessionruntime.ReActSessionRuntime
+}
+
+func (p *imRuntimeProviderStub) Runtime() sessionruntime.ReActSessionRuntime {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.runtime
+}
+
+func (p *imRuntimeProviderStub) Bind(runtime sessionruntime.ReActSessionRuntime) {
+	p.mu.Lock()
+	p.runtime = runtime
+	p.mu.Unlock()
+}
+
 func (r *imRuntimeStub) Connect(_ context.Context, req sessionruntime.ConnectRequest, onEvent sessionruntime.ReActEventHandler) (sessionruntime.ReActConnection, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -53,7 +70,7 @@ func (c *imConnectionStub) CreatedRuntime() bool  { return true }
 func TestIMAIReActBackendUsesSessionRuntimeDirectly(t *testing.T) {
 	connection := &imConnectionStub{done: make(chan struct{})}
 	runtime := &imRuntimeStub{connection: connection}
-	backend := &imAIReActBackend{runtime: runtime}
+	backend := &imAIReActBackend{runtimeProvider: &imRuntimeProviderStub{runtime: runtime}}
 
 	// Preserve the former in-process stream contract: Send only admits the
 	// message; an invalid first message terminates the actor and is observed by
@@ -102,5 +119,55 @@ func TestIMAIReActBackendUsesSessionRuntimeDirectly(t *testing.T) {
 	case <-connection.Done():
 	case <-time.After(time.Second):
 		t.Fatal("closing the IM stream did not close its runtime connection")
+	}
+}
+
+func TestIMAIReActBackendResolvesRuntimeAfterProjectBind(t *testing.T) {
+	firstConnection := &imConnectionStub{done: make(chan struct{})}
+	firstRuntime := &imRuntimeStub{connection: firstConnection}
+	provider := &imRuntimeProviderStub{runtime: firstRuntime}
+	backend := &imAIReActBackend{runtimeProvider: provider}
+
+	firstStream, err := backend.StartAIReAct(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, firstStream.Send(&ypb.AIInputEvent{
+		IsStart: true,
+		Params:  &ypb.AIStartParams{TimelineSessionID: "im-before-project-bind"},
+	}))
+	require.Eventually(t, func() bool {
+		firstRuntime.mu.Lock()
+		defer firstRuntime.mu.Unlock()
+		return len(firstRuntime.requests) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	// The process-level Service keeps the same identity across a project switch,
+	// but BindProject installs a fresh project-scoped Runtime behind it.
+	secondConnection := &imConnectionStub{done: make(chan struct{})}
+	secondRuntime := &imRuntimeStub{connection: secondConnection}
+	provider.Bind(secondRuntime)
+
+	secondStream, err := backend.StartAIReAct(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, secondStream.Send(&ypb.AIInputEvent{
+		IsStart: true,
+		Params:  &ypb.AIStartParams{TimelineSessionID: "im-after-project-bind"},
+	}))
+	require.Eventually(t, func() bool {
+		secondRuntime.mu.Lock()
+		defer secondRuntime.mu.Unlock()
+		return len(secondRuntime.requests) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	firstRuntime.mu.Lock()
+	require.Len(t, firstRuntime.requests, 1, "new IM streams must not reuse the retired project Runtime")
+	firstRuntime.mu.Unlock()
+	require.NoError(t, firstStream.CloseSend())
+	require.NoError(t, secondStream.CloseSend())
+	for _, connection := range []*imConnectionStub{firstConnection, secondConnection} {
+		select {
+		case <-connection.Done():
+		case <-time.After(time.Second):
+			t.Fatal("closing an IM stream did not release its project Runtime connection")
+		}
 	}
 }

--- a/common/yakgrpc/im_ai_react_backend_test.go
+++ b/common/yakgrpc/im_ai_react_backend_test.go
@@ -7,19 +7,20 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
 	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
 )
 
 type imRuntimeStub struct {
-	ReActSessionRuntime
+	sessionruntime.ReActSessionRuntime
 	mu         sync.Mutex
-	requests   []ConnectRequest
-	onEvent    ReActEventHandler
+	requests   []sessionruntime.ConnectRequest
+	onEvent    sessionruntime.ReActEventHandler
 	connection *imConnectionStub
 }
 
-func (r *imRuntimeStub) Connect(_ context.Context, req ConnectRequest, onEvent ReActEventHandler) (ReActConnection, error) {
+func (r *imRuntimeStub) Connect(_ context.Context, req sessionruntime.ConnectRequest, onEvent sessionruntime.ReActEventHandler) (sessionruntime.ReActConnection, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.requests = append(r.requests, req)
@@ -52,7 +53,7 @@ func (c *imConnectionStub) CreatedRuntime() bool  { return true }
 func TestIMAIReActBackendUsesSessionRuntimeDirectly(t *testing.T) {
 	connection := &imConnectionStub{done: make(chan struct{})}
 	runtime := &imRuntimeStub{connection: connection}
-	backend := &imAIReActBackend{server: &Server{reActRuntime: runtime}}
+	backend := &imAIReActBackend{runtime: runtime}
 
 	// Preserve the former in-process stream contract: Send only admits the
 	// message; an invalid first message terminates the actor and is observed by

--- a/common/yakgrpc/im_ai_react_backend_test.go
+++ b/common/yakgrpc/im_ai_react_backend_test.go
@@ -1,0 +1,105 @@
+package yakgrpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+type imRuntimeStub struct {
+	ReActSessionRuntime
+	mu         sync.Mutex
+	requests   []ConnectRequest
+	onEvent    ReActEventHandler
+	connection *imConnectionStub
+}
+
+func (r *imRuntimeStub) Connect(_ context.Context, req ConnectRequest, onEvent ReActEventHandler) (ReActConnection, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req)
+	r.onEvent = onEvent
+	return r.connection, nil
+}
+
+type imConnectionStub struct {
+	mu        sync.Mutex
+	inputs    []*ypb.AIInputEvent
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func (c *imConnectionStub) Send(event *ypb.AIInputEvent) error {
+	c.mu.Lock()
+	c.inputs = append(c.inputs, event)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *imConnectionStub) Close() error {
+	c.closeOnce.Do(func() { close(c.done) })
+	return nil
+}
+
+func (c *imConnectionStub) Done() <-chan struct{} { return c.done }
+func (c *imConnectionStub) CreatedRuntime() bool  { return true }
+
+func TestIMAIReActBackendUsesSessionRuntimeDirectly(t *testing.T) {
+	connection := &imConnectionStub{done: make(chan struct{})}
+	runtime := &imRuntimeStub{connection: connection}
+	backend := &imAIReActBackend{server: &Server{reActRuntime: runtime}}
+
+	// Preserve the former in-process stream contract: Send only admits the
+	// message; an invalid first message terminates the actor and is observed by
+	// Recv rather than synchronously by Send.
+	invalidStream, err := backend.StartAIReAct(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, invalidStream.Send(&ypb.AIInputEvent{IsFreeInput: true, FreeInput: "too early"}))
+	_, err = invalidStream.Recv()
+	require.Error(t, err)
+	require.Empty(t, runtime.requests)
+
+	closedBeforeStart, err := backend.StartAIReAct(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, closedBeforeStart.CloseSend())
+	_, err = closedBeforeStart.Recv()
+	require.ErrorContains(t, err, "recv first mgs failed")
+
+	stream, err := backend.StartAIReAct(context.Background())
+	require.NoError(t, err)
+
+	params := &ypb.AIStartParams{TimelineSessionID: "im-runtime-session"}
+	require.NoError(t, stream.Send(&ypb.AIInputEvent{IsStart: true, Params: params}))
+	require.Eventually(t, func() bool {
+		runtime.mu.Lock()
+		defer runtime.mu.Unlock()
+		return len(runtime.requests) == 1 && runtime.requests[0].StartParams == params && runtime.onEvent != nil
+	}, time.Second, 10*time.Millisecond)
+
+	runtime.mu.Lock()
+	onEvent := runtime.onEvent
+	runtime.mu.Unlock()
+	require.NoError(t, onEvent(&schema.AiOutputEvent{NodeId: "runtime-event"}))
+	output, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "runtime-event", output.GetNodeId())
+
+	input := &ypb.AIInputEvent{IsFreeInput: true, FreeInput: "forwarded"}
+	require.NoError(t, stream.Send(input))
+	require.Eventually(t, func() bool {
+		connection.mu.Lock()
+		defer connection.mu.Unlock()
+		return len(connection.inputs) == 1 && connection.inputs[0] == input
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, stream.CloseSend())
+	select {
+	case <-connection.Done():
+	case <-time.After(time.Second):
+		t.Fatal("closing the IM stream did not close its runtime connection")
+	}
+}

--- a/common/yakgrpc/react_service_adapter_test.go
+++ b/common/yakgrpc/react_service_adapter_test.go
@@ -1,0 +1,14 @@
+package yakgrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultServersShareProcessReActService(t *testing.T) {
+	first := &Server{}
+	second := &Server{}
+	require.Same(t, first.getReActService(), second.getReActService())
+	require.Equal(t, first.getReActSessionRuntime(), second.getReActSessionRuntime())
+}

--- a/common/yakgrpc/react_service_runtime_adapter.go
+++ b/common/yakgrpc/react_service_runtime_adapter.go
@@ -1,0 +1,58 @@
+package yakgrpc
+
+import (
+	"context"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aireact/sessionruntime"
+	"github.com/yaklang/yaklang/common/ai/aid/reactservice"
+	"github.com/yaklang/yaklang/common/consts"
+)
+
+func (s *Server) getReActSessionRuntime() sessionruntime.ReActSessionRuntime {
+	if s == nil {
+		return nil
+	}
+	return s.getReActService().Runtime()
+}
+
+func (s *Server) getReActService() *reactservice.Service {
+	if s == nil {
+		return nil
+	}
+	s.reActServiceMu.Lock()
+	defer s.reActServiceMu.Unlock()
+	if s.reActService == nil {
+		if s.projectDatabase != nil {
+			// Embedded servers with an explicitly injected database keep an
+			// isolated service; the normal engine Server uses the process singleton.
+			s.reActService = reactservice.New(s.GetProjectDatabase)
+		} else {
+			s.reActService = reactservice.Default()
+		}
+	}
+	return s.reActService
+}
+
+// retireReActSessionRuntime stops every session owned by the current runtime and
+// permanently quiesces that runtime before it is detached from the server. This
+// is used when the project database changes: a ReAct created for the old project
+// must never be attached through the new project context.
+func (s *Server) retireReActSessionRuntime(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	return s.getReActService().RetireCurrentProject(ctx)
+}
+
+func (s *Server) resetReActSessionRuntimeAfterProjectSwitch() {
+	if s == nil {
+		return
+	}
+	projectDB := s.GetProjectDatabase
+	if s.projectDatabase == nil {
+		// The process service must not retain a transport Server merely to find
+		// the current project. consts owns that durable process-level binding.
+		projectDB = consts.GetGormProjectDatabase
+	}
+	s.getReActService().BindProject(projectDB)
+}

--- a/common/yakgrpc/react_service_scheduler_adapter.go
+++ b/common/yakgrpc/react_service_scheduler_adapter.go
@@ -1,0 +1,52 @@
+package yakgrpc
+
+import (
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aireactscheduler"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+const (
+	aiReActScheduleTriggerSchedule = aireactscheduler.TriggerSchedule
+	aiReActScheduleTriggerManual   = aireactscheduler.TriggerManual
+)
+
+// StartAIReActScheduler starts the project-scoped scheduler. Task definitions
+// are durable, while active execution state intentionally remains in memory.
+// It is safe to call more than once and is independent of UI streams.
+func (s *Server) StartAIReActScheduler() {
+	s.ensureAIReActScheduler()
+}
+
+func (s *Server) ensureAIReActScheduler() {
+	if s == nil {
+		return
+	}
+	s.getReActService().StartScheduler()
+}
+
+// StopAIReActScheduler stops the project-scoped scheduler and waits for its
+// in-memory executions to release their resources.
+func (s *Server) StopAIReActScheduler() {
+	s.stopAIReActScheduler()
+}
+
+func (s *Server) stopAIReActScheduler() {
+	if s == nil {
+		return
+	}
+	s.getReActService().StopScheduler()
+}
+
+func (s *Server) wakeAIReActScheduler() {
+	s.getReActService().WakeScheduler()
+}
+
+func (s *Server) enqueueAIReActSchedule(schedule *schema.AIReActSchedule, scheduledAt time.Time, trigger string) error {
+	return s.getReActService().EnqueueSchedule(schedule, scheduledAt, trigger)
+}
+
+func (s *Server) cancelAIReActScheduleExecution(scheduleUUID string) {
+	s.getReActService().CancelSchedule(scheduleUUID)
+}

--- a/common/yakgrpc/server.go
+++ b/common/yakgrpc/server.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/yaklang/yaklang/common/ai/aid/reactservice"
 	"github.com/yaklang/yaklang/common/imcontrol"
 	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
 
@@ -36,14 +37,8 @@ type Server struct {
 	// imEngine 是 IM 远程控制引擎（可选，StartIMControl 启动后非 nil）。
 	imEngine *imcontrol.Engine
 
-	aiReActSchedulerMu sync.Mutex
-	aiReActScheduler   *aiReActScheduler
-
-	reActRuntimeMu sync.Mutex
-	reActRuntime   ReActSessionRuntime
-	// reActRuntimeRetired keeps a quiesced runtime installed while the project
-	// database is closed or changing, so no caller can create against the old DB.
-	reActRuntimeRetired bool
+	reActServiceMu sync.Mutex
+	reActService   *reactservice.Service
 }
 
 type ServerOpts func(config *ServerConfig)

--- a/common/yakgrpc/server.go
+++ b/common/yakgrpc/server.go
@@ -38,6 +38,12 @@ type Server struct {
 
 	aiReActSchedulerMu sync.Mutex
 	aiReActScheduler   *aiReActScheduler
+
+	reActRuntimeMu sync.Mutex
+	reActRuntime   ReActSessionRuntime
+	// reActRuntimeRetired keeps a quiesced runtime installed while the project
+	// database is closed or changing, so no caller can create against the old DB.
+	reActRuntimeRetired bool
 }
 
 type ServerOpts func(config *ServerConfig)


### PR DESCRIPTION
## Summary

- introduce a transport-independent `ReActSessionRuntime` that owns session reservation, create-or-attach arbitration, input admission, output subscription, and shutdown waiting
- route gRPC, scheduled jobs, and the IM backend through the same runtime, removing the scheduler fake gRPC stream and reverse scheduler lookups from gRPC handlers
- coordinate session deletion and project switching through runtime quiescence so ReAct tasks, lifecycle loops, and hot-patch processing finish before persistent data or project databases are changed
- preserve existing behavior for focus-mode discovery, cached start parameters, attached recovery history, event ordering, stream delivery errors, and creator-versus-attached connection lifetimes
- make session busy states explicit and documented, and remove unused `StartAIReAct` coordinator tracking

## Concurrency and lifecycle details

- scheduler reservations close the gap between trigger admission and ReAct publication
- ordinary callers wait for reserved or in-progress creation and then attach to the published runtime
- free input and config hot-patches have an acknowledgement path that preserves ordering while making scheduled task admission atomic
- attached owners cancel and wait only for tasks they admitted; runtime owners wait for the complete ReAct lifecycle before releasing session state
- session and global quiescence block new reservations/connections during deletion or project transitions

## Tests

- `go test ./common/ai/aid/aicommon -count=1`
- `go test ./common/ai/aid/aireact -run Test\(SendInputEventAndWaitAccepted\|WaitTaskByUserInputUUIDStopped\|CancelTaskByUserInputUUIDAndWait\) -count=1`
- `go test ./common/yakgrpc -run Test\(ReActEventDelivery\|AttachedReActConnection\|ReActSessionRuntime\|ServerRetireReActSessionRuntime\|AIReActSchedule\|PreviewAIReActSchedule\|AIReActScheduler\|DeleteRunningScheduleSession\|StartAIReAct\|Server_DeleteAISession\|IMAIReActBackend\) -count=1`
- `git diff origin/main...HEAD --check`