### PR TITLE
fix(aid): 修复 DeepSeek ReAct 的 Schema 重试风暴与并发调用错误

### DIFF
--- a/common/ai/aid/aicommon/config.go
+++ b/common/ai/aid/aicommon/config.go
@@ -2,6 +2,7 @@ package aicommon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"reflect"
@@ -14,6 +15,7 @@ import (
 	"github.com/yaklang/yaklang/common/utils/omap"
 
 	"github.com/google/uuid"
+	"github.com/yaklang/gorm"
 	"github.com/yaklang/yaklang/common/ai"
 	"github.com/yaklang/yaklang/common/ai/aid/aicommon/aiskillloader"
 	"github.com/yaklang/yaklang/common/ai/aid/aitool"
@@ -4015,6 +4017,10 @@ func (c *Config) restorePersistentSession() {
 
 	runtime, err := yakit.GetLatestAIAgentRuntimeByPersistentSession(c.GetDB(), c.PersistentSessionId)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Debugf("no runtime found for new persistent session [%s]", c.PersistentSessionId)
+			return
+		}
 		log.Warnf("failed to fetch AI runtime for session [%s]: %v", c.PersistentSessionId, err)
 		return
 	}

--- a/common/ai/aid/aicommon/config_ai_wrapper.go
+++ b/common/ai/aid/aicommon/config_ai_wrapper.go
@@ -375,15 +375,12 @@ func (c *Config) wrapper(i AICallbackType, tier consts.ModelTier) AICallbackType
 					CompletionTokens: int(outputTokens),
 					TotalTokens:      int(totalTokens),
 				})
