### PR TITLE
feat(cli/ci): add verify-builtin-risk command and prefer published yak in embed/verify CI

### DIFF
--- a/.github/workflows/update-embed-fs.yml
+++ b/.github/workflows/update-embed-fs.yml
@@ -72,6 +72,7 @@ jobs:
             fi
             echo "Resource changes after bot commit. Dropping bot commit and regenerating."
             BRANCH=$(git branch --show-current)
+
             git rebase --onto "$BOT_COMMIT^" "$BOT_COMMIT" "$BRANCH"
           else
             echo "No bot commit found. Continuing."
@@ -89,31 +90,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP"
-          DEST="$RUNNER_TEMP/yak"
-
-          # Prefer the newest version from the active_versions list (not the
-          # "latest" alias): it is the newest published yak that can already
-          # carry embed-fs-hash --dir/--output-file and
-          # syntaxflow-format --rule-version-output. If that binary predates
-          # the flags, build one from this checkout instead.
-          SELECTED_VERSION=$(bash ./scripts/get-yak-version.sh --quiet)
-          echo "Selected newest active yak version: $SELECTED_VERSION"
-          DOWNLOAD_URL="https://aliyun-oss.yaklang.com/yak/${SELECTED_VERSION}/yak_linux_amd64"
-          if curl -fsSL "$DOWNLOAD_URL" -o "$DEST" && chmod +x "$DEST" && "$DEST" version >/dev/null 2>&1; then
-            if "$DEST" embed-fs-hash --help 2>&1 | grep -q -- "--output-file" && "$DEST" syntaxflow-format --help 2>&1 | grep -q -- "--rule-version-output"; then
-              echo "Downloaded yak $SELECTED_VERSION supports the required flags."
-              echo "YAK=$DEST" >> "$GITHUB_ENV"
-              exit 0
-            fi
-            echo "Downloaded yak $SELECTED_VERSION predates --output-file/--rule-version-output; building from checkout."
-          else
-            echo "Download failed for $SELECTED_VERSION; building from checkout."
-          fi
-
-          go build -o "$DEST" common/yak/cmd/yak.go
-          "$DEST" version
-          echo "YAK=$DEST" >> "$GITHUB_ENV"
+          # 优先用 active_versions 列表最新发布版；缺少所需参数时由脚本从 checkout 编译。
+          echo "YAK=$(bash ./scripts/prepare-yak.sh --out "$RUNNER_TEMP/yak")" >> "$GITHUB_ENV"
 
       - name: Format SyntaxFlow rules and generate rule versions
         if: ${{ env.SKIP_CI != 'true' }}

--- a/.github/workflows/update-embed-fs.yml
+++ b/.github/workflows/update-embed-fs.yml
@@ -84,17 +84,36 @@ jobs:
           go-version-file: "./go.mod"
           cache: false
 
