### PR TITLE
fix(mcp): isolate stdio execution in a supervised worker

### DIFF
--- a/common/log/mcp_stdio.go
+++ b/common/log/mcp_stdio.go
@@ -39,6 +39,10 @@ func IsMCPStdioLogging() bool {
 	return mcpStdioMode.Load()
 }
 
+// IsMCPStdioCommand identifies the stdio CLI independently of inherited logging
+// settings, so launchers can avoid initializing services in the supervisor.
+func IsMCPStdioCommand(args []string) bool { return isMCPStdioCommand(args) }
+
 func envEnablesMCPStdioMode() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(mcpStdioModeEnv))) {
 	case "1", "true", "yes", "on":

--- a/common/mcp/command.go
+++ b/common/mcp/command.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/samber/lo"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool/buildinaitools"
 	"github.com/yaklang/yaklang/common/consts"
 	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/mcp/stdio"
 	"github.com/yaklang/yaklang/common/urfavecli"
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
@@ -68,27 +72,37 @@ var MCPCommand = &cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		transport := c.String("transport")
-		protocolStdout := os.Stdout
 		if transport == "stdio" {
-			// Re-apply at the action boundary for embedded callers that invoke
-			// MCPCommand without Yak's normal os.Args layout. Then reserve the
-			// original stdout exclusively for JSON-RPC and redirect every other
-			// process-level stdout write to stderr. This also contains direct
-			// fmt/println output from tools and embedded Yak scripts.
 			log.EnableMCPStdioLogging()
 			log.SetLevel(log.FatalLevel)
-
-			var restoreStdout func() error
-			var isolateErr error
-			protocolStdout, restoreStdout, isolateErr = reserveMCPProtocolStdout()
-			if isolateErr != nil {
-				return utils.Wrap(isolateErr, "reserve stdout for MCP stdio")
-			}
-			defer func() {
-				if err := restoreStdout(); err != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "restore stdout after MCP stdio: %v\n", err)
+			if !stdio.IsWorker() {
+				// Retain protection against incidental output in the supervisor.
+				// Tool execution and its standard streams live in the worker;
+				// the worker's protocol uses a separate connection, with no dup.
+				protocolStdout, restore, err := reserveMCPProtocolStdout()
+				if err != nil {
+					return utils.Wrap(err, "reserve stdout for MCP stdio supervisor")
 				}
-			}()
+				defer func() {
+					if err := restore(); err != nil {
+						_, _ = fmt.Fprintf(os.Stderr, "restore stdout after MCP stdio: %v\n", err)
+					}
+				}()
+				executable, err := os.Executable()
+				if err != nil {
+					return utils.Wrap(err, "resolve MCP worker executable")
+				}
+				ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+				defer stop()
+				// Reusing argv preserves every CLI option for both yak mcp and
+				// the standalone MCP binary, regardless of its executable name.
+				if err := stdio.Run(ctx, exec.Command(executable, os.Args[1:]...), os.Stdin, protocolStdout, os.Stderr); err != nil {
+					// Run already attempted a protocol failure response. Do not let
+					// the CLI log.Fatal/panic path block again on a full stderr pipe.
+					return cli.NewExitError("", 1)
+				}
+				return nil
+			}
 		}
 
 		yakit.CallPostInitDatabase()
@@ -180,7 +194,18 @@ var MCPCommand = &cli.Command{
 		}
 		switch transport {
 		case "stdio":
-			err = s.ServeStdioWithIO(os.Stdin, protocolStdout)
+			defer s.Close()
+			// Authenticate only once initialization has succeeded. In particular,
+			// the standalone entry point initializes its databases in this action.
+			if err := s.ensureLocalClient(); err != nil {
+				return err
+			}
+			conn, err := stdio.DialWorker()
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			return s.ServeStdioWithIO(conn, conn)
 		case "sse":
 			if port == 0 {
 				port = utils.GetRandomAvailableTCPPort()

--- a/common/mcp/command_stdio_integration_test.go
+++ b/common/mcp/command_stdio_integration_test.go
@@ -5,10 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +21,74 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping process-level MCP stdio test in short mode")
 	}
+	for _, entry := range []struct {
+		name   string
+		target string
+		args   []string
+	}{
+		{"yak", "./common/yak/cmd", []string{"mcp"}},
+		{"standalone", "./common/mcp/cmd", nil},
+	} {
+		t.Run(entry.name, func(t *testing.T) {
+			binary := buildMCPStdioExecutable(t, entry.target)
+			t.Run("tool-output", func(t *testing.T) { testMCPStdioToolOutput(t, binary, entry.args) })
+			t.Run("large-request-ids", func(t *testing.T) { testMCPStdioLargeRequestIDs(t, binary, entry.args) })
+			t.Run("worker-killed", func(t *testing.T) { testMCPStdioWorkerKilled(t, binary, entry.args, false) })
+			t.Run("worker-killed-blocked-stderr", func(t *testing.T) { testMCPStdioWorkerKilled(t, binary, entry.args, true) })
+		})
+	}
+}
 
+func testMCPStdioLargeRequestIDs(t *testing.T, binary string, entryArgs []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	args := append(append([]string(nil), entryArgs...), "--transport", "stdio")
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Env = appendWithoutEnvKeys(os.Environ(), "YAKIT_HOME", "YAK_MCP_STDIO", "YAK_MCP_WORKER", "YAK_MCP_WORKER_ADDRESS", "YAK_MCP_WORKER_TOKEN", "LOG_LEVEL", "YAK_DEFAULT_PROJECT_DATABASE_NAME", "YAK_DEFAULT_PROFILE_DATABASE_NAME", "SSA_DATABASE_RAW")
+	cmd.Env = append(cmd.Env, "YAKIT_HOME="+filepath.Join(t.TempDir(), "home"))
+	cmd.Stdin = strings.NewReader(strings.Join([]string{
+		`{"jsonrpc":"2.0","id":9007199254740993,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"id-regression","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":9007199254740992,"method":"ping"}`,
+		`{"jsonrpc":"2.0","id":-9007199254740993,"method":"ping"}`,
+	}, "\n") + "\n")
+	var output, logs bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &logs
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("stdio ID round trip failed: %v; stdout: %s; stderr: %s", err, &output, &logs)
+	}
+	want := map[string]bool{"9007199254740993": false, "9007199254740992": false, "-9007199254740993": false}
+	scanner := bufio.NewScanner(&output)
+	for scanner.Scan() {
+		var response struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Error   json.RawMessage `json:"error"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &response); err != nil || response.JSONRPC != "2.0" {
+			t.Fatalf("invalid response: %s", scanner.Text())
+		}
+		id := string(response.ID)
+		if id == "" {
+			continue
+		}
+		if seen, exists := want[id]; !exists || seen || len(response.Error) != 0 {
+			t.Fatalf("unexpected, duplicate or failed response: %s", scanner.Text())
+		}
+		want[id] = true
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	for id, seen := range want {
+		if !seen {
+			t.Fatalf("missing response for %s", id)
+		}
+	}
+}
+
+func buildMCPStdioExecutable(t *testing.T, target string) string {
+	t.Helper()
 	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
 		t.Fatalf("resolve repository root: %v", err)
@@ -32,12 +102,15 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 
 	buildContext, cancelBuild := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelBuild()
-	build := exec.CommandContext(buildContext, "go", "build", "-o", binaryPath, "./common/yak/cmd")
+	build := exec.CommandContext(buildContext, "go", "build", "-o", binaryPath, target)
 	build.Dir = repositoryRoot
 	if output, buildErr := build.CombinedOutput(); buildErr != nil {
-		t.Fatalf("build yak command: %v\n%s", buildErr, output)
+		t.Fatalf("build %s: %v\n%s", target, buildErr, output)
 	}
+	return binaryPath
+}
 
+func testMCPStdioToolOutput(t *testing.T, binaryPath string, entryArgs []string) {
 	const stdoutSentinel = "MCP_STDOUT_SENTINEL"
 	request := strings.Join([]string{
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stdio-regression-test","version":"1"}}}`,
@@ -46,20 +119,21 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 	}, "\n") + "\n"
 	runContext, cancelRun := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancelRun()
-	run := exec.CommandContext(
-		runContext,
-		binaryPath,
-		"mcp",
+	args := append(append([]string(nil), entryArgs...),
 		"--transport",
 		"stdio",
 		"--enable-aitool-framework",
 		"--tool",
 		"yak_script",
 	)
+	run := exec.CommandContext(runContext, binaryPath, args...)
 	run.Env = appendWithoutEnvKeys(
 		os.Environ(),
 		"YAKIT_HOME",
 		"YAK_MCP_STDIO",
+		"YAK_MCP_WORKER",
+		"YAK_MCP_WORKER_ADDRESS",
+		"YAK_MCP_WORKER_TOKEN",
 		"LOG_LEVEL",
 		"YAK_DEFAULT_PROJECT_DATABASE_NAME",
 		"YAK_DEFAULT_PROFILE_DATABASE_NAME",
@@ -97,8 +171,9 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 			t.Fatalf("stdout contains a non-JSON-RPC line: %q\nfull stderr:\n%s", line, stderr.String())
 		}
 		var response struct {
-			JSONRPC string `json:"jsonrpc"`
-			ID      int    `json:"id"`
+			JSONRPC string          `json:"jsonrpc"`
+			ID      int             `json:"id"`
+			Error   json.RawMessage `json:"error"`
 		}
 		if decodeErr := json.Unmarshal(line, &response); decodeErr != nil {
 			t.Fatalf("decode stdout response: %v", decodeErr)
@@ -107,6 +182,9 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 			t.Fatalf("stdout JSON is not JSON-RPC 2.0: %s", line)
 		}
 		if response.ID != 0 {
+			if len(response.Error) > 0 || responseIDs[response.ID] {
+				t.Fatalf("failed or duplicate response: %s", line)
+			}
 			responseIDs[response.ID] = true
 		}
 	}
