### PR TITLE
feat(mcp): add Yakit screenshots with automatic file saving

### DIFF
--- a/common/mcp/builtin_description_i18n.go
+++ b/common/mcp/builtin_description_i18n.go
@@ -11,6 +11,7 @@ import (
 //   - mcp.Tool.Description (WithDescription) remains English for AI / MCP tools/list
 //   - UI DescriptionI18n Zh/En come from this table at export time
 var builtinToolDescriptionI18n = map[string]*schema.I18n{
+	"screenshot": schema.NewI18n("截取 Yakit 当前可见页面并添加本地时间水印；支持指定保存路径，大图自动保存到引擎截图目录", "Capture the visible Yakit page with a local-time watermark; save to a chosen path or automatically save large images on the engine"),
 	// global_hotpatch
 	"get_global_hotpatch_config":      schema.NewI18n("获取当前全局热加载配置，包括启用状态、版本和生效模板", "Get current global hotpatch config (enabled, version, active template)"),
 	"enable_global_hotpatch":          schema.NewI18n("启用全局热加载模板；对新的 MITM 请求与 WebFuzzer 任务生效", "Enable global hotpatch for new MITM / WebFuzzer tasks"),

--- a/common/mcp/screenshot.go
+++ b/common/mcp/screenshot.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/server"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+const screenshotInlineLimit = 1024 * 1024        // Limit the encoded image, not the raw PNG.
+const screenshotTransferLimit = 30 * 1024 * 1024 // Matches the desktop's Base64 transfer limit.
+
+type screenshotOptions struct {
+	SavePath       string `json:"savePath"`
+	MaxInlineBytes int    `json:"maxInlineBytes"`
+}
+
+func init() {
+	AddGlobalToolSet("screenshot", WithTool(mcp.NewTool("screenshot",
+		mcp.WithDescription("Capture the visible Yakit page as a PNG with a bottom-left desktop local-time watermark. Requires one capable frontend connected to this engine. Images up to 1 MiB of Base64 are returned inline; larger images are saved under the MCP engine's YAKIT_HOME/screenshots/YYYY-MM-DD/. File results contain an engine-local absolute path and metadata, without image data. Set savePath or maxInlineBytes=0 to always save a file."),
+		mcp.WithString("savePath", mcp.Description("Optional PNG file path on the MCP engine machine. Absolute paths are accepted; relative paths are resolved under YAKIT_HOME/screenshots (normally ~/yakit-projects/screenshots). Parent directories are created. Existing files are never overwritten. Specifying a path returns file metadata only.")),
+		mcp.WithInteger("maxInlineBytes", mcp.Description("Maximum Base64 image bytes returned inline, from 0 to 1048576. Default 1048576 (1 MiB). Set 0 to always save to a file. Larger images are automatically saved without resizing or losing detail."), mcp.Default(screenshotInlineLimit), mcp.Min(0), mcp.Max(screenshotInlineLimit)),
+	), handleScreenshot))
+}
+
+func handleScreenshot(s *MCPServer) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		options, err := decodeScreenshotOptions(request.Params.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		result, err := yakit.RequestYakitScreenshot(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return screenshotToolResult(result, options)
+	}
+}
+
+func decodeScreenshotOptions(arguments map[string]any) (screenshotOptions, error) {
+	options := screenshotOptions{MaxInlineBytes: screenshotInlineLimit}
+	data, err := json.Marshal(arguments)
+	if err != nil {
+		return options, fmt.Errorf("invalid screenshot arguments: %w", err)
+	}
+	if err := json.Unmarshal(data, &options); err != nil {
+		return options, fmt.Errorf("invalid screenshot arguments: %w", err)
+	}
+	if options.MaxInlineBytes < 0 || options.MaxInlineBytes > screenshotInlineLimit {
+		return options, fmt.Errorf("maxInlineBytes must be an integer between 0 and %d", screenshotInlineLimit)
+	}
+	if _, supplied := arguments["savePath"]; supplied {
+		if strings.TrimSpace(options.SavePath) == "" {
+			return options, fmt.Errorf("savePath must be a non-empty PNG file path")
+		}
+		options.SavePath, err = resolveScreenshotSavePath(options.SavePath)
+	}
+	return options, err
+}
+
+func resolveScreenshotSavePath(name string) (string, error) {
+	if strings.ContainsRune(name, 0) || !strings.EqualFold(filepath.Ext(name), ".png") {
+		return "", fmt.Errorf("savePath must be a PNG file path without NUL characters")
+	}
+	if !filepath.IsAbs(name) {
+		name = filepath.Clean(name)
+		if name == ".." || strings.HasPrefix(name, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("relative savePath must stay under YAKIT_HOME/screenshots")
+		}
+		name = filepath.Join(consts.GetDefaultYakitBaseDir(), "screenshots", name)
+	}
+	return filepath.Abs(name)
+}
+
+func screenshotToolResult(result *yakit.YakitScreenshot, options screenshotOptions) (*mcp.CallToolResult, error) {
+	if len(result.Data) > screenshotTransferLimit {
+		return nil, fmt.Errorf("screenshot exceeds the 30 MiB Base64 transfer limit")
+	}
+	data, err := base64.StdEncoding.DecodeString(result.Data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid screenshot base64: %w", err)
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("invalid screenshot PNG: %w", err)
+	}
+	if config.Width != result.Width || config.Height != result.Height {
+		return nil, fmt.Errorf("screenshot dimensions do not match the PNG")
+	}
+	capturedAt, err := time.Parse("2006-01-02 15:04:05 -07:00", result.CapturedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid screenshot local timestamp: %w", err)
+	}
+	if options.SavePath != "" || len(result.Data) > options.MaxInlineBytes {
+		name := options.SavePath
+		reason := "savePath"
+		if name == "" {
+			name = filepath.Join(capturedAt.Format("2006-01-02"), "screenshot-"+capturedAt.Format("150405")+"-"+uuid.NewString()+".png")
+			reason = "inline_limit_exceeded"
+			if options.MaxInlineBytes == 0 {
+				reason = "file_requested"
+			}
+		}
+		name, err = resolveScreenshotSavePath(name)
+		if err != nil {
+			return nil, err
+		}
+		if err := saveScreenshotPNG(name, data); err != nil {
+			return nil, err
+		}
+		return NewCommonCallToolResult(map[string]any{
+			"delivery": "file", "path": name, "storageLocation": "mcp_engine",
+			"mimeType": "image/png", "width": result.Width, "height": result.Height,
+			"capturedAt": result.CapturedAt, "sizeBytes": len(data), "base64Bytes": len(result.Data),
+			"maxInlineBytes": options.MaxInlineBytes, "reason": reason,
+		})
+	}
+	return mcp.NewToolResultImage(
+		fmt.Sprintf("Yakit screenshot (%d × %d). Local capture time: %s. Time watermark is visible at the bottom left.", result.Width, result.Height, result.CapturedAt),
+		result.Data, "image/png",
+	), nil
+}
+
+func saveScreenshotPNG(name string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(name), 0o750); err != nil {
+		return fmt.Errorf("create screenshot directory: %w", err)
+	}
+	file, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create screenshot file (existing files are not overwritten): %w", err)
+	}
+	_, writeErr := file.Write(data)
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		_ = os.Remove(name)
+		if writeErr != nil {
+			return fmt.Errorf("write screenshot file: %w", writeErr)
+		}
+		return fmt.Errorf("close screenshot file: %w", closeErr)
+	}
+	return nil
+}

