### PR TITLE
fix(aireact): 修复移除排队任务后 AI Chat 回合无法结束

### DIFF
--- a/common/ai/aid/aireact/queue.go
+++ b/common/ai/aid/aireact/queue.go
@@ -281,6 +281,12 @@ func (tq *TaskQueue) ClearRemoveFromQueueHooks() {
 	log.Debugf("Task queue [%s]: cleared all dequeueHooks", tq.queueName)
 }
 
+func cancelRemovedTask(task aicommon.AIStatefulTask, reason string) {
+	task.SetUserCancelled()
+	task.Cancel(reason)
+	task.SetStatus(aicommon.AITaskState_Skipped)
+}
+
 // Clear 清空队列中的所有任务
 func (tq *TaskQueue) Clear() {
 	tq.mutex.Lock()
@@ -292,9 +298,7 @@ func (tq *TaskQueue) Clear() {
 	// may re-enter the queue, and newly queued tasks must survive this clear.
 	for e := removed.Front(); e != nil; e = e.Next() {
 		task := e.Value.(aicommon.AIStatefulTask)
-		task.SetUserCancelled()
-		task.Cancel("user cleared task queue")
-		task.SetStatus(aicommon.AITaskState_Skipped)
+		cancelRemovedTask(task, "user cleared task queue")
 	}
 	log.Infof("Task queue [%s]: cleared %d tasks", tq.queueName, removed.Len())
 }
@@ -421,9 +425,7 @@ func (tq *TaskQueue) RemoveTask(taskId string) bool {
 	// As in GetFirst, notify only after ownership of the queue lock has ended.
 	// The built-in hook observes the new queue length, and no hook can deadlock
 	// by re-entering TaskQueue.
-	removedTask.SetUserCancelled()
-	removedTask.Cancel("user removed task from queue")
-	removedTask.SetStatus(aicommon.AITaskState_Skipped)
+	cancelRemovedTask(removedTask, "user removed task from queue")
 	_, _ = tq.executeDequeueHooks(removedTask, "manual_remove")
 	log.Infof("Task queue [%s]: removed task [%s] from queue", tq.queueName, taskId)
 	return true

--- a/common/ai/aid/aireact/queue.go
+++ b/common/ai/aid/aireact/queue.go
@@ -284,11 +284,19 @@ func (tq *TaskQueue) ClearRemoveFromQueueHooks() {
 // Clear 清空队列中的所有任务
 func (tq *TaskQueue) Clear() {
 	tq.mutex.Lock()
-	defer tq.mutex.Unlock()
+	removed := tq.queue
+	tq.queue = list.New()
+	tq.mutex.Unlock()
 
-	count := tq.queue.Len()
-	tq.queue.Init() // 重新初始化链表，清空所有元素
-	log.Infof("Task queue [%s]: cleared %d tasks", tq.queueName, count)
+	// Detach the whole queue before emitting lifecycle events. Event handlers
+	// may re-enter the queue, and newly queued tasks must survive this clear.
+	for e := removed.Front(); e != nil; e = e.Next() {
+		task := e.Value.(aicommon.AIStatefulTask)
+		task.SetUserCancelled()
+		task.Cancel("user cleared task queue")
+		task.SetStatus(aicommon.AITaskState_Skipped)
+	}
+	log.Infof("Task queue [%s]: cleared %d tasks", tq.queueName, removed.Len())
 }
 
 // IsEmpty 检查队列是否为空
@@ -413,6 +421,9 @@ func (tq *TaskQueue) RemoveTask(taskId string) bool {
 	// As in GetFirst, notify only after ownership of the queue lock has ended.
 	// The built-in hook observes the new queue length, and no hook can deadlock
 	// by re-entering TaskQueue.
+	removedTask.SetUserCancelled()
+	removedTask.Cancel("user removed task from queue")
+	removedTask.SetStatus(aicommon.AITaskState_Skipped)
 	_, _ = tq.executeDequeueHooks(removedTask, "manual_remove")
 	log.Infof("Task queue [%s]: removed task [%s] from queue", tq.queueName, taskId)
 	return true

--- a/common/ai/aid/aireact/queue_lifecycle_test.go
+++ b/common/ai/aid/aireact/queue_lifecycle_test.go
@@ -1,0 +1,153 @@
+package aireact
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/schema"
+)
+
+func TestTaskQueue_RemovalEmitsTerminalLifecycle(t *testing.T) {
+	for _, operation := range []string{"clear", "remove"} {
+		t.Run(operation, func(t *testing.T) {
+			queue := NewTaskQueue(operation)
+			var events []*schema.AiOutputEvent
+			emitter := aicommon.NewEmitter(operation, func(event *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+				events = append(events, event)
+				return event, nil
+			})
+			newTask := func(id string) *aicommon.AIStatefulTaskBase {
+				task := aicommon.NewStatefulTaskBase(id, "input", nil, emitter)
+				t.Cleanup(func() { task.Cancel() })
+				task.SetStatus(aicommon.AITaskState_Queueing)
+				require.NoError(t, queue.Append(task))
+				return task
+			}
+			running := newTask("running")
+			require.Same(t, running, queue.GetFirst())
+			running.SetStatus(aicommon.AITaskState_Processing)
+			first := newTask("first")
+			second := newTask("second")
+
+			removed := []*aicommon.AIStatefulTaskBase{first}
+			if operation == "clear" {
+				queue.Clear()
+				queue.Clear()
+				removed = append(removed, second)
+			} else {
+				require.True(t, queue.RemoveTask(first.GetId()))
+				require.False(t, queue.RemoveTask(first.GetId()))
+				require.Same(t, second, queue.GetFirst())
+				require.Equal(t, aicommon.AITaskState_Queueing, second.GetStatus())
+				require.NoError(t, second.GetContext().Err())
+			}
+
+			require.True(t, queue.IsEmpty())
+			require.False(t, queue.RemoveTask(running.GetId()))
+			require.Equal(t, aicommon.AITaskState_Processing, running.GetStatus())
+			require.NoError(t, running.GetContext().Err())
+			for _, task := range removed {
+				require.Equal(t, aicommon.AITaskState_Skipped, task.GetStatus())
+				require.True(t, task.IsUserCancelled())
+				require.ErrorIs(t, task.GetContext().Err(), context.Canceled)
+				var terminalEvents []*schema.AiOutputEvent
+				for _, event := range events {
+					if event.TaskId == task.GetId() && event.NodeId == "react_task_status_changed" &&
+						parsePayload(t, event.Content)["react_task_now_status"] == string(aicommon.AITaskState_Skipped) {
+						terminalEvents = append(terminalEvents, event)
+					}
+				}
+				require.Len(t, terminalEvents, 1, "removed task must emit exactly one terminal lifecycle event")
+				require.Equal(t, task.GetUUID(), terminalEvents[0].TaskUUID)
+				require.Equal(t, string(aicommon.AITaskState_Queueing), parsePayload(t, terminalEvents[0].Content)["react_task_old_status"])
+			}
+		})
+	}
+}
+
+func TestTaskQueue_RemovalDetachesBeforeCallbacks(t *testing.T) {
+	for _, operation := range []string{"clear", "remove"} {
+		t.Run(operation, func(t *testing.T) {
+			queue := NewTaskQueue(operation)
+			callbackEntered := make(chan int, 1)
+			releaseCallback := make(chan struct{})
+			defer close(releaseCallback)
+			emitter := aicommon.NewEmitter(operation, func(event *schema.AiOutputEvent) (*schema.AiOutputEvent, error) {
+				if event.TaskId == "first" && event.NodeId == "react_task_status_changed" {
+					// A lifecycle observer can re-enter the queue and may block while
+					// another goroutine enqueues or starts work.
+					callbackEntered <- queue.Len()
+					<-releaseCallback
+				}
+				return event, nil
+			})
+			first := aicommon.NewStatefulTaskBase("first", "input", nil, emitter)
+			second := aicommon.NewStatefulTaskBase("second", "input", nil, nil)
+			incoming := aicommon.NewStatefulTaskBase("incoming", "input", nil, nil)
+			later := aicommon.NewStatefulTaskBase("later", "input", nil, nil)
+			for _, task := range []*aicommon.AIStatefulTaskBase{first, second, incoming, later} {
+				t.Cleanup(func() { task.Cancel() })
+			}
+			require.NoError(t, queue.Append(first))
+			require.NoError(t, queue.Append(second))
+			removedByHook := make(chan aicommon.AIStatefulTask, 1)
+			queue.AddDequeueHook(func(task aicommon.AIStatefulTask, reason string) {
+				if reason == "manual_remove" {
+					// The existing removal hook must also run without the queue lock.
+					removedByHook <- queue.GetFirst()
+				}
+			})
+			operationDone := make(chan struct{})
+			go func() {
+				defer close(operationDone)
+				if operation == "clear" {
+					queue.Clear()
+				} else {
+					queue.RemoveTask(first.GetId())
+				}
+			}()
+
+			select {
+			case count := <-callbackEntered:
+				if operation == "clear" {
+					require.Zero(t, count, "clear must detach every queued task before emitting the first terminal event")
+				} else {
+					require.Equal(t, 1, count)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("terminal lifecycle callback was missing or deadlocked on queue re-entry")
+			}
+			// While the terminal callback is blocked, concurrent consumers must
+			// see only retained/new work and cannot remove the detached task again.
+			require.False(t, queue.RemoveTask(first.GetId()))
+			require.NoError(t, queue.PrependToFirst(incoming))
+			require.Same(t, incoming, queue.GetFirst())
+			require.NoError(t, incoming.GetContext().Err())
+			require.NoError(t, queue.Append(later))
+			releaseCallback <- struct{}{}
+			select {
+			case <-operationDone:
+			case <-time.After(time.Second):
+				t.Fatal("removal hook deadlocked on queue re-entry")
+			}
+			require.Equal(t, aicommon.AITaskState_Skipped, first.GetStatus())
+			if operation == "clear" {
+				require.Equal(t, aicommon.AITaskState_Skipped, second.GetStatus())
+			} else {
+				select {
+				case task := <-removedByHook:
+					require.Same(t, second, task)
+				default:
+					t.Fatal("removal did not invoke the existing dequeue hook")
+				}
+				require.NoError(t, second.GetContext().Err())
+			}
+			require.Same(t, later, queue.GetFirst())
+			require.NoError(t, later.GetContext().Err())
+			require.True(t, queue.IsEmpty())
+		})
+	}
+}

--- a/common/aiengine/tests/queue_cancellation_test.go
+++ b/common/aiengine/tests/queue_cancellation_test.go
@@ -1,0 +1,129 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yaklang/yaklang/common/ai/aid/aicommon"
+	"github.com/yaklang/yaklang/common/aiengine"
+	"github.com/yaklang/yaklang/common/schema"
+	"github.com/yaklang/yaklang/common/yakgrpc/ypb"
+)
+
+// Exercise the production input/event path with a deterministic model callback:
+// queue a follow-up, remove it, stop the running root, then send another message.
+func TestResilienceStopAfterRemovingQueuedTasksFinishesEngine(t *testing.T) {
+	for _, operation := range []string{"clear", "remove"} {
+		t.Run(operation, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			started := make(chan struct{})
+			var once sync.Once
+			var continueConversation atomic.Bool
+			answer := mockedAnswerThenFinish("continued")
+			events := make(chan *schema.AiOutputEvent, 256)
+			engine := newTestAIEngine(t, func(config aicommon.AICallerConfigIf, request *aicommon.AIRequest) (*aicommon.AIResponse, error) {
+				if continueConversation.Load() {
+					return answer(config, request)
+				}
+				once.Do(func() { close(started) })
+				requestContext := request.GetContext()
+				if requestContext == nil {
+					requestContext = config.GetContext()
+				}
+				<-requestContext.Done()
+				return nil, requestContext.Err()
+			}, aiengine.WithContext(ctx), aiengine.WithStateless(true),
+				aiengine.WithDisableToolUse(true), aiengine.WithDisableAIForge(true),
+				aiengine.WithYOLOMode(), aiengine.WithWorkdir(t.TempDir()),
+				aiengine.WithOnEvent(func(_ aicommon.AIEngineOperator, event *schema.AiOutputEvent) {
+					if event.Type != schema.EVENT_TYPE_STRUCTURED {
+						return
+					}
+					select {
+					case events <- event:
+					case <-ctx.Done():
+					}
+				}))
+			defer engine.Close()
+			waitEvent := func(match func(*schema.AiOutputEvent) bool) *schema.AiOutputEvent {
+				t.Helper()
+				for {
+					select {
+					case event := <-events:
+						if match(event) {
+							return event
+						}
+					case <-ctx.Done():
+						t.Fatal("timed out waiting for runtime event")
+						return nil
+					}
+				}
+			}
+			rootDone := make(chan error, 1)
+			go func() { rootDone <- engine.SendMsg("running root") }()
+			select {
+			case <-started:
+			case <-ctx.Done():
+				t.Fatal("root did not start")
+			}
+			if err := engine.SendInputEvent(&ypb.AIInputEvent{IsFreeInput: true, FreeInput: "queued follow-up"}); err != nil {
+				t.Fatal(err)
+			}
+			var queuedTaskID string
+			waitEvent(func(event *schema.AiOutputEvent) bool {
+				var payload map[string]string
+				_ = json.Unmarshal(event.Content, &payload)
+				if event.NodeId == "react_task_created" && payload["react_user_input"] == "queued follow-up" {
+					queuedTaskID = payload["react_task_id"]
+				}
+				return queuedTaskID != "" && event.NodeId == "react_task_enqueue" && payload["react_task_id"] == queuedTaskID
+			})
+			control := &ypb.AIInputEvent{IsSyncMessage: true, SyncID: "remove-queued", SyncType: "react_clear_task"}
+			if operation == "remove" {
+				control.SyncType = "react_remove_task"
+				payload, _ := json.Marshal(map[string]string{"task_id": queuedTaskID})
+				control.SyncJsonInput = string(payload)
+			}
+			if err := engine.SendInputEvent(control); err != nil {
+				t.Fatal(err)
+			}
+			waitEvent(func(event *schema.AiOutputEvent) bool { return event.IsSync && event.SyncID == control.SyncID })
+			if err := engine.SendInputEvent(&ypb.AIInputEvent{IsSyncMessage: true, SyncID: "stop-root", SyncType: "react_cancel_current_task"}); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case err := <-rootDone:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-ctx.Done():
+				t.Fatal("stop did not release the root message")
+			}
+			allDone := make(chan error, 1)
+			go func() { allDone <- engine.WaitTaskFinish() }()
+			select {
+			case err := <-allDone:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("stop left removed queue tasks active: %d", engine.GetActiveTaskCount())
+			}
+			if engine.Context().Err() != nil {
+				t.Fatal("stop closed the conversation")
+			}
+			continueConversation.Store(true)
+			if err := engine.SendMsg("continue conversation"); err != nil {
+				t.Fatalf("follow-up after stop: %v", err)
+			}
+			if err := engine.WaitTaskFinish(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
执行中添加排队消息，清空或移除该消息后再点击停止，当前任务虽然已取消，AI Chat 回合仍可能持续等待。原因是移出队列的任务未进入终态，`AIEngine.WaitTaskFinish` 一直将其视为活跃任务。

B 的终态应在用户清空或移除 B 的当下产生。停止按钮仍只取消正在执行的 A；本次不是扩大停止范围，而是避免已从执行队列移出的 B 继续留在引擎活跃任务表中。

### 改动摘要

- 清空或手动移除排队任务时，先在锁内摘除任务，再在锁外通过 `cancelRemovedTask(task, reason)` 统一标记用户取消、取消上下文并设置 `Skipped`，让现有生命周期事件释放引擎等待。
- 保留正常出队执行、清空确认和手动移除通知的语义；状态回调可以重入队列，并发添加的新任务不会被此次清空误删。
- 覆盖“排队 → 清空/移除 → 停止当前任务 → 继续对话”的回归场景。

### 改动文件

- `common/ai/aid/aireact/queue.go`：补齐被移除任务的取消和终态。
- `common/ai/aid/aireact/queue_lifecycle_test.go`：覆盖终态唯一性、上下文取消、回调重入及并发添加任务。
- `common/aiengine/tests/queue_cancellation_test.go`：通过实际引擎输入和等待路径验证停止与后续对话。

### 验证方式

- T1：原实现运行新增引擎回归时，清空和移除两种场景均因残留 1 个活跃任务而失败；修复后均通过。
- `go test ./common/aiengine/tests -run TestResilienceStopAfterRemovingQueuedTasksFinishesEngine -count=1 -timeout=120s`：通过，并在 rebase 最新 `main` 后复跑。
- `go test ./common/ai/aid/aireact -run '^(TestNewTaskQueue|TestTaskQueue_|TestEmitDequeueReActTask|TestEmitEnqueueReActTask|TestGetQueueInfo)' -count=1 -timeout=90s`：通过。
- `go test -race ./common/ai/aid/aireact -run '^TestTaskQueue_(Removal|DequeueHooksRunOutsideQueueLock|EnqueueHooksRunOutsideQueueLock)' -count=1 -timeout=90s`：通过；提取公共小函数后再次通过（2.874s）。
- AIEngine 输出事件与 `WaitTaskFinish` 聚焦单测、`gofmt`、`git diff --check`：通过。
- 更宽的竞态测试选择触发现有 `TestTaskQueue_ConcurrentOperations` 测试自身的通道关闭竞态；该测试未修改，未将完整竞态套件计为通过。
- T2 尚未完成：隔离环境创建会话返回 HTTP 409；独立节点读回显示 AI runtime 未启用。没有进入真实模型的停止流程，测试栈已停止，原有环境未更新。

### 客户端影响

修复位于共享 `aireact.TaskQueue`，并非 Legion 专用分支。使用该版本引擎的 Memfit 客户端清空或移除排队任务时，会额外收到这些任务原有协议格式的 `react_task_status_changed(... skipped)`，不再留下没有终态的任务。

当前检查到的客户端 AI 实现通过 `StartAIReAct` 直接使用 ReAct，并不经过 Legion 的 `SendMsg → WaitTaskFinish → Turn` 等待链，因此不能把本次 B/S 回合挂起现象直接等同于客户端同样故障。已检查的客户端状态处理器支持 `skipped`，且按任务 ID 匹配当前任务。正常出队、仅停止当前任务、保留其他待执行任务的语义没有变化。

客户端人工使用未复现同样的停止挂起现象，与上述调用链差异一致。该结果不能替代包含本补丁的新引擎客户端兼容验证；共享事件消费者已做源码检查，新引擎实机验证尚未完成。本 PR 保持 Draft，未包含部署或发布操作。