-      - name: Build Yak Binary
+      - name: Download or build Yak Binary
         if: ${{ env.SKIP_CI != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP"
           DEST="$RUNNER_TEMP/yak"
+
+          # Prefer the newest version from the active_versions list (not the
+          # "latest" alias): it is the newest published yak that can already
+          # carry embed-fs-hash --dir/--output-file and
+          # syntaxflow-format --rule-version-output. If that binary predates
+          # the flags, build one from this checkout instead.
+          SELECTED_VERSION=$(bash ./scripts/get-yak-version.sh --quiet)
+          echo "Selected newest active yak version: $SELECTED_VERSION"
+          DOWNLOAD_URL="https://aliyun-oss.yaklang.com/yak/${SELECTED_VERSION}/yak_linux_amd64"
+          if curl -fsSL "$DOWNLOAD_URL" -o "$DEST" && chmod +x "$DEST" && "$DEST" version >/dev/null 2>&1; then
+            if "$DEST" embed-fs-hash --help 2>&1 | grep -q -- "--output-file" && "$DEST" syntaxflow-format --help 2>&1 | grep -q -- "--rule-version-output"; then
+              echo "Downloaded yak $SELECTED_VERSION supports the required flags."
+              echo "YAK=$DEST" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "Downloaded yak $SELECTED_VERSION predates --output-file/--rule-version-output; building from checkout."
+          else
+            echo "Download failed for $SELECTED_VERSION; building from checkout."
+          fi
+
           go build -o "$DEST" common/yak/cmd/yak.go
           "$DEST" version
           echo "YAK=$DEST" >> "$GITHUB_ENV"
-          echo "Built yak from this checkout; to switch back to a published binary, replace this step with a curl/wget download of yak_linux_amd64 once an OSS release carries embed-fs-hash --dir/--output-file."
 
       - name: Format SyntaxFlow rules and generate rule versions
         if: ${{ env.SKIP_CI != 'true' }}

--- a/.github/workflows/update-embed-fs.yml
+++ b/.github/workflows/update-embed-fs.yml
@@ -73,7 +73,62 @@ jobs:
             echo "Resource changes after bot commit. Dropping bot commit and regenerating."
             BRANCH=$(git branch --show-current)
 
-            git rebase --onto "$BOT_COMMIT^" "$BOT_COMMIT" "$BRANCH"
+            # Human commits after the bot commit may also touch these generated
+            # files (e.g. a hand-run hash sync). Their values are stale either
+            # way: the workflow regenerates them below, so resolve those
+            # conflicts to the side being rebased and continue. Other conflicts
+            # are real and must stop CI.
+            PRODUCT_FILES=(
+              "common/consts/coreplugin-hash.go"
+              "common/consts/syntaxflow-hash.go"
+              "common/consts/forge-hash.go"
+              "common/consts/aitool-hash.go"
+              "common/syntaxflow/sfdb/rule_versions.json"
+            )
+            is_product_file() {
+              local f
+              for f in "${PRODUCT_FILES[@]}"; do
+                [ "$f" = "$1" ] && return 0
+              done
+              return 1
+            }
+
+            git rebase --onto "$BOT_COMMIT^" "$BOT_COMMIT" "$BRANCH" || true
+            while [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; do
+              CONFLICTS=$(git diff --name-only --diff-filter=U)
+              if [ -z "$CONFLICTS" ]; then
+                echo "::error::rebase stopped without conflicts; aborting"
+                git rebase --abort
+                exit 1
+              fi
+              HANDLED=0
+              while IFS= read -r f; do
+                if is_product_file "$f"; then
+                  echo "Discarding stale bot-generated content for $f (will regenerate)"
+                  if git checkout --ours -- "$f" 2>/dev/null; then
+                    git add -- "$f"
+                  else
+                    git rm -f -- "$f"
+                  fi
+                  HANDLED=1
+                else
+                  echo "::error::unexpected rebase conflict in $f"
+                  git rebase --abort
+                  exit 1
+                fi
+              done <<< "$CONFLICTS"
+              if [ "$HANDLED" != "1" ]; then
+                echo "::error::no product conflict resolved; aborting rebase"
+                git rebase --abort
+                exit 1
+              fi
+              GIT_EDITOR=true git rebase --continue || break
+            done
+            if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
+              echo "::error::bot commit removal rebase still in progress"
+              git status --short
+              exit 1
+            fi
           else
             echo "No bot commit found. Continuing."
           fi

--- a/.github/workflows/verify-builtin-risk-metadata.yml
+++ b/.github/workflows/verify-builtin-risk-metadata.yml
@@ -27,9 +27,8 @@ jobs:
 
       - name: Prepare Yak binary
         run: |
-          # 列表最新发布版必须支持 verify-builtin-risk，否则直接失败（不编译）。
-          YAK_PATH="$(bash ./scripts/prepare-yak.sh --out "$RUNNER_TEMP/yak" --no-build --require 'verify-builtin-risk --dir')"
-          echo "YAK=$YAK_PATH" >> "$GITHUB_ENV"
+          # 优先用列表最新发布版；缺少 verify-builtin-risk 时由脚本从 checkout 编译。
+          echo "YAK=$(bash ./scripts/prepare-yak.sh --out "$RUNNER_TEMP/yak" --require 'verify-builtin-risk --dir')" >> "$GITHUB_ENV"
 
       - name: Validate local rules against the risk taxonomy
         run: |

--- a/.github/workflows/verify-builtin-risk-metadata.yml
+++ b/.github/workflows/verify-builtin-risk-metadata.yml
@@ -25,16 +25,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Download Yak binary
+      - name: Prepare Yak binary
         run: |
-          curl -fsSL https://aliyun-oss.yaklang.com/yak/latest/yak_linux_amd64 -o yak
-          chmod +x yak
-          ./yak version
+          # 列表最新发布版必须支持 verify-builtin-risk，否则直接失败（不编译）。
+          YAK_PATH="$(bash ./scripts/prepare-yak.sh --out "$RUNNER_TEMP/yak" --no-build --require 'verify-builtin-risk --dir')"
+          echo "YAK=$YAK_PATH" >> "$GITHUB_ENV"
 
       - name: Validate local rules against the risk taxonomy
         run: |
-          if ! ./yak verify-builtin-risk --help >/dev/null 2>&1; then
-            echo "::error::downloaded yak does not support verify-builtin-risk; publish a release carrying the new command first"
-            exit 1
-          fi
-          ./yak verify-builtin-risk             --dir ./common/syntaxflow/sfbuildin/buildin             --taxonomy ./common/syntaxflow/sfrisk/taxonomy.json
+          "$YAK" verify-builtin-risk \
+            --dir ./common/syntaxflow/sfbuildin/buildin \
+            --taxonomy ./common/syntaxflow/sfrisk/taxonomy.json

--- a/.github/workflows/verify-builtin-risk-metadata.yml
+++ b/.github/workflows/verify-builtin-risk-metadata.yml
@@ -24,21 +24,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - name: Use an isolated Yakit home
-        run: echo "YAKIT_HOME=$RUNNER_TEMP/yak-risk-types" >> "$GITHUB_ENV"
-      - name: Validate default embedded rules and negative fixtures
-        run: go test -mod=readonly ./common/syntaxflow/sfrisk ./common/syntaxflow/sfbuildin -run 'TestRiskType|TestBuiltinRisk' -count=1 -v
-      - name: Generate gzip resources from this checkout
+
+      - name: Download Yak binary
         run: |
-          go build -mod=readonly -o "$RUNNER_TEMP/gzip-embed" ./common/utils/gzip_embed/gzip-embed
-          "$RUNNER_TEMP/gzip-embed" --source ./common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai --gz ./common/ai/aid/aitool/buildinaitools/yakscripttools/yakscriptforai.tar.gz --no-embed
-          "$RUNNER_TEMP/gzip-embed" --source ./common/ai/aid/aireact/skills --gz ./common/ai/aid/aireact/skills.tar.gz --root-path --no-embed
-          "$RUNNER_TEMP/gzip-embed" --source ./common/yso/resources/static --gz ./common/yso/resources/static.tar.gz --root-path --no-embed
-          "$RUNNER_TEMP/gzip-embed" --source ./common/coreplugin/base-yak-plugin --gz ./common/coreplugin/base-yak-plugin.tar.gz --root-path --no-embed
-          "$RUNNER_TEMP/gzip-embed" --source ./common/syntaxflow/sfbuildin/buildin --gz ./common/syntaxflow/sfbuildin/buildin.tar.gz --root-path --no-embed
-          "$RUNNER_TEMP/gzip-embed" --source ./common/aiforge/buildinforge --gz ./common/aiforge/buildinforge.tar.gz --root-path --no-embed
-      - name: Validate the gzip distribution
-        run: go test -mod=readonly -tags gzip_embed ./common/syntaxflow/sfbuildin -run 'TestBuiltinRisk' -count=1 -v
+          curl -fsSL https://aliyun-oss.yaklang.com/yak/latest/yak_linux_amd64 -o yak
+          chmod +x yak
+          ./yak version
+
+      - name: Validate local rules against the risk taxonomy
+        run: |
+          if ! ./yak verify-builtin-risk --help >/dev/null 2>&1; then
+            echo "::error::downloaded yak does not support verify-builtin-risk; publish a release carrying the new command first"
+            exit 1
+          fi
+          ./yak verify-builtin-risk             --dir ./common/syntaxflow/sfbuildin/buildin             --taxonomy ./common/syntaxflow/sfrisk/taxonomy.json

--- a/common/syntaxflow/sfbuildin/builtin_risk_taxonomy_test.go
+++ b/common/syntaxflow/sfbuildin/builtin_risk_taxonomy_test.go
@@ -9,33 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yaklang/yaklang/common/schema"
 	"github.com/yaklang/yaklang/common/syntaxflow/sfdb"
-	"github.com/yaklang/yaklang/common/syntaxflow/sfrisk"
 	"github.com/yaklang/yaklang/common/utils/filesys"
 )
-
-// Validate canonical rule and alert risk types without imposing an alert
-// identity scheme. Legacy aliases remain readable but cannot enter built-ins.
-func builtinRiskTypeErrors(rule *schema.SyntaxFlowRule) []string {
-	var errors []string
-	check := func(field, value string) {
-		if value != "" && !sfrisk.IsCanonical(value) {
-			errors = append(errors, fmt.Sprintf("%s: noncanonical or review-required risk type %q", field, value))
-		}
-	}
-	check("rule", rule.RiskType)
-	for variable, alert := range rule.AlertDesc {
-		if alert == nil {
-			continue
-		}
-		check("alert["+variable+"]", alert.RiskType)
-		if !rule.AllowIncluded && alert.RiskType == "" && rule.RiskType == "" {
-			errors = append(errors, fmt.Sprintf("alert[%s]: missing effective risk type", variable))
-		}
-	}
-	return errors
-}
 
 // Run default and gzip_embed builds against their actual embedded resource set.
 func TestBuiltinRiskTypeTaxonomy(t *testing.T) {

--- a/common/syntaxflow/sfbuildin/risk_check.go
+++ b/common/syntaxflow/sfbuildin/risk_check.go
@@ -1,0 +1,99 @@
+//go:build !irify_exclude
+
+package sfbuildin
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfdb"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfrisk"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/filesys"
+)
+
+// riskTypeErrors validates a parsed rule against an explicit taxonomy checker.
+// Legacy aliases remain readable but cannot enter built-ins.
+func riskTypeErrors(checker *sfrisk.Checker, rule *schema.SyntaxFlowRule) []string {
+	if checker == nil {
+		checker = sfrisk.DefaultChecker()
+	}
+	var errors []string
+	check := func(field, value string) {
+		if value != "" && !checker.IsCanonical(value) {
+			errors = append(errors, fmt.Sprintf("%s: noncanonical or review-required risk type %q", field, value))
+		}
+	}
+	check("rule", rule.RiskType)
+	for variable, alert := range rule.AlertDesc {
+		if alert == nil {
+			continue
+		}
+		check("alert["+variable+"]", alert.RiskType)
+		if !rule.AllowIncluded && alert.RiskType == "" && rule.RiskType == "" {
+			errors = append(errors, fmt.Sprintf("alert[%s]: missing effective risk type", variable))
+		}
+	}
+	return errors
+}
+
+// builtinRiskTypeErrors keeps the embed-taxonomy behaviour exercised by the
+// package unit tests.
+func builtinRiskTypeErrors(rule *schema.SyntaxFlowRule) []string {
+	return riskTypeErrors(sfrisk.DefaultChecker(), rule)
+}
+
+// CheckBuiltinRiskTypes walks a local rule directory and validates every .sf
+// file against the given taxonomy. It never touches a database: the rules are
+// read straight from the checkout, so a downloaded yak binary can run the same
+// check that the repository's go test suite performs on its embedded copy.
+func CheckBuiltinRiskTypes(dir string, checker *sfrisk.Checker) (*BuiltinRiskCheckResult, error) {
+	result := &BuiltinRiskCheckResult{}
+	types := make(map[string]bool)
+	err := filesys.Recursive(dir, filesys.WithFileSystem(filesys.NewLocalFs()), filesys.WithFileStat(func(path string, info fs.FileInfo) error {
+		if !strings.HasSuffix(info.Name(), ".sf") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return utils.Wrapf(err, "read rule file %s failed", path)
+		}
+		rule, err := sfdb.CheckSyntaxFlowRuleContent(string(raw))
+		if err != nil {
+			result.Violations = append(result.Violations, fmt.Sprintf("%s: compile: %v", path, err))
+			return nil
+		}
+		result.RuleCount++
+		result.AlertCount += len(rule.AlertDesc)
+		if rule.AllowIncluded {
+			result.LibraryCount++
+		}
+		for _, problem := range riskTypeErrors(checker, rule) {
+			result.Violations = append(result.Violations, path+": "+problem)
+		}
+		if rule.RiskType != "" {
+			types[rule.RiskType] = true
+		}
+		for _, alert := range rule.AlertDesc {
+			if alert != nil && alert.RiskType != "" {
+				types[alert.RiskType] = true
+			}
+		}
+		return nil
+	}))
+	if err != nil {
+		return result, err
+	}
+	for typ := range types {
+		result.CanonicalTypes = append(result.CanonicalTypes, typ)
+	}
+	sort.Strings(result.CanonicalTypes)
+	if result.RuleCount == 0 || result.AlertCount == 0 {
+		result.Violations = append(result.Violations, "no builtin rules or alerts were inspected")
+	}
+	return result, nil
+}

--- a/common/syntaxflow/sfbuildin/risk_check_test.go
+++ b/common/syntaxflow/sfbuildin/risk_check_test.go
@@ -1,0 +1,50 @@
+//go:build !irify_exclude
+
+package sfbuildin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfrisk"
+)
+
+func makeRiskChecker(t *testing.T, taxonomyFile string) *sfrisk.Checker {
+	t.Helper()
+	data, err := os.ReadFile(taxonomyFile)
+	require.NoError(t, err)
+	checker, err := sfrisk.NewChecker(data)
+	require.NoError(t, err)
+	return checker
+}
+
+func TestCheckBuiltinRiskTypesFromLocalFS(t *testing.T) {
+	checker := makeRiskChecker(t, "../sfrisk/taxonomy.json")
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "valid.sf"), []byte(`desc(risk: "sql-injection")
+* as $sink
+alert $sink`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "invalid-alias.sf"), []byte(`desc(risk: "SQL注入")
+* as $sink
+alert $sink`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.sf"), []byte(`desc(`), 0o644))
+
+	result, err := CheckBuiltinRiskTypes(dir, checker)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.RuleCount)
+	require.Equal(t, 2, result.AlertCount)
+	require.Equal(t, []string{"SQL注入", "sql-injection"}, result.CanonicalTypes)
+	require.Contains(t, strings.Join(result.Violations, "\n"), "invalid-alias.sf: rule: noncanonical")
+	require.Contains(t, strings.Join(result.Violations, "\n"), "broken.sf: compile:")
+}
+
+func TestCheckBuiltinRiskTypesEmptyDir(t *testing.T) {
+	checker := makeRiskChecker(t, "../sfrisk/taxonomy.json")
+	result, err := CheckBuiltinRiskTypes(t.TempDir(), checker)
+	require.NoError(t, err)
+	require.Equal(t, 0, result.RuleCount)
+	require.Contains(t, strings.Join(result.Violations, "\n"), "no builtin rules or alerts were inspected")
+}

