### PR TITLE
fix(ci): restore Go cache via actions/cache in prepared-startup job

### DIFF
--- a/.github/workflows/essential-tests.yml
+++ b/.github/workflows/essential-tests.yml
@@ -332,31 +332,41 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+      - name: Configure Go build directories
+        run: |
+          mkdir -p "$RUNNER_TEMP/go-build-cache" "$RUNNER_TEMP/go-mod-cache"
+          echo "GOCACHE=$RUNNER_TEMP/go-build-cache" >> "$GITHUB_ENV"
+          echo "GOMODCACHE=$RUNNER_TEMP/go-mod-cache" >> "$GITHUB_ENV"
+      - name: Restore Go module cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/go-mod-cache
+          key: ${{ runner.os }}-essential-gomod-${{ hashFiles('go.sum') }}
+      - name: Restore Go build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/go-build-cache
+          key: ${{ runner.os }}-essential-gobuild-${{ hashFiles('go.sum') }}-base-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-essential-gobuild-${{ hashFiles('go.sum') }}-base-
+            ${{ runner.os }}-essential-gobuild-${{ hashFiles('go.sum') }}-
+            ${{ runner.os }}-essential-gobuild-
       - name: Download prepared engine
         uses: actions/download-artifact@v4
         with:
           name: essential-tests-yak
           path: ${{ runner.temp }}/yak-artifact
-      - name: Download shared Go build cache
-        uses: actions/download-artifact@v4
-        with:
-          name: essential-tests-yak-cache
-          path: ${{ runner.temp }}/go-cache-artifact
-      - name: Unpack prepared engine and cache
+      - name: Unpack prepared engine
         run: |
           ARTIFACT_PATH="$RUNNER_TEMP/yak-artifact/essential-tests-yak.tar.gz" \
           DEST_DIR="$RUNNER_TEMP/shared-yak" \
           ARTIFACT_EXPECT_PATHS="yak" ARTIFACT_EXECUTABLE_PATHS="yak" \
           ./scripts/ci/artifact-unpackage.sh
-          ARTIFACT_PATH="$RUNNER_TEMP/go-cache-artifact/essential-tests-yak-cache.tar.gz" \
-          DEST_DIR="$RUNNER_TEMP/shared-go-cache" \
-          ARTIFACT_EXPECT_PATHS="go-build-cache" \
-          ./scripts/ci/artifact-unpackage.sh
       - name: Smoke test compiled yak startup
         env:
           YAK_BINARY_PATH: ${{ runner.temp }}/shared-yak/yak
-          GOCACHE: ${{ runner.temp }}/shared-go-cache/go-build-cache
-          GOMODCACHE: ${{ runner.temp }}/go-mod-cache
+          GOCACHE: ${{ env.GOCACHE }}
+          GOMODCACHE: ${{ env.GOMODCACHE }}
         run: |
           set -o pipefail
           bash ./scripts/ci/test-yak-startup.sh 2>&1 | tee "$RUNNER_TEMP/yak-startup-smoke.log"


### PR DESCRIPTION
## Problem

The `Prepared engine startup smoke` job in `essential-tests.yml` fails with:

```
Unable to download artifact(s): Artifact not found for name: essential-tests-yak-cache
```

## Root cause

Two branches independently modified `essential-tests.yml` in **opposite directions**, but in different regions of the file. Git auto-merge produced no conflict, yet the resulting workflow was logically broken:

| | `prepare-yak` (producer) | `prepared-startup` (consumer) |
|---|---|---|
| **main side** | Refactored to use `actions/cache/save` instead of uploading the `essential-tests-yak-cache` artifact | New job that downloads `essential-tests-yak-cache` via `actions/download-artifact` |
| **PR branch side** | Still uploads `essential-tests-yak-cache` as an artifact | (job did not exist) |
| **Merge result** | Took main's version → **no artifact uploaded** | Took main's version → **still downloads the artifact** |

So `prepare-yak` stopped producing the `essential-tests-yak-cache` artifact, while `prepared-startup` still expected it → CI failure.

## Fix

Align `prepared-startup` with all other consumer jobs (`test-local`, `scannode-focused`, `slim-gate`, `prepare-yakgrpc`, etc.) that were already correctly migrated:

- **Remove** the `actions/download-artifact` step for `essential-tests-yak-cache`
- **Add** `Configure Go build directories`, `Restore Go module cache`, and `Restore Go build cache` steps using `actions/cache/restore@v4` with the same key scheme as `prepare-yak`'s `cache/save` step (`-base-` prefix)
- Keep downloading only the yak binary artifact (`essential-tests-yak`), which is still produced by `prepare-yak`
- Point `GOCACHE`/`GOMODCACHE` to the restored cache directories via `$GITHUB_ENV`, matching the pattern used by every other job