### PR TITLE
refactor(save_evidence): rename verification_payload to evidence_content

### DIFF
--- a/common/ai/aid/aicommon/action_test.go
+++ b/common/ai/aid/aicommon/action_test.go
@@ -166,7 +166,7 @@ func TestActionParser_PreservesUnsupportedObservedActionType(t *testing.T) {
 	ctx := context.Background()
 	action, err := ExtractActionFromStream(
 		ctx,
-		strings.NewReader(`{"@action":"save_evidence","verification_payload":"confirmed finding"}`),
+		strings.NewReader(`{"@action":"save_evidence","evidence_content":"confirmed finding"}`),
 		"object",
 		WithActionAlias("require_tool", "finish"),
 	)
@@ -174,7 +174,7 @@ func TestActionParser_PreservesUnsupportedObservedActionType(t *testing.T) {
 	require.Empty(t, action.ActionType(), "unsupported action must not become an admitted action")
 	require.Equal(t, "save_evidence", action.ObservedActionType(), "raw action must be available after admitted ActionType resolves")
 	require.NoError(t, action.WaitParseResult(ctx))
-	require.Equal(t, "confirmed finding", action.GetString("verification_payload"))
+	require.Equal(t, "confirmed finding", action.GetString("evidence_content"))
 }
 
 func TestActionParser_ObservedActionMatchesAdmittedAction(t *testing.T) {

--- a/common/ai/aid/aireact/reactloops/action_save_evidence.go
+++ b/common/ai/aid/aireact/reactloops/action_save_evidence.go
@@ -48,21 +48,21 @@ var loopAction_SaveEvidence = &LoopAction{
 			aitool.WithParam_Description("Optional stable semantic ID (1-128 characters: letters, digits, dot, underscore, colon, or hyphen). Reuse it to update the same finding."),
 		),
 		aitool.WithStringParam(
-			"verification_payload",
+			"evidence_content",
 			aitool.WithParam_Required(true),
 			aitool.WithParam_Description("Concise reusable evidence: what was tested or observed, how it was confirmed, the concrete result, and why it matters. This content is written directly to Session Evidence."),
 		),
 	},
 	StreamFields: []*LoopStreamField{
-		{FieldName: "verification_payload", AINodeId: "verification_payload"},
+		{FieldName: "evidence_content", AINodeId: "evidence_content"},
 	},
 	ActionVerifier: func(loop *ReActLoop, action *aicommon.Action) error {
 		if loop == nil || action == nil {
 			return utils.Error("save_evidence requires a loop and parsed action")
 		}
-		payload := strings.TrimSpace(action.GetString("verification_payload"))
+		payload := strings.TrimSpace(action.GetString("evidence_content"))
 		if payload == "" {
-			payload = strings.TrimSpace(action.GetInvokeParams("next_action").GetString("verification_payload"))
+			payload = strings.TrimSpace(action.GetInvokeParams("next_action").GetString("evidence_content"))
 		}
 		evidenceID := strings.TrimSpace(action.GetString("evidence_id"))
 		if evidenceID == "" {

--- a/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
+++ b/common/ai/aid/aireact/reactloops/loop_default/prompts/instruction.txt
@@ -151,7 +151,7 @@ Timeline 或注入记忆中的失败记录是特定输入和环境下的历史�
 
 这不需要等到任务结束，也不需要等系统自动触发验证——**你随时可以主动保存证据**。
 
-`save_evidence` 会把 `verification_payload` **直接写入共享 Session Evidence Store**，不是请求另一个模型稍后代写。可选的 `evidence_id` 是稳定语义 ID；同一事实后续补强时复用该 ID 会原位更新，避免重复。省略 ID 时系统按规范化内容生成稳定 ID，因此相同动作重试也是幂等的。`verification_payload` 必须包含具体对象、验证方式、实际观测及其对后续任务的意义，不能只写“已完成”或计划。
+`save_evidence` 会把 `evidence_content` **直接写入共享 Session Evidence Store**，不是请求另一个模型稍后代写。可选的 `evidence_id` 是稳定语义 ID；同一事实后续补强时复用该 ID 会原位更新，避免重复。省略 ID 时系统按规范化内容生成稳定 ID，因此相同动作重试也是幂等的。`evidence_content` 必须包含具体对象、验证方式、实际观测及其对后续任务的意义，不能只写“已完成”或计划。
 
 ### 3.3 收口操作指南
 

--- a/common/ai/aid/aireact/reactloops/loop_default/prompts/output_example.txt
+++ b/common/ai/aid/aireact/reactloops/loop_default/prompts/output_example.txt
@@ -37,9 +37,9 @@
 
 *. `save_evidence` 使用案例（确认关键事实后主动沉淀，不等任务结束）：
     * 确认一个安全风险后，先落证据再继续，同时把新发现的关联入口记为待探索：
-      `{"@action": "save_evidence", "evidence_id": "refresh-token-replay", "verification_payload": "确认 /api/v2/token/refresh 存在重放漏洞：同一 refresh_token 重放两次均返回 200 且下发新的有效 access_token，未做一次性校验，响应字段 access_token 每次不同但均可正常鉴权", "todo_delta": {"add": [{"id": "check_logout_invalidate", "text": "待探索：验证退出登录后 refresh_token 是否失效，来源为本次重放漏洞的关联假设"}]}}`
+      `{"@action": "save_evidence", "evidence_id": "refresh-token-replay", "evidence_content": "确认 /api/v2/token/refresh 存在重放漏洞：同一 refresh_token 重放两次均返回 200 且下发新的有效 access_token，未做一次性校验，响应字段 access_token 每次不同但均可正常鉴权", "todo_delta": {"add": [{"id": "check_logout_invalidate", "text": "待探索：验证退出登录后 refresh_token 是否失效，来源为本次重放漏洞的关联假设"}]}}`
     * 排除一条路径时，写明实验条件和对照，而不是单次未命中就下结论：
-      `{"@action": "save_evidence", "evidence_id": "admin-anonymous-access", "verification_payload": "排除 /admin/ 路径存在未授权访问：对比携带有效 session 与清空 Cookie 两种请求，未登录时返回 302 跳转至登录页，与预期基线一致，字段和状态码均无差异"}`
+      `{"@action": "save_evidence", "evidence_id": "admin-anonymous-access", "evidence_content": "排除 /admin/ 路径存在未授权访问：对比携带有效 session 与清空 Cookie 两种请求，未登录时返回 302 跳转至登录页，与预期基线一致，字段和状态码均无差异"}`
 
 {{ if .AllowKnowledgeEnhanceAnswer }}*. 如果你觉得问题是事实密集型、需要精确数据、或涉及特定专业领域的概念解释，可以通过外部知识检索来增强回答的准确性和深度:
     * `{"@action": "knowledge_enhance_answer", "rewrite_user_query_for_knowledge_enhance": "..[rewrite-user-query]..", "human_readable_thought": "先补充资料"}

--- a/common/ai/aid/aireact/reactloops/loopinfra/action_save_evidence_test.go
+++ b/common/ai/aid/aireact/reactloops/loopinfra/action_save_evidence_test.go
@@ -50,7 +50,7 @@ func TestSaveEvidence_IsCoreActionAndWritesSessionStore(t *testing.T) {
 	op := executeSaveEvidence(t, loop, task, `{
 		"@action": "save_evidence",
 		"evidence_id": "refresh-token-replay",
-		"verification_payload": "POST /token/refresh accepted the same refresh token twice and returned two valid access tokens."
+		"evidence_content": "POST /token/refresh accepted the same refresh token twice and returned two valid access tokens."
 	}`)
 
 	assert.True(t, op.IsContinued())
@@ -64,10 +64,10 @@ func TestSaveEvidence_IsCoreActionAndWritesSessionStore(t *testing.T) {
 
 func TestSaveEvidence_RetryAndUpdateAreIdempotent(t *testing.T) {
 	loop, invoker, task := newSaveEvidenceLoop(t)
-	first := `{"@action":"save_evidence","evidence_id":"api-auth","verification_payload":"Unauthenticated GET /api/users returned 401."}`
+	first := `{"@action":"save_evidence","evidence_id":"api-auth","evidence_content":"Unauthenticated GET /api/users returned 401."}`
 	executeSaveEvidence(t, loop, task, first)
 	executeSaveEvidence(t, loop, task, first)
-	executeSaveEvidence(t, loop, task, `{"@action":"save_evidence","evidence_id":"api-auth","verification_payload":"Unauthenticated GET /api/users returned 401 with no response body."}`)
+	executeSaveEvidence(t, loop, task, `{"@action":"save_evidence","evidence_id":"api-auth","evidence_content":"Unauthenticated GET /api/users returned 401 with no response body."}`)
 
 	rendered := invoker.GetConfig().GetSessionEvidenceRendered()
 	assert.Len(t, regexp.MustCompile(`\[id: api-auth\]`).FindAllStringIndex(rendered, -1), 1)
@@ -77,7 +77,7 @@ func TestSaveEvidence_RetryAndUpdateAreIdempotent(t *testing.T) {
 
 func TestSaveEvidence_DerivesStableIDAndRejectsEmptyContent(t *testing.T) {
 	loop, invoker, task := newSaveEvidenceLoop(t)
-	raw := `{"@action":"save_evidence","verification_payload":"Controlled comparison ruled out anonymous access to /admin/."}`
+	raw := `{"@action":"save_evidence","evidence_content":"Controlled comparison ruled out anonymous access to /admin/."}`
 	executeSaveEvidence(t, loop, task, raw)
 	executeSaveEvidence(t, loop, task, raw)
 

--- a/common/schema/ai_node_id_i18n.go
+++ b/common/schema/ai_node_id_i18n.go
@@ -909,9 +909,9 @@ var nodeIdMapper = map[string]*I18n{
 		Zh: "验证",
 		En: "Verification",
 	},
-	"verification_payload": {
-		Zh: "验证说明",
-		En: "Verification Payload",
+	"evidence_content": {
+		Zh: "记录",
+		En: "Recording Evidence",
 	},
 	"answer": {
 		Zh: "回答",


### PR DESCRIPTION
## Why

save_evidence 的必填字段原名 `verification_payload` 与其真实语义（可复用证据条目：对象/验证方式/结果/影响）不符,是历史命名残留。前端展示的 i18n label 同样沿用了验证说明,与其它同类状态气泡（写入文件/验证代码/加载技能）的动词+名词拟人化风格不一致。

## Changes

- Go 参数名 `verification_payload` -> `evidence_content`（action 定义、verifier、handler）
- 同步更新相关单元测试与 prompts 示例文本
- i18n label 由 验证说明 改为 记录（En: Recording Evidence）,与同类状态短语风格保持一致

## Testing

- 本地无 Go 工具链,已通过 grep 校验仓库内无残留的 `verification_payload` 引用,交由 CI 验证编译与测试。