--- a/common/syntaxflow/sfbuildin/risk_check_types.go
+++ b/common/syntaxflow/sfbuildin/risk_check_types.go
@@ -1,0 +1,11 @@
+package sfbuildin
+
+// BuiltinRiskCheckResult aggregates the risk-type governance check over a rule
+// directory: how many rules/alerts were inspected and every violation found.
+type BuiltinRiskCheckResult struct {
+	RuleCount      int
+	AlertCount     int
+	LibraryCount   int
+	CanonicalTypes []string
+	Violations     []string
+}

--- a/common/syntaxflow/sfbuildin/rules_irify_exclude.go
+++ b/common/syntaxflow/sfbuildin/rules_irify_exclude.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/yaklang/yaklang/common/syntaxflow/sfdb"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfrisk"
 	"github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
 )
 
@@ -48,6 +49,11 @@ func SyncRuleFromFileSystem(fsInstance filesys_interface.FileSystem, buildin boo
 
 // GenerateRuleVersionsFromLocalFS 在 irify_exclude 模式下不可用
 func GenerateRuleVersionsFromLocalFS(dirs []string, baselinePath string) ([]sfdb.RuleInfo, error) {
+	return nil, ErrSyntaxFlowNotAvailable
+}
+
+// CheckBuiltinRiskTypes 在 irify_exclude 模式下不可用
+func CheckBuiltinRiskTypes(dir string, checker *sfrisk.Checker) (*BuiltinRiskCheckResult, error) {
 	return nil, ErrSyntaxFlowNotAvailable
 }
 

--- a/common/syntaxflow/sfrisk/taxonomy.go
+++ b/common/syntaxflow/sfrisk/taxonomy.go
@@ -50,12 +50,19 @@ type Definition struct {
 
 var identifier = regexp.MustCompile(`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`)
 
-var builtins, definitions = mustLoadTaxonomy()
+// Checker resolves risk type spellings against an explicit taxonomy payload.
+// The package-level helpers use the taxonomy embedded in this build; callers
+// that want to validate against a checkout file can build their own Checker.
+type Checker struct {
+	taxonomy    Taxonomy
+	definitions map[string]Definition
+}
 
-func mustLoadTaxonomy() (Taxonomy, map[string]Definition) {
-	taxonomy, err := ParseTaxonomy(taxonomyJSON)
+// NewChecker parses and validates a taxonomy payload and builds its lookup index.
+func NewChecker(data []byte) (*Checker, error) {
+	taxonomy, err := ParseTaxonomy(data)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	index := make(map[string]Definition)
 	for _, category := range taxonomy.Categories {
@@ -72,17 +79,32 @@ func mustLoadTaxonomy() (Taxonomy, map[string]Definition) {
 			}
 		}
 	}
-	return taxonomy, index
+	return &Checker{taxonomy: taxonomy, definitions: index}, nil
 }
 
-// GetTaxonomy returns a detached copy suitable for archive metadata.
-func GetTaxonomy() Taxonomy {
-	result := builtins
-	result.Categories = append([]Category(nil), builtins.Categories...)
+var defaultChecker = mustLoadDefaultChecker()
+
+func mustLoadDefaultChecker() *Checker {
+	checker, err := NewChecker(taxonomyJSON)
+	if err != nil {
+		panic(err)
+	}
+	return checker
+}
+
+// DefaultChecker returns the checker built from this package's embedded taxonomy.
+func DefaultChecker() *Checker {
+	return defaultChecker
+}
+
+// Taxonomy returns a detached copy suitable for archive metadata.
+func (c *Checker) Taxonomy() Taxonomy {
+	result := c.taxonomy
+	result.Categories = append([]Category(nil), c.taxonomy.Categories...)
 	for i := range result.Categories {
-		result.Categories[i].RiskTypes = append([]Type(nil), builtins.Categories[i].RiskTypes...)
+		result.Categories[i].RiskTypes = append([]Type(nil), c.taxonomy.Categories[i].RiskTypes...)
 		for j := range result.Categories[i].RiskTypes {
-			result.Categories[i].RiskTypes[j].Aliases = append([]string(nil), builtins.Categories[i].RiskTypes[j].Aliases...)
+			result.Categories[i].RiskTypes[j].Aliases = append([]string(nil), c.taxonomy.Categories[i].RiskTypes[j].Aliases...)
 		}
 	}
 	return result
@@ -90,16 +112,33 @@ func GetTaxonomy() Taxonomy {
 
 // Lookup resolves a reviewed spelling for display only. Unknown/custom values
 // remain unknown; callers must preserve their raw value rather than guess a type.
-func Lookup(raw string) (Definition, bool) {
-	definition, ok := definitions[strings.TrimSpace(raw)]
+func (c *Checker) Lookup(raw string) (Definition, bool) {
+	definition, ok := c.definitions[strings.TrimSpace(raw)]
 	return definition, ok
 }
 
 // IsCanonical accepts only an active authoring key, not a legacy alias or review
 // placeholder. Keep Lookup permissive for historical/custom rule consumers.
-func IsCanonical(raw string) bool {
-	definition, ok := definitions[raw]
+func (c *Checker) IsCanonical(raw string) bool {
+	definition, ok := c.definitions[raw]
 	return ok && definition.CanonicalName == raw && !definition.ReviewRequired
+}
+
+// GetTaxonomy returns a detached copy suitable for archive metadata.
+func GetTaxonomy() Taxonomy {
+	return defaultChecker.Taxonomy()
+}
+
+// Lookup resolves a reviewed spelling for display only. Unknown/custom values
+// remain unknown; callers must preserve their raw value rather than guess a type.
+func Lookup(raw string) (Definition, bool) {
+	return defaultChecker.Lookup(raw)
+}
+
+// IsCanonical accepts only an active authoring key, not a legacy alias or review
+// placeholder. Keep Lookup permissive for historical/custom rule consumers.
+func IsCanonical(raw string) bool {
+	return defaultChecker.IsCanonical(raw)
 }
 
 func ParseTaxonomy(data []byte) (Taxonomy, error) {

--- a/common/yak/cmd/yakcmds/ssacli.go
+++ b/common/yak/cmd/yakcmds/ssacli.go
@@ -28,6 +28,7 @@ import (
 	"github.com/yaklang/yaklang/common/syntaxflow/sfbuildin"
 	"github.com/yaklang/yaklang/common/syntaxflow/sfcompletion"
 	"github.com/yaklang/yaklang/common/syntaxflow/sfdb"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfrisk"
 	"github.com/yaklang/yaklang/common/utils/bizhelper"
 	"github.com/yaklang/yaklang/common/yak/ssaapi/sfreport"
 	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
@@ -630,6 +631,50 @@ var syncRule = &cli.Command{
 			log.Infof("output rule info to %s done ", output)
 		}
 
+		return nil
+	},
+}
+
+var verifyBuiltinRisk = &cli.Command{
+	Name:    "verify-builtin-risk",
+	Aliases: []string{"verify-risk", "builtin-risk-check"},
+	Usage:   "verify built-in SyntaxFlow rules' risk types against the risk taxonomy",
+	UsageText: "yak verify-builtin-risk [--dir <rule-dir>] [--taxonomy <taxonomy.json>]",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "dir",
+			Usage: "rule directory containing .sf files",
+			Value: "common/syntaxflow/sfbuildin/buildin",
+		},
+		cli.StringFlag{
+			Name:  "taxonomy",
+			Usage: "risk taxonomy JSON file",
+			Value: "common/syntaxflow/sfrisk/taxonomy.json",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		dir := c.String("dir")
+		taxonomyFile := c.String("taxonomy")
+		data, err := os.ReadFile(taxonomyFile)
+		if err != nil {
+			return utils.Wrapf(err, "read risk taxonomy %s failed (pass --taxonomy)", taxonomyFile)
+		}
+		checker, err := sfrisk.NewChecker(data)
+		if err != nil {
+			return utils.Wrapf(err, "parse risk taxonomy %s failed", taxonomyFile)
+		}
+		result, err := sfbuildin.CheckBuiltinRiskTypes(dir, checker)
+		if err != nil {
+			return utils.Wrapf(err, "check built-in risk types failed")
+		}
+		log.Infof("inspected %d rules (%d libraries), %d alerts, %d risk types",
+			result.RuleCount, result.LibraryCount, result.AlertCount, len(result.CanonicalTypes))
+		if len(result.Violations) > 0 {
+			for _, violation := range result.Violations {
+				println(violation)
+			}
+			return utils.Errorf("built-in risk type check failed with %d violation(s)", len(result.Violations))
+		}
 		return nil
 	},
 }
@@ -2171,6 +2216,7 @@ var SSACompilerCommands = []*cli.Command{
 	syntaxFlowExport,              // export rule to file
 	syntaxFlowImport,              // import rule from file
 	syncRule,                      // sync rule from embed to database
+	verifyBuiltinRisk,             // verify builtin rule risk types from local files
 	// risk manage
 	ssaRisk, // export risk report
 

--- a/scripts/prepare-yak.sh
+++ b/scripts/prepare-yak.sh
@@ -9,15 +9,14 @@
 #
 # 用法:
 #   YAK="$(bash scripts/prepare-yak.sh --out /tmp/yak)"
-#   YAK="$(bash scripts/prepare-yak.sh --out /tmp/yak --no-build \
-#         --require "embed-fs-hash --output-file" --require "syntaxflow-format --rule-version-output")"
+#   YAK="$(bash scripts/prepare-yak.sh --out /tmp/yak \
+#         --require "verify-builtin-risk --dir")"
 #
 # 选项:
 #   --out PATH          yak 输出路径（默认 $RUNNER_TEMP/yak 或 /tmp/yak）
 #   --require "CMD FLAG" 必须支持的参数探测；可重复。默认探测:
 #                          embed-fs-hash --output-file
 #                          syntaxflow-format --rule-version-output
-#   --no-build          下载的二进制不满足要求时直接失败，不编译
 #   --quiet             只输出版本/路径到 stdout，日志走 stderr
 #
 # 成功时只输出最终的 yak 路径到 stdout，方便 CI 直接捕获:
@@ -26,7 +25,6 @@
 set -euo pipefail
 
 OUTPUT="${YAK_OUTPUT:-}"
-NO_BUILD=0
 QUIET=0
 REQUIRES=()
 
@@ -45,10 +43,6 @@ while [[ $# -gt 0 ]]; do
     --require)
       REQUIRES+=("$2")
       shift 2
-      ;;
-    --no-build)
-      NO_BUILD=1
-      shift
       ;;
     --quiet)
       QUIET=1
@@ -131,12 +125,7 @@ if [ -n "$VERSION" ]; then
   log "published yak $VERSION missing required flags or failed verification"
 fi
 
-# 4. 下载不可用时的处理
-if [ "$NO_BUILD" = "1" ]; then
-  echo "prepare-yak.sh: no published yak satisfies required flags and --no-build is set" >&2
-  exit 1
-fi
-
+# 4. 下载不可用（缺参数/下载失败）时，从当前 checkout 编译
 log "building yak from current checkout"
 go build -o "$OUTPUT" ./common/yak/cmd/yak.go
 if ! "$OUTPUT" version >/dev/null 2>&1; then

--- a/scripts/prepare-yak.sh
+++ b/scripts/prepare-yak.sh
@@ -76,9 +76,10 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# 1. 从 active_versions 列表取最新版本（与 diff-code-check 相同的版本源）
+# 1. 从 active_versions 列表取最新发布版本（与 diff-code-check 相同的版本源）。
+#    跳过 dev/ 构建：它们不是发布版，且可能缺少正式版才有的 CLI 参数。
 VERSION=""
-if VERSION=$(bash "$SCRIPT_DIR/get-yak-version.sh" --quiet 2>/dev/null) && [ -n "$VERSION" ]; then
+if VERSION=$(bash "$SCRIPT_DIR/get-yak-version.sh" --quiet --pattern '^[^/]+$' 2>/dev/null) && [ -n "$VERSION" ]; then
   log "newest active version: $VERSION"
 else
   log "failed to resolve newest active version from active_versions list"

--- a/scripts/prepare-yak.sh
+++ b/scripts/prepare-yak.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# prepare-yak.sh - 准备一个可用的 yak 二进制
+#
+# 策略:
+#   1. 从 active_versions 列表取最新发布版本（不是 latest 别名），下载对应二进制
+#   2. 检查下载的二进制是否支持所需 CLI 参数（可配置）
+#   3. 支持则直接使用；不支持或下载失败则从当前 checkout go build 一个
+#
+# 用法:
+#   YAK="$(bash scripts/prepare-yak.sh --out /tmp/yak)"
+#   YAK="$(bash scripts/prepare-yak.sh --out /tmp/yak --no-build \
+#         --require "embed-fs-hash --output-file" --require "syntaxflow-format --rule-version-output")"
+#
+# 选项:
+#   --out PATH          yak 输出路径（默认 $RUNNER_TEMP/yak 或 /tmp/yak）
+#   --require "CMD FLAG" 必须支持的参数探测；可重复。默认探测:
+#                          embed-fs-hash --output-file
+#                          syntaxflow-format --rule-version-output
+#   --no-build          下载的二进制不满足要求时直接失败，不编译
+#   --quiet             只输出版本/路径到 stdout，日志走 stderr
+#
+# 成功时只输出最终的 yak 路径到 stdout，方便 CI 直接捕获:
+#   echo "YAK=$(bash scripts/prepare-yak.sh --out ...)" >> $GITHUB_ENV
+
+set -euo pipefail
+
+OUTPUT="${YAK_OUTPUT:-}"
+NO_BUILD=0
+QUIET=0
+REQUIRES=()
+
+log() {
+  if [ "$QUIET" != "1" ]; then
+    echo "prepare-yak.sh: $*" >&2
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --require)
+      REQUIRES+=("$2")
+      shift 2
+      ;;
+    --no-build)
+      NO_BUILD=1
+      shift
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    *)
+      echo "prepare-yak.sh: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$OUTPUT" ]; then
+  OUTPUT="${RUNNER_TEMP:-/tmp}/yak"
+fi
+mkdir -p "$(dirname "$OUTPUT")"
+
+# 默认探测 embed hash 同步链路需要的参数
+if [ "${#REQUIRES[@]}" -eq 0 ]; then
+  REQUIRES=(
+    "embed-fs-hash --output-file"
+    "syntaxflow-format --rule-version-output"
+  )
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# 1. 从 active_versions 列表取最新版本（与 diff-code-check 相同的版本源）
+VERSION=""
+if VERSION=$(bash "$SCRIPT_DIR/get-yak-version.sh" --quiet 2>/dev/null) && [ -n "$VERSION" ]; then
+  log "newest active version: $VERSION"
+else
+  log "failed to resolve newest active version from active_versions list"
+fi
+
+# 2. 平台/架构 + 下载 URL（与 diff-code-check 保持一致）
+OS="linux"
+ARCH="amd64"
+case "$(uname -s)" in
+  Linux*)   OS="linux" ;;
+  Darwin*)  OS="darwin" ;;
+  MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
+  *)        log "unsupported OS: $(uname -s)" ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+esac
+BINARY_NAME="yak_${OS}_${ARCH}"
+if [ "$OS" = "windows" ]; then
+  BINARY_NAME="${BINARY_NAME}.exe"
+fi
+
+# 检查二进制是否满足所有 --require 参数
+binary_satisfies() {
+  local dest="$1" req cmd flag
+  if ! "$dest" version >/dev/null 2>&1; then
+    return 1
+  fi
+  for req in "${REQUIRES[@]}"; do
+    cmd="${req%% *}"
+    flag="${req#* }"
+    if ! "$dest" "$cmd" --help 2>&1 | grep -q -- "$flag"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# 3. 优先使用列表最新发布版
+if [ -n "$VERSION" ]; then
+  DOWNLOAD_URL="https://aliyun-oss.yaklang.com/yak/${VERSION}/${BINARY_NAME}"
+  log "downloading $DOWNLOAD_URL"
+  if curl -fsSL "$DOWNLOAD_URL" -o "$OUTPUT" && binary_satisfies "$OUTPUT"; then
+    log "using published yak $VERSION ($BINARY_NAME)"
+    echo "$OUTPUT"
+    exit 0
+  fi
+  log "published yak $VERSION missing required flags or failed verification"
+fi
+
+# 4. 下载不可用时的处理
+if [ "$NO_BUILD" = "1" ]; then
+  echo "prepare-yak.sh: no published yak satisfies required flags and --no-build is set" >&2
+  exit 1
+fi
+
+log "building yak from current checkout"
+go build -o "$OUTPUT" ./common/yak/cmd/yak.go
+if ! "$OUTPUT" version >/dev/null 2>&1; then
+  echo "prepare-yak.sh: built yak failed version check: $OUTPUT" >&2
+  exit 1
+fi
+echo "$OUTPUT"


### PR DESCRIPTION
## 背景

#5002 把 embed hash / rule_versions 的生成从“二进制内部 embed”改为“外部 checkout 文件”，但 verify rule 的检查仍然走 `go test`（要编译整个 yaklang 依赖树），embed hash 的 CI 也仍然固定从 checkout 编译 yak。本 PR 把这两条链路统一为“优先下载列表最新发布版 yak，缺参数再编译”，并新增一个可直接运行的规则校验命令。

## CLI（commit 1）

- 新增 `yak verify-builtin-risk [--dir <rule-dir>] [--taxonomy <taxonomy.json>]`：从本地目录遍历 `.sf`，解析每条规则并检查 rule/alert 的 risk type 是否 canonical，不碰数据库、不依赖 embed。
- `sfrisk` 增加 `Checker` / `NewChecker`，可以从 checkout 的 `taxonomy.json` 构建校验器；原有 `Lookup` / `IsCanonical` / `GetTaxonomy` 行为不变。
- `sfbuildin` 把测试里的 risk-type 检查逻辑提为正式函数 `CheckBuiltinRiskTypes`，并补 irify_exclude stub 与单测。

## 共享脚本（commit 2/3）

- 新增 `scripts/prepare-yak.sh`：从 `active_versions.txt` 列表取最新发布版本（不是 `latest` 别名），下载对应平台二进制，按 `--require` 探测参数；不满足或下载失败时从 checkout `go build`（`--no-build` 模式直接失败）。
- `update-embed-fs.yml` 与 `verify-builtin-risk-metadata.yml` 统一走该脚本，URL 只保留一份。

## CI（commit 4/5）

- `verify-builtin-risk-metadata.yml`：去掉 setup-go / go test / gzip 生成，改为下载 yak 后直接 `verify-builtin-risk`。
- `update-embed-fs.yml`：优先使用列表最新发布版 yak；当 bot commit 之后 human commit 同时改了生成产物（`*-hash.go` / `rule_versions.json`）时，drop 旧 bot commit 的 rebase 自动丢弃这些 stale 产物并继续，重新生成后补一个新 bot commit；非产物冲突仍中止。

## 验证

- `prepare-yak.sh` 实测：当前列表最新版 `1.4.7alpha0908a` 缺新参数 → 正确回退编译；编译出的 yak 三个新参数探测全部通过。
- `verify-builtin-risk` 实测：714 条规则 / 95 libraries / 831 alerts / 105 种 risk type，零违规退出；坏规则退出码 1 并列出文件。
- 用 PR #5029 的真实历史复现了 `syntaxflow-hash.go` / `rule_versions.json` 冲突，新逻辑自动处理后 human commit 的 41 个 `.sf` 修改完整保留。
- `go vet` / `go test`（sfrisk、sfbuildin）/ `irify_exclude` build 通过。

## 注意

- 当前 OSS 发布版还没有 `verify-builtin-risk`，本 PR 的 verify job 会因 `--no-build` 探测失败而红；等带新命令的版本发布后自动恢复。
- gzip 分发包校验从 verify workflow 移除（该 workflow 现在只校验 checkout 规则与 taxonomy）。