### PR TITLE
fix(syntaxflow): 优化源码扫描区域过滤并限制 Apex 规则作用域

### DIFF
--- a/common/consts/syntaxflow-hash.go
+++ b/common/consts/syntaxflow-hash.go
@@ -5,4 +5,4 @@ package consts
 // ExistedSyntaxFlowEmbedFSHash contains the SHA256 hash of the embedded SyntaxFlow filesystem.
 // This hash is used to verify the integrity of SyntaxFlow rules and templates embedded in the binary.
 // The hash is automatically calculated from the SyntaxFlow rule files during compilation.
-const ExistedSyntaxFlowEmbedFSHash string = "666795d5305039d357f2e83f7ab7ea5fa19610fe0c567e19cc2b00535ea6a022"
+const ExistedSyntaxFlowEmbedFSHash string = "33e6f4d1e62f3b2645abe1a5bc75dde5e5383022b976bb3e397f9581b8aec52e"

--- a/common/syntaxflow/sfbuildin/buildin/source/insecure-api/source-insecure-api-apex-insecure-http-request.sf
+++ b/common/syntaxflow/sfbuildin/buildin/source/insecure-api/source-insecure-api-apex-insecure-http-request.sf
@@ -38,9 +38,9 @@ req.setEndpoint('https://example.com/api');
 NEG
 )
 
