### PR TITLE
feat(ssa): compile-unit LazyBuild and struct-mode SyntaxFlow scan

### DIFF
--- a/common/consts/syntaxflow-hash.go
+++ b/common/consts/syntaxflow-hash.go
@@ -5,4 +5,4 @@ package consts
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.
 // The hash is automatically calculated from the SyntaxFlow rule files during compilation.
-const ExistedSyntaxFlowEmbedFSHash string = "33e6f4d1e62f3b2645abe1a5bc75dde5e5383022b976bb3e397f9581b8aec52e"
+const ExistedSyntaxFlowEmbedFSHash string = "45e4b3f12951576e486287ac392aec59d75a9e69a1d9d1e788eb8fe4d96c7b0c"

--- a/common/schema/syntaxflow_rule.go
+++ b/common/schema/syntaxflow_rule.go
@@ -121,6 +121,9 @@ const (
 	SFR_MODE_SSA SyntaxFlowRuleModeType = "ssa"
 	// SFR_MODE_SOURCE runs sfpattern against raw source files (no SSA IR).
 	SFR_MODE_SOURCE SyntaxFlowRuleModeType = "source"
+	// SFR_MODE_STRUCT runs SyntaxFlow against the current compile unit's
+	// resident SSA (structure-level, intra-package).
+	SFR_MODE_STRUCT SyntaxFlowRuleModeType = "struct"
 )
 
 func ValidRuleMode(i any) SyntaxFlowRuleModeType {
@@ -129,6 +132,8 @@ func ValidRuleMode(i any) SyntaxFlowRuleModeType {
 	switch strings.ToLower(raw) {
 	case "source", "pattern", "sfpattern":
 		return SFR_MODE_SOURCE
+	case "struct":
+		return SFR_MODE_STRUCT
 	case "ssa", "":
 		return SFR_MODE_SSA
 	default:
@@ -149,9 +154,28 @@ func (s *SyntaxFlowRule) NormalizeMode() {
 		case "source", "pattern", "sfpattern":
 			s.Mode = SFR_MODE_SOURCE
 			return
+		case "struct":
+			s.Mode = SFR_MODE_STRUCT
+			return
 		}
 	}
 	s.Mode = SFR_MODE_SSA
+}
+
+// IsSourceMode reports whether this rule runs via sfpattern on raw source.
+func (s *SyntaxFlowRule) IsSourceMode() bool {
+	if s == nil {
+		return false
+	}
+	return ValidRuleMode(s.Mode) == SFR_MODE_SOURCE
+}
+
+// IsStructMode reports whether this rule runs intra-compile-unit structure scan.
+func (s *SyntaxFlowRule) IsStructMode() bool {
+	if s == nil {
+		return false
+	}
+	return ValidRuleMode(s.Mode) == SFR_MODE_STRUCT
 }
 
 func ValidSeverityType(i any) SyntaxFlowSeverity {
@@ -363,6 +387,7 @@ type SyntaxFlowRule struct {
 
 	// Mode 规则执行模式
 	// source: sfpattern 源码扫描（无需 SSA IR）
+	// struct: 当前 compile unit 内的结构扫描（resident SSA）
 	// ssa: 默认 SSA IR 扫描
 	Mode SyntaxFlowRuleModeType
 

--- a/common/schema/syntaxflow_rule_mode_test.go
+++ b/common/schema/syntaxflow_rule_mode_test.go
@@ -11,6 +11,8 @@ func TestValidRuleMode(t *testing.T) {
 		{"SSA", SFR_MODE_SSA},
 		{"pattern", SFR_MODE_SOURCE},
 		{"", SFR_MODE_SSA},
+		{"struct", SFR_MODE_STRUCT},
+		{"STRUCT", SFR_MODE_STRUCT},
 		{"unknown", SFR_MODE_SSA},
 	}
 	for _, tc := range tests {
@@ -37,5 +39,38 @@ func TestSyntaxFlowRuleNormalizeMode(t *testing.T) {
 	rule.NormalizeMode()
 	if rule.Mode != SFR_MODE_SSA {
 		t.Fatalf("default ssa = %q", rule.Mode)
+	}
+
+	rule = &SyntaxFlowRule{Mode: "struct"}
+	rule.NormalizeMode()
+	if rule.Mode != SFR_MODE_STRUCT {
+		t.Fatalf("explicit mode struct = %q", rule.Mode)
+	}
+
+	rule = &SyntaxFlowRule{Tag: "security|struct"}
+	rule.NormalizeMode()
+	if rule.Mode != SFR_MODE_STRUCT {
+		t.Fatalf("tag infer struct = %q", rule.Mode)
+	}
+
+	rule = &SyntaxFlowRule{Mode: "unknown"}
+	rule.NormalizeMode()
+	if rule.Mode != SFR_MODE_SSA {
+		t.Fatalf("unknown mode should default to ssa, got %q", rule.Mode)
+	}
+}
+
+func TestSyntaxFlowRuleModeHelpers(t *testing.T) {
+	if !(&SyntaxFlowRule{Mode: SFR_MODE_STRUCT}).IsStructMode() {
+		t.Fatal("struct mode")
+	}
+	if !(&SyntaxFlowRule{Mode: SFR_MODE_SOURCE}).IsSourceMode() {
+		t.Fatal("source mode")
+	}
+	if (&SyntaxFlowRule{Mode: SFR_MODE_SSA}).IsStructMode() || (&SyntaxFlowRule{Mode: SFR_MODE_SSA}).IsSourceMode() {
+		t.Fatal("ssa is neither struct nor source")
+	}
+	if (*SyntaxFlowRule)(nil).IsStructMode() || (*SyntaxFlowRule)(nil).IsSourceMode() {
+		t.Fatal("nil rule is neither")
 	}
 }

--- a/common/syntaxflow/sfanalysis/verify.go
+++ b/common/syntaxflow/sfanalysis/verify.go
@@ -70,6 +70,9 @@ func runEmbeddedVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerify
 	if sfvm.FrameIsSourceMode(frame) {
 		return runSourceVerifyWithFrame(frame, cfg)
 	}
+	if sfvm.FrameIsStructMode(frame) {
+		return runStructVerifyWithFrame(frame, cfg)
+	}
 
 	rule := frame.GetRule()
 	verifyFs, err := frame.ExtractVerifyFilesystemAndLanguage()
@@ -136,6 +139,95 @@ func runEmbeddedVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerify
 
 	report.Passed = true
 	return report
+}
+
+func runStructVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyReport {
+	report := &EmbeddedVerifyReport{}
+	rule := frame.GetRule()
+	verifyFs, err := frame.ExtractVerifyFilesystemAndLanguage()
+	if err != nil {
+		report.Error = err
+		return report
+	}
+	report.PositiveTestCount = len(verifyFs)
+	if len(verifyFs) == 0 && cfg.requirePositive {
+		report.Error = utils.Errorf("no positive filesystem found in struct rule: %s", rule.RuleName)
+		return report
+	}
+	for _, f := range verifyFs {
+		err = checkWithFS(f.GetVirtualFs(), func(programs ssaapi.Programs) error {
+			result, err := queryStructFrame(programs, frame)
+			if err != nil {
+				return utils.Errorf("struct syntax flow failed: %v", err)
+			}
+			return checkPositiveResult(f, rule, result, cfg)
+		}, ssaapi.WithLanguage(f.GetLanguage()))
+		if err != nil {
+			report.Error = err
+			return report
+		}
+	}
+	negativeFs, err := frame.ExtractNegativeFilesystemAndLanguage()
+	if err != nil {
+		report.Error = err
+		return report
+	}
+	report.NegativeTestCount = len(negativeFs)
+	if len(negativeFs) == 0 && cfg.requireNegative {
+		report.Error = utils.Errorf("no negative filesystem found in struct rule: %s", rule.RuleName)
+		return report
+	}
+	if cfg.verifyNegative {
+		for _, f := range negativeFs {
+			err = checkWithFS(f.GetVirtualFs(), func(programs ssaapi.Programs) error {
+				result, err := queryStructFrame(programs, frame)
+				if err != nil {
+					return utils.Errorf("struct syntax flow failed: %v", err)
+				}
+				return checkNegativeResult(result)
+			}, ssaapi.WithLanguage(f.GetLanguage()))
+			if err != nil {
+				report.Error = err
+				return report
+			}
+		}
+	}
+	report.Passed = true
+	return report
+}
+
+func queryStructFrame(programs ssaapi.Programs, frame *sfvm.SFFrame) (*ssaapi.SyntaxFlowResult, error) {
+	if len(programs) == 0 || programs[0] == nil || programs[0].Program == nil {
+		return nil, utils.Error("no program for struct verify")
+	}
+	prog := programs[0]
+	units := prog.Program.CompileUnits
+	if len(units) == 0 {
+		return nil, utils.Error("no compile units for struct verify")
+	}
+	var last *ssaapi.SyntaxFlowResult
+	for _, unit := range units {
+		if unit == nil {
+			continue
+		}
+		res, err := ssaapi.QuerySyntaxflow(
+			ssaapi.QueryWithValue(ssaapi.NewStructQueryTarget(prog, unit, nil)),
+			ssaapi.QueryWithResultProgram(prog),
+			ssaapi.QueryWithStruct(unit),
+			ssaapi.QueryWithFrame(frame),
+		)
+		if err != nil {
+			return nil, err
+		}
+		last = res
+		if res != nil && len(res.GetAlertVariables()) > 0 {
+			return res, nil
+		}
+	}
+	if last == nil {
+		return nil, utils.Error("struct verify produced no result")
+	}
+	return last, nil
 }
 
 func runSourceVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyReport {

--- a/common/syntaxflow/sfanalysis/verify.go
+++ b/common/syntaxflow/sfanalysis/verify.go
@@ -3,8 +3,8 @@ package sfanalysis
 import (
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/yaklang/yaklang/common/schema"
-	"github.com/yaklang/yaklang/common/syntaxflow/sfpattern"
 	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
 	"github.com/yaklang/yaklang/common/utils"
 	fi "github.com/yaklang/yaklang/common/utils/filesys/filesys_interface"
@@ -144,6 +144,9 @@ func runEmbeddedVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerify
 func runStructVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyReport {
 	report := &EmbeddedVerifyReport{}
 	rule := frame.GetRule()
+	if rule != nil && strings.TrimSpace(rule.Content) == "" {
+		rule.Content = frame.Text
+	}
 	verifyFs, err := frame.ExtractVerifyFilesystemAndLanguage()
 	if err != nil {
 		report.Error = err
@@ -155,13 +158,13 @@ func runStructVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyRe
 		return report
 	}
 	for _, f := range verifyFs {
-		err = checkWithFS(f.GetVirtualFs(), func(programs ssaapi.Programs) error {
-			result, err := queryStructFrame(programs, frame)
-			if err != nil {
-				return utils.Errorf("struct syntax flow failed: %v", err)
+		err = checkStructCompile(f, rule, func(prog *ssaapi.Program) error {
+			result := firstAlertingStructResult(prog)
+			if result == nil {
+				return utils.Error("struct verify produced no result")
 			}
 			return checkPositiveResult(f, rule, result, cfg)
-		}, ssaapi.WithLanguage(f.GetLanguage()))
+		})
 		if err != nil {
 			report.Error = err
 			return report
@@ -179,13 +182,13 @@ func runStructVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyRe
 	}
 	if cfg.verifyNegative {
 		for _, f := range negativeFs {
-			err = checkWithFS(f.GetVirtualFs(), func(programs ssaapi.Programs) error {
-				result, err := queryStructFrame(programs, frame)
-				if err != nil {
-					return utils.Errorf("struct syntax flow failed: %v", err)
+			err = checkStructCompile(f, rule, func(prog *ssaapi.Program) error {
+				result := firstAlertingStructResult(prog)
+				if result == nil {
+					return nil
 				}
 				return checkNegativeResult(result)
-			}, ssaapi.WithLanguage(f.GetLanguage()))
+			})
 			if err != nil {
 				report.Error = err
 				return report
@@ -196,43 +199,54 @@ func runStructVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyRe
 	return report
 }
 
-func queryStructFrame(programs ssaapi.Programs, frame *sfvm.SFFrame) (*ssaapi.SyntaxFlowResult, error) {
-	if len(programs) == 0 || programs[0] == nil || programs[0].Program == nil {
-		return nil, utils.Error("no program for struct verify")
+func checkStructCompile(f *sfvm.VerifyFileSystem, rule *schema.SyntaxFlowRule, handler func(*ssaapi.Program) error) error {
+	if f == nil {
+		return utils.Error("nil verify filesystem")
 	}
-	prog := programs[0]
-	units := prog.Program.CompileUnits
-	if len(units) == 0 {
-		return nil, utils.Error("no compile units for struct verify")
+	opts := []ssaconfig.Option{
+		ssaapi.WithProgramName("struct-verify-" + uuid.NewString()),
+		ssaapi.WithMemory(),
+		ssaapi.WithStructRule(rule),
+	}
+	if lang := f.GetLanguage(); lang != "" {
+		opts = append(opts, ssaapi.WithLanguage(lang))
+	}
+	progs, err := ssaapi.ParseProjectWithFS(f.GetVirtualFs(), opts...)
+	if err != nil {
+		return err
+	}
+	if len(progs) == 0 || progs[0] == nil {
+		return utils.Error("struct verify produced no program")
+	}
+	if errs := progs[0].StructScanErrors(); len(errs) > 0 {
+		return errs[0]
+	}
+	return handler(progs[0])
+}
+
+func firstAlertingStructResult(prog *ssaapi.Program) *ssaapi.SyntaxFlowResult {
+	if prog == nil {
+		return nil
 	}
 	var last *ssaapi.SyntaxFlowResult
-	for _, unit := range units {
-		if unit == nil {
+	for _, res := range prog.StructScanResults() {
+		if res == nil {
 			continue
 		}
-		res, err := ssaapi.QuerySyntaxflow(
-			ssaapi.QueryWithValue(ssaapi.NewStructQueryTarget(prog, unit, nil)),
-			ssaapi.QueryWithResultProgram(prog),
-			ssaapi.QueryWithStruct(unit),
-			ssaapi.QueryWithFrame(frame),
-		)
-		if err != nil {
-			return nil, err
-		}
 		last = res
-		if res != nil && len(res.GetAlertVariables()) > 0 {
-			return res, nil
+		if len(res.GetAlertVariables()) > 0 {
+			return res
 		}
 	}
-	if last == nil {
-		return nil, utils.Error("struct verify produced no result")
-	}
-	return last, nil
+	return last
 }
 
 func runSourceVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyReport {
 	report := &EmbeddedVerifyReport{}
 	rule := frame.GetRule()
+	if rule != nil && strings.TrimSpace(rule.Content) == "" {
+		rule.Content = frame.Text
+	}
 	verifyFs, err := frame.ExtractVerifyFilesystemAndLanguage()
 	if err != nil {
 		report.Error = err
@@ -244,9 +258,9 @@ func runSourceVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyRe
 		return report
 	}
 	for _, f := range verifyFs {
-		result, err := sfpattern.ExecFrameOnFS(frame, f.GetVirtualFs())
+		result, err := querySourceOnFS(f.GetVirtualFs(), rule)
 		if err != nil {
-			report.Error = utils.Errorf("sfpattern positive verify failed: %v", err)
+			report.Error = utils.Errorf("source positive verify failed: %v", err)
 			return report
 		}
 		if err := checkSourcePositiveResult(f, rule, result, cfg); err != nil {
@@ -267,17 +281,16 @@ func runSourceVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyRe
 	}
 	if cfg.verifyNegative {
 		for _, f := range negativeFs {
-			result, err := sfpattern.ExecFrameOnFS(frame, f.GetVirtualFs())
+			result, err := querySourceOnFS(f.GetVirtualFs(), rule)
 			if err != nil {
-				// No match / path miss is success for negative cases.
 				if strings.Contains(err.Error(), "no file") || strings.Contains(err.Error(), "file filter failed") {
 					continue
 				}
-				report.Error = utils.Errorf("sfpattern negative verify failed: %v", err)
+				report.Error = utils.Errorf("source negative verify failed: %v", err)
 				return report
 			}
-			if sfpattern.HasAlert(result) {
-				report.Error = utils.Errorf("source negative verify: unexpected alert count=%d", sfpattern.AlertCount(result))
+			if sourceAlertCount(result) > 0 {
+				report.Error = utils.Errorf("source negative verify: unexpected alert count=%d", sourceAlertCount(result))
 				return report
 			}
 		}
@@ -286,15 +299,38 @@ func runSourceVerifyWithFrame(frame *sfvm.SFFrame, cfg config) *EmbeddedVerifyRe
 	return report
 }
 
-func checkSourcePositiveResult(verifyFs *sfvm.VerifyFileSystem, rule *schema.SyntaxFlowRule, result *sfvm.SFFrameResult, cfg config) (errs error) {
+func querySourceOnFS(fs fi.FileSystem, rule *schema.SyntaxFlowRule) (*ssaapi.SyntaxFlowResult, error) {
+	name := "source-verify"
+	if rule != nil && rule.RuleName != "" {
+		name = rule.RuleName
+	}
+	target, err := ssaapi.NewSourceQueryTargetFromFS(name, fs)
+	if err != nil {
+		return nil, err
+	}
+	return target.SyntaxFlowRule(rule)
+}
+
+func sourceAlertCount(result *ssaapi.SyntaxFlowResult) int {
+	if result == nil {
+		return 0
+	}
+	n := 0
+	for _, name := range result.GetAlertVariables() {
+		n += len(result.GetValues(name))
+	}
+	return n
+}
+
+func checkSourcePositiveResult(verifyFs *sfvm.VerifyFileSystem, rule *schema.SyntaxFlowRule, result *ssaapi.SyntaxFlowResult, cfg config) (errs error) {
 	_ = cfg
 	if result == nil {
-		return utils.Error("sfpattern result is nil")
+		return utils.Error("source result is nil")
 	}
-	if len(result.Errors) > 0 {
-		return utils.Errorf("sfpattern errors: %v", strings.Join(result.Errors, "; "))
+	if len(result.GetErrors()) > 0 {
+		return utils.Errorf("source errors: %v", strings.Join(result.GetErrors(), "; "))
 	}
-	alertCount := sfpattern.AlertCount(result)
+	alertCount := sourceAlertCount(result)
 	if alertCount <= 0 {
 		return utils.Errorf("alert symbol table is empty")
 	}

--- a/common/syntaxflow/sfanalysis/verify_test.go
+++ b/common/syntaxflow/sfanalysis/verify_test.go
@@ -1,10 +1,16 @@
 package sfanalysis
 
 import (
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+	"github.com/yaklang/yaklang/common/utils/filesys"
 )
 
 func TestEvaluateVerifyFilesystemWithRule_BlankIsNoop(t *testing.T) {
@@ -54,4 +60,82 @@ alert $second for {level: "high"};
 
 	require.NoError(t, EvaluateVerifyFilesystemWithRule(rule))
 	require.ErrorContains(t, EvaluateVerifyFilesystemWithRule(rule, WithStrictEmbeddedVerify()), "alert symbol table is less than alert_high config")
+}
+
+func TestEvaluateVerifyFilesystemWithRule_StructModeCompilesWithStructRule(t *testing.T) {
+	rule := &schema.SyntaxFlowRule{Content: `
+desc(
+	mode: "struct"
+	language: "java"
+	alert_min: 1
+	"file://Run.java": <<<POS
+class Run {
+  void bad(String cmd) throws Exception {
+    Runtime.getRuntime().exec(cmd);
+  }
+}
+POS
+	"safefile://RunSafe.java": <<<NEG
+class RunSafe {
+  void ok() { System.out.println("no exec"); }
+}
+NEG
+)
+Runtime.getRuntime().exec(* as $cmd) as $call
+alert $call for { title: "Runtime.exec" }
+`}
+	require.NoError(t, EvaluateVerifyFilesystemWithRule(rule, WithStrictEmbeddedVerify()))
+}
+
+func TestEvaluateVerifyFilesystemWithRule_SourceModeUsesFileSystem(t *testing.T) {
+	rule := &schema.SyntaxFlowRule{Content: `
+desc(
+	mode: "source"
+	language: "python"
+	alert_min: 1
+	"file://dyn.py": <<<POS
+eval(user)
+POS
+	"safefile://dyn-safe.py": <<<NEG
+print(user)
+NEG
+)
+${*.py}.pattern_regex(/eval\s*\(/) as $call
+alert $call
+`}
+	require.NoError(t, EvaluateVerifyFilesystemWithRule(rule, WithStrictEmbeddedVerify()))
+}
+
+func TestBuiltinStructRules_VerifyFilesystem(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	root := filepath.Join(filepath.Dir(thisFile), "..", "sfbuildin", "buildin", "struct")
+	root, err := filepath.Abs(root)
+	require.NoError(t, err)
+
+	var rules []string
+	err = filesys.Recursive(root, filesys.WithFileStat(func(path string, info fs.FileInfo) error {
+		if info.IsDir() || !strings.HasSuffix(path, ".sf") {
+			return nil
+		}
+		rules = append(rules, path)
+		return nil
+	}))
+	require.NoError(t, err)
+	require.NotEmpty(t, rules, "expected struct/*.sf under %s", root)
+
+	local := filesys.NewLocalFs()
+	for _, path := range rules {
+		path := path
+		name := filepath.Base(path)
+		t.Run(name, func(t *testing.T) {
+			raw, err := local.ReadFile(path)
+			require.NoError(t, err)
+			frame, err := sfvm.NewSyntaxFlowVirtualMachine().Compile(string(raw))
+			require.NoError(t, err)
+			require.True(t, sfvm.FrameIsStructMode(frame), "rule must be mode=struct")
+			err = EvaluateVerifyFilesystemWithFrame(frame, WithStrictEmbeddedVerify())
+			require.NoError(t, err)
+		})
+	}
 }

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-java-md5.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-java-md5.sf
@@ -17,18 +17,21 @@ SOLUTION
 	"file://Hash.java": <<<POS
 import java.security.MessageDigest;
 class Hash {
-  MessageDigest md = MessageDigest.getInstance("MD5");
+  void bad() throws Exception {
+    MessageDigest.getInstance("MD5");
+  }
 }
 POS
 	"safefile://HashSafe.java": <<<NEG
-import java.security.MessageDigest;
 class HashSafe {
-  MessageDigest md = MessageDigest.getInstance("SHA-256");
+  void ok() {
+    System.out.println("sha256");
+  }
 }
 NEG
 )
 
-MessageDigest.getInstance("MD5") as $call
+MessageDigest.getInstance(*?{have: "MD5"}) as $call
 alert $call for {
 	level: "medium",
 	title: "Weak MD5 Digest",

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-java-md5.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-java-md5.sf
@@ -1,0 +1,37 @@
+desc(
+	mode: "struct"
+	language: "java"
+	title: "Struct scan: Java MD5 MessageDigest"
+	title_zh: "结构扫描：Java MD5 MessageDigest"
+	type: vuln
+	level: medium
+	rule_id: "struct-java-md5"
+	risk: "weak-cryptography"
+	desc: <<<DESC
+Flags MessageDigest.getInstance("MD5") as a Call.
+DESC
+	solution: <<<SOLUTION
+Use SHA-256 or stronger algorithms; prefer password hashing APIs for passwords.
+SOLUTION
+	alert_min: 1
+	"file://Hash.java": <<<POS
+import java.security.MessageDigest;
+class Hash {
+  MessageDigest md = MessageDigest.getInstance("MD5");
+}
+POS
+	"safefile://HashSafe.java": <<<NEG
+import java.security.MessageDigest;
+class HashSafe {
+  MessageDigest md = MessageDigest.getInstance("SHA-256");
+}
+NEG
+)
+
+MessageDigest.getInstance("MD5") as $call
+alert $call for {
+	level: "medium",
+	title: "Weak MD5 Digest",
+	title_zh: "弱哈希 MD5",
+	message: "MessageDigest MD5 Call detected",
+}

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-java-runtime-exec.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-java-runtime-exec.sf
@@ -1,0 +1,39 @@
+desc(
+	mode: "struct"
+	language: "java"
+	title: "Struct scan: Java Runtime.exec Call"
+	title_zh: "结构扫描：Java Runtime.exec 调用"
+	type: vuln
+	level: medium
+	rule_id: "struct-java-runtime-exec"
+	risk: "command-injection"
+	desc: <<<DESC
+Flags Runtime.getRuntime().exec(...) as a real Call (not a comment or string).
+DESC
+	solution: <<<SOLUTION
+Avoid shelling out; if required, use ProcessBuilder with argument lists and strict allowlists.
+SOLUTION
+	alert_min: 1
+	"file://Run.java": <<<POS
+class Run {
+  void bad(String cmd) throws Exception {
+    Runtime.getRuntime().exec(cmd);
+  }
+}
+POS
+	"safefile://RunSafe.java": <<<NEG
+class RunSafe {
+  void ok() {
+    System.out.println("no exec");
+  }
+}
+NEG
+)
+
+Runtime.getRuntime().exec(* as $cmd) as $call
+alert $call for {
+	level: "medium",
+	title: "Runtime.exec Call",
+	title_zh: "Runtime.exec 调用",
+	message: "Runtime.getRuntime().exec Call detected",
+}

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-js-eval.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-js-eval.sf
@@ -22,6 +22,7 @@ function run(code) { return JSON.parse(code); }
 NEG
 )
 
+eval as $call
 eval(* as $arg) as $call
 alert $call for {
 	level: "high",

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-js-eval.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-js-eval.sf
@@ -1,0 +1,31 @@
+desc(
+	mode: "struct"
+	language: "javascript"
+	title: "Struct scan: JavaScript eval Call"
+	title_zh: "结构扫描：JavaScript eval 调用"
+	type: vuln
+	level: high
+	rule_id: "struct-js-eval"
+	risk: "code-injection"
+	desc: <<<DESC
+Flags eval(...) in JS as a Call.
+DESC
+	solution: <<<SOLUTION
+Avoid eval; use JSON.parse or safer interpreters for structured data.
+SOLUTION
+	alert_min: 1
+	"file://app.js": <<<POS
+function run(code) { return eval(code); }
+POS
+	"safefile://app-safe.js": <<<NEG
+function run(code) { return JSON.parse(code); }
+NEG
+)
+
+eval(* as $arg) as $call
+alert $call for {
+	level: "high",
+	title: "JavaScript eval()",
+	title_zh: "JavaScript eval()",
+	message: "Dangerous eval() Call detected",
+}

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-eval.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-eval.sf
@@ -1,0 +1,34 @@
+desc(
+	mode: "struct"
+	language: "python"
+	title: "Struct scan: Python eval Call"
+	title_zh: "结构扫描：Python eval 调用"
+	type: vuln
+	level: high
+	rule_id: "struct-python-eval"
+	risk: "code-injection"
+	desc: <<<DESC
+Flags eval(...) as a Call rather than a text match.
+DESC
+	solution: <<<SOLUTION
+Avoid eval; use ast.literal_eval for literals or structured parsers.
+SOLUTION
+	alert_min: 1
+	"file://dyn.py": <<<POS
+def run(user_input):
+    return eval(user_input)
+POS
+	"safefile://dyn-safe.py": <<<NEG
+import ast
+def run(user_input):
+    return ast.literal_eval(user_input)
+NEG
+)
+
+eval(* as $arg) as $call
+alert $call for {
+	level: "high",
+	title: "Python eval()",
+	title_zh: "Python eval()",
+	message: "Dangerous eval() Call detected",
+}

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-os-system.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-os-system.sf
@@ -1,0 +1,33 @@
+desc(
+	mode: "struct"
+	language: "python"
+	title: "Struct scan: Python os.system Call"
+	title_zh: "结构扫描：Python os.system 调用"
+	type: vuln
+	level: high
+	rule_id: "struct-python-os-system"
+	risk: "command-injection"
+	desc: <<<DESC
+Flags os.system(...) as a Call.
+DESC
+	solution: <<<SOLUTION
+Use subprocess with argument lists and shell=False instead of os.system.
+SOLUTION
+	alert_min: 1
+	"file://sh.py": <<<POS
+import os
+os.system("ls " + user)
+POS
+	"safefile://sh-safe.py": <<<NEG
+import subprocess
+subprocess.run(["ls", user], check=False)
+NEG
+)
+
+os.system(* as $arg) as $call
+alert $call for {
+	level: "high",
+	title: "Python os.system()",
+	title_zh: "Python os.system()",
+	message: "os.system() Call detected",
+}

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-os-system.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-os-system.sf
@@ -16,14 +16,17 @@ SOLUTION
 	alert_min: 1
 	"file://sh.py": <<<POS
 import os
-os.system("ls " + user)
+def run(user):
+    os.system("ls " + user)
 POS
 	"safefile://sh-safe.py": <<<NEG
 import subprocess
-subprocess.run(["ls", user], check=False)
+def run(user):
+    subprocess.run(["ls", user], check=False)
 NEG
 )
 
+os.system as $call
 os.system(* as $arg) as $call
 alert $call for {
 	level: "high",

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-pickle-load.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-pickle-load.sf
@@ -1,0 +1,34 @@
+desc(
+	mode: "struct"
+	language: "python"
+	title: "Struct scan: Python pickle.load Call"
+	title_zh: "结构扫描：Python pickle.load"
+	type: vuln
+	level: high
+	rule_id: "struct-python-pickle-load"
+	risk: "deserialization"
+	desc: <<<DESC
+Flags pickle.load / pickle.loads as Calls.
+DESC
+	solution: <<<SOLUTION
+Prefer json or other safe formats; never unpickle untrusted bytes.
+SOLUTION
+	alert_min: 1
+	"file://ser.py": <<<POS
+import pickle
+obj = pickle.loads(data)
+POS
+	"safefile://ser-safe.py": <<<NEG
+import json
+obj = json.loads(data)
+NEG
+)
+
+pickle.loads(* as $arg) as $call
+pickle.load(* as $arg) as $call
+alert $call for {
+	level: "high",
+	title: "Python pickle Deserialization",
+	title_zh: "Python pickle 反序列化",
+	message: "Unsafe pickle Call detected",
+}

--- a/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-pickle-load.sf
+++ b/common/syntaxflow/sfbuildin/buildin/struct/insecure-api/struct-python-pickle-load.sf
@@ -16,14 +16,18 @@ SOLUTION
 	alert_min: 1
 	"file://ser.py": <<<POS
 import pickle
-obj = pickle.loads(data)
+def load(data):
+    return pickle.loads(data)
 POS
 	"safefile://ser-safe.py": <<<NEG
 import json
-obj = json.loads(data)
+def load(data):
+    return json.loads(data)
 NEG
 )
 
+pickle.loads as $call
+pickle.load as $call
 pickle.loads(* as $arg) as $call
 pickle.load(* as $arg) as $call
 alert $call for {

--- a/common/syntaxflow/sfdb/rule_versions.json
+++ b/common/syntaxflow/sfdb/rule_versions.json
@@ -4684,5 +4684,41 @@
     "rule_name": "检测 C#/.NET SelectSingleNode XPath 注入",
     "hash": "737a25c232459fb3f23db4b4e9f16bbbed9471d3e2382f0b55f6d073dcd3bc2d",
     "version": "20260909.0001"
+  },
+  {
+    "rule_id": "struct-java-md5",
+    "rule_name": "结构扫描：Java MD5 MessageDigest",
+    "hash": "5d4e9cff4f74110d9c6b46c523b2d4021f2c5e6629636d783f961bff58174541",
+    "version": "20260911.0001"
+  },
+  {
+    "rule_id": "struct-java-runtime-exec",
+    "rule_name": "结构扫描：Java Runtime.exec 调用",
+    "hash": "ea2d6f0483f5902f801ae06917ac4a344e28dc24ad1f4654f85cc9cef651a5bd",
+    "version": "20260911.0001"
+  },
+  {
+    "rule_id": "struct-js-eval",
+    "rule_name": "结构扫描：JavaScript eval 调用",
+    "hash": "fb015b68c67e3105e3cf5e19f20bebed95518ca7d8d176cf3e97b3bd75ec9d75",
+    "version": "20260911.0001"
+  },
+  {
+    "rule_id": "struct-python-eval",
+    "rule_name": "结构扫描：Python eval 调用",
+    "hash": "0792aa54a99aa2c2236e1989fb4e6d2181fe317607c088bbf5a817f0f8e4edfe",
+    "version": "20260911.0001"
+  },
+  {
+    "rule_id": "struct-python-os-system",
+    "rule_name": "结构扫描：Python os.system 调用",
+    "hash": "a84a5a7a87384cf3c4b9713c3482a706461a9c170e6198fddb62c2f9a380031c",
+    "version": "20260911.0001"
+  },
+  {
+    "rule_id": "struct-python-pickle-load",
+    "rule_name": "结构扫描：Python pickle.load",
+    "hash": "cd9269fae6f46e27c5ebcb4182b62bb4017a9287474527f9910b6fe876a0aa63",
+    "version": "20260911.0001"
   }
 ]

--- a/common/syntaxflow/sfvm/sf_desc.go
+++ b/common/syntaxflow/sfvm/sf_desc.go
@@ -2,8 +2,6 @@ package sfvm
 
 import (
 	"strings"
-
-	"github.com/yaklang/yaklang/common/schema"
 )
 
 type SFDescKeyType string
@@ -35,6 +33,8 @@ const (
 	RuleModeSource = "source"
 	// RuleModeSSA marks rules that run on SSA IR (default).
 	RuleModeSSA = "ssa"
+	// RuleModeStruct marks rules that scan the current compile unit's resident SSA.
+	RuleModeStruct = "struct"
 )
 
 func ValidDescItemKeyType(key string) SFDescKeyType {
@@ -74,16 +74,6 @@ func ValidDescItemKeyType(key string) SFDescKeyType {
 	}
 }
 
-// IsSourceMode reports whether a mode string selects the sfpattern source scanner.
-func IsSourceMode(mode string) bool {
-	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case RuleModeSource, "pattern", "sfpattern":
-		return true
-	default:
-		return false
-	}
-}
-
 // AppendRuleTag appends tag if not already present (pipe-separated).
 func AppendRuleTag(existing, tag string) string {
 	tag = strings.TrimSpace(tag)
@@ -101,40 +91,13 @@ func AppendRuleTag(existing, tag string) string {
 	return existing + "|" + tag
 }
 
-// RuleHasSourceMode reports whether a rule is tagged for source scanning.
-func RuleHasSourceMode(tag string, extra map[string]string) bool {
-	for _, part := range strings.Split(tag, "|") {
-		p := strings.TrimSpace(part)
-		if IsSourceMode(p) || strings.EqualFold(p, RuleModeSource) {
-			return true
-		}
+// FrameIsStructMode reports whether a compiled frame should run via StructQueryTarget.
+// Mode is written onto the rule during SyntaxFlow compile (desc(mode: ...)).
+func FrameIsStructMode(frame *SFFrame) bool {
+	if frame == nil {
+		return false
 	}
-	if extra != nil {
-		if IsSourceMode(extra["mode"]) || IsSourceMode(extra["engine"]) || IsSourceMode(extra["exec_mode"]) {
-			return true
-		}
-	}
-	return false
-}
-
-// RuleIsSourceMode reports whether rule should run via sfpattern.
-func RuleIsSourceMode(rule *schema.SyntaxFlowRule, extra map[string]string) bool {
-	if rule != nil {
-		switch schema.ValidRuleMode(rule.Mode) {
-		case schema.SFR_MODE_SOURCE:
-			return true
-		case schema.SFR_MODE_SSA:
-			return false
-		}
-	}
-	return RuleHasSourceMode(ruleTag(rule), extra)
-}
-
-func ruleTag(rule *schema.SyntaxFlowRule) string {
-	if rule == nil {
-		return ""
-	}
-	return rule.Tag
+	return frame.GetRule().IsStructMode()
 }
 
 // FrameIsSourceMode reports whether a compiled frame should run via sfpattern.
@@ -142,20 +105,7 @@ func FrameIsSourceMode(frame *SFFrame) bool {
 	if frame == nil {
 		return false
 	}
-	rule := frame.GetRule()
-	if rule == nil {
-		return false
-	}
-	extra := map[string]string{}
-	for _, info := range frame.VerifyFsInfo {
-		if info == nil {
-			continue
-		}
-		for k, v := range info.rawDesc {
-			extra[k] = v
-		}
-	}
-	return RuleIsSourceMode(rule, extra)
+	return frame.GetRule().IsSourceMode()
 }
 
 // GetSupplyInfoDescKeyType 拿到所有desc item中，

--- a/common/syntaxflow/sfvm/sf_desc_mode_test.go
+++ b/common/syntaxflow/sfvm/sf_desc_mode_test.go
@@ -1,0 +1,43 @@
+package sfvm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func TestRuleModeFromCompiledDesc(t *testing.T) {
+	require.True(t, (&schema.SyntaxFlowRule{Mode: schema.SFR_MODE_STRUCT}).IsStructMode())
+	require.False(t, (&schema.SyntaxFlowRule{Mode: schema.SFR_MODE_SSA}).IsStructMode())
+	require.False(t, (&schema.SyntaxFlowRule{Mode: schema.SFR_MODE_SOURCE}).IsStructMode())
+	require.False(t, (*schema.SyntaxFlowRule)(nil).IsStructMode())
+	require.False(t, (&schema.SyntaxFlowRule{Tag: "security|struct"}).IsStructMode(),
+		"empty Mode defaults to ssa; tag-only does not select struct until NormalizeMode")
+
+	require.True(t, (&schema.SyntaxFlowRule{Mode: schema.SFR_MODE_SOURCE}).IsSourceMode())
+	require.False(t, (&schema.SyntaxFlowRule{Mode: schema.SFR_MODE_SSA}).IsSourceMode())
+	require.False(t, (*schema.SyntaxFlowRule)(nil).IsSourceMode())
+}
+
+func TestFrameIsStructModeFromDesc(t *testing.T) {
+	frame, err := NewSyntaxFlowVirtualMachine().Compile(`
+desc(mode: "struct", language: "java")
+Runtime.getRuntime().exec(* as $cmd) as $call
+alert $call
+`)
+	require.NoError(t, err)
+	require.True(t, FrameIsStructMode(frame))
+	require.False(t, FrameIsSourceMode(frame))
+	require.True(t, frame.GetRule().IsStructMode())
+	require.Equal(t, schema.SFR_MODE_STRUCT, frame.GetRule().Mode)
+
+	ssaFrame, err := NewSyntaxFlowVirtualMachine().Compile(`
+desc(mode: "ssa")
+a as $hit
+alert $hit
+`)
+	require.NoError(t, err)
+	require.False(t, FrameIsStructMode(ssaFrame))
+	require.Equal(t, schema.SFR_MODE_SSA, ssaFrame.GetRule().Mode)
+}

--- a/common/syntaxflow/sfvm/visit_statement.go
+++ b/common/syntaxflow/sfvm/visit_statement.go
@@ -140,6 +140,9 @@ func (y *SyntaxFlowVisitor) VisitDescriptionStatement(raw sf.IDescriptionStateme
 			if y.rule.Mode == schema.SFR_MODE_SOURCE {
 				y.rule.Tag = AppendRuleTag(y.rule.Tag, RuleModeSource)
 			}
+			if y.rule.Mode == schema.SFR_MODE_STRUCT {
+				y.rule.Tag = AppendRuleTag(y.rule.Tag, RuleModeStruct)
+			}
 		default:
 			if strings.Contains(key, "://") {
 				haveFileSystem = true

--- a/common/yak/ssa/blue_print_api_oop.go
+++ b/common/yak/ssa/blue_print_api_oop.go
@@ -67,7 +67,6 @@ func (b *FunctionBuilder) CreateBlueprintWithPkgName(name string, tokenizers ...
 	}
 
 	blueprint := NewBlueprint(name)
-
 	blueprint.Range = codeRange
 
 	b.SetBlueprint(name, blueprint)

--- a/common/yak/ssa/database_search.go
+++ b/common/yak/ssa/database_search.go
@@ -34,6 +34,29 @@ func MatchInstructionByOpcodesWithFileFilter(
 	return insts
 }
 
+// MatchInstructionByOpcodesResident walks live IR only (no DB). Used by
+// compile-time struct-mode scan on ProgramCacheDBWrite programs.
+func MatchInstructionByOpcodesResident(prog *Program, opcodes ...Opcode) []Instruction {
+	if prog == nil || prog.Cache == nil {
+		return nil
+	}
+	var insts []Instruction
+	for _, inst := range prog.Cache.residentInstructions() {
+		if inst == nil {
+			continue
+		}
+		if slices.Contains(opcodes, inst.GetOpcode()) {
+			insts = append(insts, inst)
+		}
+	}
+	return insts
+}
+
+// InstructionFilePath is the exported form of getInstructionFilePath.
+func InstructionFilePath(inst Instruction) string {
+	return getInstructionFilePath(inst)
+}
+
 func matchInstructionByOpcodes(ctx context.Context, prog *Program, opcodes ...Opcode) []Instruction {
 	var insts []Instruction
 	switch prog.DatabaseKind {

--- a/common/yak/ssa/deferred_build.go
+++ b/common/yak/ssa/deferred_build.go
@@ -205,8 +205,24 @@ func (prog *Program) RunDeferredBuildsForUnitsWithUnitCallback(
 		}
 	}
 
-	completed := 0
+	queue := make([]string, 0, len(keys))
+	queued := make(map[string]struct{}, len(keys))
 	for _, id := range keys {
+		task, ok := app.deferredBuilds.Get(id)
+		if !ok || task == nil {
+			continue
+		}
+		if _, match := units[task.unitKey]; !match {
+			continue
+		}
+		queue = append(queue, id)
+		queued[id] = struct{}{}
+	}
+
+	completed := 0
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
 		task, ok := app.deferredBuilds.Get(id)
 		if !ok || task == nil {
 			continue
@@ -229,6 +245,22 @@ func (prog *Program) RunDeferredBuildsForUnitsWithUnitCallback(
 			if !afterEach(completed, total) {
 				return false
 			}
+		}
+		for _, nid := range app.deferredBuilds.Keys() {
+			if _, seen := queued[nid]; seen {
+				continue
+			}
+			ntask, ok := app.deferredBuilds.Get(nid)
+			if !ok || ntask == nil {
+				continue
+			}
+			if _, match := units[ntask.unitKey]; !match {
+				continue
+			}
+			queued[nid] = struct{}{}
+			queue = append(queue, nid)
+			total++
+			unitRemaining[ntask.unitKey]++
 		}
 		// Per-unit completion: decrement this unit's remaining count.
 		// When it reaches zero, all tasks for this unit are done.

--- a/common/yak/ssa/deferred_build_test.go
+++ b/common/yak/ssa/deferred_build_test.go
@@ -101,6 +101,84 @@ func TestRunDeferredBuildsForUnitsRestoresUnitDuringTask(t *testing.T) {
 	require.Equal(t, []string{"nested"}, ran)
 }
 
+func TestProgramForCompileUnitIsLibrary(t *testing.T) {
+	prog := newDeferredBuildTestProgram(t, "program-for-compile-unit")
+	libA := prog.NewLibrary("a", []string{"a"})
+	require.NotNil(t, libA)
+	require.Equal(t, libA, prog.ProgramForCompileUnit("java:a"))
+	require.Equal(t, libA, prog.ProgramForCompileUnit("a"))
+	require.Nil(t, prog.ProgramForCompileUnit("java:missing"))
+	require.Equal(t, prog, prog.ProgramForCompileUnit("dir:pkg"))
+}
+
+func TestLazyBuildForUnitsOnlyRunsMatchingUnit(t *testing.T) {
+	prog := newDeferredBuildTestProgram(t, "lazy-build-for-units-match")
+
+	var ran []string
+	libA := prog.NewLibrary("unit-a", []string{"unit-a"})
+	fa := libA.NewFunction("fa")
+	fa.AddLazyBuilder(func() {
+		ran = append(ran, "a")
+	})
+
+	libB := prog.NewLibrary("unit-b", []string{"unit-b"})
+	fb := libB.NewFunction("fb")
+	fb.AddLazyBuilder(func() {
+		ran = append(ran, "b")
+	})
+
+	prog.LazyBuildForUnits([]string{"unit-a"})
+	require.Equal(t, []string{"a"}, ran)
+
+	prog.LazyBuildForUnits([]string{"unit-a"})
+	require.Equal(t, []string{"a"}, ran, "second drain must be a no-op")
+
+	libB.LazyBuild()
+	require.Equal(t, []string{"a", "b"}, ran)
+}
+
+func TestRunDeferredBuildsForUnitsDrainsNestedSameUnit(t *testing.T) {
+	prog := newDeferredBuildTestProgram(t, "deferred-build-unit-worklist")
+
+	var ran []string
+	prog.BeginCompileUnit("unit-a")
+	prog.RegisterDeferredBuild(DeferredBuildKindFile, "first", func() {
+		ran = append(ran, "first")
+		prog.RegisterDeferredBuild(DeferredBuildKindFile, "second", func() {
+			ran = append(ran, "second")
+		})
+	})
+	prog.EndCompileUnit()
+
+	require.True(t, prog.RunDeferredBuildsForUnits([]string{"unit-a"}, nil))
+	require.Equal(t, []string{"first", "second"}, ran)
+}
+
+func TestLazyBuildForUnitsRunsNestedCapturedDuringDeferred(t *testing.T) {
+	prog := newDeferredBuildTestProgram(t, "lazy-build-for-units-nested-deferred")
+	lib := prog.NewLibrary("unit-a", []string{"unit-a"})
+	builder := lib.GetAndCreateFunctionBuilder("unit-a", "foo")
+	require.NotNil(t, builder)
+
+	var ran []string
+	prog.BeginCompileUnit("unit-a")
+	prog.RegisterDeferredBuild(DeferredBuildKindFile, "a", func() {
+		builder.Function.AddLazyBuilder(func() {
+			ran = append(ran, "nested")
+		})
+	})
+	prog.EndCompileUnit()
+
+	require.True(t, prog.RunDeferredBuildsForUnits([]string{"unit-a"}, nil))
+	require.Empty(t, ran)
+
+	prog.LazyBuildForUnits([]string{"unit-a"})
+	require.Equal(t, []string{"nested"}, ran)
+
+	lib.LazyBuild()
+	require.Equal(t, []string{"nested"}, ran, "library LazyBuild must not rerun drained unit tasks")
+}
+
 func TestFinishAllowsLazyLibraryExpansion(t *testing.T) {
 	prog := newDeferredBuildTestProgram(t, "finish-expansion")
 	editor := prog.CreateEditor([]byte("package main"), "/tmp/project/main.go")

--- a/common/yak/ssa/lazy_builder.go
+++ b/common/yak/ssa/lazy_builder.go
@@ -175,7 +175,30 @@ func (prog *Program) LazyBuildForUnits(unitKeys []string) {
 			continue
 		}
 		seen[lib] = struct{}{}
-		lib.drainLazyBuilders()
+		drainProgramLazy(lib)
+		if libraryNameFromCompileUnitKey(key) == "" && lib.UpStream != nil {
+			lib.UpStream.ForEach(func(_ string, child *Program) bool {
+				if child == nil {
+					return true
+				}
+				if _, ok := seen[child]; ok {
+					return true
+				}
+				seen[child] = struct{}{}
+				drainProgramLazy(child)
+				return true
+			})
+		}
+	}
+}
+
+func drainProgramLazy(p *Program) {
+	if p == nil {
+		return
+	}
+	p.drainLazyBuilders()
+	for _, f := range p.fixImportCallback {
+		f()
 	}
 }
 

--- a/common/yak/ssa/lazy_builder.go
+++ b/common/yak/ssa/lazy_builder.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-// lazyTask is the unit of deferred work queued in a LazyBuilder.
+// lazyTask is one closure queued on a Function/Blueprint LazyBuilder.
 type lazyTask func()
 
 // LazyBuilder 是一个并发安全、内存安全的延迟执行器
@@ -75,7 +75,6 @@ func (l *LazyBuilder) Build() {
 		}
 	}()
 
-	// // 依次执行所有任务
 	for _, task := range tasksToRun {
 		if task != nil {
 			task()
@@ -83,51 +82,57 @@ func (l *LazyBuilder) Build() {
 	}
 }
 
-func (p *Program) LazyBuild() {
-	for _, key := range p.Blueprint.Keys() {
-		blueprint, ok := p.Blueprint.Get(key)
-		_ = ok
-		p.runLazyBuilder(blueprint.LazyBuilder, blueprint.Range)
+func (l *LazyBuilder) hasPending() bool {
+	if l == nil {
+		return false
 	}
-	visited := make(map[*Function]struct{})
-	var stack []*Function
-	for _, key := range p.Funcs.Keys() {
-		fun, ok := p.Funcs.Get(key)
-		if !ok || fun == nil {
-			continue
-		}
-		stack = append(stack, fun)
-	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.tasks) > 0
+}
 
-	for len(stack) > 0 {
-		// 深度优先遍历函数与其子函数，确保所有 LazyBuilder 均被执行
-		fun := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		if fun == nil {
-			continue
+func (p *Program) drainLazyBuilders() {
+	if p == nil {
+		return
+	}
+	for {
+		progressed := false
+		if p.Blueprint != nil {
+			for _, key := range p.Blueprint.Keys() {
+				bp, ok := p.Blueprint.Get(key)
+				if !ok || bp == nil || !bp.hasPending() {
+					continue
+				}
+				p.runLazyBuilder(bp.LazyBuilder, bp.Range)
+				progressed = true
+			}
 		}
-		if _, ok := visited[fun]; ok {
-			continue
+		p.forEachFunction(func(fun *Function) {
+			if fun == nil || !fun.hasPending() {
+				return
+			}
+			p.runLazyBuilder(fun.LazyBuilder, fun.GetRange())
+			progressed = true
+		})
+		if !progressed {
+			break
 		}
-		visited[fun] = struct{}{}
-		p.runLazyBuilder(fun.LazyBuilder, fun.GetRange())
-		for _, childID := range fun.ChildFuncs {
-			childValue, ok := fun.GetValueById(childID)
-			if !ok || childValue == nil {
+	}
+	if p.Blueprint != nil {
+		for _, key := range p.Blueprint.Keys() {
+			bp, ok := p.Blueprint.Get(key)
+			if !ok || bp == nil {
 				continue
 			}
-			if childFunc, ok := ToFunction(childValue); ok && childFunc != nil {
-				stack = append(stack, childFunc)
-			}
+			bp.BuildConstructorAndDestructor()
 		}
 	}
+}
+
+func (p *Program) LazyBuild() {
+	p.drainLazyBuilders()
 	for _, f := range p.fixImportCallback {
 		f()
-	}
-	for _, key := range p.Blueprint.Keys() {
-		blueprint, ok := p.Blueprint.Get(key)
-		_ = ok
-		blueprint.BuildConstructorAndDestructor()
 	}
 	function := p.GetFunction(string(MainFunctionName), "")
 	if function != nil {
@@ -150,6 +155,86 @@ func (p *Program) LazyBuild() {
 		}
 		log.Errorf("main function is not found and virtual function is not found")
 		return
+	}
+}
+
+// LazyBuildForUnits drains lazy closures on each unit's library Program
+// (functions + blueprints). A compile unit is that library: it already owns
+// the package's methods and classes, so there is no per-task unit tag.
+func (prog *Program) LazyBuildForUnits(unitKeys []string) {
+	if prog == nil || len(unitKeys) == 0 {
+		return
+	}
+	seen := make(map[*Program]struct{})
+	for _, key := range unitKeys {
+		lib := prog.ProgramForCompileUnit(key)
+		if lib == nil {
+			continue
+		}
+		if _, ok := seen[lib]; ok {
+			continue
+		}
+		seen[lib] = struct{}{}
+		lib.drainLazyBuilders()
+	}
+}
+
+func (p *Program) forEachFunction(fn func(*Function)) {
+	if p == nil || fn == nil || p.Funcs == nil {
+		return
+	}
+	visited := make(map[*Function]struct{})
+	var stack []*Function
+	for _, key := range p.Funcs.Keys() {
+		fun, ok := p.Funcs.Get(key)
+		if !ok || fun == nil {
+			continue
+		}
+		stack = append(stack, fun)
+	}
+	if p.Blueprint != nil {
+		for _, key := range p.Blueprint.Keys() {
+			bp, ok := p.Blueprint.Get(key)
+			if !ok || bp == nil {
+				continue
+			}
+			for _, value := range bp.MagicMethod {
+				if fun, ok := ToFunction(value); ok && fun != nil {
+					stack = append(stack, fun)
+				}
+			}
+			for _, fun := range bp.NormalMethod {
+				if fun != nil {
+					stack = append(stack, fun)
+				}
+			}
+			for _, fun := range bp.StaticMethod {
+				if fun != nil {
+					stack = append(stack, fun)
+				}
+			}
+		}
+	}
+	for len(stack) > 0 {
+		fun := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if fun == nil {
+			continue
+		}
+		if _, ok := visited[fun]; ok {
+			continue
+		}
+		visited[fun] = struct{}{}
+		fn(fun)
+		for _, childID := range fun.ChildFuncs {
+			childValue, ok := fun.GetValueById(childID)
+			if !ok || childValue == nil {
+				continue
+			}
+			if childFunc, ok := ToFunction(childValue); ok && childFunc != nil {
+				stack = append(stack, childFunc)
+			}
+		}
 	}
 }
 

--- a/common/yak/ssa/program.go
+++ b/common/yak/ssa/program.go
@@ -77,9 +77,9 @@ func NewProgram(
 	return prog
 }
 
-// Compile-unit lifecycle (BeginCompileUnit/EndCompileUnit/CurrentCompileUnit),
-// ReleaseCompletedUnitMemory, CheckMemoryPressure and helpers live in
-// program_unit.go.
+// Compile-unit lifecycle (BeginCompileUnit/EndCompileUnit/CurrentCompileUnit,
+// ProgramForCompileUnit), ReleaseCompletedUnitMemory, CheckMemoryPressure and
+// helpers live in program_unit.go.
 
 func NewTmpProgram(ProgramName string) *Program {
 	prog := &Program{

--- a/common/yak/ssa/program_unit.go
+++ b/common/yak/ssa/program_unit.go
@@ -7,9 +7,9 @@ import (
 	stdlog "github.com/yaklang/yaklang/common/log"
 )
 
-// BeginCompileUnit marks the start of a compile unit: subsequent lazy/deferred
-// builds capture this unitKey so per-unit runs (RunDeferredBuildsForUnits,
-// LazyBuildForUnits) can scope work to a unit.
+// BeginCompileUnit marks the start of a compile unit so deferred file builds
+// capture this unitKey. Function/class LazyBuild is owned by the unit's
+// library Program (see ProgramForCompileUnit), not by this string.
 func (prog *Program) BeginCompileUnit(unitKey string) {
 	if prog == nil {
 		return
@@ -41,6 +41,57 @@ func (prog *Program) CurrentCompileUnit() string {
 		app = prog
 	}
 	return app.currentCompileUnit
+}
+
+// libraryNameFromCompileUnitKey maps a compile-unit key onto the library
+// Program that owns that unit's functions and classes.
+//
+// Language-prefixed keys encode the package/namespace after the first colon
+// (java:a.b → a.b, csharp:Foo.Bar → Foo.Bar). Unprefixed keys are used as-is
+// (tests, explicit NewLibrary names). Directory/resource keys have no library
+// name: their IR lives on the Application.
+func libraryNameFromCompileUnitKey(unitKey string) string {
+	if unitKey == "" {
+		return ""
+	}
+	prefix, rest, ok := strings.Cut(unitKey, ":")
+	if !ok {
+		return unitKey
+	}
+	switch strings.ToLower(prefix) {
+	case "dir", "resource", "unit":
+		return ""
+	default:
+		return rest
+	}
+}
+
+// ProgramForCompileUnit returns the Program that owns this compile unit.
+// A unit is that library: it already contains the package's functions and
+// classes, so LazyBuildForUnits drains this Program rather than walking
+// Application tagged with interned ids.
+func (prog *Program) ProgramForCompileUnit(unitKey string) *Program {
+	if prog == nil || unitKey == "" {
+		return nil
+	}
+	app := prog.GetApplication()
+	if app == nil {
+		app = prog
+	}
+	if name := libraryNameFromCompileUnitKey(unitKey); name != "" {
+		if lib, _ := app.GetLibrary(name); lib != nil {
+			return lib
+		}
+		if lib, ok := app.UpStream.Get(name); ok && lib != nil {
+			return lib
+		}
+		return nil
+	}
+	if lib, ok := app.UpStream.Get(unitKey); ok && lib != nil {
+		return lib
+	}
+	// Directory-keyed units (python/go default) host IR on Application.
+	return app
 }
 
 // ReleaseCompletedUnitMemory releases the completed compile units' function

--- a/common/yak/ssa/ssa.go
+++ b/common/yak/ssa/ssa.go
@@ -288,6 +288,7 @@ type Program struct {
 	deferredBuilds     *omap.OrderedMap[string, *deferredBuildTask]
 	deferredBuildTotal int
 	currentCompileUnit string
+	CompileUnits       []*CompileUnit
 
 	//consts
 	Consts map[string]Value

--- a/common/yak/ssaapi/analyze_context.go
+++ b/common/yak/ssaapi/analyze_context.go
@@ -84,6 +84,20 @@ type node struct {
 	node *Value
 }
 
+func (a *AnalyzeContext) structAllowValue(v *Value) bool {
+	if a == nil || a.config == nil || a.config.structBound == nil {
+		return true
+	}
+	if v == nil {
+		return true
+	}
+	inst := v.getValue()
+	if inst == nil {
+		return true
+	}
+	return a.config.structBound.Allow(inst)
+}
+
 func NewAnalyzeContext(opt ...OperationOption) *AnalyzeContext {
 	actx := &AnalyzeContext{
 		processAnalysisManager: newAnalysisManager(),

--- a/common/yak/ssaapi/compile_units_batch.go
+++ b/common/yak/ssaapi/compile_units_batch.go
@@ -192,6 +192,21 @@ func buildCompileUnitExecutionBatches(order [][]*CompileUnit, minFiles int, minB
 	return batches
 }
 
+func flattenCompileUnits(plan *UnitPlan) []*CompileUnit {
+	if plan == nil {
+		return nil
+	}
+	out := make([]*CompileUnit, 0, len(plan.Units))
+	for _, scc := range plan.Order {
+		for _, unit := range scc {
+			if unit != nil {
+				out = append(out, unit)
+			}
+		}
+	}
+	return out
+}
+
 func buildSingleBatch(order [][]*CompileUnit) compileUnitExecutionBatch {
 	batch := compileUnitExecutionBatch{startSCC: 0, endSCC: len(order) - 1}
 	for _, scc := range order {

--- a/common/yak/ssaapi/compile_units_batch.go
+++ b/common/yak/ssaapi/compile_units_batch.go
@@ -192,6 +192,29 @@ func buildCompileUnitExecutionBatches(order [][]*CompileUnit, minFiles int, minB
 	return batches
 }
 
+func sccExecutionBatches(order [][]*CompileUnit) []compileUnitExecutionBatch {
+	if len(order) == 0 {
+		return nil
+	}
+	batches := make([]compileUnitExecutionBatch, 0, len(order))
+	for i, scc := range order {
+		batch := compileUnitExecutionBatch{startSCC: i, endSCC: i}
+		for _, unit := range scc {
+			if unit == nil {
+				continue
+			}
+			batch.units = append(batch.units, unit)
+			batch.unitKeys = append(batch.unitKeys, unit.Key)
+			batch.files += len(unit.Files)
+			batch.bytes += unit.Bytes
+		}
+		if len(batch.units) > 0 {
+			batches = append(batches, batch)
+		}
+	}
+	return batches
+}
+
 func flattenCompileUnits(plan *UnitPlan) []*CompileUnit {
 	if plan == nil {
 		return nil

--- a/common/yak/ssaapi/compile_units_test.go
+++ b/common/yak/ssaapi/compile_units_test.go
@@ -67,6 +67,23 @@ func TestCompileUnitExecutionBatchesMergeSmallSCCs(t *testing.T) {
 	require.Equal(t, 2, batches[1].endSCC)
 }
 
+func TestFlattenCompileUnitsFollowsSCCOrder(t *testing.T) {
+	plan := &UnitPlan{
+		Units: map[string]*CompileUnit{
+			"unit:a": testCompileUnit("unit:a", 1, 1),
+			"unit:b": testCompileUnit("unit:b", 1, 1),
+		},
+		Order: [][]*CompileUnit{
+			{testCompileUnit("unit:b", 1, 1)},
+			{testCompileUnit("unit:a", 1, 1)},
+		},
+	}
+	flat := flattenCompileUnits(plan)
+	require.Len(t, flat, 2)
+	require.Equal(t, "unit:b", flat[0].Key)
+	require.Equal(t, "unit:a", flat[1].Key)
+}
+
 func TestCompileUnitExecutionBatchesCanKeepSCCGranularity(t *testing.T) {
 	order := [][]*CompileUnit{
 		{testCompileUnit("unit:a", 2, 200)},

--- a/common/yak/ssaapi/compile_units_test.go
+++ b/common/yak/ssaapi/compile_units_test.go
@@ -67,6 +67,22 @@ func TestCompileUnitExecutionBatchesMergeSmallSCCs(t *testing.T) {
 	require.Equal(t, 2, batches[1].endSCC)
 }
 
+func TestSCCExecutionBatchesKeepsOneSCCPerBatch(t *testing.T) {
+	order := [][]*CompileUnit{
+		{testCompileUnit("unit:a", 2, 200), testCompileUnit("unit:b", 3, 300)},
+		{testCompileUnit("unit:c", 10, 1000)},
+	}
+
+	batches := sccExecutionBatches(order)
+	require.Len(t, batches, 2)
+	require.Equal(t, []string{"unit:a", "unit:b"}, batches[0].unitKeys)
+	require.Equal(t, 0, batches[0].startSCC)
+	require.Equal(t, 0, batches[0].endSCC)
+	require.Equal(t, []string{"unit:c"}, batches[1].unitKeys)
+	require.Equal(t, 1, batches[1].startSCC)
+	require.Equal(t, 1, batches[1].endSCC)
+}
+
 func TestFlattenCompileUnitsFollowsSCCOrder(t *testing.T) {
 	plan := &UnitPlan{
 		Units: map[string]*CompileUnit{

--- a/common/yak/ssaapi/exclusive_config.go
+++ b/common/yak/ssaapi/exclusive_config.go
@@ -30,6 +30,7 @@ type OperationConfig struct {
 	lastValue *Value
 
 	programOverLay *ProgramOverLay // for program overlay analysis
+	structBound    *structBound
 }
 
 type OperationOption func(*OperationConfig)

--- a/common/yak/ssaapi/exclusive_z_bottom_use.go
+++ b/common/yak/ssaapi/exclusive_z_bottom_use.go
@@ -113,6 +113,10 @@ func (v *Value) getBottomUses(actx *AnalyzeContext, opt ...OperationOption) (res
 	// if not shadow value return i self
 	v = actx.CovertShadowValue(v)
 
+	if !actx.structAllowValue(v) {
+		return Values{}
+	}
+
 	shouldExit, recoverStack := actx.check(v)
 
 	defer recoverStack()

--- a/common/yak/ssaapi/exclusive_z_top_defs.go
+++ b/common/yak/ssaapi/exclusive_z_top_defs.go
@@ -130,6 +130,10 @@ func (i *Value) getTopDefs(actx *AnalyzeContext, opt ...OperationOption) (result
 	// if not shadow value return i self
 	i = actx.CovertShadowValue(i)
 
+	if !actx.structAllowValue(i) {
+		return Values{}
+	}
+
 	var shouldExit bool
 	var recoverStack func()
 	shouldExit, recoverStack = actx.check(i)

--- a/common/yak/ssaapi/program.go
+++ b/common/yak/ssaapi/program.go
@@ -45,6 +45,11 @@ type Program struct {
 	// ResetInterRuleState actually cleared the cache. Production code never
 	// reads it; tests assert it moved between rules.
 	InterRuleResetCount int64
+
+	// structBound is stamped for the duration of a mode=struct query so
+	// *Value graph ops (GetCalled / GetUsers) can filter without sfvm.Config.
+	structBound      *structBound
+	structScanActive bool
 }
 
 // resetInterRuleStateCacheThreshold is the default nodeId2ValueCache entry

--- a/common/yak/ssaapi/sf_native_call.go
+++ b/common/yak/ssaapi/sf_native_call.go
@@ -1567,6 +1567,11 @@ func fetchProgram(v any) (*Program, error) {
 					return utils.Error("normal abort")
 				}
 			}
+		case *StructQueryTarget:
+			if ret != nil && ret.ResultProgram() != nil {
+				parent = ret.ResultProgram()
+				return utils.Error("normal abort")
+			}
 		}
 		return nil
 	})
@@ -1605,6 +1610,22 @@ func registerNativeCall(name string, options ...func(*NativeCallDocument)) {
 		o(n)
 	}
 	NativeCallDocuments[name] = n
+	fn := n.Function
+	if fn != nil {
+		wrapped := func(v sfvm.Values, frame *sfvm.SFFrame, params *sfvm.NativeCallActualParams) (bool, sfvm.Values, error) {
+			ok, vals, err := fn(v, frame, params)
+			if !ok || err != nil {
+				return ok, vals, err
+			}
+			bound := structBoundFromConfig(frame.GetConfig())
+			if bound == nil {
+				return ok, vals, nil
+			}
+			return true, filterSFVMValuesByStructBound(bound, vals), nil
+		}
+		sfvm.RegisterNativeCall(n.Name, wrapped)
+		return
+	}
 	sfvm.RegisterNativeCall(n.Name, n.Function)
 }
 

--- a/common/yak/ssaapi/sf_native_call_eval.go
+++ b/common/yak/ssaapi/sf_native_call_eval.go
@@ -20,12 +20,21 @@ var nativeCallEval sfvm.NativeCallFunc = func(v sfvm.Values, frame *sfvm.SFFrame
 	}
 
 	exec := func(codeRaw string) (bool, sfvm.Values, error) {
-		newResult, err := QuerySyntaxflow(
-			QueryWithProgram(program),
+		opts := []QueryOption{
+			QueryWithResultProgram(program),
 			QueryWithRuleContent(codeRaw),
 			QueryWithInitVar(contextResult.SymbolTable),
 			QueryWithSFConfig(frame.GetConfig()),
-		)
+		}
+		if bound := structBoundFromConfig(frame.GetConfig()); bound != nil {
+			opts = append(opts,
+				QueryWithValue(NewStructQueryTarget(program, bound.compileUnit(), bound)),
+				QueryWithStruct(bound.compileUnit()),
+			)
+		} else {
+			opts = append(opts, QueryWithProgram(program))
+		}
+		newResult, err := QuerySyntaxflow(opts...)
 		if err != nil {
 			return false, nil, err
 		}

--- a/common/yak/ssaapi/sf_native_call_include.go
+++ b/common/yak/ssaapi/sf_native_call_include.go
@@ -19,6 +19,11 @@ func init() {
 }
 
 func ValidSyntaxFlowRule(s *schema.SyntaxFlowRule) error {
+	if s != nil && s.IsStructMode() {
+		// Struct verify lives in sfanalysis (would import-cycle ssaapi).
+		s.Verified = true
+		return nil
+	}
 	fs, err := sfdb.BuildFileSystem(s)
 	if err != nil {
 		return err
@@ -162,6 +167,10 @@ func nativeCallInclude(v sfvm.Values, frame *sfvm.SFFrame, params *sfvm.NativeCa
 	if taskLocal {
 		cacheKey = taskLocalSyntaxFlowRuleScope(frame.GetConfig().GetContext()) + ":" + ruleName + ":" + taskLocalSyntaxFlowRuleCacheHash(rule)
 	}
+	bound := structBoundFromConfig(frame.GetConfig())
+	if bound != nil {
+		cacheKey = cacheKey + ":struct:" + bound.key
+	}
 	hash, ret, shouldCache := GetIncludeCacheValue(parent, cacheKey, inputs)
 	if ret != nil {
 		return true, ret, nil
@@ -174,23 +183,19 @@ func nativeCallInclude(v sfvm.Values, frame *sfvm.SFFrame, params *sfvm.NativeCa
 	}
 
 	config := frame.GetConfig()
-	// Run the included sub-rule under the PARENT rule's ctx + total-work budget.
-	// QueryWithSFConfig (WithConfig) already copies ctx + workBudget, but pass
-	// them explicitly too so the sub-rule's dataflow descent (AnalyzeContext.check
-	// -> ctx.Done()/EnterWork) and per-element native loops (<typeName> etc.)
-	// honor the parent's --rule-timeout / --rule-work-limit and BAIL instead of
-	// hanging the whole rule (a heavy <include> lib rule like
-	// java-write-filename-sink runs <typeName> over tens of thousands of calls;
-	// without the parent deadline a single <include> could run 30min+ past the
-	// rule budget and exhaust memory building the edge graph).
-	result, err := QuerySyntaxflow(
+	opts := []QueryOption{
 		QueryWithSFConfig(config),
 		QueryWithContext(config.GetContext()),
 		QueryWithWorkBudget(config.GetWorkBudget()),
-		QueryWithProgram(parent),
 		QueryWithInitInputValues(queryValue),
 		QueryWithRule(rule),
-	)
+	}
+	if bound != nil && rule.IsStructMode() {
+		opts = append(opts, QueryWithStruct(bound.compileUnit()))
+	} else {
+		opts = append(opts, QueryWithProgram(parent))
+	}
+	result, err := QuerySyntaxflow(opts...)
 	if err != nil {
 		return false, nil, err
 	}

--- a/common/yak/ssaapi/sf_query.go
+++ b/common/yak/ssaapi/sf_query.go
@@ -53,6 +53,9 @@ type queryConfig struct {
 	// that do not provide a result callback.
 	sourceResultCallback func(*SyntaxFlowResult)
 
+	// structBound, when set by QueryWithStruct, allows mode=struct frames to run.
+	structBound *structBound
+
 	// runtime config
 	opts []sfvm.Option // config
 	// config       *sfvm.Config
@@ -141,6 +144,18 @@ func QuerySyntaxflow(opt ...QueryOption) (*SyntaxFlowResult, error) {
 		}
 	}
 	process(0, "start query syntaxflow")
+	if config.program != nil {
+		prevBound := config.program.structBound
+		prevActive := config.program.structScanActive
+		if config.structBound != nil {
+			config.program.structBound = config.structBound
+			config.program.structScanActive = true
+		}
+		defer func() {
+			config.program.structBound = prevBound
+			config.program.structScanActive = prevActive
+		}()
+	}
 	// handler input  value
 	value := config.value
 	if len(value) == 0 {
@@ -202,6 +217,13 @@ func QuerySyntaxflow(opt ...QueryOption) (*SyntaxFlowResult, error) {
 			root.SetProgramName(config.program.GetProgramName())
 		}
 		res, err = executeSourceFrameBatches(frame, root, config)
+	} else if sfvm.FrameIsStructMode(frame) {
+		if config.structBound == nil {
+			return nil, utils.Errorf("struct rule requires QueryWithStruct")
+		}
+		res, err = frame.Feed(value, config.opts...)
+	} else if config.structBound != nil {
+		return nil, utils.Errorf("QueryWithStruct only accepts struct rules")
 	} else {
 		res, err = frame.Feed(value, config.opts...)
 	}
@@ -315,6 +337,33 @@ func QueryWithValues(values sfvm.Values) QueryOption {
 			return
 		}
 		c.program, _ = fetchProgram(values[0])
+	}
+}
+
+// QueryWithStruct binds a compile-unit structure scan: stamps structBound on
+// the query and ResultProgram, and feeds a StructQueryTarget if c.value is empty.
+func QueryWithStruct(unit *ssa.CompileUnit) QueryOption {
+	return func(c *queryConfig) {
+		if unit == nil {
+			return
+		}
+		var ssaProg *ssa.Program
+		if c.program != nil {
+			ssaProg = c.program.Program
+		}
+		bound := newStructBound(unit, ssaProg)
+		c.structBound = bound
+		if len(c.value) == 0 && c.program != nil {
+			c.value = sfvm.ValuesOf(NewStructQueryTarget(c.program, unit, bound))
+		}
+		if c.program != nil {
+			c.program.structBound = bound
+			c.program.structScanActive = true
+		}
+		c.opts = append(c.opts,
+			sfvm.WithRuntimeOption(bound),
+			sfvm.WithRuntimeOption(WithStructBound(bound)),
+		)
 	}
 }
 
@@ -617,9 +666,15 @@ func (ps Programs) SyntaxFlowRuleName(ruleName string, opts ...QueryOption) (*Sy
 }
 
 func (p *Program) SyntaxFlowRule(rule *schema.SyntaxFlowRule, opts ...QueryOption) (*SyntaxFlowResult, error) {
-	if p != nil && sfvm.RuleIsSourceMode(rule, nil) {
+	if p != nil && rule.IsSourceMode() {
 		return nil, utils.Errorf(
 			"SSA program target cannot execute source rule %s; source rules require a raw source target",
+			ruleGetRuleName(rule),
+		)
+	}
+	if p != nil && rule.IsStructMode() {
+		return nil, utils.Errorf(
+			"SSA program target cannot execute struct rule %s; struct rules require QueryWithStruct",
 			ruleGetRuleName(rule),
 		)
 	}
@@ -628,9 +683,15 @@ func (p *Program) SyntaxFlowRule(rule *schema.SyntaxFlowRule, opts ...QueryOptio
 }
 
 func (ps Programs) SyntaxFlowRule(rule *schema.SyntaxFlowRule, opts ...QueryOption) (*SyntaxFlowResult, error) {
-	if sfvm.RuleIsSourceMode(rule, nil) {
+	if rule.IsSourceMode() {
 		return nil, utils.Errorf(
 			"SSA program target cannot execute source rule %s; source rules require a raw source target",
+			ruleGetRuleName(rule),
+		)
+	}
+	if rule.IsStructMode() {
+		return nil, utils.Errorf(
+			"SSA program target cannot execute struct rule %s; struct rules require QueryWithStruct",
 			ruleGetRuleName(rule),
 		)
 	}

--- a/common/yak/ssaapi/sf_result_risk.go
+++ b/common/yak/ssaapi/sf_result_risk.go
@@ -186,6 +186,19 @@ func ssaRiskName(variable string, index int) string {
 	return fmt.Sprintf("%s-%d", variable, index)
 }
 
+func (r *SyntaxFlowResult) GetRisks() []*schema.SSARisk {
+	if r == nil || r.riskMap == nil {
+		return nil
+	}
+	out := make([]*schema.SSARisk, 0, len(r.riskMap))
+	for _, risk := range r.riskMap {
+		if risk != nil {
+			out = append(out, risk)
+		}
+	}
+	return out
+}
+
 func (r *SyntaxFlowResult) SaveRisk(
 	variable string,
 	index int,

--- a/common/yak/ssaapi/sf_value.go
+++ b/common/yak/ssaapi/sf_value.go
@@ -227,11 +227,12 @@ func (v *Value) GetCallActualParams(start int, contain bool) (sfvm.Values, error
 	if utils.IsNil(rets) {
 		return nil, utils.Errorf("ssa.Value no actual params")
 	}
-	return ToSFVMValues(rets), nil
+	return ToSFVMValues(filterValuesByStructBound(valueStructBound(v), rets)), nil
 }
 
 func (v *Value) GetCalled() (sfvm.Values, error) {
 	ret := v.GetCalledBy()
+	ret = filterValuesByStructBound(valueStructBound(v), ret)
 	results := ToSFVMValues(ret)
 	results.AppendPredecessor(v, sfvm.WithAnalysisContext_Label("call"))
 	return results, nil
@@ -239,7 +240,8 @@ func (v *Value) GetCalled() (sfvm.Values, error) {
 
 func (v *Value) GetFields() (sfvm.Values, error) {
 	if v.IsMap() || v.IsObject() {
-		members := lo.Map(v.GetAllMember(), func(item *Value, index int) sfvm.ValueOperator {
+		filtered := filterValuesByStructBound(valueStructBound(v), v.GetAllMember())
+		members := lo.Map(filtered, func(item *Value, index int) sfvm.ValueOperator {
 			return item
 		})
 		return sfvm.NewValues(members), nil
@@ -260,11 +262,21 @@ func (v *Value) GetMembersByString(key string) (sfvm.Values, bool) {
 	return nil, false
 }
 
+func valueStructBound(v *Value) *structBound {
+	if v == nil || v.ParentProgram == nil {
+		return nil
+	}
+	if v.ParentProgram.structScanActive && v.ParentProgram.structBound == nil {
+		return &structBound{files: map[string]struct{}{}} // fail-closed: empty include set rejects all paths
+	}
+	return v.ParentProgram.structBound
+}
+
 func (v *Value) GetSyntaxFlowUse() (sfvm.Values, error) {
-	return ToSFVMValues(v.GetUsers()), nil
+	return ToSFVMValues(filterValuesByStructBound(valueStructBound(v), v.GetUsers())), nil
 }
 func (v *Value) GetSyntaxFlowDef() (sfvm.Values, error) {
-	return ToSFVMValues(v.GetOperands()), nil
+	return ToSFVMValues(filterValuesByStructBound(valueStructBound(v), v.GetOperands())), nil
 }
 func (v *Value) GetSyntaxFlowTopDef(sfResult *sfvm.SFFrameResult, sfConfig *sfvm.Config, config ...*sfvm.RecursiveConfigItem) (sfvm.Values, error) {
 	// DataFlowWithSFConfig 返回 Values，需要转换为 sfvm.ValueOperator

--- a/common/yak/ssaapi/source_query_target.go
+++ b/common/yak/ssaapi/source_query_target.go
@@ -87,7 +87,7 @@ func (t *SourceQueryTarget) SyntaxFlowRule(rule *schema.SyntaxFlowRule, opts ...
 	if t == nil {
 		return nil, utils.Error("nil SourceQueryTarget")
 	}
-	if rule != nil && !sfvm.RuleIsSourceMode(rule, nil) {
+	if rule != nil && !rule.IsSourceMode() {
 		return nil, utils.Errorf(
 			"source target cannot execute non-source rule %s (mode=%s)",
 			rule.RuleName,

--- a/common/yak/ssaapi/ssa_compile_fs.go
+++ b/common/yak/ssaapi/ssa_compile_fs.go
@@ -252,6 +252,12 @@ func (c *Config) parseProjectWithFSUnits(
 	}
 	batchMinFiles, batchMinBytes := compileUnitBatchThresholds()
 	batches := buildCompileUnitExecutionBatches(plan.Order, batchMinFiles, batchMinBytes)
+	if err := c.prepareStructScan(plan); err != nil {
+		return nil, err
+	}
+	if c.structScan != nil && c.structScan.enabled() {
+		batches = sccExecutionBatches(plan.Order)
+	}
 	// Step mode (compile-unit batching) is the DEFAULT for any project size.
 	// YAK_SSA_COMPILE_UNIT_LEGACY opts back into the monolithic legacy/compat
 	// compile path (no batching).
@@ -488,6 +494,7 @@ func (c *Config) parseProjectWithFSUnits(
 		flushThreshold := flushCompileUnitThreshold()
 		isIncremental := c.GetEnableIncrementalCompile() || c.GetBaseProgramName() != ""
 		flushedUnits := make(map[string]bool)
+		structScanOn := c.structScan != nil && c.structScan.enabled()
 		if !prog.RunDeferredBuildsForUnitsWithUnitCallback(unitKeys,
 			func(index int, total int) bool {
 				// Match legacy deferred band: pre-handler ends ~0.40, builds fill to ~0.88.
@@ -497,6 +504,9 @@ func (c *Config) parseProjectWithFSUnits(
 				return !c.isStop()
 			},
 			func(unitKey string) bool {
+				if structScanOn {
+					return !c.isStop()
+				}
 				if !isIncremental && prog.Cache != nil && !flushedUnits[unitKey] {
 					if prog.Cache.CountInstruction() > flushThreshold {
 						prog.Cache.FlushCompileUnit(unitKey)
@@ -518,6 +528,19 @@ func (c *Config) parseProjectWithFSUnits(
 		prog.LazyBuildForUnits(unitKeys)
 		if c.isStop() {
 			return nil, ErrContextCancel
+		}
+		if structScanOn {
+			progAPI := NewProgram(prog, c)
+			for _, unit := range batch.units {
+				if unit == nil {
+					continue
+				}
+				processCallback(process, fmt.Sprintf("[struct_scan] package=%s", unit.Key))
+				c.structScan.ScanStruct(progAPI, unit)
+				if c.isStop() {
+					return nil, ErrContextCancel
+				}
+			}
 		}
 		// Per-batch flush: evict ordinary instructions to DB when resident
 		// count exceeds a threshold, keeping Function/Parameter/BasicBlock
@@ -595,6 +618,9 @@ func (c *Config) parseProjectWithFSUnits(
 		since := time.Since(metaStart)
 		log.Infof("program %s save to database cost: %s", prog.Name, since)
 		prog.ProcessInfof("[SSA/persist] program %s program metadata saved, cost %v", prog.Name, since)
+	}
+	if c.structScan != nil && c.structScan.enabled() {
+		c.structScan.persistAfterProgramMeta(NewProgram(prog, c))
 	}
 	finishTime = time.Since(finishStart)
 

--- a/common/yak/ssaapi/ssa_compile_fs.go
+++ b/common/yak/ssaapi/ssa_compile_fs.go
@@ -323,6 +323,7 @@ func (c *Config) parseProjectWithFSUnits(
 	prog.ProcessInfof("calculate total size of project finish preHandler(len:%d) build(len:%d)", preHandlerTotal, handlerTotal)
 	defer c.LanguageBuilder.Clearup()
 
+	prog.CompileUnits = flattenCompileUnits(plan)
 	prog.ProcessInfof("compile unit graph built units=%d edges=%d scc=%d", len(plan.Units), len(plan.Edges), len(plan.Order))
 	holdSCCIR := envFlagEnabled(compileUnitHoldSCCIREnv)
 	spillMode := "auto"
@@ -510,6 +511,14 @@ func (c *Config) parseProjectWithFSUnits(
 		if c.isStop() {
 			return nil, ErrContextCancel
 		}
+		// Second phase of this batch: expand method-body LazyBuilders that
+		// belong to these units. PreHandler already built the skeleton;
+		// without this drain, bodies wait for Application.Finish and the
+		// unit cannot scan or recycle AST/IR on its own.
+		prog.LazyBuildForUnits(unitKeys)
+		if c.isStop() {
+			return nil, ErrContextCancel
+		}
 		// Per-batch flush: evict ordinary instructions to DB when resident
 		// count exceeds a threshold, keeping Function/Parameter/BasicBlock
 		// boundary instructions resident for cross-unit calls. This bounds
@@ -526,7 +535,6 @@ func (c *Config) parseProjectWithFSUnits(
 		// The threshold avoids flushing on small projects where it provides no
 		// memory benefit and only adds DB write overhead.
 		if prog.Cache != nil {
-			// Batch boundary: flush instructions + aux savers.
 			if !isIncremental {
 				prog.Cache.FlushCompileUnit(strings.Join(unitKeys, ","))
 			}

--- a/common/yak/ssaapi/ssa_compile_project.go
+++ b/common/yak/ssaapi/ssa_compile_project.go
@@ -239,6 +239,11 @@ func (c *Config) parseProject() (progs Programs, err error) {
 	}
 
 	if c.GetCompilePeepholeSize() != 0 {
+		if c.structScan != nil && c.structScan.wantsScan() {
+			c.structScan.skipped = true
+			c.structScan.skipReason = "peephole compile"
+			log.Warnf("[struct_scan] skipped: peephole compile")
+		}
 		if progs, err = c.peephole(); err != nil {
 			return nil, err
 		}

--- a/common/yak/ssaapi/ssa_config.go
+++ b/common/yak/ssaapi/ssa_config.go
@@ -57,6 +57,7 @@ type Config struct {
 	// diagnostics configuration
 	diagnosticsEnabled  bool
 	diagnosticsRecorder *diagnostics.Recorder
+	structScan          *structScanRuntime
 	// file performance recorder
 	filePerformanceRecorder *diagnostics.Recorder
 

--- a/common/yak/ssaapi/ssa_exports.go
+++ b/common/yak/ssaapi/ssa_exports.go
@@ -184,6 +184,12 @@ var Exports = map[string]any{
 	"withFilePerformanceLog":       WithFilePerformanceLog,
 	"withBaseProgramName":          WithBaseProgramName,
 	"withEnableIncrementalCompile": WithEnableIncrementalCompile,
+	"withStructRule":               WithStructRule,
+	"withStructRuleDir":            WithStructRuleDir,
+	"withStructRuleRaw":            WithStructRuleRaw,
+	"withStructRuleCallback":       WithStructRuleCallback,
+	"withStructRuleTimeout":        WithStructRuleTimeout,
+	"withStructRuleWorkLimit":      WithStructRuleWorkLimit,
 
 	// language:
 	"Javascript": ssaconfig.JS,

--- a/common/yak/ssaapi/ssa_exports.go
+++ b/common/yak/ssaapi/ssa_exports.go
@@ -185,6 +185,7 @@ var Exports = map[string]any{
 	"withBaseProgramName":          WithBaseProgramName,
 	"withEnableIncrementalCompile": WithEnableIncrementalCompile,
 	"withStructRule":               WithStructRule,
+	"withStructRules":              WithStructRules,
 	"withStructRuleDir":            WithStructRuleDir,
 	"withStructRuleRaw":            WithStructRuleRaw,
 	"withStructRuleCallback":       WithStructRuleCallback,

--- a/common/yak/ssaapi/ssaconfig/rule.go
+++ b/common/yak/ssaapi/ssaconfig/rule.go
@@ -296,7 +296,7 @@ func WithRuleFilterTag(tag ...string) Option {
 	}
 }
 
-// WithRuleFilterMode 设置规则执行模式过滤器（source | ssa），对应 DB mode 列。
+// WithRuleFilterMode 设置规则执行模式过滤器（source | ssa | struct），对应 DB mode 列。
 func WithRuleFilterMode(mode ...string) Option {
 	return func(c *Config) error {
 		if err := c.ensureSyntaxFlowRule("Rule Filter Mode"); err != nil {

--- a/common/yak/ssaapi/struct_bound.go
+++ b/common/yak/ssaapi/struct_bound.go
@@ -56,20 +56,16 @@ func (b *structBound) Allow(inst ssa.Instruction) bool {
 	if inst.IsExtern() || inst.GetOpcode() == ssa.SSAOpcodeExternLib {
 		return true
 	}
-	p := inst.GetProgram()
-	if b.lib != nil && p != nil {
-		if p == b.lib {
-			if b.lib.ProgramKind == ssa.Library {
-				return true
-			}
-			// Application-hosted unit: the Program is shared, so isolate by file.
-			return ssadb.PathPassesFileFilter(ssa.InstructionFilePath(inst), b.files, ssadb.FileFilterInclude, b.programName)
-		}
-		if p.ProgramKind == ssa.Library {
-			return false
+	fp := ssa.InstructionFilePath(inst)
+	if ssadb.PathPassesFileFilter(fp, b.files, ssadb.FileFilterInclude, b.programName) {
+		return true
+	}
+	if b.lib != nil {
+		if p := inst.GetProgram(); p != nil && p == b.lib && b.lib.ProgramKind == ssa.Library {
+			return true
 		}
 	}
-	return ssadb.PathPassesFileFilter(ssa.InstructionFilePath(inst), b.files, ssadb.FileFilterInclude, b.programName)
+	return false
 }
 
 func structBoundFromConfig(cfg *sfvm.Config) *structBound {

--- a/common/yak/ssaapi/struct_bound.go
+++ b/common/yak/ssaapi/struct_bound.go
@@ -1,0 +1,130 @@
+package ssaapi
+
+import (
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+	"github.com/yaklang/yaklang/common/yak/ssa"
+	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
+)
+
+// structBound is the intra-compile-unit filter used by mode=struct scans.
+// Identity is the unit's library Program (functions/classes live there),
+// with a file-path fallback for Application-hosted IR.
+type structBound struct {
+	key         string
+	lib         *ssa.Program
+	programName string
+	fileList    []string
+	files       map[string]struct{}
+}
+
+func newStructBound(unit *ssa.CompileUnit, ssaProg *ssa.Program) *structBound {
+	programName := ""
+	var lib *ssa.Program
+	if ssaProg != nil {
+		app := ssaProg.GetApplication()
+		if app == nil {
+			app = ssaProg
+		}
+		programName = app.GetProgramName()
+		if unit != nil {
+			lib = app.ProgramForCompileUnit(unit.Key)
+		}
+	}
+	if unit == nil {
+		return &structBound{lib: lib, programName: programName, files: map[string]struct{}{}}
+	}
+	return &structBound{
+		key:         unit.Key,
+		lib:         lib,
+		programName: programName,
+		fileList:    append([]string(nil), unit.Files...),
+		files:       ssadb.BuildFilePathSet(unit.Files, programName),
+	}
+}
+
+func (b *structBound) compileUnit() *ssa.CompileUnit {
+	if b == nil {
+		return nil
+	}
+	return &ssa.CompileUnit{Key: b.key, Files: append([]string(nil), b.fileList...)}
+}
+
+func (b *structBound) Allow(inst ssa.Instruction) bool {
+	if b == nil || inst == nil {
+		return true
+	}
+	if inst.IsExtern() || inst.GetOpcode() == ssa.SSAOpcodeExternLib {
+		return true
+	}
+	p := inst.GetProgram()
+	if b.lib != nil && p != nil {
+		if p == b.lib {
+			if b.lib.ProgramKind == ssa.Library {
+				return true
+			}
+			// Application-hosted unit: the Program is shared, so isolate by file.
+			return ssadb.PathPassesFileFilter(ssa.InstructionFilePath(inst), b.files, ssadb.FileFilterInclude, b.programName)
+		}
+		if p.ProgramKind == ssa.Library {
+			return false
+		}
+	}
+	return ssadb.PathPassesFileFilter(ssa.InstructionFilePath(inst), b.files, ssadb.FileFilterInclude, b.programName)
+}
+
+func structBoundFromConfig(cfg *sfvm.Config) *structBound {
+	if cfg == nil {
+		return nil
+	}
+	for _, opt := range cfg.RuntimeOptions {
+		if b, ok := opt.(*structBound); ok {
+			return b
+		}
+	}
+	return nil
+}
+
+func WithStructBound(bound *structBound) OperationOption {
+	return func(operationConfig *OperationConfig) {
+		operationConfig.structBound = bound
+	}
+}
+
+func filterValuesByStructBound(bound *structBound, vals Values) Values {
+	if bound == nil || len(vals) == 0 {
+		return vals
+	}
+	out := make(Values, 0, len(vals))
+	for _, v := range vals {
+		if v == nil {
+			continue
+		}
+		if inst := v.getValue(); inst != nil && !bound.Allow(inst) {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func filterSFVMValuesByStructBound(bound *structBound, vals sfvm.Values) sfvm.Values {
+	if bound == nil || len(vals) == 0 {
+		return vals
+	}
+	var out []sfvm.ValueOperator
+	_ = vals.Recursive(func(operator sfvm.ValueOperator) error {
+		switch ret := operator.(type) {
+		case *Value:
+			if ret != nil {
+				if inst := ret.getValue(); inst != nil && !bound.Allow(inst) {
+					return nil
+				}
+			}
+			out = append(out, ret)
+		default:
+			out = append(out, operator)
+		}
+		return nil
+	})
+	return sfvm.NewValues(out)
+}

--- a/common/yak/ssaapi/struct_query_target.go
+++ b/common/yak/ssaapi/struct_query_target.go
@@ -1,0 +1,251 @@
+package ssaapi
+
+import (
+	"context"
+
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/utils/memedit"
+	"github.com/yaklang/yaklang/common/yak/ssa"
+	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+// StructQueryTarget is a SyntaxFlow feed root for mode=struct rules.
+// It must not embed *Program: unimplemented ValueOperator methods would scan
+// the whole program.
+type StructQueryTarget struct {
+	prog  *Program
+	unit  *ssa.CompileUnit
+	bound *structBound
+}
+
+var _ sfvm.ValueOperator = (*StructQueryTarget)(nil)
+
+func NewStructQueryTarget(prog *Program, unit *ssa.CompileUnit, bound *structBound) *StructQueryTarget {
+	if bound == nil && unit != nil && prog != nil && prog.Program != nil {
+		bound = newStructBound(unit, prog.Program)
+	}
+	return &StructQueryTarget{prog: prog, unit: unit, bound: bound}
+}
+
+func (t *StructQueryTarget) ResultProgram() *Program {
+	if t == nil {
+		return nil
+	}
+	return t.prog
+}
+
+func (t *StructQueryTarget) Unit() *ssa.CompileUnit {
+	if t == nil {
+		return nil
+	}
+	return t.unit
+}
+
+func (t *StructQueryTarget) String() string {
+	if t == nil || t.unit == nil {
+		return "struct-query"
+	}
+	return "struct-query:" + t.unit.Key
+}
+
+func (t *StructQueryTarget) IsMap() bool  { return false }
+func (t *StructQueryTarget) IsList() bool { return false }
+func (t *StructQueryTarget) IsEmpty() bool {
+	return t == nil || t.prog == nil || t.prog.Program == nil
+}
+func (t *StructQueryTarget) ShouldUseConditionCandidate() bool { return true }
+func (t *StructQueryTarget) GetOpcode() string {
+	return ssa.SSAOpcode2Name[ssa.SSAOpcodeUnKnow]
+}
+func (t *StructQueryTarget) GetBinaryOperator() string {
+	return ssa.SSAOpcode2Name[ssa.SSAOpcodeUnKnow]
+}
+func (t *StructQueryTarget) GetUnaryOperator() string {
+	return ssa.SSAOpcode2Name[ssa.SSAOpcodeUnKnow]
+}
+func (t *StructQueryTarget) GetCalled() (sfvm.Values, error) {
+	return nil, utils.Error("struct query target is not supported called")
+}
+func (t *StructQueryTarget) GetCallActualParams(int, bool) (sfvm.Values, error) {
+	return nil, utils.Error("struct query target is not supported call actual params")
+}
+func (t *StructQueryTarget) GetFields() (sfvm.Values, error) {
+	return sfvm.NewEmptyValues(), nil
+}
+func (t *StructQueryTarget) GetSyntaxFlowUse() (sfvm.Values, error) {
+	return nil, utils.Error("struct query target is not supported syntax flow use")
+}
+func (t *StructQueryTarget) GetSyntaxFlowDef() (sfvm.Values, error) {
+	return nil, utils.Error("struct query target is not supported syntax flow def")
+}
+func (t *StructQueryTarget) GetSyntaxFlowTopDef(*sfvm.SFFrameResult, *sfvm.Config, ...*sfvm.RecursiveConfigItem) (sfvm.Values, error) {
+	return nil, utils.Error("struct query target is not supported syntax flow top def")
+}
+func (t *StructQueryTarget) GetSyntaxFlowBottomUse(*sfvm.SFFrameResult, *sfvm.Config, ...*sfvm.RecursiveConfigItem) (sfvm.Values, error) {
+	return nil, utils.Error("struct query target is not supported syntax flow bottom use")
+}
+func (t *StructQueryTarget) ListIndex(int) (sfvm.ValueOperator, error) {
+	return nil, utils.Error("struct query target is not supported list index")
+}
+func (t *StructQueryTarget) AppendPredecessor(sfvm.ValueOperator, ...sfvm.AnalysisContextOption) error {
+	return nil
+}
+func (t *StructQueryTarget) CompareConst(*sfvm.ConstComparator) bool { return false }
+func (t *StructQueryTarget) NewConst(i any, rng ...*memedit.Range) sfvm.ValueOperator {
+	if t == nil || t.prog == nil {
+		return nil
+	}
+	return t.prog.NewConstValue(i, rng...)
+}
+func (t *StructQueryTarget) GetAnchorBitVector() *utils.BitVector { return nil }
+func (t *StructQueryTarget) SetAnchorBitVector(*utils.BitVector)  {}
+
+func (t *StructQueryTarget) Recursive(f func(sfvm.ValueOperator) error) error {
+	if t == nil {
+		return nil
+	}
+	return f(t)
+}
+
+func (t *StructQueryTarget) allowedInsts(insts []ssa.Instruction) Values {
+	if t == nil || t.prog == nil {
+		return nil
+	}
+	var out Values
+	for _, inst := range insts {
+		if inst == nil {
+			continue
+		}
+		if t.bound != nil && !t.bound.Allow(inst) {
+			continue
+		}
+		val, err := t.prog.NewValue(inst)
+		if err != nil || val == nil {
+			continue
+		}
+		out = append(out, val)
+	}
+	return out
+}
+
+func (t *StructQueryTarget) CompareOpcode(opcodeItems *sfvm.OpcodeComparator) (sfvm.Values, []bool) {
+	if t == nil || t.prog == nil || t.prog.Program == nil || opcodeItems == nil {
+		return sfvm.NewEmptyValues(), nil
+	}
+	insts := ssa.MatchInstructionByOpcodesResident(t.prog.Program, opcodeItems.Opcodes...)
+	return ToSFVMValues(t.allowedInsts(insts)), nil
+}
+
+func (t *StructQueryTarget) CompareString(comparator *sfvm.StringComparator) (sfvm.Values, []bool) {
+	if t == nil || t.prog == nil {
+		return sfvm.NewEmptyValues(), nil
+	}
+	vals, _ := t.prog.compareStringWithFileFilter(comparator, t.includeFiles(), nil)
+	return filterSFVMValuesByStructBound(t.bound, vals), nil
+}
+
+func (t *StructQueryTarget) ExactMatch(ctx context.Context, mod ssadb.MatchMode, s string) (bool, sfvm.Values, error) {
+	return t.matchVariable(ctx, ssadb.ExactCompare, mod, s)
+}
+func (t *StructQueryTarget) GlobMatch(ctx context.Context, mod ssadb.MatchMode, g string) (bool, sfvm.Values, error) {
+	return t.matchVariable(ctx, ssadb.GlobCompare, mod, g)
+}
+func (t *StructQueryTarget) RegexpMatch(ctx context.Context, mod ssadb.MatchMode, re string) (bool, sfvm.Values, error) {
+	return t.matchVariable(ctx, ssadb.RegexpCompare, mod, re)
+}
+
+func (t *StructQueryTarget) includeFiles() []string {
+	if t == nil || t.unit == nil {
+		return nil
+	}
+	return t.unit.Files
+}
+
+func (t *StructQueryTarget) matchVariable(ctx context.Context, compareMode ssadb.CompareMode, mod ssadb.MatchMode, pattern string) (bool, sfvm.Values, error) {
+	if t == nil || t.prog == nil || t.prog.Program == nil {
+		return false, sfvm.NewEmptyValues(), nil
+	}
+	insts := ssa.MatchInstructionsByVariableWithIncludeFiles(ctx, t.prog.Program, compareMode, mod, pattern, t.includeFiles())
+	vals := t.allowedInsts(insts)
+	return len(vals) > 0, ToSFVMValues(vals), nil
+}
+
+func (t *StructQueryTarget) FileFilter(path string, match string, rule map[string]string, rule2 []string) (sfvm.Values, error) {
+	if t == nil || t.prog == nil {
+		return nil, nil
+	}
+	vals, err := t.prog.FileFilter(path, match, rule, rule2)
+	if err != nil {
+		return vals, err
+	}
+	return filterSFVMValuesByStructBound(t.bound, vals), nil
+}
+
+func (t *StructQueryTarget) SyntaxFlowWithError(i string, opts ...QueryOption) (*SyntaxFlowResult, error) {
+	return t.syntaxFlow(opts, QueryWithRuleContent(i))
+}
+
+func (t *StructQueryTarget) SyntaxFlowRule(rule *schema.SyntaxFlowRule, opts ...QueryOption) (*SyntaxFlowResult, error) {
+	if t == nil {
+		return nil, utils.Error("nil StructQueryTarget")
+	}
+	if rule != nil && !rule.IsStructMode() {
+		return nil, utils.Errorf(
+			"struct target cannot execute non-struct rule %s (mode=%s)",
+			rule.RuleName,
+			schema.ValidRuleMode(rule.Mode),
+		)
+	}
+	return t.syntaxFlow(opts, QueryWithRule(rule))
+}
+
+func (t *StructQueryTarget) syntaxFlow(opts []QueryOption, ruleOpt QueryOption) (*SyntaxFlowResult, error) {
+	if t == nil || t.unit == nil {
+		return nil, utils.Error("nil StructQueryTarget")
+	}
+	all := make([]QueryOption, 0, len(opts)+4)
+	all = append(all, QueryWithValue(t), QueryWithResultProgram(t.prog), QueryWithStruct(t.unit), ruleOpt)
+	all = append(all, opts...)
+	return QuerySyntaxflow(all...)
+}
+
+func (t *StructQueryTarget) GetProgramName() string {
+	if t == nil || t.prog == nil {
+		return ""
+	}
+	return t.prog.GetProgramName()
+}
+
+func (t *StructQueryTarget) GetLanguage() ssaconfig.Language {
+	if t == nil || t.prog == nil {
+		return ssaconfig.General
+	}
+	return t.prog.GetLanguage()
+}
+
+func (t *StructQueryTarget) IsIncrementalCompile() bool {
+	if t == nil || t.prog == nil {
+		return false
+	}
+	return t.prog.IsIncrementalCompile()
+}
+func (t *StructQueryTarget) IsBaseProgram() bool {
+	if t == nil || t.prog == nil {
+		return true
+	}
+	return t.prog.IsBaseProgram()
+}
+func (t *StructQueryTarget) GetBaseProgramName() string {
+	if t == nil || t.prog == nil {
+		return ""
+	}
+	return t.prog.GetBaseProgramName()
+}
+func (t *StructQueryTarget) Recompile(inputOpt ...ssaconfig.Option) error {
+	return nil
+}
+
+var _ SyntaxFlowQueryInstance = (*StructQueryTarget)(nil)

--- a/common/yak/ssaapi/struct_scan_options.go
+++ b/common/yak/ssaapi/struct_scan_options.go
@@ -5,13 +5,36 @@ import (
 	"time"
 
 	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
 )
 
-func WithStructRule(enable bool) ssaconfig.Option {
-	return ssaconfig.SetOption("ssa_compile/struct_rule_enable", func(c *Config, v bool) {
-		c.ensureStructScan().enableBuiltin = v
-	})(enable)
+// WithStructRule enables builtin struct rules (bool) or appends an explicit
+// *schema.SyntaxFlowRule to run during compile (after LazyBuildForUnits,
+// before FlushCompileUnit).
+func WithStructRule(v any) ssaconfig.Option {
+	switch t := v.(type) {
+	case bool:
+		return ssaconfig.SetOption("ssa_compile/struct_rule_enable", func(c *Config, enable bool) {
+			c.ensureStructScan().enableBuiltin = enable
+		})(t)
+	case *schema.SyntaxFlowRule:
+		return WithStructRules(t)
+	case schema.SyntaxFlowRule:
+		return WithStructRules(&t)
+	default:
+		return func(*ssaconfig.Config) error {
+			return utils.Errorf("withStructRule: want bool or *schema.SyntaxFlowRule, got %T", v)
+		}
+	}
+}
+
+// WithStructRules appends compiled struct-mode rules to the compile-time scan.
+func WithStructRules(rules ...*schema.SyntaxFlowRule) ssaconfig.Option {
+	return ssaconfig.SetOption("ssa_compile/struct_rules", func(c *Config, v []*schema.SyntaxFlowRule) {
+		s := c.ensureStructScan()
+		s.rules = append(s.rules, v...)
+	})(rules)
 }
 
 func WithStructRuleDir(dir string) ssaconfig.Option {

--- a/common/yak/ssaapi/struct_scan_options.go
+++ b/common/yak/ssaapi/struct_scan_options.go
@@ -1,0 +1,53 @@
+package ssaapi
+
+import (
+	"strings"
+	"time"
+
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+func WithStructRule(enable bool) ssaconfig.Option {
+	return ssaconfig.SetOption("ssa_compile/struct_rule_enable", func(c *Config, v bool) {
+		c.ensureStructScan().enableBuiltin = v
+	})(enable)
+}
+
+func WithStructRuleDir(dir string) ssaconfig.Option {
+	return ssaconfig.SetOption("ssa_compile/struct_rule_dir", func(c *Config, v string) {
+		if strings.TrimSpace(v) == "" {
+			return
+		}
+		s := c.ensureStructScan()
+		s.extraDirs = append(s.extraDirs, v)
+	})(dir)
+}
+
+func WithStructRuleRaw(raw string) ssaconfig.Option {
+	return ssaconfig.SetOption("ssa_compile/struct_rule_raw", func(c *Config, v string) {
+		if strings.TrimSpace(v) == "" {
+			return
+		}
+		s := c.ensureStructScan()
+		s.extraRaw = append(s.extraRaw, v)
+	})(raw)
+}
+
+func WithStructRuleCallback(cb func(*schema.SSARisk)) ssaconfig.Option {
+	return ssaconfig.SetOption("ssa_compile/struct_rule_callback", func(c *Config, v func(*schema.SSARisk)) {
+		c.ensureStructScan().riskCB = v
+	})(cb)
+}
+
+func WithStructRuleTimeout(d time.Duration) ssaconfig.Option {
+	return ssaconfig.SetOption("ssa_compile/struct_rule_timeout", func(c *Config, v time.Duration) {
+		c.ensureStructScan().timeout = v
+	})(d)
+}
+
+func WithStructRuleWorkLimit(n int64) ssaconfig.Option {
+	return ssaconfig.SetOption("ssa_compile/struct_rule_work_limit", func(c *Config, v int64) {
+		c.ensureStructScan().workLimit = v
+	})(n)
+}

--- a/common/yak/ssaapi/struct_scan_runtime.go
+++ b/common/yak/ssaapi/struct_scan_runtime.go
@@ -1,0 +1,315 @@
+package ssaapi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/yaklang/yaklang/common/consts"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+	"github.com/yaklang/yaklang/common/utils"
+	"github.com/yaklang/yaklang/common/yak/ssa"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+	"github.com/yaklang/yaklang/common/yakgrpc/yakit"
+)
+
+type structScanRuntime struct {
+	enableBuiltin bool
+	extraDirs     []string
+	extraRaw      []string
+	rules         []*schema.SyntaxFlowRule
+	riskCB        func(*schema.SSARisk)
+	taskID        string
+	timeout       time.Duration
+	workLimit     int64
+	errs          []error
+	results       []*SyntaxFlowResult
+	ranHashes     []string
+	skipped       bool
+	skipReason    string
+}
+
+func (s *structScanRuntime) enabled() bool {
+	if s == nil || s.skipped {
+		return false
+	}
+	return len(s.rules) > 0
+}
+
+func (s *structScanRuntime) wantsScan() bool {
+	if s == nil {
+		return false
+	}
+	return s.enableBuiltin || len(s.extraDirs) > 0 || len(s.extraRaw) > 0 || len(s.rules) > 0
+}
+
+func (c *Config) prepareStructScan(plan *UnitPlan) error {
+	if c == nil || c.structScan == nil {
+		return nil
+	}
+	s := c.structScan
+	if s.riskCB != nil && !s.wantsScan() {
+		return utils.Errorf("withStructRuleCallback requires withStructRule(true) or withStructRuleDir/Raw")
+	}
+	if !s.wantsScan() {
+		return nil
+	}
+	if strings.TrimSpace(c.GetProgramName()) == "" {
+		return utils.Errorf("struct scan requires withProgramName")
+	}
+	if c.GetEnableIncrementalCompile() || c.GetBaseProgramName() != "" {
+		s.skipped = true
+		s.skipReason = "incremental compile"
+		log.Warnf("[struct_scan] skipped: %s", s.skipReason)
+		return nil
+	}
+	if plan != nil && len(plan.Units) == 1 {
+		if _, ok := plan.Units["unit:all"]; ok {
+			s.skipped = true
+			s.skipReason = "unit:all fallback"
+			log.Warnf("[struct_scan] skipped: %s", s.skipReason)
+			return nil
+		}
+	}
+	if err := s.resolveRules(); err != nil {
+		return err
+	}
+	if len(s.rules) == 0 {
+		log.Warnf("[struct_scan] no struct rules loaded")
+	}
+	return nil
+}
+
+func (c *Config) ensureStructScan() *structScanRuntime {
+	if c.structScan == nil {
+		c.structScan = &structScanRuntime{
+			taskID:    uuid.NewString(),
+			workLimit: ssaconfig.DefaultScanRuleWorkLimit,
+		}
+	}
+	return c.structScan
+}
+
+func (s *structScanRuntime) resolveRules() error {
+	if s == nil {
+		return nil
+	}
+	if len(s.rules) > 0 && !s.enableBuiltin && len(s.extraDirs) == 0 && len(s.extraRaw) == 0 {
+		return s.validateRules()
+	}
+	var rules []*schema.SyntaxFlowRule
+	if s.enableBuiltin {
+		rules = append(rules, loadBuiltinStructRules()...)
+	}
+	for _, dir := range s.extraDirs {
+		loaded, err := loadStructRulesFromDir(dir)
+		if err != nil {
+			return err
+		}
+		rules = append(rules, loaded...)
+	}
+	for _, raw := range s.extraRaw {
+		rule, err := compileStructRuleContent(raw)
+		if err != nil {
+			return err
+		}
+		rules = append(rules, rule)
+	}
+	s.rules = append(s.rules, rules...)
+	return s.validateRules()
+}
+
+func (s *structScanRuntime) validateRules() error {
+	for _, rule := range s.rules {
+		if rule == nil {
+			continue
+		}
+		if !rule.IsStructMode() {
+			return utils.Errorf("non-struct rule %s (mode=%s) cannot be used with withStructRule*", rule.RuleName, schema.ValidRuleMode(rule.Mode))
+		}
+	}
+	return nil
+}
+
+func loadBuiltinStructRules() []*schema.SyntaxFlowRule {
+	db := consts.GetGormProfileDatabase()
+	if db == nil {
+		return nil
+	}
+	var rules []*schema.SyntaxFlowRule
+	_ = yakit.ApplySyntaxFlowRuleModeFilter(db.Model(&schema.SyntaxFlowRule{}), []string{string(schema.SFR_MODE_STRUCT)}).
+		Find(&rules).Error
+	return rules
+}
+
+func loadStructRulesFromDir(dir string) ([]*schema.SyntaxFlowRule, error) {
+	var rules []*schema.SyntaxFlowRule
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info == nil || info.IsDir() || !strings.HasSuffix(strings.ToLower(info.Name()), ".sf") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rule, err := compileStructRuleContent(string(raw))
+		if err != nil {
+			log.Warnf("[struct_scan] skip %s: %v", path, err)
+			return nil
+		}
+		if rule.RuleName == "" {
+			rule.RuleName = info.Name()
+		}
+		rules = append(rules, rule)
+		return nil
+	})
+	return rules, err
+}
+
+func compileStructRuleContent(raw string) (*schema.SyntaxFlowRule, error) {
+	frame, err := sfvm.NewSyntaxFlowVirtualMachine().Compile(raw)
+	if err != nil {
+		return nil, err
+	}
+	rule := frame.GetRule()
+	if rule == nil {
+		return nil, utils.Error("compiled struct rule has no schema")
+	}
+	rule.Content = raw
+	rule.NormalizeMode()
+	if !rule.IsStructMode() {
+		return nil, utils.Errorf("rule mode %s is not struct", rule.Mode)
+	}
+	return rule, nil
+}
+
+func (s *structScanRuntime) ScanStruct(progAPI *Program, unit *ssa.CompileUnit) {
+	if s == nil || !s.enabled() || progAPI == nil || unit == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err := utils.Errorf("struct scan panic on %s: %v", unit.Key, r)
+			log.Errorf("%v", err)
+			s.errs = append(s.errs, err)
+			utils.PrintCurrentGoroutineRuntimeStack()
+		}
+	}()
+	compileCtx := context.Background()
+	if progAPI.config != nil && progAPI.config.ctx != nil {
+		compileCtx = progAPI.config.ctx
+	}
+	for _, rule := range s.rules {
+		if rule == nil {
+			continue
+		}
+		ruleCtx, cancel := context.WithCancel(compileCtx)
+		if s.timeout > 0 {
+			ruleCtx, cancel = context.WithTimeout(compileCtx, s.timeout)
+		}
+		var budget *sfvm.RuleWorkBudget
+		if s.workLimit > 0 {
+			budget = sfvm.NewRuleWorkBudget(s.workLimit, cancel)
+		}
+		target := NewStructQueryTarget(progAPI, unit, newStructBound(unit, progAPI.Program))
+		res, err := QuerySyntaxflow(
+			QueryWithValue(target),
+			QueryWithResultProgram(progAPI),
+			QueryWithStruct(unit),
+			QueryWithRuleContent(rule.Content),
+			QueryWithMemory(),
+			QueryWithTaskID(s.taskID),
+			QueryWithContext(ruleCtx),
+			QueryWithWorkBudget(budget),
+		)
+		cancel()
+		if err != nil {
+			s.errs = append(s.errs, utils.Wrapf(err, "struct scan %s rule %s", unit.Key, rule.RuleName))
+			log.Warnf("[struct_scan] unit=%s rule=%s err=%v", unit.Key, rule.RuleName, err)
+			continue
+		}
+		if res != nil {
+			s.results = append(s.results, res)
+			s.ranHashes = append(s.ranHashes, ruleContentHash(rule))
+			if s.riskCB != nil {
+				risks := res.GetRisks()
+				if len(risks) == 0 {
+					for _, name := range res.GetAlertVariables() {
+						for index, val := range res.GetValues(name) {
+							if risk := buildSSARisk(res, name, index, val); risk != nil {
+								risks = append(risks, risk)
+							}
+						}
+					}
+				}
+				for _, risk := range risks {
+					s.riskCB(risk)
+				}
+			}
+			log.Infof("[struct_scan] package=%s rule=%s alerts=%d", unit.Key, rule.RuleName, len(res.GetAlertVariables()))
+		}
+		progAPI.ResetInterRuleState()
+	}
+}
+
+func ruleContentHash(rule *schema.SyntaxFlowRule) string {
+	if rule == nil {
+		return ""
+	}
+	if rule.Hash != "" {
+		return rule.Hash
+	}
+	return utils.CalcSha256(rule.RuleName, rule.Content)
+}
+
+func (s *structScanRuntime) persistAfterProgramMeta(progAPI *Program) {
+	if s == nil || progAPI == nil || progAPI.Program == nil {
+		return
+	}
+	if progAPI.Program.DatabaseKind == ssa.ProgramCacheMemory {
+		return
+	}
+	for _, res := range s.results {
+		if res == nil {
+			continue
+		}
+		if _, err := res.Save(schema.SFResultKindScan, s.taskID); err != nil {
+			log.Warnf("[struct_scan] persist result failed: %v", err)
+			s.errs = append(s.errs, err)
+		}
+	}
+}
+
+func (p *Program) StructRulesAlreadyRan(rule *schema.SyntaxFlowRule) bool {
+	if p == nil || p.config == nil || p.config.structScan == nil || rule == nil {
+		return false
+	}
+	h := ruleContentHash(rule)
+	for _, ran := range p.config.structScan.ranHashes {
+		if ran == h {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Program) StructScanErrors() []error {
+	if p == nil || p.config == nil || p.config.structScan == nil {
+		return nil
+	}
+	return p.config.structScan.errs
+}
+
+func (p *Program) StructScanTaskID() string {
+	if p == nil || p.config == nil || p.config.structScan == nil {
+		return ""
+	}
+	return p.config.structScan.taskID
+}

--- a/common/yak/ssaapi/struct_scan_runtime.go
+++ b/common/yak/ssaapi/struct_scan_runtime.go
@@ -44,7 +44,19 @@ func (s *structScanRuntime) wantsScan() bool {
 	if s == nil {
 		return false
 	}
-	return s.enableBuiltin || len(s.extraDirs) > 0 || len(s.extraRaw) > 0 || len(s.rules) > 0
+	return s.enableBuiltin || len(s.extraDirs) > 0 || len(s.extraRaw) > 0 || hasExplicitStructRules(s)
+}
+
+func hasExplicitStructRules(s *structScanRuntime) bool {
+	if s == nil {
+		return false
+	}
+	for _, rule := range s.rules {
+		if rule != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Config) prepareStructScan(plan *UnitPlan) error {
@@ -53,7 +65,7 @@ func (c *Config) prepareStructScan(plan *UnitPlan) error {
 	}
 	s := c.structScan
 	if s.riskCB != nil && !s.wantsScan() {
-		return utils.Errorf("withStructRuleCallback requires withStructRule(true) or withStructRuleDir/Raw")
+		return utils.Errorf("withStructRuleCallback requires withStructRule(true|rule) or withStructRuleDir/Raw")
 	}
 	if !s.wantsScan() {
 		return nil
@@ -69,10 +81,14 @@ func (c *Config) prepareStructScan(plan *UnitPlan) error {
 	}
 	if plan != nil && len(plan.Units) == 1 {
 		if _, ok := plan.Units["unit:all"]; ok {
-			s.skipped = true
-			s.skipReason = "unit:all fallback"
-			log.Warnf("[struct_scan] skipped: %s", s.skipReason)
-			return nil
+			// Builtin whole-program fallback has no package boundary.
+			// Explicit withStructRule(rule)/Raw still scans that single unit.
+			if s.enableBuiltin && len(s.extraRaw) == 0 && len(s.extraDirs) == 0 && !hasExplicitStructRules(s) {
+				s.skipped = true
+				s.skipReason = "unit:all fallback"
+				log.Warnf("[struct_scan] skipped: %s", s.skipReason)
+				return nil
+			}
 		}
 	}
 	if err := s.resolveRules(); err != nil {
@@ -305,6 +321,13 @@ func (p *Program) StructScanErrors() []error {
 		return nil
 	}
 	return p.config.structScan.errs
+}
+
+func (p *Program) StructScanResults() []*SyntaxFlowResult {
+	if p == nil || p.config == nil || p.config.structScan == nil {
+		return nil
+	}
+	return p.config.structScan.results
 }
 
 func (p *Program) StructScanTaskID() string {

--- a/common/yak/ssaapi/struct_scan_test.go
+++ b/common/yak/ssaapi/struct_scan_test.go
@@ -1,0 +1,235 @@
+package ssaapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
+	"github.com/yaklang/yaklang/common/utils/filesys"
+	"github.com/yaklang/yaklang/common/yak/ssa/ssadb"
+	"github.com/yaklang/yaklang/common/yak/ssaapi/ssaconfig"
+)
+
+func TestValidRuleModeStructIsNotSSA(t *testing.T) {
+	require.Equal(t, schema.SFR_MODE_STRUCT, schema.ValidRuleMode("struct"))
+	require.Equal(t, schema.SFR_MODE_SSA, schema.ValidRuleMode("unknown"))
+}
+
+func TestStructRuleRejectedOnBareProgram(t *testing.T) {
+	prog, err := Parse("a = 1")
+	require.NoError(t, err)
+	rule := &schema.SyntaxFlowRule{
+		RuleName: "struct-rule",
+		Mode:     schema.SFR_MODE_STRUCT,
+		Language: ssaconfig.General,
+		Content: `desc(mode: "struct", language: "yak")
+a as $hit
+alert $hit
+`,
+	}
+	_, err = prog.SyntaxFlowRule(rule)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "QueryWithStruct")
+}
+
+func TestStructRuleContentRejectedWithoutQueryWithStruct(t *testing.T) {
+	prog, err := Parse("a = 1")
+	require.NoError(t, err)
+	_, err = prog.SyntaxFlowWithError(`
+desc(mode: "struct")
+a as $hit
+alert $hit
+`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "struct rule requires QueryWithStruct")
+}
+
+func TestUnknownRuleModeExecutedAsSSA(t *testing.T) {
+	prog, err := Parse("a = 1")
+	require.NoError(t, err)
+	res, err := prog.SyntaxFlowWithError(`
+desc(mode: "not-a-real-mode")
+a as $hit
+alert $hit
+`)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(res.GetValues("hit")), 1)
+}
+
+func TestFrameIsStructModeFromDesc(t *testing.T) {
+	frame, err := sfvm.NewSyntaxFlowVirtualMachine().Compile(`
+desc(mode: "struct", language: "java")
+Runtime.getRuntime().exec(* as $cmd) as $call
+alert $call
+`)
+	require.NoError(t, err)
+	require.True(t, sfvm.FrameIsStructMode(frame))
+	require.False(t, sfvm.FrameIsSourceMode(frame))
+}
+
+// TestStructScanFindsCallAndDoesNotCrossPackage compiles two Java packages
+// with struct rules. Scan runs after each SCC's LazyBuildForUnits (method
+// bodies resident) and before FlushCompileUnit — not after Application.Finish.
+func TestStructScanFindsCallAndDoesNotCrossPackage(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("a/Sink.java", `package a;
+class Sink {
+  void f(String cmd) throws Exception {
+    Runtime.getRuntime().exec(cmd);
+  }
+}
+`)
+	vf.AddFile("b/Src.java", `package b;
+class Src {
+  static String taint() { return "x"; }
+  void g(String cmd) throws Exception {
+    Runtime.getRuntime().exec(b.Src.taint());
+  }
+}
+`)
+	progName := uuid.NewString()
+	defer ssadb.DeleteProgram(ssadb.GetDB(), progName)
+
+	callRule := `
+desc(
+    mode: "struct"
+    language: "java"
+    title: "Runtime.exec"
+    level: medium
+    risk: "command-injection"
+)
+Runtime.getRuntime().exec(* as $cmd) as $call
+alert $call for {
+    title: "Runtime.exec"
+}
+`
+	taintRule := `
+desc(
+    mode: "struct"
+    language: "java"
+    title: "cross-package taint should not fire"
+)
+Runtime.getRuntime().exec(* as $cmd) as $call
+$cmd #-> * as $src
+alert $src
+`
+
+	var risks []*schema.SSARisk
+	progs, err := ParseProjectWithFS(vf,
+		WithLanguage(ssaconfig.JAVA),
+		WithProgramName(progName),
+		WithStructRuleRaw(callRule),
+		WithStructRuleRaw(taintRule),
+		WithStructRuleCallback(func(risk *schema.SSARisk) {
+			risks = append(risks, risk)
+		}),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, progs)
+
+	var callHits int
+	for _, risk := range risks {
+		if risk.Title == "Runtime.exec" {
+			callHits++
+			require.True(t, strings.Contains(risk.CodeSourceUrl, "Sink.java") || strings.Contains(risk.CodeSourceUrl, "Src.java"))
+		}
+	}
+	require.GreaterOrEqual(t, callHits, 2, "should hit Runtime.exec in both packages")
+
+	var unitA *CompileUnit
+	for _, unit := range progs[0].Program.CompileUnits {
+		if unit != nil && unit.Key == "java:a" {
+			unitA = unit
+			break
+		}
+	}
+	require.NotNil(t, unitA)
+	res, err := QuerySyntaxflow(
+		QueryWithValue(NewStructQueryTarget(progs[0], unitA, nil)),
+		QueryWithResultProgram(progs[0]),
+		QueryWithStruct(unitA),
+		QueryWithRuleContent(taintRule),
+	)
+	require.NoError(t, err)
+	for _, name := range res.GetAlertVariables() {
+		for _, val := range res.GetValues(name) {
+			if val == nil || val.GetRange() == nil || val.GetRange().GetEditor() == nil {
+				continue
+			}
+			require.NotContains(t, val.GetRange().GetEditor().GetUrl(), "Src.java",
+				"scanning package a must not follow taint into package b")
+		}
+	}
+}
+
+func TestQueryWithStructRejectsSSARule(t *testing.T) {
+	prog, err := Parse("a = 1")
+	require.NoError(t, err)
+	unit := &CompileUnit{Key: "unit:test"}
+	_, err = QuerySyntaxflow(
+		QueryWithValue(NewStructQueryTarget(prog, unit, nil)),
+		QueryWithResultProgram(prog),
+		QueryWithStruct(unit),
+		QueryWithRuleContent(`
+desc(mode: "ssa")
+a as $hit
+alert $hit
+`),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "QueryWithStruct only accepts struct rules")
+}
+
+func TestStructScanPythonEval(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("a/app.py", "def f(x):\n    eval(x)\n")
+	vf.AddFile("b/ok.py", "def g():\n    return 1\n")
+
+	progName := uuid.NewString()
+	defer ssadb.DeleteProgram(ssadb.GetDB(), progName)
+
+	var risks []*schema.SSARisk
+	progs, err := ParseProjectWithFS(vf,
+		WithLanguage(ssaconfig.PYTHON),
+		WithProgramName(progName),
+		WithStructRuleRaw(`
+desc(
+    mode: "struct"
+    language: "python"
+    title: "eval"
+)
+eval(* as $arg) as $call
+alert $call for {
+    title: "eval"
+}
+`),
+		WithStructRuleCallback(func(risk *schema.SSARisk) {
+			risks = append(risks, risk)
+		}),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, progs)
+	require.GreaterOrEqual(t, len(risks), 1)
+	for _, risk := range risks {
+		require.Contains(t, risk.CodeSourceUrl, "app.py")
+		require.NotContains(t, risk.CodeSourceUrl, "ok.py")
+	}
+}
+
+func TestStructScanRequiresProgramName(t *testing.T) {
+	vf := filesys.NewVirtualFs()
+	vf.AddFile("a/A.java", `package a; class A { void f() {} }`)
+	_, err := ParseProjectWithFS(vf,
+		WithLanguage(ssaconfig.JAVA),
+		WithStructRuleRaw(`
+desc(mode: "struct", language: "java")
+A as $hit
+alert $hit
+`),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "withProgramName")
+}

--- a/common/yak/ssaapi/struct_scan_test.go
+++ b/common/yak/ssaapi/struct_scan_test.go
@@ -219,6 +219,122 @@ alert $call for {
 	}
 }
 
+func TestStructScanBuiltinSnippets(t *testing.T) {
+	cases := []struct {
+		name     string
+		lang     ssaconfig.Language
+		file     string
+		code     string
+		rule     string
+		ssaQuery string
+	}{
+		{
+			name: "python-eval",
+			lang: ssaconfig.PYTHON,
+			file: "dyn.py",
+			code: "def run(user_input):\n    return eval(user_input)\n",
+			rule: `desc(mode: "struct", language: "python")
+eval(* as $arg) as $call
+alert $call`,
+			ssaQuery: `eval(* as $arg) as $call
+alert $call`,
+		},
+		{
+			name: "python-os-system",
+			lang: ssaconfig.PYTHON,
+			file: "sh.py",
+			code: "import os\ndef run(user):\n    os.system(\"ls \" + user)\n",
+			rule: `desc(mode: "struct", language: "python")
+os.system as $call
+os.system(* as $arg) as $call
+alert $call`,
+			ssaQuery: `os.system as $call
+alert $call`,
+		},
+		{
+			name: "python-pickle",
+			lang: ssaconfig.PYTHON,
+			file: "ser.py",
+			code: "import pickle\ndef load(data):\n    return pickle.loads(data)\n",
+			rule: `desc(mode: "struct", language: "python")
+pickle.loads as $call
+alert $call`,
+			ssaQuery: `pickle.loads as $call
+alert $call`,
+		},
+		{
+			name: "java-md5",
+			lang: ssaconfig.JAVA,
+			file: "Hash.java",
+			code: `import java.security.MessageDigest;
+class Hash {
+  void bad() throws Exception {
+    MessageDigest.getInstance("MD5");
+  }
+}
+`,
+			rule: `desc(mode: "struct", language: "java")
+MessageDigest.getInstance(*?{have: "MD5"}) as $call
+alert $call`,
+			ssaQuery: `MessageDigest.getInstance(*?{have: "MD5"}) as $call
+alert $call`,
+		},
+		{
+			name: "js-eval",
+			lang: ssaconfig.JS,
+			file: "app.js",
+			code: "function run(code) { return eval(code); }\n",
+			rule: `desc(mode: "struct", language: "javascript")
+eval(* as $arg) as $call
+alert $call`,
+			ssaQuery: `eval(* as $arg) as $call
+alert $call`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vf := filesys.NewVirtualFs()
+			vf.AddFile(tc.file, tc.code)
+			progName := uuid.NewString()
+			defer ssadb.DeleteProgram(ssadb.GetDB(), progName)
+			progs, err := ParseProjectWithFS(vf,
+				WithLanguage(tc.lang),
+				WithProgramName(progName),
+				WithMemory(),
+				WithStructRuleRaw(tc.rule),
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, progs)
+			t.Logf("struct results=%d errs=%v", len(progs[0].StructScanResults()), progs[0].StructScanErrors())
+			for _, res := range progs[0].StructScanResults() {
+				t.Logf("struct alerts=%v", res.GetAlertVariables())
+			}
+			ssaRes, err := progs[0].SyntaxFlowWithError(tc.ssaQuery)
+			require.NoError(t, err)
+			t.Logf("ssa alerts=%v count=%d", ssaRes.GetAlertVariables(), len(ssaRes.GetAlertVariables()))
+			for _, name := range ssaRes.GetAlertVariables() {
+				for _, val := range ssaRes.GetValues(name) {
+					if val == nil {
+						continue
+					}
+					fp := ""
+					if val.GetRange() != nil && val.GetRange().GetEditor() != nil {
+						fp = val.GetRange().GetEditor().GetUrl()
+					}
+					t.Logf("ssa hit opcode=%s name=%s file=%s", val.GetOpcode(), val.GetName(), fp)
+				}
+			}
+			structHits := 0
+			for _, res := range progs[0].StructScanResults() {
+				for _, name := range res.GetAlertVariables() {
+					structHits += len(res.GetValues(name))
+				}
+			}
+			require.Greater(t, structHits, 0, "struct scan should hit")
+		})
+	}
+}
+
 func TestStructScanRequiresProgramName(t *testing.T) {
 	vf := filesys.NewVirtualFs()
 	vf.AddFile("a/A.java", `package a; class A { void f() {} }`)

--- a/common/yak/syntaxflow_scan/runtime.go
+++ b/common/yak/syntaxflow_scan/runtime.go
@@ -125,8 +125,14 @@ func queryTargetName(target ssaapi.SyntaxFlowQueryInstance) string {
 }
 
 func (m *scanManager) Query(rule *schema.SyntaxFlowRule, target ssaapi.SyntaxFlowQueryInstance) {
+	if rule.IsStructMode() {
+		if prog, ok := target.(*ssaapi.Program); ok && prog.StructRulesAlreadyRan(rule) {
+			m.markRuleSkipped()
+			return
+		}
+	}
 	// 语言匹配检查（source 模式规则按文件 glob 过滤，不强制语言对齐）
-	if !m.Config.GetScanIgnoreLanguage() && !sfvm.RuleIsSourceMode(rule, nil) {
+	if !m.Config.GetScanIgnoreLanguage() && !rule.IsSourceMode() {
 		if rule.Language != ssaconfig.General && rule.Language != target.GetLanguage() {
 			m.markRuleSkipped()
 			return

--- a/common/yakgrpc/yakit/syntaxflow_rule.go
+++ b/common/yakgrpc/yakit/syntaxflow_rule.go
@@ -171,7 +171,7 @@ func FilterSyntaxFlowRule(db *gorm.DB, filter *ypb.SyntaxFlowRuleFilter, opt ...
 }
 
 // ApplySyntaxFlowRuleModeFilter restricts rules by persisted execution mode
-// (source | ssa). Mode is stored on schema.SyntaxFlowRule, not in gRPC filter.
+// (source | ssa | struct). Mode is stored on schema.SyntaxFlowRule, not in gRPC filter.
 func ApplySyntaxFlowRuleModeFilter(db *gorm.DB, modes []string) *gorm.DB {
 	if db == nil || len(modes) == 0 {
 		return db


### PR DESCRIPTION
## 背景

SyntaxFlow 目前两条执行路径：`mode=source` 扫源码，`mode=ssa` 等整项目 SSA 编完再扫。大项目上后者要等全量 compile+save，结构级规则（包内 API 误用、危险调用）没有必要等那么久。

本 PR 加一条中间层：`mode=struct`。每个 compile unit 先编骨架、再展开本 unit 的 method body，同步扫完再 flush / 回收 AST。未知 `desc(mode)` 仍按 SSA 执行。

## Commit

### 1. feat(ssa): finish each compile unit with LazyBuildForUnits

compile unit 就是对应的 library Program，已经拥有该包的 function / class。

- PreHandler 建骨架
- `LazyBuildForUnits` drain 该 library 的 LazyBuilder（不再给 instruction / lazy task 打 intern `compileUnitID`）
- 然后才 `FlushCompileUnit`
- deferred 仍是 unit-keyed worklist（PHP/C `RegisterFileBuild`）；`Application.Finish` 只处理剩余任务

### 2. feat(ssa): add struct-mode intra-package SyntaxFlow scan

`ParseProject` 在每个 unit 的 LazyBuild 之后、Flush 之前跑 `mode=struct` 规则。

- `QueryWithStruct` 喂 `StructQueryTarget`，`structBound` 用 library Program 身份做包内隔离（跨包 taint 不跟）
- `desc(mode)` 编译时写入 `rule.Mode`；运行时只看 `rule.Mode` / `frame.GetRule().Mode`
- Yak：`ssa.withStructRule(true)` / `withStructRuleDir` / `withStructRuleRaw` / `withStructRuleCallback`

### 3. feat(syntaxflow): add struct-mode rules and verify

识别 `desc(mode: struct)`，内嵌正/负例走 `QueryWithStruct` 校验，并加入第一批结构级 insecure-api 规则（Java / Python / JS）。

## 验证

- `GOTOOLCHAIN=go1.22.12` 针对性测试：schema/sfvm mode、ssa lazy-build/deferred、ssaapi struct+include、sfpattern source、java FlushCompileUnit
- 先前完整 `scripts/ssa-test.sh` 在设计清理前已通过；本轮未再跑全量