### PR TITLE
fix(docker): remove unnecessary libpcap0.8 from Dockerfile

### DIFF
--- a/common/yak/cmd/docker/Dockerfile
+++ b/common/yak/cmd/docker/Dockerfile
@@ -9,7 +9,7 @@ COPY scripts/get-yak-version.sh /get-yak-version
 
 # Always fetch version from active_versions.txt (excluding -yakit- and -irify- versions)
 # VERSION build arg is ignored, version is always determined from active_versions.txt
-RUN apt-get update -y && apt-get install -y wget curl iputils-ping libpcap0.8=1.9.1-3 && \
+RUN apt-get update -y && apt-get install -y wget curl iputils-ping && \
     ARCH=$(if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     VERSION=$(bash /get-yak-version --quiet || echo "latest") && \
     wget -q -O /app/yak https://aliyun-oss.yaklang.com/yak/${VERSION}/yak_linux_${ARCH} && \


### PR DESCRIPTION
## 问题

CI `check_version_and_github_release` -> `Build Docker Image(Tag)` 步骤构建失败：

```
E: Version '1.9.1-3' for 'libpcap0.8' was not found
ERROR: failed to build: failed to solve: process did not complete successfully: exit code: 100
```

## 原因

Dockerfile 中 `libpcap0.8` 被固定为 `1.9.1-3`，该版本已从 Ubuntu 20.04 apt 源中移除。

## 分析：libpcap0.8 根本不需要

经分析，运行时镜像中安装 `libpcap0.8` 是多余的：

1. **编译时静态链接**：`github.com/yaklang/pcap` 自带 `libpcap.a`，cgo LDFLAGS 指定 `-lpcap` 时，由于目录中没有 `libpcap.so`（只有 `libpcap.so.1.8.1`），链接器只能使用 `libpcap.a` → 静态链接
2. **构建容器无系统 libpcap**：manylinux2014 容器未安装 libpcap，不存在系统动态库干扰
3. **无 dlopen**：代码中没有任何 `dlopen` 调用动态加载 libpcap
4. **历史佐证**：Dockerfile 最初版本（`fd6ca71de`）根本不安装 libpcap；`docker/session-runtime/Dockerfile` 也不安装

## 修复

直接移除 `libpcap0.8`，而非仅去掉版本锁定。

### 关联 CI
https://github.com/yaklang/yaklang/actions/runs/34579607506/job/103203219011