--- a/common/mcp/screenshot.md
+++ b/common/mcp/screenshot.md
@@ -1,0 +1,99 @@
+# Yakit screenshot
+
+The optional `screenshot` tool set provides the `screenshot` MCP tool. Small
+images are returned as an MCP `image` content block containing a Base64 PNG,
+plus a text block with the dimensions and capture time. Larger images are
+automatically saved as PNG files, and the tool returns only file metadata.
+
+Enable the `screenshot` tool set in the MCP server configuration (`Tool:
+["screenshot"]` for `StartMcpServer`, or include `screenshot` in the CLI `-t`
+selection). `--enable-all` also includes it. Restart the updated Yak engine and
+Yakit Electron main process, and connect Yakit to the engine hosting MCP.
+
+Example `tools/call` parameters:
+
+```json
+{"name":"screenshot","arguments":{}}
+```
+
+## Saving and response size
+
+| Argument | Default | Behavior |
+| --- | --- | --- |
+| `savePath` | Omitted | A PNG file path on the MCP engine machine. Specifying it always saves the image and returns file metadata only. Relative paths resolve under `YAKIT_HOME/screenshots`; absolute paths are also accepted. |
+| `maxInlineBytes` | `1048576` | Maximum **Base64-encoded image bytes** to include in the MCP response, between 0 and 1048576. Set `0` to always save a file. |
+
+For example, a 4 MiB PNG becomes roughly 5.33 MiB after Base64 encoding. With
+the default 1 MiB inline limit it is saved to disk, and none of that image data
+is included in the MCP tool response. The original PNG is preserved without
+resizing or lossy compression. Images exactly at the inline limit stay inline.
+
+Automatic saves use:
+
+```text
+<YAKIT_HOME>/screenshots/YYYY-MM-DD/screenshot-HHMMSS-<uuid>.png
+```
+
+`YAKIT_HOME` normally resolves to `~/yakit-projects`. Date folders and filenames
+use the capture's local date/time. UUIDs avoid collisions between captures.
+These are persistent evidence files, not files under the temporary directory;
+they are not automatically removed. Parent directories are created as needed.
+Existing files are never overwritten, and failed writes return errors instead
+of falling back to a large inline response.
+
+Save with a meaningful relative name:
+
+```json
+{"name":"screenshot","arguments":{"savePath":"idor/request-response.png"}}
+```
+
+Always save, generating a filename automatically:
+
+```json
+{"name":"screenshot","arguments":{"maxInlineBytes":0}}
+```
+
+A saved result contains one text content block with JSON such as:
+
+```json
+{
+  "delivery": "file",
+  "path": "/home/user/yakit-projects/screenshots/idor/request-response.png",
+  "storageLocation": "mcp_engine",
+  "mimeType": "image/png",
+  "width": 1920,
+  "height": 1080,
+  "capturedAt": "2026-09-08 12:34:56 +08:00",
+  "sizeBytes": 4194304,
+  "base64Bytes": 5592408,
+  "maxInlineBytes": 1048576,
+  "reason": "savePath"
+}
+```
+
+`reason` is `savePath`, `file_requested`, or `inline_limit_exceeded`. A returned
+path belongs to the **MCP engine machine**, which can differ from the Yakit
+desktop or MCP caller. It is not a download URL; remote callers need file access
+to that machine to retrieve the saved image.
+
+The inline limit applies to the **MCP response**. Desktop-to-engine transfer
+still uses the existing Base64 duplex protocol and its 30 MiB encoded-image
+limit (the engine accepts at most 32 MiB for the enclosing JSON message).
+
+## Capture behavior
+
+The capture covers the main Yakit window's current visible page, including open
+dialogs rendered inside that page. It does not scroll, switch tabs, capture OS
+dialogs. Electron captures the page directly; no desktop screen
+recording permission is needed. The PNG retains the native capture resolution.
+
+A white-on-dark watermark is drawn at the bottom left on a detached canvas.
+It uses the **Yakit desktop computer's local system time**, even when the engine
+runs remotely. Format: `2026-09-08 12:34:56 +08:00`. The actual page DOM is unchanged.
+
+The existing `DuplexConnection` stream carries capability subscription, request
+IDs and replies; no additional port or protobuf RPC is introduced. Exactly one
+capable frontend must be connected. Missing/older frontends, multiple frontends,
+closed windows and capture failures return explicit errors. Desktop capture is
+bounded to 10 seconds; the engine waits at most 15 seconds (or the caller's
+shorter deadline). Replies are matched to both request ID and selected stream.

