### PR TITLE
fix(memfit): remove blocking session naming and correct memory progress

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -650,7 +650,9 @@ jobs:
           - name: "Test AI Aid / React"
             test_configs: |
               [
-                {"package": "./common/ai/aid/aireact/...", "timeout": "12m", "parallel": 1}
+                {"package": "./common/ai/aid/aireact/...", "timeout": "12m", "parallel": 1},
+                {"package": "./common/aiengine", "timeout": "3m", "parallel": 1},
+                {"package": "./common/yak/cmd/yakcmds/memfit-cli", "timeout": "3m", "parallel": 1}
               ]
 
           - name: "Test AI Aid / Core / Tool / Memory"

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -482,8 +482,9 @@ func sanitizeFolderName(name string, maxLen int) string {
 
 // ensureWorkDirectory lazily creates the artifact working directory with a semantic name.
 // This is called at the start of processReActTask, after user input is available.
-// It uses LiteForge to generate a meaningful folder name, falling back to a generic name.
-// It also generates the session title in the same LiteForge call to save overhead.
+// Synchronous enrichment may use LiteForge for the folder name and session title.
+// Otherwise create a stable generic directory immediately; ensureSessionTitle
+// generates the display title asynchronously without delaying the first answer.
 func (r *ReAct) ensureWorkDirectory(userInput string) {
 	cfg := r.config
 	if cfg == nil {
@@ -524,9 +525,9 @@ func (r *ReAct) ensureWorkDirectory(userInput string) {
 		}
 	}
 
-	// try LiteForge to generate both folder_name and session_title
-	// use a tight timeout to avoid blocking the main flow
-	if trimmedInput != "" && !cfg.GetConfigBool(sessionTitleDisableKey) && cfg.GetOriginalAICallback() != nil {
+	// Naming is optional enrichment too. The default first-response path must
+	// not spend a provider round trip here before it can enter the main loop.
+	if cfg.GetConfigBool("AllowSyncInitContext") && trimmedInput != "" && !cfg.GetConfigBool(sessionTitleDisableKey) && cfg.GetOriginalAICallback() != nil {
 		func() {
 			defer func() {
 				if err := recover(); err != nil {

--- a/common/ai/aid/aireact/session_init_latency_test.go
+++ b/common/ai/aid/aireact/session_init_latency_test.go
@@ -1,0 +1,103 @@
+package aireact
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func TestReActFirstAnswerDoesNotWaitForSessionNaming(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	namingStarted := make(chan struct{})
+	answer := make(chan struct{})
+	var namingOnce, answerOnce sync.Once
+	var calls atomic.Int32
+	r, err := NewTestReAct(
+		aicommon.WithContext(ctx),
+		aicommon.WithWorkdir(t.TempDir()),
+		aicommon.WithDisableSessionTitleGeneration(false),
+		aicommon.WithNoOpMemoryTriage(),
+		aicommon.WithAICallback(func(c aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			if calls.Add(1) > 1 {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}
+			return mockedFreeInputOutput(c, "fast-first-answer")
+		}),
+		aicommon.WithSpeedPriorityAICallback(func(c aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			namingOnce.Do(func() { close(namingStarted) })
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}),
+		aicommon.WithEventHandler(func(e *schema.AiOutputEvent) {
+			if e.NodeId == "re-act-loop-answer-payload" && len(e.StreamDelta) > 0 {
+				answerOnce.Do(func() { close(answer) })
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		cancel()
+		r.Wait()
+		if r.config.IsWorkDirReady() {
+			_ = os.RemoveAll(r.config.GetOrCreateWorkDir())
+		}
+	}()
+	started := time.Now()
+	require.NoError(t, r.SendInputEvent(&ypb.AIInputEvent{IsFreeInput: true, FreeInput: "你好"}))
+	select {
+	case <-namingStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("session naming did not start")
+	}
+	select {
+	case <-answer:
+		// The naming provider is still blocked until test cleanup cancels it.
+		t.Logf("first answer arrived after %s while session naming was blocked", time.Since(started))
+	case <-time.After(3 * time.Second):
+		t.Fatal("first answer waited for the session naming provider")
+	}
+}
+
+func TestReActSessionNamingStillSupportsSyncOptIn(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var calls atomic.Int32
+	r, err := NewTestReAct(
+		aicommon.WithContext(ctx),
+		aicommon.WithWorkdir(t.TempDir()),
+		aicommon.WithAllowSyncInitContext(true),
+		aicommon.WithDisableSessionTitleGeneration(false),
+		aicommon.WithAICallback(func(c aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+			calls.Add(1)
+			return mockedLoopDirectlyAnswerOutput(c, `{"@action":"session-init-generator","folder_name":"greeting","session_title":"Greeting"}`)
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		cancel()
+		r.Wait()
+		if r.config.IsWorkDirReady() {
+			_ = os.RemoveAll(r.config.GetOrCreateWorkDir())
+		}
+	}()
+	r.ensureWorkDirectory("hello")
+	require.EqualValues(t, 1, calls.Load())
+	dir := r.config.GetOrCreateWorkDir()
+	require.Contains(t, filepath.Base(dir), "_greeting_")
+	require.DirExists(t, dir)
+	require.Equal(t, "Greeting", r.config.GetConfigString("session_title"))
+	r.ensureWorkDirectory("another message")
+	require.Equal(t, dir, r.config.GetOrCreateWorkDir())
+	require.EqualValues(t, 1, calls.Load(), "later turns must reuse the directory")
+}

--- a/common/aiengine/aiengine.go
+++ b/common/aiengine/aiengine.go
@@ -504,6 +504,12 @@ func (e *AIEngine) processOutputEvent(event *schema.AiOutputEvent) {
 }
 
 func (e *AIEngine) handleStreamFinishedEvent(event *schema.AiOutputEvent) {
+	// Raw-event clients such as Memfit already consume the live deltas. Only
+	// read persisted content when a caller actually registered an end callback;
+	// this runs on the same queue that forwards answers and task completion.
+	if e.config.OnStreamEnd == nil && e.config.OnStreamEndWithTotal == nil {
+		return
+	}
 	streamWriterID := event.GetStreamEventWriterId()
 	if streamWriterID == "" {
 		return
@@ -532,8 +538,12 @@ func (e *AIEngine) handleStreamFinishedEvent(event *schema.AiOutputEvent) {
 	}
 
 	streamEvent := streamEvents[0]
-	e.config.OnStreamEnd(e.operator, streamEvent, streamEvent.NodeId)
-	e.config.OnStreamEndWithTotal(e.operator, streamEvent, streamEvent.NodeId, streamEvent.StreamDelta)
+	if e.config.OnStreamEnd != nil {
+		e.config.OnStreamEnd(e.operator, streamEvent, streamEvent.NodeId)
+	}
+	if e.config.OnStreamEndWithTotal != nil {
+		e.config.OnStreamEndWithTotal(e.operator, streamEvent, streamEvent.NodeId, streamEvent.StreamDelta)
+	}
 }
 
 // buildReActOptions 构建 ReAct 配置选项

--- a/common/aiengine/config.go
+++ b/common/aiengine/config.go
@@ -111,8 +111,6 @@ func NewAIEngineConfig(options ...AIEngineConfigOption) *AIEngineConfig {
 		EnableForgeSearchTool: true,
 		OnEvent:               func(aicommon.AIEngineOperator, *schema.AiOutputEvent) {},
 		OnStream:              func(aicommon.AIEngineOperator, *schema.AiOutputEvent, string, []byte) {},
-		OnStreamEnd:           func(aicommon.AIEngineOperator, *schema.AiOutputEvent, string) {},
-		OnStreamEndWithTotal:  func(aicommon.AIEngineOperator, *schema.AiOutputEvent, string, []byte) {},
 		OnData:                func(aicommon.AIEngineOperator, *schema.AiOutputEvent, string, []byte) {},
 		OnFinished:            func(aicommon.AIEngineOperator) {},
 		OnInputRequiredRaw:    func(aicommon.AIEngineOperator, *schema.AiOutputEvent, string) string { return "" },

--- a/common/aiengine/stream_finished_test.go
+++ b/common/aiengine/stream_finished_test.go
@@ -1,0 +1,80 @@
+package aiengine
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func TestStreamFinishedOnlyReadsContentForRegisteredCallbacks(t *testing.T) {
+	db := consts.GetGormProjectDatabase()
+	writerID := uuid.NewString()
+	stream := &schema.AiOutputEvent{
+		EventUUID: writerID, Type: schema.EVENT_TYPE_STREAM, NodeId: "re-act-loop-answer-payload",
+		IsStream: true, StreamDelta: []byte("hello"),
+	}
+	require.NoError(t, db.Create(stream).Error)
+	t.Cleanup(func() { db.Unscoped().Delete(stream) })
+	var queries atomic.Int32
+	callbackName := "test:stream-finished:" + writerID
+	db.Callback().Query().After("gorm:query").Register(callbackName, func(scope *gorm.Scope) {
+		for _, value := range scope.SQLVars {
+			if value == writerID {
+				queries.Add(1)
+				break
+			}
+		}
+	})
+	t.Cleanup(func() { db.Callback().Query().Remove(callbackName) })
+
+	for _, tc := range []struct {
+		name       string
+		end, total bool
+		system     bool
+	}{
+		{name: "raw events only"},
+		{name: "end callback", end: true},
+		{name: "content callback", total: true},
+		{name: "both callbacks", end: true, total: true},
+		{name: "system stream", end: true, total: true, system: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewAIEngineConfig()
+			endCalls, totalCalls := 0, 0
+			if tc.end {
+				WithOnStreamEnd(func(_ aicommon.AIEngineOperator, event *schema.AiOutputEvent, node string) {
+					endCalls++
+					require.Equal(t, writerID, event.EventUUID)
+					require.Equal(t, stream.NodeId, node)
+				})(cfg)
+			}
+			if tc.total {
+				WithOnStreamContent(func(_ aicommon.AIEngineOperator, _ *schema.AiOutputEvent, node string, content []byte) {
+					totalCalls++
+					require.Equal(t, stream.NodeId, node)
+					require.Equal(t, "hello", string(content))
+				})(cfg)
+			}
+			engine := &AIEngine{config: cfg}
+			queries.Store(0)
+			engine.handleStreamFinishedEvent(&schema.AiOutputEvent{
+				Type: schema.EVENT_TYPE_STRUCTURED, NodeId: "stream-finished", IsSystem: tc.system,
+				Content: []byte(fmt.Sprintf(`{"event_writer_id":%q}`, writerID)),
+			})
+			if (tc.end || tc.total) && !tc.system {
+				require.EqualValues(t, 1, queries.Load())
+			} else {
+				require.Zero(t, queries.Load(), "unused content must not query the database")
+			}
+			require.Equal(t, tc.end && !tc.system, endCalls == 1)
+			require.Equal(t, tc.total && !tc.system, totalCalls == 1)
+		})
+	}
+}

--- a/common/yak/cmd/yakcmds/memfit-cli/memfit_tui.go
+++ b/common/yak/cmd/yakcmds/memfit-cli/memfit_tui.go
@@ -1159,6 +1159,15 @@ func (ui *memfitTUI) recordProcessEvent(envelopeID string, event memfitWorkerEve
 		}
 		return true
 	}
+	backgroundMemory := func(detail string, state memfitProcessState) bool {
+		// Automatic recall runs alongside the model request. It must not finish
+		// the Thinking row, take over the footer, or accrue foreground wait time.
+		ui.upsertProcessItem(memfitProcessItem{
+			key: "process:memory:background", kind: "Memory", detail: detail,
+			state: state, startedAt: time.Now(), updatedAt: time.Now(),
+		})
+		return true
+	}
 
 	switch typeName {
 	case schema.EVENT_TYPE_THOUGHT:
@@ -1303,7 +1312,9 @@ func (ui *memfitTUI) recordProcessEvent(envelopeID string, event memfitWorkerEve
 			detail = "Relevant context found"
 		}
 		return add("Knowledge", detail, "Using knowledge", memfitProcessDone)
-	case schema.EVENT_TYPE_MEMORY_SEARCH_QUICKLY, schema.EVENT_TYPE_MEMORY_SEARCH_SPECIFIC:
+	case schema.EVENT_TYPE_MEMORY_SEARCH_QUICKLY:
+		return backgroundMemory("Searching in background", memfitProcessInfo)
+	case schema.EVENT_TYPE_MEMORY_SEARCH_SPECIFIC:
 		key = "process:memory"
 		return add("Memory", "Searching previous context", "Searching memory", memfitProcessRunning)
 	case schema.EVENT_TYPE_MEMORY_BUILD, schema.EVENT_TYPE_MEMORY_SAVE, schema.EVENT_TYPE_MEMORY_ADD_CONTEXT:
@@ -1327,6 +1338,10 @@ func (ui *memfitTUI) recordProcessEvent(envelopeID string, event memfitWorkerEve
 		return add("Tasks", detail, "Updating tasks", memfitProcessDone)
 	case schema.EVENT_TYPE_STRUCTURED:
 		switch event.NodeID {
+		case "stream-finished":
+			if extractMemfitJSONField(event.Content, "node_id") == "fast-memory-fetch" {
+				return backgroundMemory("Background search finished", memfitProcessDone)
+			}
 		case "timeline_item":
 			kind, group, detail, state, ok := classifyMemfitTimelineItem(event.Content)
 			if !ok {
@@ -1345,6 +1360,10 @@ func (ui *memfitTUI) recordProcessEvent(envelopeID string, event memfitWorkerEve
 			detail := extractMemfitStructuredStatus(event.Content)
 			if detail == "" {
 				return false
+			}
+			if event.NodeID == "status" && strings.HasPrefix(extractMemfitJSONField(event.Content, "code"), "reasoning.") {
+				key = "process:reasoning"
+				return add("Thinking", detail, "Thinking", memfitProcessRunning)
 			}
 			ui.activity = singleLineMemfitText(detail)
 			return true
@@ -2723,6 +2742,16 @@ func extractMemfitStructuredStatus(content string) string {
 	var root map[string]any
 	if json.Unmarshal([]byte(content), &root) != nil {
 		return ""
+	}
+	// StatusPayload carries the user-facing text in value/value_i18n; state
+	// only describes its lifecycle (usually "running").
+	if localized, ok := root["value_i18n"].(map[string]any); ok {
+		if value := scalarMemfitMapString(localized, "en", "En", "zh", "Zh"); value != "" {
+			return compactMemfitMessage(value, 480)
+		}
+	}
+	if value := scalarMemfitMapString(root, "value"); value != "" {
+		return compactMemfitMessage(value, 480)
 	}
 	if status := scalarMemfitMapString(root, "react_task_now_status", "status", "state"); status != "" {
 		return "Task " + strings.ReplaceAll(status, "_", " ")

--- a/common/yak/cmd/yakcmds/memfit-cli/memfit_tui_test.go
+++ b/common/yak/cmd/yakcmds/memfit-cli/memfit_tui_test.go
@@ -314,6 +314,39 @@ func TestMemfitFooterSegmentsAdaptToTerminalWidth(t *testing.T) {
 	require.Equal(t, "YOLO", right)
 }
 
+func TestMemfitBackgroundMemoryDoesNotReplaceForegroundProgress(t *testing.T) {
+	ui := &memfitTUI{width: 90, height: 24, busy: true, activity: "Thinking"}
+	require.True(t, ui.recordProcessEvent("request", memfitWorkerEvent{
+		Type: string(schema.EVENT_TYPE_STRUCTURED), NodeID: "status",
+		Content: `{"key":"re-act-loop","code":"reasoning.understanding","state":"running","value":"正在理解你的需求","value_i18n":{"zh":"正在理解你的需求","en":"Understanding your request"}}`,
+	}))
+	require.Equal(t, "Understanding your request", ui.processItems[0].detail)
+	require.True(t, ui.recordProcessEvent("memory-start", memfitWorkerEvent{
+		Type: string(schema.EVENT_TYPE_MEMORY_SEARCH_QUICKLY), Content: `{"query":"hello"}`,
+	}))
+	require.Equal(t, "Thinking", ui.activity)
+	require.Equal(t, memfitProcessRunning, ui.processItems[0].state)
+	require.Equal(t, memfitProcessInfo, ui.processItems[1].state)
+	require.Equal(t, "process:reasoning", ui.currentProcessKey())
+	require.Contains(t, joinMemfitLiveLines(ui.processPanelLines()), "Searching in background")
+
+	require.True(t, ui.recordProcessEvent("memory-finished", memfitWorkerEvent{
+		Type: string(schema.EVENT_TYPE_STRUCTURED), NodeID: "stream-finished", IsSystem: true,
+		Content: `{"node_id":"fast-memory-fetch","event_writer_id":"memory-stream"}`,
+	}))
+	require.Equal(t, "Thinking", ui.activity)
+	require.Equal(t, memfitProcessRunning, ui.processItems[0].state)
+	require.Equal(t, memfitProcessDone, ui.processItems[1].state)
+	require.NotContains(t, joinMemfitLiveLines(ui.processPanelLines()), "Searching")
+
+	// A deliberate memory search is still foreground work, independent of recall.
+	require.True(t, ui.recordProcessEvent("specific", memfitWorkerEvent{
+		Type: string(schema.EVENT_TYPE_MEMORY_SEARCH_SPECIFIC), Content: `{}`,
+	}))
+	require.Equal(t, "Searching memory", ui.activity)
+	require.Equal(t, memfitProcessRunning, ui.processItems[2].state)
+}
+
 func TestMemfitStructuredTimelineKeepsSemanticsAndDropsBreadcrumbs(t *testing.T) {
 	kind, group, detail, state, ok := classifyMemfitTimelineItem(`{
 		"type":"text",


### PR DESCRIPTION
Simple Memfit TUI prompts could still wait for an AI-generated artifact directory name before the main response, even with synchronous context initialization disabled. Automatic memory recall also took over the foreground status and never consumed its stream completion, making model latency appear to be a stuck memory search.

- Respect `AllowSyncInitContext` for synchronous directory naming. By default create the stable fallback directory immediately and generate the session title in the existing background path; preserve explicit opt-in naming and directory reuse.
- Keep automatic memory recall separate from foreground work, consume its completion, and display the backend's actual reasoning status text.
- Skip stream-content database reads for event-only engine clients such as Memfit. Registered end/content callbacks still receive their persisted stream data.
- Add regressions for a blocked naming provider, opt-in naming, memory/foreground status, and database query counts. Include the engine and Memfit CLI suites in Essential Tests.

Validation: the new blocked-provider regression failed before the fix and now emits the first answer while naming remains blocked (~206 ms with a deterministic mock; not a live-provider benchmark). Local Memfit CLI and AI engine suites pass, along with naming, asynchronous memory, persistent work-directory, and artifact regressions.

Remote CI passed on `d0eb2b7ef31d4f7dca2e07426530ec60e56482b2`: [Essential Tests](https://github.com/yaklang/yaklang/actions/runs/34102102173) and [Diff-Code-Check](https://github.com/yaklang/yaklang/actions/runs/34102102174). All 35 executed checks succeeded; the ScanNode-only job was skipped by the existing scope condition.
