### PR TITLE
fix(project): 修复数据库文件被移动后项目路径失效的问题

### DIFF
--- a/common/yakgrpc/grpc_project.go
+++ b/common/yakgrpc/grpc_project.go
@@ -88,6 +88,14 @@ func (s *Server) SetCurrentProject(ctx context.Context, req *ypb.SetCurrentProje
 	}
 
 	path := proj.DatabasePath
+	// 懒修复：如果数据库文件不存在，尝试按文件名在预期目录中查找
+	if !utils.FileExists(path) {
+		if repaired, ok := yakit.RepairProjectDatabasePath(db, proj); ok {
+			path = repaired
+		} else {
+			return nil, utils.Errorf("project database file not found: %s", path)
+		}
+	}
 	log.Infof("Set project db by grpc: %s", path)
 	switch req.GetType() {
 	case yakit.TypeProject:
@@ -98,7 +106,7 @@ func (s *Server) SetCurrentProject(ctx context.Context, req *ypb.SetCurrentProje
 			s.StartAIReActScheduler()
 		}
 	case yakit.TypeSSAProject:
-		raw := proj.DatabasePath
+		raw := path
 		consts.SetSSADatabaseInfo(raw)
 		err = consts.SetGormSSAProjectDatabaseByInfo(raw)
 	}
@@ -310,7 +318,17 @@ func (s *Server) ExportProject(req *ypb.ExportProjectRequest, stream ypb.Yak_Exp
 		return utils.Errorf("cannot found database file in: %s", err.Error())
 	}
 	feedProgress("寻找数据文件", 0.3)
-	fp, err := os.Open(proj.DatabasePath)
+	// 懒修复：如果数据库文件不存在，尝试按文件名在预期目录中查找
+	dbPath := proj.DatabasePath
+	if !utils.FileExists(dbPath) {
+		if repaired, ok := yakit.RepairProjectDatabasePath(s.GetProfileDatabase(), proj); ok {
+			dbPath = repaired
+		} else {
+			feedProgress("找不到数据库文件: "+dbPath, 0.4)
+			return utils.Errorf("open database failed: file not found: %s", dbPath)
+		}
+	}
+	fp, err := os.Open(dbPath)
 	if err != nil {
 		feedProgress("找不到数据库文件"+err.Error(), 0.4)
 		return utils.Errorf("open database failed: %s", err)

--- a/common/yakgrpc/yakit/projects.go
+++ b/common/yakgrpc/yakit/projects.go
@@ -85,6 +85,9 @@ func InitializingProjectDatabase() error {
 	_ = dialect
 	updateProject(TypeSSAProject, defaultSSAProjectPath)
 
+	// 修复因数据库文件被移动而失效的 DatabasePath
+	repairProjectDatabasePaths(profileDB)
+
 	return nil
 }
 
@@ -454,6 +457,78 @@ func UpdateProjectDatabasePath(db *gorm.DB, id int64, databasePath string) error
 		return utils.Errorf("update project: %s", db.Error)
 	}
 	return nil