@@ -115,6 +193,140 @@ func TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly(t *testing.T) {
 	}
 	if !responseIDs[1] || !responseIDs[2] {
 		t.Fatalf("missing initialize or tools/call response; response IDs: %v; stdout: %q", responseIDs, stdout.String())
+	}
+}
+
+func testMCPStdioWorkerKilled(t *testing.T, binary string, entryArgs []string, blockStderr bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	args := append(append([]string(nil), entryArgs...), "--enable-aitool-framework", "--tool", "yak_script")
+	run := exec.CommandContext(ctx, binary, args...)
+	run.Env = appendWithoutEnvKeys(os.Environ(), "YAKIT_HOME", "YAK_MCP_STDIO", "YAK_MCP_WORKER", "YAK_MCP_WORKER_ADDRESS", "YAK_MCP_WORKER_TOKEN", "LOG_LEVEL", "YAK_DEFAULT_PROJECT_DATABASE_NAME", "YAK_DEFAULT_PROFILE_DATABASE_NAME", "SSA_DATABASE_RAW")
+	run.Env = append(run.Env, "YAKIT_HOME="+filepath.Join(t.TempDir(), "home"))
+	pidPath := filepath.Join(t.TempDir(), "worker.pid")
+	// Plugin os.Exit is hooked to cancel the script, so kill the reported worker
+	// from the test instead. Keep client stdin open until its failure is reported.
+	code := fmt.Sprintf("file.Save(%q, sprint(os.Getpid())); sleep(60)", pidPath)
+	if blockStderr {
+		code = fmt.Sprintf("file.Save(%q, sprint(os.Getpid())); println(str.Repeat(\"MCP_DIAGNOSTIC_FILL\\n\", 1048576)); sleep(60)", pidPath)
+	}
+	call, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": "worker-killed", "method": "tools/call",
+		"params": map[string]any{"name": "exec_yak_script", "arguments": map[string]any{"pluginType": "yak", "code": code}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := run.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input.Close()
+	request := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stdio-crash-test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		string(call),
+	}, "\n") + "\n"
+	var stdout, stderr bytes.Buffer
+	run.Stdout, run.Stderr = &stdout, &stderr
+	if blockStderr {
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reader.Close()
+		defer writer.Close()
+		// No reader drains this pipe, including after worker failure. This also
+		// catches CLI fatal logging/panic that would block after Run returns.
+		run.Stderr = writer
+	}
+	if err := run.Start(); err != nil {
+		t.Fatal(err)
+	}
+	wait := make(chan error, 1)
+	go func() { wait <- run.Wait() }()
+	if _, err := io.WriteString(input, request); err != nil {
+		t.Fatal(err)
+	}
+	var worker *os.Process
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for worker == nil {
+		select {
+		case err := <-wait:
+			t.Fatalf("server exited before tool started: %v; stdout: %s; stderr: %s", err, &stdout, &stderr)
+		case <-ctx.Done():
+			<-wait
+			t.Fatalf("tool did not report worker PID: %v; stderr: %s", ctx.Err(), &stderr)
+		case <-ticker.C:
+			data, err := os.ReadFile(pidPath)
+			if err != nil {
+				continue
+			}
+			pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil {
+				continue
+			}
+			if pid == run.Process.Pid || pid == os.Getpid() {
+				t.Fatalf("tool executed outside the worker: %d", pid)
+			}
+			worker, err = os.FindProcess(pid)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	defer worker.Release()
+	if blockStderr {
+		time.Sleep(200 * time.Millisecond)
+	}
+	if err := worker.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-wait:
+		if err == nil {
+			t.Fatalf("expected worker failure; stdout: %s; stderr: %s", &stdout, &stderr)
+		}
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-wait
+		t.Fatalf("supervisor failed to exit after worker death (blocked stderr=%v)", blockStderr)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("supervisor did not exit: %v; stderr: %s", ctx.Err(), &stderr)
+	}
+	initialized, failures := 0, 0
+	scanner := bufio.NewScanner(&stdout)
+	for scanner.Scan() {
+		var message struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Error   *struct {
+				Code int `json:"code"`
+				Data struct {
+					ExitCode *int `json:"exitCode"`
+				} `json:"data"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil || message.JSONRPC != "2.0" {
+			t.Fatalf("stdout corrupted: %s; stderr: %s", scanner.Text(), &stderr)
+		}
+		switch string(message.ID) {
+		case "1":
+			if message.Error != nil {
+				t.Fatalf("initialize failed: %s; stderr: %s", scanner.Text(), &stderr)
+			}
+			initialized++
+		case `"worker-killed"`:
+			if message.Error == nil || message.Error.Code != -32603 || message.Error.Data.ExitCode == nil || *message.Error.Data.ExitCode == 0 {
+				t.Fatalf("missing crash diagnostic: %s; stderr: %s", scanner.Text(), &stderr)
+			}
+			failures++
+		}
+	}
+	if err := scanner.Err(); err != nil || initialized != 1 || failures != 1 {
+		t.Fatalf("expected initialize success and one tool error: initialized=%d failures=%d scan=%v; stderr: %s", initialized, failures, err, &stderr)
 	}
 }
 

--- a/common/mcp/mcp-go/server/server.go
+++ b/common/mcp/mcp-go/server/server.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -337,7 +338,12 @@ func (s *MCPServer) HandleMessage(
 		ID      interface{} `json:"id,omitempty"`
 	}
 
-	if err := json.Unmarshal(message, &baseMessage); err != nil {
+	// Request IDs must survive a round trip without float64 rounding. Decode
+	// only the envelope with UseNumber; tool argument decoding below keeps its
+	// existing types. Valid also rejects trailing data, as Unmarshal did.
+	decoder := json.NewDecoder(bytes.NewReader(message))
+	decoder.UseNumber()
+	if err := decoder.Decode(&baseMessage); err != nil || !json.Valid(message) {
 		return createErrorResponse(
 			nil,
 			mcp.PARSE_ERROR,

--- a/common/mcp/mcp-go/server/server.go
+++ b/common/mcp/mcp-go/server/server.go
@@ -508,8 +508,8 @@ func (s *MCPServer) HandleMessage(
 		if err := json.Unmarshal(message, &request); err != nil {
 			return createErrorResponse(
 				baseMessage.ID,
-				mcp.INVALID_REQUEST,
-				"Invalid call tool request",
+				mcp.INVALID_PARAMS,
+				"Invalid tool parameters",
 			)
 		}
 		return s.handleToolCall(ctx, baseMessage.ID, request)

--- a/common/mcp/mcp-go/server/stdio_test.go
+++ b/common/mcp/mcp-go/server/stdio_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"sync"
@@ -14,6 +15,30 @@ import (
 
 	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
 )
+
+func TestStdioServerPreservesRequestIDs(t *testing.T) {
+	for _, id := range []string{`9007199254740992`, `9007199254740993`, `-9007199254740993`, `1e30`, `"request-1"`, `0`} {
+		for _, method := range []string{"ping", "missing-method"} {
+			t.Run(method+"/"+id, func(t *testing.T) {
+				server := NewStdioServer(NewMCPServer("test", "1.0.0"))
+				request := fmt.Sprintf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":%q}\n", id, method)
+				var output bytes.Buffer
+				if err := server.Listen(context.Background(), bytes.NewBufferString(request), &output); err != nil {
+					t.Fatal(err)
+				}
+				var response struct {
+					ID json.RawMessage `json:"id"`
+				}
+				if err := json.Unmarshal(output.Bytes(), &response); err != nil {
+					t.Fatal(err)
+				}
+				if string(response.ID) != id {
+					t.Fatalf("request ID %s changed to %s", id, response.ID)
+				}
+			})
+		}
+	}
+}
 
 type concurrentWriteDetector struct {
 	active     atomic.Int32

--- a/common/mcp/mcp-go/server/tool_params_test.go
+++ b/common/mcp/mcp-go/server/tool_params_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+)
+
+func TestToolCallInvalidParameterTypes(t *testing.T) {
+	srv := NewMCPServer("parameter-test", "1")
+	srv.AddTool(mcp.NewTool("test-tool"), func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		t.Fatal("invalid parameters must not reach the tool handler")
+		return nil, nil
+	})
+	for _, params := range []string{
+		`{"name":"test-tool","arguments":[]}`,
+		`{"name":"test-tool","arguments":"invalid"}`,
+		`{"name":42,"arguments":{}}`,
+		`"invalid"`,
+	} {
+		t.Run(params, func(t *testing.T) {
+			response := srv.HandleMessage(context.Background(), []byte(
+				`{"jsonrpc":"2.0","id":"invalid-params","method":"tools/call","params":`+params+`}`,
+			))
+			failure, ok := response.(mcp.JSONRPCError)
+			require.True(t, ok)
+			require.Equal(t, "invalid-params", failure.ID)
+			require.Equal(t, mcp.INVALID_PARAMS, failure.Error.Code)
+		})
+	}
+
+	// Parameter error classification must not change malformed JSON or version errors.
+	for _, tt := range []struct {
+		message string
+		code    int
+	}{
+		{`{"jsonrpc":`, mcp.PARSE_ERROR},
+		{`{"jsonrpc":"1.0","id":1,"method":"tools/call","params":{}}`, mcp.INVALID_REQUEST},
+	} {
+		failure, ok := srv.HandleMessage(context.Background(), []byte(tt.message)).(mcp.JSONRPCError)
+		require.True(t, ok)
+		require.Equal(t, tt.code, failure.Error.Code)
+	}
+}

--- a/common/mcp/stdio/README.md
+++ b/common/mcp/stdio/README.md
@@ -1,0 +1,71 @@
+# MCP stdio process isolation
+
+`yak mcp` and the standalone MCP executable run a supervisor for stdio mode.
+The supervisor re-executes the same binary and arguments with an internal worker
+environment. SSE and HTTP continue to run directly.
+
+The implementation follows Memfit's parent/worker lifecycle, with a separate
+protocol connection instead of prefix-filtering worker stdout:
+
+```text
+client stdin/stdout <-> supervisor <-> authenticated loopback TCP <-> worker
+client stderr      <---------------- inherited stdout/stderr ----------+
+```
+
+The supervisor owns client stdout. Worker stdout and stderr are diagnostics from
+process creation onward, including package initialization, cached file handles,
+tool subprocess output and panic stacks. `DialWorker` opens the protocol connection
+after server initialization and clears internal worker credentials from the
+environment before tools execute. The listener binds only IPv4 loopback on an
+ephemeral port and authenticates the worker using a random per-launch token.
+
+The CLI retains its early stderr logging setup and supervisor stdout reservation.
+These protect output in the supervisor itself; worker protocol isolation does not
+depend on fd duplication. Yak's stdio supervisor skips database initialization.
+Other package initializers still run in each process, so new initializers must not
+write directly to client stdout.
+
+## Failure and shutdown behavior
+
+- The worker starts on the first client frame. Failure to launch or initialize can
+  therefore be returned against the client's `initialize` request ID.
+- Initialization has a 60-second deadline. The worker connects only after its
+  databases, tool registry and local client are ready.
+- Complete worker responses are drained before outstanding requests receive a
+  JSON-RPC `-32603` error. IDs are preserved, including strings and large numbers;
+  notifications and server-initiated requests do not complete client requests.
+- Errors include the failure reason and, when available, the worker exit code.
+  Raw tool logs and panic stacks go to stderr, not into JSON-RPC error data.
+- Client EOF half-closes the worker connection and allows five seconds to finish
+  queued calls and exit. This is a shutdown grace period, not a tool-call timeout
+  while the client remains connected. Cancellation also stops the worker.
+- A protocol frame has at most five seconds to finish writing to client stdout.
+  After cancellation, a write gets at most 250 ms to finish (or send a small final
+  error). If writing cannot finish, the private output handle is closed and the
+  write goroutine is joined before cleanup; no further frame is appended to a
+  partial response. These are output delivery limits, not model/tool timeouts.
+  Incoming client and worker frames have a 64 MiB scanner limit.
+- Worker diagnostics inherit the client's stderr descriptor directly. There are
+  no supervisor log-copy goroutines for `cmd.Wait` to wait on. A full stderr pipe
+  can block the worker's logging, but does not prevent killing/reaping the worker.
+  The CLI exits with a nonzero code after a session error without another fatal
+  log or panic write to the possibly blocked stderr.
+- Workers are waited on and reaped. On Unix, cleanup kills remaining members of
+  the worker process group, including tool subprocesses that stayed in that
+  group. Other platforms kill the direct worker.
+- Failed calls are not replayed and workers are not automatically restarted;
+  clients must establish a new session after an abnormal exit.
+
+## Validation
+
+`go test -race ./common/mcp/stdio` exercises real subprocesses: initialization and
+tool output, panic/exit/kill, truncated or invalid frames, request correlation,
+draining final responses, cancellation, EOF and process cleanup. Backpressure tests
+cover unread stdout/stderr, cancellable inherited pipe descriptors, and output
+write deadlines. Non-file writers supplied to `Run` must implement `Close` that
+interrupts `Write`; arbitrary blocking `io.Writer` implementations are not accepted.
+
+`go test ./common/mcp -run '^TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly$'`
+builds both CLI entry points and verifies actual Yak script output and killing
+the executing worker while the client's input remains open, including an unread,
+full stderr pipe through the CLI exit path.

--- a/common/mcp/stdio/input_other.go
+++ b/common/mcp/stdio/input_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package stdio
+
+import "io"
+
+func prepareInput(input io.ReadCloser) (io.Reader, func(), error) {
+	return input, func() {}, nil
+}

--- a/common/mcp/stdio/input_unix.go
+++ b/common/mcp/stdio/input_unix.go
@@ -1,0 +1,46 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package stdio
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// prepareInput must run after prepareOutput: terminal stdin and stdout may share
+// file status flags, so preparing output can also make stdin nonblocking. An
+// existing os.Stdin created in blocking mode cannot wait for EAGAIN via Go's
+// poller. A new wrapper observes the updated flags and enables that waiting.
+func prepareInput(input io.ReadCloser) (io.Reader, func(), error) {
+	f, ok := input.(*os.File)
+	if !ok {
+		return input, func() {}, nil
+	}
+	raw, err := f.SyscallConn()
+	if err != nil {
+		return nil, nil, err
+	}
+	duplicate := -1
+	var setupErr error
+	err = raw.Control(func(fd uintptr) {
+		var flags int
+		flags, setupErr = unix.FcntlInt(fd, unix.F_GETFL, 0)
+		if setupErr == nil && flags&unix.O_NONBLOCK != 0 {
+			duplicate, setupErr = unix.FcntlInt(fd, unix.F_DUPFD_CLOEXEC, 0)
+		}
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if setupErr != nil {
+		return nil, nil, setupErr
+	}
+	if duplicate == -1 {
+		return input, func() {}, nil
+	}
+	reader := os.NewFile(uintptr(duplicate), "mcp-cancellable-input")
+	cleanup := func() { _ = reader.Close() }
+	return reader, cleanup, nil
+}

--- a/common/mcp/stdio/output.go
+++ b/common/mcp/stdio/output.go
@@ -1,0 +1,61 @@
+package stdio
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+)
+
+const (
+	outputWriteTimeout     = 5 * time.Second
+	cancellationWriteGrace = 250 * time.Millisecond
+)
+
+// protocolWriter keeps writes ordered and joins every write before returning.
+// Close must interrupt a blocked Write; an arbitrary io.Writer cannot provide
+// that guarantee. File outputs are prepared separately for cancellable pipe I/O.
+type protocolWriter struct {
+	ctx    context.Context
+	output io.WriteCloser
+	err    error
+}
+
+func (w *protocolWriter) Write(data []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	type result struct {
+		n   int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		n, err := w.output.Write(data)
+		done <- result{n, err}
+	}()
+	timer := time.NewTimer(outputWriteTimeout)
+	defer timer.Stop()
+	select {
+	case r := <-done:
+		return r.n, r.err
+	case <-w.ctx.Done():
+		// Allow a final, small failure response when the client is still reading.
+		// A blocked or partial response is never followed by a second JSON frame.
+		grace := time.NewTimer(cancellationWriteGrace)
+		defer grace.Stop()
+		select {
+		case r := <-done:
+			return r.n, r.err
+		case <-grace.C:
+			w.err = w.ctx.Err()
+		case <-timer.C:
+			w.err = os.ErrDeadlineExceeded
+		}
+	case <-timer.C:
+		w.err = os.ErrDeadlineExceeded
+	}
+	_ = w.output.Close()
+	r := <-done
+	return r.n, w.err
+}

--- a/common/mcp/stdio/output_other.go
+++ b/common/mcp/stdio/output_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package stdio
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func prepareOutput(output io.WriteCloser) (io.WriteCloser, func(), error) {
+	if _, ok := output.(*os.File); ok {
+		return nil, nil, fmt.Errorf("cancellable MCP file output is unsupported on this platform")
+	}
+	return output, func() { _ = output.Close() }, nil
+}

--- a/common/mcp/stdio/output_test.go
+++ b/common/mcp/stdio/output_test.go
@@ -1,0 +1,68 @@
+package stdio
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestProtocolWriterBlockedFile(t *testing.T) {
+	for _, cancelWrite := range []bool{true, false} {
+		name := "timeout"
+		if cancelWrite {
+			name = "cancel"
+		}
+		t.Run(name, func(t *testing.T) {
+			reader, original, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer reader.Close()
+			defer original.Close()
+			// Match an inherited CLI descriptor: Fd puts a Unix os.Pipe back
+			// into blocking mode. prepareOutput must make its copy cancellable.
+			_ = original.Fd()
+			output, cleanup, err := prepareOutput(original)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			observed := &observedWriteCloser{WriteCloser: output, entered: make(chan struct{})}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			writer := &protocolWriter{ctx: ctx, output: observed}
+			done := make(chan error, 1)
+			go func() {
+				_, err := writer.Write(bytes.Repeat([]byte("x"), 16<<20))
+				done <- err
+			}()
+			<-observed.entered
+			wantErr := error(os.ErrDeadlineExceeded)
+			limit := outputWriteTimeout + 3*time.Second
+			if cancelWrite {
+				cancel()
+				wantErr = context.Canceled
+				limit = 3 * time.Second
+			}
+			select {
+			case err := <-done:
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("expected %v, got %v", wantErr, err)
+				}
+			case <-time.After(limit):
+				reader.Close() // release even a broken blocking implementation
+				<-done
+				t.Fatal("blocked file write did not finish")
+			}
+			if _, err := writer.Write([]byte("must not append another response\n")); !errors.Is(err, wantErr) {
+				t.Fatalf("failed output accepted a later frame: %v", err)
+			}
+			if _, err := original.Stat(); err != nil {
+				t.Fatalf("closed caller's descriptor, preventing CLI restoration: %v", err)
+			}
+		})
+	}
+}

--- a/common/mcp/stdio/output_unix.go
+++ b/common/mcp/stdio/output_unix.go
@@ -1,0 +1,65 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package stdio
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func prepareOutput(output io.WriteCloser) (io.WriteCloser, func(), error) {
+	f, ok := output.(*os.File)
+	if !ok {
+		return output, func() { _ = output.Close() }, nil
+	}
+	raw, err := f.SyscallConn()
+	if err != nil {
+		return nil, nil, err
+	}
+	var flags, duplicate int
+	var setupErr error
+	err = raw.Control(func(fd uintptr) {
+		flags, setupErr = unix.FcntlInt(fd, unix.F_GETFL, 0)
+		if setupErr != nil {
+			return
+		}
+		duplicate, setupErr = unix.FcntlInt(fd, unix.F_DUPFD_CLOEXEC, 0)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if setupErr != nil {
+		return nil, nil, setupErr
+	}
+	if err := unix.SetNonblock(duplicate, true); err != nil {
+		_ = unix.Close(duplicate)
+		return nil, nil, err
+	}
+	// NewFile registers a nonblocking pipe with Go's poller, so Close wakes Write.
+	// The original descriptor remains available to the CLI's stdout restoration.
+	writer := os.NewFile(uintptr(duplicate), "mcp-cancellable-output")
+	cleanup := func() {
+		_ = writer.Close()
+		// dup shares file status flags. Restore the caller's blocking mode after
+		// the private writer has finished; never call File.Fd(), which changes it.
+		if flags&unix.O_NONBLOCK == 0 {
+			_ = raw.Control(func(fd uintptr) { _ = unix.SetNonblock(int(fd), false) })
+		}
+	}
+	info, err := writer.Stat()
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	if info.Mode()&(os.ModeNamedPipe|os.ModeSocket) != 0 {
+		if err := writer.SetWriteDeadline(time.Time{}); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("MCP output does not support cancellable writes: %w", err)
+		}
+	}
+	return writer, cleanup, nil
+}

--- a/common/mcp/stdio/output_windows.go
+++ b/common/mcp/stdio/output_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package stdio
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func prepareOutput(output io.WriteCloser) (io.WriteCloser, func(), error) {
+	f, ok := output.(*os.File)
+	if !ok {
+		return output, func() { _ = output.Close() }, nil
+	}
+	var duplicate windows.Handle
+	process := windows.CurrentProcess()
+	if err := windows.DuplicateHandle(process, windows.Handle(f.Fd()), process,
+		&duplicate, 0, false, windows.DUPLICATE_SAME_ACCESS); err != nil {
+		return nil, nil, err
+	}
+	// os.File.Close cancels pending Windows pipe I/O via CancelIoEx.
+	writer := os.NewFile(uintptr(duplicate), "mcp-cancellable-output")
+	return writer, func() { _ = writer.Close() }, nil
+}

--- a/common/mcp/stdio/process.go
+++ b/common/mcp/stdio/process.go
@@ -1,0 +1,172 @@
+// Package stdio isolates MCP execution from the process owning the client's
+// stdin/stdout. Worker standard streams carry diagnostics, never JSON-RPC.
+package stdio
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	workerEnv       = "YAK_MCP_WORKER"
+	addressEnv      = "YAK_MCP_WORKER_ADDRESS"
+	tokenEnv        = "YAK_MCP_WORKER_TOKEN"
+	startupTimeout  = 60 * time.Second
+	shutdownTimeout = 5 * time.Second
+)
+
+// IsWorker reports the internal re-execution mode, before CLI initialization.
+func IsWorker() bool { return os.Getenv(workerEnv) == "1" }
+
+// DialWorker connects the worker's protocol transport. stdout and stderr remain
+// untouched, including handles cached by package initializers and subprocesses.
+func DialWorker() (*net.TCPConn, error) {
+	address, token := os.Getenv(addressEnv), os.Getenv(tokenEnv)
+	// Do not pass the internal worker identity to tools which launch Yak again.
+	for _, key := range []string{workerEnv, addressEnv, tokenEnv} {
+		_ = os.Unsetenv(key)
+	}
+	if len(token) != 64 {
+		return nil, fmt.Errorf("invalid MCP worker credentials")
+	}
+	addr, err := net.ResolveTCPAddr("tcp4", address)
+	if err != nil || addr == nil || !addr.IP.IsLoopback() {
+		return nil, fmt.Errorf("invalid MCP worker address")
+	}
+	conn, err := net.DialTimeout("tcp4", address, startupTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("connect MCP supervisor: %w", err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(startupTimeout))
+	if _, err = io.WriteString(conn, token); err == nil {
+		var ack [1]byte
+		_, err = io.ReadFull(conn, ack[:])
+		if err == nil && ack[0] != 1 {
+			err = fmt.Errorf("invalid MCP supervisor handshake")
+		}
+	}
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("authenticate MCP worker: %w", err)
+	}
+	_ = conn.SetDeadline(time.Time{})
+	return conn.(*net.TCPConn), nil
+}
+
+type workerProcess struct {
+	cmd     *exec.Cmd
+	conn    *net.TCPConn
+	done    chan struct{}
+	waitErr error // published by closing done
+}
+
+func childEnvironment(parent []string, address, token string) []string {
+	result := make([]string, 0, len(parent)+4)
+	for _, entry := range parent {
+		key, _, _ := strings.Cut(entry, "=")
+		switch strings.ToUpper(key) {
+		case workerEnv, addressEnv, tokenEnv, "YAK_MCP_STDIO":
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, workerEnv+"=1", addressEnv+"="+address, tokenEnv+"="+token, "YAK_MCP_STDIO=1")
+}
+
+func startWorker(ctx context.Context, cmd *exec.Cmd, logs *os.File) (_ *workerProcess, retErr error) {
+	listener, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		return nil, fmt.Errorf("listen for MCP worker: %w", err)
+	}
+	defer listener.Close()
+	var secret [32]byte
+	if _, err := rand.Read(secret[:]); err != nil {
+		return nil, fmt.Errorf("create MCP worker token: %w", err)
+	}
+	token := hex.EncodeToString(secret[:])
+	environment := cmd.Env
+	if environment == nil {
+		environment = os.Environ()
+	}
+	cmd.Env = childEnvironment(environment, listener.Addr().String(), token)
+	cmd.Stdin = nil
+	// Pass the diagnostic descriptor directly to the child. Wrapping it in an
+	// io.Writer makes exec.Cmd start copying goroutines; a full client stderr
+	// pipe can then block Wait even after the child has been killed.
+	cmd.Stdout, cmd.Stderr = nil, nil
+	if logs != nil {
+		cmd.Stdout, cmd.Stderr = logs, logs
+	}
+	configureProcess(cmd)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start MCP worker: %w", err)
+	}
+	p := &workerProcess{cmd: cmd, done: make(chan struct{})}
+	go func() {
+		p.waitErr = cmd.Wait()
+		close(p.done)
+	}()
+	defer func() {
+		if retErr != nil {
+			p.close()
+		}
+	}()
+
+	startupCtx, cancel := context.WithTimeout(ctx, startupTimeout)
+	defer cancel()
+	accepted := make(chan *net.TCPConn)
+	go func() {
+		for {
+			conn, err := listener.AcceptTCP()
+			if err != nil {
+				return
+			}
+			_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+			var supplied [64]byte
+			_, err = io.ReadFull(conn, supplied[:])
+			if err != nil || subtle.ConstantTimeCompare(supplied[:], []byte(token)) != 1 {
+				_ = conn.Close()
+				continue
+			}
+			if _, err = conn.Write([]byte{1}); err != nil {
+				_ = conn.Close()
+				continue
+			}
+			_ = conn.SetDeadline(time.Time{})
+			select {
+			case accepted <- conn:
+			case <-startupCtx.Done():
+				_ = conn.Close()
+			}
+			return
+		}
+	}()
+	select {
+	case p.conn = <-accepted:
+		return p, nil
+	case <-p.done:
+		if p.waitErr != nil {
+			return nil, fmt.Errorf("MCP worker exited during initialization: %w", p.waitErr)
+		}
+		return nil, fmt.Errorf("MCP worker exited during initialization")
+	case <-startupCtx.Done():
+		return nil, fmt.Errorf("wait for MCP worker: %w", startupCtx.Err())
+	}
+}
+
+func (p *workerProcess) close() {
+	if p.conn != nil {
+		_ = p.conn.Close()
+	}
+	killProcess(p.cmd)
+	<-p.done
+}

--- a/common/mcp/stdio/process_other.go
+++ b/common/mcp/stdio/process_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package stdio
+
+import "os/exec"
+
+func configureProcess(_ *exec.Cmd) {}
+
+func killProcess(cmd *exec.Cmd) { _ = cmd.Process.Kill() }

--- a/common/mcp/stdio/process_unix.go
+++ b/common/mcp/stdio/process_unix.go
@@ -1,0 +1,19 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package stdio
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killProcess(cmd *exec.Cmd) {
+	// Include subprocesses launched by tools, even if the worker already exited.
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/common/mcp/stdio/proxy.go
+++ b/common/mcp/stdio/proxy.go
@@ -176,7 +176,12 @@ func Run(ctx context.Context, cmd *exec.Cmd, input io.ReadCloser, output io.Writ
 		return fmt.Errorf("prepare MCP output: %w", err)
 	}
 	defer closeOutput()
-	requests := readFrames(ctx, input, false)
+	reader, closeInput, err := prepareInput(input)
+	if err != nil {
+		return fmt.Errorf("prepare MCP input: %w", err)
+	}
+	defer closeInput()
+	requests := readFrames(ctx, reader, false)
 	r := &relay{output: &protocolWriter{ctx: ctx, output: writer}, pending: make(map[string]json.RawMessage)}
 	var queued []byte
 	select {

--- a/common/mcp/stdio/proxy.go
+++ b/common/mcp/stdio/proxy.go
@@ -1,0 +1,314 @@
+package stdio
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxFrameSize = 64 << 20
+
+var errWorkerProtocol = errors.New("invalid JSON-RPC frame from MCP worker")
+
+type frame struct {
+	data []byte
+	err  error
+}
+
+func readFrames(ctx context.Context, r io.Reader, requireNewline bool) <-chan frame {
+	frames := make(chan frame)
+	go func() {
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 64<<10), maxFrameSize)
+		if requireNewline {
+			scanner.Split(func(data []byte, atEOF bool) (int, []byte, error) {
+				if i := bytes.IndexByte(data, '\n'); i >= 0 {
+					return i + 1, data[:i], nil
+				}
+				if atEOF && len(data) > 0 {
+					return 0, nil, io.ErrUnexpectedEOF
+				}
+				return 0, nil, nil
+			})
+		}
+		for scanner.Scan() {
+			data := append(bytes.Clone(scanner.Bytes()), '\n')
+			select {
+			case frames <- frame{data: data}:
+			case <-ctx.Done():
+				return
+			}
+		}
+		err := scanner.Err()
+		if err == nil {
+			err = io.EOF
+		}
+		select {
+		case frames <- frame{err: err}:
+		case <-ctx.Done():
+		}
+	}()
+	return frames
+}
+
+type envelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Result  json.RawMessage `json:"result"`
+	Error   json.RawMessage `json:"error"`
+}
+
+type relay struct {
+	output  io.Writer
+	pending map[string]json.RawMessage
+}
+
+func idKey(id json.RawMessage) string {
+	// Normalize equivalent string encodings without converting numeric IDs to
+	// float64 (which would lose precision for large request IDs).
+	var s string
+	if json.Unmarshal(id, &s) == nil && len(id) > 0 && id[0] == '"' {
+		encoded, _ := json.Marshal(s)
+		return string(encoded)
+	}
+	number := string(bytes.TrimSpace(id))
+	if number == "" || number == "null" {
+		return number
+	}
+	// JSON encoders may rewrite 1.0 or 1e0 as 1. Compare the exact decimal
+	// coefficient/exponent instead of float64, without expanding huge powers.
+	mantissa, exponentText, hasExponent := strings.Cut(strings.ToLower(number), "e")
+	exponent := new(big.Int)
+	if hasExponent {
+		if _, ok := exponent.SetString(exponentText, 10); !ok {
+			return number
+		}
+	}
+	negative := strings.HasPrefix(mantissa, "-")
+	mantissa = strings.TrimPrefix(mantissa, "-")
+	whole, fraction, _ := strings.Cut(mantissa, ".")
+	digits := strings.TrimLeft(whole+fraction, "0")
+	if digits == "" {
+		return "0"
+	}
+	coefficient := strings.TrimRight(digits, "0")
+	exponent.Add(exponent, big.NewInt(int64(len(digits)-len(coefficient)-len(fraction))))
+	if negative {
+		coefficient = "-" + coefficient
+	}
+	return coefficient + "e" + exponent.String()
+}
+
+func (r *relay) track(data []byte) {
+	var message envelope
+	if json.Unmarshal(data, &message) == nil && message.JSONRPC == "2.0" && message.Method != "" && len(message.ID) > 0 {
+		r.pending[idKey(message.ID)] = message.ID
+	}
+}
+
+func writeFrame(w io.Writer, data []byte) error {
+	n, err := w.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	return err
+}
+
+func (r *relay) forward(data []byte) error {
+	var message envelope
+	if err := json.Unmarshal(data, &message); err != nil || message.JSONRPC != "2.0" {
+		return errWorkerProtocol
+	}
+	if message.Method == "" && (len(message.ID) == 0 || (len(message.Result) == 0) == (len(message.Error) == 0)) {
+		return errWorkerProtocol
+	}
+	if err := writeFrame(r.output, data); err != nil {
+		return fmt.Errorf("write MCP response: %w", err)
+	}
+	// Server requests and notifications must not consume client request IDs.
+	if message.Method == "" {
+		delete(r.pending, idKey(message.ID))
+	}
+	return nil
+}
+
+func (r *relay) fail(cause error, exitErr error) error {
+	data := map[string]any{"reason": cause.Error()}
+	var exited *exec.ExitError
+	if errors.As(exitErr, &exited) {
+		data["exitCode"] = exited.ExitCode()
+	}
+	for key, id := range r.pending {
+		response, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": id,
+			"error": map[string]any{"code": -32603, "message": "MCP worker failed", "data": data},
+		})
+		if err := writeFrame(r.output, append(response, '\n')); err != nil {
+			return fmt.Errorf("report MCP worker failure: %w", err)
+		}
+		delete(r.pending, key)
+	}
+	return cause
+}
+
+// Run owns input until it returns, including closing it to unblock reads on
+// worker failure or cancellation. cmd must re-execute the MCP entry point with
+// its original arguments; its standard streams and worker environment are set
+// here. Protocol writes are serialized and bounded by outputWriteTimeout, shortened
+// on cancellation. Non-file output is owned by Run and its Close must unblock
+// Write. File output is duplicated privately; logs is inherited by the worker.
+func Run(ctx context.Context, cmd *exec.Cmd, input io.ReadCloser, output io.WriteCloser, logs *os.File) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer input.Close()
+	writer, closeOutput, err := prepareOutput(output)
+	if err != nil {
+		return fmt.Errorf("prepare MCP output: %w", err)
+	}
+	defer closeOutput()
+	requests := readFrames(ctx, input, false)
+	r := &relay{output: &protocolWriter{ctx: ctx, output: writer}, pending: make(map[string]json.RawMessage)}
+	var queued []byte
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case first := <-requests:
+		if first.err != nil {
+			if first.err == io.EOF {
+				return nil
+			}
+			return first.err
+		}
+		queued = first.data
+		r.track(queued)
+	}
+	// Starting on the first client frame lets initialization failures be returned
+	// against initialize's ID instead of leaving the client with an unexplained EOF.
+	p, err := startWorker(ctx, cmd, logs)
+	if err != nil {
+		return r.fail(err, err)
+	}
+	defer p.close()
+	responses := readFrames(ctx, p.conn, true)
+	outbound := make(chan []byte)
+	writeErrors := make(chan error, 1)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case data, ok := <-outbound:
+				if !ok {
+					writeErrors <- p.conn.CloseWrite()
+					return
+				}
+				if err := writeFrame(p.conn, data); err != nil {
+					writeErrors <- err
+					return
+				}
+			}
+		}
+	}()
+
+	processDone := p.done
+	var closing <-chan time.Time
+	var timer *time.Timer
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
+	beginClose := func() {
+		if timer == nil {
+			timer = time.NewTimer(shutdownTimeout)
+			closing = timer.C
+		}
+	}
+	var transportErr error
+	for {
+		incoming := requests
+		var send chan []byte
+		if queued != nil {
+			incoming = nil
+			send = outbound
+		}
+		select {
+		case <-ctx.Done():
+			return r.fail(ctx.Err(), nil)
+		case <-closing:
+			return r.fail(fmt.Errorf("MCP worker did not shut down within %s", shutdownTimeout), nil)
+		case <-processDone:
+			processDone = nil
+			// Drain complete protocol frames before synthesizing errors. A child
+			// may exit immediately after writing its final successful response.
+			_ = p.conn.SetReadDeadline(time.Now().Add(shutdownTimeout))
+		case send <- queued:
+			queued = nil
+		case request := <-incoming:
+			if request.err != nil {
+				if request.err != io.EOF {
+					return r.fail(fmt.Errorf("read MCP client: %w", request.err), nil)
+				}
+				requests = nil
+				close(outbound)
+				beginClose()
+				continue
+			}
+			queued = request.data
+			r.track(queued)
+		case err := <-writeErrors:
+			writeErrors = nil
+			if err != nil {
+				transportErr = fmt.Errorf("write MCP worker: %w", err)
+				beginClose()
+			}
+		case response := <-responses:
+			if response.err == nil {
+				if err := r.forward(response.data); err != nil {
+					if errors.Is(err, errWorkerProtocol) {
+						return r.fail(err, nil)
+					}
+					// A failed/partial client write cannot be repaired by appending
+					// another JSON object to the same stream.
+					return err
+				}
+				continue
+			}
+			// IPC EOF can precede Wait and the last stderr bytes. Bound the wait
+			// if a worker closes its transport but fails to terminate.
+			waitTimer := time.NewTimer(shutdownTimeout)
+			select {
+			case <-p.done:
+			case <-ctx.Done():
+				waitTimer.Stop()
+				return r.fail(ctx.Err(), nil)
+			case <-waitTimer.C:
+				return r.fail(fmt.Errorf("MCP worker disconnected without exiting"), nil)
+			}
+			waitTimer.Stop()
+			if p.waitErr != nil {
+				return r.fail(fmt.Errorf("MCP worker exited: %w", p.waitErr), p.waitErr)
+			}
+			if response.err != io.EOF {
+				return r.fail(fmt.Errorf("read MCP worker: %w", response.err), nil)
+			}
+			if transportErr != nil {
+				return r.fail(transportErr, nil)
+			}
+			if len(r.pending) > 0 || requests != nil {
+				return r.fail(fmt.Errorf("MCP worker exited before the client session ended"), nil)
+			}
+			return nil
+		}
+	}
+}

--- a/common/mcp/stdio/proxy_test.go
+++ b/common/mcp/stdio/proxy_test.go
@@ -1,0 +1,498 @@
+package stdio
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var cachedStdout = os.Stdout
+
+func init() {
+	if os.Getenv("TEST_MCP_WORKER") == "1" {
+		// Deliberately no newline: prefix filtering on stdout cannot isolate it.
+		fmt.Fprint(cachedStdout, "INITIALIZER_STDOUT")
+	}
+}
+
+func TestWorkerProcess(t *testing.T) {
+	if os.Getenv("TEST_MCP_WORKER") != "1" {
+		return
+	}
+	mode := os.Getenv("TEST_MCP_MODE")
+	if mode == "startup-exit" {
+		fmt.Fprintln(os.Stderr, "initialization failed")
+		os.Exit(23)
+	}
+	if mode == "startup-hang" {
+		time.Sleep(time.Minute)
+		os.Exit(1)
+	}
+	if mode == "unauthenticated" {
+		conn, err := net.DialTimeout("tcp4", os.Getenv(addressEnv), time.Second)
+		if err != nil {
+			os.Exit(6)
+		}
+		conn.SetDeadline(time.Now().Add(time.Second))
+		io.WriteString(conn, strings.Repeat("x", 64))
+		var ack [1]byte
+		if _, err := conn.Read(ack[:]); err == nil {
+			os.Exit(7)
+		}
+		conn.Close()
+	}
+	conn, err := DialWorker()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	if IsWorker() || os.Getenv(addressEnv) != "" || os.Getenv(tokenEnv) != "" {
+		os.Exit(3)
+	}
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 64<<10), maxFrameSize)
+	for scanner.Scan() {
+		var request envelope
+		if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
+			os.Exit(4)
+		}
+		fmt.Fprint(cachedStdout, "TOOL_STDOUT")
+		fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","id":"fake","result":"LOG_JSON"}`)
+		fmt.Fprintln(os.Stderr, "TOOL_STDERR")
+		if request.Method == "crash" {
+			switch mode {
+			case "panic":
+				go func() { panic("MCP_WORKER_PANIC") }()
+				time.Sleep(time.Minute)
+			case "partial":
+				fmt.Fprintf(conn, `{"jsonrpc":"2.0","id":%s,"result":`, request.ID)
+				os.Exit(24)
+			case "unterminated":
+				fmt.Fprintf(conn, `{"jsonrpc":"2.0","id":%s,"result":{}}`, request.ID)
+				os.Exit(24)
+			case "invalid":
+				fmt.Fprintln(conn, "not JSON-RPC")
+				time.Sleep(time.Minute)
+			case "hang":
+				fmt.Fprintln(conn, `{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}`)
+				time.Sleep(time.Minute)
+			case "flood-logs":
+				fmt.Fprintln(conn, `{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}`)
+				fmt.Fprint(os.Stderr, strings.Repeat("diagnostic output\n", 1<<20))
+				time.Sleep(time.Minute)
+			case "drain-exit":
+				// Read two requests, then publish the first response immediately
+				// before dying with the second request still pending.
+				firstID := bytes.Clone(request.ID)
+				if !scanner.Scan() {
+					os.Exit(5)
+				}
+				fmt.Fprintf(conn, "{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{}}\n", firstID)
+				os.Exit(23)
+			case "clean-exit":
+				os.Exit(0)
+			default:
+				os.Exit(23)
+			}
+		}
+		if request.Method != "" && len(request.ID) > 0 {
+			response, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": request.ID, "result": map[string]any{"pid": os.Getpid()}})
+			fmt.Fprintf(conn, "%s\n", response)
+		} else {
+			fmt.Fprintln(conn, `{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}`)
+		}
+	}
+	conn.Close()
+	os.Exit(0)
+}
+
+func helperCommand(mode string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWorkerProcess$")
+	cmd.Env = append(os.Environ(), "TEST_MCP_WORKER=1", "TEST_MCP_MODE="+mode)
+	return cmd
+}
+
+func decodeOutput(t *testing.T, output []byte) []envelope {
+	t.Helper()
+	var messages []envelope
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		var message envelope
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil || message.JSONRPC != "2.0" {
+			t.Fatalf("invalid stdout frame %q: %v", scanner.Text(), err)
+		}
+		messages = append(messages, message)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return messages
+}
+
+func TestRunIsolatesWorkerStreamsAndDrainsResponses(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var payload strings.Builder
+	ids := []string{`1`, `0`, `"call-2"`, `9007199254740993`}
+	for _, id := range ids {
+		fmt.Fprintf(&payload, "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"ping\"}\n", id)
+	}
+	payload.WriteString("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+	var output bytes.Buffer
+	logs := newDiagnosticFile(t)
+	cmd := helperCommand("echo")
+	if err := Run(ctx, cmd, io.NopCloser(strings.NewReader(payload.String())), nopWriteCloser{&output}, logs); err != nil {
+		t.Fatalf("run: %v; stdout: %s; logs: %s", err, &output, readDiagnostics(t, logs))
+	}
+	messages := decodeOutput(t, output.Bytes())
+	if len(messages) != len(ids)+1 {
+		t.Fatalf("missing or unexpected messages: %s", &output)
+	}
+	for i, id := range ids {
+		if string(messages[i].ID) != id || len(messages[i].Error) > 0 {
+			t.Fatalf("response %d: %+v", i, messages[i])
+		}
+		var result struct {
+			PID int `json:"pid"`
+		}
+		json.Unmarshal(messages[i].Result, &result)
+		if result.PID != cmd.Process.Pid || result.PID == os.Getpid() {
+			t.Fatalf("tool did not execute in worker: %d", result.PID)
+		}
+	}
+	if messages[len(ids)].Method != "notifications/progress" {
+		t.Fatalf("notification was lost: %s", &output)
+	}
+	for _, marker := range []string{"INITIALIZER_STDOUT", "TOOL_STDOUT", "TOOL_STDERR", "LOG_JSON"} {
+		if strings.Contains(output.String(), marker) || !strings.Contains(readDiagnostics(t, logs), marker) {
+			t.Fatalf("diagnostic %s not isolated; stdout: %s; logs: %s", marker, &output, readDiagnostics(t, logs))
+		}
+	}
+	if cmd.ProcessState == nil || !cmd.ProcessState.Success() {
+		t.Fatalf("worker not reaped successfully: %v", cmd.ProcessState)
+	}
+}
+
+func TestRunReportsWorkerFailures(t *testing.T) {
+	for _, mode := range []string{"startup-exit", "exit", "panic", "partial", "unterminated", "invalid", "clean-exit"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			var output bytes.Buffer
+			logs := newDiagnosticFile(t)
+			cmd := helperCommand(mode)
+			err := Run(ctx, cmd, io.NopCloser(strings.NewReader("{\"jsonrpc\":\"2.0\",\"id\":\"crash-id\",\"method\":\"crash\"}\n")), nopWriteCloser{&output}, logs)
+			if err == nil {
+				t.Fatal("expected worker failure")
+			}
+			messages := decodeOutput(t, output.Bytes())
+			if len(messages) != 1 || string(messages[0].ID) != `"crash-id"` || len(messages[0].Error) == 0 {
+				t.Fatalf("expected one matching error, got %s (error: %v)", &output, err)
+			}
+			var failure struct {
+				Code int `json:"code"`
+				Data struct {
+					ExitCode int `json:"exitCode"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(messages[0].Error, &failure); err != nil || failure.Code != -32603 {
+				t.Fatalf("invalid failure: %s", &output)
+			}
+			if (mode == "exit" || mode == "startup-exit") && failure.Data.ExitCode != 23 {
+				t.Fatalf("missing exit code: %s", &output)
+			}
+			if mode == "panic" && !strings.Contains(readDiagnostics(t, logs), "MCP_WORKER_PANIC") {
+				t.Fatalf("missing panic diagnostics: %s", readDiagnostics(t, logs))
+			}
+			if cmd.ProcessState == nil {
+				t.Fatal("worker was not reaped")
+			}
+		})
+	}
+}
+
+func TestRunStartupCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	var output bytes.Buffer
+	logs := newDiagnosticFile(t)
+	cmd := helperCommand("startup-hang")
+	err := Run(ctx, cmd, io.NopCloser(strings.NewReader("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n")), nopWriteCloser{&output}, logs)
+	if err == nil || cmd.ProcessState == nil {
+		t.Fatalf("startup cancellation did not reap worker: %v", err)
+	}
+	if messages := decodeOutput(t, output.Bytes()); len(messages) != 1 || len(messages[0].Error) == 0 {
+		t.Fatalf("missing initialize failure: %s", &output)
+	}
+}
+
+func TestRunMissingExecutable(t *testing.T) {
+	var output bytes.Buffer
+	cmd := exec.Command(t.TempDir() + "/missing")
+	err := Run(context.Background(), cmd, io.NopCloser(strings.NewReader("{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\"}\n")), nopWriteCloser{&output}, nil)
+	if err == nil {
+		t.Fatal("expected launch error")
+	}
+	if messages := decodeOutput(t, output.Bytes()); len(messages) != 1 || string(messages[0].ID) != "0" || len(messages[0].Error) == 0 {
+		t.Fatalf("missing initialize failure: %s", &output)
+	}
+}
+
+func TestRunEmptySessionDoesNotStartWorker(t *testing.T) {
+	cmd := helperCommand("echo")
+	if err := Run(context.Background(), cmd, io.NopCloser(strings.NewReader("")), nopWriteCloser{io.Discard}, nil); err != nil || cmd.Process != nil {
+		t.Fatalf("empty session launched a worker: %v", err)
+	}
+}
+
+func TestRunExternalKillWhileClientStaysOpen(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	input, clientWriter := io.Pipe()
+	outputReader, output := io.Pipe()
+	defer clientWriter.Close()
+	defer outputReader.Close()
+	cmd := helperCommand("hang")
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, cmd, input, output, nil)
+		output.Close()
+	}()
+	fmt.Fprintln(clientWriter, `{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	scanner := bufio.NewScanner(outputReader)
+	if !scanner.Scan() {
+		t.Fatal("missing first response")
+	}
+	fmt.Fprintln(clientWriter, `{"jsonrpc":"2.0","id":"pending","method":"crash"}`)
+	if !scanner.Scan() || !strings.Contains(scanner.Text(), "notifications/progress") {
+		t.Fatal("worker did not start tool call")
+	}
+	// A progress notification proves the pending call reached the worker.
+	// Resolve the PID from the completed response to avoid racing cmd.Start.
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if !scanner.Scan() {
+		t.Fatal("missing crash response with client stdin still open")
+	}
+	messages := decodeOutput(t, scanner.Bytes())
+	if len(messages) != 1 || string(messages[0].ID) != `"pending"` || len(messages[0].Error) == 0 {
+		t.Fatalf("wrong crash response: %s", scanner.Text())
+	}
+	if scanner.Scan() {
+		t.Fatalf("duplicate response: %s", scanner.Text())
+	}
+	if err := <-done; err == nil {
+		t.Fatal("expected abnormal exit")
+	}
+}
+
+func TestRelayDoesNotConsumePendingIDForServerRequest(t *testing.T) {
+	var output bytes.Buffer
+	r := relay{output: &output, pending: make(map[string]json.RawMessage)}
+	r.track([]byte(`{"jsonrpc":"2.0","id":"same","method":"tools/call"}`))
+	if err := r.forward([]byte("{\"jsonrpc\":\"2.0\",\"id\":\"same\",\"method\":\"sampling/createMessage\"}\n")); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.pending) != 1 {
+		t.Fatal("server request consumed the client's pending ID")
+	}
+}
+
+func TestRunDrainsSuccessBeforeFailingRemainingRequests(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var output bytes.Buffer
+	payload := "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"crash\"}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}\n"
+	err := Run(ctx, helperCommand("drain-exit"), io.NopCloser(strings.NewReader(payload)), nopWriteCloser{&output}, nil)
+	if err == nil {
+		t.Fatal("expected worker exit")
+	}
+	messages := decodeOutput(t, output.Bytes())
+	if len(messages) != 2 || string(messages[0].ID) != "1" || len(messages[0].Error) != 0 || string(messages[1].ID) != "2" || len(messages[1].Error) == 0 {
+		t.Fatalf("success was lost or duplicated: %s", &output)
+	}
+}
+
+func TestRunShutdownReapsBusyWorker(t *testing.T) {
+	for _, cancelSession := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cancel=%v", cancelSession), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			input, client := io.Pipe()
+			defer client.Close()
+			reader, output := io.Pipe()
+			defer reader.Close()
+			cmd := helperCommand("hang")
+			done := make(chan error, 1)
+			go func() {
+				done <- Run(ctx, cmd, input, output, nil)
+				output.Close()
+			}()
+			fmt.Fprintln(client, `{"jsonrpc":"2.0","id":1,"method":"crash"}`)
+			scanner := bufio.NewScanner(reader)
+			if !scanner.Scan() {
+				t.Fatal("worker did not start")
+			}
+			if cancelSession {
+				cancel()
+			} else {
+				client.Close()
+			}
+			if !scanner.Scan() {
+				t.Fatal("missing shutdown response")
+			}
+			if messages := decodeOutput(t, scanner.Bytes()); len(messages) != 1 || len(messages[0].Error) == 0 {
+				t.Fatalf("unexpected shutdown response: %s", scanner.Text())
+			}
+			if err := <-done; err == nil || cmd.ProcessState == nil {
+				t.Fatalf("worker was not stopped and reaped: %v", err)
+			}
+		})
+	}
+}
+
+func TestChildEnvironment(t *testing.T) {
+	child := childEnvironment([]string{"KEEP=value", workerEnv + "=stale", addressEnv + "=stale", strings.ToLower(tokenEnv) + "=stale", "YAK_MCP_STDIO=0"}, "127.0.0.1:1234", "secret")
+	joined := strings.Join(child, "\n")
+	if strings.Contains(joined, "stale") || !strings.Contains(joined, "KEEP=value") || !strings.Contains(joined, "YAK_MCP_STDIO=1") || !strings.Contains(joined, workerEnv+"=1") {
+		t.Fatalf("incorrect worker environment: %v", child)
+	}
+}
+
+func TestRelayMatchesEquivalentIDsWithoutRounding(t *testing.T) {
+	var output bytes.Buffer
+	r := relay{output: &output, pending: make(map[string]json.RawMessage)}
+	for _, id := range []string{"1.0", "9007199254740992", "9007199254740993", `"\u0061"`} {
+		r.track([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"method":"ping"}`, id)))
+	}
+	for _, id := range []string{"1e0", "9007199254740992", `"a"`} {
+		if err := r.forward([]byte(fmt.Sprintf("{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{}}\n", id))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(r.pending) != 1 || string(r.pending[idKey([]byte("9007199254740993"))]) != "9007199254740993" {
+		t.Fatalf("incorrect ID correlation: %v", r.pending)
+	}
+}
+
+func TestRunRejectsUnauthenticatedConnection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var output bytes.Buffer
+	err := Run(ctx, helperCommand("unauthenticated"), io.NopCloser(strings.NewReader("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n")), nopWriteCloser{&output}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if messages := decodeOutput(t, output.Bytes()); len(messages) != 1 || len(messages[0].Error) != 0 {
+		t.Fatalf("authenticated worker could not connect after rejecting intruder: %s", &output)
+	}
+}
+
+type observedWriteCloser struct {
+	io.WriteCloser
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (w *observedWriteCloser) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.entered) })
+	return w.WriteCloser.Write(p)
+}
+
+func TestRunCancellationWithBlockedOutput(t *testing.T) {
+	for _, stream := range []string{"stdout", "stderr"} {
+		t.Run(stream, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			input, client := io.Pipe()
+			reader, output := io.Pipe()
+			logReader, logWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			observed := &observedWriteCloser{WriteCloser: output, entered: make(chan struct{})}
+			mode := "hang"
+			if stream == "stderr" {
+				mode = "flood-logs"
+			}
+			cmd := helperCommand(mode)
+			done := make(chan error, 1)
+			go func() {
+				done <- Run(ctx, cmd, input, observed, logWriter)
+			}()
+			finished := false
+			t.Cleanup(func() {
+				cancel()
+				client.Close()
+				reader.Close()
+				output.Close()
+				logReader.Close()
+				logWriter.Close()
+				if !finished {
+					select {
+					case <-done:
+					case <-time.After(10 * time.Second):
+						t.Error("supervisor failed to clean up after releasing blocked outputs")
+					}
+				}
+			})
+			fmt.Fprintln(client, `{"jsonrpc":"2.0","id":"blocked","method":"crash"}`)
+			select {
+			case <-observed.entered:
+			case <-time.After(10 * time.Second):
+				t.Fatal("worker did not produce its progress notification")
+			}
+			if stream == "stderr" {
+				// Keep protocol output draining while the worker fills a real,
+				// deliberately unread diagnostic pipe.
+				go io.Copy(io.Discard, reader)
+				time.Sleep(100 * time.Millisecond)
+			}
+			cancel()
+			select {
+			case err := <-done:
+				finished = true
+				if err == nil || cmd.ProcessState == nil {
+					t.Fatalf("cancellation must return an error and reap the worker: err=%v state=%v", err, cmd.ProcessState)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatalf("supervisor still blocked on %s after cancellation", stream)
+			}
+		})
+	}
+}
+
+// Only nonblocking in-memory writers use this adapter. Blocking test outputs
+// use io.Pipe or os.Pipe so that Close really interrupts an active Write.
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+func newDiagnosticFile(t *testing.T) *os.File {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "diagnostics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { file.Close() })
+	return file
+}
+
+func readDiagnostics(t *testing.T, file *os.File) string {
+	t.Helper()
+	data, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/common/mcp/stdio/terminal_unix_test.go
+++ b/common/mcp/stdio/terminal_unix_test.go
@@ -1,0 +1,128 @@
+//go:build darwin || linux
+
+package stdio
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"golang.org/x/sys/unix"
+)
+
+func TestRunWithSharedTerminal(t *testing.T) {
+	for _, name := range []string{"cancel-before-request", "request-eof", "request-cancel"} {
+		t.Run(name, func(t *testing.T) {
+			master, slave, err := pty.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer master.Close()
+			defer slave.Close()
+			// Shells commonly duplicate one terminal descriptor onto stdin/stdout.
+			// Create Go's input wrapper while that shared description is blocking,
+			// just as os.Stdin is created before the CLI prepares protocol output.
+			fd := int(slave.Fd())
+			if err := unix.SetNonblock(fd, false); err != nil {
+				t.Fatal(err)
+			}
+			duplicate := func(label string) *os.File {
+				t.Helper()
+				copyFD, err := unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				f := os.NewFile(uintptr(copyFD), label)
+				t.Cleanup(func() { _ = f.Close() })
+				return f
+			}
+			input, output := duplicate("terminal-input"), duplicate("terminal-output")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			cmd := helperCommand("normal")
+			logs := newDiagnosticFile(t)
+			done := make(chan error, 1)
+			go func() { done <- Run(ctx, cmd, input, output, logs) }()
+			finished := false
+			t.Cleanup(func() {
+				cancel()
+				_ = master.Close()
+				_ = slave.Close()
+				if !finished {
+					select {
+					case <-done:
+					case <-time.After(10 * time.Second):
+						t.Error("terminal supervisor did not stop after closing the PTY")
+					}
+				}
+			})
+
+			select {
+			case err := <-done:
+				finished = true
+				t.Fatalf("exited before terminal input arrived: %v", err)
+			case <-time.After(150 * time.Millisecond):
+			}
+
+			if name != "cancel-before-request" {
+				responses := make(chan error, 1)
+				go func() {
+					scanner := bufio.NewScanner(master)
+					for scanner.Scan() {
+						var message envelope
+						if json.Unmarshal(scanner.Bytes(), &message) == nil && message.Method == "" && string(message.ID) == `"terminal"` {
+							if len(message.Result) == 0 || len(message.Error) != 0 {
+								responses <- fmt.Errorf("unexpected response: %s", scanner.Bytes())
+							} else {
+								responses <- nil
+							}
+							return
+						}
+					}
+					responses <- fmt.Errorf("terminal closed before response: %v", scanner.Err())
+				}()
+				if _, err := fmt.Fprintln(master, `{"jsonrpc":"2.0","id":"terminal","method":"ping"}`); err != nil {
+					t.Fatal(err)
+				}
+				select {
+				case err := <-responses:
+					if err != nil {
+						t.Fatal(err)
+					}
+				case <-time.After(10 * time.Second):
+					t.Fatal("no terminal response")
+				}
+			}
+
+			if name == "request-eof" {
+				if _, err := master.Write([]byte{4}); err != nil { // Ctrl+D on an empty canonical line.
+					t.Fatal(err)
+				}
+			} else {
+				cancel()
+			}
+			select {
+			case err := <-done:
+				finished = true
+				if name == "request-eof" && err != nil {
+					t.Fatalf("EOF failed: %v", err)
+				}
+				if name != "request-eof" && !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected cancellation, got %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("terminal input prevented shutdown")
+			}
+			flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFL, 0)
+			if err != nil || flags&unix.O_NONBLOCK != 0 {
+				t.Fatalf("terminal blocking mode was not restored: flags=%x err=%v", flags, err)
+			}
+		})
+	}
+}

--- a/common/mcp/yak_script.go
+++ b/common/mcp/yak_script.go
@@ -395,10 +395,12 @@ func handleExecYakScript(s *MCPServer) server.ToolHandlerFunc {
 			return nil, utils.Wrap(err, "failed to query yak script")
 		}
 		results := make([]any, 0, 4)
+		var executionFailed bool
 		for {
 			exec, err := stream.Recv()
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
+					executionFailed = true
 					results = append(results, mcp.TextContent{
 						Type: "text",
 						Text: fmt.Sprintf("[Error] %v", err),
@@ -431,7 +433,10 @@ func handleExecYakScript(s *MCPServer) server.ToolHandlerFunc {
 			})
 		}
 
-		return NewCommonCallToolResult(results)
+		return &mcp.CallToolResult{
+			Content: results,
+			IsError: executionFailed,
+		}, nil
 	}
 }
 

--- a/common/mcp/yak_script_error_test.go
+++ b/common/mcp/yak_script_error_test.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/mcp/mcp-go/mcp"
+	mcpserver "github.com/yaklang/yaklang/common/mcp/mcp-go/server"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+	"google.golang.org/grpc"
+)
+
+type scriptResultClient struct {
+	YakClientInterface
+	stream ypb.Yak_DebugPluginClient
+}
+
+func (c *scriptResultClient) DebugPlugin(context.Context, *ypb.DebugPluginRequest, ...grpc.CallOption) (ypb.Yak_DebugPluginClient, error) {
+	return c.stream, nil
+}
+
+type scriptResultStream struct {
+	grpc.ClientStream
+	messages []*ypb.ExecResult
+	err      error
+}
+
+func (s *scriptResultStream) Recv() (*ypb.ExecResult, error) {
+	if len(s.messages) == 0 {
+		return nil, s.err
+	}
+	message := s.messages[0]
+	s.messages = s.messages[1:]
+	return message, nil
+}
+
+func TestExecYakScriptStreamError(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		output    string
+		terminal  error
+		wantError bool
+	}{
+		{name: "empty success", terminal: io.EOF},
+		{name: "successful output", output: "script output", terminal: io.EOF},
+		{name: "panic", terminal: errors.New("YakVM Panic: test panic"), wantError: true},
+		{name: "output before failure", output: "partial output", terminal: errors.New("execution failed"), wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := &scriptResultStream{err: tt.terminal}
+			if tt.output != "" {
+				stream.messages = []*ypb.ExecResult{{IsMessage: true, Message: []byte(tt.output)}}
+			}
+			srv := &MCPServer{
+				server:     mcpserver.NewMCPServer("script-result-test", "1"),
+				grpcClient: &scriptResultClient{stream: stream},
+			}
+			request := mcp.CallToolRequest{}
+			request.Params.Arguments = map[string]any{"pluginType": "yak", "code": "test"}
+			result, err := handleExecYakScript(srv)(context.Background(), request)
+			require.NoError(t, err, "execution failures belong in the tool result")
+			require.NotNil(t, result)
+			require.Equal(t, tt.wantError, result.IsError)
+			var contents []string
+			for _, item := range result.Content {
+				text, ok := mcp.AsTextContent(item)
+				require.True(t, ok)
+				contents = append(contents, text.Text)
+			}
+			if tt.output != "" {
+				require.Contains(t, contents, tt.output, "preserve output produced before failure")
+			}
+			if tt.wantError {
+				require.Contains(t, contents, "[Error] "+tt.terminal.Error())
+			} else if tt.output == "" {
+				require.Equal(t, []string{"[System] Script execution completed with no output"}, contents)
+			}
+		})
+	}
+}

--- a/common/yak/cmd/yak.go
+++ b/common/yak/cmd/yak.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/yaklang/yaklang/common/coreplugin"
 	"github.com/yaklang/yaklang/common/cybertunnel"
 	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/mcp/stdio"
 	"github.com/yaklang/yaklang/common/schema"
 	cli "github.com/yaklang/yaklang/common/urfavecli"
 	"github.com/yaklang/yaklang/common/utils"
@@ -258,6 +259,9 @@ func init() {
 	/* 初始化数据库: 在 grpc 模式下，数据库应该不在 init 中使用 */
 	ignoreInitDatabase := []string{"grpc", "check-secret-local-grpc", "fixup-database", "ai-http-gateway"}
 	switch {
+	case len(os.Args) > 1 && os.Args[1] == "mcp" && log.IsMCPStdioCommand(os.Args) && !stdio.IsWorker():
+		// The stdio supervisor owns only the client transport. Its worker
+		// initializes databases; this branch must not print the grpc banner.
 	case len(os.Args) > 1 && slices.Contains(ignoreInitDatabase, os.Args[1]):
 		log.Debug("grpc should not initialize database in func:init")
 		fmt.Printf(`


### PR DESCRIPTION
MCP stdio clients can fail to parse JSON-RPC when server initialization or tool execution writes to stdout. A worker crash also previously terminated the transport without a correlated failure response. This change runs the MCP server in a supervised worker and keeps the client protocol output separate from worker diagnostics.

### Behavior

- Both `yak mcp` and the standalone MCP CLI re-execute the same binary and arguments after receiving the first client frame. An authenticated loopback TCP connection carries protocol messages; worker stdout/stderr inherit the client diagnostic descriptor directly.
- The supervisor tracks outstanding request IDs, drains complete responses on worker exit, and attempts `-32603` responses for unfinished requests. Calls are never replayed and workers are not automatically restarted.
- Bounded, cancellable protocol writes and direct diagnostic descriptor inheritance prevent unread stdout/stderr from indefinitely blocking shutdown. The CLI avoids a final fatal/panic write after a session failure.
- Preserve numeric request IDs in the server envelope with `json.Number`, so adjacent IDs above 2^53 round-trip correctly and do not leave false pending requests. Tool argument decoding retains its existing types.

### Validation

- `go test -race ./common/mcp/stdio ./common/mcp/mcp-go/server ./common/log -count=1 -timeout=3m`
- `go test ./common/mcp -run '^TestMUSTPASS_MCPCommandStdioKeepsStdoutJSONRPCOnly$' -count=1 -timeout=6m`
- `go vet ./common/mcp/stdio ./common/mcp/mcp-go/server ./common/log`
- Linux/amd64 and Windows/amd64 cross-compilation of the stdio test binary; execution tests ran on macOS/arm64.
- Regression tests reproduced blocked stdout/stderr cancellation and rounded request IDs before the respective fixes. CLI tests cover both entry points, actual Yak script output, large request IDs, worker death with stdin open, and an unread full stderr pipe through process exit.

### Operational boundaries

Initialization has a 60-second deadline; client EOF gives the worker five seconds to finish. Each protocol frame has a five-second write budget, shortened to a 250 ms grace period after cancellation, and the scanner limit is 64 MiB. A slow or non-reading client may therefore lose the connection; a partial JSON frame is never followed by a synthetic error. Unix cleanup covers the worker process group; Windows cleanup covers the direct worker. Parent package initializers still run, so the existing early logging/stdout protections remain necessary.
