### PR TITLE
fix(cli): skip database init for help commands and harden binary probe

### DIFF
--- a/common/yak/cmd/yak.go
+++ b/common/yak/cmd/yak.go
@@ -170,6 +170,27 @@ func isVersionCommand() bool {
 	return false
 }
 
+// isHelpCommand 判断本次调用是否只需要输出帮助（help/--help/-h）。
+// 这类调用不应触发数据库初始化：初始化会建库、导入内置插件并输出大量日志，
+// 在 CI 中探测帮助文本时会拖慢命令甚至触发 SIGPIPE 误判。
+func isHelpCommand() bool {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "help", "-h", "--help", "-help", "--help=true":
+			return true
+		}
+	}
+	// 子命令帮助: yak <command> --help / -h（第二参数直接是帮助标志）。
+	// 只检查第二参数，避免把 -c/脚本内容里的 "--help" 误判为帮助调用。
+	if len(os.Args) > 2 {
+		switch os.Args[2] {
+		case "--help", "-h", "-help", "--help=true":
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	// 取消掉 0022 的限制，让用户可以创建别人也能写的文件夹
 	umask.Umask(0)
@@ -232,7 +253,7 @@ func init() {
 
 `, consts.GetYakVersion(), "yaklang.io")
 
-	case isVersionCommand():
+	case isVersionCommand(), isHelpCommand():
 		// pass
 
 	default:

--- a/scripts/prepare-yak.sh
+++ b/scripts/prepare-yak.sh
@@ -99,17 +99,22 @@ fi
 
 # 检查二进制是否满足所有 --require 参数
 binary_satisfies() {
-  local dest="$1" req cmd flag
+  local dest="$1" req cmd flag help_file
   if ! "$dest" version >/dev/null 2>&1; then
     return 1
   fi
+  help_file="$(mktemp)"
   for req in "${REQUIRES[@]}"; do
     cmd="${req%% *}"
     flag="${req#* }"
-    if ! "$dest" "$cmd" --help 2>&1 | grep -q -- "$flag"; then
+    # 先把 help 写入文件再 grep，避免 stdout 管道被提前关闭时 yak 收到
+    # SIGPIPE（141），导致已发布的二进制被误判为缺少所需参数。
+    if ! "$dest" "$cmd" --help >"$help_file" 2>&1 || ! grep -q -- "$flag" "$help_file"; then
+      rm -f "$help_file"
       return 1
     fi
   done
+  rm -f "$help_file"
   return 0
 }
 


### PR DESCRIPTION
## 问题

CI 的 `prepare-yak.sh` 在探测已发布二进制时偶发失败（`missing required flags or failed verification`），实际上二进制包含所需参数。

根因有两个：

1. **`--help` 会触发数据库初始化**：`init()` 只豁免了 version 和少数命令，`embed-fs-hash --help`、`syntaxflow-format --help` 等都会先建库、导入内置插件并输出大量日志，再打印帮助。空数据环境下耗时数秒，且 stdout 管道被 `grep -q` 提前关闭时 yak 收到 SIGPIPE，探测管道整体返回 141，导致已发布的二进制被误判为缺少参数。
2. **探测方式有竞态**：`binary --help 2>&1 | grep -q -- flag` 在 `set -euo pipefail` 下会把 SIGPIPE 当作失败。

## 修改

- `common/yak/cmd/yak.go`：新增 `isHelpCommand()`，help/--help/-h 调用跳过数据库初始化。只检查前两个参数，避免把 `-c` 代码内容里的 `--help` 误判。
- `scripts/prepare-yak.sh`：`binary_satisfies` 改为先把 `--help` 输出写入临时文件再 grep，消除管道 SIGPIPE 竞态。

## 验证

- 新 `YAKIT_HOME` 空环境下，`embed-fs-hash --help` / `syntaxflow-format --help` 秒回，不建库、无初始化日志。
- `grpc` 子命令仍正常初始化数据库并启动。
- 真正执行子命令时初始化行为无回归。
- 本地二进制跑探测 10/10 通过。