### PR TITLE
feat(mitm): defer SSE too-large marking until body exceeds MaxContentLength

### DIFF
--- a/common/minimartian/lowhttp_exec.go
+++ b/common/minimartian/lowhttp_exec.go
@@ -287,7 +287,6 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 			// into memory. The trigger timing is decided inside the callback.
 			if isServerSentEventContentType(value) {
 				httpctx.SetNoBodyBuffer(req, true)
-				httpctx.SetResponseReadTooSlow(req, true)
 				httpctx.SetResponseHeaderCallback(req, p.makeStreamResponseCallback(isHttps, req, bwr, cancelUpstream))
 				return
 			}
@@ -386,6 +385,10 @@ func (p *Proxy) execLowhttp(ctx *Context, req *http.Request) (*http.Response, er
 // only created for SSE responses (see the kind == streamKindSSE guard below):
 // SSE disables body buffering, so the spill file is the only way to persist
 // the long-lived body. Recorder write errors never break or delay forwarding.
+//
+// The recorder defers too-large / read-too-slow marking until the accumulated
+// body exceeds MaxContentLength. Small SSE responses that stay within the
+// limit are finalized as normal flows; only large responses are marked.
 func (p *Proxy) makeStreamResponseCallback(
 	isHTTPS bool,
 	req *http.Request,
@@ -417,19 +420,25 @@ func (p *Proxy) makeStreamResponseCallback(
 		// Only SSE responses need a recorder: SSE sets NoBodyBuffer so the
 		// response builder never buffers the long-lived body, and the only
 		// way to persist it for history/audit is the spill file the recorder
-		// writes incrementally. The recorder also marks the flow as
-		// read-too-slow so History/API reconstruct the response from the
-		// spill file instead of the (empty) DB body.
+		// writes incrementally.
+		//
+		// The recorder is created with a size threshold (MaxContentLength).
+		// It does NOT mark the flow as too-large / read-too-slow upfront.
+		// Instead, it tracks the accumulated body size and only marks the
+		// flow when the body exceeds the threshold. Small SSE responses that
+		// stay within the limit are finalized as normal flows (body read
+		// back from the spill file into the DB), while large responses keep
+		// the spill files and the too-large flags — matching the behavior
+		// of non-streaming large responses.
 		//
 		// Filtered and chunked/large responses do NOT set NoBodyBuffer, so
 		// the response builder still buffers the full body and the ordinary
 		// mirror path persists it. Creating a recorder for them would
-		// unconditionally mark the flow read-too-slow and attach spill files
-		// even when the body is smaller than MaxContentLength (e.g. a chunked
-		// 4 MB response under a 5 MB limit), which is incorrect. The
-		// too-large decision for those kinds stays with the response builder,
-		// which judges by the actual body size — matching the pre-SSE
-		// behavior.
+		// unconditionally attach spill files even when the body is smaller
+		// than MaxContentLength (e.g. a chunked 4 MB response under a 5 MB
+		// limit), which is incorrect. The too-large decision for those kinds
+		// stays with the response builder, which judges by the actual body
+		// size — matching the pre-SSE behavior.
 		var recorder io.WriteCloser
 		var closeOnce sync.Once
 		closeRecorder := func() {
@@ -441,13 +450,25 @@ func (p *Proxy) makeStreamResponseCallback(
 				}
 			})
 		}
+		// MaxContentLength is used both as the recorder size threshold (for
+		// deferred too-large marking on SSE) and as the buffered trigger's
+		// size limit.
+		MaxContentLength := int(consts.GetGlobalMaxContentLength())
+		if p.GetMaxContentLength() != 0 {
+			MaxContentLength = p.maxContentLength
+		}
+
 		if kind == streamKindSSE && p.streamRecorder != nil {
 			recorderRsp, err := utils.ReadHTTPResponseFromBytes(headerBytes, nil)
 			if err != nil {
 				log.Warnf("mitm: parse response header for recorder failed: %v", err)
 			} else {
 				recorderRsp.Request = req
-				recorder, err = p.streamRecorder(isHTTPS, req, recorderRsp, headerBytes)
+				// For SSE, pass the MaxContentLength as the size threshold so
+				// the recorder defers marking the flow as too-large until the
+				// body actually exceeds the limit. Small SSE responses that
+				// stay within the limit are persisted as normal flows.
+				recorder, err = p.streamRecorder(isHTTPS, req, recorderRsp, headerBytes, int64(MaxContentLength))
 				if err != nil {
 					log.Warnf("mitm: create stream recorder failed: %v", err)
 					recorder = nil
@@ -493,11 +514,6 @@ func (p *Proxy) makeStreamResponseCallback(
 			}()
 		}
 
-		// Choose the trigger based on the streaming kind.
-		MaxContentLength := int(consts.GetGlobalMaxContentLength())
-		if p.GetMaxContentLength() != 0 {
-			MaxContentLength = p.maxContentLength
-		}
 		var writerCloser *utils.TriggerWriter
 		if immediate {
 			writerCloser = utils.NewTriggerWriterImmediate(triggerHandler)

--- a/common/minimartian/lowhttp_exec_sse_test.go
+++ b/common/minimartian/lowhttp_exec_sse_test.go
@@ -120,7 +120,7 @@ func TestExecLowHTTPStreamsAndRecordsSSEBeforeEOF(t *testing.T) {
 	t.Cleanup(cancelPool)
 	proxy.SetConnPool(lowhttp.NewHttpConnPool(poolCtx, 100, 2))
 	recorderCreated := make(chan *testStreamRecorder, 1)
-	proxy.SetHTTPStreamRecorderFactory(func(_ bool, _ *http.Request, _ *http.Response, _ []byte) (io.WriteCloser, error) {
+	proxy.SetHTTPStreamRecorderFactory(func(_ bool, _ *http.Request, _ *http.Response, _ []byte, _ int64) (io.WriteCloser, error) {
 		recorder := &testStreamRecorder{closed: make(chan struct{})}
 		recorderCreated <- recorder
 		return recorder, nil

--- a/common/minimartian/martian.go
+++ b/common/minimartian/martian.go
@@ -39,7 +39,13 @@ type ResponseModifier interface {
 // streaming responses (e.g. SSE). The recorder receives body chunks as they
 // are relayed to the downstream client. Recorder failures must not affect
 // forwarding; a nil return disables recording for this response.
-type HTTPStreamRecorderFactory func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte) (io.WriteCloser, error)
+//
+// sizeThreshold is the body size that must be exceeded before the recorder
+// marks the flow as too-large / read-too-slow. When 0, the recorder marks the
+// flow immediately (legacy behavior). When > 0, the recorder defers marking
+// until the accumulated body exceeds the threshold, allowing small streaming
+// responses to be persisted as normal flows.
+type HTTPStreamRecorderFactory func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte, sizeThreshold int64) (io.WriteCloser, error)
 
 // RequestResponseModifier is an interface that is both a ResponseModifier and
 // a RequestModifier.

--- a/common/yakgrpc/grpc_mitm.go
+++ b/common/yakgrpc/grpc_mitm.go
@@ -1577,11 +1577,11 @@ func (s *Server) MITM(stream ypb.Yak_MITMServer) error {
 		}
 	}
 
-	streamRecorderFactory := minimartian.HTTPStreamRecorderFactory(func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte) (io.WriteCloser, error) {
+	streamRecorderFactory := minimartian.HTTPStreamRecorderFactory(func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte, sizeThreshold int64) (io.WriteCloser, error) {
 		if httpctx.IsFiltered(req) {
 			return nil, nil
 		}
-		return yakit.NewHTTPFlowStreamRecorder(s.GetProjectDatabase(), isHTTPS, req, rsp, headerBytes)
+		return yakit.NewHTTPFlowStreamRecorder(s.GetProjectDatabase(), isHTTPS, req, rsp, headerBytes, sizeThreshold)
 	})
 
 	handleMirrorResponse := func(isHttps bool, reqUrl string, req *http.Request, rsp *http.Response, remoteAddr string) {

--- a/common/yakgrpc/grpc_mitm_v2.go
+++ b/common/yakgrpc/grpc_mitm_v2.go
@@ -1693,11 +1693,11 @@ func (s *Server) MITMV2(stream ypb.Yak_MITMV2Server) error {
 		}
 	}
 
-	streamRecorderFactory := minimartian.HTTPStreamRecorderFactory(func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte) (io.WriteCloser, error) {
+	streamRecorderFactory := minimartian.HTTPStreamRecorderFactory(func(isHTTPS bool, req *http.Request, rsp *http.Response, headerBytes []byte, sizeThreshold int64) (io.WriteCloser, error) {
 		if httpctx.IsFiltered(req) {
 			return nil, nil
 		}
-		return yakit.NewHTTPFlowStreamRecorder(s.GetProjectDatabase(), isHTTPS, req, rsp, headerBytes)
+		return yakit.NewHTTPFlowStreamRecorder(s.GetProjectDatabase(), isHTTPS, req, rsp, headerBytes, sizeThreshold)
 	})
 
 	handleMirrorResponse := func(isHttps bool, reqUrl string, req *http.Request, rsp *http.Response, remoteAddr string) {

--- a/common/yakgrpc/yakit/httpflow_stream.go
+++ b/common/yakgrpc/yakit/httpflow_stream.go
@@ -1,6 +1,7 @@
 package yakit
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +24,13 @@ const httpFlowStreamProgressInterval = 500 * time.Millisecond
 // HTTPFlowStreamRecorder persists response metadata as soon as headers arrive
 // and appends the streaming body to a spill file while the connection remains
 // open. It intentionally keeps database writes off the response hot path.
+//
+// When sizeThreshold > 0 (deferred mode), the recorder buffers body chunks in
+// memory until the accumulated size exceeds the threshold. Only then does it
+// create spill files and mark the flow as too-large / read-too-slow. If the
+// body stays within the threshold, the in-memory buffer is used directly in
+// Finalize — no spill files are ever created. When sizeThreshold <= 0 (legacy
+// mode), spill files are created immediately and the flow is marked upfront.
 type HTTPFlowStreamRecorder struct {
 	mu sync.Mutex
 
@@ -30,14 +38,33 @@ type HTTPFlowStreamRecorder struct {
 	insertFlow  func(*gorm.DB, *schema.HTTPFlow) error
 	req         *http.Request
 	initialFlow *schema.HTTPFlow
-	bodyFile    *os.File
-	headerFile  string
-	bodyPath    string
 	startedAt   time.Time
 	bodyLength  int64
 	writeErr    error
 	closed      bool
 	insertErr   error
+
+	// sizeThreshold is the body size that must be exceeded before the
+	// recorder creates spill files and marks the flow as too-large /
+	// read-too-slow. If 0, the recorder creates spill files immediately
+	// (legacy behavior).
+	sizeThreshold int64
+
+	// headerBytes stores the raw response header for later use (spill file
+	// creation or inline Finalize).
+	headerBytes []byte
+
+	// In-memory body buffer used in deferred mode before the threshold is
+	// exceeded. Once spilled, this is nil and bodyFile takes over.
+	bodyBuffer *bytes.Buffer
+
+	// Spill files — created lazily in deferred mode, or immediately in
+	// legacy mode.
+	bodyFile   *os.File
+	headerFile string
+	bodyPath   string
+
+	tooLargeMarked bool
 
 	insertDone chan struct{}
 	stopCh     chan struct{}
@@ -52,8 +79,9 @@ func NewHTTPFlowStreamRecorder(
 	req *http.Request,
 	rsp *http.Response,
 	headerBytes []byte,
+	sizeThreshold int64,
 ) (_ *HTTPFlowStreamRecorder, retErr error) {
-	return newHTTPFlowStreamRecorder(db, isHTTPS, req, rsp, headerBytes, InsertHTTPFlow)
+	return newHTTPFlowStreamRecorder(db, isHTTPS, req, rsp, headerBytes, sizeThreshold, InsertHTTPFlow)
 }
 
 func newHTTPFlowStreamRecorder(
@@ -62,6 +90,7 @@ func newHTTPFlowStreamRecorder(
 	req *http.Request,
 	rsp *http.Response,
 	headerBytes []byte,
+	sizeThreshold int64,
 	insertFlow func(*gorm.DB, *schema.HTTPFlow) error,
 ) (_ *HTTPFlowStreamRecorder, retErr error) {
 	if db == nil {
@@ -73,37 +102,6 @@ func newHTTPFlowStreamRecorder(
 	if insertFlow == nil {
 		return nil, utils.Error("create HTTP stream recorder: insert function is nil")
 	}
-
-	suffix := fmt.Sprintf("%s-%s", time.Now().Format(utils.DatetimePretty()), ksuid.New().String())
-	headerFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-header-%s.txt", suffix))
-	if err != nil {
-		return nil, utils.Wrap(err, "create HTTP stream response header file")
-	}
-	headerPath := headerFP.Name()
-	defer func() {
-		_ = headerFP.Close()
-		if retErr != nil {
-			_ = os.Remove(headerPath)
-		}
-	}()
-	if _, err := headerFP.Write(headerBytes); err != nil {
-		return nil, utils.Wrap(err, "write HTTP stream response header")
-	}
-	if err := headerFP.Sync(); err != nil {
-		return nil, utils.Wrap(err, "sync HTTP stream response header")
-	}
-
-	bodyFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-body-%s.bin", suffix))
-	if err != nil {
-		return nil, utils.Wrap(err, "create HTTP stream response body file")
-	}
-	bodyPath := bodyFP.Name()
-	defer func() {
-		if retErr != nil {
-			_ = bodyFP.Close()
-			_ = os.Remove(bodyPath)
-		}
-	}()
 
 	requestURL := httpctx.GetRequestURL(req)
 	if requestURL == "" {
@@ -121,33 +119,82 @@ func newHTTPFlowStreamRecorder(
 	flow.ContentType = rsp.Header.Get("Content-Type")
 	flow.BodyLength = 0
 	flow.Duration = 0
-	flow.IsReadTooSlowResponse = true
-	flow.IsTooLargeResponse = true
-	flow.TooLargeResponseHeaderFile = headerPath
-	flow.TooLargeResponseBodyFile = bodyPath
+
+	var (
+		bodyFile   *os.File
+		headerPath string
+		bodyPath   string
+	)
+
+	if sizeThreshold <= 0 {
+		// Legacy mode: create spill files immediately and mark the flow.
+		headerFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-header-%s.txt", time.Now().Format(utils.DatetimePretty())+"-"+ksuid.New().String()))
+		if err != nil {
+			return nil, utils.Wrap(err, "create HTTP stream response header file")
+		}
+		headerPath = headerFP.Name()
+		defer func() {
+			_ = headerFP.Close()
+			if retErr != nil {
+				_ = os.Remove(headerPath)
+			}
+		}()
+		if _, err := headerFP.Write(headerBytes); err != nil {
+			return nil, utils.Wrap(err, "write HTTP stream response header")
+		}
+		if err := headerFP.Sync(); err != nil {
+			return nil, utils.Wrap(err, "sync HTTP stream response header")
+		}
+
+		suffix := fmt.Sprintf("%s-%s", time.Now().Format(utils.DatetimePretty()), ksuid.New().String())
+		bodyFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-body-%s.bin", suffix))
+		if err != nil {
+			return nil, utils.Wrap(err, "create HTTP stream response body file")
+		}
+		bodyPath = bodyFP.Name()
+		bodyFile = bodyFP
+		defer func() {
+			if retErr != nil {
+				_ = bodyFP.Close()
+				_ = os.Remove(bodyPath)
+			}
+		}()
+
+		flow.IsReadTooSlowResponse = true
+		flow.IsTooLargeResponse = true
+		flow.TooLargeResponseHeaderFile = headerPath
+		flow.TooLargeResponseBodyFile = bodyPath
+
+		httpctx.SetResponseReadTooSlow(req, true)
+		httpctx.SetResponseTooLarge(req, true)
+		httpctx.SetResponseTooLargeHeaderFile(req, headerPath)
+		httpctx.SetResponseTooLargeBodyFile(req, bodyPath)
+	}
+
 	if name := httpctx.GetProcessName(req); name != "" {
 		flow.ProcessName.String = filepath.Base(name)
 		flow.ProcessName.Valid = true
 	}
 	flow.Hash = flow.CalcHash()
 
-	httpctx.SetResponseReadTooSlow(req, true)
-	httpctx.SetResponseTooLarge(req, true)
-	httpctx.SetResponseTooLargeHeaderFile(req, headerPath)
-	httpctx.SetResponseTooLargeBodyFile(req, bodyPath)
-
 	recorder := &HTTPFlowStreamRecorder{
-		db:          db,
-		insertFlow:  insertFlow,
-		req:         req,
-		initialFlow: flow,
-		bodyFile:    bodyFP,
-		headerFile:  headerPath,
-		bodyPath:    bodyPath,
-		startedAt:   time.Now(),
-		insertDone:  make(chan struct{}),
-		stopCh:      make(chan struct{}),
-		doneCh:      make(chan struct{}),
+		db:            db,
+		insertFlow:    insertFlow,
+		req:           req,
+		initialFlow:   flow,
+		headerBytes:   headerBytes,
+		bodyBuffer:    bytes.NewBuffer(nil),
+		bodyFile:      bodyFile,
+		headerFile:    headerPath,
+		bodyPath:      bodyPath,
+		startedAt:     time.Now(),
+		sizeThreshold: sizeThreshold,
+		insertDone:    make(chan struct{}),
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	if sizeThreshold <= 0 {
+		recorder.tooLargeMarked = true
 	}
 	go recorder.insertInitialFlow()
 	go recorder.runProgressUpdater()
@@ -172,6 +219,71 @@ func (r *HTTPFlowStreamRecorder) insertInitialFlow() {
 	close(r.insertDone)
 }
 
+// markTooLarge creates spill files (flushing the in-memory buffer), sets the
+// too-large / read-too-slow flags on both the httpctx and the DB row. It must
+// be called with r.mu held.
+func (r *HTTPFlowStreamRecorder) markTooLarge() {
+	if r == nil || r.req == nil {
+		return
+	}
+
+	// Create spill files and flush the in-memory buffer.
+	suffix := fmt.Sprintf("%s-%s", time.Now().Format(utils.DatetimePretty()), ksuid.New().String())
+	headerFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-header-%s.txt", suffix))
+	if err != nil {
+		log.Warnf("create spill header file for too-large stream failed: %v", err)
+		return
+	}
+	if _, err := headerFP.Write(r.headerBytes); err != nil {
+		log.Warnf("write spill header file for too-large stream failed: %v", err)
+		_ = headerFP.Close()
+		_ = os.Remove(headerFP.Name())
+		return
+	}
+	_ = headerFP.Sync()
+	_ = headerFP.Close()
+	r.headerFile = headerFP.Name()
+
+	bodyFP, err := utils.OpenTempFile(fmt.Sprintf("stream-response-body-%s.bin", suffix))
+	if err != nil {
+		log.Warnf("create spill body file for too-large stream failed: %v", err)
+		_ = os.Remove(r.headerFile)
+		return
+	}
+	r.bodyPath = bodyFP.Name()
+	r.bodyFile = bodyFP
+
+	// Flush the in-memory buffer to the spill file.
+	if r.bodyBuffer != nil && r.bodyBuffer.Len() > 0 {
+		if _, err := bodyFP.Write(r.bodyBuffer.Bytes()); err != nil {
+			log.Warnf("flush in-memory buffer to spill file failed: %v", err)
+		}
+	}
+	r.bodyBuffer = nil
+
+	httpctx.SetResponseReadTooSlow(r.req, true)
+	httpctx.SetResponseTooLarge(r.req, true)
+	httpctx.SetResponseTooLargeHeaderFile(r.req, r.headerFile)
+	httpctx.SetResponseTooLargeBodyFile(r.req, r.bodyPath)
+
+	// Best-effort DB update.
+	flowID := r.initialFlow.ID
+	if flowID > 0 {
+		go func() {
+			err := r.db.Model(&schema.HTTPFlow{}).Where("id = ?", flowID).UpdateColumns(map[string]any{
+				"is_read_too_slow_response":      true,
+				"is_too_large_response":           true,
+				"too_large_response_header_file": r.headerFile,
+				"too_large_response_body_file":   r.bodyPath,
+				"updated_at":                     time.Now(),
+			}).Error
+			if err != nil {
+				log.Warnf("mark too-large on stream flow failed: flow_id=%d error=%v", flowID, err)
+			}
+		}()
+	}
+}
+
 func (r *HTTPFlowStreamRecorder) waitForInsert() error {
 	if r == nil {
 		return nil
@@ -188,17 +300,31 @@ func (r *HTTPFlowStreamRecorder) Write(p []byte) (int, error) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.closed || r.bodyFile == nil || r.writeErr != nil {
+	if r.closed {
 		return len(p), nil
 	}
-	n, err := r.bodyFile.Write(p)
-	r.bodyLength += int64(n)
-	if err == nil && n != len(p) {
-		err = io.ErrShortWrite
-	}
-	if err != nil {
-		r.writeErr = err
-		log.Warnf("append HTTP stream response body failed: path=%s error=%v", r.bodyPath, err)
+
+	if r.bodyFile != nil {
+		// Already spilled to file.
+		n, err := r.bodyFile.Write(p)
+		r.bodyLength += int64(n)
+		if err == nil && n != len(p) {
+			err = io.ErrShortWrite
+		}
+		if err != nil {
+			r.writeErr = err
+			log.Warnf("append HTTP stream response body failed: path=%s error=%v", r.bodyPath, err)
+		}
+	} else if r.bodyBuffer != nil {
+		// In-memory buffering (deferred mode, not yet spilled).
+		r.bodyBuffer.Write(p)
+		r.bodyLength += int64(len(p))
+
+		// Check threshold: if exceeded, spill to file and mark too-large.
+		if r.sizeThreshold > 0 && !r.tooLargeMarked && r.bodyLength > r.sizeThreshold {
+			r.tooLargeMarked = true
+			r.markTooLarge()
+		}
 	}
 
 	// Capturing must never break or delay forwarding with a recorder error.
@@ -247,17 +373,22 @@ func (r *HTTPFlowStreamRecorder) updateProgress(syncFile bool) {
 	bodyLength := r.bodyLength
 	duration := time.Since(r.startedAt)
 	flowID := r.initialFlow.ID
+	tooLargeMarked := r.tooLargeMarked
+	sizeThreshold := r.sizeThreshold
 	r.mu.Unlock()
 
-	err := r.db.Model(&schema.HTTPFlow{}).Where("id = ?", flowID).UpdateColumns(map[string]any{
-		"body_length":                    bodyLength,
-		"duration":                       int64(duration),
-		"is_read_too_slow_response":      true,
-		"is_too_large_response":           true,
-		"too_large_response_header_file": r.headerFile,
-		"too_large_response_body_file":   r.bodyPath,
-		"updated_at":                     time.Now(),
-	}).Error
+	updates := map[string]any{
+		"body_length":  bodyLength,
+		"duration":     int64(duration),
+		"updated_at":   time.Now(),
+	}
+	if tooLargeMarked || sizeThreshold <= 0 {
+		updates["is_read_too_slow_response"] = true
+		updates["is_too_large_response"] = true
+		updates["too_large_response_header_file"] = r.headerFile
+		updates["too_large_response_body_file"] = r.bodyPath
+	}
+	err := r.db.Model(&schema.HTTPFlow{}).Where("id = ?", flowID).UpdateColumns(updates).Error
 	if err != nil {
 		log.Warnf("update HTTP stream flow progress failed: flow_id=%d error=%v", flowID, err)
 	}
@@ -308,6 +439,8 @@ func (r *HTTPFlowStreamRecorder) BodyFile() string {
 	if r == nil {
 		return ""
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.bodyPath
 }
 
@@ -315,6 +448,8 @@ func (r *HTTPFlowStreamRecorder) HeaderFile() string {
 	if r == nil {
 		return ""
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.headerFile
 }
 
@@ -341,19 +476,37 @@ func (r *HTTPFlowStreamRecorder) Finalize(flow *schema.HTTPFlow) error {
 	r.mu.Lock()
 	bodyLength := r.bodyLength
 	duration := time.Since(r.startedAt)
+	tooLargeMarked := r.tooLargeMarked
+	sizeThreshold := r.sizeThreshold
+	bodyBuffer := r.bodyBuffer
+	headerBytes := r.headerBytes
 	r.mu.Unlock()
 
 	flow.Model = r.initialFlow.Model
 	flow.HiddenIndex = r.initialFlow.HiddenIndex
-	flow.Response = r.initialFlow.Response
 	flow.StatusCode = r.initialFlow.StatusCode
 	flow.ContentType = r.initialFlow.ContentType
 	flow.BodyLength = bodyLength
 	flow.Duration = int64(duration)
-	flow.IsReadTooSlowResponse = true
-	flow.IsTooLargeResponse = true
-	flow.TooLargeResponseHeaderFile = r.headerFile
-	flow.TooLargeResponseBodyFile = r.bodyPath
+
+	if tooLargeMarked || sizeThreshold <= 0 {
+		// Body exceeded the threshold (or legacy mode): keep spill files
+		// and mark the flow as too-large / read-too-slow.
+		flow.Response = r.initialFlow.Response
+		flow.IsReadTooSlowResponse = true
+		flow.IsTooLargeResponse = true
+		flow.TooLargeResponseHeaderFile = r.headerFile
+		flow.TooLargeResponseBodyFile = r.bodyPath
+	} else {
+		// Body stayed within the threshold: use the in-memory buffer
+		// directly. No spill files were ever created.
+		fullPacket := make([]byte, 0, len(headerBytes)+bodyBuffer.Len())
+		fullPacket = append(fullPacket, headerBytes...)
+		if bodyBuffer != nil {
+			fullPacket = append(fullPacket, bodyBuffer.Bytes()...)
+		}
+		flow.SetResponse(string(fullPacket))
+	}
 	return SaveHTTPFlow(r.db, flow)
 }
 
@@ -363,12 +516,28 @@ func (r *HTTPFlowStreamRecorder) Drop() error {
 	}
 	_ = r.Close()
 	if err := r.waitForInsert(); err != nil {
-		_ = os.Remove(r.headerFile)
-		_ = os.Remove(r.bodyPath)
+		r.mu.Lock()
+		headerFile := r.headerFile
+		bodyPath := r.bodyPath
+		r.mu.Unlock()
+		if headerFile != "" {
+			_ = os.Remove(headerFile)
+		}
+		if bodyPath != "" {
+			_ = os.Remove(bodyPath)
+		}
 		return err
 	}
 	err := DeleteHTTPFlowByID(r.db, int64(r.initialFlow.ID))
-	_ = os.Remove(r.headerFile)
-	_ = os.Remove(r.bodyPath)
+	r.mu.Lock()
+	headerFile := r.headerFile
+	bodyPath := r.bodyPath
+	r.mu.Unlock()
+	if headerFile != "" {
+		_ = os.Remove(headerFile)
+	}
+	if bodyPath != "" {
+		_ = os.Remove(bodyPath)
+	}
 	return err
 }

--- a/common/yakgrpc/yakit/httpflow_stream_test.go
+++ b/common/yakgrpc/yakit/httpflow_stream_test.go
@@ -37,7 +37,7 @@ func TestHTTPFlowStreamRecorderPersistsBeforeEOF(t *testing.T) {
 		},
 		Request: req,
 	}
-	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header)
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = recorder.Close()
@@ -119,7 +119,7 @@ func TestHTTPFlowStreamRecorderDoesNotBlockOnInitialInsert(t *testing.T) {
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(releaseInsert) }) }
 	t.Cleanup(release)
-	recorder, err := newHTTPFlowStreamRecorder(db, true, req, rsp, header, func(db *gorm.DB, flow *schema.HTTPFlow) error {
+	recorder, err := newHTTPFlowStreamRecorder(db, true, req, rsp, header, 0, func(db *gorm.DB, flow *schema.HTTPFlow) error {
 		close(insertStarted)
 		<-releaseInsert
 		return InsertHTTPFlow(db, flow)
@@ -179,7 +179,7 @@ func TestHTTPFlowStreamRecorderDropRemovesFlowAndSpillFiles(t *testing.T) {
 		},
 		Request: req,
 	}
-	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header)
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header, 0)
 	require.NoError(t, err)
 	headerFile := recorder.HeaderFile()
 	bodyFile := recorder.BodyFile()
@@ -221,7 +221,7 @@ func TestHTTPFlowStreamRecorderInsertFailureDoesNotBreakCapture(t *testing.T) {
 		},
 		Request: req,
 	}
-	recorder, err := newHTTPFlowStreamRecorder(db, true, req, rsp, header, func(*gorm.DB, *schema.HTTPFlow) error {
+	recorder, err := newHTTPFlowStreamRecorder(db, true, req, rsp, header, 0, func(*gorm.DB, *schema.HTTPFlow) error {
 		return utils.Error("insert unavailable")
 	})
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestHTTPFlowStreamRecorderMarksTooLargeResponse(t *testing.T) {
 		},
 		Request: req,
 	}
-	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header)
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = recorder.Close()
@@ -306,4 +306,199 @@ func TestHTTPFlowStreamRecorderMarksTooLargeResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, final.IsTooLargeResponse, "finalized flow must mark IsTooLargeResponse")
 	require.True(t, final.IsReadTooSlowResponse)
+}
+
+func TestHTTPFlowStreamRecorderDefersTooLargeUntilThreshold(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.AutoMigrate(&schema.HTTPFlow{}).Error)
+
+	requestRaw := lowhttp.FixHTTPRequest([]byte("GET /events HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	req, err := lowhttp.ParseBytesToHttpRequest(requestRaw)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, requestRaw)
+	httpctx.SetPlainRequestBytes(req, requestRaw)
+	httpctx.SetRequestURL(req, "https://example.com/events")
+
+	header := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+	rsp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Request: req,
+	}
+	// Use a size threshold of 100 bytes — small SSE bodies under 100 bytes
+	// should NOT be marked as too-large.
+	const threshold = 100
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header, threshold)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = recorder.Close()
+	})
+
+	// The initial flow must NOT be marked as too-large when sizeThreshold > 0.
+	initial, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+	require.NoError(t, err)
+	require.False(t, initial.IsTooLargeResponse, "initial flow must NOT mark IsTooLargeResponse when threshold > 0")
+	require.False(t, initial.IsReadTooSlowResponse, "initial flow must NOT mark IsReadTooSlowResponse when threshold > 0")
+
+	// httpctx must also NOT be tagged.
+	require.False(t, httpctx.GetResponseTooLarge(req))
+	require.False(t, httpctx.GetResponseReadTooSlow(req))
+
+	// Write a small body that stays under the threshold.
+	smallBody := []byte("data: small\n\n")
+	_, err = recorder.Write(smallBody)
+	require.NoError(t, err)
+
+	// Still not marked as too-large.
+	require.False(t, httpctx.GetResponseTooLarge(req), "must not mark too-large while under threshold")
+
+	// Finalize: small SSE should be persisted as a normal flow (no too-large
+	// flags, spill files cleaned up, body inline in Response).
+	finalFlow, err := CreateHTTPFlowFromHTTPWithNoRspSaved(true, req, "mitm", "https://example.com/events", "127.0.0.1:443")
+	require.NoError(t, err)
+	finalFlow.StatusCode = 200
+	finalFlow.ContentType = "text/event-stream"
+	require.NoError(t, recorder.Finalize(finalFlow))
+
+	final, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+	require.NoError(t, err)
+	require.False(t, final.IsTooLargeResponse, "finalized small SSE must NOT mark IsTooLargeResponse")
+	require.False(t, final.IsReadTooSlowResponse, "finalized small SSE must NOT mark IsReadTooSlowResponse")
+	require.Empty(t, final.TooLargeResponseHeaderFile, "spill header file must be cleaned up")
+	require.Empty(t, final.TooLargeResponseBodyFile, "spill body file must be cleaned up")
+
+	// The response packet must contain both header and body.
+	packet, err := LoadHTTPFlowResponsePacket(final)
+	require.NoError(t, err)
+	require.Contains(t, string(packet), "data: small", "response packet must contain the body")
+
+	// Spill files must never have been created for a small SSE.
+	require.Empty(t, recorder.HeaderFile(), "no header spill file should exist for small SSE")
+	require.Empty(t, recorder.BodyFile(), "no body spill file should exist for small SSE")
+}
+
+func TestHTTPFlowStreamRecorderMarksTooLargeAfterThresholdExceeded(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.AutoMigrate(&schema.HTTPFlow{}).Error)
+
+	requestRaw := lowhttp.FixHTTPRequest([]byte("GET /events HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	req, err := lowhttp.ParseBytesToHttpRequest(requestRaw)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, requestRaw)
+	httpctx.SetPlainRequestBytes(req, requestRaw)
+	httpctx.SetRequestURL(req, "https://example.com/events")
+
+	header := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+	rsp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Request: req,
+	}
+	// Use a size threshold of 50 bytes — write a body that exceeds it.
+	const threshold = 50
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header, threshold)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = recorder.Close()
+	})
+
+	// Initial flow must NOT be marked.
+	initial, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+	require.NoError(t, err)
+	require.False(t, initial.IsTooLargeResponse)
+
+	// Write a body that exceeds the threshold.
+	largeBody := []byte("data: this is a large SSE body that exceeds the 50-byte threshold for sure\n\n")
+	_, err = recorder.Write(largeBody)
+	require.NoError(t, err)
+
+	// Now it must be marked as too-large.
+	require.True(t, httpctx.GetResponseTooLarge(req), "must mark too-large after exceeding threshold")
+	require.True(t, httpctx.GetResponseReadTooSlow(req), "must mark read-too-slow after exceeding threshold")
+
+	// Finalize: large SSE must keep too-large flags and spill files.
+	finalFlow, err := CreateHTTPFlowFromHTTPWithNoRspSaved(true, req, "mitm", "https://example.com/events", "127.0.0.1:443")
+	require.NoError(t, err)
+	finalFlow.StatusCode = 200
+	finalFlow.ContentType = "text/event-stream"
+	require.NoError(t, recorder.Finalize(finalFlow))
+
+	final, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+	require.NoError(t, err)
+	require.True(t, final.IsTooLargeResponse, "finalized large SSE must mark IsTooLargeResponse")
+	require.True(t, final.IsReadTooSlowResponse, "finalized large SSE must mark IsReadTooSlowResponse")
+	require.NotEmpty(t, final.TooLargeResponseHeaderFile)
+	require.NotEmpty(t, final.TooLargeResponseBodyFile)
+}
+
+func TestHTTPFlowStreamRecorderLargeSSELoadsFromSpillFile(t *testing.T) {
+	t.Setenv("YAKIT_HOME", t.TempDir())
+	db, err := utils.CreateTempTestDatabaseInMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.AutoMigrate(&schema.HTTPFlow{}).Error)
+
+	requestRaw := lowhttp.FixHTTPRequest([]byte("GET /events HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	req, err := lowhttp.ParseBytesToHttpRequest(requestRaw)
+	require.NoError(t, err)
+	httpctx.SetBareRequestBytes(req, requestRaw)
+	httpctx.SetPlainRequestBytes(req, requestRaw)
+	httpctx.SetRequestURL(req, "https://example.com/events")
+
+	header := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+	rsp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Request: req,
+	}
+	// Threshold of 30 bytes, write a body exceeding it.
+	const threshold = 30
+	recorder, err := NewHTTPFlowStreamRecorder(db, true, req, rsp, header, threshold)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = recorder.Close()
+	})
+
+	// Write body in two chunks; the first alone exceeds the threshold.
+	chunk1 := []byte("data: this exceeds 30 bytes easily\n\n")
+	_, err = recorder.Write(chunk1)
+	require.NoError(t, err)
+
+	// After exceeding threshold, spill files must exist.
+	require.NotEmpty(t, recorder.HeaderFile(), "header spill file must be created after threshold exceeded")
+	require.NotEmpty(t, recorder.BodyFile(), "body spill file must be created after threshold exceeded")
+
+	// Write a second chunk after spilling — it must go to the file.
+	chunk2 := []byte("data: second chunk after spill\n\n")
+	_, err = recorder.Write(chunk2)
+	require.NoError(t, err)
+
+	// Finalize and verify body loads from spill files.
+	finalFlow, err := CreateHTTPFlowFromHTTPWithNoRspSaved(true, req, "mitm", "https://example.com/events", "127.0.0.1:443")
+	require.NoError(t, err)
+	finalFlow.StatusCode = 200
+	finalFlow.ContentType = "text/event-stream"
+	require.NoError(t, recorder.Finalize(finalFlow))
+
+	final, err := GetHTTPFlow(db, int64(recorder.FlowID()))
+	require.NoError(t, err)
+	require.True(t, final.IsTooLargeResponse)
+	require.True(t, final.IsReadTooSlowResponse)
+
+	packet, err := LoadHTTPFlowResponsePacket(final)
+	require.NoError(t, err)
+	require.Contains(t, string(packet), "data: this exceeds 30 bytes easily")
+	require.Contains(t, string(packet), "data: second chunk after spill")
 }


### PR DESCRIPTION
## Summary

SSE 响应之前在 header 到达时就立即标记为"大响应/读太慢"并创建 spill 文件，即使 body 只有几十字节也如此。这导致所有 SSE 流量都被粗糙地标注为大响应，浪费资源且前端显示不准确。

本 PR 改为**内存缓冲 + 按需落文件**的策略：

- SSE 仍然**立即转发**（保留 immediate trigger），行为不变
- 不再在 header callback 阶段设置 `ReadTooSlow`/`TooLarge`
- recorder 先将 body chunk 缓冲在内存中，累计计数
- **超限**（body > `MaxContentLength`）：创建 spill 文件（flush 内存缓冲），标记 too-large / read-too-slow，后续数据直接写文件
- **未超限**：`Finalize` 直接从内存缓冲拼接 header+body 写入 DB，不创建任何 spill 文件，flow 不标记 too-large

## Changes

### `HTTPFlowStreamRecorder` 重构 (`httpflow_stream.go`)
- 新增 `sizeThreshold int64` 字段：body 大小阈值
- 新增 `bodyBuffer *bytes.Buffer` 字段：deferred 模式下的内存缓冲区
- 新增 `headerBytes []byte` 字段：保存原始响应头供后续使用
- `Write()`：有 `bodyFile` 写文件，否则写 `bodyBuffer` 并检查阈值
- `markTooLarge()`：按需创建 spill 文件，flush 内存缓冲，设置 flags
- `Finalize()`：未超限用内存数据，超限用 spill 文件
- `sizeThreshold <= 0`（legacy 模式）：行为完全不变

### 接口签名 (`martian.go`)
- `HTTPStreamRecorderFactory` 增加 `sizeThreshold int64` 参数

### SSE header callback (`lowhttp_exec.go`)
- 移除 `SetResponseReadTooSlow(req, true)`
- 传 `MaxContentLength` 作为 `sizeThreshold` 给 recorder

### 调用方适配 (`grpc_mitm.go`, `grpc_mitm_v2.go`)
- 工厂实现适配新签名

## Tests
- `TestHTTPFlowStreamRecorderDefersTooLargeUntilThreshold`：小 SSE 不标记、不创建文件、body 内联
- `TestHTTPFlowStreamRecorderMarksTooLargeAfterThresholdExceeded`：大 SSE 标记 + spill 文件
- `TestHTTPFlowStreamRecorderLargeSSELoadsFromSpillFile`：多 chunk 超限后 spill + 从文件加载
- 所有现有测试传 `sizeThreshold=0`（legacy 模式），行为不变

## Commits
1. `refactor(mitm): defer SSE too-large marking with in-memory buffering` — recorder 核心重构 + factory 签名
2. `feat(mitm): stop pre-marking SSE as too-large, pass MaxContentLength as threshold` — 移除提前标记 + 调用方适配
3. `test(mitm): add deferred too-large SSE recorder tests` — 新增测试