--- a/common/mcp/screenshot_test.go
+++ b/common/mcp/screenshot_test.go
@@ -1,0 +1,158 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"image"
+	"image/png"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+func TestScreenshotToolResult(t *testing.T) {
+	var buffer bytes.Buffer
+	require.NoError(t, png.Encode(&buffer, image.NewRGBA(image.Rect(0, 0, 800, 600))))
+	screenshot := &yakit.YakitScreenshot{
+		Data:       base64.StdEncoding.EncodeToString(buffer.Bytes()),
+		CapturedAt: "2026-09-08 12:34:56 +08:00", Width: 800, Height: 600,
+	}
+	result, err := screenshotToolResult(screenshot, screenshotOptions{MaxInlineBytes: screenshotInlineLimit})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 2)
+	content, ok := mcp.AsImageContent(result.Content[1])
+	require.True(t, ok)
+	require.Equal(t, "image/png", content.MIMEType)
+	require.Equal(t, screenshot.Data, content.Data)
+	screenshot.Width = 1
+	_, err = screenshotToolResult(screenshot, screenshotOptions{MaxInlineBytes: screenshotInlineLimit})
+	require.ErrorContains(t, err, "dimensions")
+	screenshot.Width = 800
+	screenshot.CapturedAt = "UTC time"
+	_, err = screenshotToolResult(screenshot, screenshotOptions{MaxInlineBytes: screenshotInlineLimit})
+	require.ErrorContains(t, err, "timestamp")
+	screenshot.Data = "not base64"
+	_, err = screenshotToolResult(screenshot, screenshotOptions{MaxInlineBytes: screenshotInlineLimit})
+	require.ErrorContains(t, err, "base64")
+	screenshot.Data = base64.StdEncoding.EncodeToString([]byte("not png"))
+	_, err = screenshotToolResult(screenshot, screenshotOptions{MaxInlineBytes: screenshotInlineLimit})
+	require.ErrorContains(t, err, "PNG")
+}
+
+func screenshotPNGFixture(t *testing.T, large bool) *yakit.YakitScreenshot {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, 80, 60))
+	if large {
+		img = image.NewNRGBA(image.Rect(0, 0, 1200, 1200))
+		_, err := rand.New(rand.NewSource(1)).Read(img.Pix)
+		require.NoError(t, err)
+	}
+	var buffer bytes.Buffer
+	require.NoError(t, png.Encode(&buffer, img))
+	return &yakit.YakitScreenshot{
+		Data:       base64.StdEncoding.EncodeToString(buffer.Bytes()),
+		CapturedAt: "2026-09-08 12:34:56 +08:00", Width: img.Bounds().Dx(), Height: img.Bounds().Dy(),
+	}
+}
+
+func screenshotFileMetadata(t *testing.T, result *mcp.CallToolResult, screenshot *yakit.YakitScreenshot) map[string]any {
+	t.Helper()
+	require.Len(t, result.Content, 1, "file responses must not include an image content block")
+	content, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	require.Less(t, len(content.Text), 2048, "file response must stay small")
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(content.Text), &metadata))
+	require.Equal(t, "file", metadata["delivery"])
+	require.Equal(t, "mcp_engine", metadata["storageLocation"])
+	require.NotContains(t, metadata, "data")
+	data, err := os.ReadFile(metadata["path"].(string))
+	require.NoError(t, err)
+	require.Equal(t, screenshot.Data, base64.StdEncoding.EncodeToString(data), "saved PNG must retain all original bytes")
+	require.EqualValues(t, len(data), metadata["sizeBytes"])
+	require.EqualValues(t, len(screenshot.Data), metadata["base64Bytes"])
+	return metadata
+}
+
+func TestScreenshotEncodedSizeBoundary(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	screenshot := screenshotPNGFixture(t, false)
+	data, err := base64.StdEncoding.DecodeString(screenshot.Data)
+	require.NoError(t, err)
+	for _, threshold := range []int{len(screenshot.Data), len(screenshot.Data) - 1, len(data), 0} {
+		result, err := screenshotToolResult(screenshot, screenshotOptions{MaxInlineBytes: threshold})
+		require.NoError(t, err)
+		if threshold == len(screenshot.Data) {
+			require.Len(t, result.Content, 2)
+			continue
+		}
+		metadata := screenshotFileMetadata(t, result, screenshot)
+		require.Equal(t, filepath.Join(os.Getenv("YAKIT_HOME"), "screenshots", "2026-09-08"), filepath.Dir(metadata["path"].(string)))
+		if threshold == 0 {
+			require.Equal(t, "file_requested", metadata["reason"])
+		} else {
+			require.Equal(t, "inline_limit_exceeded", metadata["reason"])
+		}
+	}
+}
+
+func TestScreenshotLargePNGAutomaticallySaved(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	screenshot := screenshotPNGFixture(t, true)
+	data, err := base64.StdEncoding.DecodeString(screenshot.Data)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 4*1024*1024)
+	options, err := decodeScreenshotOptions(nil)
+	require.NoError(t, err)
+	result, err := screenshotToolResult(screenshot, options)
+	require.NoError(t, err)
+	metadata := screenshotFileMetadata(t, result, screenshot)
+	require.Equal(t, "inline_limit_exceeded", metadata["reason"])
+}
+
+func TestScreenshotExplicitPathAndNoOverwrite(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	screenshot := screenshotPNGFixture(t, false)
+	for _, path := range []string{"idor/request-response.png", filepath.Join(t.TempDir(), "evidence.png")} {
+		options, err := decodeScreenshotOptions(map[string]any{"savePath": path})
+		require.NoError(t, err)
+		result, err := screenshotToolResult(screenshot, options)
+		require.NoError(t, err)
+		metadata := screenshotFileMetadata(t, result, screenshot)
+		require.Equal(t, "savePath", metadata["reason"])
+		require.Equal(t, options.SavePath, metadata["path"])
+		_, err = screenshotToolResult(screenshot, options)
+		require.ErrorIs(t, err, os.ErrExist)
+		screenshotFileMetadata(t, result, screenshot)
+	}
+}
+
+func TestScreenshotInvalidOptionsBeforeCapture(t *testing.T) {
+	for _, arguments := range []map[string]any{
+		{"maxInlineBytes": -1}, {"maxInlineBytes": screenshotInlineLimit + 1},
+		{"maxInlineBytes": 1.5}, {"maxInlineBytes": "1024"},
+		{"savePath": ""}, {"savePath": "../escape.png"}, {"savePath": "report.jpg"}, {"savePath": "bad\x00.png"},
+	} {
+		_, err := CallBuiltinTool(&MCPServer{}, context.Background(), "screenshot", arguments)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "frontend", "invalid options must be rejected before requesting a capture")
+	}
+}
+
+func TestScreenshotSaveFailure(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "file-as-parent")
+	require.NoError(t, os.WriteFile(blocked, []byte("original"), 0o600))
+	_, err := screenshotToolResult(screenshotPNGFixture(t, false), screenshotOptions{SavePath: filepath.Join(blocked, "capture.png")})
+	require.ErrorContains(t, err, "create screenshot directory")
+	contents, err := os.ReadFile(blocked)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(contents))
+}