-				if outputBytes == 0 {
+				if outputBytes == 0 && requestCtx.Err() == nil && origRsp.GetError() == nil && origRsp.GetHTTPStatusCode() < 400 {
 					rawDump := origRsp.GetRawHTTPResponseDump()
 					if rawDump != "" {
-						println(rawDump)
 						c.EmitWarning("[AI Empty Response] model=%v:%v, cost=%v, input_tokens~%d. "+
-							"The AI model returned HTTP 200 but generated 0 output tokens "+
-							"(finish_reason: stop without delta.content). "+
-							"This is typically a transient model-side issue and will be retried automatically.",
-							provider, model, du, inputTokens,
+							"No output content was received (HTTP status=%d).",
+							provider, model, du, inputTokens, origRsp.GetHTTPStatusCode(),
 						)
 					} else {
 						c.EmitWarning("[AI Empty Response] model=%v:%v, cost=%v, input_tokens~%d. "+

--- a/common/ai/aid/aicommon/config_hotpatch.go
+++ b/common/ai/aid/aicommon/config_hotpatch.go
@@ -29,7 +29,10 @@ func (c *Config) StartHotPatchLoop(ctx context.Context) {
 					//log.Infof("hotpatch loop for config %s started", c.Id)
 				case <-ctx.Done():
 					return
-				case hotPatchOption := <-c.HotPatchOptionChan.OutputChannel():
+				case hotPatchOption, ok := <-c.HotPatchOptionChan.OutputChannel():
+					if !ok {
+						return
+					}
 					if hotPatchOption == nil {
 						log.Errorf("hotpatch option is nil, will return")
 						return
@@ -77,9 +80,9 @@ func (c *Config) SimpleInfoMap() map[string]interface{} {
 		"AIAutoTransactionRetry":      c.AiTransactionAutoRetry,
 		"GenerateReport":              c.GenerateReport,
 		"ForgeName":                   c.ForgeName,
-		"EnablePlan":            c.GetEnablePlanAndExec(),
-		"SyncPerceptionTrigger": c.GetSyncPerceptionTrigger(),
-		"EnabledCapabilities":   c.GetEnabledCapabilities(),
+		"EnablePlan":                  c.GetEnablePlanAndExec(),
+		"SyncPerceptionTrigger":       c.GetSyncPerceptionTrigger(),
+		"EnabledCapabilities":         c.GetEnabledCapabilities(),
 	}
 }
 

--- a/common/ai/aid/aicommon/toolcall.go
+++ b/common/ai/aid/aicommon/toolcall.go
@@ -3,6 +3,7 @@ package aicommon
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -714,17 +715,20 @@ func buildNativeToolForParamGen(tool *aitool.Tool) aispec.Tool {
 			"description": "Short snake_case identifier for this tool call",
 		},
 	}
-	if tool.InputSchema.Properties != nil && tool.InputSchema.Properties.Len() > 0 {
-		props["params"] = map[string]any{
-			"type":        "object",
-			"description": "Tool parameters",
-			"properties":  tool.InputSchema.Properties,
-			"required":    tool.InputSchema.Required,
-		}
+	paramSchema := map[string]any{
+		"type":        "object",
+		"description": "Tool parameters",
 	}
+	if tool.InputSchema.Properties != nil && tool.InputSchema.Properties.Len() > 0 {
+		paramSchema["properties"] = tool.InputSchema.Properties
+	}
+	if len(tool.InputSchema.Required) > 0 {
+		paramSchema["required"] = tool.InputSchema.Required
+	}
+	props["params"] = paramSchema
 	props["call_expectations"] = map[string]any{
 		"type":        "string",
-			"description": "Expected duration, success criteria, and exception handling",
+		"description": "Expected duration, success criteria, and exception handling",
 	}
 
 	params := map[string]any{
@@ -1040,6 +1044,19 @@ func (t *ToolCaller) generateParams(tool *aitool.Tool, handleError func(i any)) 
 			handleError(fmt.Sprintf("error generate tool[%v] params in task: %v", tool.Name, t.task.GetName()))
 			return nil, err
 		}
+	}
+
+	// Batch children share the task/timeline prompt, but each generates params
+	// for a different invocation. Carry the selected call's intent into R2 so
+	// repeated uses of the same tool do not all target the first task item.
+	if t.reason != "" || t.destinationIdentifier != "" || t.callExpectations != "" {
+		intent, _ := json.Marshal(map[string]string{
+			"tool":              tool.Name,
+			"reason":            t.reason,
+			"identifier":        t.destinationIdentifier,
+			"call_expectations": t.callExpectations,
+		})
+		paramsPrompt += "\n\nGenerate parameters for this specific tool invocation. Use its reason, identifier and expectations to distinguish it from other calls in the task:\n" + string(intent)
 	}
 
 	invokeParams := aitool.InvokeParams{}

--- a/common/ai/aid/aicommon/toolcall_functioncall_test.go
+++ b/common/ai/aid/aicommon/toolcall_functioncall_test.go
@@ -315,7 +315,8 @@ func TestBuildNativeToolForParamGen_NoProperties(t *testing.T) {
 	_, ok = props["tool"].(map[string]any)
 	require.True(t, ok, "tool field should always exist")
 
-	// params field should NOT exist when tool has no properties
-	_, ok = props["params"]
-	require.False(t, ok, "params field should NOT exist when tool has no InputSchema properties")
+	// The protocol always requires params; a parameterless tool accepts {}.
+	paramsField, ok := props["params"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "object", paramsField["type"])
 }

--- a/common/ai/aid/aicommon/toolcall_schema_validation_test.go
+++ b/common/ai/aid/aicommon/toolcall_schema_validation_test.go
@@ -1,0 +1,25 @@
+package aicommon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+func TestNativeParamSchemaOptionalFields(t *testing.T) {
+	for _, opts := range [][]aitool.ToolOption{nil, {aitool.WithStringParam("url")}} {
+		tool := aitool.NewWithoutCallback("do_http_request", opts...)
+		raw, err := json.Marshal(buildNativeToolForParamGen(tool).Function.Parameters)
+		require.NoError(t, err)
+		var document any
+		require.NoError(t, json.Unmarshal(raw, &document))
+		compiler := jsonschema.NewCompiler()
+		require.NoError(t, compiler.AddResource("native.json", document))
+		schema, err := compiler.Compile("native.json")
+		require.NoError(t, err)
+		require.NoError(t, schema.Validate(map[string]any{"@action": "call-tool", "tool": tool.Name, "params": map[string]any{}}))
+	}
+}

--- a/common/ai/aid/aicommon/transaction.go
+++ b/common/ai/aid/aicommon/transaction.go
@@ -23,6 +23,9 @@ func normalizeTransactionPostHandlerError(rsp *AIResponse, err error) error {
 	if err == nil || rsp == nil {
 		return err
 	}
+	if rsp.GetHTTPStatusCode() >= 400 || rsp.GetError() != nil {
+		return err
+	}
 	lower := strings.ToLower(err.Error())
 	if rsp.GetTotalOutputBytes() != 0 {
 		return err
@@ -38,6 +41,20 @@ func normalizeTransactionPostHandlerError(rsp *AIResponse, err error) error {
 		return utils.Wrapf(err, "ai model returned empty response")
 	}
 	return err
+}
+
+func isNonRetryableAIHTTPResponse(rsp *AIResponse) bool {
+	status := rsp.GetHTTPStatusCode()
+	// Request/authentication errors cannot be repaired by replaying the same
+	// request. Keep transient timeout, conflict, early-data and rate limits.
+	return status >= 400 && status < 500 && status != 408 && status != 409 && status != 425 && status != 429
+}
+
+func aiHTTPResponseError(rsp *AIResponse) error {
+	if err := rsp.GetError(); err != nil {
+		return err
+	}
+	return utils.Errorf("AI provider returned HTTP %d: %s", rsp.GetHTTPStatusCode(), rsp.GetHTTPResponseBody())
 }
 
 func CallAITransaction(
@@ -94,6 +111,7 @@ func callAITransaction(
 	var lastCallAiErr error // 保留 API 调用错误，防止被 postHandler 错误覆盖
 	var lastRsp *AIResponse
 	var lastReq *AIRequest
+	var nonRetryableHTTPFailure bool
 
 	// attemptHistory records every attempt (including 429 rate-limit retries) so
 	// that the final failure message can expose the full retry history to the
@@ -176,6 +194,10 @@ func callAITransaction(
 			i++
 			attemptHistory = append(attemptHistory, buildAttemptRecord(i, finalPrompt, err, rsp))
 			rspEmitter.EmitError("call ai api error (attempt %d/%d): %v", i, trcRetry, err)
+			if isNonRetryableAIHTTPResponse(rsp) {
+				nonRetryableHTTPFailure = true
+				break
+			}
 			if i < trcRetry {
 				if waitErr := waitBeforeTransactionRetry(transactionCtx, c, rspEmitter, i, trcRetry, attemptHistory); waitErr != nil {
 					return waitErr
@@ -201,7 +223,13 @@ func callAITransaction(
 		if ctxErr := transactionCtx.Err(); ctxErr != nil {
 			return ctxErr
 		}
-		postHandlerErr = postHandler(rsp)
+		if rsp.GetHTTPStatusCode() >= 400 && rsp.GetHTTPStatusCode() != 429 {
+			// An HTTP error body is not model output. Do not send it through
+			// action parsing and generate secondary "missing @action" errors.
+			postHandlerErr = aiHTTPResponseError(rsp)
+		} else {
+			postHandlerErr = postHandler(rsp)
+		}
 		// The post-handler may consume a stream with the same request context.
 		// If that context was cancelled while parsing, do not reinterpret the
 		// cancellation as malformed model output and retry it.
@@ -219,6 +247,10 @@ func callAITransaction(
 			attemptHistory = append(attemptHistory, rec)
 			rspEmitter := bindEmitter(rsp)
 			rspEmitter.EmitError("ai transaction postHandler error (attempt %d/%d): %v", i, trcRetry, postHandlerErr)
+			if isNonRetryableAIHTTPResponse(rsp) {
+				nonRetryableHTTPFailure = true
+				break
+			}
 			if i < trcRetry {
 				if waitErr := waitBeforeTransactionRetry(transactionCtx, c, rspEmitter, i, trcRetry, attemptHistory); waitErr != nil {
 					return waitErr
@@ -263,7 +295,7 @@ func callAITransaction(
 			"2. Try switching to a different AI model\n"+
 			"3. Simplify the task or reduce the prompt complexity\n"+
 			"4. Check network connectivity and API rate limits",
-		trcRetry, modelInfo, finalErr,
+		len(attemptHistory), modelInfo, finalErr,
 	)
 	var tier consts.ModelTier
 	if lastReq != nil {
@@ -295,6 +327,9 @@ func callAITransaction(
 	// error stays concise — callers that need the full retry history should
 	// consume the emitted events rather than parsing the error string.
 	if finalErr != nil {
+		if nonRetryableHTTPFailure {
+			return utils.Wrap(finalErr, "non-retryable AI HTTP request failure")
+		}
 		return utils.Wrap(finalErr, fmt.Sprintf("max retry count[%v] reached in transaction", trcRetry))
 	}
 	return utils.Errorf("max retry count[%v] reached in transaction", trcRetry)

--- a/common/ai/aid/aicommon/transaction_async_error_test.go
+++ b/common/ai/aid/aicommon/transaction_async_error_test.go
@@ -105,3 +105,33 @@ func TestAIResponse_WaitForCallbackDone_AlreadyDone(t *testing.T) {
 	ok := rsp.WaitForCallbackDone(context.Background())
 	assert.True(t, ok)
 }
+
+func TestTransactionHTTP400StopsBeforeActionParsing(t *testing.T) {
+	cfg := newTransactionTestConfig(context.Background())
+	cfg.retryMax = 5
+	calls, parsed := 0, false
+	err := CallAITransaction(cfg, "invalid tool schema", func(*AIRequest) (*AIResponse, error) {
+		calls++
+		rsp := NewUnboundAIResponse()
+		rsp.SetRawHTTPResponseData([]byte("HTTP/1.1 400 Bad Request\r\n\r\n"), []byte(`{"error":{"message":"Invalid schema: required:null"}}`))
+		return rsp, nil
+	}, func(*AIResponse) error {
+		parsed = true
+		return fmt.Errorf("action @action not found or invalid")
+	})
+	require.ErrorContains(t, err, "400")
+	require.ErrorContains(t, err, "Invalid schema")
+	require.NotContains(t, err.Error(), "empty response")
+	require.NotContains(t, err.Error(), "max retry count")
+	require.Equal(t, 1, calls)
+	require.False(t, parsed)
+}
+
+func TestTransactionHTTPRetryClassification(t *testing.T) {
+	for _, status := range []int{0, 200, 400, 401, 403, 404, 408, 409, 413, 422, 425, 429, 500, 502, 503} {
+		rsp := NewUnboundAIResponse()
+		rsp.SetRawHTTPResponseData([]byte(fmt.Sprintf("HTTP/1.1 %d Status\r\n\r\n", status)), nil)
+		want := status == 400 || status == 401 || status == 403 || status == 404 || status == 413 || status == 422
+		require.Equal(t, want, isNonRetryableAIHTTPResponse(rsp), "status %d", status)
+	}
+}

--- a/common/ai/aid/aimem/aimemory_build_memory.go
+++ b/common/ai/aid/aimem/aimemory_build_memory.go
@@ -77,9 +77,20 @@ func (r *AIMemoryTriage) AddRawText(i string) ([]*aicommon.MemoryEntity, error) 
 	if err != nil {
 		return nil, utils.Errorf("InvokeLiteForge failed: %v", err)
 	}
-	result := ac.GetInvokeParamsArray("memory_entities")
+	if ac == nil {
+		return nil, utils.Error("memory triage returned no action")
+	}
+	result, present, err := ac.GetCanonicalObjectArray("memory_entities")
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return nil, utils.Error("memory triage response is missing memory_entities")
+	}
 	if len(result) == 0 {
-		return nil, utils.Errorf("no memory entities found")
+		// The triage prompt explicitly allows an empty array for transient
+		// tool logs and other input with no durable facts to retain.
+		return nil, nil
 	}
 
 	var entities []*aicommon.MemoryEntity

--- a/common/ai/aid/aimem/aimemory_handle_memory_test.go
+++ b/common/ai/aid/aimem/aimemory_handle_memory_test.go
@@ -83,6 +83,25 @@ func TestHandleMemory_Basic(t *testing.T) {
 	}
 }
 
+func TestMemoryTriageEmptyArrayIsSuccessfulNoop(t *testing.T) {
+	invoker := NewAdvancedMockInvoker(context.Background())
+	memory, err := CreateTestAIMemory("empty-memory-"+uuid.NewString(), WithInvoker(invoker))
+	require.NoError(t, err)
+	defer memory.Close()
+	invoker.SetReturnValue("memory-triage", `{"@action":"memory-triage","memory_entities":[]}`)
+	require.NoError(t, memory.HandleMemory("temporary tool call completed"))
+	entities, err := memory.ListAllMemories(10)
+	require.NoError(t, err)
+	require.Empty(t, entities)
+	for _, response := range []string{
+		`{"@action":"memory-triage"}`,
+		`{"@action":"memory-triage","memory_entities":null}`,
+	} {
+		invoker.SetReturnValue("memory-triage", response)
+		require.Error(t, memory.HandleMemory("temporary tool call completed"))
+	}
+}
+
 func TestHandleMemory_Deduplication(t *testing.T) {
 	sessionID := "handle-dedup-test-" + uuid.New().String()
 	defer cleanupEntryTestData(t, sessionID)

--- a/common/ai/aid/aireact/invoke_toolcall_batch.go
+++ b/common/ai/aid/aireact/invoke_toolcall_batch.go
@@ -241,8 +241,10 @@ func cloneToolBatchParams(params aitool.InvokeParams) aitool.InvokeParams {
 	return cloneToolBatchMap(map[string]any(params))
 }
 
-func cloneToolBatchMap(input map[string]any) aitool.InvokeParams {
-	result := make(aitool.InvokeParams, len(input))
+func cloneToolBatchMap(input map[string]any) map[string]any {
+	// Nested objects must remain plain JSON maps. jsonschema rejects the
+	// named InvokeParams type, even though it has the same underlying type.
+	result := make(map[string]any, len(input))
 	for key, value := range input {
 		result[key] = cloneToolBatchValue(value)
 	}

--- a/common/ai/aid/aireact/invoke_toolcall_batch_params_regression_test.go
+++ b/common/ai/aid/aireact/invoke_toolcall_batch_params_regression_test.go
@@ -1,0 +1,78 @@
+package aireact
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+func TestExecuteToolBatchNestedObjectsRemainValidAndIsolated(t *testing.T) {
+	tool, err := aitool.New("nested_batch_tool",
+		aitool.WithStructParam("query", nil, aitool.WithStringParam("value")),
+		aitool.WithDangerousNoNeedUserReview(true),
+		aitool.WithSimpleCallback(func(params aitool.InvokeParams, _, _ io.Writer) (any, error) {
+			params.GetObject("query").Set("value", "changed")
+			return "ok", nil
+		}),
+	)
+	require.NoError(t, err)
+	react := newBatchTestReAct(t, tool, nil)
+	shared := map[string]any{"value": "original"}
+	result, err := react.ExecuteToolBatch(context.Background(), react.config.DefaultTask, &aicommon.ToolBatchRequest{
+		Calls: []aicommon.ToolBatchCall{
+			{Mode: aicommon.ToolCallModeDirect, ToolName: tool.Name, Reason: "first", Params: aitool.InvokeParams{"query": shared}},
+			{Mode: aicommon.ToolCallModeDirect, ToolName: tool.Name, Reason: "second", Params: aitool.InvokeParams{"query": shared}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Outcomes, 2)
+	for _, outcome := range result.Outcomes {
+		require.Equal(t, aicommon.ToolCallStageDone, outcome.Stage, "%+v", outcome)
+		require.True(t, outcome.Result.Success)
+	}
+	require.Equal(t, "original", shared["value"], "batch children must not mutate the source payload")
+}
+
+func TestExecuteToolBatchParamPromptIncludesIndividualIntent(t *testing.T) {
+	tool, err := aitool.New("intent_batch_tool",
+		aitool.WithIntegerParam("id", aitool.WithParam_Required(true)),
+		aitool.WithDangerousNoNeedUserReview(true),
+		aitool.WithSimpleCallback(func(params aitool.InvokeParams, _, _ io.Writer) (any, error) {
+			return params.GetInt("id"), nil
+		}),
+	)
+	require.NoError(t, err)
+	react := newBatchTestReAct(t, tool, func(config aicommon.AICallerConfigIf, req *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+		id := 0
+		for _, candidate := range []int{404, 500} {
+			if strings.Contains(req.GetPrompt(), fmt.Sprintf("Only request status %d", candidate)) &&
+				strings.Contains(req.GetPrompt(), fmt.Sprintf("request_%d", candidate)) &&
+				strings.Contains(req.GetPrompt(), fmt.Sprintf("Expect HTTP %d", candidate)) {
+				id = candidate
+			}
+		}
+		response := config.NewAIResponse()
+		response.EmitOutputStream(bytes.NewBufferString(fmt.Sprintf(`{"@action":"call-tool","params":{"id":%d}}`, id)))
+		response.Close()
+		return response, nil
+	})
+	result, err := react.ExecuteToolBatch(context.Background(), react.config.DefaultTask, &aicommon.ToolBatchRequest{
+		Calls: []aicommon.ToolBatchCall{
+			{Mode: aicommon.ToolCallModeRequire, ToolName: tool.Name, Reason: "Only request status 404", Identifier: "request_404", Expectations: "Expect HTTP 404"},
+			{Mode: aicommon.ToolCallModeRequire, ToolName: tool.Name, Reason: "Only request status 500", Identifier: "request_500", Expectations: "Expect HTTP 500"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Outcomes, 2)
+	for i, id := range []int64{404, 500} {
+		require.Equal(t, aicommon.ToolCallStageDone, result.Outcomes[i].Stage)
+		require.Equal(t, id, batchTestResultParamInt(t, result.Outcomes[i].Result, "id"))
+	}
+}

--- a/common/ai/aid/aireact/re-act_mainloop.go
+++ b/common/ai/aid/aireact/re-act_mainloop.go
@@ -403,6 +403,10 @@ func (r *ReAct) ExecuteLoopTask(taskTypeName string, task aicommon.AIStatefulTas
 								log.Infof("processing memory flush[%s] for iteration %d with %d pending diffs (%d bytes)", payload.FlushReason, iteration, payload.PendingIterations, payload.PendingBytes)
 							}
 							if err := r.memoryTriage.HandleMemory(payload.ContextualInput); err != nil {
+								if r.config.GetContext().Err() != nil {
+									log.Debugf("memory processing stopped with runtime: %v", err)
+									return
+								}
 								log.Warnf("intelligent memory processing failed: %v", err)
 								return
 							}

--- a/common/ai/aid/aireact/reactloops/action_buildin.go
+++ b/common/ai/aid/aireact/reactloops/action_buildin.go
@@ -112,7 +112,12 @@ var loopAction_DirectlyAnswer = &LoopAction{
 		}
 
 		if payload == "" {
-			tagPayload := loop.Get("tag_final_answer")
+			// Parsed tags are available before the asynchronous stream emitter
+			// finishes populating loop variables.
+			tagPayload := action.GetString("tag_final_answer")
+			if tagPayload == "" {
+				tagPayload = loop.Get("tag_final_answer")
+			}
 			if tagPayload != "" {
 				payload = tagPayload
 			}

--- a/common/ai/aid/aireact/reactloops/action_schema_validation_test.go
+++ b/common/ai/aid/aireact/reactloops/action_schema_validation_test.go
@@ -1,0 +1,21 @@
+package reactloops
+
+import (
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aitool"
+)
+
+func TestActionSchemaOverlappingRequiredFields(t *testing.T) {
+	parameters, err := buildActionToolParameters([]*LoopAction{
+		{ActionType: "find_files", Options: []aitool.ToolOption{aitool.WithStringParam("pattern", aitool.WithParam_Required(true))}},
+		{ActionType: "grep_text", Options: []aitool.ToolOption{aitool.WithStringParam("pattern", aitool.WithParam_Required(true))}},
+	})
+	require.NoError(t, err)
+	compiler := jsonschema.NewCompiler()
+	require.NoError(t, compiler.AddResource("actions.json", parameters))
+	_, err = compiler.Compile("actions.json")
+	require.NoError(t, err, "loop_plan shares required pattern between multiple actions")
+}

--- a/common/ai/aid/aireact/reactloops/directly_answer_helper_test.go
+++ b/common/ai/aid/aireact/reactloops/directly_answer_helper_test.go
@@ -1,6 +1,8 @@
 package reactloops
 
 import (
+	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -10,6 +12,28 @@ import (
 	"github.com/yaklang/yaklang/common/utils"
 	"github.com/yaklang/yaklang/common/utils/omap"
 )
+
+func TestDirectlyAnswerUsesParsedTagBeforeEmitterFinishes(t *testing.T) {
+	loop := newMinimalLoopForHelperTest()
+	ctx := context.Background()
+	release := make(chan struct{})
+	defer close(release)
+	action, err := aicommon.ExtractActionFromStream(ctx, strings.NewReader(`{"@action":"directly_answer"}
+<|FINAL_ANSWER_test|>complete answer<|FINAL_ANSWER_END_test|>`), "object",
+		aicommon.WithActionAlias("directly_answer"),
+		aicommon.WithActionNonce("test"),
+		aicommon.WithActionTagToKey("FINAL_ANSWER", "tag_final_answer"),
+		aicommon.WithActionFieldStreamHandler([]string{"tag_final_answer"}, func(_ string, reader io.Reader) {
+			_, _ = io.Copy(io.Discard, reader)
+			<-release // The UI completion callback has not populated loop vars yet.
+		}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, action.WaitParseResult(ctx))
+	require.Empty(t, loop.Get("tag_final_answer"))
+	require.NoError(t, loopAction_DirectlyAnswer.ActionVerifier(loop, action))
+	require.Equal(t, "complete answer", loop.Get("directly_answer_payload"))
+}
 
 func newMinimalLoopForHelperTest() *ReActLoop {
 	return &ReActLoop{vars: omap.NewEmptyOrderedMap[string, any]()}

--- a/common/ai/aid/aireact/reactloops/exec.go
+++ b/common/ai/aid/aireact/reactloops/exec.go
@@ -203,13 +203,8 @@ func (r *ReActLoop) buildActionTagOption(emitter *aicommon.Emitter, streamWG *sy
 						log.Debugf("tag[%s] callback finished, content length: %d chars, total stream cost: %v",
 							v.TagName, contentLength, totalCost)
 
-						if totalCost.Milliseconds() <= 300 {
-							log.Warnf("AITag[%s] stream too fast, cost %v (content: %d chars), stream maybe not valid",
-								v.TagName, totalCost, contentLength)
-						} else {
-							log.Infof("AITag[%s] stream processing completed normally, cost %v for %d chars",
-								v.TagName, totalCost, contentLength)
-						}
+						// Buffered responses can drain immediately; latency is not a
+						// validity check. Parsing and action validation report failures.
 					},
 				)
 				if eventErr != nil {

--- a/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_directly_answer.go
+++ b/common/ai/aid/aireact/reactloops/loop_http_flow_analyze/action_directly_answer.go
@@ -52,7 +52,10 @@ NOTE: Even when using the external tag, a foundational Action JSON structure is 
 		if payload == "" {
 			payload = strings.TrimSpace(action.GetInvokeParams("next_action").GetString("answer_payload"))
 		}
-		tagPayload := strings.TrimSpace(loop.Get("tag_final_answer"))
+		tagPayload := strings.TrimSpace(action.GetString("tag_final_answer"))
+		if tagPayload == "" {
+			tagPayload = strings.TrimSpace(loop.Get("tag_final_answer"))
+		}
 		if payload != "" && tagPayload != "" && payload != tagPayload {
 			return utils.Error("directly_answer requires exactly one of answer_payload or FINAL_ANSWER tag, but both were provided")
 		}

--- a/common/ai/aid/aireact/reactloops/loop_syntaxflow_rule/action_directly_answer.go
+++ b/common/ai/aid/aireact/reactloops/loop_syntaxflow_rule/action_directly_answer.go
@@ -49,7 +49,10 @@ func directlyAnswerSyntaxFlowVerifier(loop *reactloops.ReActLoop, action *aicomm
 		payload = action.GetInvokeParams("next_action").GetString("answer_payload")
 	}
 	if payload == "" {
-		tagPayload := loop.Get("tag_final_answer")
+		tagPayload := action.GetString("tag_final_answer")
+		if tagPayload == "" {
+			tagPayload = loop.Get("tag_final_answer")
+		}
 		if tagPayload != "" {
 			payload = tagPayload
 		}

--- a/common/ai/aid/aitool/schema_optional_required_test.go
+++ b/common/ai/aid/aitool/schema_optional_required_test.go
@@ -1,0 +1,32 @@
+package aitool
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolSchemaOptionalRequiredIsValid(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts []ToolOption
+	}{
+		{"optional", []ToolOption{WithStringParam("url")}},
+		{"oneOf", []ToolOption{WithOneOfStructParam("choice", nil, []ToolOption{WithStringParam("url")})}},
+		{"anyOf", []ToolOption{WithAnyOfStructParam("choice", nil, []ToolOption{WithStringParam("url")})}},
+		{"noParams", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := newTool("optional_tool", tc.opts...)
+			var document any
+			require.NoError(t, json.Unmarshal([]byte(tool.ToJSONSchemaString()), &document))
+			compiler := jsonschema.NewCompiler()
+			require.NoError(t, compiler.AddResource("tool.json", document))
+			schema, err := compiler.Compile("tool.json")
+			require.NoError(t, err, "upstream validators reject required:null")
+			require.NoError(t, schema.Validate(map[string]any{"@action": "call-tool", "tool": "optional_tool", "params": map[string]any{}}))
+		})
+	}
+}

--- a/common/ai/aid/aitool/tool.go
+++ b/common/ai/aid/aitool/tool.go
@@ -106,6 +106,9 @@ func newTool(name string, options ...ToolOption) *Tool {
 	for _, option := range options {
 		option(tool)
 	}
+	// Multiple actions may contribute the same property (e.g. pattern in
+	// find_files and grep_text). JSON Schema requires unique required names.
+	tool.InputSchema.Required = utils.RemoveRepeatStringSlice(tool.InputSchema.Required)
 
 	return tool
 }
@@ -684,7 +687,9 @@ func WithOneOfStructParam(name string, opts []PropertyOption, itemsOpt ...[]Tool
 		temp := newTool("", itemOpt...)
 		m := map[string]any{
 			"properties": temp.InputSchema.Properties,
-			"required":   temp.InputSchema.Required,
+		}
+		if len(temp.InputSchema.Required) > 0 {
+			m["required"] = temp.InputSchema.Required
 		}
 		oneOfArray = append(oneOfArray, m)
 	}
@@ -702,7 +707,9 @@ func WithAnyOfStructParam(name string, opts []PropertyOption, itemsOpt ...[]Tool
 		temp := newTool("", itemOpt...)
 		m := map[string]any{
 			"properties": temp.InputSchema.Properties,
-			"required":   temp.InputSchema.Required,
+		}
+		if len(temp.InputSchema.Required) > 0 {
+			m["required"] = temp.InputSchema.Required
 		}
 		anyOfArray = append(anyOfArray, m)
 	}
@@ -884,15 +891,19 @@ func (t *Tool) ToJSONSchema() *omap.OrderedMap[string, any] {
 	})
 
 	paramProperties := t.Tool.InputSchema.Properties
-	// 将参数添加到params字段 (第三个)
-	if paramProperties != nil && paramProperties.Len() > 0 {
-		properties.Set("params", map[string]any{
-			"type":        "object",
-			"description": "工具的参数",
-			"properties":  paramProperties,
-			"required":    t.InputSchema.Required,
-		})
+	// params is required even for parameterless tools. An optional-only tool
+	// must omit required rather than serialize a nil slice as JSON null.
+	paramsSchema := map[string]any{
+		"type":        "object",
+		"description": "工具的参数",
 	}
+	if paramProperties != nil && paramProperties.Len() > 0 {
+		paramsSchema["properties"] = paramProperties
+	}
+	if len(t.InputSchema.Required) > 0 {
+		paramsSchema["required"] = t.InputSchema.Required
+	}
+	properties.Set("params", paramsSchema)
 
 	// 构建最终的JSON Schema - 使用 OrderedMap 保证顺序
 	schema := omap.NewEmptyOrderedMap[string, any]()

--- a/common/ai/aid/aitool/tool_test.go
+++ b/common/ai/aid/aitool/tool_test.go
@@ -370,6 +370,10 @@ func TestTool_ToJSONSchemaString(t *testing.T) {
 						"description": "你想要选择的工具名",
 						"const":       "noParamTool",
 					},
+					"params": map[string]interface{}{
+						"type":        "object",
+						"description": "工具的参数",
+					},
 				},
 				"required":             []interface{}{"tool", "@action", "params"},
 				"additionalProperties": false,

--- a/common/ai/aid/aive/value_feedback.go
+++ b/common/ai/aid/aive/value_feedback.go
@@ -249,6 +249,10 @@ func submitValueFeedbackInternal(ctx context.Context, cfg *aicommon.Config, reco
 
 	result, err := forge.Execute(ctx, nil, execOpts...)
 	if err != nil {
+		if ctx.Err() != nil {
+			log.Debugf("aive value feedback stopped with context: %v", err)
+			return
+		}
 		log.Warnf("aive value feedback liteforge execute failed: id=%s focus=%s err=%v", record.ID, record.FocusMode, err)
 		return
 	}

--- a/common/ai/aispec/http_error.go
+++ b/common/ai/aispec/http_error.go
@@ -1,0 +1,22 @@
+package aispec
+
+import (
+	"bytes"
+	"io"
+	"net/http/httputil"
+
+	"github.com/yaklang/yaklang/common/utils"
+)
+
+func readAIHTTPError(status int, body io.Reader, chunked bool, captured *bytes.Buffer) error {
+	if chunked {
+		body = httputil.NewChunkedReader(body)
+	}
+	// Keep diagnostics bounded while preserving the provider's error message.
+	_, readErr := io.Copy(captured, io.LimitReader(body, 4096))
+	err := utils.Errorf("AI provider returned HTTP %d: %s", status, captured.String())
+	if readErr != nil {
+		return utils.Wrapf(readErr, "%v", err)
+	}
+	return err
+}

--- a/common/ai/aispec/stream.go
+++ b/common/ai/aispec/stream.go
@@ -308,6 +308,9 @@ func processAIResponse(r []byte, closer io.ReadCloser, outWriter io.Writer, reas
 		_, _ = io.Copy(&mirrorResponse, closer)
 		return nil
 	}
+	if statusCode >= 400 {
+		return readAIHTTPError(statusCode, closer, chunked, &mirrorResponse)
+	}
 
 	var reader io.Reader = closer
 	ioReader := reader
@@ -750,6 +753,9 @@ func processAIResponseForResponses(r []byte, closer io.ReadCloser, outWriter io.
 	if statusCode == 429 {
 		_, _ = io.Copy(&mirrorResponse, closer)
 		return nil
+	}
+	if statusCode >= 400 {
+		return readAIHTTPError(statusCode, closer, chunked, &mirrorResponse)
 	}
 
 	var reader io.Reader = io.TeeReader(closer, &mirrorResponse)

--- a/common/ai/aispec/stream_http_error_test.go
+++ b/common/ai/aispec/stream_http_error_test.go
@@ -1,0 +1,31 @@
+package aispec
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamHTTPErrorIsNotEmptySuccess(t *testing.T) {
+	for name, process := range map[string]func([]byte, io.ReadCloser, io.Writer, io.Writer, io.Writer, func([]*ToolCall), RawHTTPResponseHeaderCallback, func([]byte, []byte, *ChatUsage), func(*ChatUsage)) error{
+		"chat": processAIResponse, "responses": processAIResponseForResponses,
+	} {
+		for _, status := range []int{400, 401, 403, 500, 502} {
+			t.Run(fmt.Sprintf("%s/%d", name, status), func(t *testing.T) {
+				const body = `{"error":{"message":"Invalid schema for function: required is null"}}`
+				var output, reason bytes.Buffer
+				var captured []byte
+				err := process([]byte(fmt.Sprintf("HTTP/1.1 %d Error\r\nContent-Type: application/json\r\n\r\n", status)), io.NopCloser(strings.NewReader(body)), &output, &reason, nil, nil, nil, func(_, b []byte, _ *ChatUsage) { captured = append([]byte(nil), b...) }, nil)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), fmt.Sprint(status))
+				require.Contains(t, err.Error(), "Invalid schema")
+				require.Equal(t, body, string(captured))
+				require.Empty(t, output.String())
+			})
+		}
+	}
+}

--- a/common/ai/rag/migration_concurrency_test.go
+++ b/common/ai/rag/migration_concurrency_test.go
@@ -1,0 +1,36 @@
+package rag
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+)
+
+func TestConcurrentRAGMigration(t *testing.T) {
+	db, err := gorm.Open("sqlite3", filepath.Join(t.TempDir(), "fresh.db"))
+	require.NoError(t, err)
+	defer db.Close()
+	db.LogMode(false)
+	db.DB().SetMaxOpenConns(1)
+	const workers = 8
+	start := make(chan struct{})
+	errors := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errors <- autoMigrateRAGSystem(db)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+}

--- a/common/ai/rag/utils.go
+++ b/common/ai/rag/utils.go
@@ -240,7 +240,13 @@ func NewTemporaryRAGDB() (*gorm.DB, error) {
 	return db, nil
 }
 
+var ragSchemaMigrationMu sync.Mutex
+
 func autoMigrateRAGSystem(db *gorm.DB) error {
+	// Runtime memory and timeline archive initialize concurrently. Gorm's
+	// check-then-create migration is not atomic, even with one SQL connection.
+	ragSchemaMigrationMu.Lock()
+	defer ragSchemaMigrationMu.Unlock()
 	return db.AutoMigrate(
 		&schema.KnowledgeBaseEntry{},
 		&schema.KnowledgeBaseInfo{},
@@ -266,9 +272,11 @@ func autoMigrateRAGSystem(db *gorm.DB) error {
 //
 // Example:
 // ```
-// cb = ai.MockAIService(func(msg) {
-//     return "mocked response for: " + msg
-// })
+//
+//	cb = ai.MockAIService(func(msg) {
+//	    return "mocked response for: " + msg
+//	})
+//
 // assert cb != nil, "MockAIService should return a non-nil callback"
 // println("ai.MockAIService created callback successfully")
 // ```

--- a/common/aiengine/aibenchmark/reports/2026-09-11-deepseek-v4.1-flash.md
+++ b/common/aiengine/aibenchmark/reports/2026-09-11-deepseek-v4.1-flash.md
@@ -1,0 +1,93 @@
+# deepseek-v4.1-flash / aid 本地排查记录
+
+日期：2026-09-11。基线为本次 fetch 得到的 `origin/main`：`667526d49625d311662635e7952ce2704bf88b29`（2026-09-10，lowhttp HTTP/2 修复）。工作分支：`codex/investigate-deepseek-react-warnings`。环境：macOS arm64 / Go 1.22.12。
+
+## 结论
+
+大批量错误有明确的框架原因。最严重的是无效工具 JSON Schema 被上游返回 HTTP 400，随后被错误解释成“模型 HTTP 200 空响应 / 没输出 @action”，并对原样请求反复重试。这会将一个确定性请求错误放大为几十条 warning/error，直至 bench 超时。另有 Go→Yak 并发回调的 VM 栈归属问题、批量参数复制类型错误、子调用意图丢失，以及中文检索 SQL 表达式过深。已经为这些问题补了复现测试并修复。
+
+本次观测不能把全部剩余日志都归为模型问题，也不能把剩余 WARN/ERROR 当作任务失败。测试主动制造的退出码、HTTP 错误和传输失败，与任务完成或采样预算耗尽后的取消日志需要分别判断。
+
+## 接入与覆盖范围
+
+使用用户提供的 Y CONNECT endpoint `https://aibalance.yaklang.com` 和模型 `deepseek-v4.1-flash`。API Key 仅传给独立运行进程，未写入代码和本报告。隔离 `YAKIT_HOME`，避免读写用户日常会话状态。HTTP 测试目标为 bench 自建的本地 oracle。
+
+Chat Completions 普通请求、Chat Completions SSE、Responses 普通请求、Anthropic Messages 普通请求均返回 HTTP 200 和预期的 `PROBE_OK`，耗时约 1.3–1.7 秒。因此基础鉴权、地址和模型可用性正常。完整 aid 闭环本次走 OpenAI Chat Completions；Responses / Anthropic 仅做了基础接入探针，不能据此宣称这两条路径已完成相同的 agent 验收。
+
+从 `common/yak/cmd/yak.go` 分别编译原版与修复版二进制，通过 `-c 'aim.InvokeReAct(...)'` 实测流式回调，并运行仓库的 `http-react-blackbox-benchmark.yak` 与 `aicache/cachebench/run_react.yak`。后者仅在临时副本中配置 endpoint/key 和主、质量、速度三档模型，输入改为本地 Python 标准库开发测试任务，以覆盖 plan → 子任务执行。
+
+## 黑盒对照
+
+同一组 6 个用例、相同 timeout=180 秒 / max-iteration=10，各版本各运行一轮。WARN/ERROR 为去除 ANSI 后、以日志级别开头的物理行数，包含辅助请求和收尾日志，不是独立故障数量。过程日志和 JSON 中同一错误的复制文本不重复计数。单轮测试受模型随机性、缓存和机器负载影响，耗时与通过率不能作为统计性性能结论。
+
+| 运行 | 通过 | WARN | ERROR |
+|---|---:|---:|---:|
+| 最新 main 原版 | 3/6 | 264 | 178 |
+| 第一轮修复 | 4/6 | 23 | 14 |
+| 最终修复 | 5/6 | 30 | 29 |
+
+| 用例 | 原版：秒 / 调用 / 结果 | 最终：秒 / 调用 / 结果 |
+|---|---|---|
+| exit7-stdout-success-claim | 18.4 / 1 / 通过 | 12.6 / 1 / 通过 |
+| concurrent-exit-codes-with-accepted | 31.5 / 3 / 通过 | 19.4 / 3 / 通过 |
+| http-status-cross-check | 180.0 / 7 / 未通过 | 18.8 / 3 / 通过 |
+| python-existing-file-multihunk-repair | 91.3 / 19 / 未通过 | 180.0 / 20 / 未通过 |
+| finish-recover-after-wrong-test-entry | 52.0 / 9 / 通过 | 116.5 / 13 / 通过 |
+| http-transport-timeout-cross-check | 180.0 / 6 / 未通过 | 18.8 / 3 / 通过 |
+
+原版的两个 HTTP 用例均在 180 秒硬超时退出，产生合计 60 个上游 HTTP 400；原版多位置文件修复的文件检查完成，但工具调用 19 次超过上限 16，仍按 bench 判失败。
+
+第一轮修复后 4/6 通过，两个 HTTP 用例已能结束，但分别调用 6 次与 5 次，超过上限 3。进一步对照 action、参数生成文本、tool result 与真实 oracle 请求，发现 `require_tool` 三个子调用各自要求 200/404/500，但 R2 都生成 200；随后合法的空 query/form 又被运行时拒绝。第二轮修复了这两处框架错误，没有放宽 bench 验收条件。
+
+最终黑盒为 **5/6 通过，WARN 30 / ERROR 29**。两个 HTTP 用例均为 3 次调用，分别 18.8 秒、18.8 秒通过；原版均在 180 秒超时。最终轮没有再观测到上游 schema 400、VM 栈错乱、非法嵌套对象或空记忆误报。
+
+剩余未通过项是多位置 Python 编辑：文件内容检查、目标命令和 py_compile 均通过，但累计工具调用 20 次超过 16，并在收尾阶段耗尽 180 秒。日志可见中途误覆盖 main 后修复、重复验证，以及实际的首字节 EOF / connection reset / deadline exceeded；最终思考文本已经说“Now finish”，但未在截止前完成终止动作。第一轮修复时该用例曾以 13 次调用通过，因此这里既有执行效率波动，也有网络/辅助请求干扰，不能宣称全部任务稳定通过，也没有足够证据把这些连接错误完全定位到网关或本机网络。
+
+## 根因、影响和处理
+
+| 现象 | 根因与影响 | 处理 |
+|---|---|---|
+| `Invalid schema ... required ... null` | 可选参数工具序列化出 `required:null`；无参工具缺少 `params` 定义。真正的 R2 native function schema 与文本 schema 是两条构造路径，都存在问题。`do_http_request` 可直接触发上游 400。 | 两条路径均省略空 required，始终定义 params 为 object；空 properties 不序列化成数组。 |
+| plan 的 `required ... non-unique elements` | 多个 action 的参数展平后，把 `pattern` 加入 required 两次。原版 cachebench 在规划阶段连续返回 5 次 400。 | 工具 schema 构造结束时去重 required。 |
+| 400 被报告为 HTTP 200 空响应 / `@action not found` | 流处理器没有将一般 HTTP 错误返回，wrapper 不检查状态却写死 HTTP 200；事务继续对错误正文做 action 解析并重试。 | 保留上游状态及有限长度错误正文；非瞬态 4xx 不重试原样请求；保留 408/409/425/429 与 5xx 的既有可重试语义；不再伪造 HTTP 200 和 finish_reason。 |
+| `frame stack mismatch` | 原版黑盒 15 次。Go 异步执行 Yak 回调时，复用定义该回调的 frame，其 owner goroutine/coroutine 属于原执行栈。 | 在 Go→Yak 回调边界建立属于当前 goroutine 的执行 frame，保留词法上下文；不在每个普通 Yak 函数调用中增加 goroutine 查询。 |
+| `invalid jsonType aitool.InvokeParams` | 批量执行深拷贝把嵌套普通 map 改成命名类型 InvokeParams；JSON Schema 校验器拒绝。合法 `{}`、默认 query/form 都受影响。 | 嵌套对象保持普通 map，只在参数根部使用 InvokeParams；测试验证原始 payload 不被子调用修改。 |
+| 批量请求本应不同却重复执行相同请求 | 批量 R2 共用任务/时间线提示词，只将每个调用的 reason 用于 UI，没有把该调用 reason/identifier/expectations 传给参数生成。 | 在参数生成请求中明确附上当前调用的意图。回归测试让同一工具的两个子调用各自取到 404 / 500。 |
+| `FINAL_ANSWER` 已输出但 verifier 认为没有答案 | AITag 解析完成与异步 emitter 更新 loop 字段并不同步，验证器读到旧空值。 | 优先读取 action 已解析的规范字段，再保留 loop 字段兼容回退；覆盖默认及两个专用直接回答入口。 |
+| `no memory entities found` | prompt 允许没有持久知识时返回空数组，处理器却将合法空数组当失败。原版黑盒 15 次。 | 空数组为成功的无操作；缺字段、null、错误对象仍然报错。 |
+| `table rag_knowledge_entry_v1 already exists` | 首次启动中，主记忆与时间线记忆并行迁移同一库，发生 check-then-create 竞争。 | 串行化 RAG schema migration；8 个并发初始化测试在修复前失败，修复后通过。 |
+| `Expression tree is too large (maximum depth 1000)` | 中文搜索词展开为大量 3–6 字 n-gram；FTS 不可用时对多列生成左深 OR 链。工具和 skill 搜索均可发生。 | OR 条件用平衡结构连接，保留所有关键词及匹配语义；1204 条谓词的 SQLite 回归测试通过。 |
+| `stream too fast ... maybe not valid` | 仅凭小于 300ms 判断 AITag 不可靠，模型流缓冲后快速交付也会命中。 | 删除该武断 warning，保留正常解析验证及 debug 耗时。 |
+| 新会话 `record not found`、收尾 `hotpatch option is nil` | 新会话查询不存在是正常情况；关闭通道读出的零值被当异常。 | 新会话未命中记为 debug，真正 DB 错误保留；关闭通道正常结束。 |
+
+## 剩余日志的解释
+
+- `@action` 缺失、`action` 写错键、批量与旧版单调用字段混用、`accepted_exit_codes` 用数组而 schema 要字符串、modify_file 缺 content：是真实的输出协议/参数错误。模型常能在重试后纠正，这些没有通过关闭校验来隐藏。
+- `Ignored invalid todo_delta ... immutable closed history`：模型尝试重用已关闭的 todo；框架保留状态并继续主动作。应看后续是否补了新 todo，不是数据库损坏。
+- `tool ... not in recently-used cache; runtime will resolve it`：工具缓存未命中但可以继续解析。日志级别偏高，并不等于工具不可用。
+- `empty yakit client (VirtualYakitClient)`：命令行没有连接 GUI 的虚拟客户端提示。
+- `context provider perception_* already registered`：plan 的嵌套配置重复注册，后来的 callback 被忽略。本次没有改注册策略，仍需单独梳理生命周期。
+- `use of closed network connection`、`unexpected EOF`、`context canceled`：在本次日志中有一部分紧邻正常任务完成、下个 case 启动或 cachebench 主动 cancel。底层 lowhttp/aicaller 仍可能按 WARN/ERROR 输出，需要用时间和请求上下文判断；不能把所有 EOF 都自动当正常。
+- HTTP 连接拒绝、超时和 bash 非零退出：对应黑盒用例刻意制造的条件。工具应如实记录传输状态/退出码，不能通过清除错误日志伪装成功。
+- 冷启动插件/工具同步、配置加载超过固定耗时阈值会有 warning；并行编译和 race 检查也会影响本机耗时。不能仅凭该 warning 判断接口慢。
+- 日志里的 `memfit-light-free` 并非 deepseek 自动切换模型。AIVE 的 `submitValueFeedbackInternal` 固定使用该小模型及全局 lightweight 路由，session 的模型覆盖不能替换它。对照主请求和辅助请求时需按调用来源归类。
+
+## cachebench 的停止语义
+
+原版在 plan schema 连续 HTTP 400 后 exit=1。第一轮修复后已进入 plan → 子任务执行，70 秒后累计达到 25 个 usage 样本，脚本明确输出 `max-prompts(25) reached` 并 cancel，进程 exit=0；后面的多条 Plan execution failed / context canceled 是该采样截断的传播，不能说原任务已经做完。
+
+第一轮计 25 次请求：deepseek 20 次、AIVE 固定小模型 5 次；按模型名汇总的 deepseek 上游 token cache hit 61.82%，所有模型合计 58.37%，有 1 次取消中的请求未收到 usage。缓存命中不能代替任务正确性验收。
+
+最终以 max-prompts=100、max-duration=300 秒再次运行，约 237 秒结束。磁盘上已生成 `int_stats.py`、`test_int_stats.py`、`report.md`，模型实际执行了 6 个 unittest，全部通过；排查者随后独立运行同一测试，也全部通过。会话仍是在报告写入后的收尾阶段被采样上限取消，不能说 InvokeReAct 自然完整结束。由于有并发在途请求，最终记录为 103 条：deepseek 64、固定小模型 39，2 条缺 usage、3 条在途取消。该轮 WARN 30 / ERROR 18，schema 400 与 SQL 深度错误均为 0。模型名汇总的 deepseek token hit 为 64.58%，整体为 56.12%。
+
+另发现 bench 统计自身的限制：`lib.yak:analyzeBenchmarkWithModels` 假设“同一模型的 tier 是稳定属性”，用模型名映射第一次收到的 tier。当主/质量/速度档都设为 deepseek 时该假设不成立。本轮第一次事件是 lightweight，导致全部 deepseek 记录被归 lightweight，报告竟显示 `intelligent calls: 0` 和 `high-static distinct: 0 ... PASS`；第一轮则全部被归 intelligent。**这些 intelligent-only 统计与 PASS 不可用于本次验收。** 本次未修改这套统计归因；后续应在每个 dump/usage 上记录和关联请求级 tier，并在没有合格样本时显示 N/A。不要通过选择一个有利的首个事件来解释缓存效果。
+
+最后用全新 YAKIT_HOME 再跑 -c 流式 smoke：16 秒、InvokeReAct 返回 nil、成功输出目标文本；未再出现 RAG 表创建竞争。还可见冷启动同步耗时、空 skill 目录以及模型重复直接回答被拦截的 warning，这些与 schema 400 不同。
+
+## 验证与产物
+
+修改相关的十个 Go package 定向回归通过，包括真实批量执行、schema metaschema 编译、HTTP 状态传播、已解析标签与异步输出竞争、记忆空结果、SQLite 并发迁移和长查询。Yak VM 与 aitool 全套测试通过；429/非429重试、取消和流读取错误的补充回归通过。`go test -race` 的 Go→Yak 并发回调及 RAG 并发迁移测试通过；本机 clang linker 有 LC_DYSYMTAB 警告，测试未报告 data race。本地未运行整个仓库全部测试；远端 CI 结果以 PR 检查为准。
+
+可复现参数：黑盒 `--config /tmp/yak-deepseek-diagnosis/cases.json --intelligent-model deepseek-v4.1-flash --lightweight-model deepseek-v4.1-flash --timeout 180 --max-iteration 10`；-c smoke 在主、quality、speed 三档都传入 `ai.apiKey(os.Getenv("AIBALANCE_API_KEY"))`、`ai.domain("https://aibalance.yaklang.com")`、`ai.model("deepseek-v4.1-flash")`，并监听 onEvent/onStreamContent。
+
+本机证据目录：`/tmp/yak-deepseek-diagnosis/`。其中 `baseline-blackbox.log` / `final-blackbox.log` 是原始运行日志，`*-blackbox/*.json` 保存用例事件、工具参数、实际 oracle 请求和文件检查；`comparison-summary.json` 是精简对照；`*-before.log` 保存修复前失败的回归；`final-regression-suite.log`、`concurrency-race.log` 保存验证结果。密钥已从交付文本日志中清除。

--- a/common/utils/bizhelper/dbutil.go
+++ b/common/utils/bizhelper/dbutil.go
@@ -1182,7 +1182,18 @@ func FuzzSearchWithStringArrayOrEx(db *gorm.DB, fields []string, targets []strin
 		return db
 	}
 
-	return db.Where(strings.Join(conds, " OR "), items...)
+	return db.Where(joinBalancedSearchOr(conds), items...)
+}
+
+// Build a balanced expression instead of a left-deep OR chain. Expanded
+// natural-language search terms can otherwise exceed SQLite's depth limit
+// even while the number of bound parameters is well within its limit.
+func joinBalancedSearchOr(conditions []string) string {
+	if len(conditions) <= 8 {
+		return strings.Join(conditions, " OR ")
+	}
+	middle := len(conditions) / 2
+	return "(" + joinBalancedSearchOr(conditions[:middle]) + ") OR (" + joinBalancedSearchOr(conditions[middle:]) + ")"
 }
 
 // ilike sqliter not support

--- a/common/utils/bizhelper/fuzz_search_depth_test.go
+++ b/common/utils/bizhelper/fuzz_search_depth_test.go
@@ -1,0 +1,26 @@
+package bizhelper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/gorm"
+)
+
+func TestFuzzSearchManyTermsPreservesMatches(t *testing.T) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Exec("CREATE TABLE search_depth_fixture (name TEXT, description TEXT)").Error)
+	require.NoError(t, db.Exec("INSERT INTO search_depth_fixture VALUES (?, ?), (?, ?), (?, ?)", "first-term", "", "", "last-term", "unmatched", "").Error)
+	terms := []string{"first-term"}
+	for i := 0; i < 600; i++ {
+		terms = append(terms, fmt.Sprintf("absent-%d", i))
+	}
+	terms = append(terms, "last-term")
+	var count int
+	err = FuzzSearchWithStringArrayOrEx(db.Table("search_depth_fixture"), []string{"name", "description"}, terms, false).Count(&count).Error
+	require.NoError(t, err)
+	require.Equal(t, 2, count, "both early and late keywords must match, without truncating the query")
+}

--- a/common/yak/antlr4yak/native_callback_concurrency_test.go
+++ b/common/yak/antlr4yak/native_callback_concurrency_test.go
@@ -1,0 +1,43 @@
+package antlr4yak
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/yak/antlr4yak/yakvm"
+)
+
+func TestConcurrentNativeCallbacksKeepCurrentFrames(t *testing.T) {
+	engine := New()
+	var callers sync.WaitGroup
+	entered := make(chan *yakvm.Frame, 2)
+	release := make(chan struct{})
+	results := make(chan int, 2)
+	engine.SetVars(map[string]any{
+		"observe": func() {
+			entered <- engine.GetVM().CurrentFM()
+			<-release
+		},
+		"parallel": func(callback func(int) int) {
+			parent := engine.GetVM().CurrentFM()
+			for i := 0; i < 2; i++ {
+				callers.Add(1)
+				go func(i int) { defer callers.Done(); results <- callback(i) }(i)
+			}
+			first, second := <-entered, <-entered
+			if first == nil || second == nil || first == second || first == parent || second == parent {
+				t.Error("native callbacks must have independent current frames")
+			}
+			if engine.GetVM().CurrentFM() != parent {
+				t.Error("native callback replaced the caller frame")
+			}
+			close(release)
+			callers.Wait()
+		},
+	})
+	require.NoError(t, engine.SafeEval(context.Background(), `parallel(func(i) { observe(); return i + 1 })`))
+	require.Equal(t, 3, <-results+<-results)
+	require.Nil(t, engine.GetVM().CurrentFM())
+}

--- a/common/yak/antlr4yak/yakvm/current_frame_test.go
+++ b/common/yak/antlr4yak/yakvm/current_frame_test.go
@@ -41,6 +41,42 @@ func TestCurrentGoroutineID(t *testing.T) {
 	}
 }
 
+func TestCallbackWithCapturedParentOwnsCurrentGoroutine(t *testing.T) {
+	vm := New()
+	ctx := context.Background()
+	err := vm.Exec(ctx, func(parent *Frame) {
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			done <- vm.exec(ctx, parent.nativeCallbackFrame(), func(child *Frame) {
+				if child.ownerGoroutineID != currentGoroutineID() || vm.CurrentFM() != child {
+					t.Error("native callback registered against its captured parent's goroutine")
+				}
+				if child.coroutine == parent.coroutine || child.ThreadID == parent.ThreadID {
+					t.Error("independent callback shares panic/debugger state with its parent")
+				}
+				close(entered)
+				<-release
+			}, Sub)
+		}()
+		<-entered
+		if vm.CurrentFM() != parent {
+			t.Error("callback replaced the parent's active frame")
+		}
+		close(release)
+		if err := <-done; err != nil {
+			t.Error(err)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vm.activeFrames.Load() != 0 {
+		t.Error("callback leaked active frames")
+	}
+}
+
 func TestConcurrentBareVMGetVarDoesNotRelinkGlobals(t *testing.T) {
 	vm := New()
 	start := make(chan struct{})

--- a/common/yak/antlr4yak/yakvm/func.go
+++ b/common/yak/antlr4yak/yakvm/func.go
@@ -246,6 +246,21 @@ func LuaVMValuesToFunctionMap(f *Function, vs []*Value) map[int]*Value {
 	return params
 }
 
+// nativeCallbackFrame preserves captured lexical context without registering
+// concurrent Go callbacks in the defining goroutine's execution stack.
+func (vm *Frame) nativeCallbackFrame() *Frame {
+	gid := currentGoroutineID()
+	if gid == vm.ownerGoroutineID {
+		return vm
+	}
+	frame := NewSubFrame(vm)
+	frame.ownerGoroutineID = gid
+	frame.coroutine = NewCoroutine()
+	frame.ThreadID = 0
+	frame.ownsThreadID = false
+	return frame
+}
+
 func (vm *Frame) CallYakFunction(asyncCall bool, f *Function, vs []*Value) interface{} {
 	if !asyncCall && vm.vm.debugMode && vm.vm.debugger != nil {
 		// ShouldCallback records this exact caller at OpCall. Pair the pop at

--- a/common/yak/antlr4yak/yakvm/value_types.go
+++ b/common/yak/antlr4yak/yakvm/value_types.go
@@ -315,7 +315,7 @@ func (v *Frame) AutoConvertReflectValueByType(
 					}
 				}
 
-				result := v.CallYakFunction(false, f, vmArgs)
+				result := v.nativeCallbackFrame().CallYakFunction(false, f, vmArgs)
 				outCount := targetType.NumOut()
 				if outCount <= 0 {
 					return nil

--- a/common/yak/antlr4yak/yakvm/virtual_machine.go
+++ b/common/yak/antlr4yak/yakvm/virtual_machine.go
@@ -435,8 +435,8 @@ func (v *VirtualMachine) execWithFrameFactory(ctx context.Context, parentFrame *
 		frame = NewSubFrame(parentFrame)
 		// Synchronous Yak function calls stay on the parent's goroutine. Reuse
 		// its already-resolved ID instead of calling runtime.Stack for every
-		// nested frame. Async calls do not go through this path and resolve their
-		// owner after the goroutine starts.
+		// nested frame. Native callbacks normalize their parent at the Go-to-Yak
+		// boundary; async calls resolve their owner after the goroutine starts.
 		frame.ownerGoroutineID = parentFrame.ownerGoroutineID
 	} else if flag&Inline == Inline {
 		topFrame := v.peekCurrentFrame()


### PR DESCRIPTION
## 问题与行为

使用 Y CONNECT 的 `deepseek-v4.1-flash` 运行 `aim.InvokeReAct` 时，可选参数工具和 plan 的 native tool schema 会被上游返回 HTTP 400。原处理链将其误报为 HTTP 200 空响应/缺少 @action，并反复重试相同请求。批量工具参数复制、子调用意图和 Go→Yak 回调还会造成校验失败、重复请求和 VM frame stack mismatch。

## 修改

- 修正文本及 native function schema：省略空 required、定义无参工具的 params object、去重 action 合并后的 required。
- 保留 HTTP 错误状态和有限长度的上游错误正文，跳过错误正文的 action 解析，对非瞬态 4xx 停止原样重试；保留限流和瞬态错误的重试行为。
- 将批量子调用意图传入参数生成，深拷贝时保留嵌套 JSON 对象类型；修正 Go→Yak 并发回调的执行栈归属。
- 修复直接回答 AITag 解析与异步输出间的竞争、RAG 首次建表竞争，以及大量中文关键词导致的 SQLite 表达式深度错误。
- 区分合法空记忆、新会话、通道关闭和正常取消；移除仅凭流式输出耗时判定异常的 warning。保留真实模型协议、参数及传输错误。

补充可独立复现上述缺陷的回归测试，以及[本地排查报告](common/aiengine/aibenchmark/reports/2026-09-11-deepseek-v4.1-flash.md)。没有修改 bench 的通过条件或跳过检查。

## 验证

- 十个相关 Go package 的定向回归通过；aitool、Yak VM 全套测试通过。
- 429/非429重试、请求取消和流读取错误的补充回归通过。
- `go test -race ./common/yak/antlr4yak ./common/ai/rag -run 'TestConcurrentNativeCallbacksKeepCurrentFrames|TestConcurrentRAGMigration' -count=1` 通过。
- 同组 6 个真实黑盒用例：主分支 3/6 → 最终修复版 5/6；WARN/ERROR 264/178 → 30/29；schema HTTP 400 60 → 0，VM 栈错误 15 → 0。两个 HTTP 用例由 180 秒超时变为约 19 秒、各 3 次工具调用通过。
- plan bench 实际生成模块、6 个 unittest 和报告，独立复跑全部通过；全新 YAKIT_HOME 的 `-c 'aim.InvokeReAct(...)'` 流式 smoke 通过。

## 验证边界

黑盒每版各一轮，受模型随机性及网络影响。剩余多位置文件编辑用例的产物及命令校验通过，但修改返工、重复验证和连接错误使其超出调用数与时间限制，仍按失败记录。计划会话在写出报告后的收尾阶段触发 max-prompts 采样截断。

cachebench 按模型名绑定首次出现的 tier；同一模型用于多档时 intelligent-only 统计会误归类。本 PR 记录该限制，未修改这套统计，零样本 PASS 不作为本次验收依据。完整 agent 实测使用 Chat Completions；Responses/Anthropic 仅验证基础接入。