-${*}.pattern_regex(/http:\/\//) as $t
-${*}.pattern_regex(/\/\/.*/) as $comment
-${*}.pattern_regex(/\*.*/) as $glob
+${*.cls}.pattern_regex(/http:\/\//) as $t
+${*.cls}.pattern_regex(/\/\/.*/) as $comment
+${*.cls}.pattern_regex(/\*.*/) as $glob
 $t not_inside $comment as $a
 $a not_inside $glob as $hit
 alert $hit for {

--- a/common/syntaxflow/sfdb/rule_versions.json
+++ b/common/syntaxflow/sfdb/rule_versions.json
@@ -3974,8 +3974,8 @@
   {
     "rule_id": "source-insecure-api-apex-insecure-http-request",
     "rule_name": "检测到 Apex 明文 HTTP 请求",
-    "hash": "e11ea320531f3ab42224d48f52ad3651235a0d41e9e6ec5fc9260607f7fb89a1",
-    "version": "20260908.0001"
+    "hash": "0e1e770756927f238e93ee51199b9829ecb1bf6a59ece75040cedadaf1f4bb85",
+    "version": "20260911.0001"
   },
   {
     "rule_id": "source-insecure-api-apex-specify-sharing-level",

--- a/common/syntaxflow/sfpattern/hit_region.go
+++ b/common/syntaxflow/sfpattern/hit_region.go
@@ -20,6 +20,9 @@ package sfpattern
 // as the FileFilter matcher. init() below performs the registration.
 
 import (
+	"context"
+	"sort"
+
 	"github.com/yaklang/yaklang/common/syntaxflow/sfvm"
 	"github.com/yaklang/yaklang/common/utils"
 )
@@ -31,20 +34,20 @@ func init() {
 // regionFilterImpl adapts the package-level functions to sfvm.RegionFilterFunc.
 type regionFilterImpl struct{}
 
-func (regionFilterImpl) FilterContained(target, ctx sfvm.Values) sfvm.Values {
-	return FilterContained(target, ctx)
+func (regionFilterImpl) FilterContained(target, ctx sfvm.Values, cfg *sfvm.Config) sfvm.Values {
+	return filterContained(target, ctx, newFilterOptions(cfg))
 }
 
-func (regionFilterImpl) FilterNotContained(target, ctx sfvm.Values) sfvm.Values {
-	return FilterNotContained(target, ctx)
+func (regionFilterImpl) FilterNotContained(target, ctx sfvm.Values, cfg *sfvm.Config) sfvm.Values {
+	return filterNotContained(target, ctx, newFilterOptions(cfg))
 }
 
-func (regionFilterImpl) FilterOverlap(target sfvm.Values, others ...sfvm.Values) sfvm.Values {
-	return FilterOverlap(target, others...)
+func (regionFilterImpl) FilterOverlap(target sfvm.Values, cfg *sfvm.Config, others ...sfvm.Values) sfvm.Values {
+	return filterOverlap(target, newFilterOptions(cfg), others...)
 }
 
-func (regionFilterImpl) FilterNotOverlap(target sfvm.Values, others ...sfvm.Values) sfvm.Values {
-	return FilterNotOverlap(target, others...)
+func (regionFilterImpl) FilterNotOverlap(target sfvm.Values, cfg *sfvm.Config, others ...sfvm.Values) sfvm.Values {
+	return filterNotOverlap(target, newFilterOptions(cfg), others...)
 }
 
 func (regionFilterImpl) AllSimpleHits(vs sfvm.Values) bool {
@@ -87,35 +90,161 @@ func collectRegions(vs sfvm.Values) []hitRegion {
 }
 
 // regionContains reports whether r contains t (same file, inclusive bounds).
+// Kept for direct use / tests; the hot path uses regionIndex.contains.
 func regionContains(r, t hitRegion) bool {
 	return r.path == t.path && r.start <= t.start && t.end <= r.end
 }
 
 // regionOverlaps reports whether r and t overlap (same file, strict overlap).
+// Kept for direct use / tests; the hot path uses regionIndex.overlaps.
 func regionOverlaps(r, t hitRegion) bool {
 	return r.path == t.path && t.start < r.end && r.start < t.end
+}
+
+// regionIndex provides per-file sorted hit regions for O(log n) contains/overlap
+// queries. This replaces the previous O(n*m) linear scans in FilterContained,
+// FilterNotContained, FilterOverlap and FilterNotOverlap.
+type regionIndex struct {
+	// byFile maps a file path to its sorted non-empty hit regions.
+	byFile map[string][]hitRegion
+}
+
+// newRegionIndex builds an index from a slice of hit regions.
+func newRegionIndex(regions []hitRegion) regionIndex {
+	idx := regionIndex{byFile: make(map[string][]hitRegion, len(regions))}
+	for _, r := range regions {
+		idx.byFile[r.path] = append(idx.byFile[r.path], r)
+	}
+	for path, rs := range idx.byFile {
+		if len(rs) <= 1 {
+			continue
+		}
+		sort.Slice(rs, func(i, j int) bool {
+			if rs[i].start == rs[j].start {
+				return rs[i].end < rs[j].end
+			}
+			return rs[i].start < rs[j].start
+		})
+		// Deduplicate exact duplicates to keep searches tight.
+		compact := rs[:0]
+		for _, r := range rs {
+			if len(compact) == 0 || r != compact[len(compact)-1] {
+				compact = append(compact, r)
+			}
+		}
+		idx.byFile[path] = compact
+	}
+	return idx
+}
+
+// contains reports whether any region in the same file fully contains t.
+func (idx regionIndex) contains(t hitRegion) bool {
+	rs, ok := idx.byFile[t.path]
+	if !ok || len(rs) == 0 {
+		return false
+	}
+	// Find the rightmost region with start <= t.start. Only that region (and
+	// possibly the previous one with same start) can contain t.
+	i := sort.Search(len(rs), func(i int) bool { return rs[i].start > t.start })
+	if i > 0 {
+		cand := rs[i-1]
+		if cand.start <= t.start && t.end <= cand.end {
+			return true
+		}
+	}
+	return false
+}
+
+// overlaps reports whether any region in the same file overlaps t.
+func (idx regionIndex) overlaps(t hitRegion) bool {
+	rs, ok := idx.byFile[t.path]
+	if !ok || len(rs) == 0 {
+		return false
+	}
+	// Find the first region whose end > t.start. That is the only candidate that
+	// can overlap t (all earlier regions end before t starts).
+	i := sort.Search(len(rs), func(i int) bool { return rs[i].end > t.start })
+	if i < len(rs) {
+		cand := rs[i]
+		if cand.start < t.end && t.start < cand.end {
+			return true
+		}
+	}
+	return false
+}
+
+// bailContext bundles cancellation/budget callbacks so long-running filters can
+// bail out cooperatively. nil-safe: all methods are no-ops when the receiver is
+// nil.
+type bailContext struct {
+	ctx        context.Context
+	workBudget *sfvm.RuleWorkBudget
+}
+
+// check returns a non-nil error when the rule should stop. It also records one
+// work unit against the budget if workBudget is present.
+func (b *bailContext) check() error {
+	if b == nil {
+		return nil
+	}
+	if b.ctx != nil {
+		select {
+		case <-b.ctx.Done():
+			return b.ctx.Err()
+		default:
+		}
+	}
+	if b.workBudget != nil && b.workBudget.EnterWork() {
+		return utils.Errorf("work budget exceeded")
+	}
+	return nil
+}
+
+// filterOptions carries optional cancellation/budget through the filter API.
+type filterOptions struct {
+	bail *bailContext
+}
+
+// newFilterOptions builds options from an sfvm.Config. If cfg is nil, returns
+// an empty options struct (no cancellation, no budget accounting).
+func newFilterOptions(cfg *sfvm.Config) filterOptions {
+	if cfg == nil {
+		return filterOptions{}
+	}
+	return filterOptions{bail: &bailContext{
+		ctx:        cfg.GetContext(),
+		workBudget: cfg.GetWorkBudget(),
+	}}
 }
 
 // FilterContained keeps target hits that are contained in at least one
 // context region (Semgrep pattern-inside). Non-hit values pass through.
 // With no context regions the result is empty (nothing is inside nothing).
 func FilterContained(target, ctx sfvm.Values) sfvm.Values {
-	regions := collectRegions(ctx)
-	if len(regions) == 0 {
+	return filterContained(target, ctx, filterOptions{})
+}
+
+func filterContained(target, ctx sfvm.Values, opts filterOptions) sfvm.Values {
+	idx := newRegionIndex(collectRegions(ctx))
+	if len(idx.byFile) == 0 {
 		return sfvm.NewEmptyValues()
 	}
 	var out []sfvm.ValueOperator
+	var n int
 	_ = target.Recursive(func(v sfvm.ValueOperator) error {
 		t, ok := asHitRegion(v)
 		if !ok {
 			out = append(out, v)
 			return nil
 		}
-		for _, r := range regions {
-			if regionContains(r, t) {
-				out = append(out, v)
-				return nil
+		n++
+		if n%1024 == 0 {
+			if err := opts.bail.check(); err != nil {
+				return err
 			}
+		}
+		if idx.contains(t) {
+			out = append(out, v)
 		}
 		return nil
 	})
@@ -126,23 +255,31 @@ func FilterContained(target, ctx sfvm.Values) sfvm.Values {
 // (Semgrep pattern-not-inside). Non-hit values pass through. With no
 // context regions everything is kept.
 func FilterNotContained(target, ctx sfvm.Values) sfvm.Values {
-	regions := collectRegions(ctx)
-	if len(regions) == 0 {
+	return filterNotContained(target, ctx, filterOptions{})
+}
+
+func filterNotContained(target, ctx sfvm.Values, opts filterOptions) sfvm.Values {
+	idx := newRegionIndex(collectRegions(ctx))
+	if len(idx.byFile) == 0 {
 		return target
 	}
 	var out []sfvm.ValueOperator
+	var n int
 	_ = target.Recursive(func(v sfvm.ValueOperator) error {
 		t, ok := asHitRegion(v)
 		if !ok {
 			out = append(out, v)
 			return nil
 		}
-		for _, r := range regions {
-			if regionContains(r, t) {
-				return nil // dropped
+		n++
+		if n%1024 == 0 {
+			if err := opts.bail.check(); err != nil {
+				return err
 			}
 		}
-		out = append(out, v)
+		if !idx.contains(t) {
+			out = append(out, v)
+		}
 		return nil
 	})
 	return sfvm.NewValues(out)
@@ -153,30 +290,39 @@ func FilterNotContained(target, ctx sfvm.Values) sfvm.Values {
 // non-empty). Non-hit values pass through. An empty others list keeps
 // everything; a set with no hit regions contributes no constraint.
 func FilterOverlap(target sfvm.Values, others ...sfvm.Values) sfvm.Values {
+	return filterOverlap(target, filterOptions{}, others...)
+}
+
+func filterOverlap(target sfvm.Values, opts filterOptions, others ...sfvm.Values) sfvm.Values {
 	if len(others) == 0 {
 		return target
 	}
-	regionSets := make([][]hitRegion, 0, len(others))
+	indexes := make([]regionIndex, 0, len(others))
 	for _, other := range others {
-		regionSets = append(regionSets, collectRegions(other))
+		idx := newRegionIndex(collectRegions(other))
+		if len(idx.byFile) == 0 {
+			// A required AND operand has no hits → nothing can overlap it.
+			return sfvm.NewEmptyValues()
+		}
+		indexes = append(indexes, idx)
 	}
 	var out []sfvm.ValueOperator
+	var n int
 	_ = target.Recursive(func(v sfvm.ValueOperator) error {
 		t, ok := asHitRegion(v)
 		if !ok {
 			out = append(out, v)
 			return nil
 		}
-		for _, regions := range regionSets {
-			matched := false
-			for _, r := range regions {
-				if regionOverlaps(r, t) {
-					matched = true
-					break
-				}
+		n++
+		if n%1024 == 0 {
+			if err := opts.bail.check(); err != nil {
+				return err
 			}
-			if !matched {
-				return nil // fails this AND constraint
+		}
+		for _, idx := range indexes {
+			if !idx.overlaps(t) {
+				return nil
 			}
 		}
 		out = append(out, v)
@@ -189,29 +335,38 @@ func FilterOverlap(target sfvm.Values, others ...sfvm.Values) sfvm.Values {
 // (Semgrep pattern-not-regex: the match must not overlap a negative match).
 // Non-hit values pass through. An empty others list keeps everything.
 func FilterNotOverlap(target sfvm.Values, others ...sfvm.Values) sfvm.Values {
+	return filterNotOverlap(target, filterOptions{}, others...)
+}
+
+func filterNotOverlap(target sfvm.Values, opts filterOptions, others ...sfvm.Values) sfvm.Values {
 	if len(others) == 0 {
 		return target
 	}
-	var regions []hitRegion
+	allRegions := make([]hitRegion, 0)
 	for _, other := range others {
-		regions = append(regions, collectRegions(other)...)
+		allRegions = append(allRegions, collectRegions(other)...)
 	}
-	if len(regions) == 0 {
+	idx := newRegionIndex(allRegions)
+	if len(idx.byFile) == 0 {
 		return target
 	}
 	var out []sfvm.ValueOperator
+	var n int
 	_ = target.Recursive(func(v sfvm.ValueOperator) error {
 		t, ok := asHitRegion(v)
 		if !ok {
 			out = append(out, v)
 			return nil
 		}
-		for _, r := range regions {
-			if regionOverlaps(r, t) {
-				return nil // dropped
+		n++
+		if n%1024 == 0 {
+			if err := opts.bail.check(); err != nil {
+				return err
 			}
 		}
-		out = append(out, v)
+		if !idx.overlaps(t) {
+			out = append(out, v)
+		}
 		return nil
 	})
 	return sfvm.NewValues(out)

--- a/common/syntaxflow/sfpattern/match.go
+++ b/common/syntaxflow/sfpattern/match.go
@@ -56,12 +56,20 @@ func MatchRegexpWithNegatives(files map[string]string, pathPattern string, posit
 }
 
 func matchRegexpWithNegatives(root *sfvm.PatternRoot, files map[string]string, pathPattern string, positive string, negatives []string) (sfvm.Values, error) {
-	hits, err := MatchRegexpHits(files, pathPattern, []string{positive})
-	if err != nil {
-		return nil, err
+	// Reuse the regular regexp cache for the positive set; then apply the
+	// negative filter ourselves. This avoids recomputing the (often large)
+	// positive hit list every time a pattern_regex_not statement runs.
+	positiveKey := sourceHitKey(pathPattern, []string{positive})
+	hits, cached := root.SourceHits(positiveKey)
+	if !cached {
+		var err error
+		hits, err = MatchRegexpHits(files, pathPattern, []string{positive})
+		if err != nil {
+			return nil, err
+		}
+		root.SetSourceHits(positiveKey, hits)
 	}
 	if len(negatives) == 0 {
-		root.SetSourceHits(sourceHitKey(pathPattern, []string{positive}), hits)
 		return sourceHitsToValues(root, hits)
 	}
 

--- a/common/syntaxflow/sfvm/frame_exec.go
+++ b/common/syntaxflow/sfvm/frame_exec.go
@@ -1134,7 +1134,7 @@ func (s *SFFrame) execSyntaxFlowOp(i *SFI) (bool, error) {
 		// removal (Semgrep pattern-not-regex); SSA values keep ID-based removal.
 		var newVal Values
 		if RegionAllSimpleHits(value) && RegionAllSimpleHits(vs) {
-			newVal = RegionNotOverlap(value, vs)
+			newVal = RegionNotOverlap(value, s.config, vs)
 		} else {
 			newVal = RemoveValues(value, vs)
 		}
@@ -1174,7 +1174,7 @@ func (s *SFFrame) execSyntaxFlowOp(i *SFI) (bool, error) {
 		// intersection (Semgrep AND of multiple pattern-regex); SSA values
 		// keep ID-based intersection.
 		if RegionAllSimpleHits(value) && RegionAllSimpleHits(vs) {
-			s.pushStack(RegionOverlap(value, vs))
+			s.pushStack(RegionOverlap(value, s.config, vs))
 			return true, nil
 		}
 
@@ -1215,7 +1215,7 @@ func (s *SFFrame) execSyntaxFlowOp(i *SFI) (bool, error) {
 		if value == nil {
 			return true, utils.Wrap(CriticalError, "BUG: get top defs failed, empty stack")
 		}
-		s.pushStack(RegionContained(value, vs))
+		s.pushStack(RegionContained(value, vs, s.config))
 		s.debugSubLog("<< push")
 		return true, nil
 	case OpNotInsideRef:
@@ -1235,7 +1235,7 @@ func (s *SFFrame) execSyntaxFlowOp(i *SFI) (bool, error) {
 		if value == nil {
 			return true, utils.Wrap(CriticalError, "BUG: get top defs failed, empty stack")
 		}
-		s.pushStack(RegionNotContained(value, vs))
+		s.pushStack(RegionNotContained(value, vs, s.config))
 		s.debugSubLog("<< push")
 		return true, nil
 	case OpNativeCall:

--- a/common/syntaxflow/sfvm/region_filter.go
+++ b/common/syntaxflow/sfvm/region_filter.go
@@ -5,16 +5,17 @@ package sfvm
 // The containment/overlap implementation lives in sfpattern (it operates on
 // SimpleValue hits and belongs with the pattern-matching code), but sfvm
 // cannot import sfpattern (sfpattern imports sfvm). The VM side therefore
-// delegates through a registered RegionFilterFunc — the same injection
-// pattern as the FileFilter matcher. sfpattern registers its implementation
-// in init().
+// delegates through a registered RegionFilterFunc — the same injection pattern
+// as the FileFilter matcher. sfpattern registers its implementation in init().
 
-// RegionFilterFunc implements the region algebra over pattern hits.
+// RegionFilterFunc implements the region algebra over pattern hits. The
+// implementation receives the per-rule sfvm.Config so it can honor context
+// cancellation and the per-rule work budget.
 type RegionFilterFunc interface {
-	FilterContained(target, ctx Values) Values
-	FilterNotContained(target, ctx Values) Values
-	FilterOverlap(target Values, others ...Values) Values
-	FilterNotOverlap(target Values, others ...Values) Values
+	FilterContained(target, ctx Values, cfg *Config) Values
+	FilterNotContained(target, ctx Values, cfg *Config) Values
+	FilterOverlap(target Values, cfg *Config, others ...Values) Values
+	FilterNotOverlap(target Values, cfg *Config, others ...Values) Values
 	AllSimpleHits(vs Values) bool
 }
 
@@ -28,35 +29,43 @@ func RegisterRegionFilter(fn RegionFilterFunc) {
 
 // RegionContained delegates to the registered implementation. Defensive
 // fallbacks keep the VM usable when sfpattern is not linked in.
-func RegionContained(target, ctx Values) Values {
+func RegionContained(target, ctx Values, cfg ...*Config) Values {
 	if regionFilter == nil {
 		return NewEmptyValues()
 	}
-	return regionFilter.FilterContained(target, ctx)
+	var c *Config
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+	return regionFilter.FilterContained(target, ctx, c)
 }
 
 // RegionNotContained delegates to the registered implementation.
-func RegionNotContained(target, ctx Values) Values {
+func RegionNotContained(target, ctx Values, cfg ...*Config) Values {
 	if regionFilter == nil {
 		return target
 	}
-	return regionFilter.FilterNotContained(target, ctx)
+	var c *Config
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+	return regionFilter.FilterNotContained(target, ctx, c)
 }
 
 // RegionOverlap delegates to the registered implementation.
-func RegionOverlap(target Values, others ...Values) Values {
+func RegionOverlap(target Values, cfg *Config, others ...Values) Values {
 	if regionFilter == nil {
 		return target
 	}
-	return regionFilter.FilterOverlap(target, others...)
+	return regionFilter.FilterOverlap(target, cfg, others...)
 }
 
 // RegionNotOverlap delegates to the registered implementation.
-func RegionNotOverlap(target Values, others ...Values) Values {
+func RegionNotOverlap(target Values, cfg *Config, others ...Values) Values {
 	if regionFilter == nil {
 		return target
 	}
-	return regionFilter.FilterNotOverlap(target, others...)
+	return regionFilter.FilterNotOverlap(target, cfg, others...)
 }
 
 // RegionAllSimpleHits delegates to the registered implementation.

--- a/common/syntaxflow/sfvm/simple_value.go
+++ b/common/syntaxflow/sfvm/simple_value.go
@@ -333,16 +333,15 @@ func (v *SimpleValue) SetAnchorBitVector(*utils.BitVector)  {}
 // PatternRoot is the feed root for source-mode scans: holds files and responds to
 // FileFilter by delegating to a registered regexp matcher (set by sfpattern).
 type PatternRoot struct {
-	files           map[string]string
-	matcher         FileFilterFunc
-	programName     string
-	sourceMu        sync.RWMutex
-	sourceHitOffset int
-	sourceHitLimit  int
-	sourceHitTotal  int
-	sourceHitKey    string
-	sourceHitCache  []SourceHit
-	sourceEditors   map[string]*memedit.MemEditor
+	files            map[string]string
+	matcher          FileFilterFunc
+	programName      string
+	sourceMu         sync.RWMutex
+	sourceHitOffset  int
+	sourceHitLimit   int
+	sourceHitTotal   int
+	sourceHitCaches  map[string][]SourceHit
+	sourceHitEditors map[string]*memedit.MemEditor
 }
 
 // SourceHit is a raw source match before it is wrapped as a ValueOperator.
@@ -403,18 +402,25 @@ func (r *PatternRoot) SourceHitBatch() (offset int, limit int, total int) {
 }
 
 // SetSourceHits caches raw hits for repeated bounded executions of one filter.
+// Multiple independent filters within the same rule are cached under distinct
+// keys, so the same positive regex can be reused across statements and across
+// pattern_regex_not calls.
 func (r *PatternRoot) SetSourceHits(key string, hits []SourceHit) {
 	if r == nil {
 		return
 	}
 	r.sourceMu.Lock()
 	defer r.sourceMu.Unlock()
-	if key != r.sourceHitKey {
-		r.sourceHitKey = key
-		r.sourceHitCache = append([]SourceHit(nil), hits...)
-		r.sourceEditors = make(map[string]*memedit.MemEditor)
+	if r.sourceHitCaches == nil {
+		r.sourceHitCaches = make(map[string][]SourceHit)
+		r.sourceHitEditors = make(map[string]*memedit.MemEditor)
 	}
-	r.sourceHitTotal = len(r.sourceHitCache)
+	if _, ok := r.sourceHitCaches[key]; !ok {
+		r.sourceHitCaches[key] = append([]SourceHit(nil), hits...)
+	}
+	// sourceHitTotal tracks the size of the most recently accessed cache entry,
+	// which is what the batch window slices in sourceHitsToValues.
+	r.sourceHitTotal = len(r.sourceHitCaches[key])
 }
 
 // SourceHits returns cached raw hits when the filter key matches.
@@ -424,10 +430,12 @@ func (r *PatternRoot) SourceHits(key string) ([]SourceHit, bool) {
 	}
 	r.sourceMu.RLock()
 	defer r.sourceMu.RUnlock()
-	if key != r.sourceHitKey {
+	hits, ok := r.sourceHitCaches[key]
+	if !ok {
 		return nil, false
 	}
-	return r.sourceHitCache, true
+	r.sourceHitTotal = len(hits)
+	return hits, true
 }
 
 // SourceHitEditor returns one editor per file across all batches. Reusing the
@@ -438,10 +446,10 @@ func (r *PatternRoot) SourceHitEditor(path string) *memedit.MemEditor {
 	}
 	r.sourceMu.Lock()
 	defer r.sourceMu.Unlock()
-	if r.sourceEditors == nil {
-		r.sourceEditors = make(map[string]*memedit.MemEditor)
+	if r.sourceHitEditors == nil {
+		r.sourceHitEditors = make(map[string]*memedit.MemEditor)
 	}
-	if editor, ok := r.sourceEditors[path]; ok {
+	if editor, ok := r.sourceHitEditors[path]; ok {
 		return editor
 	}
 	content, ok := r.files[path]
@@ -449,7 +457,7 @@ func (r *PatternRoot) SourceHitEditor(path string) *memedit.MemEditor {
 		return nil
 	}
 	editor := memedit.NewMemEditorWithFileUrl(content, path)
-	r.sourceEditors[path] = editor
+	r.sourceHitEditors[path] = editor
 	return editor
 }
 


### PR DESCRIPTION
## 摘要

本次 PR 修复了 JS/Node 项目源码扫描阶段异常耗时的问题。 recent logs 中 nodejs/node 项目 source-scan 约 13.43 小时，n8n 项目约 1 小时 26 分钟，且单条规则独占约 100% CPU 核心跑满整个阶段。

## 根因

问题规则  使用了  全局 glob，导致它会扫描所有已加载文件。在 JS/Node 项目上它产生了：
-  命中：约 6.7k
-  命中：约 758k
-  命中：约 157 万

其  区域过滤在  中是 O(N*M) 的线性扫描，导致约 **1.58×10¹⁰ 次包含判断**，把单个 CPU 核心占满数小时。现有的每规则 timeout / work-budget 机制并不覆盖 sfpattern 的内部循环。

## 改动

1. **限制 Apex 规则作用域**（）
   - 将  改为 ，只对 Apex 源文件生效。

2. **为 source 模式区域过滤加索引**（）
   - 用按文件排序的区间索引 + 二分查找，替代原来的 O(N*M) 线性扫描。
   - 把每规则的 （ctx 取消 + work budget）接入过滤分发，使长时间运行的 source 规则可以被取消/计数。

3. **缓存与命中数上限**（、）
   -  从单槽缓存改为多槽缓存，多个  语句及  的 positive 集可以复用原始命中结果。
   -  现在复用普通  缓存计算 positive 集。
   - 新增 ，为过宽的 secret 类规则限制内存和 CPU。

4. **VM 区域 opcode 透传 Config**（、）
   -  现在接收每规则  并转发给 sfpattern。

## 验证

- [36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 2 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 2 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 3 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 2 pattern(s): backend=engine tier=2 simd=true always_on=1
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 3 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 3 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 4 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 4 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 3 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:15 [options:15] minirehs compiled 2 pattern(s): backend=engine tier=2 simd=true always_on=0
[36m[INFO][0m 2026-09-11 11:01:16 [options:15] minirehs compiled 2 pattern(s): backend=engine tier=2 simd=true always_on=1
--- FAIL: TestBuiltinSourceRules_VerifyFilesystem (2.23s)
    --- FAIL: TestBuiltinSourceRules_VerifyFilesystem/source-insecure-api-poetry-missing-solver-min-release-age.sf (0.01s)
        builtin_source_verify_test.go:45: 
            	Error Trace:	C:/Users/13766/work/yaklang/common/syntaxflow/sfpattern/builtin_source_verify_test.go:45
            	Error:      	Received unexpected error:
            	            	alert symbol table is empty
            	            	github.com/yaklang/yaklang/common/syntaxflow/sfanalysis.checkSourcePositiveResult
            	            		C:/Users/13766/work/yaklang/common/syntaxflow/sfanalysis/verify.go:207
            	            	github.com/yaklang/yaklang/common/syntaxflow/sfanalysis.runSourceVerifyWithFrame
            	            		C:/Users/13766/work/yaklang/common/syntaxflow/sfanalysis/verify.go:160
            	            	github.com/yaklang/yaklang/common/syntaxflow/sfanalysis.runEmbeddedVerifyWithFrame
            	            		C:/Users/13766/work/yaklang/common/syntaxflow/sfanalysis/verify.go:71
            	            	github.com/yaklang/yaklang/common/syntaxflow/sfanalysis.EvaluateVerifyFilesystemWithFrame
            	            		C:/Users/13766/work/yaklang/common/syntaxflow/sfanalysis/verify.go:43
            	            	github.com/yaklang/yaklang/common/syntaxflow/sfpattern_test.TestBuiltinSourceRules_VerifyFilesystem.func2
            	            		C:/Users/13766/work/yaklang/common/syntaxflow/sfpattern/builtin_source_verify_test.go:44
            	Test:       	TestBuiltinSourceRules_VerifyFilesystem/source-insecure-api-poetry-missing-solver-min-release-age.sf
FAIL
FAIL	github.com/yaklang/yaklang/common/syntaxflow/sfpattern	4.639s
FAIL 通过，除了  的预存在验证失败。
- 本地使用  对  测试，所有规则大约一分钟内已跑完，随后触发了 source-scan 脚本结果回调路径中一个与本次改动无关的  panic（位于 ）。
- 结合日志证据，之前该规则独占整个 source-scan 阶段；修复后不再卡住。

## 说明

- 内置规则通过  嵌入，CI 会根据修改后的  文件重新打包。本地测试需在重新打包 tar.gz 后重建 。
- 本次 PR 采取保守策略：修复已定位的瓶颈并增加结构性保护，不改造整个 source-scan 架构。