+}
+
+// RepairProjectDatabasePath 检查项目的数据库文件是否存在，
+// 如果不存在则按文件名在预期目录中查找，找到则自动更新 DatabasePath。
+//
+// 适用场景：用户移动了 yakit-projects 目录后，projects 表中记录的绝对路径失效。
+// 因为数据库文件名包含时间戳，全局唯一，所以按文件名在预期目录中查找即可命中。
+//
+// 参数:
+//   - profileDB: profile 数据库连接
+//   - proj: 要修复的项目记录
+//
+// 返回值:
+//   - string: 修复后的路径（修复成功则为新路径，否则为原始路径）
+//   - bool: 是否修复成功（文件可用即为 true）
+func RepairProjectDatabasePath(profileDB *gorm.DB, proj *schema.Project) (string, bool) {
+	if proj == nil || proj.DatabasePath == "" {
+		return "", false
+	}
+	// 文件存在，无需修复
+	if utils.FileExists(proj.DatabasePath) {
+		return proj.DatabasePath, true
+	}
+	// SSA 项目可能使用 MySQL/Postgres DSN（非文件路径），跳过文件级修复
+	// DSN 格式如 "mysql://..." / "postgres://..."，SQLite 文件路径不含 "://"
+	if proj.Type == TypeSSAProject && strings.Contains(proj.DatabasePath, "://") {
+		return proj.DatabasePath, false
+	}
+	// 按 type 确定预期目录
+	var expectedDir string
+	switch proj.Type {
+	case TypeSSAProject:
+		expectedDir = consts.GetDefaultSSAProjectDir()
+	default:
+		expectedDir = consts.GetDefaultYakitProjectsDir()
+	}
+	filename := filepath.Base(proj.DatabasePath)
+	if filename == "." || filename == string(filepath.Separator) {
+		return proj.DatabasePath, false
+	}
+	candidatePath := filepath.Join(expectedDir, filename)
+	if !utils.FileExists(candidatePath) {
+		return proj.DatabasePath, false
+	}
+	// 找到了，更新数据库记录
+	if err := UpdateProjectDatabasePath(profileDB, int64(proj.ID), candidatePath); err != nil {
+		log.Errorf("repair project database path failed: %s", err)
+		return proj.DatabasePath, false
+	}
+	log.Infof("repaired project[%d] database path: %s -> %s", proj.ID, proj.DatabasePath, candidatePath)
+	return candidatePath, true
+}
+
+// repairProjectDatabasePaths 遍历所有项目，检查并修复失效的 DatabasePath。
+// 在 InitializingProjectDatabase 启动时调用，实现"移动后自愈"。
+func repairProjectDatabasePaths(profileDB *gorm.DB) {
+	projCh := YieldProject(profileDB, context.Background())
+	for proj := range projCh {
+		if proj == nil || proj.DatabasePath == "" {
+			continue
+		}
+		// 跳过文件夹类型（type=file 的 DatabasePath 为空）
+		if proj.Type == TypeFile {
+			continue
+		}
+		// 文件存在则无需修复
+		if utils.FileExists(proj.DatabasePath) {
+			continue
+		}
+		// 尝试按文件名在预期目录中查找并修复
+		RepairProjectDatabasePath(profileDB, proj)
+	}
 }
 
 func GetTemporaryProject(db *gorm.DB, Type string) (*schema.Project, error) {

--- a/common/yakgrpc/yakit/projects_repair_test.go
+++ b/common/yakgrpc/yakit/projects_repair_test.go
@@ -1,0 +1,240 @@
+package yakit
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+// newRepairTestDB creates an in-memory-style SQLite profile database
+// with the projects table migrated, for testing repair logic.
+func newRepairTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open("sqlite3", filepath.Join(t.TempDir(), "profile.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&schema.Project{}).Error)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestRepairProjectDatabasePath_NoRepairNeeded verifies that when the
+// database file exists, RepairProjectDatabasePath returns the original
+// path and true without any modification.
+func TestRepairProjectDatabasePath_NoRepairNeeded(t *testing.T) {
+	db := newRepairTestDB(t)
+
+	// create a real db file in a temp dir
+	dbFile := filepath.Join(t.TempDir(), "yakit-project-test-123.sqlite3.db")
+	_, err := consts.CreateProjectDatabase(dbFile)
+	require.NoError(t, err)
+
+	proj := &schema.Project{
+		Model:        gorm.Model{ID: 1},
+		ProjectName:  "test-project",
+		DatabasePath: dbFile,
+		Type:         TypeProject,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	path, ok := RepairProjectDatabasePath(db, proj)
+	require.True(t, ok, "file exists, should return true")
+	require.Equal(t, dbFile, path, "path should be unchanged")
+}
+
+// TestRepairProjectDatabasePath_FileMovedAndFound verifies that when the
+// database file has been moved to the expected directory, RepairProjectDatabasePath
+// finds it by filename, updates the record, and returns the new path.
+func TestRepairProjectDatabasePath_FileMovedAndFound(t *testing.T) {
+	db := newRepairTestDB(t)
+
+	// create the db file in the expected projects directory
+	expectedDir := consts.GetDefaultYakitProjectsDir()
+	dbFile := filepath.Join(expectedDir, "yakit-project-repair-test-999.sqlite3.db")
+	_, err := consts.CreateProjectDatabase(dbFile)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		consts.DeleteDatabaseFile(dbFile)
+	})
+
+	// simulate a stale path (file was "moved" from old location)
+	stalePath := filepath.Join(t.TempDir(), "old-location", "yakit-project-repair-test-999.sqlite3.db")
+
+	proj := &schema.Project{
+		Model:        gorm.Model{ID: 1},
+		ProjectName:  "repair-test",
+		DatabasePath: stalePath,
+		Type:         TypeProject,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	path, ok := RepairProjectDatabasePath(db, proj)
+	require.True(t, ok, "file should be found in expected dir")
+	require.Equal(t, dbFile, path, "path should be updated to the new location")
+
+	// verify the DB record was updated
+	var updated schema.Project
+	require.NoError(t, db.First(&updated, proj.ID).Error)
+	require.Equal(t, dbFile, updated.DatabasePath, "database record should reflect new path")
+}
+
+// TestRepairProjectDatabasePath_FileNotFound verifies that when the
+// database file cannot be found anywhere, RepairProjectDatabasePath
+// returns false and the original stale path.
+func TestRepairProjectDatabasePath_FileNotFound(t *testing.T) {
+	db := newRepairTestDB(t)
+
+	stalePath := filepath.Join(t.TempDir(), "nonexistent", "yakit-project-missing-456.sqlite3.db")
+
+	proj := &schema.Project{
+		Model:        gorm.Model{ID: 1},
+		ProjectName:  "missing-project",
+		DatabasePath: stalePath,
+		Type:         TypeProject,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	path, ok := RepairProjectDatabasePath(db, proj)
+	require.False(t, ok, "file not found, should return false")
+	require.Equal(t, stalePath, path, "should return original stale path")
+
+	// verify the DB record was NOT updated
+	var updated schema.Project
+	require.NoError(t, db.First(&updated, proj.ID).Error)
+	require.Equal(t, stalePath, updated.DatabasePath, "database record should be unchanged")
+}
+
+// TestRepairProjectDatabasePath_EmptyPath verifies nil/empty handling.
+func TestRepairProjectDatabasePath_EmptyPath(t *testing.T) {
+	db := newRepairTestDB(t)
+
+	path, ok := RepairProjectDatabasePath(db, nil)
+	require.False(t, ok)
+	require.Empty(t, path)
+
+	proj := &schema.Project{
+		DatabasePath: "",
+	}
+	path, ok = RepairProjectDatabasePath(db, proj)
+	require.False(t, ok)
+	require.Empty(t, path)
+}
+
+// TestRepairProjectDatabasePath_SSA_DSN verifies that SSA projects with
+// MySQL/Postgres DSN strings are skipped (not treated as file paths).
+func TestRepairProjectDatabasePath_SSA_DSN(t *testing.T) {
+	db := newRepairTestDB(t)
+
+	proj := &schema.Project{
+		Model:        gorm.Model{ID: 1},
+		ProjectName:  "ssa-mysql",
+		DatabasePath: "mysql://root:password@tcp(localhost:3306)/yak",
+		Type:         TypeSSAProject,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	path, ok := RepairProjectDatabasePath(db, proj)
+	require.False(t, ok, "DSN should not be treated as a file path")
+	require.Equal(t, "mysql://root:password@tcp(localhost:3306)/yak", path)
+}
+
+// TestRepairProjectDatabasePath_SSA_SQLiteMoved verifies that SSA projects
+// with SQLite file paths are repaired when the file is found in the SSA dir.
+func TestRepairProjectDatabasePath_SSA_SQLiteMoved(t *testing.T) {
+	db := newRepairTestDB(t)
+
+	// create the db file in the expected SSA projects directory
+	expectedDir := consts.GetDefaultSSAProjectDir()
+	dbFile := filepath.Join(expectedDir, "ssa-project-repair-test-888.sqlite3.db")
+	_, err := consts.CreateSSAProjectDatabase(consts.SSA_PROJECT_DB_DIALECT, dbFile)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		consts.DeleteDatabaseFile(dbFile)
+	})
+
+	stalePath := filepath.Join(t.TempDir(), "old-ssa", "ssa-project-repair-test-888.sqlite3.db")
+
+	proj := &schema.Project{
+		Model:        gorm.Model{ID: 1},
+		ProjectName:  "ssa-repair-test",
+		DatabasePath: stalePath,
+		Type:         TypeSSAProject,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	path, ok := RepairProjectDatabasePath(db, proj)
+	require.True(t, ok, "SSA SQLite file should be found in SSA dir")
+	require.Equal(t, dbFile, path, "path should be updated to the SSA dir location")
+}
+
+// TestRepairProjectDatabasePaths_ScanAll verifies the batch repair function
+// repairs multiple projects with stale paths.
+func TestRepairProjectDatabasePaths_ScanAll(t *testing.T) {
+	db := newRepairTestDB(t)
+
+	expectedDir := consts.GetDefaultYakitProjectsDir()
+
+	// project 1: file exists in expected dir, stale path
+	dbFile1 := filepath.Join(expectedDir, "yakit-project-scan-1-111.sqlite3.db")
+	_, err := consts.CreateProjectDatabase(dbFile1)
+	require.NoError(t, err)
+	t.Cleanup(func() { consts.DeleteDatabaseFile(dbFile1) })
+
+	proj1 := &schema.Project{
+		ProjectName:  "scan-test-1",
+		DatabasePath: filepath.Join(t.TempDir(), "old", "yakit-project-scan-1-111.sqlite3.db"),
+		Type:         TypeProject,
+	}
+	require.NoError(t, db.Create(proj1).Error)
+
+	// project 2: file genuinely missing
+	proj2 := &schema.Project{
+		ProjectName:  "scan-test-2",
+		DatabasePath: filepath.Join(t.TempDir(), "missing", "yakit-project-scan-2-222.sqlite3.db"),
+		Type:         TypeProject,
+	}
+	require.NoError(t, db.Create(proj2).Error)
+
+	// project 3: file exists, no repair needed
+	dbFile3 := filepath.Join(t.TempDir(), "yakit-project-scan-3-333.sqlite3.db")
+	_, err = consts.CreateProjectDatabase(dbFile3)
+	require.NoError(t, err)
+	proj3 := &schema.Project{
+		ProjectName:  "scan-test-3",
+		DatabasePath: dbFile3,
+		Type:         TypeProject,
+	}
+	require.NoError(t, db.Create(proj3).Error)
+
+	// run batch repair
+	repairProjectDatabasePaths(db)
+
+	// verify proj1 was repaired
+	var updated1 schema.Project
+	require.NoError(t, db.First(&updated1, proj1.ID).Error)
+	require.Equal(t, dbFile1, updated1.DatabasePath, "proj1 should be repaired")
+
+	// verify proj2 was NOT repaired (file missing)
+	var updated2 schema.Project
+	require.NoError(t, db.First(&updated2, proj2.ID).Error)
+	require.Equal(t, proj2.DatabasePath, updated2.DatabasePath, "proj2 should remain stale")
+
+	// verify proj3 was NOT changed
+	var updated3 schema.Project
+	require.NoError(t, db.First(&updated3, proj3.ID).Error)
+	require.Equal(t, dbFile3, updated3.DatabasePath, "proj3 should be unchanged")
+}
+
+// TestRepairProjectDatabasePath_FileExists helper to ensure utils.FileExists
+// works as expected in this context.
+func TestRepairProjectDatabasePath_FileExistsCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	existingFile := filepath.Join(tmpDir, "exists.db")
+	require.NoError(t, utils.SaveFile([]byte("test"), existingFile))
+	require.True(t, utils.FileExists(existingFile))
+	require.False(t, utils.FileExists(filepath.Join(tmpDir, "not-exists.db")))
+}


### PR DESCRIPTION
## 问题

当用户移动 `yakit-projects` 目录后（换盘、换路径等），`projects` 表中记录的 `DatabasePath` 绝对路径会失效，导致切换项目、导出项目等操作失败。

## 方案

按文件名在预期目录中查找并自动修复路径（自愈），**不改 schema、不迁移数据**。

数据库文件名格式为 `yakit-project-{name}-{timestamp}.sqlite3.db`，包含时间戳全局唯一，因此按文件名在预期目录中查找即可精确命中。

## 改动

| 文件 | 说明 |
|---|---|
| `common/yakgrpc/yakit/projects.go` | 新增 `RepairProjectDatabasePath` 函数 + `repairProjectDatabasePaths` 启动扫描 |
| `common/yakgrpc/grpc_project.go` | `SetCurrentProject` 和 `ExportProject` 加入懒修复 |
| `common/yakgrpc/yakit/projects_repair_test.go` | 8 个测试用例 |

### 三个修复入口

1. **启动扫描**：`InitializingProjectDatabase()` 末尾遍历所有项目，对文件不存在的记录按文件名在预期目录中查找并修复
2. **切换项目懒修复**：`SetCurrentProject` 中如果 `DatabasePath` 文件不存在，先尝试修复再打开
3. **导出项目懒修复**：`ExportProject` 同理

### 关键设计

- SSA 项目的 MySQL/Postgres DSN（含 `://`）跳过文件级修复
- 找不到文件时不修改任何记录，返回原始路径 + false，安全降级
- SSA 分支也使用修复后的 path 变量

## 测试

```
=== RUN   TestRepairProjectDatabasePath_NoRepairNeeded        --- PASS
=== RUN   TestRepairProjectDatabasePath_FileMovedAndFound     --- PASS
=== RUN   TestRepairProjectDatabasePath_FileNotFound          --- PASS
=== RUN   TestRepairProjectDatabasePath_EmptyPath             --- PASS
=== RUN   TestRepairProjectDatabasePath_SSA_DSN               --- PASS
=== RUN   TestRepairProjectDatabasePath_SSA_SQLiteMoved       --- PASS
=== RUN   TestRepairProjectDatabasePaths_ScanAll              --- PASS
=== RUN   TestRepairProjectDatabasePath_FileExistsCheck       --- PASS
```

现有项目测试（`TestServer_UpdateProject`、`TestServer_Project_ExportAndImportProject`、`TestServer_Project_DefaultProject` 等）均通过，无回归。