--- a/common/mcp/tool_set_catalog.go
+++ b/common/mcp/tool_set_catalog.go
@@ -39,6 +39,7 @@ var mcpToolSetCatalog = []MCPToolSetCatalogEntry{
 	{Name: "fingerprint", Tier: ToolSetTierDefault, Summary: "Service fingerprint query and CRUD"},
 
 	// --- optional: specialized / heavy / UI-oriented ---
+	{Name: "screenshot", Tier: ToolSetTierOptional, Summary: "Capture the visible Yakit frontend with a local-time watermark"},
 	{Name: "hybrid_scan", Tier: ToolSetTierOptional, Summary: "Combined hybrid scan; long-running, task-oriented"},
 	{Name: "payload", Tier: ToolSetTierOptional, Summary: "Payload dictionary CRUD; Yakit dictionary UI workflow"},
 	{Name: "yak_document", Tier: ToolSetTierOptional, Summary: "Yak API/library documentation lookup for script authors"},

--- a/common/mcp/tool_set_catalog_test.go
+++ b/common/mcp/tool_set_catalog_test.go
@@ -22,7 +22,7 @@ func TestMCPToolSetCatalogMatchesRegistration(t *testing.T) {
 
 func TestDefaultMCPToolSets_Classification(t *testing.T) {
 	require.Len(t, DefaultMCPToolSets, 12)
-	require.Len(t, OptionalMCPToolSets, 11)
+	require.Len(t, OptionalMCPToolSets, 12)
 	require.Len(t, InternalMCPToolSets, 1)
 
 	for _, name := range DefaultMCPToolSets {

--- a/common/yakgrpc/grpc_duplex_conn.go
+++ b/common/yakgrpc/grpc_duplex_conn.go
@@ -254,6 +254,10 @@ func (s *Server) DuplexConnection(stream ypb.Yak_DuplexConnectionServer) error {
 
 	yakit.YakitDuplexConnectionServer.Server(stream.Context(), stream, func(_ context.Context, req *ypb.DuplexConnectionRequest) error {
 		switch req.GetMessageType() {
+		case yakit.ScreenshotSubscribe:
+			yakit.SetServerPushSubscription(id, yakit.ScreenshotRequest, true)
+		case yakit.ScreenshotResponse:
+			return yakit.DeliverYakitScreenshot(id, req.GetData())
 		case yakit.ServerPushType_HTTPFlowCommittedSubscribe:
 			yakit.SetServerPushSubscription(id, yakit.ServerPushType_HTTPFlowCommitted, true)
 		case yakit.ServerPushType_HTTPFlowCommittedUnsubscribe:

--- a/common/yakgrpc/grpc_screenshot_test.go
+++ b/common/yakgrpc/grpc_screenshot_test.go
@@ -1,0 +1,97 @@
+package yakgrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"image"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/mcp"
+	mcpmodel "github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func TestScreenshotMCPDuplexRoundTrip(t *testing.T) {
+	client, err := NewLocalClient(true)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stream, err := client.DuplexConnection(ctx)
+	require.NoError(t, err)
+
+	// A following frame is a barrier proving the subscription has been processed.
+	ready := make(chan struct{}, 1)
+	barrier := "screenshot-test-" + uuid.NewString()
+	yakit.YakitDuplexConnectionServer.RegisterHandler(barrier, func(context.Context, *ypb.DuplexConnectionRequest) error {
+		ready <- struct{}{}
+		return nil
+	})
+	defer yakit.YakitDuplexConnectionServer.UnRegisterHandler(barrier)
+	require.NoError(t, stream.Send(&ypb.DuplexConnectionRequest{MessageType: yakit.ScreenshotSubscribe}))
+	require.NoError(t, stream.Send(&ypb.DuplexConnectionRequest{MessageType: barrier}))
+	select {
+	case <-ready:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	var buffer bytes.Buffer
+	require.NoError(t, png.Encode(&buffer, image.NewRGBA(image.Rect(0, 0, 800, 600))))
+	encoded := base64.StdEncoding.EncodeToString(buffer.Bytes())
+	frontendDone := make(chan error, 1)
+	go func() {
+		for captures := 0; captures < 2; {
+			message, err := stream.Recv()
+			if err != nil {
+				frontendDone <- err
+				return
+			}
+			if message.GetMessageType() != yakit.ScreenshotRequest {
+				continue
+			}
+			var reply yakit.YakitScreenshot
+			if err := json.Unmarshal(message.Data, &reply); err != nil {
+				frontendDone <- err
+				return
+			}
+			reply.Data, reply.Width, reply.Height = encoded, 800, 600
+			reply.CapturedAt = "2026-09-08 12:34:56 +08:00"
+			data, _ := json.Marshal(reply)
+			if err := stream.Send(&ypb.DuplexConnectionRequest{MessageType: yakit.ScreenshotResponse, Data: data}); err != nil {
+				frontendDone <- err
+				return
+			}
+			captures++
+		}
+		frontendDone <- nil
+	}()
+	result, err := mcp.CallBuiltinTool(&mcp.MCPServer{}, ctx, "screenshot", nil)
+	require.NoError(t, err)
+	content, ok := mcpmodel.AsImageContent(result.Content[1])
+	require.True(t, ok)
+	require.Equal(t, "image/png", content.MIMEType)
+	require.Equal(t, encoded, content.Data)
+
+	path := filepath.Join(t.TempDir(), "httpflow.png")
+	result, err = mcp.CallBuiltinTool(&mcp.MCPServer{}, ctx, "screenshot", map[string]any{"savePath": path})
+	require.NoError(t, err)
+	require.NoError(t, <-frontendDone)
+	require.Len(t, result.Content, 1)
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcpmodel.TextContent).Text), &metadata))
+	require.Equal(t, "file", metadata["delivery"])
+	require.Equal(t, path, metadata["path"])
+	require.NotContains(t, metadata, "data")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, encoded, base64.StdEncoding.EncodeToString(data))
+}

--- a/common/yakgrpc/yakit/screenshot.go
+++ b/common/yakgrpc/yakit/screenshot.go
@@ -1,0 +1,97 @@
+package yakit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+const (
+	ScreenshotSubscribe = "yakit_screenshot_subscribe"
+	ScreenshotRequest   = "yakit_screenshot_request"
+	ScreenshotResponse  = "yakit_screenshot_response"
+)
+
+// YakitScreenshot contains a PNG watermarked using the desktop's local time.
+type YakitScreenshot struct {
+	RequestID  string `json:"requestId"`
+	Data       string `json:"data,omitempty"`
+	CapturedAt string `json:"capturedAt,omitempty"`
+	Width      int    `json:"width,omitempty"`
+	Height     int    `json:"height,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+type pendingScreenshot struct {
+	clientID string
+	result   chan *YakitScreenshot
+}
+
+var screenshotRequests sync.Map
+
+// DeliverYakitScreenshot accepts replies only from the selected duplex client.
+func DeliverYakitScreenshot(clientID string, data []byte) error {
+	if len(data) > 32*1024*1024 {
+		return fmt.Errorf("screenshot response exceeds 32 MiB")
+	}
+	var result YakitScreenshot
+	if err := json.Unmarshal(data, &result); err != nil {
+		return fmt.Errorf("invalid screenshot response: %w", err)
+	}
+	value, ok := screenshotRequests.Load(result.RequestID)
+	if !ok {
+		return nil // A canceled or timed-out request may still receive a reply.
+	}
+	pending := value.(*pendingScreenshot)
+	if pending.clientID != clientID {
+		return nil
+	}
+	select {
+	case pending.result <- &result:
+	default:
+	}
+	return nil
+}
+
+// RequestYakitScreenshot uses the existing engine/desktop duplex transport.
+func RequestYakitScreenshot(ctx context.Context) (*YakitScreenshot, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	clients := snapshotServerPushSubscribers(ScreenshotRequest)
+	if len(clients) == 0 {
+		return nil, fmt.Errorf("no screenshot-capable Yakit frontend is connected to this engine; open an updated Yakit frontend first")
+	}
+	if len(clients) > 1 {
+		return nil, fmt.Errorf("multiple Yakit frontends are connected; keep one frontend connected before taking a screenshot")
+	}
+	client := clients[0]
+	id := uuid.NewString()
+	pending := &pendingScreenshot{clientID: client.Name, result: make(chan *YakitScreenshot, 1)}
+	screenshotRequests.Store(id, pending)
+	defer screenshotRequests.Delete(id)
+	data, _ := json.Marshal(map[string]string{"requestId": id})
+	if !client.enqueue(&ypb.DuplexConnectionResponse{
+		MessageType: ScreenshotRequest, Data: data, Timestamp: time.Now().UnixNano(),
+	}) {
+		return nil, fmt.Errorf("Yakit screenshot request could not be delivered")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("waiting for Yakit screenshot: %w", ctx.Err())
+	case <-client.done:
+		return nil, fmt.Errorf("Yakit frontend disconnected while taking a screenshot")
+	case result := <-pending.result:
+		if result.Error != "" {
+			return nil, fmt.Errorf("Yakit screenshot failed: %s", result.Error)
+		}
+		return result, nil
+	}
+}

--- a/common/yakgrpc/yakit/screenshot_test.go
+++ b/common/yakgrpc/yakit/screenshot_test.go
@@ -1,0 +1,81 @@
+package yakit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+func screenshotTestClient(t *testing.T, send func(*ypb.DuplexConnectionResponse) error) string {
+	t.Helper()
+	id := uuid.NewString()
+	registerServerPushCallback(id, context.Background(), 8, send)
+	require.True(t, SetServerPushSubscription(id, ScreenshotRequest, true))
+	t.Cleanup(func() { UnRegisterServerPushCallback(id) })
+	return id
+}
+
+func TestYakitScreenshotRoundTrip(t *testing.T) {
+	var clientID string
+	clientID = screenshotTestClient(t, func(message *ypb.DuplexConnectionResponse) error {
+		require.Equal(t, ScreenshotRequest, message.MessageType)
+		var request YakitScreenshot
+		require.NoError(t, json.Unmarshal(message.Data, &request))
+		wrong, _ := json.Marshal(YakitScreenshot{RequestID: request.RequestID, Error: "wrong client"})
+		require.NoError(t, DeliverYakitScreenshot("other-client", wrong))
+		data, _ := json.Marshal(YakitScreenshot{RequestID: request.RequestID, Data: "png", CapturedAt: "2026-09-08 12:34:56 +08:00"})
+		return DeliverYakitScreenshot(clientID, data)
+	})
+	result, err := RequestYakitScreenshot(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "png", result.Data)
+	_, pending := screenshotRequests.Load(result.RequestID)
+	require.False(t, pending)
+}
+
+func TestYakitScreenshotUnavailable(t *testing.T) {
+	_, err := RequestYakitScreenshot(context.Background())
+	require.ErrorContains(t, err, "no screenshot-capable")
+	screenshotTestClient(t, func(*ypb.DuplexConnectionResponse) error { return nil })
+	screenshotTestClient(t, func(*ypb.DuplexConnectionResponse) error { return nil })
+	_, err = RequestYakitScreenshot(context.Background())
+	require.ErrorContains(t, err, "multiple Yakit")
+}
+
+func TestYakitScreenshotCancellationAndLateReply(t *testing.T) {
+	requests := make(chan *ypb.DuplexConnectionResponse, 1)
+	id := screenshotTestClient(t, func(message *ypb.DuplexConnectionResponse) error {
+		requests <- message
+		return nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err := RequestYakitScreenshot(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	message := <-requests
+	var request YakitScreenshot
+	require.NoError(t, json.Unmarshal(message.Data, &request))
+	_, pending := screenshotRequests.Load(request.RequestID)
+	require.False(t, pending)
+	require.NoError(t, DeliverYakitScreenshot(id, message.Data))
+}
+
+func TestYakitScreenshotFrontendError(t *testing.T) {
+	var id string
+	id = screenshotTestClient(t, func(message *ypb.DuplexConnectionResponse) error {
+		var result YakitScreenshot
+		if err := json.Unmarshal(message.Data, &result); err != nil {
+			return err
+		}
+		result.Error = "Yakit main window is unavailable"
+		data, _ := json.Marshal(result)
+		return DeliverYakitScreenshot(id, data)
+	})
+	_, err := RequestYakitScreenshot(context.Background())
+	require.ErrorContains(t, err, "window is unavailable")
+}


### PR DESCRIPTION
Adds an optional `screenshot` MCP tool that captures the connected Yakit frontend with a visible bottom-left desktop local-time watermark. The engine reuses `DuplexConnection` to request captures and matches replies by request ID and frontend connection.

Small PNGs are returned as MCP image content. Images exceeding the default 1 MiB Base64 limit are saved under `YAKIT_HOME/screenshots/YYYY-MM-DD/`, returning only an engine-local path and metadata. `savePath` requests an explicit PNG destination; `maxInlineBytes: 0` always saves a file. Existing files are not overwritten.

### Implementation
- Register the optional tool set and bilingual descriptions.
- Add screenshot capability subscription, request/reply correlation, timeout and disconnect handling without adding protobuf RPCs or ports.
- Validate image metadata and arguments; preserve original PNG bytes when saving.
- Document parameters, file locations, transport limits and remote-engine behavior.

### Validation
- Targeted tests in `common/mcp`, `common/yakgrpc` and `common/yakgrpc/yakit` cover inline/file responses, a PNG larger than 4 MiB, Base64 size boundaries, invalid paths, no-overwrite behavior, failed saves, reply routing and timeouts.
- gRPC integration test covers both inline image delivery and explicit file saving with a simulated frontend.
- The companion Electron implementation was exercised on a real HTTPFlow page; that visual check invoked the desktop capture function directly.

### Frontend dependency
Requires the companion Yakit Electron change to subscribe for screenshot requests, capture the page, add the local-time watermark and return the PNG. This PR contains backend changes only. Existing frontends without that capability receive an explicit unavailable error. Capture targets the currently visible main page; selecting WebFuzzer results or page regions is outside this change.
