### PR TITLE
fix(ts2ssa): fix lazy-builder panics and downgrade per-function INFO logs

### DIFF
--- a/common/yak/ssa/cfg.go
+++ b/common/yak/ssa/cfg.go
@@ -361,6 +361,16 @@ func (i *IfBuilder) Build() *IfBuilder {
 		}
 		// create if-instruction in IfStatementBlock
 		ifStmt := SSABuilder.EmitIf()
+		if ifStmt == nil {
+			// The current block is already finished (e.g. a previous statement
+			// terminated it during broken-AST recovery), so the If instruction
+			// cannot be emitted. Calling AddTrue/SetCondition on a nil *If
+			// panics; skip the wiring and keep the builder walkable by moving
+			// on to the false branch.
+			SSABuilder.CurrentBlock = falseBlock
+			IfStatementBlock = falseBlock
+			return
+		}
 		ifStmt.AddTrue(trueBlock)
 		ifStmt.SetCondition(condition)
 		ifStmt.AddFalse(falseBlock)

--- a/common/yak/ssa/cfg.go
+++ b/common/yak/ssa/cfg.go
@@ -189,6 +189,17 @@ func (lb *LoopBuilder) Finish() {
 	SSABuild := lb.builder
 	ExternBlock := SSABuild.CurrentBlock
 	scope := ExternBlock.ScopeTable
+	if utils.IsNil(scope) {
+		// a CFG path can reach the current block before SetScope ran
+		// (e.g. broken-AST recovery); reconstruct a placeholder scope
+		// instead of panicking in NewLoopStmt on the nil scope
+		ExternBlock.restoreScopeIfMissing()
+		scope = ExternBlock.ScopeTable
+	}
+	if utils.IsNil(scope) {
+		log.Errorf("build loop: current block %v has no ScopeTable, skip loop (%s)", ExternBlock.GetName(), SSABuild.builderDebugContext())
+		return
+	}
 	header := SSABuild.NewBasicBlock(LoopHeader)
 	condition := SSABuild.NewBasicBlockUnSealed(LoopCondition)
 	body := SSABuild.NewBasicBlockNotAddBlocks(LoopBody)

--- a/common/yak/ssa/instruction.go
+++ b/common/yak/ssa/instruction.go
@@ -276,13 +276,23 @@ func (i *If) SetCondition(t Value) {
 }
 
 func (i *If) AddTrue(t *BasicBlock) {
+	if t == nil {
+		return
+	}
 	i.True = t.GetId()
-	i.GetBlock().AddSucc(t)
+	if block := i.GetBlock(); block != nil {
+		block.AddSucc(t)
+	}
 }
 
 func (i *If) AddFalse(f *BasicBlock) {
+	if f == nil {
+		return
+	}
 	i.False = f.GetId()
-	i.GetBlock().AddSucc(f)
+	if block := i.GetBlock(); block != nil {
+		block.AddSucc(f)
+	}
 }
 
 func (l *Loop) Finish(init, step []Value) {

--- a/common/yak/typescript/frontend/ast/ast.go
+++ b/common/yak/typescript/frontend/ast/ast.go
@@ -279,6 +279,10 @@ func (n *Node) Text() string {
 		return n.AsJsxNamespacedName().Namespace.Text() + ":" + n.AsJsxNamespacedName().name.Text()
 	case KindRegularExpressionLiteral:
 		return n.AsRegularExpressionLiteral().Text
+	case KindComputedPropertyName:
+		// a computed property name ({[expr]: v}) has no static text; callers
+		// treat "" as "no static name" instead of panicking here
+		return ""
 	}
 	panic(fmt.Sprintf("Unhandled case in Node.Text: %T", n.data))
 }
@@ -759,6 +763,31 @@ func (n *Node) Contains(descendant *Node) bool {
 
 func (n *Node) AsIdentifier() *Identifier {
 	return n.data.(*Identifier)
+}
+
+// TryAsIdentifier returns the node data as *Identifier, or nil when the node
+// holds a different kind (e.g. a StringLiteral / NumericLiteral /
+// ComputedPropertyName property name). Use this instead of the
+// `if x := n.AsIdentifier(); x != nil` pattern: AsIdentifier is an unchecked
+// assertion and panics on kind mismatch before the nil check can run.
+func (n *Node) TryAsIdentifier() *Identifier {
+	if n == nil {
+		return nil
+	}
+	if id, ok := n.data.(*Identifier); ok {
+		return id
+	}
+	return nil
+}
+
+func (n *Node) TryAsStringLiteral() *StringLiteral {
+	if n == nil {
+		return nil
+	}
+	if s, ok := n.data.(*StringLiteral); ok {
+		return s
+	}
+	return nil
 }
 
 func (n *Node) AsPrivateIdentifier() *PrivateIdentifier {

--- a/common/yak/typescript/ts2ssa/auxiliary.go
+++ b/common/yak/typescript/ts2ssa/auxiliary.go
@@ -272,10 +272,10 @@ func (b *builder) getDeclarationNameText(name *ast.DeclarationName) string {
 	if name == nil {
 		return ""
 	}
-	if id := name.AsIdentifier(); id != nil {
+	if id := name.TryAsIdentifier(); id != nil {
 		return id.Text
 	}
-	if str := name.AsStringLiteral(); str != nil {
+	if str := name.TryAsStringLiteral(); str != nil {
 		return strings.Trim(str.Text, `"'`)
 	}
 	return ""

--- a/common/yak/typescript/ts2ssa/build_from_ast.go
+++ b/common/yak/typescript/ts2ssa/build_from_ast.go
@@ -2316,6 +2316,14 @@ func (b *builder) VisitCallExpression(node *ast.CallExpression) ssa.Value {
 	// TODO: 函数调用导致实参发生改变如何处理?
 	call := b.EmitCall(b.NewCall(callee, args))
 
+	// EmitCall returns nil when the current block is already finished (e.g.
+	// after syntax-error recovery terminated the block). Returning a nil *Call
+	// wrapped in the ssa.Value interface would panic later at call.SetType /
+	// GetType / GetId call sites, so fall back to an undefined value here.
+	if utils.IsNil(call) {
+		return b.EmitUndefined("")
+	}
+
 	// 根据被调用函数的类型设置 Call 指令的返回类型
 	// 这对于 Promise 等返回类型的正确传递非常重要
 	if funcType := callee.GetType(); funcType != nil {
@@ -2430,7 +2438,7 @@ func (b *builder) VisitObjectLiteralExpression(objLiteral *ast.ObjectLiteralExpr
 				} else {
 					// 在作用域中查找同名变量
 					variableName := ""
-					if idNode := propertyName.AsIdentifier(); idNode != nil {
+					if idNode := propertyName.TryAsIdentifier(); idNode != nil {
 						variableName = idNode.Text
 					} else {
 						variableName = propertyName.Text()
@@ -2459,7 +2467,7 @@ func (b *builder) VisitObjectLiteralExpression(objLiteral *ast.ObjectLiteralExpr
 			var methodName string
 			if methodDecl.Name() != nil {
 				propertyName := methodDecl.Name()
-				if idNode := propertyName.AsIdentifier(); idNode != nil {
+				if idNode := propertyName.TryAsIdentifier(); idNode != nil {
 					methodName = idNode.Text
 				} else {
 					methodName = propertyName.Text()
@@ -2501,7 +2509,7 @@ func (b *builder) VisitObjectLiteralExpression(objLiteral *ast.ObjectLiteralExpr
 
 			// 处理属性名
 			if propertyName != nil {
-				if idNode := propertyName.AsIdentifier(); idNode != nil {
+				if idNode := propertyName.TryAsIdentifier(); idNode != nil {
 					accessorName = idNode.Text
 				} else {
 					accessorName = propertyName.Text()
@@ -2746,7 +2754,7 @@ func (b *builder) VisitPropertyAccessExpressionRight(node *ast.PropertyAccessExp
 	}
 
 	obj := b.VisitRightValueExpression(node.Expression)
-	if obj == nil {
+	if utils.IsNil(obj) {
 		var objName string
 		if ast.IsIdentifier(node.Expression) {
 			objName = node.Expression.AsIdentifier().Text
@@ -5333,7 +5341,7 @@ func (b *builder) ExtractPromiseResolvedType(promiseType ssa.Type) ssa.Type {
 // ExtractPromiseResolvedValue 从 Promise 值中提取解析后的值
 // 这个值代表 Promise 完成后的结果
 func (b *builder) ExtractPromiseResolvedValue(promiseValue ssa.Value) ssa.Value {
-	if promiseValue == nil {
+	if utils.IsNil(promiseValue) {
 		return b.EmitUndefined("")
 	}
 	if resolvedValue := b.extractSingleCallReturnValue(promiseValue); resolvedValue != nil {
@@ -5394,7 +5402,7 @@ func (b *builder) extractSingleCallReturnValue(value ssa.Value) ssa.Value {
 
 // WrapInPromise 将一个值包装成 Promise 类型
 func (b *builder) WrapInPromise(value ssa.Value) ssa.Value {
-	if value == nil {
+	if utils.IsNil(value) {
 		value = b.EmitUndefined("")
 	}
 

--- a/common/yak/typescript/ts2ssa/build_from_ast.go
+++ b/common/yak/typescript/ts2ssa/build_from_ast.go
@@ -2979,9 +2979,9 @@ func (b *builder) VisitFunctionDeclaration(node *ast.FunctionDeclaration) interf
 	// 创建新的函数对象
 	newFunc := b.NewFunc(funcName)
 	store := b.StoreFunctionBuilder()
-	log.Infof("add function funcName = %s", funcName)
+	log.Debugf("add function funcName = %s", funcName)
 	newFunc.AddLazyBuilder(func() {
-		log.Infof("lazy-build function funcName = %s", funcName)
+		log.Debugf("lazy-build function funcName = %s", funcName)
 		switchHandler := b.SwitchFunctionBuilder(store)
 		defer switchHandler()
 		b.FunctionBuilder = b.PushFunction(newFunc)
@@ -3054,10 +3054,10 @@ func (b *builder) VisitFunctionExpression(node *ast.FunctionExpression) ssa.Valu
 	// 创建新的函数对象
 	newFunc := b.NewFunc(funcName)
 	store := b.StoreFunctionBuilder()
-	log.Infof("add function expression funcName = %s", funcName)
+	log.Debugf("add function expression funcName = %s", funcName)
 
 	newFunc.AddLazyBuilder(func() {
-		log.Infof("lazy-build function expression funcName = %s", funcName)
+		log.Debugf("lazy-build function expression funcName = %s", funcName)
 		switchHandler := b.SwitchFunctionBuilder(store)
 		defer switchHandler()
 		b.FunctionBuilder = b.PushFunction(newFunc)
@@ -3128,10 +3128,10 @@ func (b *builder) VisitArrowFunction(node *ast.ArrowFunction) ssa.Value {
 	// 创建新的函数对象
 	newFunc := b.NewFunc(funcName)
 	store := b.StoreFunctionBuilder()
-	log.Infof("add arrow function funcName = %s", funcName)
+	log.Debugf("add arrow function funcName = %s", funcName)
 
 	newFunc.AddLazyBuilder(func() {
-		log.Infof("lazy-build arrow function funcName = %s", funcName)
+		log.Debugf("lazy-build arrow function funcName = %s", funcName)
 		switchHandler := b.SwitchFunctionBuilder(store)
 		defer switchHandler()
 		b.FunctionBuilder = b.PushFunction(newFunc)
@@ -4465,7 +4465,7 @@ func (b *builder) ProcessClassMethod(member *ast.ClassElement, class *ssa.Bluepr
 	storeImportTBL := b.importTbl
 
 	newFunc.AddLazyBuilder(func() {
-		log.Infof("lazybuild class method for uuidName and method name: %s : %s ", funcName, methodName)
+		log.Debugf("lazybuild class method for uuidName and method name: %s : %s ", funcName, methodName)
 		switchHandler := b.SwitchFunctionBuilder(store)
 		b.importTbl = storeImportTBL
 		defer switchHandler()
@@ -4553,7 +4553,7 @@ func (b *builder) ProcessClassCtor(member *ast.ClassElement, class *ssa.Blueprin
 	class.RegisterMagicMethod(ssa.Constructor, newFunc)
 	store := b.StoreFunctionBuilder()
 	newFunc.AddLazyBuilder(func() {
-		log.Infof("lazybuild: %s ", ctorName)
+		log.Debugf("lazybuild: %s ", ctorName)
 		switchHandler := b.SwitchFunctionBuilder(store)
 		defer switchHandler()
 		b.FunctionBuilder = b.PushFunction(newFunc)

--- a/common/yak/typescript/ts2ssa/tests/crash_regression_test.go
+++ b/common/yak/typescript/ts2ssa/tests/crash_regression_test.go
@@ -1,0 +1,100 @@
+package tests
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/log"
+	"github.com/yaklang/yaklang/common/yak/ssaapi"
+)
+
+// Regression tests for lazy-builder panics observed when compiling the
+// nodejs/node repository (compile-log analysis 2026-09-08):
+//
+//  1. interface conversion panics: object-literal member names that are NOT
+//     plain identifiers (string / numeric / computed keys on methods,
+//     getters and setters) hit the unchecked ast.Node.AsIdentifier
+//     assertion in VisitObjectLiteralExpression, and its fallback
+//     Node.Text() panicked on ComputedPropertyName.
+//  2. nil pointer panics: statements visited after the current basic block
+//     was already finished (e.g. unreachable code after `return`) made
+//     EmitCall/EmitIf return nil, which callers dereferenced.
+//
+// These panics are recovered by ssa.LazyBuilder.Build and only surface as
+// "lazy builder panic" log lines (in production they silently drop the rest
+// of the batch's function bodies), so the tests capture the log output and
+// assert no such line was produced.
+
+func parseJSNoPanic(t *testing.T, code string) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	prog, err := ssaapi.Parse(code, ssaapi.WithLanguage("js"))
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	// force lazy builders (function bodies) to run: the original panics
+	// surfaced inside ssa.LazyBuilder.Build during deferred compilation
+	for _, f := range prog.Program.Funcs.Values() {
+		f.Build()
+	}
+
+	out := buf.String()
+	require.False(t, strings.Contains(out, "lazy builder panic"),
+		"compile produced recovered panics:\n%s", out)
+}
+
+func TestObjectLiteralNonIdentifierMemberNames(t *testing.T) {
+	parseJSNoPanic(t, `
+const computed = "c";
+const obj = {
+  "str-method"() { return 1; },
+  42() { return 2; },
+  [computed]() { return 3; },
+  get "str-get"() { return 4; },
+  set "str-set"(v) { },
+  get 43() { return 5; },
+  set [computed](v) { },
+};
+`)
+}
+
+func TestObjectLiteralNonIdentifierKeysInValues(t *testing.T) {
+	// minimatch/undici style: string / numeric keys inside object literals
+	// passed as call arguments
+	parseJSNoPanic(t, `
+const opts = { "encoding": "utf8", 404: "not found", [k]: v };
+configure({ "str": 1, 42: 2, [computed]: 3 });
+`)
+}
+
+func TestUnreachableCallAfterReturn(t *testing.T) {
+	parseJSNoPanic(t, `
+function f(a) {
+  return 1;
+  a();
+}
+function g(a) {
+  return a.then(x => x).catch(e => e);
+  Promise.resolve(1).finally(() => {});
+}
+`)
+}
+
+func TestUnreachableIfAfterReturn(t *testing.T) {
+	parseJSNoPanic(t, `
+function f(a, b) {
+  return 1;
+  if (a) {
+    b();
+  } else if (b) {
+    a();
+  }
+}
+`)
+}


### PR DESCRIPTION
## Summary

Two conservative fixes for the JS/TS SSA compile pipeline, based on analysis of nodejs/node scan logs (67 recovered panics per compile run) and CPU/mem profiling.

### 1. Fix lazy-builder panics (`e047e31bc`)

All panics were recovered by `LazyBuilder.Build`'s recover, silently dropping remaining lazy-build tasks (underreported results). Root causes fixed:

- **Non-identifier object-literal member names**: `AsIdentifier()` is an unchecked type assertion and panics on `StringLiteral` / `NumericLiteral` / `ComputedPropertyName` keys. Added `TryAsIdentifier` / `TryAsStringLiteral` (checked casts) and use them in `getDeclarationNameText` and the shorthand / method-declaration / get-set-accessor branches of `VisitObjectLiteralExpression`.
- **`Node.Text()` on computed property names**: added `case KindComputedPropertyName: return ""` instead of panicking (callers treat "" as "no static name").
- **Unreachable code after `return`**: `EmitCall` / `EmitIf` return nil when the current block is finished; wiring a nil `*Call` / `*If` (typed-nil in `ssa.Value`) panicked. Guard with `utils.IsNil` in `VisitCallExpression` and `IfBuilder.Build`.
- **`If.AddTrue` / `AddFalse`**: guard nil target blocks and nil owning blocks before `AddSucc`.

Includes 4 regression tests (`crash_regression_test.go`) that capture log output and assert no recovered panics; red-light verified against the unfixed tree.

### 2. Downgrade per-function lazy-build logs to Debug (`f03b2f703`)

The `add function` / `lazy-build function expression` / `lazybuild class method` log sites fire once per function and produced ~28k INFO lines per large file in the scan logs. `golog.Debugf` short-circuits before `fmt.Sprintf` and the `runtime.Callers` stack walk in the log formatter when debug is disabled (default).

Matches the existing convention in go2ssa/c2ssa, which already log these at Debug level.

## Benchmark

Compile of a 244KB JS file (10x, count=3, median):

| | ns/op | allocs/op |
|---|---|---|
| before | 1767ms | 2,357k |
| after | 880ms | 2,331k |

## Testing

- `go test ./common/yak/typescript/ts2ssa/tests/...` passes (incl. new regression tests)
- No tests depend on the downgraded INFO output