### PR TITLE
fix(ssa): source-scan git workdir cleanup and attempt_lease_expired

### DIFF
--- a/common/yak/ssaapi/ssagitworkdir/workdir.go
+++ b/common/yak/ssaapi/ssagitworkdir/workdir.go
@@ -203,6 +203,8 @@ func Prepare(ctx context.Context, pid int) (string, func() error, error) {
 }
 
 // CleanupForOwner removes only SSA Git workspaces owned by a finished child process.
+// Names are yakgit-{owner}-*; that includes compile clones and Legion
+// source-scan clones (yakgit-{owner}-source-scan-*).
 func CleanupForOwner(owner string) error {
 	if err := validateOwner(owner); err != nil {
 		return err

--- a/common/yak/ssaapi/ssagitworkdir/workdir_test.go
+++ b/common/yak/ssaapi/ssagitworkdir/workdir_test.go
@@ -186,6 +186,25 @@ func TestPrepareCreatesUniqueWorkspacesConcurrently(t *testing.T) {
 	}
 }
 
+func TestCleanupForOwnerRemovesSourceScanWorkspaces(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(WorkDirEnv, root)
+	sourceScan, err := os.MkdirTemp(root, "yakgit-node-a-source-scan-")
+	require.NoError(t, err)
+	compile, err := os.MkdirTemp(root, "yakgit-node-a-task-")
+	require.NoError(t, err)
+	other, err := os.MkdirTemp(root, "yakgit-node-b-source-scan-")
+	require.NoError(t, err)
+
+	require.NoError(t, CleanupForOwner("node-a"))
+	_, err = os.Stat(sourceScan)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(compile)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(other)
+	require.NoError(t, err)
+}
+
 func TestCleanupForOwnerScopeRemovesOnlyThatScanNodeInstallation(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv(WorkDirEnv, root)

--- a/scannode/job_failure_codes.go
+++ b/scannode/job_failure_codes.go
@@ -17,11 +17,11 @@ const (
 
 const (
 	// Node-reported JobFailed.error_code values emitted by scannode.
-	JobFailureCodeNodeCapacityExceeded    = "node_capacity_exceeded"
-	JobFailureCodeInvalidDispatchCommand  = "invalid_dispatch_command"
-	JobFailureCodeScriptExecutionFailed   = "script_execution_failed"
+	JobFailureCodeNodeCapacityExceeded      = "node_capacity_exceeded"
+	JobFailureCodeInvalidDispatchCommand    = "invalid_dispatch_command"
+	JobFailureCodeScriptExecutionFailed     = "script_execution_failed"
 	JobFailureCodeRuleSnapshotPrepareFailed = "rule_snapshot_prepare_failed"
-	JobFailureCodeScriptExecutionPanic    = "script_execution_panic"
+	JobFailureCodeScriptExecutionPanic      = "script_execution_panic"
 	JobFailureCodeStartedEventPublishFailed = "started_event_publish_failed"
 
 	// JobFailureCodeUnknownNodeReported is the canonical bucket for unrecognized
@@ -42,6 +42,7 @@ const (
 	// Platform-inferred codes: never emitted by scannode, documented here so
 	// Legion and yaklang share one registry for retry decisions.
 	JobFailureCodeAttemptMissingFromHeartbeat = "attempt_missing_from_heartbeat"
+	JobFailureCodeAttemptLeaseExpired         = "attempt_lease_expired"
 )
 
 const (
@@ -63,13 +64,14 @@ type jobFailureCodeSpec struct {
 // Git hosts (e.g. github.com) regularly drop connections mid-clone; the other
 // script codes describe deterministic input or environment problems.
 var jobFailureCodeRegistry = map[string]jobFailureCodeSpec{
-	JobFailureCodeNodeCapacityExceeded:      {policy: JobFailureRetryPolicyReschedule},
-	JobFailureCodeInvalidDispatchCommand:    {policy: JobFailureRetryPolicyNone},
-	JobFailureCodeScriptExecutionFailed:     {policy: JobFailureRetryPolicyNone},
-	JobFailureCodeRuleSnapshotPrepareFailed: {policy: JobFailureRetryPolicyTransient},
-	JobFailureCodeScriptExecutionPanic:      {policy: JobFailureRetryPolicyTransient},
-	JobFailureCodeStartedEventPublishFailed: {policy: JobFailureRetryPolicyTransient},
+	JobFailureCodeNodeCapacityExceeded:        {policy: JobFailureRetryPolicyReschedule},
+	JobFailureCodeInvalidDispatchCommand:      {policy: JobFailureRetryPolicyNone},
+	JobFailureCodeScriptExecutionFailed:       {policy: JobFailureRetryPolicyNone},
+	JobFailureCodeRuleSnapshotPrepareFailed:   {policy: JobFailureRetryPolicyTransient},
+	JobFailureCodeScriptExecutionPanic:        {policy: JobFailureRetryPolicyTransient},
+	JobFailureCodeStartedEventPublishFailed:   {policy: JobFailureRetryPolicyTransient},
 	JobFailureCodeAttemptMissingFromHeartbeat: {policy: JobFailureRetryPolicyReschedule},
+	JobFailureCodeAttemptLeaseExpired:         {policy: JobFailureRetryPolicyReschedule},
 
 	JobFailureCodeGitCloneError:          {policy: JobFailureRetryPolicyTransient},
 	JobFailureCodeNotFoundFileCanCompile: {policy: JobFailureRetryPolicyNone},

--- a/scannode/job_failure_codes_test.go
+++ b/scannode/job_failure_codes_test.go
@@ -19,6 +19,7 @@ func TestResolveJobFailureCodeKnownCodes(t *testing.T) {
 		{JobFailureCodeScriptExecutionPanic, JobFailureRetryPolicyTransient},
 		{JobFailureCodeStartedEventPublishFailed, JobFailureRetryPolicyTransient},
 		{JobFailureCodeAttemptMissingFromHeartbeat, JobFailureRetryPolicyReschedule},
+		{JobFailureCodeAttemptLeaseExpired, JobFailureRetryPolicyReschedule},
 		// Script-reported codes from Legion-owned yak scripts must resolve as
 		// known so prepareJobFailureForPublish forwards them verbatim.
 		{JobFailureCodeGitCloneError, JobFailureRetryPolicyTransient},


### PR DESCRIPTION
## Summary

Shared Scan Node pieces that Legion PR https://github.com/VillanCh/legion/pull/474 depends on.

1. **`attempt_lease_expired`** is a platform-inferred job failure ID (scheduler lease expiry), not an unknown node-reported code. Legion maps it to customer copy: 执行节点已断开，请重新扫描.

2. **`CleanupForOwner`** already matches `yakgit-{owner}-*`. Legion source-scan now clones into `yakgit-{owner}-source-scan-*` under `YAK_SSA_GIT_WORKDIR`, so task-end / node-restart recovery removes those leftovers the same way as compile clones. The test covers that prefix.

## Commits

- `05c94ce9e` `fix(scannode): register attempt_lease_expired as a platform failure ID`
- `4ed7c70b6` `fix(ssa): CleanupForOwner also sweeps source-scan git workdirs`
